### PR TITLE
Add follow/unfollow button to the Followed Sites tab on Reader's management section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -19,6 +19,7 @@ import org.wordpress.android.models.ReaderBlogList;
 import org.wordpress.android.models.ReaderRecommendBlogList;
 import org.wordpress.android.models.ReaderRecommendedBlog;
 import org.wordpress.android.ui.reader.ReaderInterfaces;
+import org.wordpress.android.ui.reader.actions.ReaderActions.ActionListener;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
 import org.wordpress.android.ui.reader.views.ReaderFollowButton;
 import org.wordpress.android.util.AppLog;
@@ -234,7 +235,7 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         // disable follow button until API call returns
         followButton.setEnabled(false);
 
-        boolean result = ReaderBlogActions.followBlogById(blog.blogId, isAskingToFollow, succeeded -> {
+        final ActionListener listener = succeeded -> {
             followButton.setEnabled(true);
             if (!succeeded) {
                 int errResId = isAskingToFollow ? R.string.reader_toast_err_follow_blog
@@ -243,7 +244,15 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 followButton.setIsFollowed(!isAskingToFollow);
                 blog.isFollowing = !isAskingToFollow;
             }
-        });
+        };
+
+        final boolean result;
+
+        if (blog.feedId != 0) {
+            result = ReaderBlogActions.followFeedById(blog.feedId, isAskingToFollow, listener);
+        } else {
+            result = ReaderBlogActions.followBlogById(blog.blogId, isAskingToFollow, listener);
+        }
 
         if (result) {
             followButton.setIsFollowedAnimated(isAskingToFollow);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -36,6 +36,10 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
+import static org.wordpress.android.BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE;
+
 /*
  * adapter which shows either recommended or followed blogs - used by ReaderBlogFragment
  */
@@ -155,9 +159,13 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         blogHolder.mTxtUrl.setText("");
                     }
                     mImageManager.load(blogHolder.mImgBlog, ImageType.BLAVATAR, blogInfo.getImageUrl());
-                    blogHolder.mFollowButton.setIsFollowed(blogInfo.isFollowing);
-                    blogHolder.mFollowButton.setOnClickListener(
-                            v -> toggleFollow(blogHolder.itemView.getContext(), blogHolder.mFollowButton, blogInfo));
+                    if (INFORMATION_ARCHITECTURE_AVAILABLE) {
+                        blogHolder.mFollowButton.setIsFollowed(blogInfo.isFollowing);
+                        blogHolder.mFollowButton.setOnClickListener(v -> toggleFollow(
+                                blogHolder.itemView.getContext(),
+                                blogHolder.mFollowButton,
+                                blogInfo));
+                    }
                     break;
             }
 
@@ -203,12 +211,12 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             // recommended blogs don't have a follow button
             switch (getBlogType()) {
                 case FOLLOWED:
-                    mTxtDescription.setVisibility(View.GONE);
-                    mFollowButton.setVisibility(View.VISIBLE);
+                    mTxtDescription.setVisibility(GONE);
+                    mFollowButton.setVisibility(INFORMATION_ARCHITECTURE_AVAILABLE ? VISIBLE : GONE);
                     break;
                 case RECOMMENDED:
-                    mTxtDescription.setVisibility(View.VISIBLE);
-                    mFollowButton.setVisibility(View.GONE);
+                    mTxtDescription.setVisibility(VISIBLE);
+                    mFollowButton.setVisibility(GONE);
                     break;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -19,9 +19,13 @@ import org.wordpress.android.models.ReaderBlogList;
 import org.wordpress.android.models.ReaderRecommendBlogList;
 import org.wordpress.android.models.ReaderRecommendedBlog;
 import org.wordpress.android.ui.reader.ReaderInterfaces;
+import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
+import org.wordpress.android.ui.reader.views.ReaderFollowButton;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
@@ -151,6 +155,9 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         blogHolder.mTxtUrl.setText("");
                     }
                     mImageManager.load(blogHolder.mImgBlog, ImageType.BLAVATAR, blogInfo.getImageUrl());
