### PR TITLE
Add unit tests for PageListItemLabelsUseCase

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
@@ -9,6 +9,8 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.PostStore.PostError
 import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction
 import org.wordpress.android.util.SnackbarSequencer
 import javax.inject.Inject
@@ -99,4 +101,16 @@ class UploadUtilsWrapper @Inject constructor(
         buttonTitleRes: Int,
         onClickListener: OnClickListener?
     ) = UploadUtils.showSnackbarSuccessActionOrange(view, messageRes, buttonTitleRes, onClickListener, sequencer)
+
+    fun getErrorMessageResIdFromPostError(
+        postStatus: PostStatus,
+        isPage: Boolean,
+        postError: PostError,
+        isEligibleForAutoUpload: Boolean
+    ) = UploadUtils.getErrorMessageResIdFromPostError(
+            postStatus,
+            isPage,
+            postError,
+            isEligibleForAutoUpload
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCase.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.fluxc.model.post.PostStatus.PUBLISHED
 import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
 import org.wordpress.android.fluxc.model.post.PostStatus.TRASHED
 import org.wordpress.android.fluxc.model.post.PostStatus.UNKNOWN
-import org.wordpress.android.ui.uploads.UploadUtils
+import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
@@ -30,7 +30,8 @@ typealias LabelColor = Int?
  */
 class CreatePageListItemLabelsUseCase @Inject constructor(
     private val pageConflictResolver: PageConflictResolver,
-    private val labelColorUseCase: ResolvePageListItemsColorUseCase
+    private val labelColorUseCase: ResolvePageListItemsColorUseCase,
+    private val uploadUtilsWrapper: UploadUtilsWrapper
 ) {
     fun createLabels(postModel: PostModel, uploadUiState: PostUploadUiState): Pair<List<UiString>, LabelColor> {
         val labels = getLabels(
@@ -106,7 +107,7 @@ class CreatePageListItemLabelsUseCase @Inject constructor(
                     uploadUiState,
                     postStatus
             )
-            uploadUiState.error.postError != null -> UploadUtils.getErrorMessageResIdFromPostError(
+            uploadUiState.error.postError != null -> uploadUtilsWrapper.getErrorMessageResIdFromPostError(
                     postStatus,
                     true,
                     uploadUiState.error.postError,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCaseTest.kt
@@ -50,7 +50,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `pending review label shown for posts pending review`() {
+    fun `pending review label shown for pages pending review`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply { setStatus(PENDING.toString()) },
                 mock()
@@ -60,26 +60,26 @@ class CreatePageListItemLabelsUseCaseTest {
 
     //
     @Test
-    fun `local draft label shown for local posts`() {
+    fun `local draft label shown for local pages`() {
         val (labels, _) = useCase.createLabels(PostModel().apply { setIsLocalDraft(true) }, mock())
         assertThat(labels).contains(UiStringRes(R.string.page_local_draft))
     }
 
     @Test
-    fun `locally changed label shown for locally changed posts`() {
+    fun `locally changed label shown for locally changed pages`() {
         val (labels, _) = useCase.createLabels(PostModel().apply { setIsLocallyChanged(true) }, mock())
         assertThat(labels).contains(UiStringRes(R.string.page_local_changes))
     }
 
     @Test
-    fun `unhandled auto-save label shown for posts with existing auto-save`() {
+    fun `unhandled auto-save label shown for pages with existing auto-save`() {
         whenever(pageConflictResolver.hasUnhandledAutoSave(anyOrNull())).thenReturn(true)
         val (labels, _) = useCase.createLabels(PostModel(), mock())
         assertThat(labels).contains(UiStringRes(R.string.local_page_autosave_revision_available))
     }
 
     @Test
-    fun `uploading post label shown when the post is being uploaded`() {
+    fun `uploading page label shown when the page is being uploaded`() {
         val (labels, _) = useCase.createLabels(PostModel(), PostUploadUiState.UploadingPost(false))
         assertThat(labels).contains(UiStringRes(R.string.page_uploading))
     }
@@ -91,13 +91,13 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `uploading media label shown when the post's media is being uploaded`() {
+    fun `uploading media label shown when the page's media is being uploaded`() {
         val (labels, _) = useCase.createLabels(PostModel(), PostUploadUiState.UploadingMedia(0))
         assertThat(labels).contains(UiStringRes(R.string.uploading_media))
     }
 
     @Test
-    fun `queued post label shown when the post was enqueued for upload`() {
+    fun `queued page label shown when the page was enqueued for upload`() {
         val (labels, _) = useCase.createLabels(PostModel(), PostUploadUiState.UploadQueued)
         assertThat(labels).contains(UiStringRes(R.string.page_queued))
     }
@@ -143,7 +143,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `media upload error shown with specific message for pending post eligible for auto-upload`() {
+    fun `media upload error shown with specific message for pending page eligible for auto-upload`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply {
                     setIsLocallyChanged(true)
@@ -159,7 +159,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `media upload error shown with specific message for pending post not eligible for auto-upload`() {
+    fun `media upload error shown with specific message for pending page not eligible for auto-upload`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply {
                     setIsLocallyChanged(true)
@@ -175,7 +175,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `media upload error shown with specific message for scheduled post eligible for auto-upload`() {
+    fun `media upload error shown with specific message for scheduled page eligible for auto-upload`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply {
                     setIsLocallyChanged(true)
@@ -192,7 +192,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `media upload error shown with specific message for scheduled post not eligible for auto-upload`() {
+    fun `media upload error shown with specific message for scheduled page not eligible for auto-upload`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply {
                     setIsLocallyChanged(true)
@@ -287,7 +287,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `pending publish post label shown when post eligible for auto-upload`() {
+    fun `pending publish page label shown when page eligible for auto-upload`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply {
                     setIsLocallyChanged(true)
@@ -300,7 +300,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `pending schedule label shown when post eligible for auto-upload`() {
+    fun `pending schedule label shown when page eligible for auto-upload`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply {
                     setIsLocallyChanged(true)
@@ -313,7 +313,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `pending publish private post label shown when post eligible for auto-upload`() {
+    fun `pending publish private page label shown when page eligible for auto-upload`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply {
                     setIsLocallyChanged(true)
@@ -326,7 +326,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `pending submit post label shown when post eligible for auto-upload`() {
+    fun `pending submit page label shown when page eligible for auto-upload`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply {
                     setIsLocallyChanged(true)
@@ -339,7 +339,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `local changes post label shown when draft eligible for auto-upload`() {
+    fun `local changes page label shown when draft eligible for auto-upload`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply {
                     setIsLocallyChanged(true)
@@ -351,7 +351,7 @@ class CreatePageListItemLabelsUseCaseTest {
     }
 
     @Test
-    fun `when a post is locally changed and is local draft only "Local draft" label is displayed`() {
+    fun `when a page is locally changed and is local draft only "Local draft" label is displayed`() {
         val (labels, _) = useCase.createLabels(
                 PostModel().apply {
                     setIsLocallyChanged(true)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCaseTest.kt
@@ -1,0 +1,365 @@
+package org.wordpress.android.viewmodel.pages
+
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.page.PageStatus.DRAFT
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.model.post.PostStatus.PENDING
+import org.wordpress.android.fluxc.model.post.PostStatus.PRIVATE
+import org.wordpress.android.fluxc.model.post.PostStatus.PUBLISHED
+import org.wordpress.android.fluxc.model.post.PostStatus.SCHEDULED
+import org.wordpress.android.fluxc.store.MediaStore.MediaError
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.AUTHORIZATION_REQUIRED
+import org.wordpress.android.fluxc.store.PostStore.PostError
+import org.wordpress.android.fluxc.store.PostStore.PostErrorType
+import org.wordpress.android.fluxc.store.PostStore.PostErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.UploadStore.UploadError
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState
+
+@RunWith(MockitoJUnitRunner::class)
+class CreatePageListItemLabelsUseCaseTest {
+    @Mock private lateinit var pageConflictResolver: PageConflictResolver
+    @Mock private lateinit var labelColorUseCase: ResolvePageListItemsColorUseCase
+    private lateinit var useCase: CreatePageListItemLabelsUseCase
+
+    @Before
+    fun setUp() {
+        useCase = CreatePageListItemLabelsUseCase(
+                pageConflictResolver,
+                labelColorUseCase
+        )
+    }
+
+    @Test
+    fun `private label shown for private pages`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply { setStatus(PRIVATE.toString()) },
+                mock()
+        )
+        assertThat(labels).contains(UiStringRes(R.string.page_status_page_private))
+    }
+
+    @Test
+    fun `pending review label shown for posts pending review`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply { setStatus(PENDING.toString()) },
+                mock()
+        )
+        assertThat(labels).contains(UiStringRes(R.string.page_status_pending_review))
+    }
+
+    //
+    @Test
+    fun `local draft label shown for local posts`() {
+        val (labels, _) = useCase.createLabels(PostModel().apply { setIsLocalDraft(true) }, mock())
+        assertThat(labels).contains(UiStringRes(R.string.page_local_draft))
+    }
+
+    @Test
+    fun `locally changed label shown for locally changed posts`() {
+        val (labels, _) = useCase.createLabels(PostModel().apply { setIsLocallyChanged(true) }, mock())
+        assertThat(labels).contains(UiStringRes(R.string.page_local_changes))
+    }
+
+    @Test
+    fun `unhandled auto-save label shown for posts with existing auto-save`() {
+        whenever(pageConflictResolver.hasUnhandledAutoSave(anyOrNull())).thenReturn(true)
+        val (labels, _) = useCase.createLabels(PostModel(), mock())
+        assertThat(labels).contains(UiStringRes(R.string.local_page_autosave_revision_available))
+    }
+
+    @Test
+    fun `uploading post label shown when the post is being uploaded`() {
+        val (labels, _) = useCase.createLabels(PostModel(), PostUploadUiState.UploadingPost(false))
+        assertThat(labels).contains(UiStringRes(R.string.page_uploading))
+    }
+
+    @Test
+    fun `uploading draft label shown when the draft is being uploaded`() {
+        val (labels, _) = useCase.createLabels(PostModel(), PostUploadUiState.UploadingPost(true))
+        assertThat(labels).contains(UiStringRes(R.string.page_uploading_draft))
+    }
+
+    @Test
+    fun `uploading media label shown when the post's media is being uploaded`() {
+        val (labels, _) = useCase.createLabels(PostModel(), PostUploadUiState.UploadingMedia(0))
+        assertThat(labels).contains(UiStringRes(R.string.uploading_media))
+    }
+
+    @Test
+    fun `queued post label shown when the post was enqueued for upload`() {
+        val (labels, _) = useCase.createLabels(PostModel(), PostUploadUiState.UploadQueued)
+        assertThat(labels).contains(UiStringRes(R.string.page_queued))
+    }
+
+    @Test
+    fun `error uploading media label shown when the media upload fails`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel(),
+                PostUploadUiState.UploadFailed(
+                        error = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = false,
+                        retryWillPushChanges = false
+                )
+        )
+        assertThat(labels).contains(UiStringRes(R.string.error_media_recover_page))
+    }
+
+    @Test
+    fun `generic error message shown when upload fails from unknown reason`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel(),
+                PostUploadUiState.UploadFailed(
+                        error = UploadError(PostError(PostErrorType.GENERIC_ERROR, "testing error message")),
+                        isEligibleForAutoUpload = false,
+                        retryWillPushChanges = false
+                )
+        )
+        assertThat(labels).contains(UiStringRes(R.string.error_generic_error))
+    }
+
+    @Test
+    fun `given a mix of info and error statuses, only the error status is shown`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply { setIsLocallyChanged(true) },
+                PostUploadUiState.UploadFailed(
+                        error = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = false,
+                        retryWillPushChanges = false
+                )
+        )
+        assertThat(labels)
+                .containsOnly(UiStringRes(R.string.error_media_recover_page))
+    }
+
+    @Test
+    fun `media upload error shown with specific message for pending post eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(PENDING.toString())
+                },
+                PostUploadUiState.UploadFailed(
+                        error = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = true,
+                        retryWillPushChanges = true
+                )
+        )
+        assertThat(labels).containsOnly(UiStringRes(R.string.error_media_recover_page_not_submitted_retrying))
+    }
+
+    @Test
+    fun `media upload error shown with specific message for pending post not eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(PENDING.toString())
+                },
+                PostUploadUiState.UploadFailed(
+                        error = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = false,
+                        retryWillPushChanges = true
+                )
+        )
+        assertThat(labels).containsOnly(UiStringRes(R.string.error_media_recover_page_not_submitted))
+    }
+
+    @Test
+    fun `media upload error shown with specific message for scheduled post eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(SCHEDULED.toString())
+                },
+                PostUploadUiState.UploadFailed(
+                        error = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = true,
+                        retryWillPushChanges = true
+                )
+        )
+        assertThat(labels)
+                .containsOnly(UiStringRes(R.string.error_media_recover_page_not_scheduled_retrying))
+    }
+
+    @Test
+    fun `media upload error shown with specific message for scheduled post not eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(SCHEDULED.toString())
+                },
+                PostUploadUiState.UploadFailed(
+                        error = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = false,
+                        retryWillPushChanges = true
+                )
+        )
+        assertThat(labels).containsOnly(UiStringRes(R.string.error_media_recover_page_not_scheduled))
+    }
+
+    @Test
+    fun `retrying media upload shown for draft eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(DRAFT.toString())
+                },
+                PostUploadUiState.UploadFailed(
+                        error = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = true,
+                        retryWillPushChanges = true
+                )
+        )
+        assertThat(labels).containsOnly(UiStringRes(R.string.error_generic_error_retrying))
+    }
+
+    @Test
+    fun `base media upload error shown for draft not eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(DRAFT.toString())
+                },
+                PostUploadUiState.UploadFailed(
+                        error = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
+                        isEligibleForAutoUpload = false,
+                        retryWillPushChanges = false
+                )
+        )
+        assertThat(labels).containsOnly(UiStringRes(R.string.error_media_recover_page))
+    }
+
+    @Test
+    fun `base upload error shown on GENERIC ERROR and not eligible for auto upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(DRAFT.toString())
+                },
+                PostUploadUiState.UploadFailed(
+                        error = UploadError(PostError(GENERIC_ERROR)),
+                        isEligibleForAutoUpload = false,
+                        retryWillPushChanges = false
+                )
+        )
+        assertThat(labels)
+                .containsOnly(UiStringRes(R.string.error_generic_error))
+    }
+
+    @Test
+    fun `retrying upload shown for draft eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(DRAFT.toString())
+                },
+                PostUploadUiState.UploadFailed(
+                        error = UploadError(PostError(GENERIC_ERROR)),
+                        isEligibleForAutoUpload = true,
+                        retryWillPushChanges = true
+                )
+        )
+        assertThat(labels)
+                .containsOnly(UiStringRes(R.string.error_generic_error_retrying))
+    }
+
+    @Test
+    fun `multiple info labels are being shown together`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(PRIVATE.toString())
+                },
+                mock()
+        )
+        assertThat(labels).contains(UiStringRes(R.string.page_local_changes))
+        assertThat(labels).contains(UiStringRes(R.string.page_status_page_private))
+    }
+
+    @Test
+    fun `pending publish post label shown when post eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(PUBLISHED.toString())
+                },
+                PostUploadUiState.UploadWaitingForConnection(PUBLISHED)
+        )
+
+        assertThat((labels[0] as UiStringRes).stringRes).isEqualTo(R.string.page_waiting_for_connection_publish)
+    }
+
+    @Test
+    fun `pending schedule label shown when post eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(SCHEDULED.toString())
+                },
+                PostUploadUiState.UploadWaitingForConnection(SCHEDULED)
+        )
+
+        assertThat((labels[0] as UiStringRes).stringRes).isEqualTo(R.string.page_waiting_for_connection_scheduled)
+    }
+
+    @Test
+    fun `pending publish private post label shown when post eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(PRIVATE.toString())
+                },
+                PostUploadUiState.UploadWaitingForConnection(PRIVATE)
+        )
+
+        assertThat((labels[0] as UiStringRes).stringRes).isEqualTo(R.string.page_waiting_for_connection_private)
+    }
+
+    @Test
+    fun `pending submit post label shown when post eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(PENDING.toString())
+                },
+                PostUploadUiState.UploadWaitingForConnection(PENDING)
+        )
+
+        assertThat((labels[0] as UiStringRes).stringRes).isEqualTo(R.string.page_waiting_for_connection_pending)
+    }
+
+    @Test
+    fun `local changes post label shown when draft eligible for auto-upload`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setStatus(PostStatus.DRAFT.toString())
+                },
+                PostUploadUiState.UploadWaitingForConnection(PostStatus.DRAFT)
+        )
+        assertThat((labels[0] as UiStringRes).stringRes).isEqualTo(R.string.page_waiting_for_connection_draft)
+    }
+
+    @Test
+    fun `when a post is locally changed and is local draft only "Local draft" label is displayed`() {
+        val (labels, _) = useCase.createLabels(
+                PostModel().apply {
+                    setIsLocallyChanged(true)
+                    setIsLocalDraft(true)
+                },
+                mock()
+        )
+
+        assertThat(labels).containsOnly(UiStringRes(R.string.page_local_draft))
+    }
+}


### PR DESCRIPTION
Adds unit tests for https://github.com/wordpress-mobile/WordPress-Android/pull/11278

Review instruction
1. Review the code
2. Wait until https://github.com/wordpress-mobile/WordPress-Android/pull/11280 gets merged
3. Change target branch to feature/master-pages-offline-support
4. Remove the "Not ready for merge" label
5. Merge the PR


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
