### PR TITLE
Fix NPE in Photo picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -20,6 +20,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.ActionMode;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -352,8 +353,12 @@ public class PhotoPickerFragment extends Fragment {
             if (count == 0) {
                 finishActionMode();
             } else {
+                FragmentActivity activity = getActivity();
+                if (activity == null) {
+                    return;
+                }
                 if (mActionMode == null) {
-                    ((AppCompatActivity) getActivity()).startSupportActionMode(new ActionModeCallback());
+                    ((AppCompatActivity) activity).startSupportActionMode(new ActionModeCallback());
                 }
                 updateActionModeTitle();
             }


### PR DESCRIPTION
Fixes #11215

This PR fixes a NPE in PhotoPicker that happens when the activity is no longer present when we're trying to set the action mode. 

To test:
* There is nothing to test here, the fix is very simple

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
