### PR TITLE
Add the missing release note for the Block editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * Block editor: Add support for changing image sizes in Image blocks
 * Block editor: Add support for upload options in Gallery block
 * Block editor: Added the Button block
+* Block editor: Added the Group block
 * Block editor: Add scroll support inside block picker and block settings
 * Block editor: Fix issue preventing correct placeholder image from displaying during image upload
 * Block editor: Fix issue where adding emojis to the post title added strong HTML elements to the title of the post


### PR DESCRIPTION
Fixes #

Adding the release note for "Group block". That line was overlooked during the release of gutenberg-mobile 1.23 release.

WP-iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13538

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
