### PR TITLE
Issue/11422 quick start weight

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -5,14 +5,12 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
-import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
 import android.text.style.ImageSpan
-import android.text.style.StyleSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -91,10 +89,6 @@ class QuickStartUtils {
                 val highlightColor = ContextCompat.getColor(context, android.R.color.white)
                 mutableSpannedMessage.setSpan(
                         ForegroundColorSpan(highlightColor),
-                        startOfHighlight, endOfHighlight, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-                )
-                mutableSpannedMessage.setSpan(
-                        StyleSpan(Typeface.BOLD),
                         startOfHighlight, endOfHighlight, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
                 )
 


### PR DESCRIPTION
### FIx
Remove the `Typeface.BOLD` span from the ***Quick Start*** snackbar prompt to close #11422.  See the screenshots below for illustration.

![11422_quick_start_weight](https://user-images.githubusercontent.com/3827611/76369797-625f9a00-62fa-11ea-8f9a-62a739022559.png)

### Test
0. Create a new site.
1. Tap ***Accept*** button in ***Want a little help getting started?*** dialog.
2. Tap ***Customize Your Site*** item under ***Next Steps*** section.
3. Tap ***Browse themes*** item in list.
4. Notice ***Themes*** text with regular weight (i.e. not bold weight) in snackbar prompt.

### Review
Only one developer and one designer required to review these changes, but anyone can perform the review.

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
