### PR TITLE
Fix crash on multiple tab selection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -882,8 +882,6 @@ public class ReaderPostListFragment extends Fragment
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.reader_fragment_post_cards, container, false);
         mRecyclerView = rootView.findViewById(R.id.reader_recycler_view);
 
-        Context context = container.getContext();
-
         mActionableEmptyView = rootView.findViewById(R.id.empty_custom_view);
 
         mRecyclerView.setLogT(AppLog.T.READER);
@@ -961,13 +959,13 @@ public class ReaderPostListFragment extends Fragment
         // add the item decoration (dividers) to the recycler, skipping the first item if the first
         // item is the tag toolbar (shown when viewing posts in followed tags) - this is to avoid
         // having the tag toolbar take up more vertical space than necessary
-        int spacingHorizontal = context.getResources().getDimensionPixelSize(R.dimen.reader_card_margin);
-        int spacingVertical = context.getResources().getDimensionPixelSize(R.dimen.reader_card_gutters);
+        int spacingHorizontal = getResources().getDimensionPixelSize(R.dimen.reader_card_margin);
+        int spacingVertical = getResources().getDimensionPixelSize(R.dimen.reader_card_gutters);
         mRecyclerView.addItemDecoration(new RecyclerItemDecoration(spacingHorizontal, spacingVertical, false));
 
         // the following will change the look and feel of the toolbar to match the current design
-        mRecyclerView.setToolbarBackgroundColor(ContextCompat.getColor(context, R.color.primary));
-        mRecyclerView.setToolbarSpinnerTextColor(ContextCompat.getColor(context, android.R.color.white));
+        mRecyclerView.setToolbarBackgroundColor(ContextCompat.getColor(getContext(), R.color.primary));
+        mRecyclerView.setToolbarSpinnerTextColor(ContextCompat.getColor(getContext(), android.R.color.white));
         mRecyclerView.setToolbarSpinnerDrawable(R.drawable.ic_dropdown_primary_30_24dp);
 
         if (mIsTopLevel) {


### PR DESCRIPTION
Fixes #11204

This used to happen because we were using wrong context (on a view that didn't exist any more). I've changed the logic to use the context that should be always present in the fragment.

To test:
* Open the app
* Try to click randomly on multiple tabs
* The app doesn't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
