### PR TITLE
Issue/material log view activity

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -455,7 +455,7 @@
         <activity
             android:name=".ui.AppLogViewerActivity"
             android:label="@string/reader_title_applog"
-            android:theme="@style/CalypsoTheme" />
+            android:theme="@style/WordPress.NoActionBar" />
         <activity
             android:name=".ui.reader.ReaderUserListActivity"
             android:theme="@style/WordPress.NoActionBar" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 import org.wordpress.android.R;
 import org.wordpress.android.util.AppLog;
@@ -46,9 +47,10 @@ public class AppLogViewerActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.logviewer_activity);
 
+        Toolbar toolbar = findViewById(R.id.toolbar_main);
+        setSupportActionBar(toolbar);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
-            actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_STANDARD);
             actionBar.setDisplayShowTitleEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
             actionBar.setTitle(R.string.reader_title_applog);

--- a/WordPress/src/main/res/layout/logviewer_activity.xml
+++ b/WordPress/src/main/res/layout/logviewer_activity.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<ListView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@android:id/list"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:divider="@null"
-    android:dividerHeight="0dp" />
+    android:orientation="vertical">
+
+    <include layout="@layout/toolbar_main" />
+
+    <ListView
+        android:id="@android:id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:divider="@null"
+        android:dividerHeight="0dp" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/logviewer_listitem.xml
+++ b/WordPress/src/main/res/layout/logviewer_listitem.xml
@@ -5,25 +5,25 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="horizontal"
-    android:paddingTop="@dimen/margin_extra_small"
     android:paddingEnd="@dimen/margin_medium"
-    android:paddingStart="@dimen/margin_medium">
+    android:paddingStart="@dimen/margin_medium"
+    android:paddingTop="@dimen/margin_extra_small">
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_line"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="top"
-        android:textColor="@color/neutral_40"
-        android:textSize="@dimen/text_sz_medium"
+        android:textColor="?attr/wpColorOnSurfaceMedium"
+        android:textAppearance="?attr/textAppearanceBody2"
         tools:text="01" />
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_log"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_small"
         android:gravity="top"
-        android:textSize="@dimen/text_sz_medium"
-        tools:text="application log text"
-        android:layout_marginStart="@dimen/margin_small"/>
+        android:textAppearance="?attr/textAppearanceBody2"
+        tools:text="application log text" />
 </LinearLayout>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -201,22 +201,6 @@ public class AppLog {
 
     public enum LogLevel {
         v, d, i, w, e;
-
-        private String toHtmlColor() {
-            switch (this) {
-                case v:
-                    return "grey";
-                case i:
-                    return "black";
-                case w:
-                    return "purple";
-                case e:
-                    return "red";
-                case d:
-                default:
-                    return "teal";
-            }
-        }
     }
 
     private static class LogEntry {
@@ -244,16 +228,12 @@ public class AppLog {
 
         private String toHtml() {
             StringBuilder sb = new StringBuilder();
-            sb.append("<font color=\"");
-            sb.append(mLogLevel.toHtmlColor());
-            sb.append("\">");
             sb.append("[");
             sb.append(formatLogDate()).append(" ");
             sb.append(mLogTag.name()).append(" ");
             sb.append(mLogLevel.name());
             sb.append("] ");
             sb.append(TextUtils.htmlEncode(mLogText).replace("\n", "<br />"));
-            sb.append("</font>");
             return sb.toString();
         }
     }


### PR DESCRIPTION
This PR moves Application Log activity to material theme and adds dark mode support.

This one is pretty simple - we removed the different colors for logs since they are supposed to be shared with developers, and will be shared as a plain text.  Maintaining their colors for both light and dark modes in the Utility submodule is not worth the effort.

![comparison_cr_land](https://user-images.githubusercontent.com/728822/75215826-d456b180-5746-11ea-9d9b-60aba867bcb2.png)

To test:
- Check out the Application Log activity in both light and dark modes and make sure it looks ok.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