+                    blogHolder.mFollowButton.setIsFollowed(blogInfo.isFollowing);
+                    blogHolder.mFollowButton.setOnClickListener(
+                            v -> toggleFollow(blogHolder.itemView.getContext(), blogHolder.mFollowButton, blogInfo));
                     break;
             }
 
@@ -181,6 +188,7 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final TextView mTxtDescription;
         private final TextView mTxtUrl;
         private final ImageView mImgBlog;
+        private final ReaderFollowButton mFollowButton;
 
         BlogViewHolder(View view) {
             super(view);
@@ -189,20 +197,51 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             mTxtDescription = view.findViewById(R.id.text_description);
             mTxtUrl = view.findViewById(R.id.text_url);
             mImgBlog = view.findViewById(R.id.image_blog);
+            mFollowButton = view.findViewById(R.id.follow_button);
 
             // followed blogs don't have a description
+            // recommended blogs don't have a follow button
             switch (getBlogType()) {
                 case FOLLOWED:
                     mTxtDescription.setVisibility(View.GONE);
+                    mFollowButton.setVisibility(View.VISIBLE);
                     break;
                 case RECOMMENDED:
                     mTxtDescription.setVisibility(View.VISIBLE);
+                    mFollowButton.setVisibility(View.GONE);
                     break;
             }
         }
     }
 
     private boolean mIsTaskRunning = false;
