### PR TITLE
Sharing: Consistent messaging in Publicize to Facebook Page Error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
@@ -10,6 +10,9 @@ public class PublicizeConstants {
     public static final String TWITTER_ID = "twitter";
     public static final String LINKEDIN_ID = "linkedin";
 
+    public static final String FACEBOOK_SHARING_CHANGE_BLOG_POST =
+            "https://en.blog.wordpress.com/2018/07/23/sharing-options-from-wordpress-com-to-facebook-are-changing/";
+
     public enum ConnectAction {
         CONNECT,
         DISCONNECT,

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
@@ -10,8 +10,8 @@ public class PublicizeConstants {
     public static final String TWITTER_ID = "twitter";
     public static final String LINKEDIN_ID = "linkedin";
 
-    public static final String FACEBOOK_SHARING_CHANGE_BLOG_POST =
-            "https://en.blog.wordpress.com/2018/07/23/sharing-options-from-wordpress-com-to-facebook-are-changing/";
+    public static final String PUBLICIZE_FACEBOOK_SHARING_SUPPORT_LINK =
+            "https://en.support.wordpress.com/publicize/#facebook-pages";
 
     public enum ConnectAction {
         CONNECT,

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.publicize;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
@@ -16,7 +15,6 @@ import org.wordpress.android.datasets.PublicizeTable;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.models.PublicizeService;
-import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.adapters.PublicizeConnectionAdapter;
 import org.wordpress.android.util.ToastUtils;
@@ -25,8 +23,6 @@ import javax.inject.Inject;
 
 public class PublicizeDetailFragment extends PublicizeBaseFragment
         implements PublicizeConnectionAdapter.OnAdapterLoadedListener {
-    public static final String FACEBOOK_SHARING_CHANGE_BLOG_POST =
-            "https://en.blog.wordpress.com/2018/07/23/sharing-options-from-wordpress-com-to-facebook-are-changing/";
     private SiteModel mSite;
     private String mServiceId;
 
@@ -121,14 +117,6 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
             String description = String.format(getString(R.string.connection_service_description), mService.getLabel());
             TextView txtDescription = (TextView) mServiceCardView.findViewById(R.id.text_description);
             txtDescription.setText(description);
-
-            // Hide the Learn More button by default as at the moment it is only used for the Facebook warning below.
-            TextView learnMoreButton = (TextView) mServiceCardView.findViewById(R.id.learn_more_button);
-            learnMoreButton.setVisibility(View.GONE);
-
-            if (isFacebook()) {
-                showFacebookWarning();
-            }
         }
 
         long currentUserId = mAccountStore.getAccount().getUserId();
@@ -143,26 +131,6 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
 
     private boolean isGooglePlus() {
         return mService.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID);
-    }
-
-    private boolean isFacebook() {
-        return mService.getId().equals(PublicizeConstants.FACEBOOK_ID);
-    }
-
-    private void showFacebookWarning() {
-        String noticeText = getString(R.string.connection_service_facebook_notice);
-        TextView txtNotice = (TextView) mServiceCardView.findViewById(R.id.text_description_notice);
-        txtNotice.setText(noticeText);
-        txtNotice.setVisibility(View.VISIBLE);
-
-        TextView learnMoreButton = (TextView) mServiceCardView.findViewById(R.id.learn_more_button);
-        learnMoreButton.setOnClickListener(new OnClickListener() {
-            @Override public void onClick(View v) {
-                WPWebViewActivity.openURL(getActivity(),
-                        FACEBOOK_SHARING_CHANGE_BLOG_POST);
-            }
-        });
-        learnMoreButton.setVisibility(View.VISIBLE);
     }
 
     private boolean hasOnPublicizeActionListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeErrorDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeErrorDialogFragment.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.publicize.PublicizeConstants.PUBLICIZE_FACEBOOK_SHARING_SUPPORT_LINK
 import java.lang.NullPointerException
 
-class PublicizeErrorFragment : DialogFragment() {
+class PublicizeErrorDialogFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         arguments?.let {
             it.getInt(REASON_RES_ID).let { reasonResId ->
@@ -55,7 +55,7 @@ class PublicizeErrorFragment : DialogFragment() {
         const val TAG = "publicize_error_fragment"
 
         @JvmStatic
-        fun newInstance(@StringRes reasonId: Int) = PublicizeErrorFragment().apply {
+        fun newInstance(@StringRes reasonId: Int) = PublicizeErrorDialogFragment().apply {
             arguments = Bundle().apply {
                 putInt(REASON_RES_ID, reasonId)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeErrorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeErrorFragment.kt
@@ -1,0 +1,64 @@
+package org.wordpress.android.ui.publicize
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.os.Bundle
+import android.view.ContextThemeWrapper
+import androidx.annotation.StringRes
+import androidx.fragment.app.DialogFragment
+import org.wordpress.android.R
+import org.wordpress.android.R.style
+import org.wordpress.android.ui.WPWebViewActivity
+import org.wordpress.android.ui.publicize.PublicizeConstants.PUBLICIZE_FACEBOOK_SHARING_SUPPORT_LINK
+import java.lang.NullPointerException
+
+class PublicizeErrorFragment : DialogFragment() {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        arguments?.let {
+            it.getInt(REASON_RES_ID).let { reasonResId ->
+                // the custom dialog behavior here is specific to a user who is trying to share to Facebook
+                // but does not have any available Facebook Pages.
+                if (reasonResId == R.string.sharing_facebook_account_must_have_pages) {
+                    return AlertDialog.Builder(
+                            ContextThemeWrapper(
+                                    activity,
+                                    style.Calypso_Dialog
+                            )
+                    ).apply {
+                        setTitle(R.string.dialog_title_sharing_facebook_account_must_have_pages)
+                        setMessage(R.string.sharing_facebook_account_must_have_pages)
+                        setPositiveButton(R.string.ok) { dialog, _ -> dialog.dismiss() }
+                        setNegativeButton(R.string.learn_more) { _, _ ->
+                            WPWebViewActivity.openURL(
+                                    activity,
+                                    PUBLICIZE_FACEBOOK_SHARING_SUPPORT_LINK
+                            )
+                        }
+                    }.create()
+                } else {
+                    return AlertDialog.Builder(
+                            ContextThemeWrapper(
+                                    activity,
+                                    style.Calypso_Dialog
+                            )
+                    ).apply {
+                        setMessage(reasonResId)
+                        setPositiveButton(R.string.ok) { dialog, _ -> dialog.dismiss() }
+                    }.create()
+                }
+            }
+        } ?: throw NullPointerException("Missing argument. Utilize newInstance() to instantiate.")
+    }
+
+    companion object {
+        const val REASON_RES_ID = "REASON_RES_ID"
+        const val TAG = "publicize_error_fragment"
+
+        @JvmStatic
+        fun newInstance(@StringRes reasonId: Int) = PublicizeErrorFragment().apply {
+            arguments = Bundle().apply {
+                putInt(REASON_RES_ID, reasonId)
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeService;
+import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.services.PublicizeUpdateService;
@@ -37,6 +38,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
+
+import static org.wordpress.android.ui.publicize.PublicizeConstants.FACEBOOK_SHARING_CHANGE_BLOG_POST;
 
 public class PublicizeListActivity extends AppCompatActivity
         implements
@@ -323,7 +326,14 @@ public class PublicizeListActivity extends AppCompatActivity
             }
         } else {
             if (event.getReasonResId() != null) {
-                showAlertForFailureReason(event.getReasonResId());
+                // the custom dialog behavior here is specific to a user who is trying to share to Facebook
+                // but does not have any available Facebook Pages.
+                if (event.getService().equals(PublicizeConstants.FACEBOOK_ID)
+                    && event.getReasonResId() == R.string.sharing_facebook_account_must_have_pages) {
+                    showAlertForFacebookPageFailureReason();
+                } else {
+                    showAlertForFailureReason(event.getReasonResId());
+                }
             } else {
                 ToastUtils.showToast(this, R.string.error_generic);
             }
@@ -382,6 +392,17 @@ public class PublicizeListActivity extends AppCompatActivity
                 new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Calypso_Dialog));
         builder.setMessage(reasonResId);
         builder.setPositiveButton(R.string.ok, (dialog, which) -> dialog.dismiss());
+        builder.show();
+    }
+
+    private void showAlertForFacebookPageFailureReason() {
+        final AlertDialog.Builder builder =
+                new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+        builder.setTitle(R.string.dialog_title_sharing_facebook_account_must_have_pages);
+        builder.setMessage(R.string.sharing_facebook_account_must_have_pages);
+        builder.setPositiveButton(R.string.ok, (dialog, which) -> dialog.dismiss());
+        builder.setNegativeButton(R.string.learn_more, (dialog, which) -> WPWebViewActivity.openURL(this,
+                FACEBOOK_SHARING_CHANGE_BLOG_POST));
         builder.show();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.ui.publicize.PublicizeConstants.FACEBOOK_SHARING_CHANGE_BLOG_POST;
+import static org.wordpress.android.ui.publicize.PublicizeConstants.PUBLICIZE_FACEBOOK_SHARING_SUPPORT_LINK;
 
 public class PublicizeListActivity extends AppCompatActivity
         implements
@@ -402,7 +402,7 @@ public class PublicizeListActivity extends AppCompatActivity
         builder.setMessage(R.string.sharing_facebook_account_must_have_pages);
         builder.setPositiveButton(R.string.ok, (dialog, which) -> dialog.dismiss());
         builder.setNegativeButton(R.string.learn_more, (dialog, which) -> WPWebViewActivity.openURL(this,
-                FACEBOOK_SHARING_CHANGE_BLOG_POST));
+                PUBLICIZE_FACEBOOK_SHARING_SUPPORT_LINK));
         builder.show();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -324,8 +324,8 @@ public class PublicizeListActivity extends AppCompatActivity
             }
         } else {
             if (event.getReasonResId() != null) {
-                DialogFragment fragment = PublicizeErrorFragment.newInstance(event.getReasonResId());
-                fragment.show(getSupportFragmentManager(), PublicizeErrorFragment.TAG);
+                DialogFragment fragment = PublicizeErrorDialogFragment.newInstance(event.getReasonResId());
+                fragment.show(getSupportFragmentManager(), PublicizeErrorDialogFragment.TAG);
             } else {
                 ToastUtils.showToast(this, R.string.error_generic);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -11,6 +11,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
@@ -26,7 +27,6 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeService;
-import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.services.PublicizeUpdateService;
@@ -38,8 +38,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
-
-import static org.wordpress.android.ui.publicize.PublicizeConstants.PUBLICIZE_FACEBOOK_SHARING_SUPPORT_LINK;
 
 public class PublicizeListActivity extends AppCompatActivity
         implements
@@ -326,14 +324,8 @@ public class PublicizeListActivity extends AppCompatActivity
             }
         } else {
             if (event.getReasonResId() != null) {
-                // the custom dialog behavior here is specific to a user who is trying to share to Facebook
-                // but does not have any available Facebook Pages.
-                if (event.getService().equals(PublicizeConstants.FACEBOOK_ID)
-                    && event.getReasonResId() == R.string.sharing_facebook_account_must_have_pages) {
-                    showAlertForFacebookPageFailureReason();
-                } else {
-                    showAlertForFailureReason(event.getReasonResId());
-                }
+                DialogFragment fragment = PublicizeErrorFragment.newInstance(event.getReasonResId());
+                fragment.show(getSupportFragmentManager(), PublicizeErrorFragment.TAG);
             } else {
                 ToastUtils.showToast(this, R.string.error_generic);
             }
@@ -385,24 +377,5 @@ public class PublicizeListActivity extends AppCompatActivity
                             .addToBackStack(null)
                             .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                             .commit();
-    }
-
-    private void showAlertForFailureReason(int reasonResId) {
-        final AlertDialog.Builder builder =
-                new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Calypso_Dialog));
-        builder.setMessage(reasonResId);
-        builder.setPositiveButton(R.string.ok, (dialog, which) -> dialog.dismiss());
-        builder.show();
-    }
-
-    private void showAlertForFacebookPageFailureReason() {
-        final AlertDialog.Builder builder =
-                new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Calypso_Dialog));
-        builder.setTitle(R.string.dialog_title_sharing_facebook_account_must_have_pages);
-        builder.setMessage(R.string.sharing_facebook_account_must_have_pages);
-        builder.setPositiveButton(R.string.ok, (dialog, which) -> dialog.dismiss());
-        builder.setNegativeButton(R.string.learn_more, (dialog, which) -> WPWebViewActivity.openURL(this,
-                PUBLICIZE_FACEBOOK_SHARING_SUPPORT_LINK));
-        builder.show();
     }
 }

--- a/WordPress/src/main/res/layout/publicize_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_detail_fragment.xml
@@ -87,35 +87,6 @@
                 android:layout_marginEnd="@dimen/margin_extra_large"
                 android:layout_marginStart="@dimen/margin_extra_large"/>
 
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/text_description_notice"
-                android:visibility="gone"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingTop="@dimen/margin_large"
-                android:ellipsize="end"
-                android:textColor="?attr/wpColorTextSubtle"
-                android:textSize="@dimen/text_sz_medium"
-                android:textStyle="bold"
-                tools:text="text_description_notice"
-                android:layout_marginEnd="@dimen/margin_extra_large"
-                android:layout_marginStart="@dimen/margin_extra_large"/>
-
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/learn_more_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_large"
-                android:layout_marginTop="@dimen/margin_extra_large"
-                android:ellipsize="end"
-                android:text="@string/learn_more"
-                android:textColor="@color/primary_50"
-                android:textSize="@dimen/text_sz_medium"
-                android:textStyle="bold"
-                tools:text="learn_more_button"
-                android:layout_marginStart="@dimen/margin_extra_large"
-                android:layout_marginEnd="@dimen/margin_extra_large"/>
-
             <View
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/list_divider_height"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1928,7 +1928,8 @@
     <string name="connecting_account">Connecting account</string>
     <string name="sharing_label_message">Change the text of the sharing buttons\' label. This text won\'t appear until you add at least one sharing button.</string>
     <string name="sharing_twitter_message">This will be included in tweets when people share using the Twitter button</string>
-    <string name="sharing_facebook_account_must_have_pages">The Facebook connection could not be made because this account does not have access to any pages. Facebook supports sharing connections to Facebook Pages, but not to Facebook Profiles.</string>
+    <string name="dialog_title_sharing_facebook_account_must_have_pages">Not connected</string>
+    <string name="sharing_facebook_account_must_have_pages">The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages.</string>
 
     <!--Theme Browser-->
     <string name="current_theme">Current Theme</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1879,7 +1879,6 @@
     <string name="connected_accounts_label">Connected accounts</string>
     <string name="connection_service_label">Publicize to %s</string>
     <string name="connection_service_description">Connect to automatically share your blog posts to %s.</string>
-    <string name="connection_service_facebook_notice">As of August 1, 2018, Facebook no longer allows direct sharing of posts to Facebook Profiles. Connections to Facebook Pages remain unchanged.</string>
     <string name="share_btn_connect">Connect</string>
     <string name="share_btn_disconnect">Disconnect</string>
     <string name="share_btn_reconnect">Reconnect</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1928,7 +1928,7 @@
     <string name="connecting_account">Connecting account</string>
     <string name="sharing_label_message">Change the text of the sharing buttons\' label. This text won\'t appear until you add at least one sharing button.</string>
     <string name="sharing_twitter_message">This will be included in tweets when people share using the Twitter button</string>
-    <string name="dialog_title_sharing_facebook_account_must_have_pages">Not connected</string>
+    <string name="dialog_title_sharing_facebook_account_must_have_pages">Not Connected</string>
     <string name="sharing_facebook_account_must_have_pages">The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages.</string>
 
     <!--Theme Browser-->


### PR DESCRIPTION
Fixes #10278
## Findings
The messaging of the error that occurs when trying to publish to Facebook wasn't consistent on both platforms. This PR addresses this since the messaging on iOS was already updated to the new version. 

## Solution
I removed the obsolete messaging and learn more button from the publicize page flow. I then created a dialog specific to this since the existing dialog just supported the `message` of the dialog being set via an `EventBus` event that gets a reason message propagated from an exception that occurs within `PublicizeActions`. 

## Testing
1. I used a Facebook account that that has no pages. ( Having an existing Facebook account with no public pages should work as well.) 
2. Navigate to My Site. 
3. Select Sharing.
4. Click Facebook.
5. Click Connect. 
6. Follow through with the Facebook authentication flow. 
7. You will then be greeted with a Pages flow, which you should just go through and once it's done you should see the error dialog. 
8. To ensure no regressions occurred I tested the flow with a Facebook account that has public pages and it allowed me to go to the dialog where I see the page selected and I can connect it so posts are shared automatically. 

Step 1 | Step 2  
--------|-------
<img src="https://user-images.githubusercontent.com/1509205/76462571-e889e800-63af-11ea-9b0c-755c9cf4cb22.png" width="320"> |  <img src="https://user-images.githubusercontent.com/1509205/76462573-e9227e80-63af-11ea-8208-fa9315ba4dc0.png" width="320">
     

Step 3 | Step 4 
--------|-------
   <img src="https://user-images.githubusercontent.com/1509205/76462576-e9bb1500-63af-11ea-995e-499da711e62f.png" width="320"> |   <img src="https://user-images.githubusercontent.com/1509205/76462581-ea53ab80-63af-11ea-9ef3-7b68af57b4b5.png" width="320">


Result (Android)  | Comparison (iOS) 
--------|-------
 <img src="https://user-images.githubusercontent.com/1509205/76462569-e758bb00-63af-11ea-9904-3ef6903f40a4.png" width="320">|       <img src="https://user-images.githubusercontent.com/1509205/76463565-9944b700-63b1-11ea-8a10-845ddeae9b99.png" width="320">

* I capitalized the C in "Not connected" but decided not to update screenshot since it's a subtle change 60e3b85
## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 