### PR TITLE
Removing Feature Flag for IA reader feature.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 14.3
 -----
 * Added search to set page parent screen
-
+* Reader Information Architecture: added tab filtering; added bottom sheet to filter and navigate the followed sites/tags posts.
  
 14.2
 -----

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -67,7 +67,6 @@ android {
         testInstrumentationRunner 'org.wordpress.android.WordPressTestRunner'
 
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
-        buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "false"
     }
 
     // Gutenberg's dependency - react-native-video is using
@@ -94,7 +93,6 @@ android {
             applicationId "org.wordpress.android"
             dimension "buildType"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
-            buildConfigField "boolean", "INFORMATION_ARCHITECTURE_AVAILABLE", "true"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -30,7 +30,6 @@ import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener;
 import com.google.android.material.tabs.TabLayout.Tab;
 
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.models.FilterCriteria;
 import org.wordpress.android.util.AppLog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -173,10 +173,6 @@ public class FilteredRecyclerView extends RelativeLayout {
 
                 mUseTabsForFiltering = a.getBoolean(
                         R.styleable.FilteredRecyclerView_wpUseTabsForFiltering, false);
-
-                // TODO: once the feature flag is removed delete this row and use the
-                // app:wpUseTabsForFiltering="true|false" in reader_fragment_post_cards.xml
-                if (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) mUseTabsForFiltering = false;
             } finally {
                 a.recycle();
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -452,22 +452,20 @@ public class WPMainActivity extends AppCompatActivity implements
             });
         });
 
