### PR TITLE
Temporarily disable login and signup connected tests

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -1,63 +1,63 @@
 package org.wordpress.android.e2e;
-
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.ActivityTestRule;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.wordpress.android.e2e.flows.LoginFlow;
-import org.wordpress.android.support.BaseTest;
-import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
-
-import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
-import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
-import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_USERNAME;
-import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
-import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_SITE_ADDRESS;
-import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_USERNAME;
-
-@RunWith(AndroidJUnit4.class)
-public class LoginTests extends BaseTest {
-    @Rule
-    public ActivityTestRule<LoginMagicLinkInterceptActivity> mMagicLinkActivityTestRule =
-            new ActivityTestRule<>(LoginMagicLinkInterceptActivity.class);
-
-    @Before
-    public void setUp() {
-        logoutIfNecessary();
-    }
-
-    @Test
-    public void loginWithEmailPassword() {
-        wpLogin();
-    }
-
-    @Test
-    public void loginWithSiteAddress() {
-        new LoginFlow().loginSiteAddress(
-                E2E_WP_COM_USER_SITE_ADDRESS,
-                E2E_WP_COM_USER_USERNAME,
-                E2E_WP_COM_USER_PASSWORD);
-    }
-
-    @Test
-    public void loginWithMagicLink() {
-        new LoginFlow().loginMagicLink(mMagicLinkActivityTestRule);
-    }
-
-    @Test
-    public void loginWithSelfHostedAccount() {
-        new LoginFlow().loginSiteAddress(
-                E2E_SELF_HOSTED_USER_SITE_ADDRESS,
-                E2E_SELF_HOSTED_USER_USERNAME,
-                E2E_SELF_HOSTED_USER_PASSWORD);
-    }
-
-    @After
-    public void tearDown() {
-        logoutIfNecessary();
-    }
-}
+// Disabled temporarily
+//import androidx.test.ext.junit.runners.AndroidJUnit4;
+//import androidx.test.rule.ActivityTestRule;
+//
+//import org.junit.After;
+//import org.junit.Before;
+//import org.junit.Rule;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.wordpress.android.e2e.flows.LoginFlow;
+//import org.wordpress.android.support.BaseTest;
+//import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
+//
+//import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
+//import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
+//import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_USERNAME;
+//import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
+//import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_SITE_ADDRESS;
+//import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_USERNAME;
+//
+//@RunWith(AndroidJUnit4.class)
+//public class LoginTests extends BaseTest {
+//    @Rule
+//    public ActivityTestRule<LoginMagicLinkInterceptActivity> mMagicLinkActivityTestRule =
+//            new ActivityTestRule<>(LoginMagicLinkInterceptActivity.class);
+//
+//    @Before
+//    public void setUp() {
+//        logoutIfNecessary();
+//    }
+//
+//    @Test
+//    public void loginWithEmailPassword() {
+//        wpLogin();
+//    }
+//
+//    @Test
+//    public void loginWithSiteAddress() {
+//        new LoginFlow().loginSiteAddress(
+//                E2E_WP_COM_USER_SITE_ADDRESS,
+//                E2E_WP_COM_USER_USERNAME,
+//                E2E_WP_COM_USER_PASSWORD);
+//    }
+//
+//    @Test
+//    public void loginWithMagicLink() {
+//        new LoginFlow().loginMagicLink(mMagicLinkActivityTestRule);
+//    }
+//
+//    @Test
+//    public void loginWithSelfHostedAccount() {
+//        new LoginFlow().loginSiteAddress(
+//                E2E_SELF_HOSTED_USER_SITE_ADDRESS,
+//                E2E_SELF_HOSTED_USER_USERNAME,
+//                E2E_SELF_HOSTED_USER_PASSWORD);
+//    }
+//
+//    @After
+//    public void tearDown() {
+//        logoutIfNecessary();
+//    }
+//}

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -1,39 +1,40 @@
 package org.wordpress.android.e2e;
 
