### PR TITLE
Rename afterSavePostListener

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1525,7 +1525,7 @@ public class EditPostActivity extends AppCompatActivity implements
         mViewModel.updatePostObjectWithUIAsync(mEditPostRepository, this::updateFromEditor, null);
     }
 
-    private void updateAndSavePostAsync(final OnPostUpdatedWithUIListener listener) {
+    private void updateAndSavePostAsync(final OnPostUpdatedFromUIListener listener) {
         if (mEditorFragment == null) {
             AppLog.e(AppLog.T.POSTS, "Fragment not initialized");
             return;
@@ -1535,7 +1535,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 (post, result) -> {
                     // Ignore the result as we want to invoke the listener even when the PostModel was up-to-date
                     if (listener != null) {
-                        listener.onPostUpdatedWithUI();
+                        listener.onPostUpdatedFromUI();
                     }
                     return null;
                 });
@@ -1695,8 +1695,8 @@ public class EditPostActivity extends AppCompatActivity implements
         }
     }
 
-    public interface OnPostUpdatedWithUIListener {
-        void onPostUpdatedWithUI();
+    public interface OnPostUpdatedFromUIListener {
+        void onPostUpdatedFromUI();
     }
 
     @Override
@@ -2895,7 +2895,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void syncPostObjectWithUiAndSaveIt(@Nullable OnPostUpdatedWithUIListener listener) {
+    public void syncPostObjectWithUiAndSaveIt(@Nullable OnPostUpdatedFromUIListener listener) {
         updateAndSavePostAsync(listener);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1525,7 +1525,7 @@ public class EditPostActivity extends AppCompatActivity implements
         mViewModel.updatePostObjectWithUIAsync(mEditPostRepository, this::updateFromEditor, null);
     }
 
-    private void updateAndSavePostAsync(final AfterSavePostListener listener) {
+    private void updateAndSavePostAsync(final OnPostUpdatedWithUIListener listener) {
         if (mEditorFragment == null) {
             AppLog.e(AppLog.T.POSTS, "Fragment not initialized");
             return;
@@ -1535,7 +1535,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 (post, result) -> {
                     // Ignore the result as we want to invoke the listener even when the PostModel was up-to-date
                     if (listener != null) {
-                        listener.onPostSave();
+                        listener.onPostUpdatedWithUI();
                     }
                     return null;
                 });
@@ -1695,8 +1695,8 @@ public class EditPostActivity extends AppCompatActivity implements
         }
     }
 
-    public interface AfterSavePostListener {
-        void onPostSave();
+    public interface OnPostUpdatedWithUIListener {
+        void onPostUpdatedWithUI();
     }
 
     @Override
@@ -2895,7 +2895,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void syncPostObjectWithUiAndSaveIt(@Nullable AfterSavePostListener listener) {
+    public void syncPostObjectWithUiAndSaveIt(@Nullable OnPostUpdatedWithUIListener listener) {
         updateAndSavePostAsync(listener);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
-import org.wordpress.android.ui.posts.EditPostActivity.OnPostUpdatedWithUIListener
+import org.wordpress.android.ui.posts.EditPostActivity.OnPostUpdatedFromUIListener
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.ProgressDialogUiState
 import org.wordpress.android.ui.posts.ProgressDialogUiState.HiddenProgressDialog
@@ -48,7 +48,7 @@ import kotlin.coroutines.CoroutineContext
 
 interface EditorMediaListener {
     fun appendMediaFiles(mediaFiles: Map<String, MediaFile>)
-    fun syncPostObjectWithUiAndSaveIt(listener: OnPostUpdatedWithUIListener? = null)
+    fun syncPostObjectWithUiAndSaveIt(listener: OnPostUpdatedFromUIListener? = null)
     fun advertiseImageOptimization(listener: () -> Unit)
     fun getImmutablePost(): PostImmutableModel
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
-import org.wordpress.android.ui.posts.EditPostActivity.AfterSavePostListener
+import org.wordpress.android.ui.posts.EditPostActivity.OnPostUpdatedWithUIListener
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.ProgressDialogUiState
 import org.wordpress.android.ui.posts.ProgressDialogUiState.HiddenProgressDialog
@@ -48,7 +48,7 @@ import kotlin.coroutines.CoroutineContext
 
 interface EditorMediaListener {
     fun appendMediaFiles(mediaFiles: Map<String, MediaFile>)
-    fun syncPostObjectWithUiAndSaveIt(listener: AfterSavePostListener? = null)
+    fun syncPostObjectWithUiAndSaveIt(listener: OnPostUpdatedWithUIListener? = null)
     fun advertiseImageOptimization(listener: () -> Unit)
     fun getImmutablePost(): PostImmutableModel
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/UploadMediaUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/UploadMediaUseCase.kt
@@ -23,7 +23,7 @@ class UploadMediaUseCase @Inject constructor(
         mediaModels.let { queuedMediaModels ->
             // before starting the service, we need to update the posts' contents so we are sure the service
             // can retrieve it from there on
-            editorMediaListener.syncPostObjectWithUiAndSaveIt(EditPostActivity.OnPostUpdatedWithUIListener {
+            editorMediaListener.syncPostObjectWithUiAndSaveIt(EditPostActivity.OnPostUpdatedFromUIListener {
                 uploadServiceFacade.uploadMediaFromEditor(ArrayList(queuedMediaModels))
             })
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/UploadMediaUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/UploadMediaUseCase.kt
@@ -23,7 +23,7 @@ class UploadMediaUseCase @Inject constructor(
         mediaModels.let { queuedMediaModels ->
             // before starting the service, we need to update the posts' contents so we are sure the service
             // can retrieve it from there on
-            editorMediaListener.syncPostObjectWithUiAndSaveIt(EditPostActivity.AfterSavePostListener {
+            editorMediaListener.syncPostObjectWithUiAndSaveIt(EditPostActivity.OnPostUpdatedWithUIListener {
                 uploadServiceFacade.uploadMediaFromEditor(ArrayList(queuedMediaModels))
             })
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/UploadMediaUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/UploadMediaUseCaseTest.kt
@@ -12,7 +12,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.FAILED
-import org.wordpress.android.ui.posts.EditPostActivity.AfterSavePostListener
+import org.wordpress.android.ui.posts.EditPostActivity.OnPostUpdatedWithUIListener
 import org.wordpress.android.ui.uploads.UploadServiceFacade
 
 @RunWith(MockitoJUnitRunner::class)
@@ -83,7 +83,7 @@ class UploadMediaUseCaseTest {
 
         private fun createEditorMediaListener() = mock<EditorMediaListener> {
             on { syncPostObjectWithUiAndSaveIt(any()) }.thenAnswer { invocation ->
-                (invocation.getArgument(0) as AfterSavePostListener).onPostSave()
+                (invocation.getArgument(0) as OnPostUpdatedWithUIListener).onPostUpdatedWithUI()
             }
         }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/UploadMediaUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/UploadMediaUseCaseTest.kt
@@ -12,7 +12,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState.FAILED
-import org.wordpress.android.ui.posts.EditPostActivity.OnPostUpdatedWithUIListener
+import org.wordpress.android.ui.posts.EditPostActivity.OnPostUpdatedFromUIListener
 import org.wordpress.android.ui.uploads.UploadServiceFacade
 
 @RunWith(MockitoJUnitRunner::class)
@@ -83,7 +83,7 @@ class UploadMediaUseCaseTest {
 
         private fun createEditorMediaListener() = mock<EditorMediaListener> {
             on { syncPostObjectWithUiAndSaveIt(any()) }.thenAnswer { invocation ->
-                (invocation.getArgument(0) as OnPostUpdatedWithUIListener).onPostUpdatedWithUI()
+                (invocation.getArgument(0) as OnPostUpdatedFromUIListener).onPostUpdatedFromUI()
             }
         }
 


### PR DESCRIPTION
I've renamed the AfterPostSaveListener based on [this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/11237#discussion_r376452737). Let me know if you can think of a better name. Thanks

To test:
CI check should be enough.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
