### PR TITLE
Send encrypted logs to Wordpress API

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/util/encryption/EncryptionUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/encryption/EncryptionUtilsTest.java
@@ -11,7 +11,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.libsodium.jni.NaCl;
-import org.libsodium.jni.Sodium;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,7 +58,7 @@ public class EncryptionUtilsTest {
     public void setup() {
         mPublicKey = new byte[BOX_PUBLIC_KEY_BYTES];
         mSecretKey = new byte[BOX_SECRET_KEY_BYTES];
-        Sodium.crypto_box_keypair(mPublicKey, mSecretKey);
+        NaCl.sodium().crypto_box_keypair(mPublicKey, mSecretKey);
     }
 
     @Test
@@ -92,7 +91,7 @@ public class EncryptionUtilsTest {
         assertNotNull(header);
 
         final byte[] state = new byte[EncryptionUtils.STATEBYTES];
-        final int initPullReturnCode = Sodium.crypto_secretstream_xchacha20poly1305_init_pull(
+        final int initPullReturnCode = NaCl.sodium().crypto_secretstream_xchacha20poly1305_init_pull(
                 state,
                 header,
                 dataSpecificKey);
@@ -131,7 +130,7 @@ public class EncryptionUtilsTest {
             final byte[] decryptedKey = new byte[EncryptionUtils.KEYBYTES];
             final String encryptedKeyBase64 = encryptionDataJson.getString("encryptedKey");
             final byte[] encryptedKey = Base64.decode(encryptedKeyBase64, BASE64_DECODE_FLAGS);
-            final int returnCode = Sodium.crypto_box_seal_open(
+            final int returnCode = NaCl.sodium().crypto_box_seal_open(
                     decryptedKey,
                     encryptedKey,
                     EncryptionUtils.KEYBYTES + EncryptionUtils.BOX_SEALBYTES,
@@ -182,7 +181,7 @@ public class EncryptionUtilsTest {
         final byte[] additionalData = new byte[0]; // opting not to use this value
         final int additionalDataLength = 0;
         final int[] decryptedLineLengthOutput = new int[0]; // opting not to get this value
-        final int returnCode = Sodium.crypto_secretstream_xchacha20poly1305_pull(
+        final int returnCode = NaCl.sodium().crypto_secretstream_xchacha20poly1305_pull(
                 state,
                 decryptedLine,
                 decryptedLineLengthOutput,

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/encryption/EncryptionUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/encryption/EncryptionUtilsTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 public class EncryptionUtilsTest {
     private static final int BOX_PUBLIC_KEY_BYTES = NaCl.sodium().crypto_box_publickeybytes();
     private static final int BOX_SECRET_KEY_BYTES = NaCl.sodium().crypto_box_secretkeybytes();
-    private static final int BASE64_DECODE_FLAGS = Base64.DEFAULT;
+    private static final int BASE64_DECODE_FLAGS = Base64.NO_WRAP;
     // test data
     private static final List<String> TEST_EMPTY_STRING = new ArrayList<>();
     private static final List<String> TEST_LOG_STRING = Arrays.asList("WordPress - 13.5 - Version code: 789\n",

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/encryption/EncryptionUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/encryption/EncryptionUtilsTest.java
@@ -15,12 +15,9 @@ import org.libsodium.jni.NaCl;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -81,26 +78,10 @@ public class EncryptionUtilsTest {
     }
 
     @Test
-    public void testUUIDAreDifferent() {
-        String source1 = "v1" + "android" + System.currentTimeMillis();
-        String uuid1 = UUID.nameUUIDFromBytes(source1.getBytes()).toString();
+    public void testLogsUuidResultIsExpected() {
+        String uuid1 = EncryptionUtils.generateLogsUUID("v1", "android", 1234L).toString();
 
-        String source2 = "v1" + "android" + System.currentTimeMillis();
-        String uuid2 = UUID.nameUUIDFromBytes(source2.getBytes()).toString();
-
-        assertFalse(uuid1.equals(uuid2));
-    }
-
-    @Test
-    public void testUUIDAreEquals() {
-        long sameTime = System.currentTimeMillis();
-        String source1 = "v1" + "android" + sameTime;
-        String uuid1 = UUID.nameUUIDFromBytes(source1.getBytes()).toString();
-
-        String source2 = "v1" + "android" + sameTime;
-        String uuid2 = UUID.nameUUIDFromBytes(source2.getBytes()).toString();
-
-        assertTrue(uuid1.equals(uuid2));
+        assertTrue(uuid1.equals("72b43e4d-25b3-3f9c-a3f1-c4c8b498a988"));
     }
 
     /**
@@ -110,6 +91,9 @@ public class EncryptionUtilsTest {
     private void testEncryption(final List<String> testString) {
         final JSONObject encryptionDataJson = getEncryptionDataJson(mPublicKey, testString);
         assertNotNull(encryptionDataJson);
+
+        final String logsUUID = EncryptionUtils.getLogsUUID(encryptionDataJson);
+        assertNotNull(logsUUID);
 
         final byte[] dataSpecificKey = getDataSpecificKey(encryptionDataJson);
         assertNotNull(dataSpecificKey);

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/encryption/EncryptionUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/encryption/EncryptionUtilsTest.java
@@ -15,10 +15,14 @@ import org.libsodium.jni.NaCl;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 public class EncryptionUtilsTest {
@@ -74,6 +78,29 @@ public class EncryptionUtilsTest {
     @Test
     public void testCharacterSampleEncryptionResultIsValid() {
         testEncryption(TEST_CHAR_SAMPLE);
+    }
+
+    @Test
+    public void testUUIDAreDifferent() {
+        String source1 = "v1" + "android" + System.currentTimeMillis();
+        String uuid1 = UUID.nameUUIDFromBytes(source1.getBytes()).toString();
+
+        String source2 = "v1" + "android" + System.currentTimeMillis();
+        String uuid2 = UUID.nameUUIDFromBytes(source2.getBytes()).toString();
+
+        assertFalse(uuid1.equals(uuid2));
+    }
+
+    @Test
+    public void testUUIDAreEquals() {
+        long sameTime = System.currentTimeMillis();
+        String source1 = "v1" + "android" + sameTime;
+        String uuid1 = UUID.nameUUIDFromBytes(source1.getBytes()).toString();
+
+        String source2 = "v1" + "android" + sameTime;
+        String uuid2 = UUID.nameUUIDFromBytes(source2.getBytes()).toString();
+
+        assertTrue(uuid1.equals(uuid2));
     }
 
     /**

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/encryption/EncryptionUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/encryption/EncryptionUtilsTest.java
@@ -1,4 +1,4 @@
-package org.wordpress.android.util;
+package org.wordpress.android.util.encryption;
 
 import android.util.Base64;
 

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
@@ -38,8 +38,9 @@ class CrashLoggingUtils {
                         decodedPublicKey,
                         logsFileProvider.getMostRecentLogs(context)
                 )
-                logEncryptionActions.sendEncryptedLogsFile(JSONObject(encryptedLogsSerialized))
-                event.setExtra("LogsID", logsFileProvider.generateLogsUUID())
+                val encryptedLogsJson = JSONObject(encryptedLogsSerialized)
+                logEncryptionActions.sendEncryptedLogsFile(encryptedLogsJson)
+                event.setExtra("LogsID", EncryptionUtils.getLogsUUID(encryptedLogsJson))
                 return@BeforeSendCallback event
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
@@ -33,14 +33,13 @@ class CrashLoggingUtils {
         SentryAndroid.init(context.applicationContext) {
             it.dsn = BuildConfig.SENTRY_DSN
             it.beforeSend = BeforeSendCallback { event, hint ->
-                val logsUUID = logsFileProvider.generateLogsUUID()
                 val decodedPublicKey = Base64.decode(BuildConfig.ENCRYPTION_PUBLIC_KEY, Base64.DEFAULT)
-                val encryptedLogsJson = EncryptionUtils.generateJSONEncryptedLogs(
+                val encryptedLogsSerialized = EncryptionUtils.generateJSONEncryptedLogs(
                         decodedPublicKey,
-                        AppLog.toHtmlList(context)
+                        logsFileProvider.getMostRecentLogs(context)
                 )
-                logEncryptionActions.sendEncryptedLogsFile(JSONObject(encryptedLogsJson), logsUUID)
-                event.setExtra("LogsID", logsUUID)
+                logEncryptionActions.sendEncryptedLogsFile(JSONObject(encryptedLogsSerialized))
+                event.setExtra("LogsID", logsFileProvider.generateLogsUUID())
                 return@BeforeSendCallback event
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
@@ -11,11 +11,11 @@ import org.json.JSONObject
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.util.encryption.EncryptionUtils
-import org.wordpress.android.util.encryption.LogEncryptionTestingActions
+import org.wordpress.android.util.encryption.LogsEncryptionActions
 import org.wordpress.android.util.encryption.LogsFileProvider
 
 class CrashLoggingUtils {
-    private val logEncryptionActions = LogEncryptionTestingActions()
+    private val logEncryptionActions = LogsEncryptionActions()
     private val logsFileProvider = LogsFileProvider()
 
     fun shouldEnableCrashLogging(context: Context): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.util.encryption.LogEncryptionTestingActions
 import org.wordpress.android.util.encryption.LogsFileProvider
 
 class CrashLoggingUtils {
-
     private val logEncryptionActions = LogEncryptionTestingActions()
     private val logsFileProvider = LogsFileProvider()
 

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/EncryptionUtils.java
@@ -19,7 +19,7 @@ public class EncryptionUtils {
     static final short TAG_FINAL = (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_final();
     static final short TAG_MESSAGE = (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_message();
     private static final int HEADERBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_headerbytes();
-    private static final int BASE64_FLAGS = Base64.DEFAULT;
+    private static final int BASE64_FLAGS = Base64.NO_WRAP;
     private static final String KEYED_WITH = "v1";
     private static final String ANDROID_PLATFORM = "android";
     private static final byte[] STATE = new byte[STATEBYTES];

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/EncryptionUtils.java
@@ -56,10 +56,9 @@ public class EncryptionUtils {
         JSONObject encryptionDataJson = new JSONObject();
         encryptionDataJson.put(FIELD_KEYED_WITH, KEYED_WITH);
 
-        // Generate Logs UUID
-        String source = KEYED_WITH + ANDROID_PLATFORM + System.currentTimeMillis();
-        byte[] bytes = source.getBytes();
-        encryptionDataJson.put(FIELD_LOGS_ID, UUID.nameUUIDFromBytes(bytes));
+        // Logs UUID
+        UUID logsUUID = generateLogsUUID(KEYED_WITH, ANDROID_PLATFORM, System.currentTimeMillis());
+        encryptionDataJson.put(FIELD_LOGS_ID, logsUUID.toString());
 
         // Encryption key
         final byte[] secretKey = createEncryptionKey();
@@ -83,6 +82,13 @@ public class EncryptionUtils {
         encryptionDataJson.put(FIELD_MESSAGES, encryptedAndEncodedMessagesJson);
 
         return encryptionDataJson.toString();
+    }
+
+    static UUID generateLogsUUID(String version, String platform, long currentTimeMillis) {
+        String source = version + platform + currentTimeMillis;
+        byte[] bytes = source.getBytes();
+        // Using UUIDv3 to take more control over the UUID generation
+        return UUID.nameUUIDFromBytes(bytes);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/EncryptionUtils.java
@@ -5,18 +5,18 @@ import android.util.Base64;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.libsodium.jni.Sodium;
+import org.libsodium.jni.NaCl;
 
 import java.util.List;
 
 public class EncryptionUtils {
-    static final int ABYTES = Sodium.crypto_secretstream_xchacha20poly1305_abytes();
-    static final int BOX_SEALBYTES = Sodium.crypto_box_sealbytes();
-    static final int KEYBYTES = Sodium.crypto_secretstream_xchacha20poly1305_keybytes();
-    static final int STATEBYTES = Sodium.crypto_secretstream_xchacha20poly1305_statebytes();
-    static final short TAG_FINAL = (short) Sodium.crypto_secretstream_xchacha20poly1305_tag_final();
-    static final short TAG_MESSAGE = (short) Sodium.crypto_secretstream_xchacha20poly1305_tag_message();
-    private static final int HEADERBYTES = Sodium.crypto_secretstream_xchacha20poly1305_headerbytes();
+    static final int ABYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_abytes();
+    static final int BOX_SEALBYTES = NaCl.sodium().crypto_box_sealbytes();
+    static final int KEYBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_keybytes();
+    static final int STATEBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_statebytes();
+    static final short TAG_FINAL = (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_final();
+    static final short TAG_MESSAGE = (short) NaCl.sodium().crypto_secretstream_xchacha20poly1305_tag_message();
+    private static final int HEADERBYTES = NaCl.sodium().crypto_secretstream_xchacha20poly1305_headerbytes();
     private static final int BASE64_FLAGS = Base64.DEFAULT;
     private static final String KEYED_WITH = "v1";
     private static final byte[] STATE = new byte[STATEBYTES];
@@ -71,20 +71,20 @@ public class EncryptionUtils {
 
     private static byte[] createEncryptionKey() {
         final byte[] secretKey = new byte[KEYBYTES];
-        Sodium.crypto_secretstream_xchacha20poly1305_keygen(secretKey);
+        NaCl.sodium().crypto_secretstream_xchacha20poly1305_keygen(secretKey);
         return secretKey;
     }
 
     private static byte[] encryptEncryptionKey(final byte[] publicKeyBytes,
                                                final byte[] data) {
         final byte[] encryptedData = new byte[KEYBYTES + BOX_SEALBYTES];
-        Sodium.crypto_box_seal(encryptedData, data, KEYBYTES, publicKeyBytes);
+        NaCl.sodium().crypto_box_seal(encryptedData, data, KEYBYTES, publicKeyBytes);
         return encryptedData;
     }
 
     private static byte[] createEncryptedHeader(final byte[] key) {
         final byte[] header = new byte[HEADERBYTES];
-        Sodium.crypto_secretstream_xchacha20poly1305_init_push(STATE, header, key);
+        NaCl.sodium().crypto_secretstream_xchacha20poly1305_init_push(STATE, header, key);
         return header;
     }
 
@@ -96,7 +96,7 @@ public class EncryptionUtils {
         final byte[] dataBytes = message.getBytes();
         final byte[] encryptedMessage = new byte[dataBytes.length + ABYTES];
 
-        Sodium.crypto_secretstream_xchacha20poly1305_push(
+        NaCl.sodium().crypto_secretstream_xchacha20poly1305_push(
                 STATE,
                 encryptedMessage,
                 encryptedDataLengthOutput,

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/EncryptionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/EncryptionUtils.java
@@ -1,4 +1,4 @@
-package org.wordpress.android.util;
+package org.wordpress.android.util.encryption;
 
 import android.util.Base64;
 

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/LogEncryptionTestingActions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/LogEncryptionTestingActions.kt
@@ -1,22 +1,53 @@
 package org.wordpress.android.util.encryption
 
+import com.android.volley.NetworkResponse
+import com.android.volley.Request
+import com.android.volley.Response
 import com.android.volley.Response.ErrorListener
 import com.android.volley.Response.Listener
-import com.android.volley.toolbox.JsonObjectRequest
+import com.android.volley.VolleyError
+import com.android.volley.toolbox.HttpHeaderParser
+import com.android.volley.toolbox.JsonRequest
 import org.json.JSONObject
+import org.wordpress.android.WordPress
 import org.wordpress.android.util.AppLog
 
 class LogEncryptionTestingActions {
 
     /**
-     * Sends the encrypted logs in JSON format
+     * Sends a POST request with the encrypted logs and useful fields
+     * for the server to decrypt them.
      */
-    fun sendEncryptedLogsFile(encryptedLogsJson: JSONObject, logsUUID: String) {
-        encryptedLogsJson.put("logs_id", logsUUID)
-        val request = JsonObjectRequest("https://log-encryption-testing.herokuapp.com", encryptedLogsJson,
-                Listener<JSONObject> { AppLog.i(AppLog.T.API, "Encrypted logs sent to Wordpress API server") },
-                ErrorListener { AppLog.i(AppLog.T.API, "An error occourted when sending logs") }
+    fun sendEncryptedLogsFile(encryptedLogsJson: JSONObject) {
+        val jsonRequest = JsonStringRequest(
+                Request.Method.POST,
+                ENCRYPTION_LOGS_SERVER_URL,
+                encryptedLogsJson,
+                Listener { AppLog.i(AppLog.T.API, "Encrypted logs response successfully received by Wordpress API") },
+                ErrorListener { AppLog.e(AppLog.T.API, "An error occurred when sending logs. " + it.message) }
         )
-        // SEND REQUEST
+        WordPress.sRequestQueue.add(jsonRequest)
+        AppLog.i(AppLog.T.API, "Sending encrypted logs to Wordpress API")
     }
+}
+
+private const val ENCRYPTION_LOGS_SERVER_URL = "https://log-encryption-testing.herokuapp.com"
+
+/**
+ * This class represents a Request which response is a String.
+ */
+class JsonStringRequest(
+    method: Int,
+    url: String,
+    requestBody: JSONObject?,
+    listener: Listener<String>,
+    errorListener: ErrorListener
+) : JsonRequest<String>(method, url, requestBody?.toString(), listener, errorListener) {
+
+    override fun parseNetworkResponse(response: NetworkResponse?): Response<String> {
+        response?.data ?: return Response.error(VolleyError("The response is null"))
+
+        return Response.success<String>(String(response.data), HttpHeaderParser.parseCacheHeaders(response))
+    }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/LogEncryptionTestingActions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/LogEncryptionTestingActions.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.util.encryption
+
+import com.android.volley.Response.ErrorListener
+import com.android.volley.Response.Listener
+import com.android.volley.toolbox.JsonObjectRequest
+import org.json.JSONObject
+import org.wordpress.android.util.AppLog
+
+class LogEncryptionTestingActions {
+
+    /**
+     * Sends the encrypted logs in JSON format
+     */
+    fun sendEncryptedLogsFile(encryptedLogsJson: JSONObject, logsUUID: String) {
+        encryptedLogsJson.put("logs_id", logsUUID)
+        val request = JsonObjectRequest("https://log-encryption-testing.herokuapp.com", encryptedLogsJson,
+                Listener<JSONObject> { AppLog.i(AppLog.T.API, "Encrypted logs sent to Wordpress API server") },
+                ErrorListener { AppLog.i(AppLog.T.API, "An error occourted when sending logs") }
+        )
+        // SEND REQUEST
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/LogEncryptionTestingActions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/LogEncryptionTestingActions.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.util.AppLog
 
 class LogEncryptionTestingActions {
-
     /**
      * Sends a POST request with the encrypted logs and useful fields
      * for the server to decrypt them.
@@ -43,11 +42,9 @@ class JsonStringRequest(
     listener: Listener<String>,
     errorListener: ErrorListener
 ) : JsonRequest<String>(method, url, requestBody?.toString(), listener, errorListener) {
-
     override fun parseNetworkResponse(response: NetworkResponse?): Response<String> {
         response?.data ?: return Response.error(VolleyError("The response is null"))
 
         return Response.success<String>(String(response.data), HttpHeaderParser.parseCacheHeaders(response))
     }
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/LogsEncryptionActions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/LogsEncryptionActions.kt
@@ -12,7 +12,7 @@ import org.json.JSONObject
 import org.wordpress.android.WordPress
 import org.wordpress.android.util.AppLog
 
-class LogEncryptionTestingActions {
+class LogsEncryptionActions {
     /**
      * Sends a POST request with the encrypted logs and useful fields
      * for the server to decrypt them.
@@ -22,7 +22,7 @@ class LogEncryptionTestingActions {
                 Request.Method.POST,
                 ENCRYPTION_LOGS_SERVER_URL,
                 encryptedLogsJson,
-                Listener { AppLog.i(AppLog.T.API, "Encrypted logs response successfully received by Wordpress API") },
+                Listener { AppLog.i(AppLog.T.API, "Encrypted logs response successfully received from Wordpress API") },
                 ErrorListener { AppLog.e(AppLog.T.API, "An error occurred when sending logs. " + it.message) }
         )
         WordPress.sRequestQueue.add(jsonRequest)
@@ -34,6 +34,8 @@ private const val ENCRYPTION_LOGS_SERVER_URL = "https://log-encryption-testing.h
 
 /**
  * This class represents a Request which response is a String.
+ * We need it because at the moment the testing endpoint returns
+ * a String with the decrypted logs.
  */
 class JsonStringRequest(
     method: Int,

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/LogsFileProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/LogsFileProvider.kt
@@ -1,19 +1,17 @@
 package org.wordpress.android.util.encryption
 
 import android.content.Context
-import android.util.Base64
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.util.AppLog
-import java.io.File
-import java.io.FileOutputStream
 
 class LogsFileProvider {
 
-    fun getMostRecentLogsFile(context: Context): File? {
-        return null
+    fun getMostRecentLogs(context: Context): List<String> {
+        // TODO: Implement a specific method to retrieve logs from a file
+        return AppLog.toHtmlList(context)
     }
 
     fun generateLogsUUID(): String {
+        // TODO: Move this to encryption utils
         return "9r3xmvx284894yubsb9rkau2fu3s8y3a9"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/LogsFileProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/LogsFileProvider.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import org.wordpress.android.util.AppLog
 
 class LogsFileProvider {
-
     fun getMostRecentLogs(context: Context): List<String> {
         // TODO: Implement a specific method to retrieve logs from a file
         return AppLog.toHtmlList(context)

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/LogsFileProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/LogsFileProvider.kt
@@ -9,9 +9,4 @@ class LogsFileProvider {
         // TODO: Implement a specific method to retrieve logs from a file
         return AppLog.toHtmlList(context)
     }
-
-    fun generateLogsUUID(): String {
-        // TODO: Move this to encryption utils
-        return "9r3xmvx284894yubsb9rkau2fu3s8y3a9"
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/encryption/LogsFileProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/encryption/LogsFileProvider.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.util.encryption
+
+import android.content.Context
+import android.util.Base64
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.util.AppLog
+import java.io.File
+import java.io.FileOutputStream
+
+class LogsFileProvider {
+
+    fun getMostRecentLogsFile(context: Context): File? {
+        return null
+    }
+
+    fun generateLogsUUID(): String {
+        return "9r3xmvx284894yubsb9rkau2fu3s8y3a9"
+    }
+}

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -47,3 +47,6 @@ wp.e2e.signup_email=e2eflowsignuptestingmobile@example.com
 wp.e2e.signup_username=e2eflowsignuptestingmobile
 wp.e2e.signup_display_name=e2eflowsignuptestingmobile
 wp.e2e.signup_password=mocked_password
+
+# Encryption Utils public key
+wp.encryption.public_key = K0y2oQ++gEN00S4CbCH3IYoBIxVF6H86Wz4wi2t2C3M=


### PR DESCRIPTION
Note: This PR is a Draft until this PR https://github.com/wordpress-mobile/WordPress-Android/pull/11302 gets merged.

**Title:** Send encrypted logs to Wordpress API

**Issue:** Making progress the against Encrypting Logs Issue #10698

**Description:** 
Apart from Sending the Logs Id to Sentry, We want to send the actual encrypted Logs to our Wordpress API.

In this PR we have made some progress towards this and a working implementation is able to send the encrypted logs to the current Testing Wordpress API:

**Summary of What's done in this PR:**
- ✅ Implemented`LogEncryptionTestingActions.sendEncryptedLogsFile(...)` as a POST request to send the JSON object containing the encrypted logs information.  
- ✅ Updated `EncryptionUtils.java` to include the field `logsId` populated using a UUID V3 method https://en.wikipedia.org/wiki/Universally_unique_identifier#Versions_3_and_5_(namespace_name-based). The idea of using a namespace is to avoid collisions when generating the UUIDs before sending them to Wordrpess API and Sentry.
- ✅ Created `EncryptionUtils.getLogsUUID(...)` which returns the value of the `logsId`, this is used when we mutate the Sentry event just before it gets sent.
- ✅ Updated `CrashLoggingUtils.enableCrashLogging(...)` to perform the following operations before the Sentry event gets sent:
   - Get recent logs and encrypt them.
   - Send encrypted logs to WordPress API.
   - Attach the `LogsId` to the Sentry event as additional information or `extra`.
![Screenshot 2020-02-18 at 16 29 19](https://user-images.githubusercontent.com/2184653/74756024-e084cf80-526b-11ea-8712-bfe79a19d292.png)

- ✅ Moved the Encryption related classes to a separate package called `Encryption`.

**Pending stuff for future PRs:**
- 🚧 Update backend logic to read the new field `logsId`.
- 🚧 Update endpoint url. @jkmassel At the moment We are using the testing endpoint, so when the real one gets implemented we might need to update this.
- 🚧 Solve queue issue with Volley. When an unhandled exception closes the app the Volley request that sends the encrypted logs get successfully started but the response is not received. 
🤔 We might need a caching strategy to avoid losing requests when the app gets closed. Or use an intent service to send the request? WDYT?

```kotlin
// LogEncryptionTestingActions.kt

fun sendEncryptedLogsFile(encryptedLogsJson: JSONObject) {
     val jsonRequest = JsonStringRequest(
             Request.Method.POST,
             ENCRYPTION_LOGS_SERVER_URL,
             encryptedLogsJson,
             Listener {   // <-- This success listener never gets called for unhandled exception
AppLog.i(AppLog.T.API, "Encrypted logs response successfully received by Wordpress API") 
             },
             ErrorListener { AppLog.e(AppLog.T.API, "An error occurred when sending logs. " + it.message) }
     )
     WordPress.sRequestQueue.add(jsonRequest)
     AppLog.i(AppLog.T.API, "Sending encrypted logs to Wordpress API") // <-- I see this in the logcat
    }
```

**Testing instructions:** 
Enable CrashLogging momentarily for your `Debug` build by doing the following 
```kotlin
// CrashloggingUtils.kt
...
fun shouldEnableCrashLogging(context: Context): Boolean {
        if (PackageUtils.isDebugBuild()) {
            return true  // <-- Change this from false to true (dont forget to revert it)
        }

        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
        val hasUserOptedOut = !prefs.getBoolean(context.getString(R.string.pref_key_send_crash), true)
        return !hasUserOptedOut
    }
```
Update the `gradle.properties` file with your Sentry DSN and the base64 public key:
```
wp.sentry.dsn=https://000000000000@sentry.io/0000000
wp.encryption.public_key = XXXXXXXXXXXXXXXXXXXXXXXXXXXXX
```
Log an exception inside the Login or HelpActivity by adding this line:
```kotlin
// HelpActivity.kt

CrashloggingUtils.log(RuntimeException("This is a new exception"))
```

Build the project, deploy the app and go to the Activity where you added the exception.

*PR submission checklist:*

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