-import androidx.test.rule.ActivityTestRule;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.wordpress.android.e2e.flows.SignupFlow;
-import org.wordpress.android.support.BaseTest;
-import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
-
-import static org.wordpress.android.BuildConfig.E2E_SIGNUP_DISPLAY_NAME;
-import static org.wordpress.android.BuildConfig.E2E_SIGNUP_EMAIL;
-import static org.wordpress.android.BuildConfig.E2E_SIGNUP_PASSWORD;
-import static org.wordpress.android.BuildConfig.E2E_SIGNUP_USERNAME;
-
-public class SignUpTests extends BaseTest {
-    @Rule
-    public ActivityTestRule<LoginMagicLinkInterceptActivity> mMagicLinkActivityTestRule =
-            new ActivityTestRule<>(LoginMagicLinkInterceptActivity.class);
-
-    @Before
-    public void setUp() {
-        logoutIfNecessary();
-    }
-
-    @Test
-    public void signUpWithEmail() {
-        SignupFlow signupFlow = new SignupFlow();
-        signupFlow.chooseSignupWithEmail();
-        signupFlow.enterEmail(E2E_SIGNUP_EMAIL, mMagicLinkActivityTestRule);
-        signupFlow.checkEpilogue(
-                E2E_SIGNUP_DISPLAY_NAME,
-                E2E_SIGNUP_USERNAME);
-        signupFlow.enterPassword(E2E_SIGNUP_PASSWORD);
-        signupFlow.dismissInterstitial();
-        signupFlow.confirmSignup();
-    }
-}
+// Disabled temporarily
+//import androidx.test.rule.ActivityTestRule;
+//
+//import org.junit.Before;
+//import org.junit.Rule;
+//import org.junit.Test;
+//import org.wordpress.android.e2e.flows.SignupFlow;
+//import org.wordpress.android.support.BaseTest;
+//import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
+//
+//import static org.wordpress.android.BuildConfig.E2E_SIGNUP_DISPLAY_NAME;
+//import static org.wordpress.android.BuildConfig.E2E_SIGNUP_EMAIL;
+//import static org.wordpress.android.BuildConfig.E2E_SIGNUP_PASSWORD;
+//import static org.wordpress.android.BuildConfig.E2E_SIGNUP_USERNAME;
+//
+//public class SignUpTests extends BaseTest {
+//    @Rule
+//    public ActivityTestRule<LoginMagicLinkInterceptActivity> mMagicLinkActivityTestRule =
+//            new ActivityTestRule<>(LoginMagicLinkInterceptActivity.class);
+//
+//    @Before
+//    public void setUp() {
+//        logoutIfNecessary();
+//    }
+//
+//    @Test
+//    public void signUpWithEmail() {
+//        SignupFlow signupFlow = new SignupFlow();
+//        signupFlow.chooseSignupWithEmail();
+//        signupFlow.enterEmail(E2E_SIGNUP_EMAIL, mMagicLinkActivityTestRule);
+//        signupFlow.checkEpilogue(
+//                E2E_SIGNUP_DISPLAY_NAME,
+//                E2E_SIGNUP_USERNAME);
+//        signupFlow.enterPassword(E2E_SIGNUP_PASSWORD);
+//        signupFlow.dismissInterstitial();
+//        signupFlow.confirmSignup();
+//    }
+//}


### PR DESCRIPTION
This PR temporarily disables the login and signup connected tests. I initially intended to only disable the magic link login test, but it looks like even the `loginWithSiteAddress` is failing.

I am not entirely sure why the `loginWithSiteAddress` test would care about `LoginMagicLinkInterceptActivity`, so maybe the previous tests are having an effect or something. In any case, I think it's best to disable all of them for now until we get a chance to look into them.

```
java.lang.RuntimeException: Could not launch intent Intent { act=android.intent.action.MAIN flg=0x10000000 cmp=org.wordpress.android/.ui.accounts.LoginMagicLinkInterceptActivity } within 45 seconds. Perhaps the main thread has not gone idle within a reasonable amount of time? There could be an animation or something constantly repainting the screen. Or the activity is doing network calls on creation? See the threaddump logs. For your reference the last time the event queue was idle before your activity launch request was 1581436548916 and now the last time the queue went idle was: 1581436579229. If these numbers are the same your activity might be hogging the event queue. 
```