-        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-            mViewModel.getStartLoginFlow().observe(this, event -> {
-                event.applyIfNotHandled(startLoginFlow -> {
-                    if (mBottomNav != null) {
-                        mBottomNav.postDelayed(new Runnable() {
-                            @Override public void run() {
-                                mBottomNav.setCurrentSelectedPage(PageType.MY_SITE);
-                            }
-                        }, 500);
-                        ActivityLauncher.viewMeActivityForResult(this);
-                    }
+        mViewModel.getStartLoginFlow().observe(this, event -> {
+            event.applyIfNotHandled(startLoginFlow -> {
+                if (mBottomNav != null) {
+                    mBottomNav.postDelayed(new Runnable() {
+                        @Override public void run() {
+                            mBottomNav.setCurrentSelectedPage(PageType.MY_SITE);
+                        }
+                    }, 500);
+                    ActivityLauncher.viewMeActivityForResult(this);
+                }
 
-                    return null;
-                });
+                return null;
             });
-        }
+        });
 
         mViewModel.start(mSiteStore.hasSite() && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -34,7 +34,6 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.jetbrains.annotations.NotNull;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -316,18 +316,16 @@ public class AppPrefs {
 
         boolean wasFollowing = false;
 
-        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-            // The intention here is to check if the `DeletablePrefKey.READER_TAG_WAS_FOLLOWING` key
-            // was present at all in the Shared Prefs.
-            // We could have it not set for example in cases where user is upgrading from
-            // a previous version of the app. In those cases we do not have enough information as of the saved
-            // tag was a Following tag or not, so (as with empty `DeletablePrefKey.READER_TAG_NAME`)
-            // let's do not use this piece of information.
-            String wasFallowingString = getString(DeletablePrefKey.READER_TAG_WAS_FOLLOWING);
-            if (TextUtils.isEmpty(wasFallowingString)) return null;
+        // The intention here is to check if the `DeletablePrefKey.READER_TAG_WAS_FOLLOWING` key
+        // was present at all in the Shared Prefs.
+        // We could have it not set for example in cases where user is upgrading from
+        // a previous version of the app. In those cases we do not have enough information as of the saved
+        // tag was a Following tag or not, so (as with empty `DeletablePrefKey.READER_TAG_NAME`)
+        // let's do not use this piece of information.
+        String wasFallowingString = getString(DeletablePrefKey.READER_TAG_WAS_FOLLOWING);
+        if (TextUtils.isEmpty(wasFallowingString)) return null;
 
-            wasFollowing = getBoolean(DeletablePrefKey.READER_TAG_WAS_FOLLOWING, false);
-        }
+        wasFollowing = getBoolean(DeletablePrefKey.READER_TAG_WAS_FOLLOWING, false);
 
         return ReaderUtils.getTagFromTagName(tagName, ReaderTagType.fromInt(tagType), wasFollowing);
     }
@@ -336,25 +334,16 @@ public class AppPrefs {
         if (tag != null && !TextUtils.isEmpty(tag.getTagSlug())) {
             setString(DeletablePrefKey.READER_TAG_NAME, tag.getTagSlug());
             setInt(DeletablePrefKey.READER_TAG_TYPE, tag.tagType.toInt());
-            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-                setBoolean(
-                        DeletablePrefKey.READER_TAG_WAS_FOLLOWING,
-                        tag.isFollowedSites() || tag.isDefaultInMemoryTag()
-                );
-            }
+            setBoolean(
+                    DeletablePrefKey.READER_TAG_WAS_FOLLOWING,
+                    tag.isFollowedSites() || tag.isDefaultInMemoryTag()
+            );
         } else {
-            if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-                prefs().edit()
-                       .remove(DeletablePrefKey.READER_TAG_NAME.name())
-                       .remove(DeletablePrefKey.READER_TAG_TYPE.name())
-                       .remove(DeletablePrefKey.READER_TAG_WAS_FOLLOWING.name())
-                       .apply();
-            } else {
-                prefs().edit()
-                       .remove(DeletablePrefKey.READER_TAG_NAME.name())
-                       .remove(DeletablePrefKey.READER_TAG_TYPE.name())
-                       .apply();
-            }
+            prefs().edit()
+                   .remove(DeletablePrefKey.READER_TAG_NAME.name())
+                   .remove(DeletablePrefKey.READER_TAG_TYPE.name())
+                   .remove(DeletablePrefKey.READER_TAG_WAS_FOLLOWING.name())
+                   .apply();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -6,7 +6,6 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2878,7 +2878,7 @@ public class ReaderPostListFragment extends Fragment
 
         @Override
         protected void onPostExecute(ReaderTagList tagList) {
-            if (mFilterCriteriaLoaderListener != null) {
+            if (mFilterCriteriaLoaderListener != null && isAdded()) {
                 //noinspection unchecked
                 mFilterCriteriaLoaderListener.onFilterCriteriasLoaded((List) tagList);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -411,8 +411,8 @@ public class ReaderPostListFragment extends Fragment
                 if (isCurrentTagManagedInFollowingTab()
                     && getPostListType() != ReaderPostListType.SEARCH_RESULTS) {
                     mViewModel.onSubfilterSelected(subfilterListItem);
-                    if (!mAccountStore.hasAccessToken() && mViewModel.getCurrentSubfilterValue() instanceof SiteAll) {
-                        setEmptyTitleAndDescriptionForSelfHostedCta();
+                    if (shouldShowEmptyViewForSelfHostedCta()) {
+                        setEmptyTitleDescriptionAndButton(false);
                         showEmptyView();
                     }
                 }
@@ -594,11 +594,8 @@ public class ReaderPostListFragment extends Fragment
             }
         }
 
-        if (mIsTopLevel
-            && !mAccountStore.hasAccessToken() && mViewModel.getCurrentSubfilterValue() instanceof SiteAll
-            && isCurrentTagManagedInFollowingTab()
-        ) {
-            setEmptyTitleAndDescriptionForSelfHostedCta();
+        if (shouldShowEmptyViewForSelfHostedCta()) {
+            setEmptyTitleDescriptionAndButton(false);
             showEmptyView();
         }
 
@@ -1656,7 +1653,8 @@ public class ReaderPostListFragment extends Fragment
         if (mIsTopLevel) {
             totalMargin += getActivity().getResources().getDimensionPixelSize(R.dimen.tab_height);
             if (isCurrentTagManagedInFollowingTab()) {
-                totalMargin += mSubFilterComponent.getHeight();
+                totalMargin += getActivity().getResources()
+                                            .getDimensionPixelSize(R.dimen.reader_subfilter_component_height);
             }
         }
 
@@ -1677,15 +1675,10 @@ public class ReaderPostListFragment extends Fragment
         String description = null;
         ActionableEmptyViewButtonType button = null;
 
-        if (mIsTopLevel
-            && !mAccountStore.hasAccessToken() && mViewModel.getCurrentSubfilterValue() instanceof SiteAll
-            && isCurrentTagManagedInFollowingTab()
-        ) {
+        if (shouldShowEmptyViewForSelfHostedCta()) {
             setEmptyTitleAndDescriptionForSelfHostedCta();
             return;
-        }
-
-        if (getPostListType() == ReaderPostListType.TAG_FOLLOWED && getCurrentTag().isBookmarked()) {
+        } else if (getPostListType() == ReaderPostListType.TAG_FOLLOWED && getCurrentTag().isBookmarked()) {
             setEmptyTitleAndDescriptionForBookmarksList();
             return;
         } else if (!NetworkUtils.isNetworkAvailable(getActivity())) {
@@ -1775,6 +1768,12 @@ public class ReaderPostListFragment extends Fragment
                 setCurrentTagFromEmptyViewButton(ActionableEmptyViewButtonType.FOLLOWED);
             }
         });
+    }
+
+    private boolean shouldShowEmptyViewForSelfHostedCta() {
+        return mIsTopLevel
+               && !mAccountStore.hasAccessToken() && mViewModel.getCurrentSubfilterValue() instanceof SiteAll
+               && isCurrentTagManagedInFollowingTab();
     }
 
     private void setEmptyTitleAndDescriptionForSelfHostedCta() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -51,7 +51,6 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.jetbrains.annotations.NotNull;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -490,14 +490,12 @@ public class ReaderSubsActivity extends AppCompatActivity
 
         String pageTitle = AppPrefs.getReaderSubsPageTitle();
 
-        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-            if (getIntent().hasExtra(ReaderConstants.ARG_SUBS_TAB_POSITION)) {
-                PagerAdapter adapter = getPageAdapter();
-                int tabIndex = getIntent().getIntExtra(ReaderConstants.ARG_SUBS_TAB_POSITION, TAB_IDX_FOLLOWED_TAGS);
-                pageTitle = (String) adapter.getPageTitle(tabIndex);
+        if (getIntent().hasExtra(ReaderConstants.ARG_SUBS_TAB_POSITION)) {
+            PagerAdapter adapter = getPageAdapter();
+            int tabIndex = getIntent().getIntExtra(ReaderConstants.ARG_SUBS_TAB_POSITION, TAB_IDX_FOLLOWED_TAGS);
+            pageTitle = (String) adapter.getPageTitle(tabIndex);
 
-                if (!TextUtils.isEmpty(pageTitle)) AppPrefs.setReaderSubsPageTitle(pageTitle);
-            }
+            if (!TextUtils.isEmpty(pageTitle)) AppPrefs.setReaderSubsPageTitle(pageTitle);
         }
 
         if (TextUtils.isEmpty(pageTitle)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -30,7 +30,6 @@ import com.google.android.material.tabs.TabLayout;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.datasets.ReaderBlogTable;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -39,7 +39,6 @@ import javax.inject.Inject;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
-import static org.wordpress.android.BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE;
 
 /*
  * adapter which shows either recommended or followed blogs - used by ReaderBlogFragment
@@ -160,13 +159,11 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         blogHolder.mTxtUrl.setText("");
                     }
                     mImageManager.load(blogHolder.mImgBlog, ImageType.BLAVATAR, blogInfo.getImageUrl());
-                    if (INFORMATION_ARCHITECTURE_AVAILABLE) {
-                        blogHolder.mFollowButton.setIsFollowed(blogInfo.isFollowing);
-                        blogHolder.mFollowButton.setOnClickListener(v -> toggleFollow(
-                                blogHolder.itemView.getContext(),
-                                blogHolder.mFollowButton,
-                                blogInfo));
-                    }
+                    blogHolder.mFollowButton.setIsFollowed(blogInfo.isFollowing);
+                    blogHolder.mFollowButton.setOnClickListener(v -> toggleFollow(
+                            blogHolder.itemView.getContext(),
+                            blogHolder.mFollowButton,
+                            blogInfo));
                     break;
             }
 
@@ -213,7 +210,7 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             switch (getBlogType()) {
                 case FOLLOWED:
                     mTxtDescription.setVisibility(GONE);
-                    mFollowButton.setVisibility(INFORMATION_ARCHITECTURE_AVAILABLE ? VISIBLE : GONE);
+                    mFollowButton.setVisibility(VISIBLE);
                     break;
                 case RECOMMENDED:
                     mTxtDescription.setVisibility(VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -8,7 +8,6 @@ import com.wordpress.rest.RestRequest;
 
 import org.greenrobot.eventbus.EventBus;
 import org.json.JSONObject;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderBlogTable;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -139,27 +139,6 @@ public class ReaderUpdateLogic {
         return updateDone;
     }
 
-    private boolean downgradeFromIAFeatureFlagDetected() {
-        boolean downgradeDetected = false;
-
-        ReaderTagList savedTags = ReaderTagTable.getBookmarkTags();
-
-        if (savedTags != null && savedTags.size() == 1) {
-            ReaderTag savedTag = savedTags.get(0);
-
-            if (savedTag != null) {
-                String tagNameBefore = savedTag.getTagDisplayName();
-
-                if (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE
-                    && tagNameBefore.equals(mContext.getString(R.string.reader_save_for_later_display_name))) {
-                    downgradeDetected = true;
-                }
-            }
-        }
-
-        return downgradeDetected;
-    }
-
     private void handleUpdateTagsResponse(final JSONObject jsonObject) {
         new Thread() {
             @Override
@@ -169,11 +148,7 @@ public class ReaderUpdateLogic {
                 ReaderTagList serverTopics = new ReaderTagList();
                 serverTopics.addAll(parseTags(jsonObject, "default", ReaderTagType.DEFAULT));
 
-                boolean displayNameUpdateWasNeeded = false;
-
-                if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-                    displayNameUpdateWasNeeded = displayNameUpdateWasNeeded(serverTopics);
-                }
+                boolean displayNameUpdateWasNeeded = displayNameUpdateWasNeeded(serverTopics);
 
                 if (!mAccountStore.hasAccessToken()) {
                     serverTopics.addAll(parseTags(jsonObject, "recommended", ReaderTagType.FOLLOWED));
@@ -186,15 +161,12 @@ public class ReaderUpdateLogic {
                 serverTopics.add(
                         new ReaderTag(
                                 "",
-                                BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE
-                                        ? mContext.getString(R.string.reader_save_for_later_display_name) : "",
+                                mContext.getString(R.string.reader_save_for_later_display_name),
                                 mContext.getString(R.string.reader_save_for_later_title),
                                 "",
                                 ReaderTagType.BOOKMARKED
                         )
                 );
-
-                boolean downgradeFromIAFeatureFlagDetected = downgradeFromIAFeatureFlagDetected();
 
                 // parse topics from the response, detect whether they're different from local
                 ReaderTagList localTopics = new ReaderTagList();
@@ -206,11 +178,9 @@ public class ReaderUpdateLogic {
                 if (
                         !localTopics.isSameList(serverTopics)
                         || displayNameUpdateWasNeeded
-                        || downgradeFromIAFeatureFlagDetected
                 ) {
                     AppLog.d(AppLog.T.READER, "reader service > followed topics changed "
-                                              + "updatedDisplaYNames [" + displayNameUpdateWasNeeded
-                                              + "] donwgradeDetected [" + downgradeFromIAFeatureFlagDetected + "]");
+                                              + "updatedDisplayNames [" + displayNameUpdateWasNeeded + "]");
                     // if any local topics have been removed from the server, make sure to delete
                     // them locally (including their posts)
                     deleteTags(localTopics.getDeletions(serverTopics));

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.datasets.ReaderBlogTable
 import org.wordpress.android.datasets.ReaderTagTable
 import org.wordpress.android.fluxc.store.AccountStore
@@ -360,7 +359,7 @@ class ReaderPostListViewModel @Inject constructor(
                 if (isTopLevelFragment) ReaderTrackerType.MAIN_READER else ReaderTrackerType.FILTERED_LIST
         )
 
-        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE && isTopLevelFragment) {
+        if (isTopLevelFragment) {
             if (isFollowingTag && getCurrentSubfilterValue().isTrackedItem) {
                 AppLog.d(T.READER, "TRACK READER ReaderPostListFragment > START Count SUBFILTERED_LIST")
                 readerTracker.start(ReaderTrackerType.SUBFILTERED_LIST)
@@ -377,8 +376,7 @@ class ReaderPostListViewModel @Inject constructor(
                 if (isTopLevelFragment) ReaderTrackerType.MAIN_READER else ReaderTrackerType.FILTERED_LIST
         )
 
-        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE &&
-                isTopLevelFragment && readerTracker.isRunning(ReaderTrackerType.SUBFILTERED_LIST)) {
+        if (isTopLevelFragment && readerTracker.isRunning(ReaderTrackerType.SUBFILTERED_LIST)) {
             AppLog.d(T.READER, "TRACK READER ReaderPostListFragment > STOP Count SUBFILTERED_LIST")
             readerTracker.stop(ReaderTrackerType.SUBFILTERED_LIST)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -104,9 +104,7 @@ class ReaderPostListViewModel @Inject constructor(
             return
         }
 
-        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-            eventBusWrapper.register(this)
-        }
+        eventBusWrapper.register(this)
 
         tag?.let {
             onTagChanged(tag)
@@ -205,18 +203,12 @@ class ReaderPostListViewModel @Inject constructor(
     fun changeSubfiltersVisibility(show: Boolean) = _shouldShowSubFilters.postValue(show)
 
     fun getCurrentSubfilterValue(): SubfilterListItem {
-        return if (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-            _currentSubFilter.value ?: SiteAll(
+        return _currentSubFilter.value ?: appPrefsWrapper.getReaderSubfilter().let {
+            subfilterListItemMapper.fromJson(
+                    json = it,
                     onClickAction = ::onSubfilterClicked,
-                    isSelected = true)
-        } else {
-            _currentSubFilter.value ?: appPrefsWrapper.getReaderSubfilter().let {
-                subfilterListItemMapper.fromJson(
-                        json = it,
-                        onClickAction = ::onSubfilterClicked,
-                        isSelected = true
-                )
-            }
+                    isSelected = true
+            )
         }
     }
 
@@ -372,9 +364,7 @@ class ReaderPostListViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-            eventBusWrapper.unregister(this)
-        }
+        eventBusWrapper.unregister(this)
         newsManager.stop()
     }
 }

--- a/WordPress/src/main/res/layout/filtered_list_component.xml
+++ b/WordPress/src/main/res/layout/filtered_list_component.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                                     xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                     xmlns:tools="http://schemas.android.com/tools"
-                                                     android:layout_width="match_parent"
-                                                     android:layout_height="match_parent">
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    android:id="@+id/coordinator"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar_layout"

--- a/WordPress/src/main/res/layout/subfilter_component.xml
+++ b/WordPress/src/main/res/layout/subfilter_component.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/one_line_list_item_height"
+    android:layout_height="@dimen/reader_subfilter_component_height"
     android:background="@android:color/white"
     android:elevation="@dimen/appbar_elevation">
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -175,6 +175,8 @@
     <dimen name="reader_subfilter_title_gone_margin_top">0dp</dimen>
     <dimen name="reader_subfilter_title_gone_margin_bottom">10dp</dimen>
 
+    <dimen name="reader_subfilter_component_height">48dp</dimen>
+
     <item name="reader_photo_title_shadow_offset" format="float" type="dimen">3.0</item>
     <item name="reader_photo_title_shadow_radius" format="float" type="dimen">1.5</item>
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -78,10 +78,10 @@ class ReaderPostListViewModelTest {
                 onClickAction = ::onClickActionDummy
         )
         val json = "{\"blogId\":0,\"feedId\":0,\"tagSlug\":\"news\",\"tagType\":1,\"type\":4}"
-        if (BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-            whenever(appPrefsWrapper.getReaderSubfilter()).thenReturn(json)
-            whenever(subfilterListItemMapper.fromJson(any(), any(), any())).thenReturn(tag)
-        }
+
+        whenever(appPrefsWrapper.getReaderSubfilter()).thenReturn(json)
+        whenever(subfilterListItemMapper.fromJson(any(), any(), any())).thenReturn(tag)
+
         viewModel = ReaderPostListViewModel(
                 newsManager,
                 newsTracker,
@@ -201,11 +201,7 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun `view model returns default filter on start`() {
-        if (!BuildConfig.INFORMATION_ARCHITECTURE_AVAILABLE) {
-            assertThat(viewModel.getCurrentSubfilterValue()).isInstanceOf(SiteAll::class.java)
-        } else {
-            assertThat(viewModel.getCurrentSubfilterValue()).isInstanceOf(Tag::class.java)
-        }
+        assertThat(viewModel.getCurrentSubfilterValue()).isInstanceOf(Tag::class.java)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -17,7 +17,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore


### PR DESCRIPTION
This PR has been created to move the IA reader modifications from behind the `INFORMATION_ARCHITECTURE_AVAILABLE` feature flag and release it into develop.

cc @osullivanchris , @khaykov , @renanferrari 

### Main items introduced

1. 1st level filtering is implemented with tabs that replaces the previous spinner. Available categories are Following, Discover, Likes, Saved (plus Automattic if logged in with an Automattic account)

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/74931034-27470680-53df-11ea-9b0a-d365d6bcd7ef.png>
</p>

2. 2nd level filtering is available only in the Following tab and it is implemented with a bottom sheet listing selectable Sites/Tags followed by the user

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/74931149-53628780-53df-11ea-8ea6-c2270f7af46a.png>
</p>

3. We moved the Settings selector to the subfiltering component and added possibility to follow/unfollow a site from settings as per below images

| ![image](https://user-images.githubusercontent.com/47797566/74931385-c5d36780-53df-11ea-9f86-0697e9aae2e1.png) | ![image](https://user-images.githubusercontent.com/47797566/74932131-5a8a9500-53e1-11ea-8299-eba3f7f53a01.png) |
|---|---|

### Main linked PRs (and related test steps)

1. Saving and restoring subfilter to/from shared prefs #10925
2. Site not removed from subfilter when unfollowed #11155
3. New design reader bottom sheet - step 1 #11183
4. New design reader bottom sheet - step 2 #11184
5. New design reader bottom sheet - step3 #11193
6. IA Reader self-hosted improvements #11270
7. Add historical searches list to the Reader initial search screen #11293
8. Add follow/unfollow button to the Followed Sites tab on Reader's management section #11219

### Smoke test rules of thumbs
If you want/can give this PR a smoke test, use both wp.com and self-hosted sites and here below some of the possible steps for smoke testing but feel free to add 😊 :

- Move between tabs
- Use the subfilter to select different sources (Sites/Tags) to navigate
- Open posts from the reader
- Save posts for later and open them from the SAVED tab (both WP.com and self-hosted)
- Follow/Unfollow tags/sites from the Reader (only for WP.com)
- Follow/Unfollow tags/sites from the Setting (only for WP.com)
- Whatever else you can think of 😊... 

### Note
While testing this PR we found a small issue with the self-hosted empty view for cta.

**steps to reproduce**
- Log out from WP.com and add a pure self-hosted site
- Go to the reader and be sure you are in `FOLLOWING` and no subfilter is selected
- See you have the empty view image saying 'Use the filter button to find posts on specific subjects'
- Go to My Site and come back to Reader
- See the empty view image is wrongly placed at a higher position than before
- Open the Filter and see the image moving a bit down to the correct position

We fixed it in 78c4b67 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
