### PR TITLE
Accessibility: My Site - Create Button and Tooltip

### DIFF
--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -68,6 +68,7 @@
         android:layout_marginStart="@dimen/margin_medium"
         android:layout_alignParentEnd="true"
         android:layout_marginEnd="@dimen/margin_medium"
+        android:importantForAccessibility="noHideDescendants"
         android:layout_above="@+id/fab_button"/>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -80,7 +81,7 @@
         android:layout_marginEnd="@dimen/fab_margin"
         android:visibility="gone"
         tools:visibility="visible"
-        android:contentDescription="@string/fab_create_desc"
+        android:contentDescription="@string/create_post_page_fab_tooltip"
         android:src="@drawable/ic_create_white_24dp"
         app:borderWidth="0dp"/>
 


### PR DESCRIPTION
Fixes #11161 

## Findings
The create button's accessibility behavior needed updating since it was being announced as "create a post" when it does both posts and pages. These changes are related to great work done in the Information Architecture project. #11012
## Solution
To update the content description of the FAB and make the tooltip inaccessible since the content description will act as a tooltip in TalkBack mode. 

## Testing
1. Enable TalkBack. 
2. Go to`My Site` tab.
3. Select FAB and see the new description.

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/73106246-f56a7f00-3ec8-11ea-828f-e1fc8b3563d1.png" width="320">  | <img src="https://user-images.githubusercontent.com/1509205/73106984-c3f2b300-3eca-11ea-93b0-4876618c7d03.png" width="320">

4. Try to access tooltip and see that it's inaccessible.

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/73106378-45e1dc80-3ec9-11ea-940e-ebac4770efc7.png" width="320">        |  <img src="https://user-images.githubusercontent.com/1509205/73107098-0caa6c00-3ecb-11ea-91ef-936d130b22ea.png" width="320">





## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
