### PR TITLE
Issue/11128 page label colors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.pages
 
+import androidx.annotation.ColorRes
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import org.wordpress.android.R
@@ -22,6 +23,7 @@ sealed class PageItem(open val type: Type) {
         open val title: String,
         open val date: Date,
         open val labels: List<UiString>,
+        @ColorRes open val labelsColor: Int?,
         open var indent: Int,
         open var imageUrl: String?,
         open val actions: Set<Action>,
@@ -36,6 +38,7 @@ sealed class PageItem(open val type: Type) {
         override val title: String,
         override val date: Date,
         override val labels: List<UiString> = emptyList(),
+        override val labelsColor: Int? = null,
         override var indent: Int = 0,
         override var imageUrl: String? = null,
         override var actionsEnabled: Boolean = true,
@@ -46,6 +49,7 @@ sealed class PageItem(open val type: Type) {
             title = title,
             date = date,
             labels = labels,
+            labelsColor = labelsColor,
             indent = indent,
             imageUrl = imageUrl,
             actions = setOf(VIEW_PAGE, SET_PARENT, MOVE_TO_DRAFT, MOVE_TO_TRASH),
@@ -60,6 +64,7 @@ sealed class PageItem(open val type: Type) {
         override val title: String,
         override val date: Date,
         override val labels: List<UiString> = emptyList(),
+        override val labelsColor: Int? = null,
         override var imageUrl: String? = null,
         override var actionsEnabled: Boolean = true,
         override val progressBarUiState: ProgressBarUiState,
@@ -69,6 +74,7 @@ sealed class PageItem(open val type: Type) {
             title = title,
             date = date,
             labels = labels,
+            labelsColor = labelsColor,
             indent = 0,
             imageUrl = imageUrl,
             actions = setOf(VIEW_PAGE, SET_PARENT, PUBLISH_NOW, MOVE_TO_TRASH),
@@ -83,6 +89,7 @@ sealed class PageItem(open val type: Type) {
         override val title: String,
         override val date: Date,
         override val labels: List<UiString> = emptyList(),
+        override val labelsColor: Int? = null,
         override var imageUrl: String? = null,
         override var actionsEnabled: Boolean = true,
         override val progressBarUiState: ProgressBarUiState,
@@ -92,6 +99,7 @@ sealed class PageItem(open val type: Type) {
             title = title,
             date = date,
             labels = labels,
+            labelsColor = labelsColor,
             indent = 0,
             imageUrl = imageUrl,
             actions = setOf(VIEW_PAGE, SET_PARENT, MOVE_TO_DRAFT, MOVE_TO_TRASH),
@@ -105,6 +113,8 @@ sealed class PageItem(open val type: Type) {
         override val id: Long,
         override val title: String,
         override val date: Date,
+        override val labels: List<UiString> = emptyList(),
+        override val labelsColor: Int? = null,
         override var imageUrl: String? = null,
         override var actionsEnabled: Boolean = true,
         override val progressBarUiState: ProgressBarUiState,
@@ -113,7 +123,8 @@ sealed class PageItem(open val type: Type) {
             id = id,
             title = title,
             date = date,
-            labels = emptyList(),
+            labels = labels,
+            labelsColor = labelsColor,
             indent = 0,
             imageUrl = imageUrl,
             actions = setOf(MOVE_TO_DRAFT, DELETE_PERMANENTLY),

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -13,6 +13,7 @@ import android.widget.ProgressBar
 import android.widget.RadioButton
 import android.widget.TextView
 import androidx.annotation.LayoutRes
+import androidx.core.content.ContextCompat
 import androidx.core.widget.CompoundButtonCompat
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
@@ -84,6 +85,14 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
 
                 labels.text = page.labels.map { uiHelper.getTextOfUiString(parent.context, it) }.sorted()
                         .joinToString(separator = " · ")
+                page.labelsColor?.let { labelsColor ->
+                    labels.setTextColor(
+                            ContextCompat.getColor(
+                                    itemView.context,
+                                    labelsColor
+                            )
+                    )
+                }
                 uiHelper.updateVisibility(labels, page.labels.isNotEmpty())
 
                 itemView.setOnClickListener { onItemTapped(page) }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCase.kt
@@ -24,12 +24,16 @@ import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.Post
 import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingPost
 import javax.inject.Inject
 
+typealias LabelColor = Int?
 /**
  * Most of this code has been copied from PostListItemUIStateHelper.
  */
-class CreatePageListItemLabelsUseCase @Inject constructor(private val pageConflictResolver: PageConflictResolver) {
-    fun createLabels(pagePostModel: PostModel, uploadUiState: PostUploadUiState): List<UiString> {
-        return getLabels(
+class CreatePageListItemLabelsUseCase @Inject constructor(
+    private val pageConflictResolver: PageConflictResolver,
+    private val labelColorUseCase: ResolvePageListItemsColorUseCase
+) {
+    fun createLabels(pagePostModel: PostModel, uploadUiState: PostUploadUiState): Pair<List<UiString>, LabelColor> {
+        val labels = getLabels(
                 PostStatus.fromPost(pagePostModel),
                 pagePostModel.isLocalDraft,
                 pagePostModel.isLocallyChanged,
@@ -37,6 +41,8 @@ class CreatePageListItemLabelsUseCase @Inject constructor(private val pageConfli
                 false, // TODO use conflict resolver
                 pageConflictResolver.hasUnhandledAutoSave(pagePostModel)
         )
+        val labelColor = labelColorUseCase.getLabelsColor(pagePostModel, uploadUiState)
+        return Pair(labels, labelColor)
     }
 
     private fun getLabels(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.viewmodel.pages
 
+import androidx.annotation.ColorRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
@@ -252,7 +253,8 @@ class PageListViewModel @Inject constructor(
                     val itemUiStateData = createItemUiStateData(it)
 
                     PublishedPage(
-                            it.remoteId, it.title, it.date, itemUiStateData.labels, pageItemIndent,
+                            it.remoteId, it.title, it.date, itemUiStateData.labels, itemUiStateData.labelsColor,
+                            pageItemIndent,
                             getFeaturedImageUrl(it.featuredImageId),
                             actionsEnabled,
                             itemUiStateData.progressBarUiState,
@@ -273,6 +275,7 @@ class PageListViewModel @Inject constructor(
 
                                 ScheduledPage(
                                         it.remoteId, it.title, it.date, itemUiStateData.labels,
+                                        itemUiStateData.labelsColor,
                                         getFeaturedImageUrl(it.featuredImageId),
                                         actionsEnabled,
                                         itemUiStateData.progressBarUiState,
@@ -294,6 +297,7 @@ class PageListViewModel @Inject constructor(
                     it.title,
                     it.date,
                     itemUiStateData.labels,
+                    itemUiStateData.labelsColor,
                     getFeaturedImageUrl(it.featuredImageId),
                     actionsEnabled,
                     itemUiStateData.progressBarUiState,
@@ -312,6 +316,8 @@ class PageListViewModel @Inject constructor(
                     it.remoteId,
                     it.title,
                     it.date,
+                    itemUiStateData.labels,
+                    itemUiStateData.labelsColor,
                     getFeaturedImageUrl(it.featuredImageId),
                     actionsEnabled,
                     itemUiStateData.progressBarUiState,
@@ -364,17 +370,18 @@ class PageListViewModel @Inject constructor(
                 postModel,
                 pagesViewModel.site
         )
-        val labels = createPageListItemLabelsUseCase.createLabels(postModel, uploadUiState)
+        val (labels, labelColor) = createPageListItemLabelsUseCase.createLabels(postModel, uploadUiState)
 
         val (progressBarUiState, showOverlay) = progressHelper.getProgressStateForPage(
                 postModel,
                 uploadUiState
         )
-        return ItemUiStateData(labels, progressBarUiState, showOverlay)
+        return ItemUiStateData(labels, labelColor, progressBarUiState, showOverlay)
     }
 
     private data class ItemUiStateData(
         val labels: List<UiString>,
+        @ColorRes val labelsColor: Int?,
         val progressBarUiState: ProgressBarUiState,
         val showOverlay: Boolean
     )

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/ResolvePageListItemsColorUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/ResolvePageListItemsColorUseCase.kt
@@ -1,0 +1,63 @@
+package org.wordpress.android.viewmodel.pages
+
+import androidx.annotation.ColorRes
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.model.post.PostStatus.PENDING
+import org.wordpress.android.fluxc.model.post.PostStatus.PRIVATE
+import org.wordpress.android.fluxc.model.post.PostStatus.fromPost
+import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState
+import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadFailed
+import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadQueued
+import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
+import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingMedia
+import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingPost
+import javax.inject.Inject
+
+const val ERROR_COLOR = R.color.error
+const val PROGRESS_INFO_COLOR = R.color.neutral_50
+const val STATE_INFO_COLOR = R.color.warning_dark
+
+class ResolvePageListItemsColorUseCase @Inject constructor(
+    private val pageConflictResolver: PageConflictResolver
+) {
+    @ColorRes fun getLabelsColor(post: PostModel, uploadUiState: PostUploadUiState): Int? {
+        return getLabelColor(
+                fromPost(post),
+                post.isLocalDraft,
+                post.isLocallyChanged,
+                uploadUiState,
+                false, // TODO use conflict resolver
+                pageConflictResolver.hasUnhandledAutoSave(post)
+        )
+    }
+
+    /**
+     * Copied from PostListItemUiStateHelper since the behavior is similar for the Page List UI State.
+     */
+    @ColorRes private fun getLabelColor(
+        postStatus: PostStatus,
+        isLocalDraft: Boolean,
+        isLocallyChanged: Boolean,
+        uploadUiState: PostUploadUiState,
+        hasUnhandledConflicts: Boolean,
+        hasAutoSave: Boolean
+    ): Int? {
+        // TODO consider removing this logic and explicitly list which labels have which color
+        val isError = (uploadUiState is UploadFailed && !uploadUiState.isEligibleForAutoUpload) ||
+                hasUnhandledConflicts
+        val isProgressInfo = uploadUiState is UploadingPost || uploadUiState is UploadingMedia ||
+                uploadUiState is UploadQueued
+        val isStateInfo = (uploadUiState is UploadFailed && uploadUiState.isEligibleForAutoUpload) ||
+                isLocalDraft || isLocallyChanged || postStatus == PRIVATE || postStatus == PENDING ||
+                uploadUiState is UploadWaitingForConnection || hasAutoSave
+
+        return when {
+            isError -> ERROR_COLOR
+            isProgressInfo -> PROGRESS_INFO_COLOR
+            isStateInfo -> STATE_INFO_COLOR
+            else -> null
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -308,6 +308,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         hasUnhandledConflicts: Boolean,
         hasAutoSave: Boolean
     ): Int? {
+        // TODO consider removing this logic and explicitly list which labels have which color
         val isError = (uploadUiState is UploadFailed && !uploadUiState.isEligibleForAutoUpload) ||
                 hasUnhandledConflicts
         val isProgressInfo = uploadUiState is UploadingPost || uploadUiState is UploadingMedia ||

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -74,6 +74,7 @@ class PageListViewModelTest : BaseUnitTest() {
         whenever(createUploadStateUseCase.createUploadUiState(any(), any())).thenReturn(
                 PostUploadUiState.NothingToUpload
         )
+        whenever(createLabelsUseCase.createLabels(any(), any())).thenReturn(Pair(emptyList(), 0))
         site.id = 10
         pageListState.value = PageListState.DONE
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
@@ -144,6 +144,7 @@ class SearchListViewModelTest {
                 Date(),
                 listOf(),
                 0,
+                0,
                 null,
                 false,
                 ProgressBarUiState.Hidden,
@@ -159,7 +160,7 @@ class SearchListViewModelTest {
     @Test
     fun `passes page to page view model on item tapped`() {
         val clickedPage = PageItem.PublishedPage(
-                1, "title", Date(), listOf(), 0, null, false, ProgressBarUiState.Hidden,
+                1, "title", Date(), listOf(), 0, 0, null, false, ProgressBarUiState.Hidden,
                 false
         )
 


### PR DESCRIPTION
Fixes #11128 

Review instructions:
1. Review this PR
2. Wait until https://github.com/wordpress-mobile/WordPress-Android/pull/11278 gets merged
3. Update the target branch with feature/master-pages-offline-support
4. Remove the "Not ready for merge" label
5. Merge this PR

Adds colors to page list items. The business logic was copy-pasted from PostListItemUiStateHelper.

I decided not to add any unit tests at the moment. The main reason is that I'm still considering rewriting this logic in both post-page list from scratch since it feels a bit weird that we evaluate the state of the PostModel twice -> labels + label colors.


To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
