### PR TITLE
Add historical searches list to the Reader initial search screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -62,6 +62,7 @@ public class FilteredRecyclerView extends RelativeLayout {
     private View mCustomEmptyView;
     private Toolbar mToolbar;
     private AppBarLayout mAppBarLayout;
+    private RecyclerView mSearchSuggestionsRecyclerView;
 
     private List<FilterCriteria> mFilterCriteriaOptions;
     private FilterCriteria mCurrentFilter;
@@ -194,6 +195,8 @@ public class FilteredRecyclerView extends RelativeLayout {
             params.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
                                   | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
         }
+
+        mSearchSuggestionsRecyclerView = findViewById(R.id.suggestions_recycler_view);
 
         mEmptyView = findViewById(R.id.empty_view);
 
@@ -494,6 +497,18 @@ public class FilteredRecyclerView extends RelativeLayout {
     * */
     public void refreshFilterCriteriaOptions() {
         setup(true);
+    }
+
+    public void showSearchSuggestions() {
+        mSearchSuggestionsRecyclerView.setVisibility(View.VISIBLE);
+    }
+
+    public void hideSearchSuggestions() {
+        mSearchSuggestionsRecyclerView.setVisibility(View.GONE);
+    }
+
+    public void setSearchSuggestionAdapter(RecyclerView.Adapter searchSuggestionAdapter) {
+        mSearchSuggestionsRecyclerView.setAdapter(searchSuggestionAdapter);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -13,6 +13,7 @@ import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.ImageSpan;
+import android.view.ContextThemeWrapper;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -100,6 +101,7 @@ import org.wordpress.android.ui.reader.actions.ReaderBlogActions.BlockedBlogResu
 import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionAdapter;
+import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionRecyclerAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSiteSearchAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSiteSearchAdapter.SiteSearchAdapterListener;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
@@ -159,6 +161,7 @@ public class ReaderPostListFragment extends Fragment
     private ReaderPostAdapter mPostAdapter;
     private ReaderSiteSearchAdapter mSiteSearchAdapter;
     private ReaderSearchSuggestionAdapter mSearchSuggestionAdapter;
+    private ReaderSearchSuggestionRecyclerAdapter mSearchSuggestionRecyclerAdapter;
 
     private FilteredRecyclerView mRecyclerView;
     private boolean mFirstLoad = true;
@@ -1037,7 +1040,8 @@ public class ReaderPostListFragment extends Fragment
                     AnalyticsTracker.track(AnalyticsTracker.Stat.READER_SEARCH_LOADED);
                 }
                 resetPostAdapter(ReaderPostListType.SEARCH_RESULTS);
-                showSearchMessage();
+                populateSearchSuggestions(null);
+                showSearchMessageOrSuggestions();
                 mSettingsMenuItem.setVisible(false);
                 mRecyclerView.setTabLayoutVisibility(false);
                 mViewModel.setSubfiltersVisibility(false);
@@ -1061,8 +1065,9 @@ public class ReaderPostListFragment extends Fragment
             @Override
             public boolean onMenuItemActionCollapse(MenuItem item) {
                 hideSearchMessage();
+                hideSearchSuggestions();
                 hideSearchTabs();
-                resetSearchSuggestionAdapter();
+                resetSearchSuggestions();
                 if (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE || !mIsTopLevel) {
                     mSettingsMenuItem.setVisible(true);
                 }
@@ -1108,16 +1113,50 @@ public class ReaderPostListFragment extends Fragment
 
                 @Override
                 public boolean onQueryTextChange(String newText) {
-                    if (TextUtils.isEmpty(newText)) {
-                        showSearchMessage();
-                        hideSearchTabs();
-                    } else {
-                        populateSearchSuggestionAdapter(newText);
-                    }
+                    populateSearchSuggestions(newText);
+                    showSearchMessageOrSuggestions();
                     return true;
                     }
                 }
         );
+    }
+
+    private void showSearchMessageOrSuggestions() {
+        boolean hasQuery = !isSearchViewEmpty();
+        boolean hasPerformedSearch = !TextUtils.isEmpty(mCurrentSearchQuery);
+        boolean isSearching = getPostListType() == ReaderPostListType.SEARCH_RESULTS;
+
+        // prevents suggestions from being shown after the search view has been collapsed
+        if (!isSearching) {
+            return;
+        }
+
+        // prevents suggestions from being shown above search results after configuration changes
+        if (mWasPaused && hasPerformedSearch) {
+            return;
+        }
+
+        if (!hasQuery || !hasPerformedSearch) {
+            // clear posts and sites so only the suggestions or the empty view are visible
+            getPostAdapter().clear();
+            getSiteSearchAdapter().clear();
+
+            hideSearchTabs();
+
+            // clears the last performed query
+            mCurrentSearchQuery = null;
+
+            final boolean hasSuggestions =
+                    mSearchSuggestionRecyclerAdapter != null && mSearchSuggestionRecyclerAdapter.getItemCount() > 0;
+
+            if (hasSuggestions) {
+                hideSearchMessage();
+                showSearchSuggestions();
+            } else {
+                showSearchMessage();
+                hideSearchSuggestions();
+            }
+        }
     }
 
     /*
@@ -1154,6 +1193,7 @@ public class ReaderPostListFragment extends Fragment
 
         mSearchView.clearFocus(); // this will hide suggestions and the virtual keyboard
         hideSearchMessage();
+        hideSearchSuggestions();
 
         // remember this query for future suggestions
         String trimQuery = query.trim();
@@ -1220,16 +1260,20 @@ public class ReaderPostListFragment extends Fragment
             return;
         }
 
-        // clear posts and sites so only the empty view is visible
-        getPostAdapter().clear();
-        getSiteSearchAdapter().clear();
-
         setEmptyTitleDescriptionAndButton(false);
         showEmptyView();
     }
 
     private void hideSearchMessage() {
         hideEmptyView();
+    }
+
+    private void showSearchSuggestions() {
+        mRecyclerView.showSearchSuggestions();
+    }
+
+    private void hideSearchSuggestions() {
+        mRecyclerView.hideSearchSuggestions();
     }
 
     /*
@@ -1330,6 +1374,16 @@ public class ReaderPostListFragment extends Fragment
         return isSearchTabsShowing() ? mSearchTabs.getSelectedTabPosition() : -1;
     }
 
+    private void populateSearchSuggestions(String query) {
+        populateSearchSuggestionAdapter(query);
+        populateSearchSuggestionRecyclerAdapter(null); // always passing null as there's no need to filter
+    }
+
+    private void resetSearchSuggestions() {
+        resetSearchSuggestionAdapter();
+        resetSearchSuggestionRecyclerAdapter();
+    }
+
     /*
      * create and assign the suggestion adapter for the search view
      */
