### PR TITLE
Me/ Profile - Change Photo  -  Image Preview Fix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -285,36 +285,35 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
         }
         showProgress(true);
 
-        mImageManager
-                .loadWithResultListener(mImageView, ImageType.IMAGE, Uri.parse(mediaUri), ScaleType.CENTER, null,
-                        new RequestListener<Drawable>() {
-                            @Override
-                            public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
-                                if (isAdded()) {
-                                    // assign the photo attacher to enable pinch/zoom - must come before
-                                    // setImageBitmap
-                                    // for it to be correctly resized upon loading
-                                    PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
-                                    attacher.setOnViewTapListener((view, x, y) -> {
-                                        if (mMediaTapListener != null) {
-                                            mMediaTapListener.onMediaTapped();
-                                        }
-                                    });
-                                    showProgress(false);
+        mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, Uri.parse(mediaUri), ScaleType.CENTER, null,
+                new RequestListener<Drawable>() {
+                    @Override
+                    public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
+                        if (isAdded()) {
+                            // assign the photo attacher to enable pinch/zoom - must come before
+                            // setImageBitmap
+                            // for it to be correctly resized upon loading
+                            PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
+                            attacher.setOnViewTapListener((view, x, y) -> {
+                                if (mMediaTapListener != null) {
+                                    mMediaTapListener.onMediaTapped();
                                 }
-                            }
+                            });
+                            showProgress(false);
+                        }
+                    }
 
-                            @Override
-                            public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
-                                if (isAdded()) {
-                                    if (e != null) {
-                                        AppLog.e(T.MEDIA, e);
-                                    }
-                                    showProgress(false);
-                                    showLoadingError();
-                                }
+                    @Override
+                    public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
+                        if (isAdded()) {
+                            if (e != null) {
+                                AppLog.e(T.MEDIA, e);
                             }
-                        });
+                            showProgress(false);
+                            showLoadingError();
+                        }
+                    }
+                });
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -30,6 +30,7 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.SiteUtils;
+import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageManager.RequestListener;
 import org.wordpress.android.util.image.ImageType;
@@ -277,43 +278,74 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
         }
 
         mImageView.setVisibility(View.VISIBLE);
-        if (mSite == null || SiteUtils.isPhotonCapable(mSite)) {
+        if ((mSite == null || SiteUtils.isPhotonCapable(mSite)) && !UrlUtils.checkIfContentUri(mediaUri)) {
             int maxWidth = Math.max(DisplayUtils.getDisplayPixelWidth(getActivity()),
                     DisplayUtils.getDisplayPixelHeight(getActivity()));
             mediaUri = PhotonUtils.getPhotonImageUrl(mediaUri, maxWidth, 0);
         }
         showProgress(true);
-        mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, mediaUri, ScaleType.CENTER, null,
-                new RequestListener<Drawable>() {
-                    @Override
-                    public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
-                        if (isAdded()) {
-                            // assign the photo attacher to enable pinch/zoom - must come before setImageBitmap
-                            // for it to be correctly resized upon loading
-                            PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
-                            attacher.setOnViewTapListener(new PhotoViewAttacher.OnViewTapListener() {
+
+        if (UrlUtils.checkIfContentUri(mediaUri)) {
+            mImageManager
+                    .loadWithResultListener(mImageView, ImageType.IMAGE, Uri.parse(mediaUri), ScaleType.CENTER, null,
+                            new RequestListener<Drawable>() {
                                 @Override
-                                public void onViewTap(View view, float x, float y) {
-                                    if (mMediaTapListener != null) {
-                                        mMediaTapListener.onMediaTapped();
+                                public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
+                                    if (isAdded()) {
+                                        // assign the photo attacher to enable pinch/zoom - must come before
+                                        // setImageBitmap
+                                        // for it to be correctly resized upon loading
+                                        PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
+                                        attacher.setOnViewTapListener((view, x, y) -> {
+                                            if (mMediaTapListener != null) {
+                                                mMediaTapListener.onMediaTapped();
+                                            }
+                                        });
+                                        showProgress(false);
+                                    }
+                                }
+
+                                @Override
+                                public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
+                                    if (isAdded()) {
+                                        if (e != null) {
+                                            AppLog.e(T.MEDIA, e);
+                                        }
+                                        showProgress(false);
+                                        showLoadingError();
                                     }
                                 }
                             });
-                            showProgress(false);
-                        }
-                    }
-
-                    @Override
-                    public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
-                        if (isAdded()) {
-                            if (e != null) {
-                                AppLog.e(T.MEDIA, e);
+        } else {
+            mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, mediaUri, ScaleType.CENTER, null,
+                    new RequestListener<Drawable>() {
+                        @Override
+                        public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
+                            if (isAdded()) {
+                                // assign the photo attacher to enable pinch/zoom - must come before setImageBitmap
+                                // for it to be correctly resized upon loading
+                                PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
+                                attacher.setOnViewTapListener((view, x, y) -> {
+                                    if (mMediaTapListener != null) {
+                                        mMediaTapListener.onMediaTapped();
+                                    }
+                                });
+                                showProgress(false);
                             }
-                            showProgress(false);
-                            showLoadingError();
                         }
-                    }
-                });
+
+                        @Override
+                        public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
+                            if (isAdded()) {
+                                if (e != null) {
+                                    AppLog.e(T.MEDIA, e);
+                                }
+                                showProgress(false);
+                                showLoadingError();
+                            }
+                        }
+                    });
+        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -278,14 +278,14 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
         }
 
         mImageView.setVisibility(View.VISIBLE);
