### PR TITLE
Allow separate handling of requests to load a thumbnail and a full-sized image using ImageManager

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -598,13 +598,13 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             mImageManager.loadIntoCircle(mHeaderAvatar, ImageType.AVATAR_WITHOUT_BACKGROUND,
                     newAvatarUploaded ? injectFilePath : avatarUrl, new RequestListener<Drawable>() {
                         @Override
-                        public void onLoadFailed(@Nullable Exception e) {
+                        public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
                             AppLog.e(T.NUX, "Uploading image to Gravatar succeeded, but setting image view failed");
                             showErrorDialogWithCloseButton(getString(R.string.signup_epilogue_error_avatar_view));
                         }
 
                         @Override
-                        public void onResourceReady(@NotNull Drawable resource) {
+                        public void onResourceReady(@NotNull Drawable resource, boolean isFirstResource) {
                             if (newAvatarUploaded && resource instanceof BitmapDrawable) {
                                 Bitmap bitmap = ((BitmapDrawable) resource).getBitmap();
                                 // create a copy since the original bitmap may by automatically recycled

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -324,7 +324,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
             mImageManager.loadIntoCircle(mAvatarImageView, ImageType.AVATAR_WITHOUT_BACKGROUND,
                     newAvatarUploaded ? injectFilePath : avatarUrl, new RequestListener<Drawable>() {
                         @Override
-                        public void onLoadFailed(@Nullable Exception e) {
+                        public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
                             final String appLogMessage = "onLoadFailed while loading Gravatar image!";
                             if (e == null) {
                                 AppLog.e(T.MAIN, appLogMessage + " e == null");
@@ -340,7 +340,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
                         }
 
                         @Override
-                        public void onResourceReady(@NotNull Drawable resource) {
+                        public void onResourceReady(@NotNull Drawable resource, boolean isFirstResource) {
                             if (newAvatarUploaded && resource instanceof BitmapDrawable) {
                                 Bitmap bitmap = ((BitmapDrawable) resource).getBitmap();
                                 // create a copy since the original bitmap may by automatically recycled

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -287,7 +287,7 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
         mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, mediaUri, ScaleType.CENTER, null,
                 new RequestListener<Drawable>() {
                     @Override
-                    public void onResourceReady(@NotNull Drawable resource) {
+                    public void onResourceReady(@NotNull Drawable resource, boolean isFirstResource) {
                         if (isAdded()) {
                             // assign the photo attacher to enable pinch/zoom - must come before setImageBitmap
                             // for it to be correctly resized upon loading
@@ -305,7 +305,7 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
                     }
 
                     @Override
-                    public void onLoadFailed(@Nullable Exception e) {
+                    public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
                         if (isAdded()) {
                             if (e != null) {
                                 AppLog.e(T.MEDIA, e);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -767,7 +767,7 @@ public class MediaSettingsActivity extends AppCompatActivity
         mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, imageUrl, ScaleType.CENTER, null,
                 new RequestListener<Drawable>() {
                     @Override
-                    public void onResourceReady(@NotNull Drawable resource) {
+                    public void onResourceReady(@NotNull Drawable resource, boolean isFirstResource) {
                         if (!isFinishing()) {
                             showProgress(false);
 
@@ -778,7 +778,7 @@ public class MediaSettingsActivity extends AppCompatActivity
                     }
 
                     @Override
-                    public void onLoadFailed(@Nullable Exception e) {
+                    public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
                         if (!isFinishing()) {
                             if (e != null) {
                                 AppLog.e(T.MEDIA, e);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
@@ -163,7 +163,7 @@ public class NoteBlock {
                             StringUtils.notNullStr(getNoteMediaItem().getUrl()), ScaleType.CENTER, null,
                             new ImageManager.RequestListener<Drawable>() {
                                 @Override
-                                public void onLoadFailed(@Nullable Exception e) {
+                                public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
                                     if (e != null) {
                                         AppLog.e(T.NOTIFS, e);
                                     }
@@ -171,7 +171,7 @@ public class NoteBlock {
                                 }
 
                                 @Override
-                                public void onResourceReady(@Nullable Drawable resource) {
+                                public void onResourceReady(@Nullable Drawable resource, boolean isFirstResource) {
                                     if (!mHasAnimatedBadge && view.getContext() != null && resource != null) {
                                         mHasAnimatedBadge = true;
                                         Animation pop = AnimationUtils.loadAnimation(view.getContext(), R.anim.pop);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -998,10 +998,10 @@ public class EditPostSettingsFragment extends Fragment {
                 mImageManager.loadWithResultListener(mFeaturedImageView, ImageType.IMAGE,
                         currentFeaturedImageState.getMediaUri(), ScaleType.FIT_CENTER,
                         null, new RequestListener<Drawable>() {
-                            @Override public void onLoadFailed(@org.jetbrains.annotations.Nullable Exception e) {
+                            @Override public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
                             }
 
-                            @Override public void onResourceReady(Drawable resource) {
+                            @Override public void onResourceReady(Drawable resource, boolean isFirstResource) {
                                 if (currentFeaturedImageState.getUiState() == FeaturedImageState.REMOTE_IMAGE_LOADING) {
                                     updateFeaturedImageViews(FeaturedImageState.REMOTE_IMAGE_SET);
                                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
@@ -108,7 +108,7 @@ public class ReaderPhotoView extends RelativeLayout {
                 .loadWithResultListener(mImageView, ImageType.IMAGE, mHiResImageUrl, ScaleType.CENTER, mLoResImageUrl,
                 new RequestListener<Drawable>() {
                     @Override
-                    public void onLoadFailed(@Nullable Exception e) {
+                    public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
                         if (e != null) {
                             AppLog.e(AppLog.T.READER, e);
                         }
@@ -120,7 +120,7 @@ public class ReaderPhotoView extends RelativeLayout {
                     }
 
                     @Override
-                    public void onResourceReady(Drawable resource) {
+                    public void onResourceReady(Drawable resource, boolean isFirstResource) {
                         handleResponse();
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/SiteCreationSegmentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/SiteCreationSegmentViewHolder.kt
@@ -44,10 +44,13 @@ sealed class SiteCreationSegmentViewHolder(internal val parent: ViewGroup, @Layo
                     ScaleType.CENTER,
                     null,
                     object : RequestListener<Drawable> {
-                        override fun onLoadFailed(e: Exception?) {
+                        override fun onLoadFailed(e: Exception?, isFirstResource: Boolean) {
                         }
 
-                        override fun onResourceReady(resource: Drawable) {
+                        override fun onResourceReady(
+                            resource: Drawable,
+                            isFirstResource: Boolean
+                        ) {
                             try {
                                 icon.setColorFilter(Color.parseColor(uiState.iconColor), PorterDuff.Mode.SRC_IN)
                             } catch (e: IllegalArgumentException) {

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -37,8 +37,22 @@ import javax.inject.Singleton
 @Singleton
 class ImageManager @Inject constructor(private val placeholderManager: ImagePlaceholderManager) {
     interface RequestListener<T> {
-        fun onLoadFailed(e: Exception?)
-        fun onResourceReady(resource: T)
+        /**
+         * Called when an exception occurs during a load
+         *
+         * @param e The maybe {@code null} exception containing information about why the request failed.
+         * @param isFirstResource {@code true} if this exception is for the first resource to load.
+         */
+        fun onLoadFailed(e: Exception?, isFirstResource: Boolean)
+        /**
+         * Called when a load completes successfully
+         *
+         * @param resource The resource that was loaded for the target.
+         * @param isFirstResource {@code true} if this is the first resource to be loaded
+         *     into the target. For example when loading a thumbnail and a full-sized image, this will be
+         *     {@code true} for the first image to load and {@code false} for the second.
+         */
+        fun onResourceReady(resource: T, isFirstResource: Boolean)
     }
 
     /**
@@ -340,7 +354,7 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
                     target: Target<T>?,
                     isFirstResource: Boolean
                 ): Boolean {
-                    requestListener.onLoadFailed(e)
+                    requestListener.onLoadFailed(e, isFirstResource)
                     return false
                 }
 
@@ -352,11 +366,11 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
                     isFirstResource: Boolean
                 ): Boolean {
                     if (resource != null) {
-                        requestListener.onResourceReady(resource)
+                        requestListener.onResourceReady(resource, isFirstResource)
                     } else {
                         // according to the Glide's JavaDoc, this shouldn't happen
                         AppLog.e(AppLog.T.UTILS, "Resource in ImageManager.onResourceReady is null.")
-                        requestListener.onLoadFailed(null)
+                        requestListener.onLoadFailed(null, isFirstResource)
                     }
                     return false
                 }


### PR DESCRIPTION
Fixes #11304

This PR allows separate handling of  thumbnail and a full-sized image requests on using `ImageManager's` `loadWithResultListener`.

To test
-  `RequestListener`'s methods
     `onLoadFailed` 
    `onResourceReady`
are refactored to include the new param `isFirstResource` in the method signature. 

- `ImageManager`'s `attachRequestListener` passes Glide's `isFirstResource` param to corresponding `RequestListener` methods.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
