### PR TITLE
Dark SwipeRefreshLayout Indicator

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPSwipeToRefreshHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPSwipeToRefreshHelper.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.util;
 
+import com.google.android.material.elevation.ElevationOverlayProvider;
+
 import org.wordpress.android.R;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper.RefreshListener;
@@ -11,12 +13,18 @@ public class WPSwipeToRefreshHelper {
      * instance with colors designated for the WordPress app.
      *
      * @param swipeRefreshLayout {@link CustomSwipeRefreshLayout} for refreshing the contents
-     * of a view via a vertical swipe gesture.
-     * @param listener {@link RefreshListener} notified when a refresh is triggered
-     * via the swipe gesture.
+     *                           of a view via a vertical swipe gesture.
+     * @param listener           {@link RefreshListener} notified when a refresh is triggered
+     *                           via the swipe gesture.
      */
     public static SwipeToRefreshHelper buildSwipeToRefreshHelper(CustomSwipeRefreshLayout swipeRefreshLayout,
                                                                  RefreshListener listener) {
-        return new SwipeToRefreshHelper(swipeRefreshLayout, listener, R.color.primary, R.color.accent);
+        ElevationOverlayProvider elevationOverlayProvider =
+                new ElevationOverlayProvider(swipeRefreshLayout.getContext());
+
+        int appbarElevation = swipeRefreshLayout.getResources().getDimensionPixelOffset(R.dimen.appbar_elevation);
+        int backgroundColor = elevationOverlayProvider.compositeOverlayWithThemeSurfaceColorIfNeeded(appbarElevation);
+
+        return new SwipeToRefreshHelper(swipeRefreshLayout, listener, backgroundColor, R.color.accent);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPSwipeToRefreshHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPSwipeToRefreshHelper.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.util;
 
+import android.content.Context;
+
 import com.google.android.material.elevation.ElevationOverlayProvider;
 
 import org.wordpress.android.R;
@@ -19,12 +21,16 @@ public class WPSwipeToRefreshHelper {
      */
     public static SwipeToRefreshHelper buildSwipeToRefreshHelper(CustomSwipeRefreshLayout swipeRefreshLayout,
                                                                  RefreshListener listener) {
-        ElevationOverlayProvider elevationOverlayProvider =
-                new ElevationOverlayProvider(swipeRefreshLayout.getContext());
+        Context context = swipeRefreshLayout.getContext();
 
+        ElevationOverlayProvider elevationOverlayProvider = new ElevationOverlayProvider(context);
         int appbarElevation = swipeRefreshLayout.getResources().getDimensionPixelOffset(R.dimen.appbar_elevation);
         int backgroundColor = elevationOverlayProvider.compositeOverlayWithThemeSurfaceColorIfNeeded(appbarElevation);
 
-        return new SwipeToRefreshHelper(swipeRefreshLayout, listener, backgroundColor, R.color.accent);
+        int primaryProgressColor = ContextExtensionsKt.getColorResIdFromAttribute(context, R.attr.colorPrimary);
+        int secondaryProgressColor = ContextExtensionsKt.getColorResIdFromAttribute(context, R.attr.colorSecondary);
+
+        return new SwipeToRefreshHelper(swipeRefreshLayout, listener, backgroundColor, primaryProgressColor,
+                secondaryProgressColor);
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
@@ -2,7 +2,9 @@ package org.wordpress.android.util.helpers;
 
 import android.content.Context;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.ColorRes;
+import androidx.core.content.ContextCompat;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener;
 
@@ -27,12 +29,13 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
      * @param listener {@link RefreshListener} notified when a refresh is triggered
      * via the swipe gesture.
      *
-     * @deprecated Use {@link #SwipeToRefreshHelper(CustomSwipeRefreshLayout, RefreshListener, int...)} instead.
+     * @deprecated Use {@link #SwipeToRefreshHelper(CustomSwipeRefreshLayout, RefreshListener, int, int...)} instead.
      */
     @Deprecated
     public SwipeToRefreshHelper(Context context, CustomSwipeRefreshLayout swipeRefreshLayout,
                                 RefreshListener listener) {
-        init(swipeRefreshLayout, listener, android.R.color.holo_blue_dark);
+        init(swipeRefreshLayout, listener, ContextCompat.getColor(context, android.R.color.white),
+                android.R.color.holo_blue_dark);
     }
 
     /**
@@ -43,13 +46,14 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
      * of a view via a vertical swipe gesture.
      * @param listener {@link RefreshListener} notified when a refresh is triggered
      * via the swipe gesture.
-     * @param colorResIds Comma-separated color resource integers used in the progress
+     * @param progressAnimationColors Comma-separated color resource integers used in the progress
      * animation. The first color will also be the color of the bar
      * that grows in response to a user swipe gesture.
      */
     public SwipeToRefreshHelper(CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener,
-                                @ColorRes int... colorResIds) {
-        init(swipeRefreshLayout, listener, colorResIds);
+                                @ColorInt int backgroundColor,
+                                @ColorRes int... progressAnimationColors) {
+        init(swipeRefreshLayout, listener, backgroundColor, progressAnimationColors);
     }
 
     /**
@@ -60,16 +64,18 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
      * of a view via a vertical swipe gesture.
      * @param listener {@link RefreshListener} notified when a refresh is triggered
      * via the swipe gesture.
-     * @param colorResIds Comma-separated color resource integers used in the progress
+     * @param progressAnimationColors Comma-separated color resource integers used in the progress
      * animation. The first color will also be the color of the bar
      * that grows in response to a user swipe gesture.
      */
     public void init(CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener,
-                     @ColorRes int... colorResIds) {
+                     @ColorInt int backgroundColor,
+                     @ColorRes int... progressAnimationColors) {
         mRefreshListener = listener;
         mSwipeRefreshLayout = swipeRefreshLayout;
         mSwipeRefreshLayout.setOnRefreshListener(this);
-        mSwipeRefreshLayout.setColorSchemeResources(colorResIds);
+        mSwipeRefreshLayout.setProgressBackgroundColorSchemeColor(backgroundColor);
+        mSwipeRefreshLayout.setColorSchemeResources(progressAnimationColors);
     }
 
     public void setRefreshing(boolean refreshing) {


### PR DESCRIPTION
Fixes #11085

This PR adds a dark background to Swipe To Refresh indicator. 

Amazingly, we can't style `SwipeRefreshLayout`  through theming/styles at all. We have to pass the colors we want through the helper and apply them to the view programmatically.

[![Image from Gyazo](https://i.gyazo.com/ca4c8921f23b292f78f7cde783cfc266.png)](https://gyazo.com/ca4c8921f23b292f78f7cde783cfc266)

To test:
- Check out indicator of SwipeRefreshLayout and make sure it looks nice.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
