### PR TITLE
New design reader bottom sheet - step 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SiteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SiteViewHolder.kt
@@ -1,18 +1,32 @@
 package org.wordpress.android.ui.reader.subfilter.viewholders
 
+import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import org.wordpress.android.R
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Site
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.UrlUtils
 
 class SiteViewHolder(
     parent: ViewGroup
 ) : SubfilterListItemViewHolder(parent, R.layout.subfilter_list_item) {
     private val itemTitle = itemView.findViewById<TextView>(R.id.item_title)
+    private val itemUrl = itemView.findViewById<TextView>(R.id.item_url)
 
     fun bind(site: Site, uiHelpers: UiHelpers) {
         super.bind(site, uiHelpers)
         this.itemTitle.text = uiHelpers.getTextOfUiString(parent.context, site.label)
+        this.itemUrl.visibility = View.VISIBLE
+
+        val blog = site.blog
+
+        this.itemUrl.text = if (blog.hasUrl()) {
+            UrlUtils.getHost(blog.url)
+        } else if (blog.hasFeedUrl()) {
+            UrlUtils.getHost(blog.feedUrl)
+        } else {
+            ""
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SiteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SiteViewHolder.kt
@@ -21,12 +21,10 @@ class SiteViewHolder(
 
         val blog = site.blog
 
-        this.itemUrl.text = if (blog.hasUrl()) {
-            UrlUtils.getHost(blog.url)
-        } else if (blog.hasFeedUrl()) {
-            UrlUtils.getHost(blog.feedUrl)
-        } else {
-            ""
+        this.itemUrl.text = when {
+            blog.hasUrl() -> UrlUtils.getHost(blog.url)
+            blog.hasFeedUrl() -> UrlUtils.getHost(blog.feedUrl)
+            else -> ""
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
@@ -26,10 +26,11 @@ open class SubfilterListItemViewHolder(
         itemText?.let {
             it.setTextColor(ContextCompat.getColor(
                     parent.context,
-                    if (filter.isSelected)
+                    if (filter.isSelected) {
                         R.color.primary
-                    else
+                    } else {
                         parent.context.getColorResIdFromAttribute(R.attr.wpColorText)
+                    }
             ))
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.R
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.getColorResIdFromAttribute
 
 open class SubfilterListItemViewHolder(
     internal val parent: ViewGroup,
@@ -23,9 +24,13 @@ open class SubfilterListItemViewHolder(
         }
         val itemText: TextView? = this.itemView.findViewById(R.id.item_title)
         itemText?.let {
-            if (filter.isSelected) {
-                it.setTextColor(ContextCompat.getColor(parent.context, R.color.primary))
-            }
+            it.setTextColor(ContextCompat.getColor(
+                    parent.context,
+                    if (filter.isSelected)
+                        R.color.primary
+                    else
+                        parent.context.getColorResIdFromAttribute(R.attr.wpColorText)
+            ))
         }
 
         this.itemView.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/TagViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/TagViewHolder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.subfilter.viewholders
 
+import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import org.wordpress.android.R
@@ -10,9 +11,11 @@ class TagViewHolder(
     parent: ViewGroup
 ) : SubfilterListItemViewHolder(parent, R.layout.subfilter_list_item) {
     private val itemTitle = itemView.findViewById<TextView>(R.id.item_title)
+    private val itemUrl = itemView.findViewById<TextView>(R.id.item_url)
 
     fun bind(tag: Tag, uiHelpers: UiHelpers) {
         super.bind(tag, uiHelpers)
         this.itemTitle.text = uiHelpers.getTextOfUiString(parent.context, tag.label)
+        this.itemUrl.visibility = View.GONE
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -147,7 +147,7 @@ class ReaderPostListViewModel @Inject constructor(
                         onClickAction = ::onSubfilterClicked,
                         blog = blog,
                         isSelected = (getCurrentSubfilterValue() is Site) &&
-                                (getCurrentSubfilterValue() as Site).blog.name == blog.name
+                                (getCurrentSubfilterValue() as Site).blog.isSameAs(blog)
                 ))
             }
 
@@ -158,7 +158,7 @@ class ReaderPostListViewModel @Inject constructor(
                         onClickAction = ::onSubfilterClicked,
                         tag = tag,
                         isSelected = (getCurrentSubfilterValue() is Tag) &&
-                                (getCurrentSubfilterValue() as Tag).tag.tagTitle == tag.tagTitle
+                                (getCurrentSubfilterValue() as Tag).tag == tag
                 ))
             }
 

--- a/WordPress/src/main/res/layout/subfilter_component.xml
+++ b/WordPress/src/main/res/layout/subfilter_component.xml
@@ -33,7 +33,7 @@
 
     <TextView
         android:id="@+id/selected_filter_name"
-        style="@style/SiteTagFilteredTitle"
+        style="@style/SiteTagSelectedFilter"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:ellipsize="end"

--- a/WordPress/src/main/res/layout/subfilter_list_item.xml
+++ b/WordPress/src/main/res/layout/subfilter_list_item.xml
@@ -3,19 +3,32 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/SubfilterSiteTagItem"
-    android:layout_width="match_parent"
-    android:orientation="horizontal">
+    android:layout_width="match_parent">
 
     <TextView
         android:id="@+id/item_title"
         style="@style/SiteTagFilteredTitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        app:layout_constraintEnd_toStartOf="@+id/item_selected"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/item_url"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_goneMarginBottom="@dimen/reader_subfilter_title_gone_margin_bottom"
+        app:layout_goneMarginTop="@dimen/reader_subfilter_title_gone_margin_top"
+        tools:text="Unknown" />
+
+    <TextView
+        android:id="@+id/item_url"
+        style="@style/SiteTagFilteredUrl"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/item_selected"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="@string/unknown" />
+        app:layout_constraintTop_toBottomOf="@+id/item_title"
+        android:visibility="visible"
+        tools:text="www.unknown.com" />
 
     <ImageView
         android:id="@+id/item_selected"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -163,6 +163,9 @@
     <dimen name="reader_remove_filter_icon_width">32dp</dimen>
     <dimen name="reader_subfilter_end_guideline_margin">58dp</dimen>
 
+    <dimen name="reader_subfilter_title_gone_margin_top">0dp</dimen>
+    <dimen name="reader_subfilter_title_gone_margin_bottom">10dp</dimen>
+
     <item name="reader_photo_title_shadow_offset" format="float" type="dimen">3.0</item>
     <item name="reader_photo_title_shadow_radius" format="float" type="dimen">1.5</item>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1079,14 +1079,32 @@
     </style>
 
     <style name="SubfilterSiteTagItem">
-        <item name="android:layout_height">@dimen/one_line_list_item_height</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:minHeight">@dimen/one_line_list_item_height</item>
         <item name="android:paddingStart">@dimen/content_margin_site_row_start</item>
         <item name="android:paddingEnd">@dimen/content_margin_site_row_start</item>
         <item name="android:background">?attr/selectableItemBackground</item>
+        <item name="android:gravity">center_vertical</item>
     </style>
 
     <style name="SiteTagFilteredTitle" parent="MySiteListRowTextView">
         <item name="android:layout_gravity">center_vertical</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:paddingTop">@dimen/margin_large</item>
+        <item name="android:paddingBottom">@dimen/margin_extra_small</item>
+    </style>
+
+    <style name="SiteTagSelectedFilter" parent="SiteTagFilteredTitle">
+        <item name="android:layout_gravity">center_vertical</item>
+        <item name="android:paddingTop">@dimen/margin_large</item>
+        <item name="android:paddingBottom">@dimen/margin_large</item>
+    </style>
+
+
+    <style name="SiteTagFilteredUrl" parent="SiteTagFilteredTitle">
+        <item name="android:textSize">@dimen/text_sz_medium</item>
+        <item name="android:textColor">?attr/wpColorTextSubtle</item>
+        <item name="android:paddingTop">0dp</item>
     </style>
 
     <style name="SiteTagBottomSheetTitle" parent="SiteTagFilteredTitle">


### PR DESCRIPTION
Fixes #11009 and partially #10887

**NOTE: this requires PR #11183 merged first into develop**

| ![image](https://user-images.githubusercontent.com/47797566/73530774-648c2a00-4419-11ea-86e2-fa6b9422df99.png) | ![image](https://user-images.githubusercontent.com/47797566/73530800-75d53680-4419-11ea-8a39-ec1aa9a376d3.png) |
|---|---|

## Notes
The feature is active in the zalpha flavor.

This PR covers the following:
1. Modifies the `SITES` section to present the list items with both the site title and a URL. In this way it's easier to manage cases where the site title is empty or equal since the match and selection is done on both.
2. Fixes a possible issue with the recycler view recycling (see [this comment ](https://github.com/wordpress-mobile/WordPress-Android/pull/10986#issuecomment-570216861)for more context)

## To test
### Test case 1: SITES tab shows site title and URL
- Follow some sites and tags if not already 
- Open the filter bottom sheet
- Check that the list of SITES shows both site title and url
- Check that the list of TAGS shows only tag title
- Smoke test the two lists checking the correct filter is selected and correct posts are loaded

### Test case 2: SITES tab shows and select Untitled sites correctly
- Follow at least a couple of sites with empty title (maybe not the only way to do this but you can set it empty from the web page settings)
- Open the bottom sheet and select one of the untitled site
- check that the correct posts load in the reader
- open the bottom sheet again and check that only the desired untitled site is highlighted as selected whereas the other one is not selected
- switch between the two untitled sites and check posts are correctly loaded
- smoke test selecting other sites and tags
### Test case 3
Since we made modifications to the `add_content_bottom_sheet` that is used also in the main create fab bottom sheet, makes sense to tap on the main FAB in My Site and smoke test the bottom sheet.

PR submission checklist:
note: not adding accessibility here since there will be a dedicated audit of the feature to close ticket #10962

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
