### PR TITLE
[Site Creation] Step 2: Remove site title and tagline in site creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -34,8 +34,6 @@ const val KEY_SITE_CREATION_STATE = "key_site_creation_state"
 @SuppressLint("ParcelCreator")
 data class SiteCreationState(
     val segmentId: Long? = null,
-    val siteTitle: String? = null,
-    val siteTagLine: String? = null,
     val domain: String? = null
 ) : WizardState, Parcelable
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -155,7 +155,6 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
 
     companion object {
         const val TAG = "site_creation_domains_fragment_tag"
-        const val EXTRA_SITE_TITLE = "extra_site_title"
         private const val EXTRA_SEGMENT_ID = "extra_segment_id"
 
         fun newInstance(screenTitle: String, segmentId: Long): SiteCreationDomainsFragment {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -121,8 +121,6 @@ class SitePreviewViewModel @Inject constructor(
             siteCreationState.apply {
                 val serviceData = SiteCreationServiceData(
                         segmentId,
-                        siteTitle,
-                        siteTagLine,
                         urlWithoutScheme
                 )
                 _startCreateSiteService.value = SitePreviewStartServiceData(serviceData, previousState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceData.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceData.kt
@@ -8,7 +8,5 @@ import kotlinx.android.parcel.Parcelize
 @SuppressLint("ParcelCreator")
 data class SiteCreationServiceData(
     val segmentId: Long?,
-    val siteTitle: String?,
-    val siteTagLine: String?,
     val domain: String
 ) : Parcelable

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManager.kt
@@ -100,7 +100,7 @@ class SiteCreationServiceManager @Inject constructor(
         launch {
             AppLog.i(
                     T.SITE_CREATION,
-                    "Dispatching Create Site Action, title: ${siteData.siteTitle}, SiteName: ${siteData.domain}"
+                    "Dispatching Create Site Action, SiteName: ${siteData.domain}"
             )
             val createSiteEvent: OnNewSiteCreated
             try {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
@@ -50,11 +50,9 @@ class CreateSiteUseCase @Inject constructor(
         return suspendCoroutine { cont ->
             val newSitePayload = NewSitePayload(
                     domain,
-                    siteData.siteTitle ?: "",
                     languageWordPressId,
                     siteVisibility,
                     siteData.segmentId,
-                    siteData.siteTagLine,
                     dryRun
             )
             continuation = cont

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
@@ -26,8 +26,6 @@ import org.wordpress.android.util.UrlUtilsWrapper
 
 private val DUMMY_SITE_DATA: SiteCreationServiceData = SiteCreationServiceData(
         123,
-        "title",
-        "tagLine",
         "slug"
 )
 private const val LANGUAGE_ID = "lang_id"
@@ -70,9 +68,7 @@ class CreateSiteUseCaseTest {
         assertThat(captor.value.payload).isInstanceOf(NewSitePayload::class.java)
         val payload = captor.value.payload as NewSitePayload
         assertThat(payload.siteName).isEqualTo(DUMMY_SITE_DATA.domain)
-        assertThat(payload.siteTitle).isEqualTo(DUMMY_SITE_DATA.siteTitle)
         assertThat(payload.segmentId).isEqualTo(DUMMY_SITE_DATA.segmentId)
-        assertThat(payload.tagLine).isEqualTo(DUMMY_SITE_DATA.siteTagLine)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -47,7 +47,7 @@ private const val DOMAIN = ".wordpress.com"
 private const val URL = "$SUB_DOMAIN$DOMAIN"
 private const val REMOTE_SITE_ID = 1L
 private const val LOCAL_SITE_ID = 2
-private val SITE_CREATION_STATE = SiteCreationState(1, null, null, URL)
+private val SITE_CREATION_STATE = SiteCreationState(1, URL)
 
 @InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManagerTest.kt
@@ -33,8 +33,6 @@ private const val NEW_SITE_REMOTE_ID = 1234L
 
 private val DUMMY_SITE_DATA: SiteCreationServiceData = SiteCreationServiceData(
         123,
-        "title",
-        "tagLine",
         "slug"
 )
 

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '71bc264dac84f9b5361a012c0f7e5c1318ac7fda'
+    fluxCVersion = 'd4d23eec4849ab796900ab25c6954e1e749669ca'
 }
 
 // Onboarding and dev env setup tasks


### PR DESCRIPTION
This PR removes site title and tagline params in site creation as part of #11420 and #11421.

PR in FluxC - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1514

P.S. Review after #11440 is merged to the Master PR.

**To test:** 

- Go to My site
- Click Switch Site
- Click "+" button to launch Add new site
- Click Create WordPress.com site on Add new site
- Choose a segment Blog/Business/Professional/Blank Canvas to open domains step
- Search a valid domain and select one
- Click Create Site button to create a new site
- Verify `siteTitle` is not sent as `blog_title`, and `siteTagLine` is not sent as `site_tagline` in options parameter in `/sites/new` request from Stetho

<img width="627" alt="new_site_without_site_title" src="https://user-images.githubusercontent.com/1405144/76736032-201bda00-678c-11ea-9d46-548c2bce4f83.png">

- Verify new site is created successfully with "Site Title" site title, blank tag line. 

[Click OK on "Your site has been created" and delete above test site from My Site -> Settings.]

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
