### PR TITLE
Ensuring the fragment isAdded before to continue with the AsyncTask.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2878,7 +2878,7 @@ public class ReaderPostListFragment extends Fragment
 
         @Override
         protected void onPostExecute(ReaderTagList tagList) {
-            if (mFilterCriteriaLoaderListener != null) {
+            if (mFilterCriteriaLoaderListener != null && isAdded()) {
                 //noinspection unchecked
                 mFilterCriteriaLoaderListener.onFilterCriteriasLoaded((List) tagList);
             }


### PR DESCRIPTION
This PR is related to some consideration made during #11343 review (see [here](https://github.com/wordpress-mobile/WordPress-Android/pull/11343#pullrequestreview-361948620) for more context)

With the following call path in `ReaderPostListFragment`: 

> LoadTagsTask -> onPostExecute -> onFilterCriteriasLoaded -> setCurrentFilter(mFilterListener.onRecallSelection())

it can happen that the onRecallSelection (who calls requireActivity) could be called when the fragment is not added so resulting in a crash. This PR tries to mitigate that possibility checking that the fragment is attached to activity in `onPostExecute`

### To test
Was not able to trigger the issue so not fully sure how to test. At least smoke test the reader to check that we did not introduce issues.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
