### PR TITLE
Fix update gravatar feature

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -128,7 +128,23 @@ public class ActivityLauncher {
                                                 @NonNull MediaBrowserType browserType,
                                                 @Nullable SiteModel site,
                                                 @Nullable Integer localPostId) {
-        Intent intent = new Intent(activity, PhotoPickerActivity.class);
+        Intent intent = createShowPhotoPickerIntent(activity, browserType, site, localPostId);
+        activity.startActivityForResult(intent, RequestCodes.PHOTO_PICKER);
+    }
+
+    public static void showPhotoPickerForResult(Fragment fragment,
+                                                @NonNull MediaBrowserType browserType,
+                                                @Nullable SiteModel site,
+                                                @Nullable Integer localPostId) {
+        Intent intent = createShowPhotoPickerIntent(fragment.getContext(), browserType, site, localPostId);
+        fragment.startActivityForResult(intent, RequestCodes.PHOTO_PICKER);
+    }
+
+    private static Intent createShowPhotoPickerIntent(Context context,
+                                                      @NonNull MediaBrowserType browserType,
+                                                      @Nullable SiteModel site,
+                                                      @Nullable Integer localPostId) {
+        Intent intent = new Intent(context, PhotoPickerActivity.class);
         intent.putExtra(PhotoPickerFragment.ARG_BROWSER_TYPE, browserType);
         if (site != null) {
             intent.putExtra(WordPress.SITE, site);
@@ -136,7 +152,7 @@ public class ActivityLauncher {
         if (localPostId != null) {
             intent.putExtra(PhotoPickerActivity.LOCAL_POST_ID, localPostId.intValue());
         }
-        activity.startActivityForResult(intent, RequestCodes.PHOTO_PICKER);
+        return intent;
     }
 
     public static void showStockMediaPickerForResult(Activity activity,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -446,7 +446,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
     }
 
     private void showPhotoPickerForGravatar() {
-        ActivityLauncher.showPhotoPickerForResult(getActivity(), MediaBrowserType.GRAVATAR_IMAGE_PICKER, null, null);
+        ActivityLauncher.showPhotoPickerForResult(this, MediaBrowserType.GRAVATAR_IMAGE_PICKER, null, null);
     }
 
     private void startCropActivity(Uri uri) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -947,7 +947,7 @@ public class WPMainActivity extends AppCompatActivity implements
                 break;
             case RequestCodes.PHOTO_PICKER:
                 Fragment fragment = mBottomNav.getActiveFragment();
-                if (fragment instanceof MeFragment || fragment instanceof MySiteFragment) {
+                if (fragment instanceof MySiteFragment) {
                     fragment.onActivityResult(requestCode, resultCode, data);
                 }
                 break;


### PR DESCRIPTION
Fixes #11196

This PR fixes an issue with `startActivityForResult` being called on an activity, but the result being expected in a fragment. 
This issue was introduced when we moved "Me" section from the bottom navigation bar into the toolbar (it's own activity). In the previous location the WPMainActivity would manually delegate the `onActivityResult` to the fragment. 
Imo it's better to let the system handle the delegation, so I decided to call `fragment.startActivityForResult` instead of adding something similar to [this](https://github.com/wordpress-mobile/WordPress-Android/blob/f1663e6a9b49ad6226a60dc210d6bcf20ae15eba/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java#L950) to `MeActivity`. Wdyt?

To test:
1. Click on "Me" section in the toolbar
2. Click on "Switch photo"
3. Choose an image and confirm
4. Edit Image screen is opened (this didn't work before)
5. Confirm again and notice the gravatar gets uploaded and set
------------------------
1. Create a new post
2. Open EditPostSettings
3. Click on "Set featured image"
4. Select an image and make sure the image gets uploaded and set


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @maxme @jkmassel This bug was introduced in 14.1. It'd be great if we could release a new beta version with the fix. Thanks!
