### PR TITLE
Fix crash when user creates a site after trying to sign up with an existing Google account

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -224,7 +224,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         switch (getLoginMode()) {
             case FULL:
             case WPCOM_LOGIN_ONLY:
-                if (!mSiteStore.hasSite() && AppPrefs.shouldShowPostSignupInterstitial()) {
+                if (!mSiteStore.hasSite() && AppPrefs.shouldShowPostSignupInterstitial() && !doLoginUpdate) {
                     ActivityLauncher.showPostSignupInterstitial(this);
                 } else {
                     ActivityLauncher.showMainActivityAndLoginEpilogue(this, oldSitesIds, doLoginUpdate);


### PR DESCRIPTION
Fixes #11394

For more context around this issue, you can read [this comment](https://github.com/wordpress-mobile/WordPress-Android/issues/11394#issuecomment-598881692).

## To test

0. Use a Google account to create a new WordPress.com account and make sure you **don't** create any sites with it.
1. Clear app data.
2. On the initial screen, tap _**Sign up for WordPress.com**_ and then _**Sign up with Google**_.
3. Notice the Google account picker dialog.
4. Pick a Google account that **already has** a WordPress.com account associated with it.
5. Notice the Post-Signup Interstitial screen.
6. Tap _**Create WordPress.com Site**_.
7. Skip the next two steps.
8. Choose a domain name and tap _**Create Site**_.
9. Verify that the site preview is displayed correctly.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
