### PR TITLE
Offline Pages : Code Refactoring, Phase 3

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageItemProgressUiStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageItemProgressUiStateUseCase.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.viewmodel.pages
 
-import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadQueued
@@ -15,15 +14,10 @@ class PageItemProgressUiStateUseCase @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper
 ) {
     fun getProgressStateForPage(
-        post: PostModel?,
         uploadUiState: PostUploadUiState
     ): Pair<ProgressBarUiState, ShouldShowOverlay> {
-        // TODO ideally don't accept nullable PostModel
-        post?.let {
-            val shouldShowOverlay = shouldShowOverlay(uploadUiState)
-            return Pair(getProgressBarState(uploadUiState), shouldShowOverlay)
-        }
-        return Pair(ProgressBarUiState.Hidden, false)
+        val shouldShowOverlay = shouldShowOverlay(uploadUiState)
+        return Pair(getProgressBarState(uploadUiState), shouldShowOverlay)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -383,10 +383,7 @@ class PageListViewModel @Inject constructor(
         )
         val (labels, labelColor) = createPageListItemLabelsUseCase.createLabels(pageModel.post, uploadUiState)
 
-        val (progressBarUiState, showOverlay) = pageItemProgressUiStateUseCase.getProgressStateForPage(
-                pageModel.post,
-                uploadUiState
-        )
+        val (progressBarUiState, showOverlay) = pageItemProgressUiStateUseCase.getProgressStateForPage(uploadUiState)
         val actions = pageListItemActionsUseCase.setupPageActions(listType, uploadUiState)
         return ItemUiStateData(labels, labelColor, progressBarUiState, showOverlay, actions)
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
@@ -99,8 +99,7 @@ class SearchListViewModel
                 pagesViewModel.site,
                 pagesViewModel.uploadStatusTracker
         )
-        val (progressBarUiState, showOverlay) = pageItemProgressUiStateUseCase.getProgressStateForPage(this.post,
-                uploadUiState)
+        val (progressBarUiState, showOverlay) = pageItemProgressUiStateUseCase.getProgressStateForPage(uploadUiState)
         val (labels, labelColor) = createPageListItemLabelsUseCase.createLabels(this.post, uploadUiState)
 
         return when (status) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageItemProgressUiStateUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageItemProgressUiStateUseCaseTest.kt
@@ -1,0 +1,165 @@
+package org.wordpress.android.viewmodel.pages
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.NothingToUpload
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadFailed
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadQueued
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadWaitingForConnection
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingMedia
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingPost
+import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
+
+@RunWith(MockitoJUnitRunner::class)
+class PageItemProgressUiStateUseCaseTest {
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
+    private lateinit var useCase: PageItemProgressUiStateUseCase
+
+    @Before
+    fun setUp() {
+        useCase = PageItemProgressUiStateUseCase(appPrefsWrapper)
+    }
+
+    @Test
+    fun `show progress when post is uploading`() {
+        // Arrange
+        val uploadState = UploadingPost(false)
+        // Act
+        val (progressState, _) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(progressState).isEqualTo(ProgressBarUiState.Indeterminate)
+    }
+
+    @Test
+    fun `show progress when post is queued`() {
+        // Arrange
+        val uploadState = UploadQueued
+        // Act
+        val (progressState, _) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(progressState).isEqualTo(ProgressBarUiState.Indeterminate)
+    }
+
+    @Test
+    fun `show progress when uploading media`() {
+        // Arrange
+        val uploadState = UploadingMedia(0)
+        // Act
+        val (progressState, _) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(progressState).isInstanceOf(ProgressBarUiState.Determinate::class.java)
+    }
+
+    @Test
+    fun `do not show progress when upload failed`() {
+        // Arrange
+        val uploadState = UploadFailed(mock(), isEligibleForAutoUpload = false, retryWillPushChanges = false)
+        // Act
+        val (progressState, _) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(progressState).isEqualTo(ProgressBarUiState.Hidden)
+    }
+
+    @Test
+    fun `do not show progress when nothing to upload`() {
+        // Arrange
+        val uploadState = NothingToUpload
+        // Act
+        val (progressState, _) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(progressState).isEqualTo(ProgressBarUiState.Hidden)
+    }
+
+    @Test
+    fun `do not show progress when upload waiting for a connection`() {
+        // Arrange
+        val uploadState = UploadWaitingForConnection(mock())
+        // Act
+        val (progressState, _) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(progressState).isEqualTo(ProgressBarUiState.Hidden)
+    }
+
+    @Test
+    fun `show overlay when uploading post`() {
+        // Arrange
+        val uploadState = UploadingPost(false)
+        // Act
+        val (_, showOverlay) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(showOverlay).isTrue()
+    }
+
+    @Test
+    fun `show overlay when uploading media and aztec is disabled`() {
+        // Arrange
+        val uploadState = UploadingMedia(0)
+        whenever(appPrefsWrapper.isAztecEditorEnabled).thenReturn(false)
+        // Act
+        val (_, showOverlay) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(showOverlay).isTrue()
+    }
+
+    @Test
+    fun `do NOT show overlay when uploading media and aztec is enabled`() {
+        // Arrange
+        val uploadState = UploadingMedia(0)
+        whenever(appPrefsWrapper.isAztecEditorEnabled).thenReturn(true)
+        // Act
+        val (_, showOverlay) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(showOverlay).isFalse()
+    }
+
+    @Test
+    fun `do NOT show overlay when upload queued`() {
+        // Arrange
+        val uploadState = UploadQueued
+        // Act
+        val (_, showOverlay) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(showOverlay).isFalse()
+    }
+
+    @Test
+    fun `do NOT show overlay when upload waiting for a connection`() {
+        // Arrange
+        val uploadState = UploadWaitingForConnection(mock())
+        // Act
+        val (_, showOverlay) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(showOverlay).isFalse()
+    }
+
+    @Test
+    fun `do NOT show overlay when nothing to upload`() {
+        // Arrange
+        val uploadState = NothingToUpload
+        // Act
+        val (_, showOverlay) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(showOverlay).isFalse()
+    }
+
+    @Test
+    fun `do NOT show overlay when upload fails`() {
+        // Arrange
+        val uploadState = UploadFailed(
+                mock(),
+                false,
+                retryWillPushChanges = false
+        )
+        // Act
+        val (_, showOverlay) = useCase.getProgressStateForPage(uploadState)
+        // Assert
+        assertThat(showOverlay).isFalse()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.viewmodel.pages
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
-import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
@@ -24,9 +23,9 @@ import org.wordpress.android.ui.pages.PageItem.Divider
 import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.PageItem.PublishedPage
 import org.wordpress.android.util.LocaleManagerWrapper
-import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.PUBLISHED
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
 import java.util.Date
 import java.util.Locale
@@ -59,7 +58,7 @@ class PageListViewModelTest : BaseUnitTest() {
                 Dispatchers.Unconfined
         )
 
-        whenever(pageItemProgressUiStateUseCase.getProgressStateForPage(any(), any())).thenReturn(Pair(
+        whenever(pageItemProgressUiStateUseCase.getProgressStateForPage(any())).thenReturn(Pair(
                 ProgressBarUiState.Hidden, false))
 
         val invalidateUploadStatus = MutableLiveData<List<LocalId>>()
@@ -227,10 +226,7 @@ class PageListViewModelTest : BaseUnitTest() {
         val pages = MutableLiveData<List<PageModel>>()
 
         whenever(
-                pageItemProgressUiStateUseCase.getProgressStateForPage(
-                        anyOrNull(),
-                        anyOrNull()
-                )
+                pageItemProgressUiStateUseCase.getProgressStateForPage(anyOrNull())
         ).thenReturn(
                 Pair(
                         mock(),
@@ -256,7 +252,7 @@ class PageListViewModelTest : BaseUnitTest() {
         val expectedProgressBarUiState = ProgressBarUiState.Indeterminate
         val pages = MutableLiveData<List<PageModel>>()
 
-        whenever(pageItemProgressUiStateUseCase.getProgressStateForPage(anyOrNull(), anyOrNull())).thenReturn(
+        whenever(pageItemProgressUiStateUseCase.getProgressStateForPage(anyOrNull())).thenReturn(
                 Pair(
                         expectedProgressBarUiState,
                         true
@@ -273,52 +269,6 @@ class PageListViewModelTest : BaseUnitTest() {
 
         // Assert
         assertThat((result[0].first[0] as Page).progressBarUiState).isEqualTo(expectedProgressBarUiState)
-    }
-
-    @Test
-    fun `progressState is specific to each page`() {
-        // Arrange
-        val pages = MutableLiveData<List<PageModel>>()
-
-        whenever(pageItemProgressUiStateUseCase.getProgressStateForPage(argThat { this.id == 0 }, any())).thenReturn(
-                Pair(
-                        ProgressBarUiState.Indeterminate,
-                        true
-                )
-        )
-
-        whenever(pageItemProgressUiStateUseCase.getProgressStateForPage(argThat { this.id == 1 }, any())).thenReturn(
-                Pair(
-                        ProgressBarUiState.Hidden,
-                        false
-                )
-        )
-
-        whenever(pagesViewModel.pages).thenReturn(pages)
-
-        viewModel.start(PUBLISHED, pagesViewModel)
-
-        val result = mutableListOf<Pair<List<PageItem>, Boolean>>()
-
-        viewModel.pages.observeForever { result.add(it) }
-
-        val firstPage = buildPageModel(0)
-        val secondPage = buildPageModel(1)
-
-        // Act
-        val pageModels = mutableListOf<PageModel>()
-        pageModels += secondPage
-        pageModels += firstPage
-        pages.value = pageModels
-
-        // Assert
-        assertThat((result[0].first[0] as Page).progressBarUiState).isEqualTo(
-                ProgressBarUiState.Indeterminate
-        )
-        assertThat((result[0].first[0] as Page).showOverlay).isEqualTo(true)
-
-        assertThat((result[0].first[1] as Page).progressBarUiState).isEqualTo(ProgressBarUiState.Hidden)
-        assertThat((result[0].first[1] as Page).showOverlay).isEqualTo(false)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCaseTest.kt
@@ -146,7 +146,8 @@ class PostPageListLabelColorUseCaseTest {
         return post
     }
 
-    private fun failedUpload(isEligibleForAutoUpload: Boolean = false) = PostUploadUiState.UploadFailed(mock(), isEligibleForAutoUpload, false)
+    private fun failedUpload(isEligibleForAutoUpload: Boolean = false) =
+            PostUploadUiState.UploadFailed(mock(), isEligibleForAutoUpload, false)
 
     private fun mediaUploadInProgress() = PostUploadUiState.UploadingMedia(0)
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
@@ -64,7 +64,7 @@ class SearchListViewModelTest {
         )
         searchPages = MutableLiveData()
 
-        whenever(pageItemProgressUiStateUseCase.getProgressStateForPage(any(), any())).thenReturn(
+        whenever(pageItemProgressUiStateUseCase.getProgressStateForPage(any())).thenReturn(
                 Pair(
                         ProgressBarUiState.Hidden,
                         false

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -953,7 +953,8 @@ class PostListItemUiStateHelperTest {
     )
 
     private fun createFailedUploadUiState(
-        uploadError: UploadError = createGenericError(), isEligibleForAutoUpload: Boolean = false,
+        uploadError: UploadError = createGenericError(),
+        isEligibleForAutoUpload: Boolean = false,
         retryWillPushChanges: Boolean = false
     ): UploadFailed {
         return UploadFailed(


### PR DESCRIPTION
## Solution
This is part 3 in a series of PRs that aim to refactor the functionality added in the Offline Support: Pages Project. `PageItemProgressUiStateUseCaseTest ` was created so the associated use case could be properly tested. 

## Testing
Go to the pages and post lists and create uploads in both online and offline mode and verify that there are no crashes and right labels are being shown with their associated colors. 
## Reviewing 
1. Review and merge #11399
2. Review this PR
3. Update the target branch with `feature/master-pages-offline-support`
4. Remove the "Not ready for merge" label
5. Merge this PR

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 


