### PR TITLE
Align method signature to account for null possible values.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTableWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTableWrapper.kt
@@ -6,6 +6,6 @@ import javax.inject.Inject
 class ReaderBlogTableWrapper
 @Inject constructor() {
     fun getFollowedBlogs(): List<ReaderBlog> = ReaderBlogTable.getFollowedBlogs()!!
-    fun getBlogInfo(blogId: Long): ReaderBlog = ReaderBlogTable.getBlogInfo(blogId)
-    fun getFeedInfo(feedId: Long): ReaderBlog = ReaderBlogTable.getFeedInfo(feedId)
+    fun getBlogInfo(blogId: Long): ReaderBlog? = ReaderBlogTable.getBlogInfo(blogId)
+    fun getFeedInfo(feedId: Long): ReaderBlog? = ReaderBlogTable.getFeedInfo(feedId)
 }


### PR DESCRIPTION
Fixes #11448 

This PR corrects the `getBlogInfo` and the `getFeedInfo` return value signature in `ReaderBlogTableWrapper` since they were wrongly put as not nullable even if the static relevant methods in `ReaderBlogTable` can return null under some conditions.

### To Reproduce
- Before applying the current patch use develop, go to the reader and select a site from the subfilter
- Close and open the app to verify that the correct subfilter is restored
- Place the following breakpoint in the AS (ReaderBlogTable.getBlogId) to force a null return value 
<p align="center">
  <img width="500" src=https://user-images.githubusercontent.com/47797566/76780879-0be8d480-67ae-11ea-9edc-ab654d7ef4e5.png>
</p>

- Start a debug session and check the issue is reproduced in logcat

### To Test
- Using this PR code repeat the above steps and check that the Filter is set to the default state (no filter selected) and no crash occurs
- Smock test the reader that should behave as normal


### Note
Track currently reports 1.5M users with 14.3 app version and current impact in sentry is 1 user, so I'm merging the fix toward develop and monitor the sentry stats in case this value changes. cc @designsimply in case I'm getting the above numbers wrong.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
