### PR TITLE
Fixing reader bottom sheet RTL support.

### DIFF
--- a/WordPress/src/main/res/layout/subfilter_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/subfilter_bottom_sheet.xml
@@ -16,8 +16,7 @@
         android:id="@+id/title"
         style="@style/SiteTagBottomSheetTitle"
         android:layout_width="match_parent"
-        android:text="@string/reader_filter_main_title"
-        tools:text="Following"/>
+        android:text="@string/reader_filter_main_title"/>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1088,6 +1088,7 @@
     </style>
 
     <style name="SiteTagFilteredTitle" parent="MySiteListRowTextView">
+        <item name="android:textAlignment">viewStart</item>
         <item name="android:layout_gravity">center_vertical</item>
         <item name="android:gravity">center_vertical</item>
         <item name="android:paddingTop">@dimen/margin_large</item>


### PR DESCRIPTION
Fixes #11300

This PR fixes an issue with RTL support as per below images.

| Description | Wrong 👎 | Correct 👍 |
|---|---|---|
| `Following` title alignement and `SITES` list | ![image](https://user-images.githubusercontent.com/47797566/74452537-822daa80-4e81-11ea-8d24-07ac970dadb2.png) | ![image](https://user-images.githubusercontent.com/47797566/74458107-7e058b00-4e89-11ea-8454-dfc75f703dfd.png) |
| `Following` title alignement and `TAGS` list | ![image](https://user-images.githubusercontent.com/47797566/74457472-93c68080-4e88-11ea-9c56-899253589053.png) | ![image](https://user-images.githubusercontent.com/47797566/74458174-9aa1c300-4e89-11ea-8ca3-56d070eabad1.png) |


## NOTES
- Some strings for Hebrew language are not set so we get english defaults but the alignements should be correct with this patch.

## To test
- Run the zalpha flavor of the app and check first with English that you get left alignment in the reader bottom sheet like below 

| ![image](https://user-images.githubusercontent.com/47797566/74458446-01bf7780-4e8a-11ea-940a-4f0281b6197c.png) | ![image](https://user-images.githubusercontent.com/47797566/74458482-0f74fd00-4e8a-11ea-89db-f28c6a1453e9.png) |
|---|---|

- Change now the language to a RTL language (like Hebrew) and check you get something similar to the `Correct 👍` column above.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
