### PR TITLE
WIP: Autosave or update draft

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/AutosavePostOrUpdateDraftUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/AutosavePostOrUpdateDraftUseCase.kt
@@ -1,0 +1,85 @@
+package org.wordpress.android.ui.uploads
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode.BACKGROUND
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.PostActionBuilder
+import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.RemoteAutoSavePost
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
+import org.wordpress.android.fluxc.store.PostStore.OnPostStatusFetched
+import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
+import org.wordpress.android.ui.uploads.AutoSavePostIfNotDraftResult.PostAutoSaved
+import org.wordpress.android.ui.uploads.AutoSavePostIfNotDraftResult.PostIsDraftInRemote
+import javax.inject.Inject
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+
+// TODO: Not be so verbose in naming
+
+private const val DRAFT_POST_STATUS = "draft"
+
+interface OnAutoSavePostIfNotDraftCallback {
+    fun handleAutoSavePostIfNotDraftResult(result: AutoSavePostIfNotDraftResult)
+}
+
+sealed class AutoSavePostIfNotDraftResult {
+    data class PostIsDraftInRemote(val post: PostModel): AutoSavePostIfNotDraftResult()
+    data class PostAutoSaved(val post: PostModel): AutoSavePostIfNotDraftResult()
+}
+
+// TODO: Add documentation
+// TODO: Add unit tests
+class AutoSavePostIfNotDraftUseCase @Inject constructor(
+    val dispatcher: Dispatcher,
+    val postStore: PostStore,
+    val callback: OnAutoSavePostIfNotDraftCallback
+) {
+    private var postStatusPair: Pair<LocalId, Continuation<String>>? = null
+    private var autoSavePair: Pair<LocalId, Continuation<PostModel>>? = null
+
+    // TODO: Shouldn't be a suspend function
+    suspend fun autoSavePostOrUpdateDraft(site: SiteModel, post: PostModel) {
+        val remotePostPayload = RemotePostPayload(post, site)
+        val remotePostStatus: String = suspendCancellableCoroutine { cont ->
+            postStatusPair = Pair(LocalId(post.id), cont)
+            dispatcher.dispatch(PostActionBuilder.newFetchPostStatusAction(remotePostPayload))
+        }
+        if (remotePostStatus != DRAFT_POST_STATUS) {
+            dispatcher.dispatch(PostActionBuilder.newRemoteAutoSavePostAction(remotePostPayload))
+        } else {
+            callback.handleAutoSavePostIfNotDraftResult(PostIsDraftInRemote(post))
+        }
+    }
+
+    // TODO: Handle errors
+    // TODO: Do we need to observe the event in `MAIN` thread? (Probably not)
+    @Subscribe(threadMode = BACKGROUND)
+    @Suppress("unused")
+    fun onPostStatusFetched(event: OnPostStatusFetched) {
+        postStatusPair?.let {
+            if (event.post.id == it.first.value) {
+                it.second.resume(event.remotePostStatus)
+                postStatusPair = null
+            }
+        }
+    }
+
+    // TODO: Handle errors
+    // TODO: Do we need to observe the event in `MAIN` thread? (Probably not)
+    @Subscribe(threadMode = BACKGROUND)
+    @Suppress("unused")
+    fun onPostChanged(event: OnPostChanged) {
+        autoSavePair?.let {
+            if (event.causeOfChange is RemoteAutoSavePost) {
+                val postLocalId = (event.causeOfChange as RemoteAutoSavePost).localPostId
+                val post: PostModel = postStore.getPostByLocalPostId(postLocalId)
+                callback.handleAutoSavePostIfNotDraftResult(PostAutoSaved(post))
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'c5ea220f70c3a77681d376a17ce5c57e26c1c392'
+    fluxCVersion = 'bc810ea94e47a7f56184848fbb7e0f46a4de1d53'
 }
 
 // Onboarding and dev env setup tasks

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1d2a933ea35ba0ca0286c805a12785b59d219d7f'
+    fluxCVersion = '751696ad02d3446bbfe902c21b16747745616990'
 }
 
 // Onboarding and dev env setup tasks

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'bc810ea94e47a7f56184848fbb7e0f46a4de1d53'
+    fluxCVersion = '1d2a933ea35ba0ca0286c805a12785b59d219d7f'
 }
 
 // Onboarding and dev env setup tasks


### PR DESCRIPTION
This is a PR to discuss possible approaches to fix #10951. This issue is happening because `/autosave` endpoint has the following behavior:

* If the post is a draft, it directly updates the post. Due to a bug, while updating the post it also disables discussions on the post.
* If the post is not a draft, it creates an autosave (this is what we would have liked)

Unfortunately we are unable to address the issue in the API side, so we are left to fix it in the client in a somewhat hacky way. We'll do what the API does and update the actual draft instead of calling `/autosave`. This will fix the comments getting disabled issue and also make it obvious what's happening in the client side. (we didn't know that API was updating the actual draft until recently)

@malinajirka As discussed on Slack, I don't really know what the best way to go about this is. The approach I like the most is to encapsulate the solution as much as possible so it doesn't affect the rest of the app.

I have considered 3 types of use cases for this:
1. `AutoSavePostOrUpdateDraftUseCase`: If we were to go with this, we'd encapsulate everything in the use case and don't return a result back to `PostUploadHandler` until the whole thing is done.
2. `AutoSavePostIfNotDraftUseCase`: This is the use case I explored in this PR. The reason I tried this one over the first option is the complication around push post in `PostUploadHandler`. If we go with the first option we'll have to duplicate the push post logic or refactor that logic into a usecase and somehow chain them. Refactoring is probably a good idea, but I am not sure how complicated it'll be.
3. `FetchPostStatusUseCase`: This would be the simplest approach and we'll just return the remote post status to `PostUploadHandler`. Architecturally, this makes the most sense because it does one thing only. If we (only) do this, we can't encapsulate the complication. However, if we go with the first option, we can have this as a helper use case which would work very well.

There are other combinations of these approaches and we might even go with something completely different. I was hoping your experience with `PostUploadHandler`, however little that might be, could be helpful in deciding what makes the most sense time/value-wise.

Please keep in mind that this is a heavily WIP PR and the goal is to figure out the solution we want as fast as possible. The polish will come later and the `TODO`s in the PR points to things that I am already thinking about. That said, please feel free to comment on them, especially the question ones.

**_This is a discussion PR and will be closed once it serves it's purpose, so both testing steps and PR submission checklist is removed._**
