### PR TITLE
Offline Pages : Added Support for unpublished revision to Page List 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -556,15 +556,17 @@ public class ActivityLauncher {
         activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
-    public static void editPageForResult(@NonNull Fragment fragment, @NonNull PageModel page) {
+    public static void editPageForResult(@NonNull Fragment fragment, @NonNull PageModel page,
+                                         boolean loadAutoSaveRevision) {
         Intent intent = new Intent(fragment.getContext(), EditPostActivity.class);
-        editPageForResult(intent, fragment, page.getSite(), page.getPageId());
+        editPageForResult(intent, fragment, page.getSite(), page.getPageId(), loadAutoSaveRevision);
     }
 
     public static void editPageForResult(Intent intent, @NonNull Fragment fragment, @NonNull SiteModel site,
-                                         int pageLocalId) {
+                                         int pageLocalId, boolean loadAutoSaveRevision) {
         intent.putExtra(WordPress.SITE, site);
         intent.putExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, pageLocalId);
+        intent.putExtra(EditPostActivity.EXTRA_LOAD_AUTO_SAVE_REVISION, loadAutoSaveRevision);
         fragment.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
@@ -56,6 +56,8 @@ class PagesActivity : AppCompatActivity(),
         val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
         if (fragment is PagesFragment) {
             fragment.onPositiveClickedForBasicDialog(instanceTag)
+        } else {
+            throw IllegalStateException("PagesFragment is required to consume this event.")
         }
     }
 
@@ -63,6 +65,8 @@ class PagesActivity : AppCompatActivity(),
         val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
         if (fragment is PagesFragment) {
             fragment.onNegativeClickedForBasicDialog(instanceTag)
+        } else {
+            throw IllegalStateException("PagesFragment is required to consume this event.")
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
@@ -53,16 +53,16 @@ class PagesActivity : AppCompatActivity(),
     }
 
     override fun onPositiveClicked(instanceTag: String) {
-        passDeleteConfirmation(instanceTag.toLong())
+        val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
+        if (fragment is PagesFragment) {
+            fragment.onPositiveClickedForBasicDialog(instanceTag)
+        }
     }
 
     override fun onNegativeClicked(instanceTag: String) {
-    }
-
-    private fun passDeleteConfirmation(remoteId: Long) {
         val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
         if (fragment is PagesFragment) {
-            fragment.onPageDeleteConfirmed(remoteId)
+            fragment.onNegativeClickedForBasicDialog(instanceTag)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -42,8 +42,6 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.PAGE_FROM_PAGES_LIST
 import org.wordpress.android.ui.RequestCodes
-import org.wordpress.android.ui.pages.PageItem.Page
-import org.wordpress.android.ui.posts.BasicFragmentDialog
 import org.wordpress.android.ui.posts.EditPostActivity
 import org.wordpress.android.ui.posts.PostListAction.PreviewPost
 import org.wordpress.android.ui.posts.PreviewStateHelper
@@ -345,10 +343,6 @@ class PagesFragment : Fragment() {
             page?.let { ActivityLauncher.viewPageParentForResult(this, page) }
         })
 
-        viewModel.displayDeleteDialog.observe(this, Observer { page ->
-            page?.let { displayDeleteDialog(page) }
-        })
-
         viewModel.isNewPageButtonVisible.observe(this, Observer { isVisible ->
             isVisible?.let {
                 if (isVisible) {
@@ -378,10 +372,6 @@ class PagesFragment : Fragment() {
         initializeSearchView()
     }
 
-    fun onPageDeleteConfirmed(remoteId: Long) {
-        viewModel.onDeleteConfirmed(remoteId)
-    }
-
     private fun refreshProgressBars(listState: PageListState?) {
         if (!isAdded || view == null) {
             return
@@ -408,16 +398,12 @@ class PagesFragment : Fragment() {
         }
     }
 
-    private fun displayDeleteDialog(page: Page) {
-        val dialog = BasicFragmentDialog()
-        dialog.initialize(
-                page.id.toString(),
-                getString(R.string.delete_page),
-                getString(R.string.page_delete_dialog_message, page.title),
-                getString(R.string.delete),
-                getString(R.string.cancel)
-        )
-        dialog.show(fragmentManager, page.id.toString())
+    fun onPositiveClickedForBasicDialog(instanceTag: String) {
+        viewModel.onPositiveClickedForBasicDialog(instanceTag)
+    }
+
+    fun onNegativeClickedForBasicDialog(instanceTag: String) {
+        viewModel.onNegativeClickedForBasicDialog(instanceTag)
     }
 
     override fun onStart() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -123,7 +123,7 @@ class PagesFragment : Fragment() {
 
             if (EditPostActivity.checkToRestart(data)) {
                 ActivityLauncher.editPageForResult(data, this@PagesFragment, viewModel.site,
-                        data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0))
+                        data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0), false)
 
                 // a restart will happen so, no need to continue here
                 return
@@ -312,15 +312,9 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.editPage.observe(this, Observer { page ->
+        viewModel.editPage.observe(this, Observer { (page, loadAutoRevision) ->
             page?.let {
-                ActivityLauncher.editPageForResult(this, page)
-            }
-        })
-
-        viewModel.editAutoRevisionPage.observe(this, Observer { (page, site) ->
-            page?.let {
-                ActivityLauncher.editPostOrPageForResult(activity, site, page, true)
+                ActivityLauncher.editPageForResult(this, page, loadAutoRevision)
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -318,9 +318,11 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.editAutoRevisionPage.observe(this, Observer { models -> models.first?.let {
-            ActivityLauncher.editPostOrPageForResult(activity, models.second, it)
-        } })
+        viewModel.editAutoRevisionPage.observe(this, Observer { models ->
+            models.first?.let {
+                ActivityLauncher.editPostOrPageForResult(activity, models.second, it)
+            }
+        })
 
         viewModel.previewPage.observe(this, Observer { post ->
             post?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -318,6 +318,10 @@ class PagesFragment : Fragment() {
             }
         })
 
+        viewModel.editAutoRevisionPage.observe(this, Observer { models -> models.first?.let {
+            ActivityLauncher.editPostOrPageForResult(activity, models.second, it)
+        } })
+
         viewModel.previewPage.observe(this, Observer { post ->
             post?.let {
                 previewPage(activity, post)
@@ -359,6 +363,10 @@ class PagesFragment : Fragment() {
                 pagesPager.currentItem = pagerIndex
                 (pagesPager.adapter as PagesPagerAdapter).scrollToPage(page)
             }
+        })
+
+        viewModel.dialogAction.observe(this, Observer {
+            it?.show(activity, activity.supportFragmentManager, uiHelpers)
         })
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -318,9 +318,9 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.editAutoRevisionPage.observe(this, Observer { models ->
-            models.first?.let {
-                ActivityLauncher.editPostOrPageForResult(activity, models.second, it)
+        viewModel.editAutoRevisionPage.observe(this, Observer { (page, site) ->
+            page?.let {
+                ActivityLauncher.editPostOrPageForResult(activity, site, page, true)
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -460,8 +460,13 @@ public class PostUtils {
     }
 
     public static UiStringText getCustomStringForAutosaveRevisionDialog(PostModel post) {
+        return getCustomStringForAutosaveRevisionDialog(post, false);
+    }
+
+    public static UiStringText getCustomStringForAutosaveRevisionDialog(PostModel post, boolean isPage) {
         Context context = WordPress.getContext();
-        String firstPart = context.getString(R.string.dialog_confirm_autosave_body_first_part);
+        String firstPart = isPage ? context.getString(R.string.dialog_confirm_autosave_body_first_part_for_page)
+                : context.getString(R.string.dialog_confirm_autosave_body_first_part);
 
         String lastModified =
                 TextUtils.isEmpty(post.getDateLocallyChanged()) ? post.getLastModified() : post.getDateLocallyChanged();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -460,12 +460,8 @@ public class PostUtils {
     }
 
     public static UiStringText getCustomStringForAutosaveRevisionDialog(PostModel post) {
-        return getCustomStringForAutosaveRevisionDialog(post, false);
-    }
-
-    public static UiStringText getCustomStringForAutosaveRevisionDialog(PostModel post, boolean isPage) {
         Context context = WordPress.getContext();
-        String firstPart = isPage ? context.getString(R.string.dialog_confirm_autosave_body_first_part_for_page)
+        String firstPart = post.isPage() ? context.getString(R.string.dialog_confirm_autosave_body_first_part_for_page)
                 : context.getString(R.string.dialog_confirm_autosave_body_first_part);
 
         String lastModified =

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -29,7 +29,7 @@ class UiHelpers @Inject constructor() {
             when (uiString) {
                 is UiStringRes -> context.getString(uiString.stringRes)
                 is UiStringText -> uiString.text
-                is UiStringResWithParams -> context.getString(uiString.stringRes, uiString.params)
+                is UiStringResWithParams -> context.getString(uiString.stringRes, *uiString.params.toTypedArray())
             }
 
     fun updateVisibility(view: View, visible: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 import android.graphics.Point
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 
 class UiHelpers @Inject constructor() {
     fun getPxOfUiDimen(context: Context, uiDimen: UiDimen): Int =
@@ -28,6 +29,7 @@ class UiHelpers @Inject constructor() {
             when (uiString) {
                 is UiStringRes -> context.getString(uiString.stringRes)
                 is UiStringText -> uiString.text
+                is UiStringResWithParams -> context.getString(uiString.stringRes, uiString.params)
             }
 
     fun updateVisibility(view: View, visible: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -29,7 +29,15 @@ class UiHelpers @Inject constructor() {
             when (uiString) {
                 is UiStringRes -> context.getString(uiString.stringRes)
                 is UiStringText -> uiString.text
-                is UiStringResWithParams -> context.getString(uiString.stringRes, *uiString.params.toTypedArray())
+                is UiStringResWithParams -> context.getString(
+                        uiString.stringRes,
+                        *uiString.params.map { value ->
+                            getTextOfUiString(
+                                    context,
+                                    value
+                            )
+                        }.toTypedArray()
+                )
             }
 
     fun updateVisibility(view: View, visible: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
@@ -9,5 +9,5 @@ import androidx.annotation.StringRes
 sealed class UiString {
     data class UiStringText(val text: String) : UiString()
     data class UiStringRes(@StringRes val stringRes: Int) : UiString()
-    data class UiStringResWithParams(@StringRes val stringRes: Int, val params: List<Any>) : UiString()
+    data class UiStringResWithParams(@StringRes val stringRes: Int, val params: List<UiString>) : UiString()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
@@ -9,5 +9,5 @@ import androidx.annotation.StringRes
 sealed class UiString {
     data class UiStringText(val text: String) : UiString()
     data class UiStringRes(@StringRes val stringRes: Int) : UiString()
-    data class UiStringResWithParams(@StringRes val stringRes: Int, val params : List<Any>) : UiString()
+    data class UiStringResWithParams(@StringRes val stringRes: Int, val params: List<Any>) : UiString()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
@@ -9,4 +9,5 @@ import androidx.annotation.StringRes
 sealed class UiString {
     data class UiStringText(val text: String) : UiString()
     data class UiStringRes(@StringRes val stringRes: Int) : UiString()
+    data class UiStringResWithParams(@StringRes val stringRes: Int, val params : List<Any>) : UiString()
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageConflictResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageConflictResolver.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.viewmodel.pages
+
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.ui.posts.PostUtils
+import javax.inject.Inject
+
+class PageConflictResolver @Inject constructor() {
+    fun hasUnhandledAutoSave(post: PostModel): Boolean {
+        return PostUtils.hasAutoSave(post)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.viewmodel.pages
 
 import org.wordpress.android.R
+import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_SHOWN
@@ -9,6 +10,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.helpers.DialogHolder
 
@@ -36,11 +38,15 @@ class PageListDialogHelper(
         showDialog.invoke(dialogHolder)
     }
 
-    fun showDeletePostConfirmationDialog(pageId : RemoteId) {
+    fun showDeletePostConfirmationDialog(pageId : RemoteId, pageTitle :String) {
+        val dialogMessage = {
+            WordPress.getContext().getString(R.string.page_delete_dialog_message, pageTitle)
+        }
+
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_DELETE_PAGE_DIALOG_TAG,
                 title = UiStringRes(R.string.delete_page),
-                message = UiStringRes(R.string.page_delete_dialog_message),
+                message = UiStringText(dialogMessage()),
                 positiveButton = UiStringRes(R.string.delete),
                 negativeButton = UiStringRes(R.string.cancel)
         )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -55,7 +55,7 @@ class PageListDialogHelper(
     fun onPositiveClickedForBasicDialog(
         instanceTag: String,
         deletePage: (RemoteId) -> Unit,
-        editRestoredAutoSavePage: (RemoteId, LoadAutoSaveRevision) -> Unit
+        editPage: (RemoteId, LoadAutoSaveRevision) -> Unit
     ) {
         when (instanceTag) {
             CONFIRM_DELETE_PAGE_DIALOG_TAG -> pageIdForDeleteDialog?.let {
@@ -65,7 +65,7 @@ class PageListDialogHelper(
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> pageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the restored auto save
                 pageIdForAutosaveRevisionResolutionDialog = null
-                editRestoredAutoSavePage(it, true)
+                editPage(it, true)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED)
             }
             else -> throw IllegalArgumentException("Dialog's positive button click is not handled: $instanceTag")
@@ -74,13 +74,13 @@ class PageListDialogHelper(
 
     fun onNegativeClickedForBasicDialog(
         instanceTag: String,
-        editLocalPage: (RemoteId, LoadAutoSaveRevision) -> Unit
+        editPage: (RemoteId, LoadAutoSaveRevision) -> Unit
     ) {
         when (instanceTag) {
             CONFIRM_DELETE_PAGE_DIALOG_TAG -> pageIdForDeleteDialog = null
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> pageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the local page (don't use the auto save version)
-                editLocalPage(it, false)
+                editPage(it, false)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED)
             }
             else -> throw IllegalArgumentException("Dialog's negative button click is not handled: $instanceTag")

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -21,8 +21,8 @@ class PageListDialogHelper(
     private val showDialog: (DialogHolder) -> Unit,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) {
-    private var localPageIdForAutosaveRevisionResolutionDialog: LocalId? = null
-    private var remotePageIdForDeleteDialog: RemoteId? = null
+    private var pageIdForAutosaveRevisionResolutionDialog: LocalId? = null
+    private var pageIdForDeleteDialog: RemoteId? = null
 
     fun showAutoSaveRevisionDialog(post: PostModel) {
         analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_SHOWN)
@@ -33,11 +33,11 @@ class PageListDialogHelper(
                 positiveButton = UiStringRes(R.string.dialog_confirm_autosave_restore_button),
                 negativeButton = UiStringRes(R.string.dialog_confirm_autosave_dont_restore_button)
         )
-        localPageIdForAutosaveRevisionResolutionDialog = LocalId(post.id)
+        pageIdForAutosaveRevisionResolutionDialog = LocalId(post.id)
         showDialog.invoke(dialogHolder)
     }
 
-    fun showDeletePostConfirmationDialog(pageId: RemoteId, pageTitle: String) {
+    fun showDeletePageConfirmationDialog(pageId: RemoteId, pageTitle: String) {
         val dialogMessage = {
             WordPress.getContext().getString(R.string.page_delete_dialog_message, pageTitle)
         }
@@ -49,7 +49,7 @@ class PageListDialogHelper(
                 positiveButton = UiStringRes(R.string.delete),
                 negativeButton = UiStringRes(R.string.cancel)
         )
-        remotePageIdForDeleteDialog = pageId
+        pageIdForDeleteDialog = pageId
         showDialog.invoke(dialogHolder)
     }
 
@@ -59,13 +59,13 @@ class PageListDialogHelper(
         editRestoredAutoSavePage: (LocalId) -> Unit
     ) {
         when (instanceTag) {
-            CONFIRM_DELETE_PAGE_DIALOG_TAG -> remotePageIdForDeleteDialog?.let {
-                remotePageIdForDeleteDialog = null
+            CONFIRM_DELETE_PAGE_DIALOG_TAG -> pageIdForDeleteDialog?.let {
+                pageIdForDeleteDialog = null
                 deletePage(it)
             }
-            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPageIdForAutosaveRevisionResolutionDialog?.let {
+            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> pageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the restored auto save
-                localPageIdForAutosaveRevisionResolutionDialog = null
+                pageIdForAutosaveRevisionResolutionDialog = null
                 editRestoredAutoSavePage(it)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED)
             }
@@ -78,8 +78,8 @@ class PageListDialogHelper(
         editLocalPage: (LocalId) -> Unit
     ) {
         when (instanceTag) {
-            CONFIRM_DELETE_PAGE_DIALOG_TAG -> remotePageIdForDeleteDialog = null
-            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPageIdForAutosaveRevisionResolutionDialog?.let {
+            CONFIRM_DELETE_PAGE_DIALOG_TAG -> pageIdForDeleteDialog = null
+            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> pageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the local post (don't use the auto save version)
                 editLocalPage(it)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -61,7 +61,7 @@ class PageListDialogHelper(
                 pageIdForDeleteDialog = null
                 deletePage(it)
             } ?: run {
-               throw NullPointerException("pageIdForDeleteDialog shouldn't be null.")
+                throw NullPointerException("pageIdForDeleteDialog shouldn't be null.")
             }
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> pageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the restored auto save

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -15,6 +15,7 @@ import java.lang.NullPointerException
 
 private const val CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG = "CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG"
 private const val CONFIRM_DELETE_PAGE_DIALOG_TAG = "CONFIRM_DELETE_PAGE_DIALOG_TAG"
+private const val POST_TYPE ="post_type"
 
 class PageListDialogHelper(
     private val showDialog: (DialogHolder) -> Unit,
@@ -24,7 +25,7 @@ class PageListDialogHelper(
     private var pageIdForDeleteDialog: RemoteId? = null
 
     fun showAutoSaveRevisionDialog(page: PostModel) {
-        analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_SHOWN)
+        analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_SHOWN, mapOf(POST_TYPE to "page"))
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG,
                 title = UiStringRes(R.string.dialog_confirm_autosave_title),
@@ -67,7 +68,10 @@ class PageListDialogHelper(
                 // open the editor with the restored auto save
                 pageIdForAutosaveRevisionResolutionDialog = null
                 editPage(it, true)
-                analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED)
+                analyticsTracker.track(
+                        UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED,
+                        mapOf(POST_TYPE to "page")
+                )
             } ?: run {
                 throw NullPointerException("pageIdForAutosaveRevisionResolutionDialog shouldn't be null.")
             }
@@ -84,7 +88,10 @@ class PageListDialogHelper(
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> pageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the local page (don't use the auto save version)
                 editPage(it, false)
-                analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED)
+                analyticsTracker.track(
+                        UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED,
+                        mapOf(POST_TYPE to "page")
+                )
             } ?: run {
                 throw NullPointerException("pageIdForAutosaveRevisionResolutionDialog shouldn't be null.")
             }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -1,0 +1,68 @@
+package org.wordpress.android.viewmodel.pages
+
+import org.wordpress.android.R.string
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_SHOWN
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.ui.posts.PostUtils
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.helpers.DialogHolder
+
+private const val CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG = "CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG"
+
+class PageListDialogHelper(
+    private val showDialog: (DialogHolder) -> Unit,
+    private val checkNetworkConnection: () -> Boolean,
+    private val analyticsTracker: AnalyticsTrackerWrapper
+) {
+    private var localPostIdForAutosaveRevisionResolutionDialog: Int? = null
+
+    fun showAutoSaveRevisionDialog(post: PostModel) {
+        analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_SHOWN)
+        val dialogHolder = DialogHolder(
+                tag = CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG,
+                title = UiStringRes(string.dialog_confirm_autosave_title),
+                message = PostUtils.getCustomStringForAutosaveRevisionDialog(post),
+                positiveButton = UiStringRes(string.dialog_confirm_autosave_restore_button),
+                negativeButton = UiStringRes(string.dialog_confirm_autosave_dont_restore_button)
+        )
+        localPostIdForAutosaveRevisionResolutionDialog = post.id
+        showDialog.invoke(dialogHolder)
+    }
+
+    fun onPositiveClickedForBasicDialog(
+        instanceTag: String,
+        trashPostWithLocalChanges: (Int) -> Unit,
+        deletePost: (Int) -> Unit,
+        publishPost: (Int) -> Unit,
+        updateConflictedPostWithRemoteVersion: (Int) -> Unit,
+        editRestoredAutoSavePost: (Int) -> Unit
+    ) {
+        when (instanceTag) {
+            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPostIdForAutosaveRevisionResolutionDialog?.let {
+                // open the editor with the restored auto save
+                localPostIdForAutosaveRevisionResolutionDialog = null
+                editRestoredAutoSavePost(it)
+                analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED)
+            }
+            else -> throw IllegalArgumentException("Dialog's positive button click is not handled: $instanceTag")
+        }
+    }
+
+    fun onNegativeClickedForBasicDialog(
+        instanceTag: String,
+        updateConflictedPostWithLocalVersion: (Int) -> Unit,
+        editLocalPost: (Int) -> Unit
+    ) {
+        when (instanceTag) {
+            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPostIdForAutosaveRevisionResolutionDialog?.let {
+                // open the editor with the local post (don't use the auto save version)
+                editLocalPost(it)
+                analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED)
+            }
+            else -> throw IllegalArgumentException("Dialog's negative button click is not handled: $instanceTag")
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -15,7 +15,7 @@ import java.lang.NullPointerException
 
 private const val CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG = "CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG"
 private const val CONFIRM_DELETE_PAGE_DIALOG_TAG = "CONFIRM_DELETE_PAGE_DIALOG_TAG"
-private const val POST_TYPE ="post_type"
+private const val POST_TYPE = "post_type"
 
 class PageListDialogHelper(
     private val showDialog: (DialogHolder) -> Unit,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -62,9 +62,7 @@ class PageListDialogHelper(
             CONFIRM_DELETE_PAGE_DIALOG_TAG -> pageIdForDeleteDialog?.let {
                 pageIdForDeleteDialog = null
                 deletePage(it)
-            } ?: run {
-                throw NullPointerException("pageIdForDeleteDialog shouldn't be null.")
-            }
+            } ?: throw NullPointerException("pageIdForDeleteDialog shouldn't be null.")
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> pageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the restored auto save
                 pageIdForAutosaveRevisionResolutionDialog = null
@@ -73,9 +71,9 @@ class PageListDialogHelper(
                         UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED,
                         mapOf(POST_TYPE to "page")
                 )
-            } ?: run {
-                throw NullPointerException("pageIdForAutosaveRevisionResolutionDialog shouldn't be null.")
             }
+                    ?: throw NullPointerException("pageIdForAutosaveRevisionResolutionDialog shouldn't be null.")
+
             else -> throw IllegalArgumentException("Dialog's positive button click is not handled: $instanceTag")
         }
     }
@@ -93,9 +91,9 @@ class PageListDialogHelper(
                         UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED,
                         mapOf(POST_TYPE to "page")
                 )
-            } ?: run {
-                throw NullPointerException("pageIdForAutosaveRevisionResolutionDialog shouldn't be null.")
             }
+                    ?: throw NullPointerException("pageIdForAutosaveRevisionResolutionDialog shouldn't be null.")
+
             else -> throw IllegalArgumentException("Dialog's negative button click is not handled: $instanceTag")
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -23,16 +23,16 @@ class PageListDialogHelper(
     private var pageIdForAutosaveRevisionResolutionDialog: RemoteId? = null
     private var pageIdForDeleteDialog: RemoteId? = null
 
-    fun showAutoSaveRevisionDialog(post: PostModel) {
+    fun showAutoSaveRevisionDialog(page: PostModel) {
         analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_SHOWN)
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG,
                 title = UiStringRes(R.string.dialog_confirm_autosave_title),
-                message = PostUtils.getCustomStringForAutosaveRevisionDialog(post, true),
+                message = PostUtils.getCustomStringForAutosaveRevisionDialog(page, true),
                 positiveButton = UiStringRes(R.string.dialog_confirm_autosave_restore_button),
                 negativeButton = UiStringRes(R.string.dialog_confirm_autosave_dont_restore_button)
         )
-        pageIdForAutosaveRevisionResolutionDialog = RemoteId(post.remotePostId)
+        pageIdForAutosaveRevisionResolutionDialog = RemoteId(page.remotePostId)
         showDialog.invoke(dialogHolder)
     }
 
@@ -79,7 +79,7 @@ class PageListDialogHelper(
         when (instanceTag) {
             CONFIRM_DELETE_PAGE_DIALOG_TAG -> pageIdForDeleteDialog = null
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> pageIdForAutosaveRevisionResolutionDialog?.let {
-                // open the editor with the local post (don't use the auto save version)
+                // open the editor with the local page (don't use the auto save version)
                 editLocalPage(it, false)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED)
             }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.viewmodel.pages
 
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_SHOWN
@@ -9,7 +8,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.helpers.DialogHolder
 
@@ -37,14 +36,13 @@ class PageListDialogHelper(
     }
 
     fun showDeletePageConfirmationDialog(pageId: RemoteId, pageTitle: String) {
-        val dialogMessage = {
-            WordPress.getContext().getString(R.string.page_delete_dialog_message, pageTitle)
-        }
-
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_DELETE_PAGE_DIALOG_TAG,
                 title = UiStringRes(R.string.delete_page),
-                message = UiStringText(dialogMessage()),
+                message = UiStringResWithParams(
+                        R.string.page_delete_dialog_message,
+                        listOf(pageTitle)
+                ),
                 positiveButton = UiStringRes(R.string.delete),
                 negativeButton = UiStringRes(R.string.cancel)
         )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.helpers.DialogHolder
+import java.lang.NullPointerException
 
 private const val CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG = "CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG"
 private const val CONFIRM_DELETE_PAGE_DIALOG_TAG = "CONFIRM_DELETE_PAGE_DIALOG_TAG"
@@ -59,12 +60,16 @@ class PageListDialogHelper(
             CONFIRM_DELETE_PAGE_DIALOG_TAG -> pageIdForDeleteDialog?.let {
                 pageIdForDeleteDialog = null
                 deletePage(it)
+            } ?: run {
+               throw NullPointerException("pageIdForDeleteDialog shouldn't be null.")
             }
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> pageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the restored auto save
                 pageIdForAutosaveRevisionResolutionDialog = null
                 editPage(it, true)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED)
+            } ?: run {
+                throw NullPointerException("pageIdForAutosaveRevisionResolutionDialog shouldn't be null.")
             }
             else -> throw IllegalArgumentException("Dialog's positive button click is not handled: $instanceTag")
         }
@@ -80,6 +85,8 @@ class PageListDialogHelper(
                 // open the editor with the local page (don't use the auto save version)
                 editPage(it, false)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED)
+            } ?: run {
+                throw NullPointerException("pageIdForAutosaveRevisionResolutionDialog shouldn't be null.")
             }
             else -> throw IllegalArgumentException("Dialog's negative button click is not handled: $instanceTag")
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -5,7 +5,6 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_SHOWN
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.ui.posts.PostUtils
@@ -21,7 +20,7 @@ class PageListDialogHelper(
     private val showDialog: (DialogHolder) -> Unit,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) {
-    private var pageIdForAutosaveRevisionResolutionDialog: LocalId? = null
+    private var pageIdForAutosaveRevisionResolutionDialog: RemoteId? = null
     private var pageIdForDeleteDialog: RemoteId? = null
 
     fun showAutoSaveRevisionDialog(post: PostModel) {
@@ -33,7 +32,7 @@ class PageListDialogHelper(
                 positiveButton = UiStringRes(R.string.dialog_confirm_autosave_restore_button),
                 negativeButton = UiStringRes(R.string.dialog_confirm_autosave_dont_restore_button)
         )
-        pageIdForAutosaveRevisionResolutionDialog = LocalId(post.id)
+        pageIdForAutosaveRevisionResolutionDialog = RemoteId(post.remotePostId)
         showDialog.invoke(dialogHolder)
     }
 
@@ -56,7 +55,7 @@ class PageListDialogHelper(
     fun onPositiveClickedForBasicDialog(
         instanceTag: String,
         deletePage: (RemoteId) -> Unit,
-        editRestoredAutoSavePage: (LocalId) -> Unit
+        editRestoredAutoSavePage: (RemoteId, LoadAutoSaveRevision) -> Unit
     ) {
         when (instanceTag) {
             CONFIRM_DELETE_PAGE_DIALOG_TAG -> pageIdForDeleteDialog?.let {
@@ -66,7 +65,7 @@ class PageListDialogHelper(
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> pageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the restored auto save
                 pageIdForAutosaveRevisionResolutionDialog = null
-                editRestoredAutoSavePage(it)
+                editRestoredAutoSavePage(it, true)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED)
             }
             else -> throw IllegalArgumentException("Dialog's positive button click is not handled: $instanceTag")
@@ -75,13 +74,13 @@ class PageListDialogHelper(
 
     fun onNegativeClickedForBasicDialog(
         instanceTag: String,
-        editLocalPage: (LocalId) -> Unit
+        editLocalPage: (RemoteId, LoadAutoSaveRevision) -> Unit
     ) {
         when (instanceTag) {
             CONFIRM_DELETE_PAGE_DIALOG_TAG -> pageIdForDeleteDialog = null
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> pageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the local post (don't use the auto save version)
-                editLocalPage(it)
+                editLocalPage(it, false)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED)
             }
             else -> throw IllegalArgumentException("Dialog's negative button click is not handled: $instanceTag")

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -28,7 +28,7 @@ class PageListDialogHelper(
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG,
                 title = UiStringRes(R.string.dialog_confirm_autosave_title),
-                message = PostUtils.getCustomStringForAutosaveRevisionDialog(page, true),
+                message = PostUtils.getCustomStringForAutosaveRevisionDialog(page),
                 positiveButton = UiStringRes(R.string.dialog_confirm_autosave_restore_button),
                 negativeButton = UiStringRes(R.string.dialog_confirm_autosave_dont_restore_button)
         )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -14,7 +14,6 @@ private const val CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG = "CONFIRM_ON_AUTOSAVE
 
 class PageListDialogHelper(
     private val showDialog: (DialogHolder) -> Unit,
-    private val checkNetworkConnection: () -> Boolean,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) {
     private var localPostIdForAutosaveRevisionResolutionDialog: Int? = null
@@ -34,17 +33,13 @@ class PageListDialogHelper(
 
     fun onPositiveClickedForBasicDialog(
         instanceTag: String,
-        trashPostWithLocalChanges: (Int) -> Unit,
-        deletePost: (Int) -> Unit,
-        publishPost: (Int) -> Unit,
-        updateConflictedPostWithRemoteVersion: (Int) -> Unit,
-        editRestoredAutoSavePost: (Int) -> Unit
+        editRestoredAutoSavePage: (Int) -> Unit
     ) {
         when (instanceTag) {
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPostIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the restored auto save
                 localPostIdForAutosaveRevisionResolutionDialog = null
-                editRestoredAutoSavePost(it)
+                editRestoredAutoSavePage(it)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED)
             }
             else -> throw IllegalArgumentException("Dialog's positive button click is not handled: $instanceTag")
@@ -53,13 +48,12 @@ class PageListDialogHelper(
 
     fun onNegativeClickedForBasicDialog(
         instanceTag: String,
-        updateConflictedPostWithLocalVersion: (Int) -> Unit,
-        editLocalPost: (Int) -> Unit
+        editLocalPage: (Int) -> Unit
     ) {
         when (instanceTag) {
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPostIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the local post (don't use the auto save version)
-                editLocalPost(it)
+                editLocalPage(it)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED)
             }
             else -> throw IllegalArgumentException("Dialog's negative button click is not handled: $instanceTag")

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -36,7 +36,7 @@ class PageListDialogHelper(
         showDialog.invoke(dialogHolder)
     }
 
-    fun showDeletePostConfirmationDialog(localPageId : RemoteId) {
+    fun showDeletePostConfirmationDialog(pageId : RemoteId) {
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_DELETE_PAGE_DIALOG_TAG,
                 title = UiStringRes(R.string.delete_page),
@@ -44,7 +44,7 @@ class PageListDialogHelper(
                 positiveButton = UiStringRes(R.string.delete),
                 negativeButton = UiStringRes(R.string.cancel)
         )
-        remotePageIdForDeleteDialog = localPageId
+        remotePageIdForDeleteDialog = pageId
         showDialog.invoke(dialogHolder)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.viewmodel.helpers.DialogHolder
 private const val CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG = "CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG"
 private const val CONFIRM_DELETE_PAGE_DIALOG_TAG = "CONFIRM_DELETE_PAGE_DIALOG_TAG"
 
-
 class PageListDialogHelper(
     private val showDialog: (DialogHolder) -> Unit,
     private val analyticsTracker: AnalyticsTrackerWrapper
@@ -38,7 +37,7 @@ class PageListDialogHelper(
         showDialog.invoke(dialogHolder)
     }
 
-    fun showDeletePostConfirmationDialog(pageId : RemoteId, pageTitle :String) {
+    fun showDeletePostConfirmationDialog(pageId: RemoteId, pageTitle: String) {
         val dialogMessage = {
             WordPress.getContext().getString(R.string.page_delete_dialog_message, pageTitle)
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -28,7 +28,7 @@ class PageListDialogHelper(
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG,
                 title = UiStringRes(R.string.dialog_confirm_autosave_title),
-                message = PostUtils.getCustomStringForAutosaveRevisionDialog(post),
+                message = PostUtils.getCustomStringForAutosaveRevisionDialog(post, true),
                 positiveButton = UiStringRes(R.string.dialog_confirm_autosave_restore_button),
                 negativeButton = UiStringRes(R.string.dialog_confirm_autosave_dont_restore_button)
         )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.helpers.DialogHolder
 import java.lang.NullPointerException
@@ -43,7 +44,7 @@ class PageListDialogHelper(
                 title = UiStringRes(R.string.delete_page),
                 message = UiStringResWithParams(
                         R.string.page_delete_dialog_message,
-                        listOf(pageTitle)
+                        listOf(UiStringText(pageTitle))
                 ),
                 positiveButton = UiStringRes(R.string.delete),
                 negativeButton = UiStringRes(R.string.cancel)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListDialogHelper.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.viewmodel.pages
 
-import org.wordpress.android.R.string
+import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNPUBLISHED_REVISION_DIALOG_SHOWN
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -11,34 +13,54 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.helpers.DialogHolder
 
 private const val CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG = "CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG"
+private const val CONFIRM_DELETE_PAGE_DIALOG_TAG = "CONFIRM_DELETE_PAGE_DIALOG_TAG"
+
 
 class PageListDialogHelper(
     private val showDialog: (DialogHolder) -> Unit,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) {
-    private var localPostIdForAutosaveRevisionResolutionDialog: Int? = null
+    private var localPageIdForAutosaveRevisionResolutionDialog: LocalId? = null
+    private var remotePageIdForDeleteDialog: RemoteId? = null
 
     fun showAutoSaveRevisionDialog(post: PostModel) {
         analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_SHOWN)
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG,
-                title = UiStringRes(string.dialog_confirm_autosave_title),
+                title = UiStringRes(R.string.dialog_confirm_autosave_title),
                 message = PostUtils.getCustomStringForAutosaveRevisionDialog(post),
-                positiveButton = UiStringRes(string.dialog_confirm_autosave_restore_button),
-                negativeButton = UiStringRes(string.dialog_confirm_autosave_dont_restore_button)
+                positiveButton = UiStringRes(R.string.dialog_confirm_autosave_restore_button),
+                negativeButton = UiStringRes(R.string.dialog_confirm_autosave_dont_restore_button)
         )
-        localPostIdForAutosaveRevisionResolutionDialog = post.id
+        localPageIdForAutosaveRevisionResolutionDialog = LocalId(post.id)
+        showDialog.invoke(dialogHolder)
+    }
+
+    fun showDeletePostConfirmationDialog(localPageId : RemoteId) {
+        val dialogHolder = DialogHolder(
+                tag = CONFIRM_DELETE_PAGE_DIALOG_TAG,
+                title = UiStringRes(R.string.delete_page),
+                message = UiStringRes(R.string.page_delete_dialog_message),
+                positiveButton = UiStringRes(R.string.delete),
+                negativeButton = UiStringRes(R.string.cancel)
+        )
+        remotePageIdForDeleteDialog = localPageId
         showDialog.invoke(dialogHolder)
     }
 
     fun onPositiveClickedForBasicDialog(
         instanceTag: String,
-        editRestoredAutoSavePage: (Int) -> Unit
+        deletePage: (RemoteId) -> Unit,
+        editRestoredAutoSavePage: (LocalId) -> Unit
     ) {
         when (instanceTag) {
-            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPostIdForAutosaveRevisionResolutionDialog?.let {
+            CONFIRM_DELETE_PAGE_DIALOG_TAG -> remotePageIdForDeleteDialog?.let {
+                remotePageIdForDeleteDialog = null
+                deletePage(it)
+            }
+            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the restored auto save
-                localPostIdForAutosaveRevisionResolutionDialog = null
+                localPageIdForAutosaveRevisionResolutionDialog = null
                 editRestoredAutoSavePage(it)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_UNPUBLISHED_VERSION_CLICKED)
             }
@@ -48,10 +70,11 @@ class PageListDialogHelper(
 
     fun onNegativeClickedForBasicDialog(
         instanceTag: String,
-        editLocalPage: (Int) -> Unit
+        editLocalPage: (LocalId) -> Unit
     ) {
         when (instanceTag) {
-            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPostIdForAutosaveRevisionResolutionDialog?.let {
+            CONFIRM_DELETE_PAGE_DIALOG_TAG -> remotePageIdForDeleteDialog = null
+            CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPageIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the local post (don't use the auto save version)
                 editLocalPage(it)
                 analyticsTracker.track(UNPUBLISHED_REVISION_DIALOG_LOAD_LOCAL_VERSION_CLICKED)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -391,7 +391,7 @@ class PagesViewModel
 
     private fun deletePage(page: Page) {
         performIfNetworkAvailable {
-            pageListDialogHelper.showDeletePostConfirmationDialog(RemoteId(page.id))
+            pageListDialogHelper.showDeletePostConfirmationDialog(RemoteId(page.id), page.title)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -697,7 +697,7 @@ class PagesViewModel
     fun onPositiveClickedForBasicDialog(instanceTag: String) {
         pageListDialogHelper.onPositiveClickedForBasicDialog(
                 instanceTag = instanceTag,
-                editRestoredAutoSavePage = this::editPage,
+                editPage = this::editPage,
                 deletePage = this::onDeleteConfirmed
         )
     }
@@ -705,7 +705,7 @@ class PagesViewModel
     fun onNegativeClickedForBasicDialog(instanceTag: String) {
         pageListDialogHelper.onNegativeClickedForBasicDialog(
                 instanceTag = instanceTag,
-                editLocalPage = this::editPage
+                editPage = this::editPage
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -459,6 +459,9 @@ class PagesViewModel
     }
 
     fun onItemTapped(pageItem: Page) {
+        // TODO We are going to be doing a refactor of the ViewModels related to Pages so that the PostModel is
+        //  available without doing subsequent fetches from the PostStore
+        //  https://github.com/wordpress-mobile/WordPress-Android/issues/11233
         val page = postStore.getPostByRemotePostId(pageItem.id, site)
         // Then check if an autosave revision is available
         if (pageConflictResolver.hasUnhandledAutoSave(page)) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -391,7 +391,7 @@ class PagesViewModel
 
     private fun deletePage(page: Page) {
         performIfNetworkAvailable {
-            pageListDialogHelper.showDeletePostConfirmationDialog(RemoteId(page.id), page.title)
+            pageListDialogHelper.showDeletePageConfirmationDialog(RemoteId(page.id), page.title)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -118,8 +118,8 @@ class PagesViewModel
     private val _editPage = SingleLiveEvent<PageModel?>()
     val editPage: LiveData<PageModel?> = _editPage
 
-    private val _editAutoRevisionPage = SingleLiveEvent<Pair<PostModel?,SiteModel>>()
-    val editAutoRevisionPage: LiveData<Pair<PostModel?,SiteModel>> = _editAutoRevisionPage
+    private val _editAutoRevisionPage = SingleLiveEvent<Pair<PostModel?, SiteModel>>()
+    val editAutoRevisionPage: LiveData<Pair<PostModel?, SiteModel>> = _editAutoRevisionPage
 
     private val _previewPage = SingleLiveEvent<PostModel?>()
     val previewPage: LiveData<PostModel?> = _previewPage

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -358,6 +358,7 @@
     <!-- post autosave revision dialog -->
     <string name="dialog_confirm_autosave_title">Which version would you like to edit?</string>
     <string name="dialog_confirm_autosave_body_first_part">You recently made changes to this post but didn\'t save them. Choose a version to load:\n\n</string>
+    <string name="dialog_confirm_autosave_body_first_part_for_page">You recently made changes to this page but didn\'t save them. Choose a version to load:\n\n</string>
     <string name="dialog_confirm_autosave_body_second_part">From this app\nSaved on %s\n\nFrom another device\nSaved on %s\n</string>
     <string name="dialog_confirm_autosave_restore_button">The version from another device</string>
     <string name="dialog_confirm_autosave_dont_restore_button">The version from this app</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -63,7 +63,8 @@ class PagesViewModelTest {
                 analyticsTracker = mock(),
                 uiDispatcher = Dispatchers.Unconfined,
                 defaultDispatcher = Dispatchers.Unconfined,
-                eventBusWrapper = mock()
+                eventBusWrapper = mock(),
+                pageConflictResolver = mock()
         )
         listStates = mutableListOf()
         pages = mutableListOf()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -65,11 +65,11 @@ class PagesViewModelTest {
                 networkUtils = networkUtils,
                 previewStateHelper = mock(),
                 analyticsTracker = mock(),
-                uiDispatcher = Dispatchers.Unconfined,
+                pageConflictResolver = mock(),
+                        uiDispatcher = Dispatchers.Unconfined,
                 defaultDispatcher = Dispatchers.Unconfined,
                 eventBusWrapper = mock(),
                 uploadStarter = uploadStarter
-                pageConflictResolver = mock()
         )
         listStates = mutableListOf()
         pages = mutableListOf()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -60,6 +60,7 @@ class PagesViewModelTest {
                 actionPerfomer = actionPerformer,
                 networkUtils = networkUtils,
                 previewStateHelper = mock(),
+                analyticsTracker = mock(),
                 uiDispatcher = Dispatchers.Unconfined,
                 defaultDispatcher = Dispatchers.Unconfined,
                 eventBusWrapper = mock()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -66,7 +66,7 @@ class PagesViewModelTest {
                 previewStateHelper = mock(),
                 analyticsTracker = mock(),
                 pageConflictResolver = mock(),
-                        uiDispatcher = Dispatchers.Unconfined,
+                uiDispatcher = Dispatchers.Unconfined,
                 defaultDispatcher = Dispatchers.Unconfined,
                 eventBusWrapper = mock(),
                 uploadStarter = uploadStarter


### PR DESCRIPTION
Fixes #11131 

## Findings

The `Page List` didn't support loading an unpublished revision when changes were made on other devices. 

## Solution
* To reuse logic that allows the `Post List` to support this functionality. Most of this logic lives within the `PostListDialogHelper`. Since it has way more responsibilities than required in this PR, a `PageListDialogHelper` was created to extract only the functionality needed. 

* While adding this feature, I noticed that the `Delete Page Confirmation Dialog` was utilizing the `BasicFragmentDialog` and mixing both implementations would reduce code quality so I opted to migrate the `Delete Confirmation Dialog` to the `PageListDialogHelper` for consistency. 

* For the "You've made unsaved changes to this page" label, I didn't add it since @malinajirka will be working on a PR to refactor how labels are generated and that would cause a conflict. 

* I reused the tracking events from the `PostListDialogHelper` but I am wondering if pages need to be tracked separately from posts.  

## Testing

### Page Auto Revision Testing 
1. Edit a page in WP Calypso and don't click save. You can monitor the network tab in the chrome debugging tools to see when an `autosave` request is made since this implementation doesn't contain a label. 
2. Ensure the device is online and then refresh the page. 
3. Click on the page that was edited online and you should see the dialog below. 

Before Click | After Click
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/73781137-c1f7e200-475d-11ea-90b2-566fc1aefbd8.png" width="320"> |   <img src="https://user-images.githubusercontent.com/1509205/73781152-c7552c80-475d-11ea-984c-9113106aec72.png" width="320">

4. Verify that clicking `The Version From Another Device` shows the contents that exist in Calypso. 
5. Click back without saving and press the page again to verify that `The Version From This App` is accurate.

### Page Deletion Testing 
1. Go to the `Trash` tab and click the `More` icon. 
2. Select `Delete Permanently` 
3. A dialog should be shown that asks you if you are sure you want to delete the page. 
4. Once you confirm the deletion, the page should be removed and the list should be empty. A snackbar should also be shown confirming deletion. 

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/73781678-b2c56400-475e-11ea-82bd-4a98b083faca.png" width="320">        |    <img src="https://user-images.githubusercontent.com/1509205/73781731-c40e7080-475e-11ea-8ab5-aabb2cd38d38.png" width="320">

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
