### PR TITLE
Fix page list upload state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -203,7 +203,7 @@ class PagesViewModel
                 postStore = postStore,
                 eventBusWrapper = eventBusWrapper,
                 site = site,
-                handlePostUploadedWithoutError = this::handlePostUploadedWithoutError,
+                handlePageUpdated = this::handlePageUpdated,
                 invalidateUploadStatus = this::handleInvalidateUploadStatus,
                 handleRemoteAutoSave = this::handleRemoveAutoSaveEvent,
                 handlePostUploadedStarted = this::postUploadStarted
@@ -248,10 +248,6 @@ class PagesViewModel
 
     private suspend fun refreshPages() {
         pageMap = pageStore.getPagesFromDb(site).associateBy { it.remoteId }
-    }
-
-    private fun invalidatePages() {
-        pageMap = pageMap
     }
 
     fun onPageEditFinished(localPageId: Int, data: Intent) {
@@ -750,7 +746,7 @@ class PagesViewModel
     private fun hasRemoteAutoSavePreviewError() = _previewState.value != null &&
             _previewState.value == PostListRemotePreviewState.REMOTE_AUTO_SAVE_PREVIEW_ERROR
 
-    fun handlePostUploadedWithoutError(remotePostId: RemoteId) {
+    fun handlePageUpdated(remotePostId: RemoteId) {
         var id = 0L
         if (!pageUpdateContinuations.contains(id)) {
             id = remotePostId.value
@@ -772,8 +768,8 @@ class PagesViewModel
 
     private fun handleInvalidateUploadStatus(ids: List<LocalId>) {
         launch {
-            _invalidateUploadStatus.postValue(ids)
-            invalidatePages()
+            _invalidateUploadStatus.value = ids
+            refreshPages()
         }
     }
 
@@ -781,7 +777,6 @@ class PagesViewModel
         launch {
             performIfNetworkAvailableAsync {
                 waitForPageUpdate(remoteId.value)
-                reloadPages()
             }
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -190,7 +190,7 @@ class PagesViewModelTest {
         assertThat(viewModel.arePageActionsEnabled).isFalse()
 
         // When
-        viewModel.handlePostUploadedWithoutError(RemoteId(page.remotePostId))
+        viewModel.handlePageUpdated(RemoteId(page.remotePostId))
 
         // Then
         assertThat(viewModel.arePageActionsEnabled).isTrue()

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'fa54194d78483da7ca8726d382f6a0942bb5a47d'
+    fluxCVersion = 'd0d86ffaca87e920bc1da9ba13741452d6e2139c'
 }
 
 // Onboarding and dev env setup tasks


### PR DESCRIPTION
Fixes #11263
Fixes #11265

**Review instructions**
1. Review this PR
2. Wait until https://github.com/wordpress-mobile/WordPress-Android/pull/11335 gets merged
3. Update target branch to `feature/master-pages-offline-support`
4. Merge this PR

------------------

This PR should fix all the weird issues with upload state on the page list items.
- progress which never disappears
- local changes label remains visible even after the page gets uploaded
- upload error isn't displayed
- 3-5s delay after the upload finishes and the ui state gets updated
- ...

I tried to simplify the logic in PageListEventListener. 
- call `uploadStatusChanged` whenever we receive an event related to upload - no matter if it's a success or an error
- removed `handlePostUploadedWithoutError` and replaced it with `handlePageUpdated` which is invoked whenever we receive `UpdatePost` or `RemoteAutoSave` events - no matter if it's a success or an error

To test:
Anything related to upload you can think of
- remote auto save
- media upload
- failed upload
- failed media upload
- offline/online
We'll test all the different scenarios before we merge this whole feature into develop, so don't worry about testing all the scenarios.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
