### PR TITLE
Reverted restore button and logic.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.widgets.PostListButtonType.BUTTON_MORE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_MOVE_TO_DRAFT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PREVIEW
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PUBLISH
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_RESTORE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_RETRY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_STATS
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_SUBMIT
@@ -74,6 +75,9 @@ class PostActionHandler(
         when (buttonType) {
             BUTTON_EDIT -> editPostButtonAction(site, post)
             BUTTON_RETRY -> triggerPostListAction.invoke(RetryUpload(post))
+            BUTTON_RESTORE -> {
+                restorePost(post)
+            }
             BUTTON_MOVE_TO_DRAFT -> {
                 moveTrashedPostToDraft(post)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.widgets.PostListButtonType.BUTTON_MORE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_MOVE_TO_DRAFT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PREVIEW
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PUBLISH
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_RESTORE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_RETRY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_STATS
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_SUBMIT
@@ -44,6 +45,7 @@ fun trackPostListAction(site: SiteModel, buttonType: PostListButtonType, postDat
         BUTTON_SYNC -> "sync"
         BUTTON_MORE -> "more"
         BUTTON_MOVE_TO_DRAFT -> "move_to_draft"
+        BUTTON_RESTORE -> "restore"
         BUTTON_CANCEL_PENDING_AUTO_UPLOAD -> "cancel_pending_auto_upload"
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -45,9 +45,9 @@ import org.wordpress.android.widgets.PostListButtonType.BUTTON_CANCEL_PENDING_AU
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE_PERMANENTLY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
-import org.wordpress.android.widgets.PostListButtonType.BUTTON_MOVE_TO_DRAFT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PREVIEW
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PUBLISH
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_RESTORE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_RETRY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_STATS
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_SUBMIT
@@ -388,7 +388,7 @@ class PostListItemUiStateHelper @Inject constructor(private val appPrefsWrapper:
         when {
             isLocalDraft -> buttonTypes.add(BUTTON_DELETE)
             postStatus == TRASHED -> {
-                buttonTypes.add(BUTTON_MOVE_TO_DRAFT)
+                buttonTypes.add(BUTTON_RESTORE)
                 buttonTypes.add(BUTTON_DELETE_PERMANENTLY)
             }
             postStatus != TRASHED -> buttonTypes.add(BUTTON_TRASH)

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -30,7 +30,8 @@ enum class PostListButtonType constructor(
             R.drawable.ic_trash_white_24dp,
             R.attr.wpColorTextSubtle
     ),
-    BUTTON_CANCEL_PENDING_AUTO_UPLOAD(14, R.string.cancel, R.drawable.ic_undo_white_24dp, R.attr.wpColorWarningDark);
+    BUTTON_CANCEL_PENDING_AUTO_UPLOAD(14, R.string.cancel, R.drawable.ic_undo_white_24dp, R.attr.wpColorWarningDark),
+    BUTTON_RESTORE(15, R.string.button_restore, R.drawable.ic_refresh_white_24dp, R.attr.wpColorTextSubtle);
 
     companion object {
         fun fromInt(value: Int): PostListButtonType? = values().firstOrNull { it.value == value }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -284,6 +284,7 @@
     <string name="button_discard">Discard</string>
     <string name="button_retry">Retry</string>
     <string name="button_move_to_draft">Move to Draft</string>
+    <string name="button_restore">Restore</string>
 
     <!-- post uploads -->
     <string name="upload_failed_param">Upload failed for \"%s\"</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -242,7 +242,7 @@ class PostListItemUiStateHelperTest {
                 post = createPostModel(status = POST_STATE_TRASHED)
         )
 
-        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_RESTORE)
         assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_DELETE_PERMANENTLY)
         assertThat(state.actions).hasSize(2)
     }
@@ -724,7 +724,7 @@ class PostListItemUiStateHelperTest {
     @Test
     fun `show only delete and move to draft buttons on trashed posts`() {
         val state = createPostListItemUiState(post = createPostModel(POST_STATE_TRASHED))
-        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
+        assertThat(state.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_RESTORE)
         assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_DELETE_PERMANENTLY)
         assertThat(state.actions).hasSize(2)
     }


### PR DESCRIPTION
Fixes #11026 

In #9613 we changed the way posts are restored - from calling `restore` endpoint, to manually marking trashed posts as `DRAFT` and updating them. This led to the disappearance of comments of the posts we were restoring by "drafting".

I brought back the Restore button and it's logic and kept code related to the Move to Draft button just in case.

I understand that the change was motivated by a desire to improve user experience, and removing the ambiguity of where the post will be restored to like it is in Calypso.

To achieve this we will need a more involved process, that will potentially store or retrieve the status of the post before it was Trashed, and reflect this status in UI, so the users will be aware of where it will go after restoration.

Since this issue leads to a content loss, I would like to merge it ASAP. We can work on improving the restoration logic at a later time, and I created an issue to track it #11364.

To test:
- Trash Published post and restore it from Trashed posts list. Make sure it's restored to Published posts tab.
- Trash Published post with comments in them, and restore it from Trashed posts list. Make sure it's restored to Published posts tab and comments are restored as well.
- Trash Draft post and restore it from Trashed posts list. Make sure it's restored to the Draft posts tab.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
