### PR TITLE
Issue/10203 img local path

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 * Block editor: Fix issue where adding emojis to the post title added strong HTML elements to the title of the post
 * Block editor: We’ve introduced a new toolbar that floats above the block you’re editing, which makes navigating your blocks easier — especially complex ones.
 * Reader Information Architecture: added tab filtering; added bottom sheet to filter and navigate the followed sites/tags posts.
+* Fix an issue where image is sometimes uploaded with a path to local storage
  
 14.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -433,8 +433,11 @@ public class PostUtils {
     public static boolean isMediaInGutenbergPostBody(@NonNull String postContent,
                                             String localMediaId) {
         // check if media is in Gutenberg Post
-        String imgBlockHeaderToSearchFor = String.format("<!-- wp:image {\"id\":%s} -->", localMediaId);
-        return postContent.indexOf(imgBlockHeaderToSearchFor) != -1;
+        String imgBlockHeaderToSearchFor =
+                String.format("<!-- wp:image \\{[^\\}]*\"id\":%s[^\\}]*\\} -->", localMediaId);
+        Pattern pattern = Pattern.compile(imgBlockHeaderToSearchFor);
+        Matcher matcher = pattern.matcher(postContent);
+        return matcher.find();
     }
 
     public static boolean isPostInConflictWithRemote(PostImmutableModel post) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
@@ -95,6 +95,27 @@ class PostUtilsUnitTest {
         assertThat(post.status).isEqualTo(PostStatus.PRIVATE.toString())
     }
 
+    @Test
+    fun `isMediaInGutenberg returns true when the image is found in the post content`() {
+        val imgId = "999"
+        val postContent = "<!-- wp:image {\"id\":$imgId} --> ...... <!-- /wp:image -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()
+    }
+
+    @Test
+    fun `isMediaInGutenberg returns false when the image with provided id is NOT found in the post content`() {
+        val imgId = "123"
+        val postContent = "<!-- wp:image {\"id\":$imgId} --> ...... <!-- /wp:image -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "999")).isFalse()
+    }
+
+    @Test
+    fun `isMediaInGutenberg works when the image tag has multiple attributes`() {
+        val imgId = "999"
+        val postContent = "<!-- wp:image {\"id\":$imgId,\"sizeSlug\":\"large\"} --> ...... <!-- /wp:image -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()
+    }
+
     private companion object Fixtures {
         fun invokePreparePostForPublish(
             hasCapabilityPublishPosts: Boolean = true,


### PR DESCRIPTION
Fixes #10203 

@maxme @hypest @mzorz I think it'd be good to merge this fix into the next release (14.3) as we are not sure how many users are affected.

The previous implementation of `isMediaInGutenbergPostBody` wasn't taking into account that the `wp:image` tag can contain any number of attributes in any order. It always expected `id` would be the only attribute in the tag. More info https://github.com/wordpress-mobile/WordPress-Android/issues/10203#issuecomment-582355987.

To test:
1. Copy the regex into an online tool, such as https://regexr.com/ (remove the escape chars `\`)
2. Play with it and verify it works as intended
-------------------
1. Verify this issue https://github.com/wordpress-mobile/WordPress-Android/issues/10203#issuecomment-582346379 isn't reproducible

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
