### PR TITLE
Inject Tracker and disable tracking for tests

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
@@ -26,6 +26,7 @@ import javax.inject.Singleton
     AndroidSupportInjectionModule::class,
     ViewModelModule::class,
     StatsModule::class,
+    TrackerTestModule::class,
     // Login flow library
     LoginAnalyticsModule::class,
     LoginFragmentModule::class,

--- a/WordPress/src/androidTest/java/org/wordpress/android/modules/TrackerTestModule.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/modules/TrackerTestModule.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.modules
 
-import android.content.Context
 import dagger.Module
 import dagger.Provides
 import org.mockito.Mockito
@@ -9,7 +8,7 @@ import org.wordpress.android.analytics.Tracker
 @Module
 class TrackerTestModule {
     @Provides
-    fun provideTracker(appContext: Context): Tracker {
+    fun provideTracker(): Tracker {
         return Mockito.mock(Tracker::class.java)
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/modules/TrackerTestModule.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/modules/TrackerTestModule.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.modules
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import org.mockito.Mockito
+import org.wordpress.android.analytics.Tracker
+
+@Module
+class TrackerTestModule {
+    @Provides
+    fun provideTracker(appContext: Context): Tracker {
+        return Mockito.mock(Tracker::class.java)
+    }
+}

--- a/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
@@ -29,6 +29,7 @@ import dagger.android.support.AndroidSupportInjectionModule;
         AndroidSupportInjectionModule.class,
         ViewModelModule.class,
         StatsModule.class,
+        TrackerModule.class,
         // Login flow library
         LoginAnalyticsModule.class,
         LoginFragmentModule.class,

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -45,6 +45,7 @@ import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.analytics.AnalyticsTrackerNosara;
+import org.wordpress.android.analytics.Tracker;
 import org.wordpress.android.datasets.NotificationsTable;
 import org.wordpress.android.datasets.ReaderDatabase;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -153,6 +154,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
     @Inject StatsStore mStatsStore;
     @Inject SystemNotificationsTracker mSystemNotificationsTracker;
     @Inject ReaderTracker mReaderTracker;
+    @Inject Tracker mTracker;
 
     @Inject @Named("custom-ssl") RequestQueue mRequestQueue;
     public static RequestQueue sRequestQueue;
@@ -397,7 +399,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
     }
 
     private void initAnalytics(final long elapsedTimeOnCreate) {
-        AnalyticsTracker.registerTracker(new AnalyticsTrackerNosara(getContext()));
+        AnalyticsTracker.registerTracker(mTracker);
         AnalyticsTracker.init(getContext());
 
         AnalyticsUtils.refreshMetadata(mAccountStore, mSiteStore);

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -44,7 +44,6 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
-import org.wordpress.android.analytics.AnalyticsTrackerNosara;
 import org.wordpress.android.analytics.Tracker;
 import org.wordpress.android.datasets.NotificationsTable;
 import org.wordpress.android.datasets.ReaderDatabase;

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -154,6 +154,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
     @Inject StatsStore mStatsStore;
     @Inject SystemNotificationsTracker mSystemNotificationsTracker;
     @Inject ReaderTracker mReaderTracker;
+
+    // For development and production `AnalyticsTrackerNosara`, for testing a mocked `Tracker` will be injected.
     @Inject Tracker mTracker;
 
     @Inject @Named("custom-ssl") RequestQueue mRequestQueue;

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -182,6 +182,7 @@ import dagger.android.support.AndroidSupportInjectionModule;
         StatsModule.class,
         SupportModule.class,
         ThreadModule.class,
+        TrackerModule.class,
         // Login flow library
         LoginAnalyticsModule.class,
         LoginFragmentModule.class,

--- a/WordPress/src/main/java/org/wordpress/android/modules/TrackerModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/TrackerModule.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.modules
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import org.wordpress.android.analytics.AnalyticsTrackerNosara
+import org.wordpress.android.analytics.Tracker
+
+@Module
+class TrackerModule {
+    @Provides
+    fun provideTracker(appContext: Context): Tracker {
+        return AnalyticsTrackerNosara(appContext)
+    }
+}


### PR DESCRIPTION
This PR adds Dagger modules for tracking. `TrackerModule` provides `AnalyticsTrackerNosara` for development and production whereas `TrackerTestModule` provides a mocked `Tracker` for testing.

I initially wanted to create a `MockTracker` class where I'd `override` some of the methods to add some useful logs, however since `Tracker`s `abstract` methods are not `public`, I am unable to do it from the main app. I didn't want to add it directly to the library since its value was going to be pretty low, so for now I opted for the simplest solution which is to just mock it through `Mockito`.

@malinajirka Just for extra safety do you mind having a quick look at the Dagger usage?

_P.S: There is a lot of refactoring we could do around tracking, but unfortunately it's out of scope for this PR. We are looking for the simplest way (and a good one, of course) to disable tracking for tests._

To test:
* Make sure the events are still sent to Nosara preferably checking the Live view instead of using breakpoints to be extra sure.
* CI will run the instrumentation tests, so we should be fine there.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
