### PR TITLE
Offline Pages : Code Refactoring, Phase 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/AutoSaveConflictResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/AutoSaveConflictResolver.kt
@@ -4,7 +4,7 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.ui.posts.PostUtils
 import javax.inject.Inject
 
-class PageConflictResolver @Inject constructor() {
+class AutoSaveConflictResolver @Inject constructor() {
     fun hasUnhandledAutoSave(post: PostModel): Boolean {
         return PostUtils.hasAutoSave(post)
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCase.kt
@@ -29,20 +29,27 @@ typealias LabelColor = Int?
  * Most of this code has been copied from PostListItemUIStateHelper.
  */
 class CreatePageListItemLabelsUseCase @Inject constructor(
-    private val pageConflictResolver: PageConflictResolver,
+    private val autoSaveConflictResolver: AutoSaveConflictResolver,
     private val labelColorUseCase: PostPageListLabelColorUseCase,
     private val uploadUtilsWrapper: UploadUtilsWrapper
 ) {
     fun createLabels(postModel: PostModel, uploadUiState: PostUploadUiState): Pair<List<UiString>, LabelColor> {
+        val hasUnhandledAutoSave = autoSaveConflictResolver.hasUnhandledAutoSave(postModel)
+        val hasUnhandledConflicts = false // TODO use conflict resolver
         val labels = getLabels(
                 PostStatus.fromPost(postModel),
                 postModel.isLocalDraft,
                 postModel.isLocallyChanged,
                 uploadUiState,
-                false, // TODO use conflict resolver
-                pageConflictResolver.hasUnhandledAutoSave(postModel)
+                hasUnhandledConflicts,
+                hasUnhandledAutoSave
         )
-        val labelColor = labelColorUseCase.getLabelsColor(postModel, uploadUiState)
+        val labelColor = labelColorUseCase.getLabelsColor(
+                postModel,
+                uploadUiState,
+                hasUnhandledConflicts,
+                hasUnhandledAutoSave
+        )
         return Pair(labels, labelColor)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -91,7 +91,7 @@ class PagesViewModel
     private val previewStateHelper: PreviewStateHelper,
     private val uploadStarter: UploadStarter,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val pageConflictResolver: PageConflictResolver,
+    private val autoSaveConflictResolver: AutoSaveConflictResolver,
     val uploadStatusTracker: PostModelUploadStatusTracker,
     private val pageListEventListenerFactory: PageListEventListener.Factory,
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
@@ -485,7 +485,7 @@ class PagesViewModel
     fun onItemTapped(pageItem: Page) {
         val page = pageMap[pageItem.remoteId]!!.post
         // Then check if an autosave revision is available
-        if (pageConflictResolver.hasUnhandledAutoSave(page)) {
+        if (autoSaveConflictResolver.hasUnhandledAutoSave(page)) {
             pageListDialogHelper.showAutoSaveRevisionDialog(page)
             return
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCase.kt
@@ -6,7 +6,6 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.model.post.PostStatus.PENDING
 import org.wordpress.android.fluxc.model.post.PostStatus.PRIVATE
-import org.wordpress.android.fluxc.model.post.PostStatus.fromPost
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadFailed
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadQueued
@@ -19,17 +18,20 @@ const val ERROR_COLOR = R.color.error
 const val PROGRESS_INFO_COLOR = R.color.neutral_50
 const val STATE_INFO_COLOR = R.color.warning_dark
 
-class PostPageListLabelColorUseCase @Inject constructor(
-    private val pageConflictResolver: PageConflictResolver
-) {
-    @ColorRes fun getLabelsColor(post: PostModel, uploadUiState: PostUploadUiState): Int? {
+class PostPageListLabelColorUseCase @Inject constructor() {
+    @ColorRes fun getLabelsColor(
+        post: PostModel,
+        uploadUiState: PostUploadUiState,
+        hasUnhandledConflicts: Boolean,
+        hasUnhandledAutoSave: Boolean
+    ): Int? {
         return getLabelColor(
-                fromPost(post),
+                PostStatus.fromPost(post),
                 post.isLocalDraft,
                 post.isLocallyChanged,
                 uploadUiState,
-                false, // TODO use conflict resolver
-                pageConflictResolver.hasUnhandledAutoSave(post)
+                hasUnhandledConflicts,
+                hasUnhandledAutoSave
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemLabelsUseCaseTest.kt
@@ -31,7 +31,7 @@ import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostU
 
 @RunWith(MockitoJUnitRunner::class)
 class CreatePageListItemLabelsUseCaseTest {
-    @Mock private lateinit var pageConflictResolver: PageConflictResolver
+    @Mock private lateinit var autoSaveConflictResolver: AutoSaveConflictResolver
     @Mock private lateinit var labelColorUseCase: PostPageListLabelColorUseCase
     @Mock private lateinit var uploadUtilsWrapper: UploadUtilsWrapper
     private lateinit var useCase: CreatePageListItemLabelsUseCase
@@ -39,7 +39,7 @@ class CreatePageListItemLabelsUseCaseTest {
     @Before
     fun setUp() {
         useCase = CreatePageListItemLabelsUseCase(
-                pageConflictResolver,
+                autoSaveConflictResolver,
                 labelColorUseCase,
                 uploadUtilsWrapper
         )
@@ -77,7 +77,7 @@ class CreatePageListItemLabelsUseCaseTest {
 
     @Test
     fun `unhandled auto-save label shown for pages with existing auto-save`() {
-        whenever(pageConflictResolver.hasUnhandledAutoSave(anyOrNull())).thenReturn(true)
+        whenever(autoSaveConflictResolver.hasUnhandledAutoSave(anyOrNull())).thenReturn(true)
         val (labels, _) = useCase.createLabels(PostModel(), mock())
         assertThat(labels).contains(UiStringRes(R.string.local_page_autosave_revision_available))
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -70,7 +70,7 @@ class PagesViewModelTest {
                 previewStateHelper = mock(),
                 analyticsTracker = mock(),
                 uploadStatusTracker = mock(),
-                pageConflictResolver = mock(),
+                autoSaveConflictResolver = mock(),
                 uiDispatcher = Dispatchers.Unconfined,
                 defaultDispatcher = Dispatchers.Unconfined,
                 eventBusWrapper = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCaseTest.kt
@@ -146,7 +146,8 @@ class PostPageListLabelColorUseCaseTest {
         return post
     }
 
-    private fun failedUpload(isEligibleForAutoUpload: Boolean = false) = PostUploadUiState.UploadFailed(mock(), isEligibleForAutoUpload, false)
+    private fun failedUpload(isEligibleForAutoUpload: Boolean = false) =
+            PostUploadUiState.UploadFailed(mock(), isEligibleForAutoUpload, false)
 
     private fun mediaUploadInProgress() = PostUploadUiState.UploadingMedia(0)
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCaseTest.kt
@@ -8,6 +8,8 @@ import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadQueued
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingPost
 
 @RunWith(MockitoJUnitRunner::class)
 class PostPageListLabelColorUseCaseTest {
@@ -48,13 +50,103 @@ class PostPageListLabelColorUseCaseTest {
         assertThat(labelsColor).isEqualTo(PROGRESS_INFO_COLOR)
     }
 
+    @Test
+    fun `label has progress color when post queued`() {
+        // Arrange
+        val uploadState = UploadQueued
+        // Act
+        val labelsColor = useCase.getLabelsColor(
+                dummyPostModel(),
+                uploadState,
+                hasUnhandledConflicts = false,
+                hasUnhandledAutoSave = false
+        )
+        // Assert
+        assertThat(labelsColor).isEqualTo(PROGRESS_INFO_COLOR)
+    }
+
+    @Test
+    fun `label has progress color when uploading post`() {
+        // Arrange
+        val uploadState = UploadingPost(false)
+        // Act
+        val labelsColor = useCase.getLabelsColor(
+                dummyPostModel(),
+                uploadState,
+                hasUnhandledConflicts = false,
+                hasUnhandledAutoSave = false
+        )
+        // Assert
+        assertThat(labelsColor).isEqualTo(PROGRESS_INFO_COLOR)
+    }
+
+    @Test
+    fun `label has state info color after failed upload but eligible for auto upload`() {
+        // Arrange
+        val uploadState = failedUpload(isEligibleForAutoUpload = true)
+        // Act
+        val labelsColor = useCase.getLabelsColor(
+                dummyPostModel(),
+                uploadState,
+                hasUnhandledConflicts = false,
+                hasUnhandledAutoSave = false
+        )
+        // Assert
+        assertThat(labelsColor).isEqualTo(STATE_INFO_COLOR)
+    }
+
+    @Test
+    fun `label has error color after failed upload when not eligible for auto upload`() {
+        // Arrange
+        val uploadState = failedUpload(isEligibleForAutoUpload = false)
+        // Act
+        val labelsColor = useCase.getLabelsColor(
+                dummyPostModel(),
+                uploadState,
+                hasUnhandledConflicts = false,
+                hasUnhandledAutoSave = false
+        )
+        // Assert
+        assertThat(labelsColor).isEqualTo(ERROR_COLOR)
+    }
+
+    @Test
+    fun `label has state info color on auto-save conflict`() {
+        // Arrange
+        val hasUnhandledAutoSave = true
+        // Act
+        val labelsColor = useCase.getLabelsColor(
+                dummyPostModel(),
+                mock(),
+                hasUnhandledConflicts = false,
+                hasUnhandledAutoSave = hasUnhandledAutoSave
+        )
+        // Assert
+        assertThat(labelsColor).isEqualTo(STATE_INFO_COLOR)
+    }
+
+    @Test
+    fun `label has error color on version conflict`() {
+        // Arrange
+        val hasUnhandledConflicts = true
+        // Act
+        val labelsColor = useCase.getLabelsColor(
+                dummyPostModel(),
+                mock(),
+                hasUnhandledConflicts = hasUnhandledConflicts,
+                hasUnhandledAutoSave = false
+        )
+        // Assert
+        assertThat(labelsColor).isEqualTo(ERROR_COLOR)
+    }
+
     private fun dummyPostModel(): PostModel {
         val post = PostModel()
         post.setDateCreated("1970-01-01'T'00:00:01Z")
         return post
     }
 
-    private fun failedUpload() = PostUploadUiState.UploadFailed(mock(), false, false)
+    private fun failedUpload(isEligibleForAutoUpload: Boolean = false) = PostUploadUiState.UploadFailed(mock(), isEligibleForAutoUpload, false)
 
     private fun mediaUploadInProgress() = PostUploadUiState.UploadingMedia(0)
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCaseTest.kt
@@ -1,0 +1,60 @@
+package org.wordpress.android.viewmodel.pages
+
+import com.nhaarman.mockitokotlin2.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
+
+@RunWith(MockitoJUnitRunner::class)
+class PostPageListLabelColorUseCaseTest {
+    private lateinit var useCase: PostPageListLabelColorUseCase
+
+    @Before
+    fun setUp() {
+        useCase = PostPageListLabelColorUseCase()
+    }
+
+    @Test
+    fun `label has error color on upload error`() {
+        // Arrange
+        val uploadState = failedUpload()
+        // Act
+        val labelsColor = useCase.getLabelsColor(
+                dummyPostModel(),
+                uploadState,
+                hasUnhandledConflicts = false,
+                hasUnhandledAutoSave = false
+        )
+        // Assert
+        assertThat(labelsColor).isEqualTo(ERROR_COLOR)
+    }
+
+    @Test
+    fun `label has progress color on when media upload in progress`() {
+        // Arrange
+        val uploadState = mediaUploadInProgress()
+        // Act
+        val labelsColor = useCase.getLabelsColor(
+                dummyPostModel(),
+                uploadState,
+                hasUnhandledConflicts = false,
+                hasUnhandledAutoSave = false
+        )
+        // Assert
+        assertThat(labelsColor).isEqualTo(PROGRESS_INFO_COLOR)
+    }
+
+    private fun dummyPostModel(): PostModel {
+        val post = PostModel()
+        post.setDateCreated("1970-01-01'T'00:00:01Z")
+        return post
+    }
+
+    private fun failedUpload() = PostUploadUiState.UploadFailed(mock(), false, false)
+
+    private fun mediaUploadInProgress() = PostUploadUiState.UploadingMedia(0)
+}

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -953,7 +953,8 @@ class PostListItemUiStateHelperTest {
     )
 
     private fun createFailedUploadUiState(
-        uploadError: UploadError = createGenericError(), isEligibleForAutoUpload: Boolean = false,
+        uploadError: UploadError = createGenericError(),
+        isEligibleForAutoUpload: Boolean = false,
         retryWillPushChanges: Boolean = false
     ): UploadFailed {
         return UploadFailed(

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -31,6 +31,8 @@ import org.wordpress.android.ui.posts.PostModelUploadStatusTracker
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.viewmodel.pages.ERROR_COLOR
+import org.wordpress.android.viewmodel.pages.PROGRESS_INFO_COLOR
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadFailed
@@ -38,6 +40,8 @@ import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostU
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingMedia
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingPost
+import org.wordpress.android.viewmodel.pages.PostPageListLabelColorUseCase
+import org.wordpress.android.viewmodel.pages.STATE_INFO_COLOR
 import org.wordpress.android.viewmodel.posts.PostListItemAction.MoreItem
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
@@ -57,11 +61,12 @@ class PostListItemUiStateHelperTest {
     @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock private lateinit var uploadUiStateUseCase: PostModelUploadUiStateUseCase
     @Mock private lateinit var uploadStatusTracker: PostModelUploadStatusTracker
+    @Mock private lateinit var labelColorUseCase: PostPageListLabelColorUseCase
     private lateinit var helper: PostListItemUiStateHelper
 
     @Before
     fun setup() {
-        helper = PostListItemUiStateHelper(appPrefsWrapper, uploadUiStateUseCase)
+        helper = PostListItemUiStateHelper(appPrefsWrapper, uploadUiStateUseCase, labelColorUseCase)
         whenever(appPrefsWrapper.isAztecEditorEnabled).thenReturn(true)
     }
 
@@ -70,24 +75,6 @@ class PostListItemUiStateHelperTest {
         val testUrl = "https://example.com"
         val state = createPostListItemUiState(featuredImageUrl = testUrl)
         assertThat(state.data.imageUrl).isEqualTo(testUrl)
-    }
-
-    @Test
-    fun `label has error color on upload error`() {
-        whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                createFailedUploadUiState()
-        )
-        val state = createPostListItemUiState()
-        assertThat(state.data.statusesColor).isEqualTo(ERROR_COLOR)
-    }
-
-    @Test
-    fun `label has progress color on when media upload in progress`() {
-        whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                PostUploadUiState.UploadingMedia(0)
-        )
-        val state = createPostListItemUiState()
-        assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -31,17 +31,13 @@ import org.wordpress.android.ui.posts.PostModelUploadStatusTracker
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
-import org.wordpress.android.viewmodel.pages.ERROR_COLOR
-import org.wordpress.android.viewmodel.pages.PROGRESS_INFO_COLOR
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase
-import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadFailed
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadQueued
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingMedia
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingPost
 import org.wordpress.android.viewmodel.pages.PostPageListLabelColorUseCase
-import org.wordpress.android.viewmodel.pages.STATE_INFO_COLOR
 import org.wordpress.android.viewmodel.posts.PostListItemAction.MoreItem
 import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiState
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
@@ -435,83 +431,6 @@ class PostListItemUiStateHelperTest {
         assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
         assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
-    }
-
-    @Test
-    fun `label has progress color when post queued`() {
-        whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                UploadQueued
-        )
-        val state = createPostListItemUiState()
-        assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
-    }
-
-    @Test
-    fun `label has progress color when media queued`() {
-        whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                UploadQueued
-        )
-        val state = createPostListItemUiState()
-        assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
-    }
-
-    @Test
-    fun `label has progress color when uploading media`() {
-        whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                UploadingMedia(0)
-        )
-        val state = createPostListItemUiState()
-        assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
-    }
-
-    @Test
-    fun `label has progress color when uploading post`() {
-        whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                UploadingPost(false)
-        )
-        val state = createPostListItemUiState()
-        assertThat(state.data.statusesColor).isEqualTo(PROGRESS_INFO_COLOR)
-    }
-
-    @Test
-    fun `label has state info color after failed upload but eligible for auto upload`() {
-        whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                createFailedUploadUiState(
-                        UploadError(MediaError(AUTHORIZATION_REQUIRED)),
-                        isEligibleForAutoUpload = true
-                )
-        )
-        val state = createPostListItemUiState(
-                post = createPostModel(status = POST_STATE_PUBLISH, isLocallyChanged = true)
-        )
-
-        assertThat(state.data.statusesColor).isEqualTo(STATE_INFO_COLOR)
-    }
-
-    @Test
-    fun `label has error color after failed upload when not eligible for auto upload`() {
-        whenever(uploadUiStateUseCase.createUploadUiState(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(
-                createFailedUploadUiState(
-                        UploadError(MediaError(AUTHORIZATION_REQUIRED)),
-                        isEligibleForAutoUpload = false
-                )
-        )
-        val state = createPostListItemUiState(
-                post = createPostModel(status = POST_STATE_PUBLISH, isLocallyChanged = true)
-        )
-        assertThat(state.data.statusesColor).isEqualTo(ERROR_COLOR)
-    }
-
-    @Test
-    fun `label has error color on version conflict`() {
-        val state = createPostListItemUiState(unhandledConflicts = true)
-        assertThat(state.data.statusesColor).isEqualTo(ERROR_COLOR)
-    }
-
-    @Test
-    fun `label has state info color on auto-save conflict`() {
-        val state = createPostListItemUiState(hasAutoSave = true)
-        assertThat(state.data.statusesColor).isEqualTo(STATE_INFO_COLOR)
     }
 
     @Test


### PR DESCRIPTION
## Solution
This is part 2 in a series of PRs that aims to refactor the functionality added in the Offline Support: Pages Project. `PostPageListLabelColorUseCaseTest ` was created so the associated use case could be properly tested. The `PageConflictResolver` and `PostConflictResolver` usage was refactored so that they can be used in a more seamless manner. 

## Testing
Go to the pages and post lists and create uploads in both online and offline mode and verify that there are no crashes and right labels are being shown with their associated colors. 
## Reviewing 
1. Review and merge #11398
2. Review this PR
3. Update the target branch with `feature/master-pages-offline-support`
4. Remove the "Not ready for merge" label
5. Merge this PR

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 

