### PR TITLE
Comments : Prevent empty comment submission

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
@@ -30,7 +30,6 @@ class CommentFullScreenDialogFragment : Fragment(), CollapseFullScreenDialogCont
     @Inject lateinit var siteStore: SiteStore
     private lateinit var dialogController: CollapseFullScreenDialogController
     private lateinit var reply: SuggestionAutoCompleteText
-    private lateinit var siteModel: SiteModel
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui
 import android.content.Context
 import android.os.Bundle
 import android.text.Editable
+import android.text.TextUtils
 import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
@@ -45,7 +46,7 @@ class CommentFullScreenDialogFragment : Fragment(), CollapseFullScreenDialogCont
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}
 
             override fun afterTextChanged(s: Editable) {
-                dialogController.setConfirmEnabled(s.isNotEmpty())
+                dialogController.setConfirmEnabled(!TextUtils.isEmpty(s.toString().trim()))
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -309,7 +309,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
             @Override
             public void afterTextChanged(Editable s) {
-                mSubmitReplyBtn.setEnabled(s.length() > 0);
+                mSubmitReplyBtn.setEnabled(!TextUtils.isEmpty(s.toString().trim()));
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -219,7 +219,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
 
             @Override
             public void afterTextChanged(Editable s) {
-                mSubmitReplyBtn.setEnabled(s.length() > 0);
+                mSubmitReplyBtn.setEnabled(!TextUtils.isEmpty(s.toString().trim()));
             }
         });
         mSubmitReplyBtn = mCommentBox.findViewById(R.id.btn_submit_reply);


### PR DESCRIPTION
Fixes #11137
## Findings
The `EditText`s being used for the comments was only checking if text length was greater than 0 and not considering whitespace.

## Solution
`.trim()` is utilized to remove whitespace so that an empty comment can't be submitted.

## Testing
1. Go to Notifications.
2. Go to Comments.
3. Click on a comment.
4. In the Reply to section enter a whitespace character and realize the submit button isn't enabled. 
5. Also, press the up arrow in the comment box to expand the other comment component and test for the same behavior.
--------------
1. Go to Reader.
2. Go to Discover.
3. Click on the comments icon (between save post and like button).
4. In the Reply to section enter a whitespace character and realize the submit button isn't enabled. 
5. Also, press the up arrow in the comment box to expand the other comment component and test for the same behavior.

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
