### PR TITLE
Issue/11177 update snackbar msgs 1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -48,6 +48,9 @@ import org.wordpress.android.ui.posts.PreviewStateHelper
 import org.wordpress.android.ui.posts.ProgressDialogHelper
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper
 import org.wordpress.android.ui.quickstart.QuickStartEvent
+import org.wordpress.android.ui.uploads.UploadActionUseCase
+import org.wordpress.android.ui.uploads.UploadUtils
+import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.QuickStartUtils
@@ -85,6 +88,8 @@ class PagesFragment : Fragment() {
     @Inject lateinit var remotePreviewLogicHelper: RemotePreviewLogicHelper
     @Inject lateinit var previewStateHelper: PreviewStateHelper
     @Inject lateinit var progressDialogHelper: ProgressDialogHelper
+    @Inject internal lateinit var uploadActionUseCase: UploadActionUseCase
+    @Inject internal lateinit var uploadUtilsWrapper: UploadUtilsWrapper
     private var quickStartEvent: QuickStartEvent? = null
     private var progressDialog: ProgressDialog? = null
 
@@ -119,8 +124,6 @@ class PagesFragment : Fragment() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == RequestCodes.EDIT_POST && resultCode == Activity.RESULT_OK && data != null) {
-            val pageId = data.getLongExtra(EditPostActivity.EXTRA_POST_REMOTE_ID, -1)
-
             if (EditPostActivity.checkToRestart(data)) {
                 ActivityLauncher.editPageForResult(data, this@PagesFragment, viewModel.site,
                         data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0), false)
@@ -129,8 +132,9 @@ class PagesFragment : Fragment() {
                 return
             }
 
-            if (pageId != -1L) {
-                viewModel.onPageEditFinished()
+            val localPageId = data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, -1)
+            if (localPageId != -1) {
+                viewModel.onPageEditFinished(localPageId, data)
             }
         } else if (requestCode == RequestCodes.PAGE_PARENT && resultCode == Activity.RESULT_OK && data != null) {
             val parentId = data.getLongExtra(EXTRA_PAGE_PARENT_ID_KEY, -1)
@@ -363,6 +367,26 @@ class PagesFragment : Fragment() {
 
         viewModel.dialogAction.observe(this, Observer {
             it?.show(activity, activity.supportFragmentManager, uiHelpers)
+        })
+
+        viewModel.postUploadAction.observe(this, Observer {
+            it?.let { (post, site, data) ->
+                uploadUtilsWrapper.handleEditPostResultSnackbars(
+                        activity,
+                        activity.findViewById(R.id.coordinator),
+                        data,
+                        post,
+                        site,
+                        uploadActionUseCase.getUploadAction(post),
+                        View.OnClickListener {
+                            UploadUtils.publishPost(
+                                    activity,
+                                    post,
+                                    site,
+                                    dispatcher
+                            ) }
+                )
+            }
         })
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -88,8 +88,8 @@ class PagesFragment : Fragment() {
     @Inject lateinit var remotePreviewLogicHelper: RemotePreviewLogicHelper
     @Inject lateinit var previewStateHelper: PreviewStateHelper
     @Inject lateinit var progressDialogHelper: ProgressDialogHelper
-    @Inject internal lateinit var uploadActionUseCase: UploadActionUseCase
-    @Inject internal lateinit var uploadUtilsWrapper: UploadUtilsWrapper
+    @Inject lateinit var uploadActionUseCase: UploadActionUseCase
+    @Inject lateinit var uploadUtilsWrapper: UploadUtilsWrapper
     private var quickStartEvent: QuickStartEvent? = null
     private var progressDialog: ProgressDialog? = null
 
@@ -132,9 +132,9 @@ class PagesFragment : Fragment() {
                 return
             }
 
-            val localPageId = data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, -1)
-            if (localPageId != -1) {
-                viewModel.onPageEditFinished(localPageId, data)
+            val remotePageId = data.getLongExtra(EditPostActivity.EXTRA_POST_REMOTE_ID, -1L)
+            if (remotePageId != -1L) {
+                viewModel.onPageEditFinished(remotePageId, data)
             }
         } else if (requestCode == RequestCodes.PAGE_PARENT && resultCode == Activity.RESULT_OK && data != null) {
             val parentId = data.getLongExtra(EXTRA_PAGE_PARENT_ID_KEY, -1)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -131,10 +131,10 @@ class PagesFragment : Fragment() {
                 // a restart will happen so, no need to continue here
                 return
             }
-
-            val remotePageId = data.getLongExtra(EditPostActivity.EXTRA_POST_REMOTE_ID, -1L)
-            if (remotePageId != -1L) {
-                viewModel.onPageEditFinished(remotePageId, data)
+            // we need to work with local ids, since local drafts don't have remote ids
+            val localPageId = data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, -1)
+            if (localPageId != -1) {
+                viewModel.onPageEditFinished(localPageId, data)
             }
         } else if (requestCode == RequestCodes.PAGE_PARENT && resultCode == Activity.RESULT_OK && data != null) {
             val parentId = data.getLongExtra(EXTRA_PAGE_PARENT_ID_KEY, -1)

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -157,15 +157,15 @@ public class UploadUtils {
         return uploadError != null && uploadError.mediaError != null;
     }
 
-    public static void handleEditPostResultSnackbars(@NonNull final Activity activity,
-                                                     @NonNull final Dispatcher dispatcher,
-                                                     @NonNull View snackbarAttachView,
-                                                     @NonNull Intent data,
-                                                     @NonNull final PostModel post,
-                                                     @NonNull final SiteModel site,
-                                                     @NonNull final UploadAction uploadAction,
-                                                     SnackbarSequencer sequencer,
-                                                     View.OnClickListener publishPostListener) {
+    public static void handleEditPostModelResultSnackbars(@NonNull final Activity activity,
+                                                          @NonNull final Dispatcher dispatcher,
+                                                          @NonNull View snackbarAttachView,
+                                                          @NonNull Intent data,
+                                                          @NonNull final PostModel post,
+                                                          @NonNull final SiteModel site,
+                                                          @NonNull final UploadAction uploadAction,
+                                                          SnackbarSequencer sequencer,
+                                                          View.OnClickListener publishPostListener) {
         boolean hasChanges = data.getBooleanExtra(EditPostActivity.EXTRA_HAS_CHANGES, false);
         if (!hasChanges) {
             // if there are no changes, we don't need to do anything
@@ -177,7 +177,7 @@ public class UploadUtils {
             // The network is not available, we can enqueue a request to upload local changes later
             UploadWorkerKt.enqueueUploadWorkRequestForSite(site);
             // And tell the user about it
-            showSnackbar(snackbarAttachView, getDeviceOfflinePostNotUploadedMessage(post, uploadAction),
+            showSnackbar(snackbarAttachView, getDeviceOfflinePostModelNotUploadedMessage(post, uploadAction),
                     R.string.cancel,
                     v -> {
                         int msgRes = cancelPendingAutoUpload(post, dispatcher);
@@ -545,23 +545,28 @@ public class UploadUtils {
     }
 
     @StringRes
-    private static int getDeviceOfflinePostNotUploadedMessage(@NonNull final PostModel post,
-                                                              @NonNull final UploadAction uploadAction) {
+    private static int getDeviceOfflinePostModelNotUploadedMessage(@NonNull final PostModel post,
+                                                                   @NonNull final UploadAction uploadAction) {
         if (uploadAction != UploadAction.UPLOAD) {
-            return R.string.error_publish_no_network;
+            return post.isPage() ? R.string.error_publish_page_no_network : R.string.error_publish_no_network;
         } else {
             switch (PostStatus.fromPost(post)) {
                 case PUBLISHED:
                 case UNKNOWN:
-                    return R.string.post_waiting_for_connection_publish;
+                    return post.isPage() ? R.string.page_waiting_for_connection_publish
+                            : R.string.post_waiting_for_connection_publish;
                 case DRAFT:
-                    return R.string.post_waiting_for_connection_draft;
+                    return post.isPage() ? R.string.page_waiting_for_connection_draft
+                            : R.string.post_waiting_for_connection_draft;
                 case PRIVATE:
-                    return R.string.post_waiting_for_connection_private;
+                    return post.isPage() ? R.string.page_waiting_for_connection_private
+                            : R.string.post_waiting_for_connection_private;
                 case PENDING:
-                    return R.string.post_waiting_for_connection_pending;
+                    return post.isPage() ? R.string.page_waiting_for_connection_pending
+                            : R.string.post_waiting_for_connection_pending;
                 case SCHEDULED:
-                    return R.string.post_waiting_for_connection_scheduled;
+                    return post.isPage() ? R.string.page_waiting_for_connection_scheduled
+                            : R.string.post_waiting_for_connection_scheduled;
                 case TRASHED:
                     throw new IllegalArgumentException("Trashing posts should be handled in a different code path.");
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
@@ -73,7 +73,7 @@ class UploadUtilsWrapper @Inject constructor(
         site: SiteModel,
         uploadAction: UploadAction,
         publishPostListener: OnClickListener?
-    ) = UploadUtils.handleEditPostResultSnackbars(
+    ) = UploadUtils.handleEditPostModelResultSnackbars(
             activity,
             dispatcher,
             snackbarAttachView,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -254,11 +254,13 @@ class PagesViewModel
         pageMap = pageMap
     }
 
-    fun onPageEditFinished(remotePageId: Long, data: Intent) {
+    fun onPageEditFinished(localPageId: Int, data: Intent) {
         launch {
             refreshPages() // show local changes immediately
-            pageMap[remotePageId]?.let {
-                _postUploadAction.postValue(Triple(it.post, it.site, data))
+            withContext(defaultDispatcher) {
+                pageStore.getPageByLocalId(pageId = localPageId, site = site)?.let {
+                    _postUploadAction.postValue(Triple(it.post, it.site, data))
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.viewmodel.pages
 
+import android.content.Intent
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -136,6 +137,9 @@ class PagesViewModel
     private val _invalidateUploadStatus = MutableLiveData<List<LocalId>>()
     val invalidateUploadStatus: LiveData<List<LocalId>> = _invalidateUploadStatus
 
+    private val _postUploadAction = SingleLiveEvent<Triple<PostModel, SiteModel, Intent>>()
+    val postUploadAction: LiveData<Triple<PostModel, SiteModel, Intent>> = _postUploadAction
+
     private var isInitialized = false
     private var scrollToPageId: Long? = null
 
@@ -250,9 +254,14 @@ class PagesViewModel
         pageMap = pageMap
     }
 
-    fun onPageEditFinished() {
+    fun onPageEditFinished(localPageId: Int, data: Intent) {
         launch {
             refreshPages() // show local changes immediately
+            withContext(defaultDispatcher) {
+                pageStore.getPageByLocalId(pageId = localPageId, site = site)?.let {
+                    _postUploadAction.postValue(Triple(it.post, it.site, data))
+                }
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -254,13 +254,11 @@ class PagesViewModel
         pageMap = pageMap
     }
 
-    fun onPageEditFinished(localPageId: Int, data: Intent) {
+    fun onPageEditFinished(remotePageId: Long, data: Intent) {
         launch {
             refreshPages() // show local changes immediately
-            withContext(defaultDispatcher) {
-                pageStore.getPageByLocalId(pageId = localPageId, site = site)?.let {
-                    _postUploadAction.postValue(Triple(it.post, it.site, data))
-                }
+            pageMap[remotePageId]?.let {
+                _postUploadAction.postValue(Triple(it.post, it.site, data))
             }
         }
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1507,6 +1507,7 @@
     <string name="error_publish_empty_page">Can\'t publish an empty page</string>
     <string name="error_save_empty_draft">Can\'t save an empty draft</string>
     <string name="error_publish_no_network">Device is offline. Post saved locally.</string>
+    <string name="error_publish_page_no_network">Device is offline. Page saved locally.</string>
     <string name="error_upload_post_param">There was an error uploading this post: %s.</string>
     <string name="error_upload_page_param">There was an error uploading this page: %s.</string>
     <string name="error_upload_post_media_param">There was an error uploading the media in this post: %s.</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -1,7 +1,10 @@
 package org.wordpress.android.viewmodel.pages
 
+import android.content.Intent
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -23,6 +26,7 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus.DRAFT
+import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.test
@@ -213,6 +217,24 @@ class PagesViewModelTest {
         // Then
         // invoked twice - once in start() and once in onPullToRefresh()
         verify(uploadStarter, times(2)).queueUploadFromSite(site)
+    }
+
+    @Test
+    fun `postUploadAction invoked on edit post activity result`() = test {
+        // Given
+        val localPageId = 999
+        val intent = mock<Intent>()
+        val postModel = PostModel().apply { setStatus(PostStatus.PUBLISHED.toString()) }
+        val siteModel = SiteModel()
+        whenever(pageStore.getPageByLocalId(eq(localPageId), anyOrNull()))
+                .thenReturn(PageModel(postModel, siteModel, null))
+
+        setUpPageStoreWithEmptyPages()
+        viewModel.start(site)
+        // When
+        viewModel.onPageEditFinished(localPageId, intent)
+        // Then
+        assertThat(viewModel.postUploadAction.value).isEqualTo(Triple(postModel, siteModel, intent))
     }
 
     private suspend fun setUpPageStoreWithEmptyPages() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -3,8 +3,6 @@ package org.wordpress.android.viewmodel.pages
 import android.content.Intent
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.anyOrNull
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -26,7 +24,6 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus.DRAFT
-import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.test
@@ -222,19 +219,13 @@ class PagesViewModelTest {
     @Test
     fun `postUploadAction invoked on edit post activity result`() = test {
         // Given
-        val localPageId = 999
         val intent = mock<Intent>()
-        val postModel = PostModel().apply { setStatus(PostStatus.PUBLISHED.toString()) }
-        val siteModel = SiteModel()
-        whenever(pageStore.getPageByLocalId(eq(localPageId), anyOrNull()))
-                .thenReturn(PageModel(postModel, siteModel, null))
-
-        setUpPageStoreWithEmptyPages()
+        val pageModel = setUpPageStoreWithASinglePage()
         viewModel.start(site)
         // When
-        viewModel.onPageEditFinished(localPageId, intent)
+        viewModel.onPageEditFinished(pageModel.remoteId, intent)
         // Then
-        assertThat(viewModel.postUploadAction.value).isEqualTo(Triple(postModel, siteModel, intent))
+        assertThat(viewModel.postUploadAction.value).isEqualTo(Triple(pageModel.post, pageModel.site, intent))
     }
 
     private suspend fun setUpPageStoreWithEmptyPages() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -3,6 +3,8 @@ package org.wordpress.android.viewmodel.pages
 import android.content.Intent
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -221,9 +223,12 @@ class PagesViewModelTest {
         // Given
         val intent = mock<Intent>()
         val pageModel = setUpPageStoreWithASinglePage()
+        whenever(pageStore.getPageByLocalId(eq(pageModel.pageId), anyOrNull()))
+                .thenReturn(pageModel)
+
         viewModel.start(site)
         // When
-        viewModel.onPageEditFinished(pageModel.remoteId, intent)
+        viewModel.onPageEditFinished(pageModel.pageId, intent)
         // Then
         assertThat(viewModel.postUploadAction.value).isEqualTo(Triple(pageModel.post, pageModel.site, intent))
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/11129, partially fixes #11177

Review instructions
1. ~Review and merge https://github.com/wordpress-mobile/WordPress-Android/pull/11332~
2. ~Update target branch to `feature/master-pages-offline-support`~
3. Review and merge this PR


To test:
1. My Site
2. Page List
3. Turn on airplane mode
4. Open an existing page
5. Make changes to its content
6. Press back
7. Notice "Device is offline. Paged saved locally" snackbar message


Repeat the above steps but in step 6 click on "Publish/Update/Save/Schedule". Notice "We'll publish/schedule/save .... " message.


Repeat the testing steps and make sure [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/69bd622c1f8a914a15a49d9c05b940117a0060b6/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java#L178) gets hit.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
