### PR TITLE
Offline Pages : Scroll To Page Once Edited

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.pages_list_fragment.*
 import org.wordpress.android.R
@@ -96,7 +97,12 @@ class PageListFragment : Fragment() {
 
         viewModel.scrollToPosition.observe(this, Observer { position ->
             position?.let {
-                recyclerView.smoothScrollToPosition(position)
+                val smoothScroller = object : LinearSmoothScroller(context) {
+                    override fun getVerticalSnapPreference(): Int {
+                        return SNAP_TO_START
+                    }
+                }.apply { targetPosition = position }
+                recyclerView.layoutManager?.startSmoothScroll(smoothScroller)
             }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.pages_list_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.image.ImageManager
@@ -119,7 +120,7 @@ class PageListFragment : Fragment() {
         adapter.update(pages)
     }
 
-    fun scrollToPage(remotePageId: Long) {
-        viewModel.onScrollToPageRequested(remotePageId)
+    fun scrollToPage(localPageId: Int) {
+        viewModel.setPageToScrollTo(LocalId(localPageId))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -15,7 +15,6 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.pages_list_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.image.ImageManager
@@ -121,6 +120,6 @@ class PageListFragment : Fragment() {
     }
 
     fun scrollToPage(localPageId: Int) {
-        viewModel.setPageToScrollTo(LocalId(localPageId))
+        viewModel.onScrollToPageRequested(localPageId)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -160,7 +160,6 @@ class PagesFragment : Fragment() {
     private fun initializeViews(activity: FragmentActivity) {
         pagesPager.adapter = PagesPagerAdapter(activity, childFragmentManager)
         tabLayout.setupWithViewPager(pagesPager)
-        pagesPager.offscreenPageLimit = 3
 
         swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
             viewModel.onPullToRefresh()

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -160,6 +160,7 @@ class PagesFragment : Fragment() {
     private fun initializeViews(activity: FragmentActivity) {
         pagesPager.adapter = PagesPagerAdapter(activity, childFragmentManager)
         tabLayout.setupWithViewPager(pagesPager)
+        pagesPager.offscreenPageLimit = 3
 
         swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
             viewModel.onPullToRefresh()

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -492,6 +492,6 @@ class PagesPagerAdapter(val context: Context, val fm: FragmentManager) : Fragmen
 
     fun scrollToPage(page: PageModel) {
         val listFragment = listFragments[PageListType.fromPageStatus(page.status)]?.get()
-        listFragment?.scrollToPage(page.remoteId)
+        listFragment?.scrollToPage(page.pageId)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -148,7 +148,7 @@ class PageListViewModel @Inject constructor(
         pagesViewModel.onNewPageButtonTapped()
     }
 
-     fun onScrollToPageRequested(localPageId: Int) {
+    fun onScrollToPageRequested(localPageId: Int) {
         val position = _pages.value?.indexOfFirst { it is Page && it.localId == localPageId } ?: -1
         if (position != -1) {
             _scrollToPosition.postValue(position)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -156,6 +156,7 @@ class PageListViewModel @Inject constructor(
         val position = _pages.value?.indexOfFirst { it is Page && it.localId == localPageId } ?: -1
         if (position != -1) {
             _scrollToPosition.postValue(position)
+            pageToScrollTo = null
         } else {
             AppLog.e(AppLog.T.PAGES, "Attempt to scroll to a missing page with ID $localPageId")
         }
@@ -217,7 +218,6 @@ class PageListViewModel @Inject constructor(
 
         pageToScrollTo?.let {
             onScrollToPageRequested(it.value)
-            pageToScrollTo = null
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -68,6 +68,7 @@ class PageListViewModel @Inject constructor(
     private val _scrollToPosition = SingleLiveEvent<Int>()
     val scrollToPosition: LiveData<Int> = _scrollToPosition
 
+    private var pageToScrollTo: LocalId? = null
     private var isStarted: Boolean = false
     private lateinit var listType: PageListType
 
@@ -147,12 +148,16 @@ class PageListViewModel @Inject constructor(
         pagesViewModel.onNewPageButtonTapped()
     }
 
-    fun onScrollToPageRequested(remotePageId: Long) {
-        val position = _pages.value?.indexOfFirst { it is Page && it.remoteId == remotePageId } ?: -1
+    fun setPageToScrollTo(pageId: LocalId) {
+        pageToScrollTo = pageId
+    }
+
+    private fun onScrollToPageRequested(localPageId: Int) {
+        val position = _pages.value?.indexOfFirst { it is Page && it.localId == localPageId } ?: -1
         if (position != -1) {
             _scrollToPosition.postValue(position)
         } else {
-            AppLog.e(AppLog.T.PAGES, "Attempt to scroll to a missing page with ID $remotePageId")
+            AppLog.e(AppLog.T.PAGES, "Attempt to scroll to a missing page with ID $localPageId")
         }
     }
 
@@ -208,6 +213,11 @@ class PageListViewModel @Inject constructor(
             val pagesWithBottomGap = newPages.toMutableList()
             pagesWithBottomGap.addAll(listOf(Divider(), Divider()))
             _pages.postValue(pagesWithBottomGap)
+        }
+
+        pageToScrollTo?.let {
+            onScrollToPageRequested(it.value)
+            pageToScrollTo = null
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -68,7 +68,7 @@ class PageListViewModel @Inject constructor(
     private val _scrollToPosition = SingleLiveEvent<Int>()
     val scrollToPosition: LiveData<Int> = _scrollToPosition
 
-    private var pageToScrollTo: LocalId? = null
+    private var retryScrollToPage: LocalId? = null
     private var isStarted: Boolean = false
     private lateinit var listType: PageListType
 
@@ -148,16 +148,13 @@ class PageListViewModel @Inject constructor(
         pagesViewModel.onNewPageButtonTapped()
     }
 
-    fun setPageToScrollTo(pageId: LocalId) {
-        pageToScrollTo = pageId
-    }
-
-    private fun onScrollToPageRequested(localPageId: Int) {
+     fun onScrollToPageRequested(localPageId: Int) {
         val position = _pages.value?.indexOfFirst { it is Page && it.localId == localPageId } ?: -1
         if (position != -1) {
             _scrollToPosition.postValue(position)
-            pageToScrollTo = null
+            retryScrollToPage = null
         } else {
+            retryScrollToPage = LocalId(localPageId)
             AppLog.e(AppLog.T.PAGES, "Attempt to scroll to a missing page with ID $localPageId")
         }
     }
@@ -216,7 +213,7 @@ class PageListViewModel @Inject constructor(
             _pages.postValue(pagesWithBottomGap)
         }
 
-        pageToScrollTo?.let {
+        retryScrollToPage?.let {
             onScrollToPageRequested(it.value)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -252,13 +252,13 @@ class PagesViewModel
 
     fun onPageEditFinished(localPageId: Int, data: Intent) {
         launch {
-            refreshPages() // show local changes immediately
             withContext(defaultDispatcher) {
                 pageStore.getPageByLocalId(pageId = localPageId, site = site)?.let {
                     _scrollToPage.postOnUi(it)
                     _postUploadAction.postValue(Triple(it.post, it.site, data))
                 }
             }
+            refreshPages() // show local changes immediately
         }
     }
 
@@ -614,18 +614,18 @@ class PagesViewModel
                         val updatedPage = updatePageStatus(page, status)
                         pageStore.updatePageInDb(updatedPage)
 
+                        _scrollToPage.postOnUi(updatedPage)
                         refreshPages()
                         pageStore.uploadPageToServer(updatedPage)
-                        _scrollToPage.postOnUi(updatedPage)
                     }
                 } else {
                     // Local pages are trashed locally
                     PageAction(remoteId, UPDATE) {
                         val updatedPage = updatePageStatus(page, status)
                         pageStore.updatePageInDb(updatedPage)
-
-                        refreshPages()
+                        
                         _scrollToPage.postOnUi(updatedPage)
+                        refreshPages()
                     }
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -252,13 +252,13 @@ class PagesViewModel
 
     fun onPageEditFinished(localPageId: Int, data: Intent) {
         launch {
+            refreshPages() // show local changes immediately
             withContext(defaultDispatcher) {
                 pageStore.getPageByLocalId(pageId = localPageId, site = site)?.let {
                     _scrollToPage.postOnUi(it)
                     _postUploadAction.postValue(Triple(it.post, it.site, data))
                 }
             }
-            refreshPages() // show local changes immediately
         }
     }
 
@@ -613,8 +613,8 @@ class PagesViewModel
                     PageAction(remoteId, UPLOAD) {
                         val updatedPage = updatePageStatus(page, status)
                         pageStore.updatePageInDb(updatedPage)
-                        _scrollToPage.postOnUi(updatedPage)
                         refreshPages()
+                        _scrollToPage.postOnUi(updatedPage)
                         pageStore.uploadPageToServer(updatedPage)
                     }
                 } else {
@@ -622,8 +622,8 @@ class PagesViewModel
                     PageAction(remoteId, UPDATE) {
                         val updatedPage = updatePageStatus(page, status)
                         pageStore.updatePageInDb(updatedPage)
-                        _scrollToPage.postOnUi(updatedPage)
                         refreshPages()
+                        _scrollToPage.postOnUi(updatedPage)
                     }
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -613,7 +613,6 @@ class PagesViewModel
                     PageAction(remoteId, UPLOAD) {
                         val updatedPage = updatePageStatus(page, status)
                         pageStore.updatePageInDb(updatedPage)
-
                         _scrollToPage.postOnUi(updatedPage)
                         refreshPages()
                         pageStore.uploadPageToServer(updatedPage)
@@ -623,7 +622,6 @@ class PagesViewModel
                     PageAction(remoteId, UPDATE) {
                         val updatedPage = updatePageStatus(page, status)
                         pageStore.updatePageInDb(updatedPage)
-                        
                         _scrollToPage.postOnUi(updatedPage)
                         refreshPages()
                     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -477,9 +477,7 @@ class PagesViewModel
     private fun publishPageNow(remoteId: Long) {
         _publishAction.value = pageMap[remoteId]
         launch(uiDispatcher) {
-            withContext(defaultDispatcher) {
-                delay(SCROLL_DELAY)
-            }
+            delay(SCROLL_DELAY)
             pageMap[remoteId]?.let {
                 _scrollToPage.postValue(it)
             }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -255,6 +255,7 @@ class PagesViewModel
             refreshPages() // show local changes immediately
             withContext(defaultDispatcher) {
                 pageStore.getPageByLocalId(pageId = localPageId, site = site)?.let {
+                    _scrollToPage.postOnUi(it)
                     _postUploadAction.postValue(Triple(it.post, it.site, data))
                 }
             }
@@ -615,6 +616,7 @@ class PagesViewModel
 
                         refreshPages()
                         pageStore.uploadPageToServer(updatedPage)
+                        _scrollToPage.postOnUi(updatedPage)
                     }
                 } else {
                     // Local pages are trashed locally
@@ -623,6 +625,7 @@ class PagesViewModel
                         pageStore.updatePageInDb(updatedPage)
 
                         refreshPages()
+                        _scrollToPage.postOnUi(updatedPage)
                     }
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -74,6 +74,7 @@ import kotlin.coroutines.resume
 
 private const val ACTION_DELAY = 100L
 private const val SEARCH_DELAY = 200L
+private const val SCROLL_DELAY = 200L
 private const val SNACKBAR_DELAY = 500L
 private const val SEARCH_COLLAPSE_DELAY = 500L
 private const val PAGE_UPLOAD_TIMEOUT = 5000L
@@ -475,6 +476,14 @@ class PagesViewModel
 
     private fun publishPageNow(remoteId: Long) {
         _publishAction.value = pageMap[remoteId]
+        launch(uiDispatcher) {
+            withContext(defaultDispatcher) {
+                delay(SCROLL_DELAY)
+            }
+            pageMap[remoteId]?.let {
+                _scrollToPage.postValue(it)
+            }
+        }
     }
 
     fun onImagesChanged() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -640,7 +640,6 @@ class PagesViewModel
                 action.onSuccess = {
                     launch(defaultDispatcher) {
                         delay(ACTION_DELAY)
-                        reloadPages()
 
                         val message = prepareStatusChangeSnackbar(status, action.undo)
                         showSnackbar(message)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -233,6 +233,21 @@ class PagesViewModelTest {
         assertThat(viewModel.postUploadAction.value).isEqualTo(Triple(pageModel.post, pageModel.site, intent))
     }
 
+    @Test
+    fun `scrollToPage is invoked on edit post activity result`() = test {
+        // Given
+        val intent = mock<Intent>()
+        val pageModel = setUpPageStoreWithASinglePage()
+        whenever(pageStore.getPageByLocalId(eq(pageModel.pageId), anyOrNull()))
+                .thenReturn(pageModel)
+
+        viewModel.start(site)
+        // When
+        viewModel.onPageEditFinished(pageModel.pageId, intent)
+        // Then
+        assertThat(viewModel.scrollToPage.value).isEqualTo(pageModel)
+    }
+
     private suspend fun setUpPageStoreWithEmptyPages() {
         whenever(pageStore.getPagesFromDb(site)).thenReturn(listOf())
         whenever(pageStore.requestPagesFromServer(any())).thenReturn(


### PR DESCRIPTION
Fixes #11132

## Findings
There was already behavior for scrolling so that was leveraged to make scrolling possible when pages are modified. 

## Solution
1. The `scrollToPage` LiveData object was triggered when page edits are finished and when a page's status is changed. This was done since those were the times when a user would be interacting with the `Pages List` and not know the location of a post they performed an action on. 

2. I switched the use of `remoteId` for `localId` for the page query since pages that haven't been uploaded don't have a `remoteId` and scroll wasn't working for them. 

3. I realized that scrolling to an item before I am sure the list data was loaded in the `ViewModel` was sometimes causing scrolls to not work, so I set the scroll to retry since we know the page exists and there could always be timing issues. This seemed like the most sensible solution without disrupting the existing scroll behavior. 

4. Something I have realized with this solution is it's easier to identify a page when it's being uploaded since the progress bar will be visible but with a page status change, you have to find the page in the screen port since it's position won't be obvious. This might only be happening because I am testing, as others will have more meaningful page names and such forth, so this can be overlooked. I experimented with `scaling` and modifying the `alpha` using animations to add a subtle hint for the page but it didn't work well since the page is being invalidated a lot and to prevent this behavior, a modification would have to be made to the adapter which isn't necessary at this point in time. 

5. Sometimes the scroll didnt't complete because during the smooth scroll animation the list is invalidated. I think this happens because within the `changePageStatus` function, the page is refreshed and the scroll is initiated and then when the action is completed a `reloadPages` function was called. I removed this f328d58 since the database was updated and I didn't see why the pages needed to be reloaded. This removal is somewhat similar to the removal from the `postUploadStarted` function you did when cleaning up the `PageEventListener`.  Let me know what you think about this. 

6. There are a few times, I have noticed that after saving a draft, it doesn't scroll to the location. I am still trying to figure out why that happens. 

## Testing

1. Go to my site. 
2. Go to Pages. 
3. Change the page status of pages on the Published, Drafts,  Scheduled, Trashed Tab. 
4. The app should then jump to that tab and the page should be visible. 
---------------
1. Go to my site. 
2. Go to Pages. 
3. Create a new page or update a page, especially by scheduling it.
4. Publish or save the page.
5. The app should then jump to that tab and the page should be visible. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 