### PR TITLE
Issue/11145 start ucrop with high res image

### DIFF
--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
@@ -47,7 +47,7 @@ class EditImageActivity : AppCompatActivity(), UCropFragmentCallback {
 
     override fun onSupportNavigateUp(): Boolean {
         // Allows NavigationUI to support proper up navigation
-        return if (navController.currentDestination?.id == R.id.ucrop_dest) {
+        return if (navController.currentDestination?.id == R.id.crop_dest) {
             // Using popUpToInclusive for popping the start destination of the graph off the back stack
             // in a multi-module project doesn't seem to be working. Explicitly invoking back action as a workaround.
             // Related issue: https://issuetracker.google.com/issues/147312109

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
@@ -6,8 +6,8 @@ import androidx.appcompat.widget.Toolbar
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
-import androidx.navigation.ui.NavigationUI.navigateUp
 import androidx.navigation.ui.NavigationUI.setupActionBarWithNavController
+import androidx.navigation.ui.navigateUp
 import com.yalantis.ucrop.UCropFragment.UCropResult
 import com.yalantis.ucrop.UCropFragmentCallback
 
@@ -47,7 +47,15 @@ class EditImageActivity : AppCompatActivity(), UCropFragmentCallback {
 
     override fun onSupportNavigateUp(): Boolean {
         // Allows NavigationUI to support proper up navigation
-        return (navigateUp(navController, appBarConfiguration) || super.onSupportNavigateUp())
+        return if (navController.currentDestination?.id == R.id.ucrop_dest) {
+            // Using popUpToInclusive for popping the start destination of the graph off the back stack
+            // in a multi-module project doesn't seem to be working. Explicitly invoking back action as a workaround.
+            // Related issue: https://issuetracker.google.com/issues/147312109
+            onBackPressed()
+            true
+        } else {
+            navController.navigateUp(appBarConfiguration) || super.onSupportNavigateUp()
+        }
     }
 
     override fun onCropFinish(result: UCropResult?) { }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
@@ -8,8 +8,10 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI.navigateUp
 import androidx.navigation.ui.NavigationUI.setupActionBarWithNavController
+import com.yalantis.ucrop.UCropFragment.UCropResult
+import com.yalantis.ucrop.UCropFragmentCallback
 
-class EditImageActivity : AppCompatActivity() {
+class EditImageActivity : AppCompatActivity(), UCropFragmentCallback {
     private lateinit var hostFragment: NavHostFragment
     private lateinit var appBarConfiguration: AppBarConfiguration
 
@@ -47,4 +49,8 @@ class EditImageActivity : AppCompatActivity() {
         // Allows NavigationUI to support proper up navigation
         return (navigateUp(navController, appBarConfiguration) || super.onSupportNavigateUp())
     }
+
+    override fun onCropFinish(result: UCropResult?) { }
+
+    override fun loadingProgress(showLoader: Boolean) { }
 }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -10,13 +10,16 @@ import android.widget.ImageView.ScaleType.CENTER
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
 import kotlinx.android.synthetic.main.fragment_preview_image.*
 import org.wordpress.android.imageeditor.ImageEditor
 import org.wordpress.android.imageeditor.ImageEditor.RequestListener
+import org.wordpress.android.imageeditor.R
 import org.wordpress.android.imageeditor.R.layout
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
+import org.wordpress.android.imageeditor.utils.UCropUtil
 import org.wordpress.android.imageeditor.utils.UiHelpers
 import java.io.File
 
@@ -103,5 +106,14 @@ class PreviewImageFragment : Fragment() {
         )
     }
 
-    private fun startUCrop(inputFilePath: String) { }
+    private fun startUCrop(inputFilePath: String) {
+        findNavController().navigate(
+            R.id.action_previewFragment_to_ucropFragment,
+            UCropUtil.getUCropOptionsBundle(
+                File(inputFilePath),
+                // TODO: output file location
+                File(requireContext().cacheDir, UCropUtil.IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME)
+            )
+        )
+    }
 }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -68,8 +68,8 @@ class PreviewImageFragment : Fragment() {
             }
         })
 
-        viewModel.startCrop.observe(this, Observer { filesInfo ->
-            startCrop(filesInfo)
+        viewModel.navigateToCropScreenWithFilesInfo.observe(this, Observer { filesInfo ->
+            navigateToCropScreenWithFilesInfo(filesInfo)
         })
     }
 
@@ -106,7 +106,7 @@ class PreviewImageFragment : Fragment() {
         )
     }
 
-    private fun startCrop(filesInfo: Pair<File, File>) {
+    private fun navigateToCropScreenWithFilesInfo(filesInfo: Pair<File, File>) {
         findNavController().navigate(
             R.id.action_previewFragment_to_cropFragment,
             CropUtil.getCropInfoBundleWithFilesInfo(filesInfo)

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.imageeditor.ImageEditor
 import org.wordpress.android.imageeditor.ImageEditor.RequestListener
 import org.wordpress.android.imageeditor.R
 import org.wordpress.android.imageeditor.R.layout
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.Companion.IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
@@ -52,7 +51,7 @@ class PreviewImageFragment : Fragment() {
 
         viewModel = ViewModelProvider(this).get(PreviewImageViewModel::class.java)
         setupObservers()
-        viewModel.onCreateView(lowResImageUrl, highResImageUrl)
+        viewModel.onCreateView(lowResImageUrl, highResImageUrl, requireContext().cacheDir)
     }
 
     private fun setupObservers() {
@@ -69,8 +68,8 @@ class PreviewImageFragment : Fragment() {
             }
         })
 
-        viewModel.startUCrop.observe(this, Observer { filePath ->
-            startUCrop(filePath)
+        viewModel.startUCrop.observe(this, Observer { filesInfo ->
+            startUCrop(filesInfo)
         })
     }
 
@@ -107,13 +106,10 @@ class PreviewImageFragment : Fragment() {
         )
     }
 
-    private fun startUCrop(inputFilePath: String) {
+    private fun startUCrop(filesInfo: Pair<File, File>) {
         findNavController().navigate(
             R.id.action_previewFragment_to_ucropFragment,
-            UCropUtil.getUCropOptionsBundle(
-                File(inputFilePath),
-                File(requireContext().cacheDir, IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME)
-            )
+            UCropUtil.getUCropOptionsBundleWithFilesInfo(filesInfo)
         )
     }
 }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -64,6 +64,10 @@ class PreviewImageFragment : Fragment() {
                 loadIntoFile(fileState.imageUrl)
             }
         })
+
+        viewModel.startUCrop.observe(this, Observer { filePath ->
+            startUCrop(filePath)
+        })
     }
 
     private fun loadIntoImageView(imageData: ImageData) {
@@ -98,4 +102,6 @@ class PreviewImageFragment : Fragment() {
             }
         )
     }
