### PR TITLE
Add editor session startup time

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2669,6 +2669,10 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onEditorFragmentContentReady(ArrayList<Object> unsupportedBlocksList) {
+        // Note that this method is also used to track startup performance
+        // It assumes this is being called when the editor has finished loading
+        // If you need to refactor this, please ensure that the startup_time_ms property
+        // is still reflecting the actual startup time of the editor
         mPostEditorAnalyticsSession.start(unsupportedBlocksList);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -94,6 +94,13 @@ public class PostEditorAnalyticsSession implements Serializable {
             Map<String, Object> properties = getCommonProperties();
             properties.put(KEY_UNSUPPORTED_BLOCKS,
                     unsupportedBlocksList != null ? unsupportedBlocksList : new ArrayList<>());
+            // Note that start time only counts when the analytics session was created and not when the editor
+            // activity started. We are mostly interested in measuring the loading times for the block editor,
+            // where the main bottleneck seems to be initializing React Native and doing the initial load of Gutenberg.
+            //
+            // Measuring the full editor activity initialization would be more accurate, but we don't expect the
+            // difference to be significant enough, and doing that would add more complexity to how we are initializing
+            // the session.
             properties.put(KEY_STARTUP_TIME, System.currentTimeMillis() - mStartTime);
             AnalyticsTracker.track(Stat.EDITOR_SESSION_START, properties);
             mStarted = true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -26,6 +26,7 @@ public class PostEditorAnalyticsSession implements Serializable {
     private static final String KEY_POST_TYPE = "post_type";
     private static final String KEY_OUTCOME = "outcome";
     private static final String KEY_SESSION_ID = "session_id";
+    private static final String KEY_STARTUP_TIME = "startup_time_ms";
     private static final String KEY_TEMPLATE = "template";
 
     private String mSessionId = UUID.randomUUID().toString();
@@ -38,6 +39,7 @@ public class PostEditorAnalyticsSession implements Serializable {
     private Outcome mOutcome = null;
     private String mTemplate;
     private boolean mHWAccOff = false;
+    private long mStartTime = System.currentTimeMillis();
 
     enum Editor {
         GUTENBERG,
@@ -92,6 +94,7 @@ public class PostEditorAnalyticsSession implements Serializable {
             Map<String, Object> properties = getCommonProperties();
             properties.put(KEY_UNSUPPORTED_BLOCKS,
                     unsupportedBlocksList != null ? unsupportedBlocksList : new ArrayList<>());
+            properties.put(KEY_STARTUP_TIME, System.currentTimeMillis() - mStartTime);
             AnalyticsTracker.track(Stat.EDITOR_SESSION_START, properties);
             mStarted = true;
         } else {


### PR DESCRIPTION
Adds startup time to the `editor_session_start` event.

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1988
iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13605

I do like one Android PR a year on average, so please let me know if there's a better way to do this 😅 

To test:

Set a breakpoint or some extra logging on `AnalyticsTracker.track()`, and ensure the `startup_time_ms` gets added to `editor_session_start` and it reflects the actual startup time of the editor.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
