### PR TITLE
Update Nokogiri to 1.10.9 to fix a warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.2.6)
     naturally (2.2.0)
-    nokogiri (1.10.5)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -216,4 +216,4 @@ DEPENDENCIES
   rmagick (~> 3.2.0)
 
 BUNDLED WITH
-   2.1.1
+   2.1.4


### PR DESCRIPTION
Dismisses the warning – will not be a breaking change as it just updates the libxml version.

_Shamelessly copied from @jkmassel's similar PRs on other repos 😄_