### PR TITLE
Fixing i18n auto update when changing language. 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -702,10 +702,10 @@ public class ActivityLauncher {
         context.startActivity(intent);
     }
 
-    public static void viewMeActivity(Context context) {
-        Intent intent = new Intent(context, MeActivity.class);
+    public static void viewMeActivityForResult(Activity activity) {
+        Intent intent = new Intent(activity, MeActivity.class);
         AnalyticsTracker.track(AnalyticsTracker.Stat.ME_ACCESSED);
-        context.startActivity(intent);
+        activity.startActivityForResult(intent, RequestCodes.APP_SETTINGS);
     }
 
     public static void viewAccountSettings(Context context) {
@@ -714,7 +714,7 @@ public class ActivityLauncher {
         context.startActivity(intent);
     }
 
-    public static void viewAppSettings(Activity activity) {
+    public static void viewAppSettingsForResult(Activity activity) {
         Intent intent = new Intent(activity, AppSettingsActivity.class);
         AnalyticsTracker.track(AnalyticsTracker.Stat.OPENED_APP_SETTINGS);
         activity.startActivityForResult(intent, RequestCodes.APP_SETTINGS);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
@@ -1,12 +1,21 @@
 package org.wordpress.android.ui.main
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.R
+import org.wordpress.android.ui.RequestCodes
+import org.wordpress.android.ui.prefs.AppSettingsFragment.LANGUAGE_CHANGED
+import org.wordpress.android.util.LocaleManager
 
 class MeActivity : AppCompatActivity() {
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.me_activity)
@@ -24,5 +33,20 @@ class MeActivity : AppCompatActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        when (requestCode) {
+            RequestCodes.APP_SETTINGS -> {
+                if (resultCode == LANGUAGE_CHANGED) {
+                    // Refresh the app
+                    val refresh = Intent(this, this.javaClass)
+                    startActivity(refresh)
+                    setResult(LANGUAGE_CHANGED)
+                    finish()
+                }
+            }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -166,7 +166,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
         rootView.findViewById(R.id.row_app_settings).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                ActivityLauncher.viewAppSettings(getActivity());
+                ActivityLauncher.viewAppSettingsForResult(getActivity());
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -375,7 +375,7 @@ public class MySiteFragment extends Fragment implements
         mToolbar.inflateMenu(R.menu.my_site_menu);
         mToolbar.setOnMenuItemClickListener(item -> {
             if (item.getItemId() == R.id.me_item) {
-                ActivityLauncher.viewMeActivity(getActivity());
+                ActivityLauncher.viewMeActivityForResult(getActivity());
                 return true;
             }
             return false;


### PR DESCRIPTION
Fixes #11246

This was introduced moving the Me screen into My Site and this PR does the following:
1. Adds the following code in the `MeActivity` (more context on why this is needed [here](https://github.com/wordpress-mobile/WordPress-Android/pull/7413/files))
```
override fun attachBaseContext(newBase: Context) {
        super.attachBaseContext(LocaleManager.setLocale(newBase))
}
```

2. Start MeActivity for result from MeFragment to get notified of the language change.

## To test
- With main vanilla develop version follow the steps in the linked issue to confirm it
- With the vanilla version from this PR repeat the steps and confirm now the language is auto-updated

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
