### PR TITLE
Issue/fix lifecycle crash with appcompat 1 1 0

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.sitecreation.domains
 
 import android.content.Context
 import android.os.Bundle
-import android.os.Parcelable
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
@@ -22,8 +21,6 @@ import org.wordpress.android.ui.sitecreation.misc.OnHelpClickedListener
 import org.wordpress.android.ui.sitecreation.misc.SearchInputWithHeader
 import org.wordpress.android.ui.utils.UiHelpers
 import javax.inject.Inject
-
-private const val KEY_LIST_STATE = "list_state"
 
 class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
     private lateinit var nonNullActivity: FragmentActivity
@@ -87,16 +84,8 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
         (nonNullActivity.application as WordPress).component().inject(this)
     }
 
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putParcelable(KEY_LIST_STATE, linearLayoutManager.onSaveInstanceState())
-    }
-
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
-        savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
-            linearLayoutManager.onRestoreInstanceState(it)
-        }
         // we need to set the `onTextChanged` after the viewState has been restored otherwise the viewModel.updateQuery
         // is called when the system sets the restored value to the EditText which results in an unnecessary request
         searchInputWithHeader.onTextChanged = { viewModel.updateQuery(it) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/SiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/SiteCreationSegmentsFragment.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.sitecreation.segments
 
 import android.content.Context
 import android.os.Bundle
-import android.os.Parcelable
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
@@ -23,8 +22,6 @@ import org.wordpress.android.ui.sitecreation.segments.SegmentsUiState.SegmentsEr
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
-
-private const val KEY_LIST_STATE = "list_state"
 
 class SiteCreationSegmentsFragment : SiteCreationBaseFormFragment() {
     private lateinit var linearLayoutManager: LinearLayoutManager
@@ -131,18 +128,6 @@ class SiteCreationSegmentsFragment : SiteCreationBaseFormFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (activity!!.application as WordPress).component().inject(this)
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putParcelable(KEY_LIST_STATE, linearLayoutManager.onSaveInstanceState())
-    }
-
-    override fun onViewStateRestored(savedInstanceState: Bundle?) {
-        super.onViewStateRestored(savedInstanceState)
-        savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
-            linearLayoutManager.onRestoreInstanceState(it)
-        }
     }
 
     private fun updateContentLayout(segments: SegmentsContentUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationVerticalsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationVerticalsFragment.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.sitecreation.verticals
 
 import android.content.Context
 import android.os.Bundle
-import android.os.Parcelable
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.annotation.LayoutRes
@@ -27,8 +26,6 @@ import org.wordpress.android.ui.sitecreation.verticals.SiteCreationVerticalsView
 import org.wordpress.android.ui.utils.UiHelpers
 import javax.inject.Inject
 import kotlin.properties.Delegates
-
-private const val KEY_LIST_STATE = "list_state"
 
 class SiteCreationVerticalsFragment : SiteCreationBaseFormFragment() {
     private lateinit var nonNullActivity: FragmentActivity
@@ -99,16 +96,8 @@ class SiteCreationVerticalsFragment : SiteCreationBaseFormFragment() {
         }
     }
 
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putParcelable(KEY_LIST_STATE, linearLayoutManager.onSaveInstanceState())
-    }
-
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
-        savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
-            linearLayoutManager.onRestoreInstanceState(it)
-        }
         // we need to set the `onTextChanged` after the viewState has been restored otherwise the viewModel.updateQuery
         // is called when the system sets the restored value to the EditText which results in an unnecessary request
         searchInputWithHeader.onTextChanged = { viewModel.updateQuery(it) }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
@@ -54,7 +54,6 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     public static final String TAG = "login_magic_link_request_fragment_tag";
 
     private static final String KEY_IN_PROGRESS = "KEY_IN_PROGRESS";
-    private static final String KEY_GRAVATAR_IN_PROGRESS = "KEY_GRAVATAR_IN_PROGRESS";
     private static final String ARG_EMAIL_ADDRESS = "ARG_EMAIL_ADDRESS";
     private static final String ARG_MAGIC_LINK_SCHEME = "ARG_MAGIC_LINK_SCHEME";
     private static final String ARG_IS_JETPACK_CONNECT = "ARG_IS_JETPACK_CONNECT";
@@ -224,9 +223,6 @@ public class LoginMagicLinkRequestFragment extends Fragment {
             if (mInProgress) {
                 showMagicLinkRequestProgressDialog();
             }
-
-            boolean gravatarInProgress = savedInstanceState.getBoolean(KEY_GRAVATAR_IN_PROGRESS);
-            mAvatarProgressBar.setVisibility(gravatarInProgress ? View.VISIBLE : View.GONE);
         }
         // important for accessibility - talkback
         getActivity().setTitle(R.string.magic_link_login_title);
@@ -243,7 +239,6 @@ public class LoginMagicLinkRequestFragment extends Fragment {
         super.onSaveInstanceState(outState);
 
         outState.putBoolean(KEY_IN_PROGRESS, mInProgress);
-        outState.putBoolean(KEY_GRAVATAR_IN_PROGRESS, mAvatarProgressBar.getVisibility() == View.VISIBLE);
     }
 
     @Override


### PR DESCRIPTION
Related to #9905

CC @oguzkocer @malinajirka @marecar3 

This PR fixes a couple of crashes that resulted from a change in fragment lifecycle behavior introduced in `appcompat` 1.1.0.

I'm targeting this fix towards the feature branch, since develop branch will need other changes related to migration to the new appcompat library. 

The crash happens when we try to access a fragment's layout in `onSaveInstanceState` during configuration change, while it's in a backstack. I have a feeling we were using the lifecycle bug as a feature :)

Luckily, I was only able to find two places where we do this - in Login and Site Creation flows.

After looking at the code that causes all this jazz, I made a conclusion that it might be redundant, and here is why:

With Login Flow, we were trying to preserve the state of Gravatar loading progress. I don't think we need to do it since the progress indicator is visible when the view is created and is hidden when Glide loads cashed image or request fails. All this happens in `onCreateView` and we don't need to toggle it manually.

With Site Creation flow, I removed the explicit saving/restoring of the LinearLayoutManager. I don't have enough context to assume what it was used for, but I assume to preserve the scrolling state? If so it's already preserved during a normal configuration change. If it's something else, maybe @malinajirka can correct me.

If you think you might know other places where this issue might happen, please let me know!

To test (Login):
- Go to an email login flow, at the Magic Link request screen, choose to enter the password.
- At the Password input screen, rotate your device twice.

To test (Site Creation):
- Go through site creation flow, while rotating your device multiple times at each screen.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
