### PR TITLE
Don't show post history button for self-hosted Jetpack-connected sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -954,7 +954,7 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         if (historyMenuItem != null) {
-            boolean hasHistory = !mIsNewPost && (mSite.isWPCom() || mSite.isJetpackConnected());
+            boolean hasHistory = !mIsNewPost && mSite.isUsingWpComRestApi();
             historyMenuItem.setVisible(showMenuItems && hasHistory);
         }
 


### PR DESCRIPTION
Fixes #11061. The post history button shouldn't be visible for sites that communicate through XML-RPC API. The `isJetpackConnected` check can be confusing for some, but it doesn't mean that this site is currently using the REST API or that it should be treated as if it's a Jetpack site. The limitation of "Post History" button here is not about whether there is an active Jetpack connection in remote, but whether we have the API capability for post history which we don't if the site is only connected through XML-RPC. I hope this distinction makes sense.

**To test:**

* Add a site that's connected to Jetpack through "Add self-hosted site" (this can be done with the + button from the site picker or from the login screen)
* Open a post in the editor
* Tap on the "⋮" icon
* Verify that "History" button is not visible

These test instructions assume familiarity with Jetpack, so please let me know if you need any help with this @jd-alexander.

_P.S: I don't think screenshots or gifs will make these test instructions more clear since it needs a specific site setup. So, I am omitting them for this PR._

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
