### PR TITLE
Issue/11144 load high res image into file

### DIFF
--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/ImageEditor.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/ImageEditor.kt
@@ -3,10 +3,13 @@ package org.wordpress.android.imageeditor
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType
+import java.io.File
 
 class ImageEditor private constructor(
-    private val loadImageWithResultListener: ((String, ImageView, ScaleType, String, RequestListener<Drawable>) -> Unit)
-
+    private val loadIntoImageViewWithResultListener: (
+        (String, ImageView, ScaleType, String, RequestListener<Drawable>) -> Unit
+    ),
+    private val loadIntoFileWithResultListener: ((String, RequestListener<File>) -> Unit)
 ) {
     interface RequestListener<T> {
         /**
@@ -16,6 +19,7 @@ class ImageEditor private constructor(
          * @param url The url of the image we were trying to load when the exception occurred.
          */
         fun onLoadFailed(e: Exception?, url: String)
+
         /**
          * Called when a load completes successfully
          *
@@ -25,14 +29,21 @@ class ImageEditor private constructor(
         fun onResourceReady(resource: T, url: String)
     }
 
-    fun loadImageWithResultListener(
+    fun loadIntoImageViewWithResultListener(
         imageUrl: String,
         imageView: ImageView,
         scaleType: ScaleType,
         thumbUrl: String,
         listener: RequestListener<Drawable>
     ) {
-        loadImageWithResultListener.invoke(imageUrl, imageView, scaleType, thumbUrl, listener)
+        loadIntoImageViewWithResultListener.invoke(imageUrl, imageView, scaleType, thumbUrl, listener)
+    }
+
+    fun loadIntoFileWithResultListener(
+        imageUrl: String,
+        listener: RequestListener<File>
+    ) {
+        loadIntoFileWithResultListener.invoke(imageUrl, listener)
     }
 
     companion object {
@@ -41,9 +52,15 @@ class ImageEditor private constructor(
         val instance: ImageEditor get() = INSTANCE
 
         fun init(
-            loadImageWithResultListener: ((String, ImageView, ScaleType, String, RequestListener<Drawable>) -> Unit)
+            loadIntoImageViewWithResultListener: (
+                (String, ImageView, ScaleType, String, RequestListener<Drawable>) -> Unit
+            ),
+            loadIntoFileWithResultListener: ((String, RequestListener<File>) -> Unit)
         ) {
-            INSTANCE = ImageEditor(loadImageWithResultListener)
+            INSTANCE = ImageEditor(
+                loadIntoImageViewWithResultListener,
+                loadIntoFileWithResultListener
+            )
         }
     }
 }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.imageeditor.preview
 import android.content.Intent
 import android.graphics.drawable.Drawable
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -17,6 +18,7 @@ import org.wordpress.android.imageeditor.R.layout
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
 import org.wordpress.android.imageeditor.utils.UiHelpers
+import java.io.File
 
 class PreviewImageFragment : Fragment() {
     private lateinit var viewModel: PreviewImageViewModel
@@ -52,13 +54,17 @@ class PreviewImageFragment : Fragment() {
     private fun setupObservers() {
         viewModel.uiState.observe(this, Observer { uiState ->
             if (uiState is ImageDataStartLoadingUiState) {
-                loadImage(uiState.imageData)
+                loadIntoImageView(uiState.imageData)
             }
             UiHelpers.updateVisibility(progressBar, uiState.progressBarVisible)
         })
+
+        viewModel.loadIntoFile.observe(this, Observer { url ->
+            loadIntoFile(url)
+        })
     }
 
-    private fun loadImage(imageData: ImageData) {
+    private fun loadIntoImageView(imageData: ImageData) {
         ImageEditor.instance.loadIntoImageViewWithResultListener(
             imageData.highResImageUrl,
             previewImageView,
@@ -72,6 +78,20 @@ class PreviewImageFragment : Fragment() {
                 override fun onLoadFailed(e: Exception?, url: String) {
                     viewModel.onImageLoadFailed(url)
                 }
+            }
+        )
+    }
+
+    private fun loadIntoFile(url: String) {
+        ImageEditor.instance.loadIntoFileWithResultListener(
+            url,
+            object : RequestListener<File> {
+                override fun onResourceReady(resource: File, url: String) {
+                    // TODO: image file path obtained here, pass it to uCrop
+                    Log.d("PreviewImageFragment", "file path " + resource.path)
+                }
+
+                override fun onLoadFailed(e: Exception?, url: String) { }
             }
         )
     }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -74,11 +74,11 @@ class PreviewImageFragment : Fragment() {
             imageData.lowResImageUrl,
             object : RequestListener<Drawable> {
                 override fun onResourceReady(resource: Drawable, url: String) {
-                    viewModel.onImageLoadSuccess(url)
+                    viewModel.onLoadIntoImageViewSuccess(url)
                 }
 
                 override fun onLoadFailed(e: Exception?, url: String) {
-                    viewModel.onImageLoadFailed(url)
+                    viewModel.onLoadIntoImageViewFailed(url)
                 }
             }
         )

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -59,7 +59,7 @@ class PreviewImageFragment : Fragment() {
     }
 
     private fun loadImage(imageData: ImageData) {
-        ImageEditor.instance.loadImageWithResultListener(
+        ImageEditor.instance.loadIntoImageViewWithResultListener(
             imageData.highResImageUrl,
             previewImageView,
             CENTER,

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.imageeditor.preview
 import android.content.Intent
 import android.graphics.drawable.Drawable
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -16,6 +15,7 @@ import org.wordpress.android.imageeditor.ImageEditor
 import org.wordpress.android.imageeditor.ImageEditor.RequestListener
 import org.wordpress.android.imageeditor.R.layout
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
 import org.wordpress.android.imageeditor.utils.UiHelpers
 import java.io.File
@@ -59,8 +59,10 @@ class PreviewImageFragment : Fragment() {
             UiHelpers.updateVisibility(progressBar, uiState.progressBarVisible)
         })
 
-        viewModel.loadIntoFile.observe(this, Observer { url ->
-            loadIntoFile(url)
+        viewModel.loadIntoFile.observe(this, Observer { fileState ->
+            if (fileState is ImageStartLoadingToFileState) {
+                loadIntoFile(fileState.imageUrl)
+            }
         })
     }
 
@@ -87,11 +89,12 @@ class PreviewImageFragment : Fragment() {
             url,
             object : RequestListener<File> {
                 override fun onResourceReady(resource: File, url: String) {
-                    // TODO: image file path obtained here, pass it to uCrop
-                    Log.d("PreviewImageFragment", "file path " + resource.path)
+                    viewModel.onLoadIntoFileSuccess(resource.path)
                 }
 
-                override fun onLoadFailed(e: Exception?, url: String) { }
+                override fun onLoadFailed(e: Exception?, url: String) {
+                    viewModel.onLoadIntoFileFailed()
+                }
             }
         )
     }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -74,7 +74,7 @@ class PreviewImageViewModel : ViewModel() {
         data class ImageDataStartLoadingUiState(val imageData: ImageData) : ImageUiState(progressBarVisible = true)
         // Continue displaying progress bar on low res image load success
         object ImageInLowResLoadSuccessUiState : ImageUiState(progressBarVisible = true)
-        object ImageInLowResLoadFailedUiState : ImageUiState(progressBarVisible = false)
+        object ImageInLowResLoadFailedUiState : ImageUiState(progressBarVisible = true)
         object ImageInHighResLoadSuccessUiState : ImageUiState(progressBarVisible = false)
         object ImageInHighResLoadFailedUiState : ImageUiState(progressBarVisible = false)
     }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -13,6 +13,9 @@ class PreviewImageViewModel : ViewModel() {
     private val _uiState: MutableLiveData<ImageUiState> = MutableLiveData()
     val uiState: LiveData<ImageUiState> = _uiState
 
+    private val _loadIntoFile: MutableLiveData<String> = MutableLiveData()
+    val loadIntoFile: LiveData<String> = _loadIntoFile
+
     fun onCreateView(loResImageUrl: String, hiResImageUrl: String) {
         updateUiState(
             ImageDataStartLoadingUiState(
@@ -33,6 +36,9 @@ class PreviewImageViewModel : ViewModel() {
             else -> ImageInHighResLoadSuccessUiState
         }
 
+        if (newState == ImageInHighResLoadSuccessUiState) {
+            updateUrlToLoadIntoFile(url)
+        }
         updateUiState(newState)
     }
 
@@ -54,6 +60,10 @@ class PreviewImageViewModel : ViewModel() {
 
     private fun updateUiState(uiState: ImageUiState) {
         _uiState.value = uiState
+    }
+
+    private fun updateUrlToLoadIntoFile(url: String) {
+        _loadIntoFile.value = url
     }
 
     data class ImageData(val lowResImageUrl: String, val highResImageUrl: String)

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -27,7 +27,7 @@ class PreviewImageViewModel : ViewModel() {
         )
     }
 
-    fun onImageLoadSuccess(url: String) {
+    fun onLoadIntoImageViewSuccess(url: String) {
         val newState = when (val currentState = uiState.value) {
             is ImageDataStartLoadingUiState -> {
                 if (url == currentState.imageData.lowResImageUrl) {
@@ -45,7 +45,7 @@ class PreviewImageViewModel : ViewModel() {
         updateUiState(newState)
     }
 
-    fun onImageLoadFailed(url: String) {
+    fun onLoadIntoImageViewFailed(url: String) {
         val newState = when (val currentState = uiState.value) {
             is ImageDataStartLoadingUiState -> {
                 val lowResImageUrl = currentState.imageData.lowResImageUrl

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileSuccessState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileFailedState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileIdleState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadFailedUiState
@@ -16,7 +17,7 @@ class PreviewImageViewModel : ViewModel() {
     private val _uiState: MutableLiveData<ImageUiState> = MutableLiveData()
     val uiState: LiveData<ImageUiState> = _uiState
 
-    private val _loadIntoFile: MutableLiveData<ImageLoadToFileState> = MutableLiveData()
+    private val _loadIntoFile: MutableLiveData<ImageLoadToFileState> = MutableLiveData(ImageLoadToFileIdleState)
     val loadIntoFile: LiveData<ImageLoadToFileState> = _loadIntoFile
 
     fun onCreateView(loResImageUrl: String, hiResImageUrl: String) {
@@ -93,6 +94,7 @@ class PreviewImageViewModel : ViewModel() {
     }
 
     sealed class ImageLoadToFileState {
+        object ImageLoadToFileIdleState : ImageLoadToFileState()
         data class ImageStartLoadingToFileState(val imageUrl: String) : ImageLoadToFileState()
         data class ImageLoadToFileSuccessState(val filePath: String) : ImageLoadToFileState()
         object ImageLoadToFileFailedState : ImageLoadToFileState()

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -28,7 +28,8 @@ class PreviewImageViewModel : ViewModel() {
     }
 
     fun onLoadIntoImageViewSuccess(url: String) {
-        val newState = when (val currentState = uiState.value) {
+        val currentState = uiState.value
+        val newState = when (currentState) {
             is ImageDataStartLoadingUiState -> {
                 if (url == currentState.imageData.lowResImageUrl) {
                     ImageInLowResLoadSuccessUiState
@@ -39,7 +40,7 @@ class PreviewImageViewModel : ViewModel() {
             else -> ImageInHighResLoadSuccessUiState
         }
 
-        if (newState == ImageInHighResLoadSuccessUiState) {
+        if (newState == ImageInHighResLoadSuccessUiState && currentState != ImageInHighResLoadSuccessUiState) {
             updateLoadIntoFileState(ImageStartLoadingToFileState(url))
         }
         updateUiState(newState)
@@ -66,6 +67,7 @@ class PreviewImageViewModel : ViewModel() {
     }
 
     fun onLoadIntoFileFailed() {
+        // TODO: Do we need to display any error message to the user?
         updateLoadIntoFileState(ImageLoadToFileFailedState)
     }
 

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -3,6 +3,9 @@ package org.wordpress.android.imageeditor.preview
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileSuccessState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileFailedState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadFailedUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadSuccessUiState
@@ -13,8 +16,8 @@ class PreviewImageViewModel : ViewModel() {
     private val _uiState: MutableLiveData<ImageUiState> = MutableLiveData()
     val uiState: LiveData<ImageUiState> = _uiState
 
-    private val _loadIntoFile: MutableLiveData<String> = MutableLiveData()
-    val loadIntoFile: LiveData<String> = _loadIntoFile
+    private val _loadIntoFile: MutableLiveData<ImageLoadToFileState> = MutableLiveData()
+    val loadIntoFile: LiveData<ImageLoadToFileState> = _loadIntoFile
 
     fun onCreateView(loResImageUrl: String, hiResImageUrl: String) {
         updateUiState(
@@ -37,7 +40,7 @@ class PreviewImageViewModel : ViewModel() {
         }
 
         if (newState == ImageInHighResLoadSuccessUiState) {
-            updateUrlToLoadIntoFile(url)
+            updateLoadIntoFileState(ImageStartLoadingToFileState(url))
         }
         updateUiState(newState)
     }
@@ -58,12 +61,20 @@ class PreviewImageViewModel : ViewModel() {
         updateUiState(newState)
     }
 
+    fun onLoadIntoFileSuccess(filePath: String) {
+        updateLoadIntoFileState(ImageLoadToFileSuccessState(filePath))
+    }
+
+    fun onLoadIntoFileFailed() {
+        updateLoadIntoFileState(ImageLoadToFileFailedState)
+    }
+
     private fun updateUiState(uiState: ImageUiState) {
         _uiState.value = uiState
     }
 
-    private fun updateUrlToLoadIntoFile(url: String) {
-        _loadIntoFile.value = url
+    private fun updateLoadIntoFileState(fileState: ImageLoadToFileState) {
+        _loadIntoFile.value = fileState
     }
 
     data class ImageData(val lowResImageUrl: String, val highResImageUrl: String)
@@ -77,5 +88,11 @@ class PreviewImageViewModel : ViewModel() {
         object ImageInLowResLoadFailedUiState : ImageUiState(progressBarVisible = true)
         object ImageInHighResLoadSuccessUiState : ImageUiState(progressBarVisible = false)
         object ImageInHighResLoadFailedUiState : ImageUiState(progressBarVisible = false)
+    }
+
+    sealed class ImageLoadToFileState {
+        data class ImageStartLoadingToFileState(val imageUrl: String) : ImageLoadToFileState()
+        data class ImageLoadToFileSuccessState(val filePath: String) : ImageLoadToFileState()
+        object ImageLoadToFileFailedState : ImageLoadToFileState()
     }
 }

--- a/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -8,6 +8,8 @@ import org.junit.Rule
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadFailedUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadSuccessUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadFailedUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadSuccessUiState
 
 private const val TEST_LOW_RES_IMAGE_URL = "https://wordpress.com/low_res_image.png"
 private const val TEST_HIGH_RES_IMAGE_URL = "https://wordpress.com/image.png"
@@ -43,10 +45,10 @@ class PreviewImageViewModelTest {
     }
 
     @Test
-    fun `progress bar hidden on low res image load failed`() {
+    fun `progress bar shown on low res image load failed`() {
         initViewModel()
         viewModel.onImageLoadFailed(TEST_LOW_RES_IMAGE_URL)
-        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
+        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(true)
     }
 
     @Test
@@ -61,6 +63,42 @@ class PreviewImageViewModelTest {
         initViewModel()
         viewModel.onImageLoadFailed(TEST_LOW_RES_IMAGE_URL)
         assertThat(viewModel.uiState.value).isInstanceOf(ImageInLowResLoadFailedUiState::class.java)
+    }
+
+    @Test
+    fun `progress bar hidden on high res image load success`() {
+        initViewModel()
+        viewModel.onImageLoadSuccess(TEST_HIGH_RES_IMAGE_URL)
+        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
+    }
+
+    @Test
+    fun `progress bar hidden on high res image load failed`() {
+        initViewModel()
+        viewModel.onImageLoadFailed(TEST_HIGH_RES_IMAGE_URL)
+        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
+    }
+
+    @Test
+    fun `high res image success ui shown on high res image load success`() {
+        initViewModel()
+        viewModel.onImageLoadSuccess(TEST_HIGH_RES_IMAGE_URL)
+        assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
+    }
+
+    @Test
+    fun `high res image failed ui shown on high res image load failed`() {
+        initViewModel()
+        viewModel.onImageLoadFailed(TEST_HIGH_RES_IMAGE_URL)
+        assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadFailedUiState::class.java)
+    }
+
+    @Test
+    fun `high res image success ui shown when low res image loads after high res image`() {
+        initViewModel()
+        viewModel.onImageLoadSuccess(TEST_HIGH_RES_IMAGE_URL)
+        viewModel.onImageLoadSuccess(TEST_LOW_RES_IMAGE_URL)
+        assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
     }
 
     private fun initViewModel() = viewModel.onCreateView(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL)

--- a/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -44,71 +44,71 @@ class PreviewImageViewModelTest {
     @Test
     fun `progress bar shown on low res image load success`() {
         initViewModel()
-        viewModel.onImageLoadSuccess(TEST_LOW_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL)
         assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(true)
     }
 
     @Test
     fun `progress bar shown on low res image load failed`() {
         initViewModel()
-        viewModel.onImageLoadFailed(TEST_LOW_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewFailed(TEST_LOW_RES_IMAGE_URL)
         assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(true)
     }
 
     @Test
     fun `low res image success ui shown on low res image load success`() {
         initViewModel()
-        viewModel.onImageLoadSuccess(TEST_LOW_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL)
         assertThat(viewModel.uiState.value).isInstanceOf(ImageInLowResLoadSuccessUiState::class.java)
     }
 
     @Test
     fun `low res image failed ui shown on low res image load failed`() {
         initViewModel()
-        viewModel.onImageLoadFailed(TEST_LOW_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewFailed(TEST_LOW_RES_IMAGE_URL)
         assertThat(viewModel.uiState.value).isInstanceOf(ImageInLowResLoadFailedUiState::class.java)
     }
 
     @Test
     fun `progress bar hidden on high res image load success`() {
         initViewModel()
-        viewModel.onImageLoadSuccess(TEST_HIGH_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL)
         assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
     }
 
     @Test
     fun `progress bar hidden on high res image load failed`() {
         initViewModel()
-        viewModel.onImageLoadFailed(TEST_HIGH_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
         assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
     }
 
     @Test
     fun `high res image success ui shown on high res image load success`() {
         initViewModel()
-        viewModel.onImageLoadSuccess(TEST_HIGH_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL)
         assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
     }
 
     @Test
     fun `high res image failed ui shown on high res image load failed`() {
         initViewModel()
-        viewModel.onImageLoadFailed(TEST_HIGH_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
         assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadFailedUiState::class.java)
     }
 
     @Test
     fun `high res image success ui shown when low res image loads after high res image`() {
         initViewModel()
-        viewModel.onImageLoadSuccess(TEST_HIGH_RES_IMAGE_URL)
-        viewModel.onImageLoadSuccess(TEST_LOW_RES_IMAGE_URL) // low res image loaded after high res image
+        viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL) // low res image loaded after high res image
         assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
     }
 
     @Test
     fun `high res image file loading started when high res image shown`() {
         initViewModel()
-        viewModel.onImageLoadSuccess(TEST_HIGH_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL)
         assertThat(viewModel.loadIntoFile.value).isEqualTo(ImageStartLoadingToFileState(TEST_HIGH_RES_IMAGE_URL))
     }
 

--- a/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -6,6 +6,7 @@ import org.junit.Test
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileFailedState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileIdleState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileSuccessState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadFailedUiState
@@ -125,7 +126,7 @@ class PreviewImageViewModelTest {
         initViewModel()
         viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL)
         viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
-        assertThat(viewModel.loadIntoFile.value).isNull()
+        assertThat(viewModel.loadIntoFile.value).isEqualTo(ImageLoadToFileIdleState)
     }
 
     @Test

--- a/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -5,6 +5,9 @@ import org.junit.Before
 import org.junit.Test
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileFailedState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileSuccessState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadFailedUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadSuccessUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
@@ -13,6 +16,7 @@ import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiSt
 
 private const val TEST_LOW_RES_IMAGE_URL = "https://wordpress.com/low_res_image.png"
 private const val TEST_HIGH_RES_IMAGE_URL = "https://wordpress.com/image.png"
+private const val TEST_FILE_PATH = "/file/path"
 class PreviewImageViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
@@ -97,8 +101,36 @@ class PreviewImageViewModelTest {
     fun `high res image success ui shown when low res image loads after high res image`() {
         initViewModel()
         viewModel.onImageLoadSuccess(TEST_HIGH_RES_IMAGE_URL)
-        viewModel.onImageLoadSuccess(TEST_LOW_RES_IMAGE_URL)
+        viewModel.onImageLoadSuccess(TEST_LOW_RES_IMAGE_URL) // low res image loaded after high res image
         assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
+    }
+
+    @Test
+    fun `high res image file loading started when high res image shown`() {
+        initViewModel()
+        viewModel.onImageLoadSuccess(TEST_HIGH_RES_IMAGE_URL)
+        assertThat(viewModel.loadIntoFile.value).isEqualTo(ImageStartLoadingToFileState(TEST_HIGH_RES_IMAGE_URL))
+    }
+
+    @Test
+    fun `load image to file success state triggered for the loaded image file on image load to file success`() {
+        initViewModel()
+        viewModel.onLoadIntoFileSuccess(TEST_FILE_PATH)
+        assertThat(viewModel.loadIntoFile.value).isEqualTo(ImageLoadToFileSuccessState(TEST_FILE_PATH))
+    }
+
+    @Test
+    fun `load image to file success state triggered on image load to file success`() {
+        initViewModel()
+        viewModel.onLoadIntoFileSuccess(TEST_FILE_PATH)
+        assertThat(viewModel.loadIntoFile.value).isInstanceOf(ImageLoadToFileSuccessState::class.java)
+    }
+
+    @Test
+    fun `load image to file failed state triggered on image load to file failure`() {
+        initViewModel()
+        viewModel.onLoadIntoFileFailed()
+        assertThat(viewModel.loadIntoFile.value).isInstanceOf(ImageLoadToFileFailedState::class.java)
     }
 
     private fun initViewModel() = viewModel.onCreateView(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL)

--- a/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -113,7 +113,31 @@ class PreviewImageViewModelTest {
     }
 
     @Test
-    fun `load image to file success state triggered for the loaded image file on image load to file success`() {
+    fun `high res image file loading started when low res image shown after high res image`() {
+        initViewModel()
+        viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL)
+        assertThat(viewModel.loadIntoFile.value).isEqualTo(ImageStartLoadingToFileState(TEST_HIGH_RES_IMAGE_URL))
+    }
+
+    @Test
+    fun `high res image file loading not started when low res image shown but high res image show failed`() {
+        initViewModel()
+        viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
+        assertThat(viewModel.loadIntoFile.value).isNull()
+    }
+
+    @Test
+    fun `high res image file loading started when low res image show failed but high res image shown`() {
+        initViewModel()
+        viewModel.onLoadIntoImageViewFailed(TEST_LOW_RES_IMAGE_URL)
+        viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL)
+        assertThat(viewModel.loadIntoFile.value).isEqualTo(ImageStartLoadingToFileState(TEST_HIGH_RES_IMAGE_URL))
+    }
+
+    @Test
+    fun `load image to file success state triggered for the loaded image file on image loaded`() {
         initViewModel()
         viewModel.onLoadIntoFileSuccess(TEST_FILE_PATH)
         assertThat(viewModel.loadIntoFile.value).isEqualTo(ImageLoadToFileSuccessState(TEST_FILE_PATH))

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorInitializer.kt
@@ -23,7 +23,7 @@ class ImageEditorInitializer {
         private fun loadIntoImageViewWithResultListener(
             imageManager: ImageManager
         ): (String, ImageView, ScaleType, String, ImageEditor.RequestListener<Drawable>) -> Unit =
-                { imageUrl, imageView, scaleType, thumbUrl, requestListener ->
+                { imageUrl, imageView, scaleType, thumbUrl, listener ->
                     imageManager.loadWithResultListener(
                         imageView,
                         IMAGE,
@@ -31,48 +31,37 @@ class ImageEditorInitializer {
                         scaleType,
                         thumbUrl,
                         object : RequestListener<Drawable> {
-                            override fun onLoadFailed(e: Exception?, model: Any?) {
-                                if (model != null && model is String) {
-                                    requestListener.onLoadFailed(e, model)
-                                } else {
-                                    throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
-                                }
-                            }
-
-                            override fun onResourceReady(resource: Drawable, model: Any?) {
-                                if (model != null && model is String) {
-                                    requestListener.onResourceReady(resource, model)
-                                } else {
-                                    throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
-                                }
-                            }
+                            override fun onLoadFailed(e: Exception?, model: Any?) = onLoadFailed(model, listener, e)
+                            override fun onResourceReady(resource: Drawable, model: Any?) =
+                                onResourceReady(model, listener, resource)
                         }
                     )
                 }
 
-        private fun loadIntoFileWithResultListener(
-            imageManager: ImageManager
-        ): (String, ImageEditor.RequestListener<File>) -> Unit = { imageUrl, requestListener ->
+        private fun loadIntoFileWithResultListener(imageManager: ImageManager):
+                (String, ImageEditor.RequestListener<File>) -> Unit = { imageUrl, listener ->
             imageManager.loadIntoFileWithResultListener(
                 imageUrl,
                 object : RequestListener<File> {
-                    override fun onLoadFailed(e: Exception?, model: Any?) {
-                        if (model != null && model is String) {
-                            requestListener.onLoadFailed(e, model)
-                        } else {
-                            throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
-                        }
-                    }
-
-                    override fun onResourceReady(resource: File, model: Any?) {
-                        if (model != null && model is String) {
-                            requestListener.onResourceReady(resource, model)
-                        } else {
-                            throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
-                        }
-                    }
+                    override fun onLoadFailed(e: Exception?, model: Any?) = onLoadFailed(model, listener, e)
+                    override fun onResourceReady(resource: File, model: Any?) =
+                        onResourceReady(model, listener, resource)
                 }
             )
         }
+
+        private fun <T : Any> onResourceReady(model: Any?, listener: ImageEditor.RequestListener<T>, resource: T) =
+            if (model != null && model is String) {
+                listener.onResourceReady(resource, model)
+            } else {
+                throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
+            }
+
+        private fun <T : Any> onLoadFailed(model: Any?, listener: ImageEditor.RequestListener<T>, e: Exception?) =
+            if (model != null && model is String) {
+                listener.onLoadFailed(e, model)
+            } else {
+                throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
+            }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorInitializer.kt
@@ -1,41 +1,78 @@
 package org.wordpress.android.ui.posts.editor
 
 import android.graphics.drawable.Drawable
+import android.widget.ImageView
+import android.widget.ImageView.ScaleType
 import org.wordpress.android.imageeditor.ImageEditor
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageManager.RequestListener
 import org.wordpress.android.util.image.ImageType.IMAGE
-import java.lang.IllegalArgumentException
+import java.io.File
 
 class ImageEditorInitializer {
     companion object {
+        private const val IMAGE_STRING_URL_MSG = "ImageEditor requires a not-null string image url."
+
         fun init(imageManager: ImageManager) {
-            ImageEditor.init { imageUrl, imageView, scaleType, thumbUrl, requestListener ->
-                imageManager.loadWithResultListener(
-                    imageView,
-                    IMAGE,
-                    imageUrl,
-                    scaleType,
-                    thumbUrl,
-                    object : RequestListener<Drawable> {
-                        override fun onLoadFailed(e: Exception?, model: Any?) {
-                            if (model != null && model is String) {
-                                requestListener.onLoadFailed(e, model)
-                            } else {
-                                throw(IllegalArgumentException("ImageEditor requires a not-null string image url."))
+            ImageEditor.init(
+                loadIntoImageViewWithResultListener(imageManager),
+                loadIntoFileWithResultListener(imageManager)
+            )
+        }
+
+        private fun loadIntoImageViewWithResultListener(
+            imageManager: ImageManager
+        ): (String, ImageView, ScaleType, String, ImageEditor.RequestListener<Drawable>) -> Unit =
+                { imageUrl, imageView, scaleType, thumbUrl, requestListener ->
+                    imageManager.loadWithResultListener(
+                        imageView,
+                        IMAGE,
+                        imageUrl,
+                        scaleType,
+                        thumbUrl,
+                        object : RequestListener<Drawable> {
+                            override fun onLoadFailed(e: Exception?, model: Any?) {
+                                if (model != null && model is String) {
+                                    requestListener.onLoadFailed(e, model)
+                                } else {
+                                    throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
+                                }
+                            }
+
+                            override fun onResourceReady(resource: Drawable, model: Any?) {
+                                if (model != null && model is String) {
+                                    requestListener.onResourceReady(resource, model)
+                                } else {
+                                    throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
+                                }
                             }
                         }
+                    )
+                }
 
-                        override fun onResourceReady(resource: Drawable, model: Any?) {
-                            if (model != null && model is String) {
-                                requestListener.onResourceReady(resource, model)
-                            } else {
-                                throw(IllegalArgumentException("ImageEditor requires a not-null string image url."))
-                            }
+        private fun loadIntoFileWithResultListener(
+            imageManager: ImageManager
+        ): (String, ImageEditor.RequestListener<File>) -> Unit = { imageUrl, requestListener ->
+            imageManager.loadIntoFileWithResultListener(
+                imageUrl,
+                object : RequestListener<File> {
+                    override fun onLoadFailed(e: Exception?, model: Any?) {
+                        if (model != null && model is String) {
+                            requestListener.onLoadFailed(e, model)
+                        } else {
+                            throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
                         }
                     }
-                )
-            }
+
+                    override fun onResourceReady(resource: File, model: Any?) {
+                        if (model != null && model is String) {
+                            requestListener.onResourceReady(resource, model)
+                        } else {
+                            throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
+                        }
+                    }
+                }
+            )
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -21,13 +21,16 @@ import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.target.AppWidgetTarget
 import com.bumptech.glide.request.target.BaseTarget
+import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.target.Target
 import com.bumptech.glide.request.target.ViewTarget
+import com.bumptech.glide.request.transition.Transition
 import com.bumptech.glide.signature.ObjectKey
 import org.wordpress.android.WordPress
 import org.wordpress.android.modules.GlideApp
 import org.wordpress.android.modules.GlideRequest
 import org.wordpress.android.util.AppLog
+import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -170,6 +173,31 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
                 .attachRequestListener(requestListener)
                 .into(imageView)
                 .clearOnDetach()
+    }
+
+    /**
+     * Loads a File from the Glide's disk cache for the provided imgUrl using asFile().
+     *
+     * We can use asFile() asynchronously on the ui thread or synchronously on a background thread.
+     * This function uses the asynchronous api which takes a Target argument to invoke asFile().
+     */
+    fun loadIntoFileWithResultListener(
+        imgUrl: String,
+        requestListener: RequestListener<File>
+    ) {
+        val context = WordPress.getContext()
+        if (!context.isAvailable()) return
+        GlideApp.with(context)
+            .asFile()
+            .load(imgUrl)
+            .attachRequestListener(requestListener)
+            .into(
+                // Used just to invoke asFile() and ignored thereafter.
+                object : CustomTarget<File>() {
+                    override fun onLoadCleared(placeholder: Drawable?) {}
+                    override fun onResourceReady(resource: File, transition: Transition<in File>?) {}
+                }
+            )
     }
 
     /**


### PR DESCRIPTION
Closes #11144

This PR

- Supports loading images asynchronously into files using Glide's `asFile()` in the `ImageManager`.  As discussed,  it uses the `Target` just to invoke `asFile()`.

- Updates pending tests for loading the image into `ImageView` as per https://github.com/wordpress-mobile/WordPress-Android/pull/11241#issuecomment-588110399 as we continued to use the same logic.

-  Loads the image into file in a ui thread in the fragment using the newly supported asynchronous API. As discussed, states for loading the image into file are added to the VM and observed in the fragment.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
