### PR TITLE
Refactor getValidTagForSharedPrefs and don't return null value

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -359,33 +359,32 @@ public class ReaderUtils {
         }
     }
 
-    public static ReaderTag getValidTagForSharedPrefs(
-            ReaderTag tag,
+    public static @NonNull ReaderTag getValidTagForSharedPrefs(
+            @NonNull ReaderTag tag,
             boolean isTopLevelReader,
             FilteredRecyclerView recyclerView
     ) {
-        ReaderTag validTag = tag;
+        if (!isTopLevelReader) {
+            return tag;
+        }
 
-        if (isTopLevelReader) {
-            if (tag.isDiscover() || tag.isPostsILike() || tag.isBookmarked()
-                    ||
-                (recyclerView != null && recyclerView.isValidFilter(tag))
-            ) {
-                validTag = tag;
+        boolean isValidFilter = (recyclerView != null && recyclerView.isValidFilter(tag));
+        boolean isSpecialTag = tag.isDiscover() || tag.isPostsILike() || tag.isBookmarked();
+        if (!isSpecialTag && !isValidFilter && isFollowing(tag, isTopLevelReader, recyclerView)) {
+            ReaderTag defaultTag = ReaderUtils.getDefaultTag();
+            // it's possible the default tag won't exist if the user just changed the app's
+            // language, in which case default to the first tag in the table
+            if (ReaderTagTable.tagExists(defaultTag)) {
+                return defaultTag;
             } else {
-                if (isFollowing(tag, isTopLevelReader, recyclerView)) {
-                    validTag = ReaderUtils.getDefaultTag();
-
-                    // it's possible the default tag won't exist if the user just changed the app's
-                    // language, in which case default to the first tag in the table
-                    if (!ReaderTagTable.tagExists(validTag)) {
-                        validTag = ReaderTagTable.getFirstTag();
-                    }
+                ReaderTag firstTag = ReaderTagTable.getFirstTag();
+                if (firstTag != null) {
+                    return firstTag;
                 }
             }
         }
 
-        return validTag;
+        return tag;
     }
 
     public static boolean isDefaultTag(ReaderTag tag) {


### PR DESCRIPTION
Fixes #11195. This is an alternative to #11198 which was preventing the crash in a higher level which would prevent us from getting valuable information through these types of crashes. First of, here is how to reproduce the original crash:

**To test:**
* Make sure `INFORMATION_ARCHITECTURE_AVAILABLE` feature flag is `true`
* Temporarily comment out [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java#L103). We do this to simulate an error response from the update tags request. You can also do this by using a proxy or manually changing the network request to fail.
* Do a fresh installation
* Login to the app
* Go to reader which will crash in `develop` and `release/14.1`

Before proceeding, please make sure that you can reproduce the crash in the base branch so we can ensure that the fix works.

---

The reason these steps results in a crash is that when the `ReaderTagTable` is created, it'll be empty and it'll only have tags added to it after successfully fetching the tags from remote. If this never happens, when we do `ReaderTagTable.getFirstTag()` we can get a `null` result.

This crash is only one of the symptoms of this, but we actually rely on getting a `@NonNull` object in a couple more places [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java#L591) and [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java#L1705). Both of these will later result in an NPE when `tag.isFollowedSites` is called. We also use it [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java#L101) but I don't think it'll result in an issue, but I am not sure.

I am opening this PR to fix the immediate crash and refactor the logic a bit to make it easier to follow however I think we need to address the other cases as well. Since these are all results of the new `INFORMATION_ARCHITECTURE_AVAILABLE` feature which looks like an active project, I have some suggestions:

* Close #11198.
* Review and test this PR with the steps above. Make sure the refactored logic is the same except for not returning `null` when `ReaderTagTable.getFirstTag()` is `null`.
* I'll leave a couple notes as line comments on this PR, it'd be great if we can address them in a separate PR. I don't know the intentions behind some of these, so I couldn't do it myself.
* We can go about fixing the actual issue in 2 ways:

1. If we don't have to get the tags from remote and have some local values we can add to the table, we should do that. From a quick look it looks like we already add some local tags, so if that's the case, we should just do this when the table is first created. Once we do that, we should add `@NonNull` to `ReaderTagTable.getFirstTag()` and before returning the result, do an assertion (at least for `DEBUG` builds) that we are not returning a `null` value. A custom message saying `This should never return a null value, because local tags should be added when the table is created. If it's returning a null value, all the rows were deleted which should never happen and should be fixed` or something along those lines. So, that'll make the intentions very clear.
2. If that's not an option, we should add `@Nullable` to `ReaderTagTable.getFirstTag()` and make sure all the usages of it are accounting for this fact. It means we at least need to fix the other 2 cases.

cc @frosty 

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
