### PR TITLE
Fix QuickStart dialog configuration change issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -212,6 +212,8 @@ public class MySiteFragment extends Fragment implements
 
         updateSiteSettingsIfNecessary();
 
+        reattachQuickStartFragmentListeners();
+
         // Site details may have changed (e.g. via Settings and returning to this Fragment) so update the UI
         refreshSelectedSiteDetails(getSelectedSite());
 
@@ -233,6 +235,18 @@ public class MySiteFragment extends Fragment implements
         }
 
         showQuickStartNoticeIfNecessary();
+    }
+
+    private void reattachQuickStartFragmentListeners() {
+        if (getFragmentManager() != null) {
+            for (Fragment fragment : getFragmentManager().getFragments()) {
+                if (fragment instanceof FullScreenDialogFragment) {
+                    FullScreenDialogFragment targetFragment = (FullScreenDialogFragment) fragment;
+                    targetFragment.setOnConfirmListener(this);
+                    targetFragment.setOnDismissListener(this);
+                }
+            }
+        }
     }
 
     private void showQuickStartNoticeIfNecessary() {


### PR DESCRIPTION
Fixes #10845

## Findings
The `FullScreenDialogFragment`s being used to communicate with the `MySiteFragment` to confirmation clicks. When a configuration change takes place, the fragment loses reference to the parent fragment. 

## Solution
To reattach the listeners on all fragments within the `MySiteFragment` that are of the type `FullScreenDialogFragment`

## Testing
1. Click on "Customize your site" or "Grow your audience" section of the QuickStart
2. Rotate your device
3. Click on one of the items (eg. View Site)
4. Notice that the actions work similarly to how they did before the configuration change. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
