### PR TITLE
Initiate upload starter on Pull-to-refresh and opening post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -44,6 +44,7 @@ import org.wordpress.android.ui.posts.PostListRemotePreviewState
 import org.wordpress.android.ui.posts.PreviewStateHelper
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
 import org.wordpress.android.ui.uploads.PostEvents
+import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.EventBusWrapper
@@ -88,6 +89,7 @@ class PagesViewModel
     private val networkUtils: NetworkUtilsWrapper,
     private val eventBusWrapper: EventBusWrapper,
     private val previewStateHelper: PreviewStateHelper,
+    private val uploadStarter: UploadStarter,
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val defaultDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(uiDispatcher) {
@@ -175,6 +177,7 @@ class PagesViewModel
             eventBusWrapper.register(this)
 
             loadPagesAsync()
+            uploadStarter.queueUploadFromSite(site)
         }
     }
 
@@ -458,6 +461,7 @@ class PagesViewModel
     }
 
     fun onPullToRefresh() {
+        uploadStarter.queueUploadFromSite(site)
         launch {
             reloadPages(FETCHING)
         }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -189,8 +189,9 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun `Auto-upload is initiated when the user enters the screen`() {
+    fun `Auto-upload is initiated when the user enters the screen`() = test {
         // Given
+        setUpPageStoreWithEmptyPages()
         // When
         viewModel.start(site)
         // Then
@@ -198,8 +199,9 @@ class PagesViewModelTest {
     }
 
     @Test
-    fun `Auto-upload is initiated when the user pulls to refresh`() {
+    fun `Auto-upload is initiated when the user pulls to refresh`() = test {
         // Given
+        setUpPageStoreWithEmptyPages()
         viewModel.start(site)
         // When
         viewModel.onPullToRefresh()


### PR DESCRIPTION
Fixes #11130 

Initiates the UploadStarter whenever the user opens the page list screen or when they pull to refresh.

To test:

Ideally comment out [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/a89450d78b4052fc355b455f91498accdc38ecdb/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt#L93
) so the upload starter isn't initiated when the device is back online
1. Open Pages list
2. Turn on the airplane mode
3. Create a new page with title "1" and publish it
4. Go to "Published tab" and find the page (it should be one of the top items)
5. Turn off the airplane mode
6. Make sure the upload isn't initiated automatically (shouldn't happen if you commented out the line)
7. Pull to refresh and notice the page is uploading - notification is shown
----------------
1. Open Pages list
2. Turn on the airplane mode
3. Create a new page with title "2" and publish it
4. Go to "Published tab" and find the page (it should be one of the top items)
5. Turn off the airplane mode
6. Make sure the upload isn't initiated automatically (shouldn't happen if you commented out the line)
7. Press back
8. Open the pages list again and notice the page is uploading - notification is shown



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
