### PR TITLE
Removed updating of locale in attachBaseContext of Application.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -214,11 +214,6 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
     }
 
     @Override
-    protected void attachBaseContext(Context base) {
-        super.attachBaseContext(LocaleManager.setLocale(base));
-    }
-
-    @Override
     public void onCreate() {
         super.onCreate();
         mContext = this;


### PR DESCRIPTION
Fixes #10748

When investigating why automatic switch between Light and Dark modes does not work in feature material theme branch, I pinpointed the issue to us trying to update locally in `attachBaseContext` method of the application class. Investigating a bit further, I came to the conclusion that we actually don't need to update context locale in the Application class - `attachBaseContext` will be called only once, when you start the app. It will also be called in multiple places like activities and services when you start the app. Changing locale of the system when the app is open, or within the app will not result in a call to `attachBaseContext`. 

I did some testing with RTL languages on a variety of emulators (API 21, 22, 25, 27 and 29) and experienced no issue switching languages on the system or the app level and having them applied when the app is alive or restarted.

This method might have been necessary at some point, but I think we can safely remove it now.

To test:
- On devices with older (API 21-25) and newer (API 25+) try to switch app or/and system language to RTL language, and make sure it's updated in the app, and that the language change persists through app restart.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
