### PR TITLE
Open blogs in external browser with custom domains 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -360,13 +360,9 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
             }
         });
 
-        mViewModel.getOpenExternalBrowser().observe(this, new Observer<Unit>() {
-            @Override
-            public void onChanged(@Nullable Unit unit) {
-                ReaderActivityLauncher.openUrl(WPWebViewActivity.this, mWebView.getUrl(),
-                        ReaderActivityLauncher.OpenUrlType.EXTERNAL);
-            }
-        });
+        mViewModel.getOpenExternalBrowser().observe(this,
+                unit -> ReaderActivityLauncher.openUrl(WPWebViewActivity.this, getExternalBrowserUrl(),
+                        ReaderActivityLauncher.OpenUrlType.EXTERNAL));
 
         mViewModel.getPreviewModeSelector().observe(this, new Observer<PreviewModeSelectorStatus>() {
             @Override
@@ -802,6 +798,27 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
         }
 
         return "";
+    }
+
+    /**
+     * This function is necessary because we want the external browser to use a link with a primary domain without
+     * preview parameters.
+     *
+     * 1. Within the loadContent function at line 734, the primary domain is being removed for authentication reasons.
+     * 2. For posts on all site types, the shareable url will be available which doesn't have any preview parameters.
+     * 3. In any other case we just fallback to the WebView's current URL.
+     * @return external url
+     */
+    public String getExternalBrowserUrl() {
+        final Bundle extras = getIntent().getExtras();
+        if (extras != null) {
+            String shareableUrl = extras.getString(SHAREABLE_URL, null);
+            if (!TextUtils.isEmpty(shareableUrl)) {
+                return shareableUrl;
+            }
+        }
+
+        return mWebView.getUrl();
     }
 
     /**


### PR DESCRIPTION
Fixes #8884

## Findings
The action that opens the external browser was using the current URL of the `WebView` which gets supplied with a URL that might have the `.wordpress.com` site address or preview params. 

## Solution
To utilize the shareable URL as the target URL for the external browser action since it doesn't contain preview parameters and it has the original post link. 

## Testing
Before carrying out this test ensure that the blog has a custom domain set as the primary domain for the blog. 

1. Open the app and go to pages or posts. 
2. Click View or Preview on the post.
3. Click on the World icon which should open the external browser. 
4. Notice that the URL is that of a custom domain.

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
