### PR TITLE
Add localization doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 
 - [Coding Style](coding-style.md) - guidelines and validation and auto-formatting tools
 - [Using Android Resources](using-android-resources.md) - describes how to add or use Android resources like strings and drawables
+- [Localization](localization.md)
 - [Pull Request Guidelines](pull-request-guidelines.md) - branch naming and how to write good pull requests
 - [Subtree'd Library Projects](subtreed-library-projects.md) - how to deal with subtree dependencies
 - [UI Tests](../WordPress/src/androidTest/java/org/wordpress/android/e2e/)

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -23,3 +23,23 @@ val label = context.getString(R.string.stats_comments_posts_and_pages)
 
 You shouldn't need to touch the `strings.xml` for the other languages. During the release process, the `values/strings.xml` file is uploaded to [GlotPress](https://translate.wordpress.org/projects/apps/android/) for translation. Before the release build is finalized, all the translations are grabbed from GlotPress and saved back to their appropriate `values-[lang_code]/strings.xml` file.
 
+## Use Meaningful IDs
+
+Meaningful IDs help give more context to translators. Whenever possible, the first part of the `id` should succinctly describe where the string is used. 
+
+```xml
+<!-- Do -->
+<string name="stats_comments_posts_and_pages">Posts and pages</string>
+```
+
+```xml
+<!-- Avoid -->
+<string name="comments_posts_and_pages">Posts and pages</string>
+```
+
+If the string is for a [`contentDescription`](https://developer.android.com/reference/android/view/View.html#attr_android:contentDescription), consider adding `_content_description` to the end.
+
+```xml
+<string name="stats_expand_content_description">Expand</string>
+```
+

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -23,9 +23,9 @@ val label = context.getString(R.string.stats_comments_posts_and_pages)
 
 You shouldn't need to touch the `strings.xml` for the other languages. During the release process, the `values/strings.xml` file is uploaded to [GlotPress](https://translate.wordpress.org/projects/apps/android/) for translation. Before the release build is finalized, all the translations are grabbed from GlotPress and saved back to their appropriate `values-[lang_code]/strings.xml` file.
 
-## Use Meaningful IDs
+## Use Meaningful Names
 
-Meaningful IDs help give more context to translators. Whenever possible, the first part of the `id` should succinctly describe where the string is used. 
+Meaningful names help give more context to translators. Whenever possible, the first part of the `name` should succinctly describe where the string is used. 
 
 ```xml
 <!-- Do -->

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,0 +1,25 @@
+# Localization
+
+During development, adding a string in the [`values/strings.xml`](../WordPress/src/main/res/values/strings.xml) resource and using it in the code or layout file should be enough. 
+
+```xml
+<!-- strings.xml -->
+<string name="stats_comments_posts_and_pages">Posts and pages</string>
+```
+
+```kotlin
+// In code
+val label = context.getString(R.string.stats_comments_posts_and_pages)
+```
+
+```xml
+<!-- layout.xml -->
+<TextView
+    ...
+    android:text="@string/stats_comments_posts_and_pages"
+    ...
+    />
+```
+
+You shouldn't need to touch the `strings.xml` for the other languages. During the release process, the `values/strings.xml` file is uploaded to [GlotPress](https://translate.wordpress.org/projects/apps/android/) for translation. Before the release build is finalized, all the translations are grabbed from GlotPress and saved back to their appropriate `values-[lang_code]/strings.xml` file.
+

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -43,3 +43,36 @@ If the string is for a [`contentDescription`](https://developer.android.com/refe
 <string name="stats_expand_content_description">Expand</string>
 ```
 
+## Use Placeholders Instead of Concatenation
+
+Concatenating strings to include dynamic values splits them into separate translatable items. The completed (joined) sentence may end up not being grammatically correct. 
+
+```xml
+<!-- Don't -->
+<string name="reader_discover_attribution_first_part">Originally posted by</string>
+<string name="reader_discover_attribution_second_part">on</string>
+```
+
+```kotlin
+// Don't
+val label = context.getString(string.reader_discover_attribution_first_part) +
+        " $author " + context.getString(string.reader_discover_attribution_second_part) + " $blog"
+```
+
+Use placeholders instead. They give more context and enables translators to move them where they make sense.
+
+```xml
+<!-- Do -->
+<string name="reader_discover_attribution_author_and_blog">Originally posted by %1$s on %2$s</string>
+```
+
+```kotlin
+// Do 
+val label = String.format(
+        context.getString(string.reader_discover_attribution_author_and_blog),
+        author, blog
+)
+```
+
+Also consider adding information about what the placeholders are in the `name`.
+

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -95,4 +95,3 @@ val message = if (notUploadedCount == 1) {
     )
 }
 ```
-

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -76,3 +76,23 @@ val label = String.format(
 
 Also consider adding information about what the placeholders are in the `name`.
 
+## Pluralization
+
+GlotPress currently does not support pluralization using [Quantity strings](https://developer.android.com/guide/topics/resources/string-resource.html#Plurals). So, right now, you have to support plurals manually by creating separate strings.
+
+```xml
+<string name="media_files_not_uploaded_singular">1 file not uploaded</string>
+<string name="media_files_not_uploaded_plural">%d files uploaded</string>
+```
+
+```kotlin
+val message = if (notUploadedCount == 1) {
+    context.getString(string.media_files_not_uploaded_singular)
+} else {
+    String.format(
+            context.getString(string.media_files_not_uploaded_plural),
+            notUploadedCount
+    )
+}
+```
+

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -45,7 +45,7 @@ If the string is for a [`contentDescription`](https://developer.android.com/refe
 
 ## Use Placeholders Instead of Concatenation
 
-Concatenating strings to include dynamic values splits them into separate translatable items. The completed (joined) sentence may end up not being grammatically correct. 
+Concatenating strings to include dynamic values splits them into separate translatable items. The completed (joined) sentence may end up not being grammatically correct, especially for RTL languages.
 
 ```xml
 <!-- Don't -->


### PR DESCRIPTION
This adds a short guide for how to localize strings. This is based on @loremattei's work (p77Llu-bLz-p2). 

## Reviewing 

1. View the file [here](https://github.com/wordpress-mobile/WordPress-Android/blob/ce83d68115557f0446909ea630bd4ae7bfeb0902/docs/localization.md).
2. Please feel free to scrutinize. 😄 
3. Please check that the examples are correct.

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.