### PR TITLE
IA Reader self-hosted improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
@@ -6,6 +6,8 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
 import android.text.TextUtils;
 
+import androidx.annotation.Nullable;
+
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagList;
 import org.wordpress.android.models.ReaderTagType;
@@ -273,7 +275,7 @@ public class ReaderTagTable {
         }
     }
 
-    public static ReaderTag getFirstTag() {
+    public static @Nullable ReaderTag getFirstTag() {
         Cursor c = ReaderDatabase.getReadableDb().rawQuery("SELECT * FROM tbl_tags ORDER BY tag_slug LIMIT 1", null);
         try {
             if (c.moveToFirst()) {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderBlog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderBlog.java
@@ -182,7 +182,7 @@ public class ReaderBlog {
                && this.getImageUrl().equals(blogInfo.getImageUrl());
     }
 
-    public boolean isSameBlogAs(ReaderBlog blogInfo) {
+    public boolean isSameBlogOrFeedAs(ReaderBlog blogInfo) {
         boolean areBothValidFeeds = this.blogId == this.feedId
                                     && blogInfo.blogId == blogInfo.feedId
                                     && this.hasFeedUrl()

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderBlog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderBlog.java
@@ -169,20 +169,28 @@ public class ReaderBlog {
     }
 
     public boolean isSameAs(ReaderBlog blogInfo) {
-        return isSameAs(blogInfo, true);
-    }
-
-    public boolean isSameAs(ReaderBlog blogInfo, boolean compareSubscribers) {
         return blogInfo != null
                && this.blogId == blogInfo.blogId
                && this.feedId == blogInfo.feedId
                && this.isFollowing == blogInfo.isFollowing
                && this.isPrivate == blogInfo.isPrivate
-               && ((this.numSubscribers == blogInfo.numSubscribers) || !compareSubscribers)
+               && this.numSubscribers == blogInfo.numSubscribers
                && this.getName().equals(blogInfo.getName())
                && this.getDescription().equals(blogInfo.getDescription())
                && this.getUrl().equals(blogInfo.getUrl())
                && this.getFeedUrl().equals(blogInfo.getFeedUrl())
                && this.getImageUrl().equals(blogInfo.getImageUrl());
+    }
+
+    public boolean isSameBlogAs(ReaderBlog blogInfo) {
+        boolean areBothValidFeeds = this.blogId == this.feedId
+                                    && blogInfo.blogId == blogInfo.feedId
+                                    && this.hasFeedUrl()
+                                    && blogInfo.hasFeedUrl();
+
+        return blogInfo != null
+               && this.blogId == blogInfo.blogId
+               && this.getUrl().equals(blogInfo.getUrl())
+               && (!areBothValidFeeds || this.getFeedUrl().equals(blogInfo.getFeedUrl()));
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -26,7 +26,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
     private String mTagTitle; // title, used for default tags
     private String mEndpoint; // endpoint for updating posts with this tag
 
-    private boolean mIsDefaultTag;
+    private boolean mIsDefaultInMemoryTag;
 
     public final ReaderTagType tagType;
 
@@ -43,7 +43,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
                      String title,
                      String endpoint,
                      ReaderTagType tagType,
-                     boolean isDefaultTag) {
+                     boolean isDefaultInMemoryTag) {
         // we need a slug since it's used to uniquely ID the tag (including setting it as the
         // primary key in the tag table)
         if (TextUtils.isEmpty(slug)) {
@@ -62,14 +62,14 @@ public class ReaderTag implements Serializable, FilterCriteria {
         setTagTitle(title);
         setEndpoint(endpoint);
         this.tagType = tagType;
-        mIsDefaultTag = isDefaultTag;
+        mIsDefaultInMemoryTag = isDefaultInMemoryTag;
     }
 
     public String getEndpoint() {
         return StringUtils.notNullStr(mEndpoint);
     }
 
-    private void setEndpoint(String endpoint) {
+    public void setEndpoint(String endpoint) {
         this.mEndpoint = StringUtils.notNullStr(endpoint);
     }
 
@@ -77,7 +77,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
         return StringUtils.notNullStr(mTagTitle);
     }
 
-    private void setTagTitle(String title) {
+    public void setTagTitle(String title) {
         this.mTagTitle = StringUtils.notNullStr(title);
     }
 
@@ -174,8 +174,8 @@ public class ReaderTag implements Serializable, FilterCriteria {
         return tagType == ReaderTagType.DEFAULT && getEndpoint().endsWith(FOLLOWING_PATH);
     }
 
-    public boolean isDefaultTag() {
-        return tagType == ReaderTagType.DEFAULT && mIsDefaultTag;
+    public boolean isDefaultInMemoryTag() {
+        return tagType == ReaderTagType.DEFAULT && mIsDefaultInMemoryTag;
     }
 
     public boolean isBookmarked() {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
@@ -67,4 +67,17 @@ public class ReaderTagList extends ArrayList<ReaderTag> {
 
         return deletions;
     }
+
+    public boolean containsFollowingTag() {
+        boolean containsFollowing = false;
+
+        for (ReaderTag tag : this) {
+            if (tag.isFollowedSites() || tag.isDefaultInMemoryTag()) {
+                containsFollowing = true;
+                break;
+            }
+        }
+
+        return containsFollowing;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -34,6 +34,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.jetbrains.annotations.NotNull;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -450,6 +451,23 @@ public class WPMainActivity extends AppCompatActivity implements
                 return null;
             });
         });
+
+        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
+            mViewModel.getStartLoginFlow().observe(this, event -> {
+                event.applyIfNotHandled(startLoginFlow -> {
+                    if (mBottomNav != null) {
+                        mBottomNav.postDelayed(new Runnable() {
+                            @Override public void run() {
+                                mBottomNav.setCurrentSelectedPage(PageType.MY_SITE);
+                            }
+                        }, 500);
+                        ActivityLauncher.viewMeActivityForResult(this);
+                    }
+
+                    return null;
+                });
+            });
+        }
 
         mViewModel.start(mSiteStore.hasSite() && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -317,8 +317,13 @@ public class AppPrefs {
         boolean wasFollowing = false;
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
+            // The intention here is to check if the `DeletablePrefKey.READER_TAG_WAS_FOLLOWING` key
+            // was present at all in the Shared Prefs.
+            // We could have it not set for example in cases where user is upgrading from
+            // a previous version of the app. In those cases we do not have enough information as of the saved
+            // tag was a Following tag or not, so (as with empty `DeletablePrefKey.READER_TAG_NAME`)
+            // let's do not use this piece of information.
             String wasFallowingString = getString(DeletablePrefKey.READER_TAG_WAS_FOLLOWING);
-
             if (TextUtils.isEmpty(wasFallowingString)) return null;
 
             wasFollowing = getBoolean(DeletablePrefKey.READER_TAG_WAS_FOLLOWING, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -189,6 +189,10 @@ public class AppPrefs {
         // user id last used to login with
         LAST_USED_USER_ID,
 
+        // last user access status in reader
+        LAST_READER_KNOWN_ACCESS_TOKEN_STATUS,
+        LAST_READER_KNOWN_USER_ID,
+
         // used to indicate that user opted out of quick start
         IS_QUICK_START_DISABLED,
 
@@ -420,6 +424,22 @@ public class AppPrefs {
 
     public static void setLastUsedUserId(long userId) {
         setLong(UndeletablePrefKey.LAST_USED_USER_ID, userId);
+    }
+
+    public static boolean getLastReaderKnownAccessTokenStatus() {
+        return getBoolean(UndeletablePrefKey.LAST_READER_KNOWN_ACCESS_TOKEN_STATUS, false);
+    }
+
+    public static void setLastReaderKnownAccessTokenStatus(boolean accessTokenStatus) {
+        setBoolean(UndeletablePrefKey.LAST_READER_KNOWN_ACCESS_TOKEN_STATUS, accessTokenStatus);
+    }
+
+    public static long getLastReaderKnownUserId() {
+        return getLong(UndeletablePrefKey.LAST_READER_KNOWN_USER_ID);
+    }
+
+    public static void setLastReaderKnownUserId(long userId) {
+        setLong(UndeletablePrefKey.LAST_READER_KNOWN_USER_ID, userId);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -317,6 +317,10 @@ public class AppPrefs {
         boolean wasFollowing = false;
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
+            String wasFallowingString = getString(DeletablePrefKey.READER_TAG_WAS_FOLLOWING);
+
+            if (TextUtils.isEmpty(wasFallowingString)) return null;
+
             wasFollowing = getBoolean(DeletablePrefKey.READER_TAG_WAS_FOLLOWING, false);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -115,6 +115,13 @@ class AppPrefsWrapper @Inject constructor() {
     fun getReaderSubfilter() = AppPrefs.getReaderSubfilter()
     fun setReaderSubfilter(json: String) = AppPrefs.setReaderSubfilter(json)
 
+    fun getLastReaderKnownAccessTokenStatus() = AppPrefs.getLastReaderKnownAccessTokenStatus()
+    fun setLastReaderKnownAccessTokenStatus(lastKnownAccessTokenStatus: Boolean) =
+            AppPrefs.setLastReaderKnownAccessTokenStatus(lastKnownAccessTokenStatus)
+
+    fun getLastReaderKnownUserId() = AppPrefs.getLastReaderKnownUserId()
+    fun setLastReaderKnownUserId(userId: Long) = AppPrefs.setLastReaderKnownUserId(userId)
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -409,7 +409,7 @@ public class ReaderPostListFragment extends Fragment
                                                          .get(WPMainActivityViewModel.class);
 
             mViewModel.getCurrentSubFilter().observe(this, subfilterListItem -> {
-                if (isCurrentTagTheFollowingTag()
+                if (isCurrentTagManagedInFollowingTab()
                     && getPostListType() != ReaderPostListType.SEARCH_RESULTS) {
                     mViewModel.onSubfilterChanged(subfilterListItem, true);
                     if (!mAccountStore.hasAccessToken() && mViewModel.getCurrentSubfilterValue() instanceof SiteAll) {
@@ -501,7 +501,7 @@ public class ReaderPostListFragment extends Fragment
 
         mViewModel.start(
                 mCurrentTag,
-                isCurrentTagTheFollowingTag()
+                isCurrentTagManagedInFollowingTab()
                 && BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
                 BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel
         );
@@ -604,7 +604,7 @@ public class ReaderPostListFragment extends Fragment
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel
             && !mAccountStore.hasAccessToken() && mViewModel.getCurrentSubfilterValue() instanceof SiteAll
-            && isCurrentTagTheFollowingTag()
+            && isCurrentTagManagedInFollowingTab()
         ) {
             setEmptyTitleAndDescriptionForSelfHostedCta();
             showEmptyView();
@@ -1144,7 +1144,7 @@ public class ReaderPostListFragment extends Fragment
 
 
                 if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
-                    if (isCurrentTagTheFollowingTag()) {
+                    if (isCurrentTagManagedInFollowingTab()) {
                         mViewModel.onSubfilterChanged(mViewModel.getCurrentSubfilterValue(), false);
                     } else {
                         // return to the followed tag that was showing prior to searching
@@ -1152,7 +1152,7 @@ public class ReaderPostListFragment extends Fragment
                     }
 
                     mRecyclerView.setTabLayoutVisibility(true);
-                    mViewModel.changeSubfiltersVisibility(isCurrentTagTheFollowingTag());
+                    mViewModel.changeSubfiltersVisibility(isCurrentTagManagedInFollowingTab());
                     mViewModel.onSearchMenuCollapse(true);
                 } else {
                     // return to the followed tag that was showing prior to searching
@@ -1564,7 +1564,7 @@ public class ReaderPostListFragment extends Fragment
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
             totalMargin += getActivity().getResources().getDimensionPixelSize(R.dimen.tab_height);
-            if (isCurrentTagTheFollowingTag()) {
+            if (isCurrentTagManagedInFollowingTab()) {
                 totalMargin += mSubFilterComponent.getHeight();
             }
         }
@@ -1588,7 +1588,7 @@ public class ReaderPostListFragment extends Fragment
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel
             && !mAccountStore.hasAccessToken() && mViewModel.getCurrentSubfilterValue() instanceof SiteAll
-            && isCurrentTagTheFollowingTag()
+            && isCurrentTagManagedInFollowingTab()
         ) {
             setEmptyTitleAndDescriptionForSelfHostedCta();
             return;
@@ -2136,7 +2136,7 @@ public class ReaderPostListFragment extends Fragment
 
         getPostAdapter().setCurrentTag(mCurrentTag);
         mViewModel.changeSubfiltersVisibility(
-                BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && isCurrentTagTheFollowingTag()
+                BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel && isCurrentTagManagedInFollowingTab()
         );
         hideNewPostsBar();
         showLoadingProgress(false);
@@ -2766,12 +2766,12 @@ public class ReaderPostListFragment extends Fragment
         mLastAutoUpdateDt = null;
     }
 
-    private boolean isCurrentTagTheFollowingTag() {
-        return ReaderUtils.isFollowing(
+    private boolean isCurrentTagManagedInFollowingTab() {
+        return ReaderUtils.isTagManagedInFollowingTab(
                 mCurrentTag,
                 BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
                 mRecyclerView
-        ) || ReaderUtils.isDefaultInMemoryTag(mCurrentTag);
+        );
     }
 
     private class LoadTagsTask extends AsyncTask<Void, Void, ReaderTagList> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -630,7 +630,7 @@ public class ReaderPostListFragment extends Fragment
             AppLog.d(T.READER, "reader post list > current tag no longer valid");
             ReaderTag tag;
             if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-                tag = ReaderUtils.getDbOrInMemoryDefaultTag(requireActivity(), mTagUpdateClientUtilsProvider);
+                tag = ReaderUtils.getDefaultTagFromDbOrCreateInMemory(requireActivity(), mTagUpdateClientUtilsProvider);
             } else {
                 tag = ReaderUtils.getDefaultTag();
                 // it's possible the default tag won't exist if the user just changed the app's
@@ -944,7 +944,7 @@ public class ReaderPostListFragment extends Fragment
                     ReaderTag defaultTag;
 
                     if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-                        defaultTag = ReaderUtils.getDbOrInMemoryDefaultTag(
+                        defaultTag = ReaderUtils.getDefaultTagFromDbOrCreateInMemory(
                                 requireActivity(),
                                 mTagUpdateClientUtilsProvider
                         );
@@ -1782,7 +1782,7 @@ public class ReaderPostListFragment extends Fragment
 
         if (!ReaderTagTable.tagExists(tag)) {
             if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-                tag = ReaderUtils.getDbOrInMemoryDefaultTag(
+                tag = ReaderUtils.getDefaultTagFromDbOrCreateInMemory(
                         requireActivity(),
                         mTagUpdateClientUtilsProvider
                 );
@@ -2100,7 +2100,7 @@ public class ReaderPostListFragment extends Fragment
                     tag,
                     BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel,
                     mRecyclerView,
-                    ReaderUtils.getDbOrInMemoryDefaultTag(
+                    ReaderUtils.getDefaultTagFromDbOrCreateInMemory(
                             requireActivity(),
                             mTagUpdateClientUtilsProvider
                     )
@@ -2188,7 +2188,7 @@ public class ReaderPostListFragment extends Fragment
         ReaderTag defaultTag = null;
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-            defaultTag = ReaderUtils.getDbOrInMemoryDefaultTag(
+            defaultTag = ReaderUtils.getDefaultTagFromDbOrCreateInMemory(
                     requireActivity(),
                     mTagUpdateClientUtilsProvider
             );

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -463,7 +463,7 @@ public class ReaderPostListFragment extends Fragment
                 });
             });
 
-            mViewModel.getExecEmptyViewAction().observe(this, event -> {
+            mViewModel.getBottomSheetEmptyViewAction().observe(this, event -> {
                 event.applyIfNotHandled(action -> {
                     if (action instanceof OpenSubsAtPage) {
                         ReaderActivityLauncher.showReaderSubs(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2796,7 +2796,7 @@ public class ReaderPostListFragment extends Fragment
             tagList.addAll(ReaderTagTable.getBookmarkTags());
 
             if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
-                if (!ReaderUtils.containsFollowing(tagList)) {
+                if (!tagList.containsFollowingTag()) {
                     tagList.add(mDefaultTag);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -507,7 +507,7 @@ public class ReaderPostListFragment extends Fragment
         );
 
         if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && mIsTopLevel) {
-            mViewModel.onUserChangedUpdate(getContext());
+            mViewModel.onUserComesToReader();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -55,6 +55,7 @@ public class ReaderUpdateLogic {
     private Context mContext;
 
     @Inject AccountStore mAccountStore;
+    @Inject TagUpdateClientUtilsProvider mClientUtilsProvider;
 
     public ReaderUpdateLogic(Context context, WordPress app, ServiceCompletionListener listener) {
         mCompletionListener = listener;
@@ -114,7 +115,8 @@ public class ReaderUpdateLogic {
         AppLog.d(AppLog.T.READER, "reader service > updating tags");
         HashMap<String, String> params = new HashMap<>();
         params.put("locale", mLanguage);
-        WordPress.getRestClientUtilsV1_2().get("read/menu", params, null, listener, errorListener);
+        mClientUtilsProvider.getRestClientForTagUpdate()
+                            .get("read/menu", params, null, listener, errorListener);
     }
 
     private boolean displayNameUpdateWasNeeded(ReaderTagList serverTopics) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/TagUpdateClientUtilsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/TagUpdateClientUtilsProvider.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.ui.reader.services.update
+
+import org.wordpress.android.WordPress
+import org.wordpress.android.networking.RestClientUtils
+import javax.inject.Inject
+
+class TagUpdateClientUtilsProvider @Inject constructor() {
+    fun getRestClientForTagUpdate(): RestClientUtils {
+        return WordPress.getRestClientUtilsV1_2()
+    }
+
+    fun getTagUpdateEndpointURL(): String {
+        return WordPress.getRestClientUtilsV1_2().restClient.endpointURL
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/BottomSheetEmptyUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/BottomSheetEmptyUiState.kt
@@ -8,6 +8,14 @@ sealed class BottomSheetEmptyUiState {
     data class VisibleEmptyUiState(
         val title: UiStringRes,
         val buttonText: UiStringRes,
-        val actionTabIndex: Int
+        val action: ActionType
     ) : BottomSheetEmptyUiState()
+}
+
+sealed class ActionType {
+    data class OpenSubsAtPage(
+        val tabIndex: Int
+    ) : ActionType()
+
+    object OpenLoginPage : ActionType()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterBottomSheetEmptyUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterBottomSheetEmptyUiState.kt
@@ -2,14 +2,14 @@ package org.wordpress.android.ui.reader.subfilter
 
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 
-sealed class BottomSheetEmptyUiState {
-    object HiddenEmptyUiState : BottomSheetEmptyUiState()
+sealed class SubfilterBottomSheetEmptyUiState {
+    object HiddenEmptyUiState : SubfilterBottomSheetEmptyUiState()
 
     data class VisibleEmptyUiState(
         val title: UiStringRes,
         val buttonText: UiStringRes,
         val action: ActionType
-    ) : BottomSheetEmptyUiState()
+    ) : SubfilterBottomSheetEmptyUiState()
 }
 
 sealed class ActionType {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
@@ -23,7 +23,7 @@ sealed class SubfilterListItem(val type: ItemType) {
         return if (type == otherItem.type) {
             when (type) {
                 SECTION_TITLE -> label == otherItem.label
-                SITE -> (this as Site).blog.isSameAs((otherItem as Site).blog, false)
+                SITE -> (this as Site).blog.isSameBlogAs((otherItem as Site).blog)
                 TAG -> (this as Tag).tag == (otherItem as Tag).tag
                 SITE_ALL,
                 DIVIDER -> true

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
@@ -23,7 +23,7 @@ sealed class SubfilterListItem(val type: ItemType) {
         return if (type == otherItem.type) {
             when (type) {
                 SECTION_TITLE -> label == otherItem.label
-                SITE -> (this as Site).blog.isSameBlogAs((otherItem as Site).blog)
+                SITE -> (this as Site).blog.isSameBlogOrFeedAs((otherItem as Site).blog)
                 TAG -> (this as Tag).tag == (otherItem as Tag).tag
                 SITE_ALL,
                 DIVIDER -> true

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -18,8 +18,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.android.support.DaggerFragment
 import org.wordpress.android.R
-import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState.HiddenEmptyUiState
-import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState.VisibleEmptyUiState
+import org.wordpress.android.ui.reader.subfilter.SubfilterBottomSheetEmptyUiState.HiddenEmptyUiState
+import org.wordpress.android.ui.reader.subfilter.SubfilterBottomSheetEmptyUiState.VisibleEmptyUiState
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.SITES
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.TAGS
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -97,7 +97,7 @@ class SubfilterPageFragment : DaggerFragment() {
                         title.setText(uiState.title.stringRes)
                         actionButton.setText(uiState.buttonText.stringRes)
                         actionButton.setOnClickListener {
-                            readerViewModel.onBottomSheetActionClicked(uiState.actionTabIndex)
+                            readerViewModel.onBottomSheetActionClicked(uiState.action)
                         }
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -25,6 +25,8 @@ import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.TAGS
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SITE
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.TAG
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Site
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
 import org.wordpress.android.ui.reader.subfilter.adapters.SubfilterListAdapter
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel
 import org.wordpress.android.ui.reader.viewmodels.SubfilterPageViewModel
@@ -81,7 +83,17 @@ class SubfilterPageFragment : DaggerFragment() {
 
         readerViewModel.subFilters.observe(this, Observer {
             (recyclerView.adapter as? SubfilterListAdapter)?.let { adapter ->
-                val items = it?.filter { it.type == category.type } ?: listOf()
+                var items = it?.filter { it.type == category.type } ?: listOf()
+
+                val currentFilter = readerViewModel.getCurrentSubfilterValue()
+
+                if (items.isNotEmpty() && (currentFilter is Site || currentFilter is Tag)) {
+                    items = items.map {
+                        it.isSelected = it.isSameItem(currentFilter)
+                        it
+                    }
+                }
+
                 viewModel.onSubFiltersChanged(items.isEmpty())
                 adapter.update(items)
                 readerViewModel.onSubfilterPageUpdated(category, items.size)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubFilterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubFilterDiffCallback.kt
@@ -21,7 +21,7 @@ class SubFilterDiffCallback(
         return if (oldItem.type == newItem.type) {
             when (oldItem.type) {
                 SECTION_TITLE -> oldItem.label == newItem.label
-                SITE -> (oldItem as Site).blog.isSameBlogAs((newItem as Site).blog)
+                SITE -> (oldItem as Site).blog.isSameBlogOrFeedAs((newItem as Site).blog)
                 TAG -> (oldItem as Tag).tag == (newItem as Tag).tag
                 SITE_ALL,
                 DIVIDER -> true

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubFilterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubFilterDiffCallback.kt
@@ -21,7 +21,7 @@ class SubFilterDiffCallback(
         return if (oldItem.type == newItem.type) {
             when (oldItem.type) {
                 SECTION_TITLE -> oldItem.label == newItem.label
-                SITE -> (oldItem as Site).blog.isSameAs((newItem as Site).blog, false)
+                SITE -> (oldItem as Site).blog.isSameBlogAs((newItem as Site).blog)
                 TAG -> (oldItem as Tag).tag == (newItem as Tag).tag
                 SITE_ALL,
                 DIVIDER -> true

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -358,31 +358,44 @@ public class ReaderUtils {
         return orderedTagList;
     }
 
-    public static boolean isFollowing(
-            ReaderTag currentTag,
+    public static boolean isTagManagedInFollowingTab(
+            ReaderTag tag,
             boolean isTopLevelReader,
             FilteredRecyclerView recyclerView
     ) {
         if (isTopLevelReader) {
-            if (currentTag != null
-                &&
-                (currentTag.isDiscover() || currentTag.isPostsILike() || currentTag.isBookmarked())) {
+            if (ReaderUtils.isDefaultInMemoryTag(tag)) {
+                return true;
+            }
+
+            boolean isSpecialTag = tag != null
+                                   &&
+                                   (tag.isDiscover() || tag.isPostsILike() || tag.isBookmarked());
+
+            boolean tabsInitializingNow = recyclerView != null && recyclerView.getCurrentFilter() == null;
+
+            boolean tagIsFollowedSitesOrAFollowedTag = tag != null
+                                                       && (
+                                                               tag.isFollowedSites()
+                                                               || tag.tagType == ReaderTagType.FOLLOWED
+                                                       );
+
+            if (isSpecialTag) {
                 return false;
-            } else if (recyclerView != null && recyclerView.getCurrentFilter() == null) {
-                // we are initializing now
-                return currentTag != null
-                       && (currentTag.isFollowedSites() || currentTag.tagType == ReaderTagType.FOLLOWED);
+            } else if (tabsInitializingNow) {
+                return tagIsFollowedSitesOrAFollowedTag;
             } else if (recyclerView != null && recyclerView.getCurrentFilter() instanceof ReaderTag) {
-                if (currentTag != null && recyclerView.isValidFilter(currentTag)) {
-                    return currentTag.isFollowedSites();
+                if (recyclerView.isValidFilter(tag)) {
+                    return tag.isFollowedSites();
                 } else {
+                    // If we reach here it means we are setting a followed tag or site in the Following tab
                     return true;
                 }
             } else {
                 return false;
             }
         } else {
-            return currentTag != null && currentTag.isFollowedSites();
+            return tag != null && tag.isFollowedSites();
         }
     }
 
@@ -398,7 +411,7 @@ public class ReaderUtils {
 
         boolean isValidFilter = (recyclerView != null && recyclerView.isValidFilter(tag));
         boolean isSpecialTag = tag.isDiscover() || tag.isPostsILike() || tag.isBookmarked();
-        if (!isSpecialTag && !isValidFilter && isFollowing(tag, isTopLevelReader, recyclerView)) {
+        if (!isSpecialTag && !isValidFilter && isTagManagedInFollowingTab(tag, isTopLevelReader, recyclerView)) {
             return defaultTag;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -384,11 +384,11 @@ public class ReaderUtils {
                 (currentTag.isDiscover() || currentTag.isPostsILike() || currentTag.isBookmarked())) {
                 return false;
             } else if (recyclerView != null && recyclerView.getCurrentFilter() == null) {
-                // we are initializing now: return true to get the subfiltering first init
+                // we are initializing now
                 return currentTag != null
                        && (currentTag.isFollowedSites() || currentTag.tagType == ReaderTagType.FOLLOWED);
             } else if (recyclerView != null && recyclerView.getCurrentFilter() instanceof ReaderTag) {
-                if (recyclerView.isValidFilter(currentTag)) {
+                if (currentTag != null && recyclerView.isValidFilter(currentTag)) {
                     return currentTag.isFollowedSites();
                 } else {
                     return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -358,21 +358,6 @@ public class ReaderUtils {
         return orderedTagList;
     }
 
-    public static boolean containsFollowing(ReaderTagList tagList) {
-        if (tagList == null) return false;
-
-        boolean containsFollowing = false;
-
-        for (ReaderTag tag : tagList) {
-            if (tag.isFollowedSites() || tag.isDefaultInMemoryTag()) {
-                containsFollowing = true;
-                break;
-            }
-        }
-
-        return containsFollowing;
-    }
-
     public static boolean isFollowing(
             ReaderTag currentTag,
             boolean isTopLevelReader,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -17,6 +17,7 @@ import org.wordpress.android.models.ReaderTagList;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.FilteredRecyclerView;
+import org.wordpress.android.ui.reader.services.update.TagUpdateClientUtilsProvider;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.PhotonUtils;
@@ -208,12 +209,12 @@ public class ReaderUtils {
         return getTagFromTagName(tagName, tagType, false);
     }
 
-    public static ReaderTag getTagFromTagName(String tagName, ReaderTagType tagType, boolean isDefaultTag) {
+    public static ReaderTag getTagFromTagName(String tagName, ReaderTagType tagType, boolean markDefaultIfInMemory) {
         ReaderTag tag = ReaderTagTable.getTag(tagName, tagType);
         if (tag != null) {
             return tag;
         } else {
-            return createTagFromTagName(tagName, tagType, isDefaultTag);
+            return createTagFromTagName(tagName, tagType, markDefaultIfInMemory);
         }
     }
 
@@ -221,7 +222,7 @@ public class ReaderUtils {
         return createTagFromTagName(tagName, tagType, false);
     }
 
-    public static ReaderTag createTagFromTagName(String tagName, ReaderTagType tagType, boolean isDefaultTag) {
+    public static ReaderTag createTagFromTagName(String tagName, ReaderTagType tagType, boolean isDefaultInMemoryTag) {
         String tagSlug = sanitizeWithDashes(tagName).toLowerCase(Locale.ROOT);
         String tagDisplayName = tagType == ReaderTagType.DEFAULT ? tagName : tagSlug;
         return new ReaderTag(
@@ -230,7 +231,7 @@ public class ReaderUtils {
                 tagName,
                 null,
                 tagType,
-                isDefaultTag
+                isDefaultInMemoryTag
         );
     }
 
@@ -244,6 +245,32 @@ public class ReaderUtils {
             defaultTag = getTagFromTagName(ReaderTag.TAG_TITLE_DEFAULT, ReaderTagType.DEFAULT, true);
         }
         return defaultTag;
+    }
+
+    public static @NonNull ReaderTag getDbOrInMemoryDefaultTag(
+            @NonNull Context context,
+            TagUpdateClientUtilsProvider clientUtilsProvider
+    ) {
+        // getDefaultTag() tries to get the default tag from reader db by tag endpoint or tag name.
+        // In case it cannot get the default tag from db, it creates it in memory with createTagFromTagName
+        ReaderTag tag = getDefaultTag();
+
+        if (tag.isDefaultInMemoryTag()) {
+            // if the tag was created in memory from createTagFromTagName
+            // we need to set some fields as below before to use it
+            tag.setTagTitle(context.getString(R.string.reader_following_display_name));
+            tag.setTagDisplayName(context.getString(R.string.reader_following_display_name));
+
+            String baseUrl = clientUtilsProvider.getTagUpdateEndpointURL();
+
+            if (baseUrl.endsWith("/")) {
+                baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+            }
+
+            tag.setEndpoint(baseUrl + ReaderTag.FOLLOWING_PATH);
+        }
+
+        return tag;
     }
 
     /*
@@ -331,6 +358,21 @@ public class ReaderUtils {
         return orderedTagList;
     }
 
+    public static boolean containsFollowing(ReaderTagList tagList) {
+        if (tagList == null) return false;
+
+        boolean containsFollowing = false;
+
+        for (ReaderTag tag : tagList) {
+            if (tag.isFollowedSites() || tag.isDefaultInMemoryTag()) {
+                containsFollowing = true;
+                break;
+            }
+        }
+
+        return containsFollowing;
+    }
+
     public static boolean isFollowing(
             ReaderTag currentTag,
             boolean isTopLevelReader,
@@ -362,7 +404,8 @@ public class ReaderUtils {
     public static @NonNull ReaderTag getValidTagForSharedPrefs(
             @NonNull ReaderTag tag,
             boolean isTopLevelReader,
-            FilteredRecyclerView recyclerView
+            FilteredRecyclerView recyclerView,
+            @NonNull ReaderTag defaultTag
     ) {
         if (!isTopLevelReader) {
             return tag;
@@ -371,23 +414,13 @@ public class ReaderUtils {
         boolean isValidFilter = (recyclerView != null && recyclerView.isValidFilter(tag));
         boolean isSpecialTag = tag.isDiscover() || tag.isPostsILike() || tag.isBookmarked();
         if (!isSpecialTag && !isValidFilter && isFollowing(tag, isTopLevelReader, recyclerView)) {
-            ReaderTag defaultTag = ReaderUtils.getDefaultTag();
-            // it's possible the default tag won't exist if the user just changed the app's
-            // language, in which case default to the first tag in the table
-            if (ReaderTagTable.tagExists(defaultTag)) {
-                return defaultTag;
-            } else {
-                ReaderTag firstTag = ReaderTagTable.getFirstTag();
-                if (firstTag != null) {
-                    return firstTag;
-                }
-            }
+            return defaultTag;
         }
 
         return tag;
     }
 
-    public static boolean isDefaultTag(ReaderTag tag) {
-        return tag != null && tag.isDefaultTag();
+    public static boolean isDefaultInMemoryTag(ReaderTag tag) {
+        return tag != null && tag.isDefaultInMemoryTag();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -247,7 +247,7 @@ public class ReaderUtils {
         return defaultTag;
     }
 
-    public static @NonNull ReaderTag getDbOrInMemoryDefaultTag(
+    public static @NonNull ReaderTag getDefaultTagFromDbOrCreateInMemory(
             @NonNull Context context,
             TagUpdateClientUtilsProvider clientUtilsProvider
     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -77,8 +77,8 @@ class ReaderPostListViewModel @Inject constructor(
     private val _filtersMatchCount = MutableLiveData<HashMap<SubfilterCategory, Int>>()
     val filtersMatchCount: LiveData<HashMap<SubfilterCategory, Int>> = _filtersMatchCount
 
-    private val _execEmptyViewAction = MutableLiveData<Event<ActionType>>()
-    val execEmptyViewAction: LiveData<Event<ActionType>> = _execEmptyViewAction
+    private val _bottomSheetEmptyViewAction = MutableLiveData<Event<ActionType>>()
+    val bottomSheetEmptyViewAction: LiveData<Event<ActionType>> = _bottomSheetEmptyViewAction
 
     private val _updateTagsAndSites = MutableLiveData<Event<EnumSet<UpdateTask>>>()
     val updateTagsAndSites: LiveData<Event<EnumSet<UpdateTask>>> = _updateTagsAndSites
@@ -319,7 +319,7 @@ class ReaderPostListViewModel @Inject constructor(
 
     fun onBottomSheetActionClicked(action: ActionType) {
         _changeBottomSheetVisibility.postValue(Event(false))
-        _execEmptyViewAction.postValue(Event(action))
+        _bottomSheetEmptyViewAction.postValue(Event(action))
     }
 
     private fun updateSubfilter(filter: SubfilterListItem) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader.viewmodels
 
-import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -341,38 +340,36 @@ class ReaderPostListViewModel @Inject constructor(
         loadSubFilters()
     }
 
-    fun onUserChangedUpdate(context: Context?) {
-        context?.let {
-            if (lastKnownUserId == null) {
-                lastKnownUserId = appPrefsWrapper.getLastReaderKnownUserId()
-            }
+    fun onUserComesToReader() {
+        if (lastKnownUserId == null) {
+            lastKnownUserId = appPrefsWrapper.getLastReaderKnownUserId()
+        }
 
-            if (lastTokenAvailableStatus == null) {
-                lastTokenAvailableStatus = appPrefsWrapper.getLastReaderKnownAccessTokenStatus()
-            }
+        if (lastTokenAvailableStatus == null) {
+            lastTokenAvailableStatus = appPrefsWrapper.getLastReaderKnownAccessTokenStatus()
+        }
 
-            val userIdChanged = accountStore.hasAccessToken() && accountStore.account != null &&
-                    accountStore.account.userId != lastKnownUserId
-            val accessTokenStatusChanged = accountStore.hasAccessToken() != lastTokenAvailableStatus
+        val userIdChanged = accountStore.hasAccessToken() && accountStore.account != null &&
+                accountStore.account.userId != lastKnownUserId
+        val accessTokenStatusChanged = accountStore.hasAccessToken() != lastTokenAvailableStatus
 
-            if (userIdChanged) {
-                lastKnownUserId = accountStore.account.userId
-                appPrefsWrapper.setLastReaderKnownUserId(accountStore.account.userId)
-            }
+        if (userIdChanged) {
+            lastKnownUserId = accountStore.account.userId
+            appPrefsWrapper.setLastReaderKnownUserId(accountStore.account.userId)
+        }
 
-            if (accessTokenStatusChanged) {
-                lastTokenAvailableStatus = accountStore.hasAccessToken()
-                appPrefsWrapper.setLastReaderKnownAccessTokenStatus(accountStore.hasAccessToken())
-            }
+        if (accessTokenStatusChanged) {
+            lastTokenAvailableStatus = accountStore.hasAccessToken()
+            appPrefsWrapper.setLastReaderKnownAccessTokenStatus(accountStore.hasAccessToken())
+        }
 
-            if (userIdChanged || accessTokenStatusChanged) {
-                _updateTagsAndSites.value = Event(EnumSet.of(
-                        UpdateTask.TAGS,
-                        UpdateTask.FOLLOWED_BLOGS
-                ))
+        if (userIdChanged || accessTokenStatusChanged) {
+            _updateTagsAndSites.value = Event(EnumSet.of(
+                    UpdateTask.TAGS,
+                    UpdateTask.FOLLOWED_BLOGS
+            ))
 
-                setDefaultSubfilter()
-            }
+            setDefaultSubfilter()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/SubfilterPageViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/SubfilterPageViewModel.kt
@@ -8,9 +8,9 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.reader.ReaderSubsActivity
 import org.wordpress.android.ui.reader.subfilter.ActionType.OpenLoginPage
 import org.wordpress.android.ui.reader.subfilter.ActionType.OpenSubsAtPage
-import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState
-import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState.HiddenEmptyUiState
-import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState.VisibleEmptyUiState
+import org.wordpress.android.ui.reader.subfilter.SubfilterBottomSheetEmptyUiState
+import org.wordpress.android.ui.reader.subfilter.SubfilterBottomSheetEmptyUiState.HiddenEmptyUiState
+import org.wordpress.android.ui.reader.subfilter.SubfilterBottomSheetEmptyUiState.VisibleEmptyUiState
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.SITES
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -19,8 +19,8 @@ import javax.inject.Inject
 class SubfilterPageViewModel @Inject constructor(
     private val accountStore: AccountStore
 ) : ViewModel() {
-    private val _emptyState = MutableLiveData<BottomSheetEmptyUiState>()
-    val emptyState: LiveData<BottomSheetEmptyUiState> = _emptyState
+    private val _emptyState = MutableLiveData<SubfilterBottomSheetEmptyUiState>()
+    val emptyState: LiveData<SubfilterBottomSheetEmptyUiState> = _emptyState
 
     private var isStarted = false
     private lateinit var category: SubfilterCategory

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/SubfilterPageViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/SubfilterPageViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.reader.ReaderSubsActivity
+import org.wordpress.android.ui.reader.subfilter.ActionType.OpenLoginPage
+import org.wordpress.android.ui.reader.subfilter.ActionType.OpenSubsAtPage
 import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState
 import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState.HiddenEmptyUiState
 import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState.VisibleEmptyUiState
@@ -36,24 +38,47 @@ class SubfilterPageViewModel @Inject constructor(
     }
 
     fun onSubFiltersChanged(isEmpty: Boolean) {
-        _emptyState.value = if (isEmpty && accountStore.hasAccessToken()) {
+        _emptyState.value = if (isEmpty) {
             VisibleEmptyUiState(
                     title = UiStringRes(
-                        if (category == SITES)
-                            R.string.reader_filter_empty_sites_list
-                        else
-                            R.string.reader_filter_empty_tags_list
+                        if (category == SITES) {
+                            if (accountStore.hasAccessToken()) {
+                                R.string.reader_filter_empty_sites_list
+                            } else {
+                                R.string.reader_filter_self_hosted_empty_sites_list
+                            }
+                        } else {
+                            if (accountStore.hasAccessToken()) {
+                                R.string.reader_filter_empty_tags_list
+                            } else {
+                                R.string.reader_filter_self_hosted_empty_tagss_list
+                            }
+                        }
                     ),
                     buttonText = UiStringRes(
-                        if (category == SITES)
-                            R.string.reader_filter_empty_sites_action
-                        else
-                            R.string.reader_filter_empty_tags_action
+                        if (category == SITES) {
+                            if (accountStore.hasAccessToken()) {
+                                R.string.reader_filter_empty_sites_action
+                            } else {
+                                R.string.reader_filter_self_hosted_empty_sites_tags_action
+                            }
+                        } else {
+                            if (accountStore.hasAccessToken()) {
+                                R.string.reader_filter_empty_tags_action
+                            } else {
+                                R.string.reader_filter_self_hosted_empty_sites_tags_action
+                            }
+                        }
                     ),
-                    actionTabIndex = if (category == SITES)
-                            ReaderSubsActivity.TAB_IDX_FOLLOWED_BLOGS
-                        else
-                            ReaderSubsActivity.TAB_IDX_FOLLOWED_TAGS
+                    action = if (accountStore.hasAccessToken()) {
+                        if (category == SITES) {
+                            OpenSubsAtPage(ReaderSubsActivity.TAB_IDX_FOLLOWED_BLOGS)
+                        } else {
+                            OpenSubsAtPage(ReaderSubsActivity.TAB_IDX_FOLLOWED_TAGS)
+                        }
+                    } else {
+                        OpenLoginPage
+                    }
             )
         } else {
             HiddenEmptyUiState

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/SubfilterPageViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/SubfilterPageViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.reader.ReaderSubsActivity
 import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState
 import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState.HiddenEmptyUiState
@@ -13,7 +14,9 @@ import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.SITES
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import javax.inject.Inject
 
-class SubfilterPageViewModel @Inject constructor() : ViewModel() {
+class SubfilterPageViewModel @Inject constructor(
+    private val accountStore: AccountStore
+) : ViewModel() {
     private val _emptyState = MutableLiveData<BottomSheetEmptyUiState>()
     val emptyState: LiveData<BottomSheetEmptyUiState> = _emptyState
 
@@ -33,7 +36,7 @@ class SubfilterPageViewModel @Inject constructor() : ViewModel() {
     }
 
     fun onSubFiltersChanged(isEmpty: Boolean) {
-        _emptyState.value = if (isEmpty) {
+        _emptyState.value = if (isEmpty && accountStore.hasAccessToken()) {
             VisibleEmptyUiState(
                     title = UiStringRes(
                         if (category == SITES)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -31,6 +31,9 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
     private val _isBottomSheetShowing = MutableLiveData<Event<Boolean>>()
     val isBottomSheetShowing: LiveData<Event<Boolean>> = _isBottomSheetShowing
 
+    private val _startLoginFlow = MutableLiveData<Event<Boolean>>()
+    val startLoginFlow: LiveData<Event<Boolean>> = _startLoginFlow
+
     fun start(isFabVisible: Boolean) {
         if (isStarted) return
         isStarted = true
@@ -99,6 +102,10 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
 
     fun onFabLongPressed() {
         disableTooltip()
+    }
+
+    fun onOpenLoginPage() {
+        _startLoginFlow.value = Event(true)
     }
 
     private fun setMainFabUiState(isFabVisible: Boolean) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1243,11 +1243,11 @@
     <string name="reader_filter_main_title">Following</string>
     <string name="reader_filter_empty_sites_list">See the newest posts from sites you follow</string>
     <string name="reader_filter_empty_tags_list">You can follow posts on a specific subject by adding a tag</string>
-    <string name="reader_filter_self_hosted_empty_sites_list">Login to WordPress.com to see the newest posts from sites you follow</string>
-    <string name="reader_filter_self_hosted_empty_tagss_list">Login to WordPress.com to see the newest posts from tags you follow</string>
+    <string name="reader_filter_self_hosted_empty_sites_list">Log in to WordPress.com to see the latest posts from sites you follow</string>
+    <string name="reader_filter_self_hosted_empty_tagss_list">Log in to WordPress.com to see the latest posts from tags you follow</string>
     <string name="reader_filter_empty_sites_action">Follow a site</string>
     <string name="reader_filter_empty_tags_action">Add a tag</string>
-    <string name="reader_filter_self_hosted_empty_sites_tags_action">Login to WordPress.com</string>
+    <string name="reader_filter_self_hosted_empty_sites_tags_action">Log in to WordPress.com</string>
 
     <!-- editor -->
     <string name="editor_post_saved_online">Post saved online</string>
@@ -1719,7 +1719,7 @@
     <!-- empty list/grid text -->
     <string name="reader_empty_posts_no_connection" translatable="false">@string/no_network_title</string>
     <string name="reader_empty_posts_request_failed">Unable to retrieve posts</string>
-    <string name="reader_self_hosted_select_filter">Use the filter button to see posts from selected subjects</string>
+    <string name="reader_self_hosted_select_filter">Use the filter button to find posts on specific subjects</string>
     <string name="reader_empty_posts_in_tag">No posts with this tag</string>
     <string name="reader_empty_posts_in_tag_updating">Fetching posts…</string>
     <string name="reader_empty_posts_in_custom_list">The sites in this list haven\'t posted anything recently</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1716,6 +1716,7 @@
     <!-- empty list/grid text -->
     <string name="reader_empty_posts_no_connection" translatable="false">@string/no_network_title</string>
     <string name="reader_empty_posts_request_failed">Unable to retrieve posts</string>
+    <string name="reader_self_hostes_select_filter">Use the filter button to see posts from selected subjects</string>
     <string name="reader_empty_posts_in_tag">No posts with this tag</string>
     <string name="reader_empty_posts_in_tag_updating">Fetching posts…</string>
     <string name="reader_empty_posts_in_custom_list">The sites in this list haven\'t posted anything recently</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1243,8 +1243,11 @@
     <string name="reader_filter_main_title">Following</string>
     <string name="reader_filter_empty_sites_list">See the newest posts from sites you follow</string>
     <string name="reader_filter_empty_tags_list">You can follow posts on a specific subject by adding a tag</string>
+    <string name="reader_filter_self_hosted_empty_sites_list">Login to WordPress.com to see the newest posts from sites you follow</string>
+    <string name="reader_filter_self_hosted_empty_tagss_list">Login to WordPress.com to see the newest posts from tags you follow</string>
     <string name="reader_filter_empty_sites_action">Follow a site</string>
     <string name="reader_filter_empty_tags_action">Add a tag</string>
+    <string name="reader_filter_self_hosted_empty_sites_tags_action">Login to WordPress.com</string>
 
     <!-- editor -->
     <string name="editor_post_saved_online">Post saved online</string>
@@ -1716,7 +1719,7 @@
     <!-- empty list/grid text -->
     <string name="reader_empty_posts_no_connection" translatable="false">@string/no_network_title</string>
     <string name="reader_empty_posts_request_failed">Unable to retrieve posts</string>
-    <string name="reader_self_hostes_select_filter">Use the filter button to see posts from selected subjects</string>
+    <string name="reader_self_hosted_select_filter">Use the filter button to see posts from selected subjects</string>
     <string name="reader_empty_posts_in_tag">No posts with this tag</string>
     <string name="reader_empty_posts_in_tag_updating">Fetching posts…</string>
     <string name="reader_empty_posts_in_custom_list">The sites in this list haven\'t posted anything recently</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/TagUpdateClientUtilsProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/TagUpdateClientUtilsProviderTest.kt
@@ -1,0 +1,34 @@
+package org.wordpress.android.ui.reader
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.reader.services.update.TagUpdateClientUtilsProvider
+
+@RunWith(MockitoJUnitRunner::class)
+class TagUpdateClientUtilsProviderTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    private lateinit var clientProvider: TagUpdateClientUtilsProvider
+
+    @Before
+    fun setUp() {
+        clientProvider = TagUpdateClientUtilsProvider()
+    }
+
+    @Test
+    fun `getRestClientForTagUpdate return the expected client version`() {
+        assertThat(clientProvider.getRestClientForTagUpdate()).isEqualTo(WordPress.getRestClientUtilsV1_2())
+    }
+
+    @Test
+    fun `getTagUpdateEndpointURL return the expected end point URL`() {
+        assertThat(clientProvider.getTagUpdateEndpointURL()).isEqualTo("https://public-api.wordpress.com/rest/v1.2/")
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
@@ -58,9 +58,9 @@ class ReaderUtilsTest {
     @Test
     fun `isFollowing is based on currentTag status if is not top level reader`() {
         whenever(currentTag.isFollowedSites).thenReturn(true)
-        assertThat(ReaderUtils.isFollowing(currentTag, false, null)).isEqualTo(true)
+        assertThat(ReaderUtils.isTagManagedInFollowingTab(currentTag, false, null)).isEqualTo(true)
         whenever(currentTag.isFollowedSites).thenReturn(false)
-        assertThat(ReaderUtils.isFollowing(currentTag, false, null)).isEqualTo(false)
+        assertThat(ReaderUtils.isTagManagedInFollowingTab(currentTag, false, null)).isEqualTo(false)
     }
 
     @Test
@@ -68,12 +68,12 @@ class ReaderUtilsTest {
         whenever(currentTag.isFollowedSites).thenReturn(true)
         whenever(filteredRecyclerView.currentFilter).thenReturn(currentTag)
         whenever(filteredRecyclerView.isValidFilter(currentTag)).thenReturn(true)
-        var result = ReaderUtils.isFollowing(currentTag, true, filteredRecyclerView)
+        var result = ReaderUtils.isTagManagedInFollowingTab(currentTag, true, filteredRecyclerView)
         assertThat(result).isEqualTo(true)
 
         whenever(currentTag.isFollowedSites).thenReturn(false)
         whenever(filteredRecyclerView.currentFilter).thenReturn(currentTag)
-        result = ReaderUtils.isFollowing(currentTag, true, filteredRecyclerView)
+        result = ReaderUtils.isTagManagedInFollowingTab(currentTag, true, filteredRecyclerView)
         assertThat(result).isEqualTo(false)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -93,4 +93,11 @@ class WPMainActivityViewModelTest {
         action.onClickAction?.invoke(CREATE_NEW_PAGE)
         assertThat(viewModel.createAction.value).isEqualTo(CREATE_NEW_PAGE)
     }
+
+    @Test
+    fun `when user taps to open the login page from the bottom sheet empty view cta the correct action is triggered`() {
+        viewModel.onOpenLoginPage()
+
+        assertThat(viewModel.startLoginFlow.value!!.peekContent()).isEqualTo(true)
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -19,6 +19,8 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType.BOOKMARKED
 import org.wordpress.android.models.news.NewsItem
@@ -28,6 +30,9 @@ import org.wordpress.android.ui.news.NewsTracker.NewsCardOrigin.READER
 import org.wordpress.android.ui.news.NewsTrackerHelper
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.ReaderSubsActivity
+import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask
+import org.wordpress.android.ui.reader.subfilter.ActionType.OpenLoginPage
+import org.wordpress.android.ui.reader.subfilter.ActionType.OpenSubsAtPage
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.SITES
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.TAGS
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
@@ -36,6 +41,7 @@ import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItemMapper
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel
 import org.wordpress.android.util.EventBusWrapper
+import java.util.EnumSet
 
 @InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -58,6 +64,7 @@ class ReaderPostListViewModelTest {
     @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock private lateinit var subfilterListItemMapper: SubfilterListItemMapper
     @Mock private lateinit var eventBusWrapper: EventBusWrapper
+    @Mock private lateinit var accountStore: AccountStore
 
     private lateinit var viewModel: ReaderPostListViewModel
     private val liveData = MutableLiveData<NewsItem>()
@@ -82,20 +89,21 @@ class ReaderPostListViewModelTest {
                 TEST_DISPATCHER,
                 appPrefsWrapper,
                 subfilterListItemMapper,
-                eventBusWrapper
+                eventBusWrapper,
+                accountStore
         )
         val observable = viewModel.getNewsDataSource()
         observable.observeForever(observer)
     }
 
     @Test
-    fun verifyPullInvokedInOnStart() {
+    fun `when view model starts pull is invoked`() {
         viewModel.start(initialTag, false, false)
         verify(newsManager).pull(false)
     }
 
     @Test
-    fun verifyViewModelPropagatesNewsItems() {
+    fun `view model propagates news items`() {
         viewModel.start(initialTag, false, false)
         liveData.postValue(item)
         liveData.postValue(null)
@@ -108,13 +116,13 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifyViewModelPropagatesDismissToNewsManager() {
+    fun `view model propagates dismiss to NewsManager`() {
         viewModel.onNewsCardDismissed(item)
         verify(newsManager).dismiss(item)
     }
 
     @Test
-    fun emitNullOnInitialTagChanged() {
+    fun `when view model starts emits null on first onTagChanged`() {
         viewModel.start(otherTag, false, false)
         // propagates the item since the card hasn't been shown yet
         liveData.postValue(item)
@@ -129,7 +137,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifyNewsItemAvailableOnlyForFirstTagForWhichCardWasShown() {
+    fun `news item is available only for first tag for which card was shown`() {
         viewModel.start(otherTag, false, false)
         // propagate the item since the card hasn't been shown yet
         liveData.postValue(item)
@@ -154,13 +162,13 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifyViewModelPropagatesDismissToNewsTracker() {
+    fun `view model propagates dismiss to NewsTracker`() {
         viewModel.onNewsCardDismissed(item)
         verify(newsTracker).trackNewsCardDismissed(argThat { this == READER }, any())
     }
 
     @Test
-    fun verifyViewModelPropagatesCardShownToNewsTracker() {
+    fun `view model propagates CardShown to to NewsTracker`() {
         whenever(newsTrackerHelper.shouldTrackNewsCardShown(any())).thenReturn(true)
         viewModel.onNewsCardShown(item, initialTag)
         verify(newsTracker).trackNewsCardShown(argThat { this == READER }, any())
@@ -168,7 +176,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifyViewModelDoesNotPropagatesCardShownToNewsTracker() {
+    fun `view model does not propagates CardShown to NewsTracker`() {
         whenever(newsTrackerHelper.shouldTrackNewsCardShown(any())).thenReturn(false)
         viewModel.onNewsCardShown(item, initialTag)
         verify(newsTracker, times(0)).trackNewsCardShown(argThat { this == READER }, any())
@@ -176,13 +184,13 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifyViewModelPropagatesExtendedInfoRequestedToNewsTracker() {
+    fun `view model propagates ExtendedInfoRequested to to NewsTracker`() {
         viewModel.onNewsCardExtendedInfoRequested(item)
         verify(newsTracker).trackNewsCardExtendedInfoRequested(argThat { this == READER }, any())
     }
 
     @Test
-    fun verifyChangeSubfiltersVisibility() {
+    fun `view model change subfilter visibility as requested`() {
         viewModel.changeSubfiltersVisibility(true)
         assertThat(viewModel.shouldShowSubFilters.value).isEqualTo(true)
 
@@ -191,7 +199,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun getCurrentSubfilterReturnsDefaultAtStart() {
+    fun `view model returns default filter on start`() {
         if (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
             assertThat(viewModel.getCurrentSubfilterValue()).isInstanceOf(SiteAll::class.java)
         } else {
@@ -200,7 +208,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifySetSubfilterFromTag() {
+    fun `view model is able to set requested subfilter given a tag`() {
         val tag = ReaderTag("", "", "", "", BOOKMARKED)
         var item: SubfilterListItem? = null
         viewModel.setSubfilterFromTag(tag)
@@ -211,7 +219,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifySetDefaultSubfilter() {
+    fun `view model is able to set default subfilter`() {
         var item: SubfilterListItem? = null
         viewModel.setDefaultSubfilter()
 
@@ -221,7 +229,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifyOnSubfilterPageUpdated() {
+    fun `view model updates count of matched sites and tags`() {
         val data = hashMapOf(SITES to 3, TAGS to 25)
         viewModel.start(initialTag, false, false)
 
@@ -233,21 +241,115 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun verifyOnBottomSheetActionClickedEmitsFollowedBlogs() {
-        viewModel.onBottomSheetActionClicked(ReaderSubsActivity.TAB_IDX_FOLLOWED_BLOGS)
+    fun `when WPCOM user selects empty bottom sheet SITES cta the subs is opened on followed blogs page`() {
+        val action = OpenSubsAtPage(ReaderSubsActivity.TAB_IDX_FOLLOWED_BLOGS)
+        viewModel.onBottomSheetActionClicked(action)
 
         assertThat(viewModel.changeBottomSheetVisibility.value!!.peekContent()).isEqualTo(false)
-        assertThat(viewModel.startSubsActivity.value!!.peekContent())
-                .isEqualTo(ReaderSubsActivity.TAB_IDX_FOLLOWED_BLOGS)
+        assertThat(viewModel.execEmptyViewAction.value!!.peekContent())
+                .isEqualTo(action)
     }
 
     @Test
-    fun verifyOnBottomSheetActionClickedEmitsFollowedTags() {
-        viewModel.onBottomSheetActionClicked(ReaderSubsActivity.TAB_IDX_FOLLOWED_TAGS)
+    fun `when WPCOM user selects empty bottom sheet TAGS cta the subs is opened on followed tags page`() {
+        val action = OpenSubsAtPage(ReaderSubsActivity.TAB_IDX_FOLLOWED_TAGS)
+        viewModel.onBottomSheetActionClicked(action)
 
         assertThat(viewModel.changeBottomSheetVisibility.value!!.peekContent()).isEqualTo(false)
-        assertThat(viewModel.startSubsActivity.value!!.peekContent())
-                .isEqualTo(ReaderSubsActivity.TAB_IDX_FOLLOWED_TAGS)
+        assertThat(viewModel.execEmptyViewAction.value!!.peekContent())
+                .isEqualTo(action)
+    }
+
+    @Test
+    fun `when self-hosted user selects empty bottom sheet cta the me page is opened`() {
+        val action = OpenLoginPage
+        viewModel.onBottomSheetActionClicked(action)
+
+        assertThat(viewModel.changeBottomSheetVisibility.value!!.peekContent()).isEqualTo(false)
+        assertThat(viewModel.execEmptyViewAction.value!!.peekContent())
+                .isEqualTo(action)
+    }
+
+    @Test
+    fun `when user id changed a tags and blogs update is triggered and default subfilter is set`() {
+        whenever(appPrefsWrapper.getLastReaderKnownUserId()).thenReturn(0)
+        whenever(appPrefsWrapper.getLastReaderKnownAccessTokenStatus()).thenReturn(true)
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        val account = AccountModel()
+        account.userId = 100
+        whenever(accountStore.account).thenReturn(account)
+
+        viewModel.onUserComesToReader()
+
+        verify(appPrefsWrapper, times(1)).setLastReaderKnownUserId(any())
+        verify(appPrefsWrapper, times(0)).setLastReaderKnownAccessTokenStatus(any())
+
+        assertThat(viewModel.updateTagsAndSites.value!!.peekContent()).isEqualTo(
+                EnumSet.of(
+                        UpdateTask.TAGS,
+                        UpdateTask.FOLLOWED_BLOGS
+                )
+        )
+
+        assertThat(viewModel.currentSubFilter.value).isInstanceOf(SiteAll::class.java)
+    }
+
+    @Test
+    fun `when user switches from wpcom and self-hosted an update is triggered and default subfilter is set`() {
+        whenever(appPrefsWrapper.getLastReaderKnownUserId()).thenReturn(100)
+        whenever(appPrefsWrapper.getLastReaderKnownAccessTokenStatus()).thenReturn(true)
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+
+        viewModel.onUserComesToReader()
+
+        verify(appPrefsWrapper, times(0)).setLastReaderKnownUserId(any())
+        verify(appPrefsWrapper, times(1)).setLastReaderKnownAccessTokenStatus(any())
+
+        assertThat(viewModel.updateTagsAndSites.value!!.peekContent()).isEqualTo(
+                EnumSet.of(
+                        UpdateTask.TAGS,
+                        UpdateTask.FOLLOWED_BLOGS
+                )
+        )
+
+        assertThat(viewModel.currentSubFilter.value).isInstanceOf(SiteAll::class.java)
+    }
+
+    @Test
+    fun `when user id do not change nothing happens`() {
+        whenever(appPrefsWrapper.getLastReaderKnownUserId()).thenReturn(100)
+        whenever(appPrefsWrapper.getLastReaderKnownAccessTokenStatus()).thenReturn(true)
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        val account = AccountModel()
+        account.userId = 100
+        whenever(accountStore.account).thenReturn(account)
+
+        viewModel.onUserComesToReader()
+
+        verify(appPrefsWrapper, times(0)).setLastReaderKnownUserId(any())
+        verify(appPrefsWrapper, times(0)).setLastReaderKnownAccessTokenStatus(any())
+
+        assertThat(viewModel.updateTagsAndSites.value).isEqualTo(null)
+
+        // we didn't call start so noone should have changed the value
+        assertThat(viewModel.currentSubFilter.value).isEqualTo(null)
+    }
+
+    @Test
+    fun `when user remains self-hosted nothing happens`() {
+        whenever(appPrefsWrapper.getLastReaderKnownUserId()).thenReturn(100)
+        whenever(appPrefsWrapper.getLastReaderKnownAccessTokenStatus()).thenReturn(false)
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+
+        viewModel.onUserComesToReader()
+
+        verify(appPrefsWrapper, times(0)).setLastReaderKnownUserId(any())
+        verify(appPrefsWrapper, times(0)).setLastReaderKnownAccessTokenStatus(any())
+
+        assertThat(viewModel.updateTagsAndSites.value).isEqualTo(null)
+
+        // we didn't call start so noone should have changed the value
+        assertThat(viewModel.currentSubFilter.value).isEqualTo(null)
     }
 
     private fun onClickActionDummy(filter: SubfilterListItem) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -246,7 +246,7 @@ class ReaderPostListViewModelTest {
         viewModel.onBottomSheetActionClicked(action)
 
         assertThat(viewModel.changeBottomSheetVisibility.value!!.peekContent()).isEqualTo(false)
-        assertThat(viewModel.execEmptyViewAction.value!!.peekContent())
+        assertThat(viewModel.bottomSheetEmptyViewAction.value!!.peekContent())
                 .isEqualTo(action)
     }
 
@@ -256,7 +256,7 @@ class ReaderPostListViewModelTest {
         viewModel.onBottomSheetActionClicked(action)
 
         assertThat(viewModel.changeBottomSheetVisibility.value!!.peekContent()).isEqualTo(false)
-        assertThat(viewModel.execEmptyViewAction.value!!.peekContent())
+        assertThat(viewModel.bottomSheetEmptyViewAction.value!!.peekContent())
                 .isEqualTo(action)
     }
 
@@ -266,7 +266,7 @@ class ReaderPostListViewModelTest {
         viewModel.onBottomSheetActionClicked(action)
 
         assertThat(viewModel.changeBottomSheetVisibility.value!!.peekContent()).isEqualTo(false)
-        assertThat(viewModel.execEmptyViewAction.value!!.peekContent())
+        assertThat(viewModel.bottomSheetEmptyViewAction.value!!.peekContent())
                 .isEqualTo(action)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -87,6 +87,7 @@ class ReaderPostListViewModelTest {
                 newsTracker,
                 newsTrackerHelper,
                 TEST_DISPATCHER,
+                TEST_DISPATCHER,
                 appPrefsWrapper,
                 subfilterListItemMapper,
                 eventBusWrapper,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/SubfilterPageViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/SubfilterPageViewModelTest.kt
@@ -10,13 +10,14 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.reader.ReaderSubsActivity
 import org.wordpress.android.ui.reader.subfilter.ActionType.OpenLoginPage
 import org.wordpress.android.ui.reader.subfilter.ActionType.OpenSubsAtPage
-import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState
-import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState.HiddenEmptyUiState
-import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState.VisibleEmptyUiState
+import org.wordpress.android.ui.reader.subfilter.SubfilterBottomSheetEmptyUiState
+import org.wordpress.android.ui.reader.subfilter.SubfilterBottomSheetEmptyUiState.HiddenEmptyUiState
+import org.wordpress.android.ui.reader.subfilter.SubfilterBottomSheetEmptyUiState.VisibleEmptyUiState
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.SITES
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.TAGS
@@ -90,21 +91,21 @@ class SubfilterPageViewModelTest {
         fun getExpectedForCategory(
             accountStore: AccountStore,
             category: SubfilterCategory
-        ): BottomSheetEmptyUiState {
+        ): SubfilterBottomSheetEmptyUiState {
             return when (category) {
                 SITES -> {
                     VisibleEmptyUiState(
                             title = UiStringRes(
                                     if (accountStore.hasAccessToken())
-                                        R.string.reader_filter_empty_sites_list
+                                        string.reader_filter_empty_sites_list
                                     else
-                                        R.string.reader_filter_self_hosted_empty_sites_list
+                                        string.reader_filter_self_hosted_empty_sites_list
                             ),
                             buttonText = UiStringRes(
                                     if (accountStore.hasAccessToken())
-                                        R.string.reader_filter_empty_sites_action
+                                        string.reader_filter_empty_sites_action
                                     else
-                                        R.string.reader_filter_self_hosted_empty_sites_tags_action
+                                        string.reader_filter_self_hosted_empty_sites_tags_action
                             ),
                             action = if (accountStore.hasAccessToken())
                                 OpenSubsAtPage(ReaderSubsActivity.TAB_IDX_FOLLOWED_BLOGS)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/SubfilterPageViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/SubfilterPageViewModelTest.kt
@@ -1,14 +1,19 @@
 package org.wordpress.android.viewmodel.reader
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.reader.ReaderSubsActivity
+import org.wordpress.android.ui.reader.subfilter.ActionType.OpenLoginPage
+import org.wordpress.android.ui.reader.subfilter.ActionType.OpenSubsAtPage
 import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState
 import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState.HiddenEmptyUiState
 import org.wordpress.android.ui.reader.subfilter.BottomSheetEmptyUiState.VisibleEmptyUiState
@@ -23,11 +28,13 @@ class SubfilterPageViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 
+    @Mock private lateinit var accountStore: AccountStore
+
     private lateinit var viewModel: SubfilterPageViewModel
 
     @Before
     fun setUp() {
-        viewModel = SubfilterPageViewModel()
+        viewModel = SubfilterPageViewModel(accountStore)
     }
 
     @Test
@@ -40,46 +47,89 @@ class SubfilterPageViewModelTest {
     }
 
     @Test
-    fun `onSubFiltersChanged shows empty view for sites when requested`() {
+    fun `onSubFiltersChanged shows empty view for WPCOM sites when requested`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
         viewModel.start(SITES)
 
         viewModel.onSubFiltersChanged(true)
 
-        assertThat(viewModel.emptyState.value).isEqualTo(getExpectedForCategory(SITES))
+        assertThat(viewModel.emptyState.value).isEqualTo(getExpectedForCategory(accountStore, SITES))
     }
 
     @Test
-    fun `onSubFiltersChanged shows empty view for tags when requested`() {
+    fun `onSubFiltersChanged shows empty view for WPCOM tags when requested`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
         viewModel.start(TAGS)
 
         viewModel.onSubFiltersChanged(true)
 
-        assertThat(viewModel.emptyState.value).isEqualTo(getExpectedForCategory(TAGS))
+        assertThat(viewModel.emptyState.value).isEqualTo(getExpectedForCategory(accountStore, TAGS))
+    }
+
+    @Test
+    fun `onSubFiltersChanged shows empty view for self-hosted sites when requested`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        viewModel.start(SITES)
+
+        viewModel.onSubFiltersChanged(true)
+
+        assertThat(viewModel.emptyState.value).isEqualTo(getExpectedForCategory(accountStore, SITES))
+    }
+
+    @Test
+    fun `onSubFiltersChanged shows empty view for self-hosted tags when requested`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        viewModel.start(TAGS)
+
+        viewModel.onSubFiltersChanged(true)
+
+        assertThat(viewModel.emptyState.value).isEqualTo(getExpectedForCategory(accountStore, TAGS))
     }
 
     private companion object Fixtures {
-        fun getExpectedForCategory(category: SubfilterCategory): BottomSheetEmptyUiState {
+        fun getExpectedForCategory(
+            accountStore: AccountStore,
+            category: SubfilterCategory
+        ): BottomSheetEmptyUiState {
             return when (category) {
                 SITES -> {
                     VisibleEmptyUiState(
                             title = UiStringRes(
+                                    if (accountStore.hasAccessToken())
                                         R.string.reader_filter_empty_sites_list
+                                    else
+                                        R.string.reader_filter_self_hosted_empty_sites_list
                             ),
                             buttonText = UiStringRes(
+                                    if (accountStore.hasAccessToken())
                                         R.string.reader_filter_empty_sites_action
+                                    else
+                                        R.string.reader_filter_self_hosted_empty_sites_tags_action
                             ),
-                            actionTabIndex = ReaderSubsActivity.TAB_IDX_FOLLOWED_BLOGS
+                            action = if (accountStore.hasAccessToken())
+                                OpenSubsAtPage(ReaderSubsActivity.TAB_IDX_FOLLOWED_BLOGS)
+                            else
+                                OpenLoginPage
                     )
                 }
                 TAGS -> {
                     VisibleEmptyUiState(
                             title = UiStringRes(
+                                    if (accountStore.hasAccessToken())
                                         R.string.reader_filter_empty_tags_list
+                                    else
+                                        R.string.reader_filter_self_hosted_empty_tagss_list
                             ),
                             buttonText = UiStringRes(
+                                    if (accountStore.hasAccessToken())
                                         R.string.reader_filter_empty_tags_action
+                                    else
+                                        R.string.reader_filter_self_hosted_empty_sites_tags_action
                             ),
-                            actionTabIndex = ReaderSubsActivity.TAB_IDX_FOLLOWED_TAGS
+                            action = if (accountStore.hasAccessToken())
+                                OpenSubsAtPage(ReaderSubsActivity.TAB_IDX_FOLLOWED_TAGS)
+                            else
+                                OpenLoginPage
                     )
                 }
             }


### PR DESCRIPTION
Replaces and supersedes #10986 (point 1 was fixed in #11206)

This PR introduces enhancements to the new IA reader for users that have self-hosted sites only or they do have also WP.com account but currently logged off from it. (cc @osullivanchris )

**Note for the reviewer:** the PR dimension/scope should be still good enough I hope, but if you feel it's too large/wide let me know and will try to split in some way 🙇‍♂️.

What we introduced:

- When a user is logged out from WP.com and has at least a self-hosted site in the app, the reader is as follows:

| Id | Description | Image |
|---|---|:-:|
| Fig1 | On fresh install the Discover page is presented first (both wp.com and self-hosted) | ![image](https://user-images.githubusercontent.com/47797566/74345211-07478f80-4dae-11ea-9c73-716e03840243.png) |
| Fig2 | 3 tabs and `Filter` subfiltering + Empty view with dedicated message + no access to settings cog (nor search icon but this was not introduced in this PR) | ![image](https://user-images.githubusercontent.com/47797566/74343424-54763200-4dab-11ea-960f-0b02bfffe1af.png) |
| Fig3 | Empty SITES in bottomsheet with CTA to login; if tapped on CTA, user is landed to Me page to login | ![image](https://user-images.githubusercontent.com/47797566/74343656-b20a7e80-4dab-11ea-829e-f8a8ef73e1cb.png) |

## Notes
1. On user id switches or when the user passes from having access token (wp.com user) to not having it (pure self-hosted) and viceversa, we trigger a Blogs/Tags auto refresh when the user comes to the reader
2. As a follow up to #11206 we implemented an in memory default tag used as a sort of `null object` in cases where the tag table could be empty (see `getDbOrInMemoryDefaultTag ` function)
3. We added a `TagUpdateClientUtilsProvider` class to create a single point where to get the client for tags update

## To test
### Test case 1
- Make a fresh install and login with WP.com (no self-hosted)
- Go to Reader and check you are landed in the Discover page
- Go to `FOLLOWING` tab
- Logout from WP.com and add a self-hosted site
- Go to Reader and check you are landed in the Discover page as well (Fig1)
- Go to `Following` and check you get something similar to Fig2

### Test case 2
- Verify you are logged out from WP.com account and you have added a pure self-hosted site
- In `FOLLOWING` open bottom sheet and check you get something similar to Fig3
- Press the Login CTA and check you are landed into `Me` page
- Login into WP.com and come back to Reader
- Check you have now your followed SITES and TAGS similar to below image

<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/74348879-ade25f00-4db3-11ea-88c9-134b84aadb41.png">
</p>

### Test case 3
Smoke test the reader both with wp.com and self-hosted sites (below some of the possible steps for smoke testing but feel free to add 😊):
- Move between tabs
- Use the subfilter to select different sources (Sites/Tags) to navigate
- Open posts from the reader
- Save posts for later and open them from the `SAVED` tab (both WP.com and self-hosted)
- Follow/Unfollow tags/sites from the Reader (only for WP.com)
- Follow/Unfollow tags/sites from the Setting (only for WP.com)
- Whatever else you can think of 😊...

### Test case 4
See comment [here](https://github.com/wordpress-mobile/WordPress-Android/pull/11270#issuecomment-587904945)

**NOTE**: for the modifications 2 and 3 reported in the NOTES above, a part the smoke test I retested the steps reported in #11206 (good if you could also retry those steps, thanks).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