+
+    private fun startUCrop(inputFilePath: String) { }
 }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -19,7 +19,7 @@ import org.wordpress.android.imageeditor.R.layout
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
-import org.wordpress.android.imageeditor.utils.UCropUtil
+import org.wordpress.android.imageeditor.utils.CropUtil
 import org.wordpress.android.imageeditor.utils.UiHelpers
 import java.io.File
 
@@ -68,8 +68,8 @@ class PreviewImageFragment : Fragment() {
             }
         })
 
-        viewModel.startUCrop.observe(this, Observer { filesInfo ->
-            startUCrop(filesInfo)
+        viewModel.startCrop.observe(this, Observer { filesInfo ->
+            startCrop(filesInfo)
         })
     }
 
@@ -106,10 +106,10 @@ class PreviewImageFragment : Fragment() {
         )
     }
 
-    private fun startUCrop(filesInfo: Pair<File, File>) {
+    private fun startCrop(filesInfo: Pair<File, File>) {
         findNavController().navigate(
-            R.id.action_previewFragment_to_ucropFragment,
-            UCropUtil.getUCropOptionsBundleWithFilesInfo(filesInfo)
+            R.id.action_previewFragment_to_cropFragment,
+            CropUtil.getCropInfoBundleWithFilesInfo(filesInfo)
         )
     }
 }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.imageeditor.ImageEditor
 import org.wordpress.android.imageeditor.ImageEditor.RequestListener
 import org.wordpress.android.imageeditor.R
 import org.wordpress.android.imageeditor.R.layout
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.Companion.IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
@@ -111,8 +112,7 @@ class PreviewImageFragment : Fragment() {
             R.id.action_previewFragment_to_ucropFragment,
             UCropUtil.getUCropOptionsBundle(
                 File(inputFilePath),
-                // TODO: output file location
-                File(requireContext().cacheDir, UCropUtil.IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME)
+                File(requireContext().cacheDir, IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME)
             )
         )
     }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiSt
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadSuccessUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadFailedUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadSuccessUiState
+import java.io.File
 
 class PreviewImageViewModel : ViewModel() {
     private val _uiState: MutableLiveData<ImageUiState> = MutableLiveData()
@@ -20,10 +21,14 @@ class PreviewImageViewModel : ViewModel() {
     private val _loadIntoFile = MutableLiveData<ImageLoadToFileState>(ImageLoadToFileIdleState)
     val loadIntoFile: LiveData<ImageLoadToFileState> = _loadIntoFile
 
-    private val _startUCrop = MutableLiveData<String>()
-    val startUCrop: LiveData<String> = _startUCrop
+    private val _startUCrop = MutableLiveData<Pair<File, File>>()
+    val startUCrop: LiveData<Pair<File, File>> = _startUCrop
 
-    fun onCreateView(loResImageUrl: String, hiResImageUrl: String) {
+    private lateinit var cacheDir: File
+
+    fun onCreateView(loResImageUrl: String, hiResImageUrl: String, cacheDir: File) {
+        this.cacheDir = cacheDir
+
         updateUiState(
             ImageDataStartLoadingUiState(
                 ImageData(loResImageUrl, hiResImageUrl)
@@ -68,9 +73,9 @@ class PreviewImageViewModel : ViewModel() {
         updateUiState(newState)
     }
 
-    fun onLoadIntoFileSuccess(filePath: String) {
-        updateLoadIntoFileState(ImageLoadToFileSuccessState(filePath))
-        _startUCrop.value = filePath
+    fun onLoadIntoFileSuccess(inputFilePath: String) {
+        updateLoadIntoFileState(ImageLoadToFileSuccessState(inputFilePath))
+        _startUCrop.value = Pair(File(inputFilePath), File(cacheDir, IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME))
     }
 
     fun onLoadIntoFileFailed() {

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -44,10 +44,9 @@ class PreviewImageViewModel : ViewModel() {
             else -> ImageInHighResLoadSuccessUiState
         }
 
-        if (newState == ImageInHighResLoadSuccessUiState &&
-                currentState != ImageInHighResLoadSuccessUiState &&
-                loadIntoFile.value !is ImageLoadToFileSuccessState
-        ) {
+        val highResImageJustLoadedIntoView = newState != currentState && newState == ImageInHighResLoadSuccessUiState
+        val imageNotLoadedIntoFile = loadIntoFile.value !is ImageLoadToFileSuccessState
+        if (highResImageJustLoadedIntoView && imageNotLoadedIntoFile) {
             updateLoadIntoFileState(ImageStartLoadingToFileState(url))
         }
         updateUiState(newState)

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -21,8 +21,8 @@ class PreviewImageViewModel : ViewModel() {
     private val _loadIntoFile = MutableLiveData<ImageLoadToFileState>(ImageLoadToFileIdleState)
     val loadIntoFile: LiveData<ImageLoadToFileState> = _loadIntoFile
 
-    private val _startCrop = MutableLiveData<Pair<File, File>>()
-    val startCrop: LiveData<Pair<File, File>> = _startCrop
+    private val _navigateToCropScreenWithFilesInfo = MutableLiveData<Pair<File, File>>()
+    val navigateToCropScreenWithFilesInfo: LiveData<Pair<File, File>> = _navigateToCropScreenWithFilesInfo
 
     private lateinit var cacheDir: File
 
@@ -75,7 +75,10 @@ class PreviewImageViewModel : ViewModel() {
 
     fun onLoadIntoFileSuccess(inputFilePath: String) {
         updateLoadIntoFileState(ImageLoadToFileSuccessState(inputFilePath))
-        _startCrop.value = Pair(File(inputFilePath), File(cacheDir, IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME))
+        _navigateToCropScreenWithFilesInfo.value = Pair(
+            File(inputFilePath),
+            File(cacheDir, IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME)
+        )
     }
 
     fun onLoadIntoFileFailed() {

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -105,4 +105,8 @@ class PreviewImageViewModel : ViewModel() {
         data class ImageLoadToFileSuccessState(val filePath: String) : ImageLoadToFileState()
         object ImageLoadToFileFailedState : ImageLoadToFileState()
     }
+
+    companion object {
+        const val IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME = "image_editor_output_image.jpg"
+    }
 }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -21,8 +21,8 @@ class PreviewImageViewModel : ViewModel() {
     private val _loadIntoFile = MutableLiveData<ImageLoadToFileState>(ImageLoadToFileIdleState)
     val loadIntoFile: LiveData<ImageLoadToFileState> = _loadIntoFile
 
-    private val _startUCrop = MutableLiveData<Pair<File, File>>()
-    val startUCrop: LiveData<Pair<File, File>> = _startUCrop
+    private val _startCrop = MutableLiveData<Pair<File, File>>()
+    val startCrop: LiveData<Pair<File, File>> = _startCrop
 
     private lateinit var cacheDir: File
 
@@ -75,7 +75,7 @@ class PreviewImageViewModel : ViewModel() {
 
     fun onLoadIntoFileSuccess(inputFilePath: String) {
         updateLoadIntoFileState(ImageLoadToFileSuccessState(inputFilePath))
-        _startUCrop.value = Pair(File(inputFilePath), File(cacheDir, IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME))
+        _startCrop.value = Pair(File(inputFilePath), File(cacheDir, IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME))
     }
 
     fun onLoadIntoFileFailed() {

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -17,8 +17,11 @@ class PreviewImageViewModel : ViewModel() {
     private val _uiState: MutableLiveData<ImageUiState> = MutableLiveData()
     val uiState: LiveData<ImageUiState> = _uiState
 
-    private val _loadIntoFile: MutableLiveData<ImageLoadToFileState> = MutableLiveData(ImageLoadToFileIdleState)
+    private val _loadIntoFile = MutableLiveData<ImageLoadToFileState>(ImageLoadToFileIdleState)
     val loadIntoFile: LiveData<ImageLoadToFileState> = _loadIntoFile
+
+    private val _startUCrop = MutableLiveData<String>()
+    val startUCrop: LiveData<String> = _startUCrop
 
     fun onCreateView(loResImageUrl: String, hiResImageUrl: String) {
         updateUiState(
@@ -41,7 +44,10 @@ class PreviewImageViewModel : ViewModel() {
             else -> ImageInHighResLoadSuccessUiState
         }
 
-        if (newState == ImageInHighResLoadSuccessUiState && currentState != ImageInHighResLoadSuccessUiState) {
+        if (newState == ImageInHighResLoadSuccessUiState &&
+                currentState != ImageInHighResLoadSuccessUiState &&
+                loadIntoFile.value !is ImageLoadToFileSuccessState
+        ) {
             updateLoadIntoFileState(ImageStartLoadingToFileState(url))
         }
         updateUiState(newState)
@@ -65,6 +71,7 @@ class PreviewImageViewModel : ViewModel() {
 
     fun onLoadIntoFileSuccess(filePath: String) {
         updateLoadIntoFileState(ImageLoadToFileSuccessState(filePath))
+        _startUCrop.value = filePath
     }
 
     fun onLoadIntoFileFailed() {

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/utils/CropUtil.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/utils/CropUtil.kt
@@ -9,8 +9,8 @@ import com.yalantis.ucrop.model.AspectRatio
 import com.yalantis.ucrop.view.CropImageView
 import java.io.File
 
-object UCropUtil {
-    private val uCropOptions
+object CropUtil {
+    private val cropOptions
         get() = Options().also {
             it.setShowCropGrid(true)
             it.setFreeStyleCropEnabled(true)
@@ -26,11 +26,11 @@ object UCropUtil {
             )
         }
 
-    fun getUCropOptionsBundleWithFilesInfo(filesInfo: Pair<File, File>) = Bundle().also {
+    fun getCropInfoBundleWithFilesInfo(filesInfo: Pair<File, File>) = Bundle().also {
         val inputFile = filesInfo.first
         val outputFile = filesInfo.second
         it.putParcelable(EXTRA_INPUT_URI, Uri.fromFile(inputFile))
         it.putParcelable(EXTRA_OUTPUT_URI, Uri.fromFile(outputFile))
-        it.putAll(uCropOptions.optionBundle)
+        it.putAll(cropOptions.optionBundle)
     }
 }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/utils/UCropUtil.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/utils/UCropUtil.kt
@@ -10,8 +10,6 @@ import com.yalantis.ucrop.view.CropImageView
 import java.io.File
 
 object UCropUtil {
-    const val IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME = "image_editor_output_image.jpg"
-
     private val uCropOptions
         get() = Options().also {
             it.setShowCropGrid(true)

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/utils/UCropUtil.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/utils/UCropUtil.kt
@@ -26,7 +26,9 @@ object UCropUtil {
             )
         }
 
-    fun getUCropOptionsBundle(inputFile: File, outputFile: File) = Bundle().also {
+    fun getUCropOptionsBundleWithFilesInfo(filesInfo: Pair<File, File>) = Bundle().also {
+        val inputFile = filesInfo.first
+        val outputFile = filesInfo.second
         it.putParcelable(EXTRA_INPUT_URI, Uri.fromFile(inputFile))
         it.putParcelable(EXTRA_OUTPUT_URI, Uri.fromFile(outputFile))
         it.putAll(uCropOptions.optionBundle)

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/utils/UCropUtil.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/utils/UCropUtil.kt
@@ -1,0 +1,36 @@
+package org.wordpress.android.imageeditor.utils
+
+import android.net.Uri
+import android.os.Bundle
+import com.yalantis.ucrop.UCrop.EXTRA_INPUT_URI
+import com.yalantis.ucrop.UCrop.EXTRA_OUTPUT_URI
+import com.yalantis.ucrop.UCrop.Options
+import com.yalantis.ucrop.model.AspectRatio
+import com.yalantis.ucrop.view.CropImageView
+import java.io.File
+
+object UCropUtil {
+    const val IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME = "image_editor_output_image.jpg"
+
+    private val uCropOptions
+        get() = Options().also {
+            it.setShowCropGrid(true)
+            it.setFreeStyleCropEnabled(true)
+            it.setShowCropFrame(true)
+            it.setHideBottomControls(false)
+            it.setAspectRatioOptions(
+                0,
+                AspectRatio("1:2", 1f, 2f),
+                AspectRatio("3:4", 3f, 4f),
+                AspectRatio("Original", CropImageView.DEFAULT_ASPECT_RATIO, CropImageView.DEFAULT_ASPECT_RATIO),
+                AspectRatio("16:9", 16f, 9f),
+                AspectRatio("1:1", 1f, 1f)
+            )
+        }
+
+    fun getUCropOptionsBundle(inputFile: File, outputFile: File) = Bundle().also {
+        it.putParcelable(EXTRA_INPUT_URI, Uri.fromFile(inputFile))
+        it.putParcelable(EXTRA_OUTPUT_URI, Uri.fromFile(outputFile))
+        it.putAll(uCropOptions.optionBundle)
+    }
+}

--- a/ImageEditor/src/main/res/layout/activity_edit_image.xml
+++ b/ImageEditor/src/main/res/layout/activity_edit_image.xml
@@ -7,32 +7,21 @@
     android:fitsSystemWindows="true"
     android:orientation="vertical">
 
-    <FrameLayout
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_gravity="center"
+    <fragment
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_graph"/>
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/black_translucent_40"
+        android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent">
-
-        <fragment
-            android:id="@+id/nav_host_fragment"
-            android:name="androidx.navigation.fragment.NavHostFragment"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:defaultNavHost="true"
-            app:navGraph="@navigation/nav_graph"/>
-
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/black_translucent_40"
-            android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
-
-    </FrameLayout>
+        app:layout_constraintTop_toTopOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/ImageEditor/src/main/res/navigation/nav_graph.xml
+++ b/ImageEditor/src/main/res/navigation/nav_graph.xml
@@ -7,7 +7,6 @@
     <fragment
         android:id="@+id/preview_dest"
         android:name="org.wordpress.android.imageeditor.preview.PreviewImageFragment"
-        android:label="@string/preview"
         tools:layout="@layout/fragment_preview_image">
     </fragment>
     <fragment

--- a/ImageEditor/src/main/res/navigation/nav_graph.xml
+++ b/ImageEditor/src/main/res/navigation/nav_graph.xml
@@ -8,6 +8,11 @@
         android:id="@+id/preview_dest"
         android:name="org.wordpress.android.imageeditor.preview.PreviewImageFragment"
         tools:layout="@layout/fragment_preview_image">
+        <action
+            android:id="@+id/action_previewFragment_to_ucropFragment"
+            app:destination="@id/ucrop_dest"
+            app:popUpTo="@id/preview_dest"
+            app:popUpToInclusive="true"/>
     </fragment>
     <fragment
         android:id="@+id/ucrop_dest"

--- a/ImageEditor/src/main/res/navigation/nav_graph.xml
+++ b/ImageEditor/src/main/res/navigation/nav_graph.xml
@@ -10,4 +10,8 @@
         android:label="@string/preview"
         tools:layout="@layout/fragment_preview_image">
     </fragment>
+    <fragment
+        android:id="@+id/ucrop_dest"
+        android:name="com.yalantis.ucrop.UCropFragment">
+    </fragment>
 </navigation>

--- a/ImageEditor/src/main/res/navigation/nav_graph.xml
+++ b/ImageEditor/src/main/res/navigation/nav_graph.xml
@@ -9,13 +9,13 @@
         android:name="org.wordpress.android.imageeditor.preview.PreviewImageFragment"
         tools:layout="@layout/fragment_preview_image">
         <action
-            android:id="@+id/action_previewFragment_to_ucropFragment"
-            app:destination="@id/ucrop_dest"
+            android:id="@+id/action_previewFragment_to_cropFragment"
+            app:destination="@id/crop_dest"
             app:popUpTo="@id/preview_dest"
             app:popUpToInclusive="true"/>
     </fragment>
     <fragment
-        android:id="@+id/ucrop_dest"
+        android:id="@+id/crop_dest"
         android:name="com.yalantis.ucrop.UCropFragment">
     </fragment>
 </navigation>

--- a/ImageEditor/src/main/res/values/strings.xml
+++ b/ImageEditor/src/main/res/values/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="app_name">ImageEditor</string>
-    <string name="preview">Preview</string>
-</resources>

--- a/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -15,16 +15,19 @@ import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiSt
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadFailedUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadSuccessUiState
+import java.io.File
 
 private const val TEST_LOW_RES_IMAGE_URL = "https://wordpress.com/low_res_image.png"
 private const val TEST_HIGH_RES_IMAGE_URL = "https://wordpress.com/image.png"
 private const val TEST_FILE_PATH = "/file/path"
+
 class PreviewImageViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 
     // Class under test
     private lateinit var viewModel: PreviewImageViewModel
+    private val cacheDir = File("/cache/dir")
 
     @Before
     fun setUp() {
@@ -163,7 +166,7 @@ class PreviewImageViewModelTest {
     fun `uCrop started with image file path on image load to file success`() {
         initViewModel()
         viewModel.onLoadIntoFileSuccess(TEST_FILE_PATH)
-        assertThat(viewModel.startUCrop.value).isEqualTo(TEST_FILE_PATH)
+        assertThat(requireNotNull(viewModel.startUCrop.value).first).isEqualTo(File(TEST_FILE_PATH))
     }
 
     @Test
@@ -173,5 +176,5 @@ class PreviewImageViewModelTest {
         assertNull(viewModel.startUCrop.value)
     }
 
-    private fun initViewModel() = viewModel.onCreateView(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL)
+    private fun initViewModel() = viewModel.onCreateView(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL, cacheDir)
 }

--- a/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -163,17 +163,17 @@ class PreviewImageViewModelTest {
     }
 
     @Test
-    fun `uCrop started with image file path on image load to file success`() {
+    fun `crop view started with image file path on image load to file success`() {
         initViewModel()
         viewModel.onLoadIntoFileSuccess(TEST_FILE_PATH)
-        assertThat(requireNotNull(viewModel.startUCrop.value).first).isEqualTo(File(TEST_FILE_PATH))
+        assertThat(requireNotNull(viewModel.startCrop.value).first).isEqualTo(File(TEST_FILE_PATH))
     }
 
     @Test
-    fun `uCrop not started on image load to file failure`() {
+    fun `crop view not started on image load to file failure`() {
         initViewModel()
         viewModel.onLoadIntoFileFailed()
-        assertNull(viewModel.startUCrop.value)
+        assertNull(viewModel.startCrop.value)
     }
 
     private fun initViewModel() = viewModel.onCreateView(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL, cacheDir)

--- a/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -163,17 +163,20 @@ class PreviewImageViewModelTest {
     }
 
     @Test
-    fun `crop view started with image file path on image load to file success`() {
+    fun `navigated to crop screen with input, output files info on image load to file success`() {
         initViewModel()
         viewModel.onLoadIntoFileSuccess(TEST_FILE_PATH)
-        assertThat(requireNotNull(viewModel.startCrop.value).first).isEqualTo(File(TEST_FILE_PATH))
+        assertThat(requireNotNull(viewModel.navigateToCropScreenWithFilesInfo.value).first)
+                .isEqualTo(File(TEST_FILE_PATH))
+        assertThat(requireNotNull(viewModel.navigateToCropScreenWithFilesInfo.value).second)
+                .isEqualTo(File(cacheDir, PreviewImageViewModel.IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME))
     }
 
     @Test
-    fun `crop view not started on image load to file failure`() {
+    fun `not navigated to crop screen on image load to file failure`() {
         initViewModel()
         viewModel.onLoadIntoFileFailed()
-        assertNull(viewModel.startCrop.value)
+        assertNull(viewModel.navigateToCropScreenWithFilesInfo.value)
     }
 
     private fun initViewModel() = viewModel.onCreateView(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL, cacheDir)

--- a/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import org.junit.Before
 import org.junit.Test
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileFailedState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileIdleState
@@ -156,6 +157,20 @@ class PreviewImageViewModelTest {
         initViewModel()
         viewModel.onLoadIntoFileFailed()
         assertThat(viewModel.loadIntoFile.value).isInstanceOf(ImageLoadToFileFailedState::class.java)
+    }
+
+    @Test
+    fun `uCrop started with image file path on image load to file success`() {
+        initViewModel()
+        viewModel.onLoadIntoFileSuccess(TEST_FILE_PATH)
+        assertThat(viewModel.startUCrop.value).isEqualTo(TEST_FILE_PATH)
+    }
+
+    @Test
+    fun `uCrop not started on image load to file failure`() {
+        initViewModel()
+        viewModel.onLoadIntoFileFailed()
+        assertNull(viewModel.startUCrop.value)
     }
 
     private fun initViewModel() = viewModel.onCreateView(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL)


### PR DESCRIPTION
Fixes #11145

This PR
- Starts `uCrop` from the preview fragment with the high res image file path.
- Returns to the original post on the `Gutenberg` editor skipping preview fragment on back action.

P.S.
Few observations related to `uCrop` fragment which may require separate tasks (adding them as  a checklist): 

- [X] On back action from the app bar on the `uCrop` fragment, we want to go to the original post on the `Gutenberg` editor skipping preview fragment. 
    Using `popUpToInclusive` property for this purpose  doesn't pop the start destination (preview fragment) off the back stack  in a module.
     On doing so, [activity finishes](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-master-dev/navigation/navigation-runtime/src/main/java/androidx/navigation/NavController.java#386) and then a failed attempt is made to reopen the start destination. As a workaround, explicitly invoking back action for the `uCrop` fragment. Will further investigate it when we pass edited image to the `Gutenberg` editor.

    Related Android issue [here](https://issuetracker.google.com/issues/147312109).

    **UPDATE**: As discussed in comments, workaround looks ok. 

- [ ] Using temporary options (aspect ratios, crop frame/ grid) and styling as shown in this screenshot. Will update with actual options after a discussion with the designer.
cc @mbshakti 

![device-2020-02-25-140701](https://user-images.githubusercontent.com/1405144/75229746-8be7d400-57d8-11ea-8dd9-89224d150cb2.png)

- [ ] The cropping rectangle in the `uCrop` fragment is currently shown behind the toolbar. As a result we cannot drag upper corners. Propagating events to the view behind (by setting `clickable`, `focusable` to `false`) doesn't seem to be working in case of [Toolbar](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/Toolbar.java#1585) as it eats all touch events, regardless of the `clickable` attribute and `@null` background.

```
@Override
public boolean onTouchEvent(MotionEvent ev) {
  // Toolbars always eat touch events
```
Will take care of this issue in a separate PR.

- [X] `uCrop` doesn't seem to be saving image state and restoring it on orientation change (at least with the version we're using`2.2.2`). Will investigate it more in a separate task. 

    Related `uCrop` issue [here](https://git.io/JvE7P).
    
   **UPDATE**: As discussed in comments, leaving this issue to the end of the project. Added a note in the Media Editing project.

- [X] Yet to decide output file path.

    **UPDATE**: As discussed in comments, output file location is ok.

- [X] Noticed a bug, low res(LR) image was saved to file and sent to `uCrop` on moving the app to background while LR image was loading and bringing the app to foreground after it was loaded but before HR image was loaded. 

    It is probably happening because `viewModel.onLoadIntoImageViewSuccess(url)` is called again due to the [LiveData fact](https://developer.android.com/topic/libraries/architecture/livedata#the_advantages_of_using_livedata):

    > If a lifecycle becomes inactive, it receives the latest data upon becoming active again. For example, an activity that was in the background receives the latest data right after it returns to the foreground.

    Will create an issue and fix it in a separate PR.
    
    **UPDATE**: Will take care of it in this issue: https://github.com/wordpress-mobile/WordPress-Android/issues/11377.

![LR_image](https://user-images.githubusercontent.com/1405144/75240389-46340700-57ea-11ea-8a71-f0c074df2bd7.png)

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
