### PR TITLE
Offline Pages : Pagel Labels in Search Mode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.fluxc.model.page.PageStatus
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged
-import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.pages.PageItem
 import org.wordpress.android.ui.pages.PageItem.Action

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -55,7 +55,6 @@ class PageListViewModel @Inject constructor(
     private val pageListItemActionsUseCase: CreatePageListItemActionsUseCase,
     private val pageItemProgressUiStateUseCase: PageItemProgressUiStateUseCase,
     private val mediaStore: MediaStore,
-    private val postStore: PostStore,
     private val dispatcher: Dispatcher,
     private val localeManagerWrapper: LocaleManagerWrapper,
     @Named(BG_THREAD) private val coroutineDispatcher: CoroutineDispatcher

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus
-import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.modules.UI_SCOPE
 import org.wordpress.android.ui.pages.PageItem
 import org.wordpress.android.ui.pages.PageItem.Action
@@ -32,10 +31,10 @@ import javax.inject.Named
 
 class SearchListViewModel
 @Inject constructor(
+    private val createPageListItemLabelsUseCase: CreatePageListItemLabelsUseCase,
     private val createPageUploadUiStateUseCase: CreatePageUploadUiStateUseCase,
     private val pageListItemActionsUseCase: CreatePageListItemActionsUseCase,
     private val pageItemProgressUiStateUseCase: PageItemProgressUiStateUseCase,
-    private val postStore: PostStore,
     private val resourceProvider: ResourceProvider,
     @Named(UI_SCOPE) private val uiScope: CoroutineScope
 ) : ViewModel() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
@@ -99,9 +99,9 @@ class SearchListViewModel
                 pagesViewModel.site,
                 pagesViewModel.uploadStatusTracker
         )
-        // TODO any reason why we don't show labels in search?
         val (progressBarUiState, showOverlay) = pageItemProgressUiStateUseCase.getProgressStateForPage(this.post,
                 uploadUiState)
