### PR TITLE
Enable publish page action on page list in offline

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -49,7 +49,6 @@ import org.wordpress.android.ui.posts.ProgressDialogHelper
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper
 import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.uploads.UploadActionUseCase
-import org.wordpress.android.ui.uploads.UploadUtils
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
@@ -379,11 +378,10 @@ class PagesFragment : Fragment() {
                         site,
                         uploadActionUseCase.getUploadAction(post),
                         View.OnClickListener {
-                            UploadUtils.publishPost(
+                            uploadUtilsWrapper.publishPost(
                                     activity,
                                     post,
-                                    site,
-                                    dispatcher
+                                    site
                             ) }
                 )
             }
@@ -391,7 +389,7 @@ class PagesFragment : Fragment() {
 
         viewModel.publishAction.observe(this, Observer {
             it?.let {
-                UploadUtils.publishPost(activity, it.post, it.site, dispatcher)
+                uploadUtilsWrapper.publishPost(activity, it.post, it.site)
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -388,6 +388,12 @@ class PagesFragment : Fragment() {
                 )
             }
         })
+
+        viewModel.publishAction.observe(this, Observer {
+            it?.let {
+                UploadUtils.publishPost(activity, it.post, it.site, dispatcher)
+            }
+        })
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -394,6 +394,19 @@ class PagesFragment : Fragment() {
                 UploadUtils.publishPost(activity, it.post, it.site, dispatcher)
             }
         })
+
+        viewModel.uploadFinishedAction.observe(this, Observer {
+            it?.let { (page, isError) ->
+                uploadUtilsWrapper.onPostUploadedSnackbarHandler(
+                        activity,
+                        activity.findViewById(R.id.coordinator),
+                        isError,
+                        page.post,
+                        null,
+                        page.site
+                )
+            }
+        })
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
@@ -113,4 +113,7 @@ class UploadUtilsWrapper @Inject constructor(
             postError,
             isEligibleForAutoUpload
     )
+
+    fun publishPost(activity: Activity, post: PostModel, site: SiteModel) =
+            UploadUtils.publishPost(activity, post, site, dispatcher)
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListEventListener.kt
@@ -40,6 +40,7 @@ class PageListEventListener(
     private val handleRemoteAutoSave: (LocalId, Boolean) -> Unit,
     private val handlePageUpdated: (RemoteId) -> Unit,
     private val handlePostUploadedStarted: (RemoteId) -> Unit,
+    private val handlePostUploadFinished: (RemoteId, Boolean) -> Unit,
     private val invalidateUploadStatus: (List<LocalId>) -> Unit
 ) : CoroutineScope {
     init {
@@ -117,6 +118,7 @@ class PageListEventListener(
     fun onPostUploaded(event: OnPostUploaded) {
         if (event.post != null && event.post.isPage && event.post.localSiteId == site.id) {
             uploadStatusChanged(LocalId(event.post.id))
+            handlePostUploadFinished(RemoteId(event.post.remotePostId), event.isError)
         }
     }
 
@@ -183,7 +185,8 @@ class PageListEventListener(
             handlePageUpdated: (RemoteId) -> Unit,
             invalidateUploadStatus: (List<LocalId>) -> Unit,
             handleRemoteAutoSave: (LocalId, Boolean) -> Unit,
-            handlePostUploadedStarted: (RemoteId) -> Unit
+            handlePostUploadedStarted: (RemoteId) -> Unit,
+            handlePostUploadFinished: (RemoteId, Boolean) -> Unit
         ): PageListEventListener {
             return PageListEventListener(
                     dispatcher = dispatcher,
@@ -194,7 +197,8 @@ class PageListEventListener(
                     handlePageUpdated = handlePageUpdated,
                     invalidateUploadStatus = invalidateUploadStatus,
                     handleRemoteAutoSave = handleRemoteAutoSave,
-                    handlePostUploadedStarted = handlePostUploadedStarted
+                    handlePostUploadedStarted = handlePostUploadedStarted,
+                    handlePostUploadFinished = handlePostUploadFinished
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -66,7 +66,6 @@ import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.DRAF
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.PUBLISHED
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.SCHEDULED
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.TRASHED
-import java.util.Date
 import java.util.SortedMap
 import javax.inject.Inject
 import javax.inject.Named
@@ -139,6 +138,9 @@ class PagesViewModel
 
     private val _postUploadAction = SingleLiveEvent<Triple<PostModel, SiteModel, Intent>>()
     val postUploadAction: LiveData<Triple<PostModel, SiteModel, Intent>> = _postUploadAction
+
+    private val _publishAction = SingleLiveEvent<PageModel>()
+    val publishAction = _publishAction
 
     private var isInitialized = false
     private var scrollToPageId: Long? = null
@@ -467,10 +469,7 @@ class PagesViewModel
     }
 
     private fun publishPageNow(remoteId: Long) {
-        performIfNetworkAvailable {
-            pageMap[remoteId]?.date = Date()
-            changePageStatus(remoteId, PageStatus.PUBLISHED)
-        }
+        _publishAction.value = pageMap[remoteId]
     }
 
     fun onImagesChanged() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -749,7 +749,7 @@ class PagesViewModel
     private fun hasRemoteAutoSavePreviewError() = _previewState.value != null &&
             _previewState.value == PostListRemotePreviewState.REMOTE_AUTO_SAVE_PREVIEW_ERROR
 
-    private fun handlePageUpdated(remotePostId: RemoteId) {
+    fun handlePageUpdated(remotePostId: RemoteId) {
         var id = 0L
         if (!pageUpdateContinuations.contains(id)) {
             id = remotePostId.value
@@ -776,7 +776,7 @@ class PagesViewModel
         }
     }
 
-    private fun postUploadStarted(remoteId: RemoteId) {
+    fun postUploadStarted(remoteId: RemoteId) {
         launch {
             performIfNetworkAvailableAsync {
                 waitForPageUpdate(remoteId.value)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -29,6 +29,8 @@ import org.wordpress.android.fluxc.model.page.PageStatus.DRAFT
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.test
+import org.wordpress.android.ui.pages.PageItem
+import org.wordpress.android.ui.pages.PageItem.Action.PUBLISH_NOW
 import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState
@@ -231,6 +233,20 @@ class PagesViewModelTest {
         viewModel.onPageEditFinished(pageModel.pageId, intent)
         // Then
         assertThat(viewModel.postUploadAction.value).isEqualTo(Triple(pageModel.post, pageModel.site, intent))
+    }
+
+    @Test
+    fun `publish now menu action updates publishAction live data`() = test {
+        // Given
+        val pageModel = setUpPageStoreWithASinglePage()
+        val page: PageItem.Page = mock()
+        whenever(page.remoteId).thenReturn(pageModel.remoteId)
+        viewModel.start(site)
+        // When
+        viewModel.onMenuAction(PUBLISH_NOW, page)
+
+        // Then
+        assertThat(viewModel.publishAction.value).isEqualTo(pageModel)
     }
 
     private suspend fun setUpPageStoreWithEmptyPages() {


### PR DESCRIPTION
Fixes #11177

Enables "Publish Now" action on page list in offline. This new approach doesn't support "Undo" action, but it's not supported even on the post list.

Also shows snackbar messages when upload finished (both success and fail).

To test:
1. Open page list
2. Select "drafts" tab
3. Turn on airplane mode
4. Click on "Publish now" menu item on one of the pages
5. Notice the page is moved to Published tab and "We'll publish the page when your device is back online." label is shown
6. Turn off airplane mode
7. Notice the page gets published and a snackbar is shown

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
