### PR TITLE
Remove duplicate release not for gallery image sizes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 14.3
 -----
 * Added search to set page parent screen
-* Block editor: Add support for changing image sizes in Gallery and Image blocks
+* Block editor: Add support for changing image sizes in Image blocks
 * Block editor: Add support for upload options in Gallery block
 * Block editor: Added the Button block
 * Block editor: Add scroll support inside block picker and block settings


### PR DESCRIPTION
Removes gallery image size release note from 14.3 because that was added (and included in the release notes) in 14.2.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