+        val (labels, labelColor) = createPageListItemLabelsUseCase.createLabels(this.post, uploadUiState)
 
         return when (status) {
             PageStatus.PUBLISHED, PageStatus.PRIVATE ->
@@ -110,6 +110,8 @@ class SearchListViewModel
                         pageId,
                         title,
                         date,
+                        labels,
+                        labelColor,
                         actions = pageListItemActionsUseCase.setupPageActions(PUBLISHED, uploadUiState),
                         actionsEnabled = areActionsEnabled,
                         progressBarUiState = progressBarUiState,
@@ -120,6 +122,8 @@ class SearchListViewModel
                     pageId,
                     title,
                     date,
+                    labels,
+                    labelColor,
                     actions = pageListItemActionsUseCase.setupPageActions(DRAFTS, uploadUiState),
                     actionsEnabled = areActionsEnabled,
                     progressBarUiState = progressBarUiState,
@@ -130,6 +134,8 @@ class SearchListViewModel
                     pageId,
                     title,
                     date,
+                    labels,
+                    labelColor,
                     actions = pageListItemActionsUseCase.setupPageActions(TRASHED, uploadUiState),
                     actionsEnabled = areActionsEnabled,
                     progressBarUiState = progressBarUiState,
@@ -140,6 +146,8 @@ class SearchListViewModel
                     pageId,
                     title,
                     date,
+                    labels,
+                    labelColor,
                     actions = pageListItemActionsUseCase.setupPageActions(SCHEDULED, uploadUiState),
                     actionsEnabled = areActionsEnabled,
                     progressBarUiState = progressBarUiState,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus
 import org.wordpress.android.fluxc.store.MediaStore
-import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.ui.pages.PageItem
 import org.wordpress.android.ui.pages.PageItem.Divider
 import org.wordpress.android.ui.pages.PageItem.Page
@@ -36,7 +35,6 @@ private const val HOUR_IN_MILLISECONDS = 3600000L
 
 class PageListViewModelTest : BaseUnitTest() {
     @Mock lateinit var mediaStore: MediaStore
-    @Mock lateinit var postStore: PostStore
     @Mock lateinit var dispatcher: Dispatcher
     @Mock lateinit var pagesViewModel: PagesViewModel
     @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
@@ -56,7 +54,6 @@ class PageListViewModelTest : BaseUnitTest() {
                 pageListItemActionsUseCase,
                 pageItemProgressUiStateUseCase,
                 mediaStore,
-                postStore,
                 dispatcher,
                 localeManagerWrapper,
                 Dispatchers.Unconfined

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
@@ -41,6 +41,7 @@ class SearchListViewModelTest {
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var site: SiteModel
     @Mock lateinit var pagesViewModel: PagesViewModel
+    @Mock lateinit var createPageListItemLabelsUseCase: CreatePageListItemLabelsUseCase
     @Mock lateinit var pageItemProgressUiStateUseCase: PageItemProgressUiStateUseCase
     @Mock lateinit var pageListItemActionsUseCase: CreatePageListItemActionsUseCase
     @Mock lateinit var createUploadStateUseCase: CreatePageUploadUiStateUseCase
@@ -54,6 +55,7 @@ class SearchListViewModelTest {
     fun setUp() {
         page = PageModel(PostModel(), site, 1, "title", PUBLISHED, Date(), false, 11L, null, 0)
         viewModel = SearchListViewModel(
+                createPageListItemLabelsUseCase,
                 createUploadStateUseCase,
                 pageListItemActionsUseCase,
                 pageItemProgressUiStateUseCase,
@@ -71,6 +73,12 @@ class SearchListViewModelTest {
         whenever(pagesViewModel.searchPages).thenReturn(searchPages)
         whenever(pagesViewModel.site).thenReturn(site)
         whenever(pagesViewModel.uploadStatusTracker).thenReturn(mock())
+        whenever(pagesViewModel.arePageActionsEnabled).thenReturn(true)
+        whenever(createPageListItemLabelsUseCase.createLabels(any(), any())).thenReturn(
+                Pair(
+                        mock(), 0
+                )
+        )
         whenever(createUploadStateUseCase.createUploadUiState(any(), any(), any())).thenReturn(
                 PostUploadUiState.NothingToUpload
         )

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
@@ -73,7 +73,6 @@ class SearchListViewModelTest {
         whenever(pagesViewModel.searchPages).thenReturn(searchPages)
         whenever(pagesViewModel.site).thenReturn(site)
         whenever(pagesViewModel.uploadStatusTracker).thenReturn(mock())
-        whenever(pagesViewModel.arePageActionsEnabled).thenReturn(true)
         whenever(createPageListItemLabelsUseCase.createLabels(any(), any())).thenReturn(
                 Pair(
                         mock(), 0

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus.DRAFT
 import org.wordpress.android.fluxc.model.page.PageStatus.PUBLISHED
-import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.ui.pages.PageItem
 import org.wordpress.android.ui.pages.PageItem.Action.VIEW_PAGE
 import org.wordpress.android.ui.pages.PageItem.Divider
@@ -45,7 +44,6 @@ class SearchListViewModelTest {
     @Mock lateinit var pageItemProgressUiStateUseCase: PageItemProgressUiStateUseCase
     @Mock lateinit var pageListItemActionsUseCase: CreatePageListItemActionsUseCase
     @Mock lateinit var createUploadStateUseCase: CreatePageUploadUiStateUseCase
-    @Mock lateinit var postStore: PostStore
 
     private lateinit var searchPages: MutableLiveData<SortedMap<PageListType, List<PageModel>>>
     private lateinit var viewModel: SearchListViewModel
@@ -59,7 +57,6 @@ class SearchListViewModelTest {
                 createUploadStateUseCase,
                 pageListItemActionsUseCase,
                 pageItemProgressUiStateUseCase,
-                postStore,
                 resourceProvider,
                 TEST_SCOPE
         )


### PR DESCRIPTION
Fixes #11279

## Findings
The `Post List` and `Page List` contained related logic to support this feature. 

## Solution
Reuse the `CreatePageListItemLabelsUseCase` to get the labels and their respective colors for each page type in the `Search List`. 

## Testing
1. Go to My Site.
2. Go to Pages. 
3. Ensure that the pages have labels such as unsaved changes, local changes, errors, etc. 
4. Press the search button and ensure that the same pages with labels being shown in normal mode are being shown in search mode with the same labels.

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 