### PR TITLE
Replace isFirstResource in ImageManager's RequestListener methods with model param

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -598,13 +598,13 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             mImageManager.loadIntoCircle(mHeaderAvatar, ImageType.AVATAR_WITHOUT_BACKGROUND,
                     newAvatarUploaded ? injectFilePath : avatarUrl, new RequestListener<Drawable>() {
                         @Override
-                        public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
+                        public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
                             AppLog.e(T.NUX, "Uploading image to Gravatar succeeded, but setting image view failed");
                             showErrorDialogWithCloseButton(getString(R.string.signup_epilogue_error_avatar_view));
                         }
 
                         @Override
-                        public void onResourceReady(@NotNull Drawable resource, boolean isFirstResource) {
+                        public void onResourceReady(@NotNull Drawable resource, @Nullable Object model) {
                             if (newAvatarUploaded && resource instanceof BitmapDrawable) {
                                 Bitmap bitmap = ((BitmapDrawable) resource).getBitmap();
                                 // create a copy since the original bitmap may by automatically recycled

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -324,7 +324,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
             mImageManager.loadIntoCircle(mAvatarImageView, ImageType.AVATAR_WITHOUT_BACKGROUND,
                     newAvatarUploaded ? injectFilePath : avatarUrl, new RequestListener<Drawable>() {
                         @Override
-                        public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
+                        public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
                             final String appLogMessage = "onLoadFailed while loading Gravatar image!";
                             if (e == null) {
                                 AppLog.e(T.MAIN, appLogMessage + " e == null");
@@ -340,7 +340,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
                         }
 
                         @Override
-                        public void onResourceReady(@NotNull Drawable resource, boolean isFirstResource) {
+                        public void onResourceReady(@NotNull Drawable resource, @Nullable Object model) {
                             if (newAvatarUploaded && resource instanceof BitmapDrawable) {
                                 Bitmap bitmap = ((BitmapDrawable) resource).getBitmap();
                                 // create a copy since the original bitmap may by automatically recycled

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -286,7 +286,7 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
         mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, mediaUri, ScaleType.CENTER, null,
                 new RequestListener<Drawable>() {
                     @Override
-                    public void onResourceReady(Drawable resource, @Nullable Object model) {
+                    public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
                         if (isAdded()) {
                             // assign the photo attacher to enable pinch/zoom - must come before setImageBitmap
                             // for it to be correctly resized upon loading

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -287,7 +287,7 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
         mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, mediaUri, ScaleType.CENTER, null,
                 new RequestListener<Drawable>() {
                     @Override
-                    public void onResourceReady(@NotNull Drawable resource, boolean isFirstResource) {
+                    public void onResourceReady(Drawable resource, @Nullable Object model) {
                         if (isAdded()) {
                             // assign the photo attacher to enable pinch/zoom - must come before setImageBitmap
                             // for it to be correctly resized upon loading
@@ -305,7 +305,7 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
                     }
 
                     @Override
-                    public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
+                    public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
                         if (isAdded()) {
                             if (e != null) {
                                 AppLog.e(T.MEDIA, e);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -19,7 +19,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.MediaModel;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -767,7 +767,7 @@ public class MediaSettingsActivity extends AppCompatActivity
         mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, imageUrl, ScaleType.CENTER, null,
                 new RequestListener<Drawable>() {
                     @Override
-                    public void onResourceReady(@NotNull Drawable resource, boolean isFirstResource) {
+                    public void onResourceReady(@NotNull Drawable resource, @Nullable Object model) {
                         if (!isFinishing()) {
                             showProgress(false);
 
@@ -778,7 +778,7 @@ public class MediaSettingsActivity extends AppCompatActivity
                     }
 
                     @Override
-                    public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
+                    public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
                         if (!isFinishing()) {
                             if (e != null) {
                                 AppLog.e(T.MEDIA, e);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
@@ -163,7 +163,7 @@ public class NoteBlock {
                             StringUtils.notNullStr(getNoteMediaItem().getUrl()), ScaleType.CENTER, null,
                             new ImageManager.RequestListener<Drawable>() {
                                 @Override
-                                public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
+                                public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
                                     if (e != null) {
                                         AppLog.e(T.NOTIFS, e);
                                     }
@@ -171,7 +171,7 @@ public class NoteBlock {
                                 }
 
                                 @Override
-                                public void onResourceReady(@Nullable Drawable resource, boolean isFirstResource) {
+                                public void onResourceReady(@Nullable Drawable resource, @Nullable Object model) {
                                     if (!mHasAnimatedBadge && view.getContext() != null && resource != null) {
                                         mHasAnimatedBadge = true;
                                         Animation pop = AnimationUtils.loadAnimation(view.getContext(), R.anim.pop);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
@@ -19,7 +19,9 @@ import android.widget.LinearLayout;
 import android.widget.MediaController;
 import android.widget.VideoView;
 
-import org.jetbrains.annotations.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.wordpress.android.R;
 import org.wordpress.android.fluxc.tools.FormattableContent;
 import org.wordpress.android.fluxc.tools.FormattableMedia;
@@ -171,8 +173,8 @@ public class NoteBlock {
                                 }
 
                                 @Override
-                                public void onResourceReady(@Nullable Drawable resource, @Nullable Object model) {
-                                    if (!mHasAnimatedBadge && view.getContext() != null && resource != null) {
+                                public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
+                                    if (!mHasAnimatedBadge && view.getContext() != null) {
                                         mHasAnimatedBadge = true;
                                         Animation pop = AnimationUtils.loadAnimation(view.getContext(), R.anim.pop);
                                         noteBlockHolder.getImageView().startAnimation(pop);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -998,10 +998,10 @@ public class EditPostSettingsFragment extends Fragment {
                 mImageManager.loadWithResultListener(mFeaturedImageView, ImageType.IMAGE,
                         currentFeaturedImageState.getMediaUri(), ScaleType.FIT_CENTER,
                         null, new RequestListener<Drawable>() {
-                            @Override public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
+                            @Override public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
                             }
 
-                            @Override public void onResourceReady(Drawable resource, boolean isFirstResource) {
+                            @Override public void onResourceReady(Drawable resource, @Nullable Object model) {
                                 if (currentFeaturedImageState.getUiState() == FeaturedImageState.REMOTE_IMAGE_LOADING) {
                                     updateFeaturedImageViews(FeaturedImageState.REMOTE_IMAGE_SET);
                                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -1001,7 +1001,7 @@ public class EditPostSettingsFragment extends Fragment {
                             @Override public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
                             }
 
-                            @Override public void onResourceReady(Drawable resource, @Nullable Object model) {
+                            @Override public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
                                 if (currentFeaturedImageState.getUiState() == FeaturedImageState.REMOTE_IMAGE_LOADING) {
                                     updateFeaturedImageViews(FeaturedImageState.REMOTE_IMAGE_SET);
                                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
@@ -11,6 +11,7 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.wordpress.android.R;
@@ -120,7 +121,7 @@ public class ReaderPhotoView extends RelativeLayout {
                     }
 
                     @Override
-                    public void onResourceReady(Drawable resource, @Nullable Object model) {
+                    public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
                         handleResponse();
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
@@ -108,7 +108,7 @@ public class ReaderPhotoView extends RelativeLayout {
                 .loadWithResultListener(mImageView, ImageType.IMAGE, mHiResImageUrl, ScaleType.CENTER, mLoResImageUrl,
                 new RequestListener<Drawable>() {
                     @Override
-                    public void onLoadFailed(@Nullable Exception e, boolean isFirstResource) {
+                    public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
                         if (e != null) {
                             AppLog.e(AppLog.T.READER, e);
                         }
@@ -120,7 +120,7 @@ public class ReaderPhotoView extends RelativeLayout {
                     }
 
                     @Override
-                    public void onResourceReady(Drawable resource, boolean isFirstResource) {
+                    public void onResourceReady(Drawable resource, @Nullable Object model) {
                         handleResponse();
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/SiteCreationSegmentViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/SiteCreationSegmentViewHolder.kt
@@ -44,12 +44,12 @@ sealed class SiteCreationSegmentViewHolder(internal val parent: ViewGroup, @Layo
                     ScaleType.CENTER,
                     null,
                     object : RequestListener<Drawable> {
-                        override fun onLoadFailed(e: Exception?, isFirstResource: Boolean) {
+                        override fun onLoadFailed(e: Exception?, model: Any?) {
                         }
 
                         override fun onResourceReady(
                             resource: Drawable,
-                            isFirstResource: Boolean
+                            model: Any?
                         ) {
                             try {
                                 icon.setColorFilter(Color.parseColor(uiState.iconColor), PorterDuff.Mode.SRC_IN)

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -41,18 +41,16 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
          * Called when an exception occurs during a load
          *
          * @param e The maybe {@code null} exception containing information about why the request failed.
-         * @param isFirstResource {@code true} if this exception is for the first resource to load.
+         * @param model The model we were trying to load when the exception occurred.
          */
-        fun onLoadFailed(e: Exception?, isFirstResource: Boolean)
+        fun onLoadFailed(e: Exception?, model: Any?)
         /**
          * Called when a load completes successfully
          *
          * @param resource The resource that was loaded for the target.
-         * @param isFirstResource {@code true} if this is the first resource to be loaded
-         *     into the target. For example when loading a thumbnail and a full-sized image, this will be
-         *     {@code true} for the first image to load and {@code false} for the second.
+         * @param model The specific model that was used to load the image.
          */
-        fun onResourceReady(resource: T, isFirstResource: Boolean)
+        fun onResourceReady(resource: T, model: Any?)
     }
 
     /**
@@ -354,7 +352,7 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
                     target: Target<T>?,
                     isFirstResource: Boolean
                 ): Boolean {
-                    requestListener.onLoadFailed(e, isFirstResource)
+                    requestListener.onLoadFailed(e, model)
                     return false
                 }
 
@@ -366,11 +364,11 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
                     isFirstResource: Boolean
                 ): Boolean {
                     if (resource != null) {
-                        requestListener.onResourceReady(resource, isFirstResource)
+                        requestListener.onResourceReady(resource, model)
                     } else {
                         // according to the Glide's JavaDoc, this shouldn't happen
                         AppLog.e(AppLog.T.UTILS, "Resource in ImageManager.onResourceReady is null.")
-                        requestListener.onLoadFailed(null, isFirstResource)
+                        requestListener.onLoadFailed(null, model)
                     }
                     return false
                 }


### PR DESCRIPTION
Fixes #11304

`isFirstResource` param was added to `ImageManager` -> `RequestListener` methods but it was found it was not the best option to differentiate between thumb and full-sized image. When full-sized image was in the cache, Glide directly picked it up next time, ignoring the thumbnail and returning isFirstResource as true for the cached full-sized image.

This PR replaces `isFirstResource` added above with `model` param . Glide returns the url of the image being loaded to the [model](https://github.com/bumptech/glide/blob/master/library/src/main/java/com/bumptech/glide/request/RequestListener.java#L71) param.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
