### PR TITLE
Offline Pages : Code Refactoring, Phase 1 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemActionsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemActionsUseCase.kt
@@ -8,9 +8,9 @@ import org.wordpress.android.ui.pages.PageItem.Action.MOVE_TO_TRASH
 import org.wordpress.android.ui.pages.PageItem.Action.PUBLISH_NOW
 import org.wordpress.android.ui.pages.PageItem.Action.SET_PARENT
 import org.wordpress.android.ui.pages.PageItem.Action.VIEW_PAGE
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadFailed
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadFailed
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.DRAFTS
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.PUBLISHED

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCase.kt
@@ -16,12 +16,12 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.PAGES
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadFailed
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadQueued
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingMedia
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingPost
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadFailed
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadQueued
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingMedia
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingPost
 import javax.inject.Inject
 
 typealias LabelColor = Int?
@@ -30,7 +30,7 @@ typealias LabelColor = Int?
  */
 class CreatePageListItemLabelsUseCase @Inject constructor(
     private val pageConflictResolver: PageConflictResolver,
-    private val labelColorUseCase: ResolvePageListItemsColorUseCase,
+    private val labelColorUseCase: PostPageListLabelColorUseCase,
     private val uploadUtilsWrapper: UploadUtilsWrapper
 ) {
     fun createLabels(postModel: PostModel, uploadUiState: PostUploadUiState): Pair<List<UiString>, LabelColor> {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageItemProgressUiStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageItemProgressUiStateUseCase.kt
@@ -2,10 +2,10 @@ package org.wordpress.android.viewmodel.pages
 
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadQueued
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingMedia
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingPost
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadQueued
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingMedia
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingPost
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
 import javax.inject.Inject
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -50,7 +50,7 @@ private const val DEFAULT_INDENT = 0
 
 class PageListViewModel @Inject constructor(
     private val createPageListItemLabelsUseCase: CreatePageListItemLabelsUseCase,
-    private val createPageUploadUiStateUseCase: CreatePageUploadUiStateUseCase,
+    private val postModelUploadUiStateUseCase: PostModelUploadUiStateUseCase,
     private val pageListItemActionsUseCase: CreatePageListItemActionsUseCase,
     private val pageItemProgressUiStateUseCase: PageItemProgressUiStateUseCase,
     private val mediaStore: MediaStore,
@@ -376,7 +376,7 @@ class PageListViewModel @Inject constructor(
     }
 
     private fun createItemUiStateData(pageModel: PageModel): ItemUiStateData {
-        val uploadUiState = createPageUploadUiStateUseCase.createUploadUiState(
+        val uploadUiState = postModelUploadUiStateUseCase.createUploadUiState(
                 pageModel.post,
                 pagesViewModel.site,
                 pagesViewModel.uploadStatusTracker

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PostModelUploadUiStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PostModelUploadUiStateUseCase.kt
@@ -6,15 +6,15 @@ import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.model.post.PostStatus.DRAFT
 import org.wordpress.android.fluxc.store.UploadStore.UploadError
 import org.wordpress.android.ui.posts.PostModelUploadStatusTracker
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.NothingToUpload
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadFailed
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadQueued
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingMedia
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingPost
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.NothingToUpload
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadFailed
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadQueued
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingMedia
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingPost
 import javax.inject.Inject
 
-class CreatePageUploadUiStateUseCase @Inject constructor() {
+class PostModelUploadUiStateUseCase @Inject constructor() {
     /**
      * Copied from PostListItemUiStateHelper since the behavior is similar for the Page List UI State.
      */

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCase.kt
@@ -7,19 +7,19 @@ import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.model.post.PostStatus.PENDING
 import org.wordpress.android.fluxc.model.post.PostStatus.PRIVATE
 import org.wordpress.android.fluxc.model.post.PostStatus.fromPost
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadFailed
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadQueued
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingMedia
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingPost
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadFailed
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadQueued
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingMedia
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingPost
 import javax.inject.Inject
 
 const val ERROR_COLOR = R.color.error
 const val PROGRESS_INFO_COLOR = R.color.neutral_50
 const val STATE_INFO_COLOR = R.color.warning_dark
 
-class ResolvePageListItemsColorUseCase @Inject constructor(
+class PostPageListLabelColorUseCase @Inject constructor(
     private val pageConflictResolver: PageConflictResolver
 ) {
     @ColorRes fun getLabelsColor(post: PostModel, uploadUiState: PostUploadUiState): Int? {
@@ -33,9 +33,6 @@ class ResolvePageListItemsColorUseCase @Inject constructor(
         )
     }
 
-    /**
-     * Copied from PostListItemUiStateHelper since the behavior is similar for the Page List UI State.
-     */
     @ColorRes private fun getLabelColor(
         postStatus: PostStatus,
         isLocalDraft: Boolean,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
@@ -32,7 +32,7 @@ import javax.inject.Named
 class SearchListViewModel
 @Inject constructor(
     private val createPageListItemLabelsUseCase: CreatePageListItemLabelsUseCase,
-    private val createPageUploadUiStateUseCase: CreatePageUploadUiStateUseCase,
+    private val postModelUploadUiStateUseCase: PostModelUploadUiStateUseCase,
     private val pageListItemActionsUseCase: CreatePageListItemActionsUseCase,
     private val pageItemProgressUiStateUseCase: PageItemProgressUiStateUseCase,
     private val resourceProvider: ResourceProvider,
@@ -94,7 +94,7 @@ class SearchListViewModel
     }
 
     private fun PageModel.toPageItem(areActionsEnabled: Boolean): PageItem {
-        val uploadUiState = createPageUploadUiStateUseCase.createUploadUiState(
+        val uploadUiState = postModelUploadUiStateUseCase.createUploadUiState(
                 this.post,
                 pagesViewModel.site,
                 pagesViewModel.uploadStatusTracker

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.ui.posts.PostListType.SEARCH
+import org.wordpress.android.ui.posts.PostModelUploadStatusTracker
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.posts.trackPostListAction
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
@@ -69,6 +70,7 @@ class PostListViewModel @Inject constructor(
     private val uploadStarter: UploadStarter,
     private val readerUtilsWrapper: ReaderUtilsWrapper,
     private val uploadUtilsWrapper: UploadUtilsWrapper,
+    private val uploadStatusTracker: PostModelUploadStatusTracker,
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     connectionStatus: LiveData<ConnectionStatus>
@@ -358,7 +360,7 @@ class PostListViewModel @Inject constructor(
             listItemUiStateHelper.createPostListItemUiState(
                     authorFilterSelection,
                     post = post,
-                    uploadStatus = connector.getUploadStatus(post, connector.site),
+                    site = connector.site,
                     unhandledConflicts = connector.doesPostHaveUnhandledConflict(post),
                     hasAutoSave = connector.hasAutoSave(post),
                     capabilitiesToPublish = uploadUtilsWrapper.userCanPublish(connector.site),
@@ -370,7 +372,8 @@ class PostListViewModel @Inject constructor(
                     onAction = { postModel, buttonType, statEvent ->
                         trackPostListAction(connector.site, buttonType, postModel, statEvent)
                         connector.postActionHandler.handlePostButton(buttonType, postModel)
-                    }
+                    },
+                    uploadStatusTracker = uploadStatusTracker
             )
 
     private fun retryOnConnectionAvailableAfterRefreshError() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemActionsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemActionsUseCaseTest.kt
@@ -13,8 +13,8 @@ import org.wordpress.android.ui.pages.PageItem.Action.MOVE_TO_TRASH
 import org.wordpress.android.ui.pages.PageItem.Action.PUBLISH_NOW
 import org.wordpress.android.ui.pages.PageItem.Action.SET_PARENT
 import org.wordpress.android.ui.pages.PageItem.Action.VIEW_PAGE
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState.UploadingPost
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingPost
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.DRAFTS
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.PUBLISHED
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.SCHEDULED

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCaseTest.kt
@@ -27,12 +27,12 @@ import org.wordpress.android.fluxc.store.PostStore.PostErrorType
 import org.wordpress.android.fluxc.store.UploadStore.UploadError
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 
 @RunWith(MockitoJUnitRunner::class)
 class CreatePageListItemLabelsUseCaseTest {
     @Mock private lateinit var pageConflictResolver: PageConflictResolver
-    @Mock private lateinit var labelColorUseCase: ResolvePageListItemsColorUseCase
+    @Mock private lateinit var labelColorUseCase: PostPageListLabelColorUseCase
     @Mock private lateinit var uploadUtilsWrapper: UploadUtilsWrapper
     private lateinit var useCase: CreatePageListItemLabelsUseCase
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -24,7 +24,7 @@ import org.wordpress.android.ui.pages.PageItem.Divider
 import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.PageItem.PublishedPage
 import org.wordpress.android.util.LocaleManagerWrapper
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.PUBLISHED
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
@@ -40,7 +40,7 @@ class PageListViewModelTest : BaseUnitTest() {
     @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
     @Mock lateinit var pageItemProgressUiStateUseCase: PageItemProgressUiStateUseCase
     @Mock lateinit var pageListItemActionsUseCase: CreatePageListItemActionsUseCase
-    @Mock lateinit var createUploadStateUseCase: CreatePageUploadUiStateUseCase
+    @Mock lateinit var createUploadStateUseCase: PostModelUploadUiStateUseCase
     @Mock lateinit var createLabelsUseCase: CreatePageListItemLabelsUseCase
 
     private lateinit var viewModel: PageListViewModel

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
@@ -27,7 +27,7 @@ import org.wordpress.android.ui.pages.PageItem.DraftPage
 import org.wordpress.android.ui.pages.PageItem.Empty
 import org.wordpress.android.ui.pages.PageItem.PublishedPage
 import org.wordpress.android.viewmodel.ResourceProvider
-import org.wordpress.android.viewmodel.pages.CreatePageUploadUiStateUseCase.PostUploadUiState
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
 import java.util.Date
@@ -44,7 +44,7 @@ class SearchListViewModelTest {
     @Mock lateinit var createPageListItemLabelsUseCase: CreatePageListItemLabelsUseCase
     @Mock lateinit var pageItemProgressUiStateUseCase: PageItemProgressUiStateUseCase
     @Mock lateinit var pageListItemActionsUseCase: CreatePageListItemActionsUseCase
-    @Mock lateinit var createUploadStateUseCase: CreatePageUploadUiStateUseCase
+    @Mock lateinit var createUploadStateUseCase: PostModelUploadUiStateUseCase
 
     private lateinit var searchPages: MutableLiveData<SortedMap<PageListType, List<PageModel>>>
     private lateinit var viewModel: SearchListViewModel

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -1047,7 +1047,8 @@ class PostListItemUiStateHelperTest {
     )
 
     private fun createFailedUploadUiState(
-        uploadError: UploadError = createGenericError(), isEligibleForAutoUpload: Boolean = false,
+        uploadError: UploadError = createGenericError(),
+        isEligibleForAutoUpload: Boolean = false,
         retryWillPushChanges: Boolean = false
     ): UploadFailed {
         return UploadFailed(

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.PostListType
 import org.wordpress.android.ui.posts.PostListType.DRAFTS
 import org.wordpress.android.ui.posts.PostListType.SEARCH
+import org.wordpress.android.ui.posts.PostModelUploadStatusTracker
 import org.wordpress.android.ui.uploads.UploadStarter
 
 private const val DEFAULT_PHOTON_DIMENSIONS = -9
@@ -29,6 +30,7 @@ private val DEFAULT_AUTHOR_FILTER = AuthorFilterSelection.EVERYONE
 class PostListViewModelTest : BaseUnitTest() {
     @Mock private lateinit var site: SiteModel
     @Mock private lateinit var uploadStarter: UploadStarter
+    @Mock private lateinit var uploadStatusTracker: PostModelUploadStatusTracker
 
     private lateinit var viewModel: PostListViewModel
 
@@ -61,7 +63,8 @@ class PostListViewModelTest : BaseUnitTest() {
                 connectionStatus = mock(),
                 uploadUtilsWrapper = mock(),
                 uiDispatcher = TEST_DISPATCHER,
-                bgDispatcher = TEST_DISPATCHER
+                bgDispatcher = TEST_DISPATCHER,
+                uploadStatusTracker = uploadStatusTracker
         )
     }
 


### PR DESCRIPTION
## Solution
This is part 1 in a series of PRs that aims to refactor the functionality added in the Offline Support: Pages Project. `PostModelUploadUiStateUseCase` was used to provide the `UploadUiState` for both post and page components. The associated tests were also updated. 

## Testing
Go to the pages and post lists and create uploads in both online and offline mode and verify that there are no crashes and progress state is being shown. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
