### PR TITLE
11195 Illegal argument exception fix 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -101,7 +101,7 @@ public class FilteredRecyclerView extends RelativeLayout {
         mCurrentFilter = filter;
 
         if (mUseTabsForFiltering) {
-            int position = mFilteredPagerAdapter.getItemPosition(filter);
+            int position = filter == null ? -1 : mFilteredPagerAdapter.getItemPosition(filter);
             if (position > -1 && position != mViewPager.getCurrentItem()) {
                 mViewPager.setCurrentItem(position);
             } else if (position > -1 && position == mViewPager.getCurrentItem()) {


### PR DESCRIPTION
Fixes #11195 

Was not able to reproduce. 

The fix basically adds a null check outside of the call into the `mFilteredPagerAdapter.getItemPosition` and so before the `kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull` can take care of it. We are basically following the same logic that is inside `mSpinnerAdapter.getIndexOfCriteria`.

Just as a note, AFAIU the issue (and the fix) currently affects only the alpha internal so we should be safe enough.

## To test:
Not able to reproduce myself so not sure how to test it. I can just report that @frosty (thanks for this 🙇‍♂️) was having the issue on his android device and was able to confirm the patched apk removed the crash.

cc @maxme (as anticipated can make sense to update the current alpha with this patch when reviewed/approved)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
