### PR TITLE
Fix gallery size labels - 1.22.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * Block editor: Retry displaying image when connectivity restores
 * Block editor: Show an "Edit" button overlay on selected image blocks
 * Block editor: Fix blank post when sharing media from another app
+* Block editor: Add support for image size options in the gallery block
 
 14.1
 -----


### PR DESCRIPTION
#### Related PR:
`gutenberg`: https://github.com/WordPress/gutenberg/pull/20045
`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1856
`WordPress-iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/13375


## Description
This brings the fix from https://github.com/WordPress/gutenberg/pull/19800 to the release branch for `1.22.0` and updates the release notes to reflect the new feature.

## How has this been tested?
Tested via steps here: https://github.com/WordPress/gutenberg/pull/19800#issue-365661691

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
