### PR TITLE
Fix upload status cache issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageUploadUiStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageUploadUiStateUseCase.kt
@@ -14,13 +14,14 @@ import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.Post
 import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingPost
 import javax.inject.Inject
 
-class CreatePageUploadUiStateUseCase @Inject constructor(val uploadStatusTracker: PostModelUploadStatusTracker) {
+class CreatePageUploadUiStateUseCase @Inject constructor() {
     /**
      * Copied from PostListItemUiStateHelper since the behavior is similar for the Page List UI State.
      */
     fun createUploadUiState(
         post: PostModel,
-        site: SiteModel
+        site: SiteModel,
+        uploadStatusTracker: PostModelUploadStatusTracker
     ): PostUploadUiState {
         val postStatus = PostStatus.fromPost(post)
         val uploadStatus = uploadStatusTracker.getUploadStatus(post, site)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -164,7 +164,7 @@ class PageListViewModel @Inject constructor(
     }
 
     private val uploadStatusObserver = Observer<List<LocalId>> { ids ->
-        createPageUploadUiStateUseCase.uploadStatusTracker.invalidateUploadStatus(ids.map { localId -> localId.value })
+        pagesViewModel.uploadStatusTracker.invalidateUploadStatus(ids.map { localId -> localId.value })
     }
 
     private fun loadPagesAsync(pages: List<PageModel>) = launch {
@@ -368,7 +368,8 @@ class PageListViewModel @Inject constructor(
         // TODO the postmodel is sometimes null, why?
         val uploadUiState = createPageUploadUiStateUseCase.createUploadUiState(
                 postModel,
-                pagesViewModel.site
+                pagesViewModel.site,
+                pagesViewModel.uploadStatusTracker
         )
         val (labels, labelColor) = createPageListItemLabelsUseCase.createLabels(postModel, uploadUiState)
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.PostInfoType
 import org.wordpress.android.ui.posts.PostListRemotePreviewState
+import org.wordpress.android.ui.posts.PostModelUploadStatusTracker
 import org.wordpress.android.ui.posts.PreviewStateHelper
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
 import org.wordpress.android.ui.uploads.UploadStarter
@@ -89,6 +90,7 @@ class PagesViewModel
     private val uploadStarter: UploadStarter,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val pageConflictResolver: PageConflictResolver,
+    val uploadStatusTracker: PostModelUploadStatusTracker,
     private val pageListEventListenerFactory: PageListEventListener.Factory,
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val defaultDispatcher: CoroutineDispatcher

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
@@ -94,7 +94,8 @@ class SearchListViewModel
         val postModel = postStore.getPostByLocalPostId(this.pageId)
         val uploadUiState = createPageUploadUiStateUseCase.createUploadUiState(
                 postModel,
-                pagesViewModel.site
+                pagesViewModel.site,
+                pagesViewModel.uploadStatusTracker
         )
         // TODO any reason why we don't show labels in search?
         val (progressBarUiState, showOverlay) = progressHelper.getProgressStateForPage(postModel,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -69,9 +69,10 @@ class PageListViewModelTest : BaseUnitTest() {
         whenever(pagesViewModel.arePageActionsEnabled).thenReturn(false)
         whenever(pagesViewModel.site).thenReturn(site)
         whenever(pagesViewModel.invalidateUploadStatus).thenReturn(invalidateUploadStatus)
+        whenever(pagesViewModel.uploadStatusTracker).thenReturn(mock())
         whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.getDefault())
         whenever(postStore.getPostByLocalPostId(anyInt())).thenReturn(PostModel())
-        whenever(createUploadStateUseCase.createUploadUiState(any(), any())).thenReturn(
+        whenever(createUploadStateUseCase.createUploadUiState(any(), any(), any())).thenReturn(
                 PostUploadUiState.NothingToUpload
         )
         whenever(createLabelsUseCase.createLabels(any(), any())).thenReturn(Pair(emptyList(), 0))

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -64,6 +64,7 @@ class PagesViewModelTest {
                 networkUtils = networkUtils,
                 previewStateHelper = mock(),
                 analyticsTracker = mock(),
+                uploadStatusTracker = mock(),
                 pageConflictResolver = mock(),
                 uiDispatcher = Dispatchers.Unconfined,
                 defaultDispatcher = Dispatchers.Unconfined,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.viewmodel.pages
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
@@ -71,8 +72,9 @@ class SearchListViewModelTest {
         )
         whenever(pagesViewModel.searchPages).thenReturn(searchPages)
         whenever(pagesViewModel.site).thenReturn(site)
+        whenever(pagesViewModel.uploadStatusTracker).thenReturn(mock())
         whenever(postStore.getPostByLocalPostId(ArgumentMatchers.anyInt())).thenReturn(PostModel())
-        whenever(createUploadStateUseCase.createUploadUiState(any(), any())).thenReturn(
+        whenever(createUploadStateUseCase.createUploadUiState(any(), any(), any())).thenReturn(
                 PostUploadUiState.NothingToUpload
         )
         viewModel.start(pagesViewModel)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/11303

A single instance of PostModelUploadStatusTracker is injected into PagesViewModel and reused in all the child view models. This fixes the issue as all the vms are working with the same instance and the cache is always up to date.

To test:
1. Smoke Test:  Try to publish a post and make sure the progress bar indicator is shown

I tested it by merging this branch into https://github.com/wordpress-mobile/WordPress-Android/pull/11266 and:
1. Open Page list
2. Turn on airplane mode
3. Open a page and make changes
4. Click on Update/Publish
5. Find the page in the page list
6. Click on the "Cancel" action
7. Make sure the Cancel action disappears 


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
