### PR TITLE
Set webview data directory suffix before starting crash logging

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -221,10 +221,10 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         mContext = this;
         long startDate = SystemClock.elapsedRealtime();
 
-        CrashLoggingUtils.startCrashLogging(getContext());
-
         // This call needs be made before accessing any methods in android.webkit package
         setWebViewDataDirectorySuffixOnAndroidP();
+
+        CrashLoggingUtils.startCrashLogging(getContext());
 
         initWellSql();
 


### PR DESCRIPTION
Fixes #10494. (maybe) To quote @mzorz from [the previous PR](https://github.com/wordpress-mobile/WordPress-Android/pull/10613):

> This is a tricky issue.

@mzorz did a great job explaining the issue in both [the original issue](https://github.com/wordpress-mobile/WordPress-Android/issues/10494) and [its PR](https://github.com/wordpress-mobile/WordPress-Android/pull/10613) and for quite a while I couldn't even come up with a theory for how we were still having this crash. Now, I have a theory, but it might be a stupid one and a little far fetched. What if the issue is related to Sentry setup?

When we enable the crash logging Sentry might be accessing methods from `android.webkit` which means we won't have the WebView data directory suffix setup before it. I am not sure how best we can check if that's the case, but I think it's reasonable for Sentry to setup network stuff since they need to send the crash reports.

Now the tricky bit is that, if we make the suggested change in this PR and the app crashes in `setWebViewDataDirectorySuffixOnAndroidP` we won't be aware of it and related crash reports might disappear. I feel it's very unlikely for that to be the cause of this crash or to result in a crash itself, but it's a risk we'd have to take.

It'd be great to get opinions of a few people for this. What do you think @mzorz @maxme @jkmassel ?

To test:
* Make sure the app builds and runs OK since we don't know how to reproduce the issue.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.