@@ -1346,12 +1400,13 @@ public class ReaderPostListFragment extends Fragment
             @Override
             public boolean onSuggestionClick(int position) {
                 String query = mSearchSuggestionAdapter.getSuggestion(position);
-                if (!TextUtils.isEmpty(query)) {
-                    mSearchView.setQuery(query, true);
-                }
+                onSearchSuggestionClicked(query);
                 return true;
             }
         });
+
+        mSearchSuggestionAdapter.setOnSuggestionDeleteClickListener(this::onSearchSuggestionDeleteClicked);
+        mSearchSuggestionAdapter.setOnSuggestionClearClickListener(this::onSearchSuggestionClearClicked);
     }
 
     private void populateSearchSuggestionAdapter(String query) {
@@ -1364,6 +1419,65 @@ public class ReaderPostListFragment extends Fragment
     private void resetSearchSuggestionAdapter() {
         mSearchView.setSuggestionsAdapter(null);
         mSearchSuggestionAdapter = null;
+    }
+
+    private void createSearchSuggestionRecyclerAdapter() {
+        mSearchSuggestionRecyclerAdapter = new ReaderSearchSuggestionRecyclerAdapter();
+        mRecyclerView.setSearchSuggestionAdapter(mSearchSuggestionRecyclerAdapter);
+
+        mSearchSuggestionRecyclerAdapter.setOnSuggestionClickListener(this::onSearchSuggestionClicked);
+        mSearchSuggestionRecyclerAdapter.setOnSuggestionDeleteClickListener(this::onSearchSuggestionDeleteClicked);
+        mSearchSuggestionRecyclerAdapter.setOnSuggestionClearClickListener(this::onSearchSuggestionClearClicked);
+    }
+
+    private void populateSearchSuggestionRecyclerAdapter(String query) {
+        if (mSearchSuggestionRecyclerAdapter == null) {
+            createSearchSuggestionRecyclerAdapter();
+        }
+        mSearchSuggestionRecyclerAdapter.setQuery(query);
+    }
+
+    private void resetSearchSuggestionRecyclerAdapter() {
+        mRecyclerView.setSearchSuggestionAdapter(null);
+        mSearchSuggestionRecyclerAdapter = null;
+    }
+
+    private void onSearchSuggestionClicked(String query) {
+        if (!TextUtils.isEmpty(query)) {
+            mSearchView.setQuery(query, true);
+        }
+    }
+
+    private void onSearchSuggestionDeleteClicked(String query) {
+        ReaderSearchTable.deleteQueryString(query);
+
+        mSearchSuggestionAdapter.reload();
+        mSearchSuggestionRecyclerAdapter.reload();
+
+        showSearchMessageOrSuggestions();
+    }
+
+    private void onSearchSuggestionClearClicked() {
+        showClearSearchSuggestionsConfirmationDialog(getContext());
+    }
+
+    private void showClearSearchSuggestionsConfirmationDialog(final Context context) {
+        new AlertDialog.Builder(new ContextThemeWrapper(context, R.style.Calypso_Dialog_Alert))
+                .setMessage(R.string.dlg_confirm_clear_search_history)
+                .setCancelable(true)
+                .setNegativeButton(R.string.no, null)
+                .setPositiveButton(R.string.yes, (dialog, id) -> clearSearchSuggestions())
+                .create()
+                .show();
+    }
+
+    private void clearSearchSuggestions() {
+        ReaderSearchTable.deleteAllQueries();
+
+        mSearchSuggestionAdapter.swapCursor(null);
+        mSearchSuggestionRecyclerAdapter.swapCursor(null);
+
+        showSearchMessageOrSuggestions();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1146,15 +1146,19 @@ public class ReaderPostListFragment extends Fragment
             // clears the last performed query
             mCurrentSearchQuery = null;
 
-            final boolean hasSuggestions =
-                    mSearchSuggestionRecyclerAdapter != null && mSearchSuggestionRecyclerAdapter.getItemCount() > 0;
+            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
+                final boolean hasSuggestions =
+                        mSearchSuggestionRecyclerAdapter != null && mSearchSuggestionRecyclerAdapter.getItemCount() > 0;
 
-            if (hasSuggestions) {
-                hideSearchMessage();
-                showSearchSuggestions();
+                if (hasSuggestions) {
+                    hideSearchMessage();
+                    showSearchSuggestions();
+                } else {
+                    showSearchMessage();
+                    hideSearchSuggestions();
+                }
             } else {
                 showSearchMessage();
-                hideSearchSuggestions();
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
@@ -168,12 +168,4 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
     public void setOnSuggestionClearClickListener(OnSuggestionClearClickListener onSuggestionClearClickListener) {
         mOnSuggestionClearClickListener = onSuggestionClearClickListener;
     }
-
-    public interface OnSuggestionDeleteClickListener {
-        void onDeleteClicked(String query);
-    }
-
-    public interface OnSuggestionClearClickListener {
-        void onClearClicked();
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionListeners.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionListeners.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.ui.reader.adapters
+
+interface OnSuggestionClickListener {
+    fun onSuggestionClicked(query: String?)
+}
+
+interface OnSuggestionDeleteClickListener {
+    fun onDeleteClicked(query: String?)
+}
+
+interface OnSuggestionClearClickListener {
+    fun onClearClicked()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionRecyclerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionRecyclerAdapter.java
@@ -150,16 +150,4 @@ public class ReaderSearchSuggestionRecyclerAdapter extends RecyclerView.Adapter<
             mDeleteImageView = itemView.findViewById(R.id.image_delete);
         }
     }
-
-    public interface OnSuggestionClickListener {
-        void onSuggestionClicked(String query);
-    }
-
-    public interface OnSuggestionDeleteClickListener {
-        void onDeleteClicked(String query);
-    }
-
-    public interface OnSuggestionClearClickListener {
-        void onClearClicked();
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionRecyclerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionRecyclerAdapter.java
@@ -1,0 +1,165 @@
+package org.wordpress.android.ui.reader.adapters;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.recyclerview.widget.RecyclerView;
+
+import org.jetbrains.annotations.NotNull;
+import org.wordpress.android.R;
+import org.wordpress.android.datasets.ReaderSearchTable;
+import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionRecyclerAdapter.SearchSuggestionHolder;
+import org.wordpress.android.util.SqlUtils;
+
+public class ReaderSearchSuggestionRecyclerAdapter extends RecyclerView.Adapter<SearchSuggestionHolder> {
+    private static final int MAX_SUGGESTIONS = 5;
+    private static final int MAX_SUGGESTIONS_WHEN_EMPTY = 10;
+    private static final int CLEAR_ALL_ROW_ID = -1;
+
+    private Cursor mCursor;
+    private String mCurrentQuery;
+    private OnSuggestionClickListener mOnSuggestionClickListener;
+    private OnSuggestionDeleteClickListener mOnSuggestionDeleteClickListener;
+    private OnSuggestionClearClickListener mOnSuggestionClearClickListener;
+
+    public ReaderSearchSuggestionRecyclerAdapter() {
+        setHasStableIds(true);
+        swapCursor(null);
+    }
+
+    @Override
+    @NotNull
+    public SearchSuggestionHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        final Context context = parent.getContext();
+        final View view =
+                LayoutInflater.from(context).inflate(R.layout.reader_listitem_suggestion_recycler, parent, false);
+        return new SearchSuggestionHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NotNull SearchSuggestionHolder holder, int position) {
+        if (isLast(position)) {
+            onBindClearAllViewHolder(holder);
+        } else if (!mCursor.moveToPosition(position)) {
+            throw new IllegalStateException("couldn't move cursor to position " + position);
+        } else {
+            onBindSuggestionViewHolder(holder);
+        }
+    }
+
+    private void onBindClearAllViewHolder(final SearchSuggestionHolder holder) {
+        final Context context = holder.itemView.getContext();
+        final String text = context.getString(R.string.label_clear_search_history);
+        holder.mHistoryImageView.setVisibility(View.INVISIBLE);
+        holder.mSuggestionTextView.setText(text);
+        holder.mDeleteImageView.setVisibility(View.INVISIBLE);
+        holder.itemView.setOnClickListener(v -> {
+            if (mOnSuggestionClearClickListener != null) {
+                mOnSuggestionClearClickListener.onClearClicked();
+            }
+        });
+    }
+
+    private void onBindSuggestionViewHolder(final SearchSuggestionHolder holder) {
+        final String query = mCursor.getString(mCursor.getColumnIndex(ReaderSearchTable.COL_QUERY));
+        holder.mHistoryImageView.setVisibility(View.VISIBLE);
+        holder.mSuggestionTextView.setText(query);
+        holder.mDeleteImageView.setVisibility(View.VISIBLE);
+        holder.mDeleteImageView.setOnClickListener(v -> {
+            if (mOnSuggestionDeleteClickListener != null) {
+                mOnSuggestionDeleteClickListener.onDeleteClicked(query);
+            }
+        });
+        holder.itemView.setOnClickListener(v -> {
+            if (mOnSuggestionClickListener != null) {
+                mOnSuggestionClickListener.onSuggestionClicked(query);
+            }
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        final int count = mCursor == null ? 0 : mCursor.getCount();
+        return count > 0 ? count + 1 : 0; // we add an extra row at the end to show the "Clear search history" button
+    }
+
+    @Override
+    public long getItemId(int position) {
+        if (isLast(position)) {
+            return CLEAR_ALL_ROW_ID;
+        } else if (!mCursor.moveToPosition(position)) {
+            throw new IllegalStateException("couldn't move cursor to position " + position);
+        }
+        return mCursor.getLong(mCursor.getColumnIndex(ReaderSearchTable.COL_ID));
+    }
+
+    private boolean isLast(final int position) {
+        return position == mCursor.getCount();
+    }
+
+    public void swapCursor(final Cursor newCursor) {
+        if (newCursor == mCursor) return;
+        SqlUtils.closeCursor(mCursor);
+        mCursor = newCursor;
+        notifyDataSetChanged();
+    }
+
+    public void setOnSuggestionClickListener(OnSuggestionClickListener onSuggestionClickListener) {
+        mOnSuggestionClickListener = onSuggestionClickListener;
+    }
+
+    public void setOnSuggestionDeleteClickListener(OnSuggestionDeleteClickListener onSuggestionDeleteClickListener) {
+        mOnSuggestionDeleteClickListener = onSuggestionDeleteClickListener;
+    }
+
+    public void setOnSuggestionClearClickListener(OnSuggestionClearClickListener onSuggestionClearClickListener) {
+        mOnSuggestionClearClickListener = onSuggestionClearClickListener;
+    }
+
+    public void reload() {
+        setQuery(mCurrentQuery, true);
+    }
+
+    public void setQuery(final String newQuery) {
+        setQuery(newQuery, false);
+    }
+
+    private void setQuery(final String newQuery, final boolean forceUpdate) {
+        if (!forceUpdate && newQuery != null && newQuery.equalsIgnoreCase(mCurrentQuery) && mCursor != null) {
+            return;
+        }
+        mCurrentQuery = newQuery;
+        final int maxSuggestions = newQuery == null ? MAX_SUGGESTIONS_WHEN_EMPTY : MAX_SUGGESTIONS;
+        swapCursor(ReaderSearchTable.getQueryStringCursor(newQuery, maxSuggestions));
+    }
+
+    class SearchSuggestionHolder extends RecyclerView.ViewHolder {
+        private final ImageView mHistoryImageView;
+        private final TextView mSuggestionTextView;
+        private final ImageView mDeleteImageView;
+
+        SearchSuggestionHolder(final View itemView) {
+            super(itemView);
+            mHistoryImageView = itemView.findViewById(R.id.image_history);
+            mSuggestionTextView = itemView.findViewById(R.id.text_suggestion);
+            mDeleteImageView = itemView.findViewById(R.id.image_delete);
+        }
+    }
+
+    public interface OnSuggestionClickListener {
+        void onSuggestionClicked(String query);
+    }
+
+    public interface OnSuggestionDeleteClickListener {
+        void onDeleteClicked(String query);
+    }
+
+    public interface OnSuggestionClearClickListener {
+        void onClearClicked();
+    }
+}

--- a/WordPress/src/main/res/layout/filtered_list_component.xml
+++ b/WordPress/src/main/res/layout/filtered_list_component.xml
@@ -86,6 +86,13 @@
             android:text="@string/empty_list_default"
             android:visibility="gone"/>
 
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/suggestions_recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
         <ProgressBar
             android:id="@+id/progress_loading"
             android:layout_width="32dp"

--- a/WordPress/src/main/res/layout/reader_listitem_suggestion_recycler.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_suggestion_recycler.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@android:color/white"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?android:attr/selectableItemBackground"
+    tools:ignore="UnusedAttribute">
+
+    <ImageView
+        android:id="@+id/image_history"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_extra_large"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_history_white_24dp"
+        android:tint="@color/neutral_60" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/text_suggestion"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:gravity="center_vertical|start"
+        android:maxLines="1"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        android:textColor="?attr/wpColorText"
+        tools:text="Suggestion" />
+
+    <ImageView
+        android:id="@+id/image_delete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_extra_large"
+        android:background="?android:selectableItemBackground"
+        android:contentDescription="@string/reader_list_item_suggestion_remove_desc"
+        android:src="@drawable/ic_cross_white_24dp"
+        android:tint="@color/neutral_60" />
+</LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1603,7 +1603,7 @@
     <string name="reader_title_post_detail">Reader Post</string>
     <string name="reader_title_post_detail_wpcom">WordPress.com Post</string>
     <string name="reader_title_related_post_detail">Related Post</string>
-    <string name="reader_title_subs">Tags &amp; Sites</string>
+    <string name="reader_title_subs">Manage Tags &amp; Sites</string>
     <string name="reader_title_photo_viewer">%1$d of %2$d</string>
     <string name="reader_title_comments" translatable="false">@string/comments</string>
 


### PR DESCRIPTION
Fixes #11168

This PR introduces a list of historical searches to the initial search screen of the Reader, as shown below. 

<img src="https://user-images.githubusercontent.com/830056/74399295-0f78ec80-4df9-11ea-98d8-68e144408f2f.gif" width=300>

The implementation here turned out to be quite rudimentary, but it took several rounds of trial and error to reach the minimum code needed to make it work well. 

The main challenge here is to keep track of the search screen state, given it is tightly coupled with `ReaderPostListFragment`. For example, here are some of the conditions we need to keep track of to know when to show the historical searches list:
- Is the search view visible?
- Has the user typed a query?
- Has the user performed a search?
- Is the user seeing any results from a previous search?
- etc.

I considered the possibility of extracting part of this logic to another fragment or to the existing `ViewModel`, and while I certainly think it can be done, I also think these solutions seemed to require a disproportionate amount of effort when compared to the potential payoffs for this particular feature. In other words, it didn't seem like the right time to invest more in this, especially considering that this is such a small feature.

## To test

For each of the tests below, you first need to make sure you're using the build variant thas has enabled IA flags.

#### 1. Basic scenario
0. Make sure you haven't searched for anything before.
1. Open the **Reader**.
2. Tap the search icon.
3. Notice the initial search screen with the "What would you like to find" message.
4. Make a new search.
5. Notice the loading progress.
6. Wait for the search results.
7. Clear the search field.
8. Notice the initial screen with the historical searches list.
9. Type a new search query.
10. Notice the historical searches list is _not_ being filtered while typing.

#### 2. Repeat search
0. Make sure you've made at least one search before.
1. Open the **Reader**.
2. Tap the search icon.
3. Notice the initial screen with the historical searches list.
4. Tap on an item in the historical searches list.
5. Notice the search field is now filled with that item query.
6. Notice the loading progress.
7. Wait for the search results.

#### 3. Delete and clear
0. Make sure you've made several searches before.
1. Open the **Reader**.
2. Tap the search icon.
3. Notice the initial screen with the historical searches list.
4. Tap the delete icon **(X)** on an item in the historical searches list.
5. Notice the item is gone.
6. Tap the **Clear search history** button.
7. Notice the initial search screen with the "What would you like to find" message.

## Notes

- The search screen can behave erratically after configuration changes, but I think I've managed to prevent the most critical bugs related to that.
- Sometimes the historical searches list can be covered by the suggestions popup – this is an expected behavior.
- @osullivanchris already reviewed this on Slack, so we can go straight to code review.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