+
+    private void toggleFollow(Context context, ReaderFollowButton followButton, ReaderBlog blog) {
+        if (!NetworkUtils.checkConnection(context)) {
+            return;
+        }
+
+        final boolean isAskingToFollow = !blog.isFollowing;
+
+        // disable follow button until API call returns
+        followButton.setEnabled(false);
+
+        boolean result = ReaderBlogActions.followBlogById(blog.blogId, isAskingToFollow, succeeded -> {
+            followButton.setEnabled(true);
+            if (!succeeded) {
+                int errResId = isAskingToFollow ? R.string.reader_toast_err_follow_blog
+                        : R.string.reader_toast_err_unfollow_blog;
+                ToastUtils.showToast(context, errResId);
+                followButton.setIsFollowed(!isAskingToFollow);
+                blog.isFollowing = !isAskingToFollow;
+            }
+        });
+
+        if (result) {
+            followButton.setIsFollowedAnimated(isAskingToFollow);
+            blog.isFollowing = isAskingToFollow;
+        }
+    }
 
     private class LoadBlogsTask extends AsyncTask<Void, Void, Boolean> {
         private ReaderRecommendBlogList mTmpRecommendedBlogs;

--- a/WordPress/src/main/res/layout/reader_listitem_blog.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_blog.xml
@@ -20,7 +20,7 @@
         android:id="@+id/image_blog"
         android:layout_width="@dimen/avatar_sz_medium"
         android:layout_height="@dimen/avatar_sz_medium"
-        android:layout_marginEnd="@dimen/margin_large"
+        android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_weight="0"
         android:contentDescription="@null"
         tools:src="@drawable/bg_rectangle_neutral_10_globe_32dp" />
@@ -49,6 +49,7 @@
             android:id="@+id/text_url"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_medium"
             android:ellipsize="end"
             android:gravity="start"
             android:maxLines="1"
@@ -61,6 +62,7 @@
             android:id="@+id/text_description"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_medium"
             android:ellipsize="end"
             android:gravity="start"
             android:maxLines="2"
@@ -75,7 +77,7 @@
         android:id="@+id/follow_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
+        android:padding="@dimen/margin_medium"
         app:wpShowFollowButtonCaption="false" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/reader_listitem_blog.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_blog.xml
@@ -4,24 +4,26 @@
     list item which shows a recommended or followed blog - see ReaderBlogAdapter
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:selectableItemBackground"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    android:paddingBottom="@dimen/margin_large"
+    android:paddingStart="@dimen/margin_extra_large"
     android:paddingTop="@dimen/margin_large"
     android:paddingEnd="@dimen/margin_extra_large"
-    android:paddingStart="@dimen/margin_extra_large">
+    android:paddingBottom="@dimen/margin_large">
 
     <ImageView
         android:id="@+id/image_blog"
         android:layout_width="@dimen/avatar_sz_medium"
         android:layout_height="@dimen/avatar_sz_medium"
-        android:layout_weight="0"
         android:layout_marginEnd="@dimen/margin_large"
-        android:contentDescription="@null"/>
+        android:layout_weight="0"
+        android:contentDescription="@null"
+        tools:src="@drawable/bg_rectangle_neutral_10_globe_32dp" />
 
     <LinearLayout
         android:id="@+id/layout_content"
@@ -31,42 +33,49 @@
         android:orientation="vertical">
 
         <org.wordpress.android.widgets.WPTextView
-            android:textAlignment="viewStart"
-            android:gravity="start"
             android:id="@+id/text_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_medium"
             android:ellipsize="end"
+            android:gravity="start"
             android:maxLines="1"
+            android:textAlignment="viewStart"
             android:textColor="?attr/wpColorText"
             android:textSize="@dimen/text_sz_medium"
-            tools:text="text_title"
-            android:layout_marginEnd="@dimen/margin_medium"/>
+            tools:text="text_title" />
 
         <org.wordpress.android.widgets.WPTextView
-            android:textAlignment="viewStart"
-            android:gravity="start"
             android:id="@+id/text_url"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:ellipsize="end"
+            android:gravity="start"
             android:maxLines="1"
+            android:textAlignment="viewStart"
             android:textColor="@color/link_reader"
             android:textSize="@dimen/text_sz_small"
             tools:text="text_url" />
 
         <org.wordpress.android.widgets.WPTextView
-            android:textAlignment="viewStart"
-            android:gravity="start"
             android:id="@+id/text_description"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:ellipsize="end"
+            android:gravity="start"
             android:maxLines="2"
+            android:textAlignment="viewStart"
             android:textColor="@color/neutral_40"
             android:textSize="@dimen/text_sz_small"
             tools:text="text_description" />
 
     </LinearLayout>
+
+    <org.wordpress.android.ui.reader.views.ReaderFollowButton
+        android:id="@+id/follow_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        app:wpShowFollowButtonCaption="false" />
 
 </LinearLayout>


### PR DESCRIPTION
Fixes #11167

This PR adds a follow/unfollow button to the **Followed Sites** tab on **Reader**'s management section. Some considerations that probably need to be reviewed by a designer:
1. Right now, when the user taps on the button, the site gets followed/unfollowed in the background and the icon animates between both states. 
2. The list is **not** automatically updated to reflect the changes, as that would simply cause the site to immediatelly disappear if the user unfollowed it. Instead, we leave the site in place while the screen is open, in case the user wants to easily revert the change. 
3. No further visual feedback is given to user, unless an error occurs, which then shows a toast with the error message while the button animation is reverted.

## To test

For each of the tests below, you first need to make sure you're using the build variant thas has enabled IA flags.

#### 1. Unfollow
1. Open the **Reader**.
2. Select the **Following** tab.
3. Tap on the cog icon on the right side, below the tab bar.
4. Select the **Followed Sites** tab.
5. Notice the follow/unfollow icon besides each item in the list.
6. Tap on the follow/unfollow icon.
7. Notice the animation between follow/unfollow states.
8. Close the screen.
9. Verify that the site is no longer being followed.

#### 2. Undo Unfollow
1. Open the **Reader**.
2. Select the **Following** tab.
3. Tap on the cog icon on the right side, below the tab bar.
4. Select the **Followed Sites** tab.
5. Notice the follow/unfollow icon besides each item in the list.
6. Tap on the follow/unfollow icon.
7. Notice the animation between the follow/unfollow states.
8. Tap on the follow/unfollow icon again.
9. Notice the animation between the follow/unfollow states.
10. Close the screen.
11. Verify that the site is still being followed.

---

**PR submission checklist:**

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