-        if ((mSite == null || SiteUtils.isPhotonCapable(mSite)) && !UrlUtils.checkIfContentUri(mediaUri)) {
+        if ((mSite == null || SiteUtils.isPhotonCapable(mSite)) && !UrlUtils.isContentUri(mediaUri)) {
             int maxWidth = Math.max(DisplayUtils.getDisplayPixelWidth(getActivity()),
                     DisplayUtils.getDisplayPixelHeight(getActivity()));
             mediaUri = PhotonUtils.getPhotonImageUrl(mediaUri, maxWidth, 0);
         }
         showProgress(true);
 
-        if (UrlUtils.checkIfContentUri(mediaUri)) {
+        if (UrlUtils.isContentUri(mediaUri)) {
             mImageManager
                     .loadWithResultListener(mImageView, ImageType.IMAGE, Uri.parse(mediaUri), ScaleType.CENTER, null,
                             new RequestListener<Drawable>() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -286,7 +286,7 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
         showProgress(true);
 
         mImageManager
-                .loadWithResultListener(mImageView, ImageType.IMAGE, mediaUri, ScaleType.CENTER, null,
+                .loadWithResultListener(mImageView, ImageType.IMAGE, Uri.parse(mediaUri), ScaleType.CENTER, null,
                         new RequestListener<Drawable>() {
                             @Override
                             public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -285,67 +285,36 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
         }
         showProgress(true);
 
-        if (UrlUtils.isContentUri(mediaUri)) {
-            mImageManager
-                    .loadWithResultListener(mImageView, ImageType.IMAGE, Uri.parse(mediaUri), ScaleType.CENTER, null,
-                            new RequestListener<Drawable>() {
-                                @Override
-                                public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
-                                    if (isAdded()) {
-                                        // assign the photo attacher to enable pinch/zoom - must come before
-                                        // setImageBitmap
-                                        // for it to be correctly resized upon loading
-                                        PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
-                                        attacher.setOnViewTapListener((view, x, y) -> {
-                                            if (mMediaTapListener != null) {
-                                                mMediaTapListener.onMediaTapped();
-                                            }
-                                        });
-                                        showProgress(false);
-                                    }
-                                }
-
-                                @Override
-                                public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
-                                    if (isAdded()) {
-                                        if (e != null) {
-                                            AppLog.e(T.MEDIA, e);
+        mImageManager
+                .loadWithResultListener(mImageView, ImageType.IMAGE, mediaUri, ScaleType.CENTER, null,
+                        new RequestListener<Drawable>() {
+                            @Override
+                            public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
+                                if (isAdded()) {
+                                    // assign the photo attacher to enable pinch/zoom - must come before
+                                    // setImageBitmap
+                                    // for it to be correctly resized upon loading
+                                    PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
+                                    attacher.setOnViewTapListener((view, x, y) -> {
+                                        if (mMediaTapListener != null) {
+                                            mMediaTapListener.onMediaTapped();
                                         }
-                                        showProgress(false);
-                                        showLoadingError();
-                                    }
+                                    });
+                                    showProgress(false);
                                 }
-                            });
-        } else {
-            mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, mediaUri, ScaleType.CENTER, null,
-                    new RequestListener<Drawable>() {
-                        @Override
-                        public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
-                            if (isAdded()) {
-                                // assign the photo attacher to enable pinch/zoom - must come before setImageBitmap
-                                // for it to be correctly resized upon loading
-                                PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
-                                attacher.setOnViewTapListener((view, x, y) -> {
-                                    if (mMediaTapListener != null) {
-                                        mMediaTapListener.onMediaTapped();
-                                    }
-                                });
-                                showProgress(false);
                             }
-                        }
 
-                        @Override
-                        public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
-                            if (isAdded()) {
-                                if (e != null) {
-                                    AppLog.e(T.MEDIA, e);
+                            @Override
+                            public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
+                                if (isAdded()) {
+                                    if (e != null) {
+                                        AppLog.e(T.MEDIA, e);
+                                    }
+                                    showProgress(false);
+                                    showLoadingError();
                                 }
-                                showProgress(false);
-                                showLoadingError();
                             }
-                        }
-                    });
-        }
+                        });
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -163,36 +163,7 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
         val context = imageView.context
         if (!context.isAvailable()) return
         GlideApp.with(context)
-                .load(imgUrl)
-                .addFallback(imageType)
-                .addPlaceholder(imageType)
-                .addThumbnail(context, thumbnailUrl, requestListener)
-                .applyScaleType(scaleType)
-                .attachRequestListener(requestListener)
-                .into(imageView)
-                .clearOnDetach()
-    }
-
-    /**
-     * Loads an image from the "imgUri" into the ImageView. Adds a placeholder and an error placeholder depending
-     * on the ImageType. Attaches the ResultListener so the client can manually show/hide progress and error
-     * views or add a PhotoViewAttacher(adds support for pinch-to-zoom gesture). Optionally adds
-     * thumbnailUrl - mostly used for loading low resolution images.
-     *
-     * Unless you necessarily need to react on the request result, preferred way is to use one of the load(...) methods.
-     */
-    fun loadWithResultListener(
-        imageView: ImageView,
-        imageType: ImageType,
-        imgUri: Uri,
-        scaleType: ScaleType = CENTER,
-        thumbnailUrl: String? = null,
-        requestListener: RequestListener<Drawable>
-    ) {
-        val context = imageView.context
-        if (!context.isAvailable()) return
-        GlideApp.with(context)
-                .load(imgUri)
+                .load(Uri.parse(imgUrl))
                 .addFallback(imageType)
                 .addPlaceholder(imageType)
                 .addThumbnail(context, thumbnailUrl, requestListener)

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.text.TextUtils
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType
@@ -163,6 +164,35 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
         if (!context.isAvailable()) return
         GlideApp.with(context)
                 .load(imgUrl)
+                .addFallback(imageType)
+                .addPlaceholder(imageType)
+                .addThumbnail(context, thumbnailUrl, requestListener)
+                .applyScaleType(scaleType)
+                .attachRequestListener(requestListener)
+                .into(imageView)
+                .clearOnDetach()
+    }
+
+    /**
+     * Loads an image from the "imgUri" into the ImageView. Adds a placeholder and an error placeholder depending
+     * on the ImageType. Attaches the ResultListener so the client can manually show/hide progress and error
+     * views or add a PhotoViewAttacher(adds support for pinch-to-zoom gesture). Optionally adds
+     * thumbnailUrl - mostly used for loading low resolution images.
+     *
+     * Unless you necessarily need to react on the request result, preferred way is to use one of the load(...) methods.
+     */
+    fun loadWithResultListener(
+        imageView: ImageView,
+        imageType: ImageType,
+        imgUri: Uri,
+        scaleType: ScaleType = CENTER,
+        thumbnailUrl: String? = null,
+        requestListener: RequestListener<Drawable>
+    ) {
+        val context = imageView.context
+        if (!context.isAvailable()) return
+        GlideApp.with(context)
+                .load(imgUri)
                 .addFallback(imageType)
                 .addPlaceholder(imageType)
                 .addThumbnail(context, thumbnailUrl, requestListener)

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -174,6 +174,36 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
     }
 
     /**
+     * Loads an image from the "imgUri" into the ImageView. Doing this allows content and remote URIs to interchangeable.
+     * Adds a placeholder and an error placeholder depending
+     * on the ImageType. Attaches the ResultListener so the client can manually show/hide progress and error
+     * views or add a PhotoViewAttacher(adds support for pinch-to-zoom gesture). Optionally adds
+     * thumbnailUrl - mostly used for loading low resolution images.
+     *
+     * Unless you necessarily need to react on the request result, preferred way is to use one of the load(...) methods.
+     */
+    fun loadWithResultListener(
+        imageView: ImageView,
+        imageType: ImageType,
+        imgUri: Uri,
+        scaleType: ScaleType = CENTER,
+        thumbnailUrl: String? = null,
+        requestListener: RequestListener<Drawable>
+    ) {
+        val context = imageView.context
+        if (!context.isAvailable()) return
+        GlideApp.with(context)
+                .load(imgUri)
+                .addFallback(imageType)
+                .addPlaceholder(imageType)
+                .addThumbnail(context, thumbnailUrl, requestListener)
+                .applyScaleType(scaleType)
+                .attachRequestListener(requestListener)
+                .into(imageView)
+                .clearOnDetach()
+    }
+
+    /**
      * Loads the Bitmap into the ImageView.
      */
     @JvmOverloads

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -49,7 +49,7 @@ public class UrlUtils {
         return "";
     }
 
-    public static boolean checkIfContentUri(String uri) {
+    public static boolean isContentUri(String uri) {
         return "content".equals(Uri.parse(uri).getScheme());
     }
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -49,6 +49,10 @@ public class UrlUtils {
         return "";
     }
 
+    public static boolean checkIfContentUri(String uri) {
+        return "content".equals(Uri.parse(uri).getScheme());
+    }
+
     /**
      * Convert IDN names to punycode if necessary
      */


### PR DESCRIPTION
Fixes #11314

## Findings
The `MediaPreviewFragment` primarily uses a URL to load images from the web. A content URI was being passed to the `ImageManager`'s image loading function which only knew how to deal with Photon based URLs.

## Solution
An overload was created in the `ImageManager` that loads a content URI and a check is being done so that the appropriate function is utilized based on the image URI type. 

I had to do a bit of code duplication to support the additional type. Let me know if you have any ideas to simplify the fix. I was going to use generics but that would involve making a change to a function being used in other places so for simplicity, I just utilized method overloading.
## Testing
1. Go to Me page. 
2. Click on "Change Photo"
3. Long press on an image in "Choose Photo" Picker. 
4. See the image preview. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 