### PR TITLE
Enable Group block in production

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 14.2
 -----
- 
+ * Block editor: New Group block for nesting blocks.
+
+14.2
+-----
+
 14.1
 -----
 * Fixes an issue where searching for posts sometimes doesn't show some results.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,4 @@
-14.2
+14.3
 -----
  * Block editor: New Group block for nesting blocks.
 


### PR DESCRIPTION
Updates Gutenberg so the `Group` block is available in production.

`Gutenberg PR`:  https://github.com/WordPress/gutenberg/pull/20004

To test:
- Run the app without metro running
- Start a new post
- Verify Group block is visible in the block picker
- Select the `Group` block
- Verify it is working as expected:
  - Try to break it
  - Use try portrait & landscape modes 
  - Try nesting it more than expected
  - Check if the navigation button on `FloatingToolbar` works
  - Check if `AppenderButton` is visible when `Group` is selected
  - Check if `AppenderButton` is show as placeholder when `Group` is unselected
  - Check if `AppenderButton` open the `Inserter` after press (when `Group` block is empty and when it already has some nested blocks)
  - Move the block between other ones inside a `Group` and check it works correctly
  - Move the whole `Group` block between another `Group` blocks in RootList
  - Try to use `Ungroup` button on `Toolbar`
  - Remove the block
  - Add one again
- Save as draft
- Open your draft and check the Group block is shown correctly

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
