### PR TITLE
Update Sentry sdk to v2.0

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -291,7 +291,7 @@ dependencies {
     lintChecks 'org.wordpress:lint:1.0.1'
 
     // Sentry
-    implementation 'io.sentry:sentry-android:1.7.16'
+    implementation 'io.sentry:sentry-android-core:2.0.0-rc04'
     implementation 'org.slf4j:slf4j-nop:1.7.25'
 
     // Debug

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -109,6 +109,7 @@ android {
             // but we don't obfuscate the bytecode.
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
+            multiDexKeepProguard file('multidex-config.pro')
         }
 
         debug {

--- a/WordPress/multidex-config.pro
+++ b/WordPress/multidex-config.pro
@@ -1,0 +1,2 @@
+-keep class io.sentry.android.core.SentryAndroidOptions
+-keep class io.sentry.android.ndk.SentryNdk

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -60,6 +60,9 @@
         android:supportsRtl="true"
         tools:ignore="UnusedAttribute">
 
+        <!-- Force manual initialization for Sentry to provide DSN programmatically-->
+        <meta-data android:name="io.sentry.auto-init" android:value="false" />
+
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/com_google_android_geo_api_key"/>

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
@@ -41,7 +41,6 @@ class CrashLoggingUtils {
         }
 
         @JvmStatic fun stopCrashLogging() {
-            Sentry.clearBreadcrumbs()
             Sentry.close()
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
@@ -7,6 +7,7 @@ import io.sentry.core.Breadcrumb
 import io.sentry.core.Sentry
 import io.sentry.core.SentryOptions.BeforeSendCallback
 import org.wordpress.android.BuildConfig
+import org.wordpress.android.R
 
 class CrashLoggingUtils {
     fun shouldEnableCrashLogging(context: Context): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
@@ -1,14 +1,15 @@
 package org.wordpress.android.util
 
+import android.content.Context
 import android.preference.PreferenceManager
-import io.sentry.Sentry
-import io.sentry.android.AndroidSentryClientFactory
-import io.sentry.event.BreadcrumbBuilder
+import io.sentry.android.core.SentryAndroid
+import io.sentry.core.Breadcrumb
+import io.sentry.core.Sentry
+import io.sentry.core.SentryOptions.BeforeSendCallback
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.R
 
 class CrashLoggingUtils {
-    fun shouldEnableCrashLogging(context: android.content.Context): Boolean {
+    fun shouldEnableCrashLogging(context: Context): Boolean {
         if (PackageUtils.isDebugBuild()) {
             return false
         }
@@ -18,9 +19,15 @@ class CrashLoggingUtils {
         return !hasUserOptedOut
     }
 
-    fun enableCrashLogging(context: android.content.Context) {
-        Sentry.init(BuildConfig.SENTRY_DSN, AndroidSentryClientFactory(context))
-        Sentry.getContext().addTag("version", BuildConfig.VERSION_NAME)
+    fun enableCrashLogging(context: Context) {
+        SentryAndroid.init(context.applicationContext) {
+            it.dsn = BuildConfig.SENTRY_DSN
+            it.beforeSend = BeforeSendCallback { event, hint ->
+                // Todo: Update event with additional info (extras)
+                return@BeforeSendCallback event
+            }
+        }
+        Sentry.setTag("version", BuildConfig.VERSION_NAME)
     }
 
     companion object {
@@ -33,7 +40,7 @@ class CrashLoggingUtils {
         }
 
         @JvmStatic fun stopCrashLogging() {
-            Sentry.clearContext()
+            Sentry.clearBreadcrumbs()
             Sentry.close()
         }
 
@@ -42,13 +49,11 @@ class CrashLoggingUtils {
                 return
             }
 
-            Sentry.getContext().recordBreadcrumb(
-                    BreadcrumbBuilder().setMessage(message).build()
-            )
+            Sentry.addBreadcrumb(Breadcrumb(message))
         }
 
         @JvmStatic fun log(exception: Throwable) {
-            Sentry.capture(exception)
+            Sentry.captureException(exception)
         }
 
         @JvmStatic fun logException(tr: Throwable, tag: AppLog.T) {


### PR DESCRIPTION
**Title:** Update Sentry SDK to v2.0 Release Candidate

**Issue:** Making progress the against Encrypting Logs Issue #10698 

**Description:** 
We want to be able to link Sentry events (unhandled or caught exceptions) to future Encrypted logs we are gonna submit to Wordpress API. 

This PR allows us to attach additional information to any Sentry event before it gets sent to Sentry server. 

- _Implemented already_: Logic to encrypt the logs #11230 #10738 
- _Not implemented yet_: The logic to generate the UUID and sending the encrypted log. (Next PR)

_Why not using Sentry v1.X?_  Because there is a race condition when sending the event for caught exceptions. If we try to attach additional data or tags or anything before the event is sent, it seems the logic is not waiting for the info to be attached and sends the event anyway without it.

_Why V2.0?_ With Sentry v2.0, we gain the ability to update the event with the future UUID we are going to generate in the next PR. E.g.
```
SentryAndroid.init(context.applicationContext) {
            it.dsn = BuildConfig.SENTRY_DSN
            it.beforeSend = BeforeSendCallback { event, hint ->
                // Todo: Update event with a UUID from the Logs we want to encrypt.
                return@BeforeSendCallback event
            }
        }
```

**Testing instructions:** 
Enable CrashLogging momentarily for your `Debug` build by doing the following 
```
# CrashloggingUtils.kt
fun shouldEnableCrashLogging(context: Context): Boolean {
        if (PackageUtils.isDebugBuild()) {
            return true  // <-- Change this from false to true (dont forget to revert it)
        }

        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
        val hasUserOptedOut = !prefs.getBoolean(context.getString(R.string.pref_key_send_crash), true)
        return !hasUserOptedOut
    }
```
Build the project, deploy the app nd check out the logcat to see if the following messages are displayed:
```
2020-02-13 15:31:26.847 6970-6970/org.wordpress.android D/Sentry: Auto-init: false
2020-02-13 15:31:26.847 6970-6970/org.wordpress.android I/Sentry: Retrieving auto-init from AndroidManifest.xml
```
If there are no other errors, then it should be fine.

If we attach info to events, how is it gonna look like? Let's see a dummy `Logs` id sent as Additional Data
![Screenshot 2020-02-12 at 13 14 11](https://user-images.githubusercontent.com/2184653/74460129-53650380-4e84-11ea-9a9b-76f760446ed2.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
