### PR TITLE
IA Reader: fix potential issue with version update or language change

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1003,6 +1003,11 @@ public class WPMainActivity extends AppCompatActivity implements
     private void appLanguageChanged() {
         // Recreate this activity (much like a configuration change)
         recreate();
+
+        // When language changed we need to reset the shared prefs reader tag since if we have it stored
+        // it's fields can be in a different language and we can get odd behaviors since we will generally fail
+        // to get the ReaderTag.equals method recognize the equality based on the ReaderTag.getLabel method.
+        AppPrefs.setReaderTag(null);
     }
 
     private void startWithNewAccount() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -915,7 +915,9 @@ public class ReaderPostListFragment extends Fragment
                 if (mIsTopLevel) {
                     if (AppPrefs.getReaderTag() == null) {
                         ReaderTag discoverTag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
-                        if (discoverTag != null) {
+                        String discoverLabel = requireActivity().getString(R.string.reader_discover_display_name);
+
+                        if (discoverTag != null && discoverTag.getTagDisplayName().equals(discoverLabel)) {
                             setCurrentTag(discoverTag, mIsTopLevel);
                         }
                     }


### PR DESCRIPTION
Fixes two issues found while working on another PR related to Reader. 

1. Upgrading from previous version can make the reader be wrongly selecting the `Following` tab
2. Changing app language when Reader was last in Discover tab (actually should be the same if the reader is in a tab not being Following) cause the reader to not auto-refresh posts first time user goes to reader again

Below steps to reproduce the issue and to test this PR.

## Test Cases

### Test case 1
Upgrade to 14.3 version from a previous installed one.

#### To Reproduce
- Remove other app version if installed and from AS checkout, for example, version 14.0 tag, compile and run on the device/emu
- Open the app and go to the Reader (you should be in the `Followed Sites` stream)
- Close the app
- From AS checkout version 14.3-rc1 tag, compile and run on the device/emu to update current installation 
- Opening the app you will be in the reader Discover content without the subfilter (as it should be) but `Following` tab is wrongly selected

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/75451015-17e03400-5970-11ea-8770-7376c6d01195.png>
</p>

#### To Test
- Remove other app version if installed and from AS checkout version 14.0 tag, compile and run on the device/emu
- Open the app and go to the Reader (you should be in the `Followed Sites` stream)
- Close the app
- From AS checkout the version from this PR, compile and run on the device/emu to update current installation 
- Opening the app you will be in the reader Discover content without the subfilter and Discover tab correctly selected

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/75452781-24b25700-5973-11ea-81dd-effeeca84f61.png>
</p>

### Test case 2
Change language does not auto-update posts first time going to reader. (NB: since as a solution in the code we are resetting the Shared Prefs for selected reader when changing language, even if you selected another tab before to change language you will be brought always in Discover first time right after changing language)

#### To Reproduce
- Remove other app version if installed and from AS checkout version 14.3-rc1 tag, compile and run on the device/emu
- Open the app, go to the Reader and select Discover tab
- Change app language from app settings then come back to Reader
- Check that you are set in Following (first) tab and posts are not loaded
<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/75453308-04cf6300-5974-11ea-9132-eb3fc596e0ea.png>
</p>
- Changing tab or closing/opening the app restores normal working conditions

#### To Test
- From AS install the current PR version
- Open the app, go to the Reader and select Discover tab
- Change app language from app settings then come back to Reader
- Check you are in Discover tab and posts are loaded 
<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/75454106-2d0b9180-5975-11ea-8c43-564cc33551e7.png>
</p>

### Test case 3 - Smoke test rules of thumbs
Smoke test the reader, if possible use both wp.com and self-hosted sites and here below some of the steps for smoke testing but feel free to add 😊 :

- Move between tabs
- Use the subfilter to select different sources (Sites/Tags) to navigate
- Open posts from the reader
- Save posts for later and open them from the SAVED tab (both WP.com and self-hosted)
- Follow/Unfollow tags/sites from the Reader (only for WP.com)
- Follow/Unfollow tags/sites from the Setting (only for WP.com)
- Whatever else you can think of 😊...

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
