### PR TITLE
Fixing clickable state of notifications

### DIFF
--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -1,117 +1,120 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/header_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
+        android:paddingBottom="@dimen/margin_large"
+        android:paddingEnd="@dimen/margin_extra_large"
         android:paddingStart="@dimen/margin_extra_large"
         android:paddingTop="@dimen/margin_large"
-        android:paddingEnd="@dimen/margin_extra_large"
-        android:paddingBottom="@dimen/margin_large"
         android:textAppearance="?attr/textAppearanceSubtitle2"
         android:textColor="?attr/wpColorOnSurfaceMedium"
         android:visibility="gone"
         tools:text="Today"
         tools:visibility="visible" />
 
-    <RelativeLayout
+    <FrameLayout
         android:id="@+id/note_content_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/header_text"
-        android:background="?android:selectableItemBackground"
-        android:clickable="true"
-        android:focusable="true"
-        android:minHeight="?attr/listPreferredItemHeight"
-        android:paddingStart="@dimen/margin_extra_large"
-        android:paddingTop="@dimen/margin_medium"
-        android:paddingEnd="@dimen/margin_extra_large"
-        android:paddingBottom="@dimen/margin_medium">
+        android:layout_height="match_parent"
+        android:foreground="?android:selectableItemBackground">
 
-        <FrameLayout
-            android:id="@+id/note_avatar_container"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentStart="true">
-
-            <ImageView
-                android:id="@+id/note_avatar"
-                android:layout_width="@dimen/activity_log_icon_size"
-                android:layout_height="@dimen/activity_log_icon_size"
-                android:layout_marginTop="@dimen/margin_small"
-                android:layout_marginEnd="@dimen/activity_log_icon_margin"
-                android:contentDescription="@null"
-                tools:src="@drawable/bg_oval_neutral_30_user_32dp" />
-
-            <ImageView
-                android:id="@+id/note_icon"
-                android:layout_width="@dimen/note_icon_sz"
-                android:layout_height="@dimen/note_icon_sz"
-                android:layout_marginStart="@dimen/notifications_note_icon_margin"
-                android:layout_marginTop="@dimen/notifications_note_icon_margin"
-                android:background="@drawable/bg_oval_primary_stroke_surface"
-                android:gravity="center"
-                android:importantForAccessibility="no"
-                android:padding="4dp" />
-
-        </FrameLayout>
-
-        <FrameLayout
-            android:id="@+id/note_subject_container"
+        <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_toEndOf="@+id/note_avatar_container">
+            android:minHeight="?attr/listPreferredItemHeight"
+            android:paddingBottom="@dimen/margin_medium"
+            android:paddingEnd="@dimen/margin_extra_large"
+            android:paddingStart="@dimen/margin_extra_large"
+            android:paddingTop="@dimen/margin_medium"
+            tools:ignore="UselessParent">
 
-            <org.wordpress.android.widgets.NoticonTextView
-                android:id="@+id/note_subject_noticon"
+            <FrameLayout
+                android:id="@+id/note_avatar_container"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_extra_small"
-                android:gravity="start"
-                android:textAlignment="viewStart"
-                android:textColor="?attr/wpColorOnSurfaceMedium"
-                android:textSize="@dimen/text_sz_larger" />
+                android:layout_alignParentStart="true">
+
+                <ImageView
+                    android:id="@+id/note_avatar"
+                    android:layout_width="@dimen/activity_log_icon_size"
+                    android:layout_height="@dimen/activity_log_icon_size"
+                    android:layout_marginEnd="@dimen/activity_log_icon_margin"
+                    android:layout_marginTop="@dimen/margin_small"
+                    android:contentDescription="@null"
+                    tools:src="@drawable/bg_oval_neutral_30_user_32dp" />
+
+                <ImageView
+                    android:id="@+id/note_icon"
+                    android:layout_width="@dimen/note_icon_sz"
+                    android:layout_height="@dimen/note_icon_sz"
+                    android:layout_marginStart="@dimen/notifications_note_icon_margin"
+                    android:layout_marginTop="@dimen/notifications_note_icon_margin"
+                    android:background="@drawable/bg_oval_primary_stroke_surface"
+                    android:gravity="center"
+                    android:importantForAccessibility="no"
+                    android:padding="4dp" />
+
+            </FrameLayout>
+
+            <FrameLayout
+                android:id="@+id/note_subject_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_toEndOf="@+id/note_avatar_container">
+
+                <org.wordpress.android.widgets.NoticonTextView
+                    android:id="@+id/note_subject_noticon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_small"
+                    android:gravity="start"
+                    android:textAlignment="viewStart"
+                    android:textColor="?attr/wpColorOnSurfaceMedium"
+                    android:textSize="@dimen/text_sz_larger" />
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/note_subject"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:gravity="start"
+                    android:maxLines="2"
+                    android:textAlignment="viewStart"
+                    android:textAppearance="?attr/textAppearanceSubtitle1"
+                    tools:text="Bob Ross commented on your post Happy Trees" />
+
+            </FrameLayout>
 
             <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/note_subject"
-                android:layout_width="fill_parent"
+                android:id="@+id/note_detail"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_below="@+id/note_subject_container"
+                android:layout_toEndOf="@+id/note_avatar_container"
                 android:ellipsize="end"
-                android:gravity="start"
+                android:importantForAccessibility="no"
                 android:maxLines="2"
-                android:textAlignment="viewStart"
-                android:textAppearance="?attr/textAppearanceSubtitle1"
-                tools:text="Bob Ross commented on your post Happy Trees" />
+                android:textAppearance="?attr/textAppearanceBody1"
+                android:textColor="?attr/wpColorOnSurfaceMedium"
+                android:visibility="gone"
+                tools:text="What an amazing post!"
+                tools:visibility="visible" />
 
-        </FrameLayout>
-
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/note_detail"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/note_subject_container"
-            android:layout_toEndOf="@+id/note_avatar_container"
-            android:ellipsize="end"
-            android:importantForAccessibility="no"
-            android:maxLines="2"
-            android:textAppearance="?attr/textAppearanceBody1"
-            android:textColor="?attr/wpColorOnSurfaceMedium"
-            android:visibility="gone"
-            tools:text="What an amazing post!"
-            tools:visibility="visible" />
-
-    </RelativeLayout>
+        </RelativeLayout>
+    </FrameLayout>
 
     <View
         android:layout_width="match_parent"
         android:layout_height="@dimen/list_divider_height"
-        android:layout_below="@+id/note_content_container"
         android:background="?android:attr/listDivider" />
 
-</RelativeLayout>
+</LinearLayout>


### PR DESCRIPTION
We lost a clickable background during the transition to the material theme, and this PR restores it.

I wrapped up the body of notification in Frame layout that can utilize both background and foreground attributes.

[![Image from Gyazo](https://i.gyazo.com/3e411b4b1eefebe932ffee77e9e4281d.gif)](https://gyazo.com/3e411b4b1eefebe932ffee77e9e4281d)

To test:
- Open notification list an press on a notification. Observe touch feedback (ripple).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
