### PR TITLE
Issue/material insight management

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementAdapter.kt
@@ -35,7 +35,10 @@ class InsightsManagementAdapter : Adapter<InsightsManagementViewHolder>() {
     ) {
         val item = items[position]
         when (holder) {
-            is HeaderViewHolder -> holder.bind(item as Header)
+            is HeaderViewHolder -> holder.bind(
+                    item as Header,
+                    position == 0
+            )
             is InsightViewHolder -> holder.bind(
                     item as InsightModel,
                     payloads.firstOrNull() as? Payload

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementViewHolder.kt
@@ -34,7 +34,9 @@ sealed class InsightsManagementViewHolder(
             if (isTopHeader) {
                 lp.topMargin = itemView.context.resources.getDimensionPixelOffset(R.dimen.margin_extra_large)
             } else {
-                lp.topMargin = itemView.context.resources.getDimensionPixelOffset(R.dimen.margin_extra_extra_medium_large)
+                lp.topMargin = itemView.context.resources.getDimensionPixelOffset(
+                        R.dimen.margin_extra_extra_medium_large
+                )
             }
             itemView.layoutParams = lp
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementViewHolder.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.insights.managemen
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
@@ -27,8 +28,15 @@ sealed class InsightsManagementViewHolder(
     ) : InsightsManagementViewHolder(parent, R.layout.insights_management_header_item) {
         private val title: TextView = itemView.findViewById(R.id.itemTitle)
 
-        fun bind(insight: InsightListItem.Header) {
+        fun bind(insight: InsightListItem.Header, isTopHeader: Boolean) {
             title.setText(insight.text)
+            val lp = itemView.layoutParams as MarginLayoutParams
+            if (isTopHeader) {
+                lp.topMargin = itemView.context.resources.getDimensionPixelOffset(R.dimen.margin_extra_large)
+            } else {
+                lp.topMargin = itemView.context.resources.getDimensionPixelOffset(R.dimen.margin_extra_extra_medium_large)
+            }
+            itemView.layoutParams = lp
         }
     }
 

--- a/WordPress/src/main/res/layout/insights_management_header_item.xml
+++ b/WordPress/src/main/res/layout/insights_management_header_item.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/one_line_list_item_height">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/itemTitle"
         style="@style/InsightsManagementHeader"
+        android:paddingBottom="@dimen/margin_medium"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_extra_large"
-        android:layout_marginTop="@dimen/margin_large"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginBottom="@dimen/margin_large"
+        android:layout_centerVertical="true"
         android:ellipsize="end"
         android:lines="1"
-        android:minHeight="@dimen/margin_extra_large"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingStart="@dimen/margin_extra_large"
         android:textAlignment="viewStart"
         android:textSize="@dimen/text_sz_large"
         tools:text="@string/unknown" />
 
-</FrameLayout>
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/insights_management_list_item.xml
+++ b/WordPress/src/main/res/layout/insights_management_list_item.xml
@@ -1,32 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="@dimen/one_line_list_item_height"
-    android:background="@color/white">
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:orientation="vertical">
 
-    <FrameLayout
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/itemTitle"
+        style="@style/InsightsManagementItem"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="?attr/selectableItemBackground"
-        android:id="@+id/container"
-        android:clickable="true"
-        android:focusable="true">
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/divider"
+        android:layout_alignParentTop="true"
+        android:ellipsize="end"
+        android:gravity="center_vertical"
+        android:lines="1"
+        android:minHeight="@dimen/margin_extra_large"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingStart="@dimen/margin_extra_large"
+        tools:text="@string/unknown" />
 
-        <TextView
-            android:id="@+id/itemTitle"
-            style="@style/InsightsManagementItem"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_extra_large"
-            android:layout_marginTop="@dimen/margin_large"
-            android:layout_marginEnd="@dimen/margin_extra_large"
-            android:layout_marginBottom="@dimen/margin_large"
-            android:ellipsize="end"
-            android:lines="1"
-            android:minHeight="@dimen/margin_extra_large"
-            android:textAlignment="viewStart"
-            android:textSize="@dimen/text_sz_large"
-            tools:text="@string/unknown" />
-    </FrameLayout>
-</FrameLayout>
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/divider_size"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:background="?android:listDivider" />
+
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/insights_management_list_item.xml
+++ b/WordPress/src/main/res/layout/insights_management_list_item.xml
@@ -22,6 +22,7 @@
         android:minHeight="@dimen/margin_extra_large"
         android:paddingEnd="@dimen/margin_extra_large"
         android:paddingStart="@dimen/margin_extra_large"
+        android:textAlignment="viewStart"
         tools:text="@string/unknown" />
 
     <View

--- a/WordPress/src/main/res/layout/insights_management_list_item.xml
+++ b/WordPress/src/main/res/layout/insights_management_list_item.xml
@@ -17,7 +17,7 @@
         android:layout_above="@+id/divider"
         android:layout_alignParentTop="true"
         android:ellipsize="end"
-        android:gravity="center_vertical"
+        android:gravity="start|center_vertical"
         android:lines="1"
         android:minHeight="@dimen/margin_extra_large"
         android:paddingEnd="@dimen/margin_extra_large"

--- a/WordPress/src/main/res/values/stats_styles.xml
+++ b/WordPress/src/main/res/values/stats_styles.xml
@@ -334,12 +334,9 @@
         <item name="android:textColor">@color/gray_50</item>
     </style>
 
-    <style name="InsightsManagementHeader" parent="TextAppearance.AppCompat.Body2">
-        <item name="android:textColor">@color/neutral_50</item>
-        <item name="android:textSize">@dimen/text_sz_medium</item>
+    <style name="InsightsManagementHeader" parent="TextAppearance.MaterialComponents.Subtitle2">
+        <item name="android:textColor">?attr/colorAccent</item>
     </style>
 
-    <style name="InsightsManagementItem" parent="TextAppearance.AppCompat.Body1">
-        <item name="android:textSize">@dimen/text_sz_large</item>
-    </style>
+    <style name="InsightsManagementItem" parent="TextAppearance.MaterialComponents.Body1" />
 </resources>


### PR DESCRIPTION
New insight management was merged just recently, so I'm updating its look to match the material theme, according to the mock provided by @mattmiklic:

<img width="595" alt="mock" src="https://user-images.githubusercontent.com/728822/76848272-a1ad4f80-6800-11ea-8555-5da08f0a8d01.png">

Here is the result:

[![Image from Gyazo](https://i.gyazo.com/0f01bcda39e376d6e3958905a39ce94f.png)](https://gyazo.com/0f01bcda39e376d6e3958905a39ce94f)

To test:
- Check stats insight management and make sure it looks like the mock.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
