### PR TITLE
Check user rights to create content to give access to main bottom sheet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -9,7 +9,6 @@ import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import androidx.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.ABOVE
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.BELOW

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPTooltipView.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.LayoutRes
+import androidx.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.ABOVE
 import org.wordpress.android.ui.WPTooltipView.TooltipPosition.BELOW
@@ -41,6 +42,7 @@ class WPTooltipView @JvmOverloads constructor (
     private var arrowHorizontalOffsetFromEnd = -1
     private var arrowHorizontalOffsetFromStart = -1
     private var animationDuration: Int
+    private var tvMessage: TextView
 
     init {
         attrs?.also {
@@ -69,7 +71,7 @@ class WPTooltipView @JvmOverloads constructor (
 
         inflate(getContext(), position.layout, this)
         val root = findViewById<LinearLayout>(R.id.root_view)
-        val tvMessage = findViewById<TextView>(R.id.tooltip_message)
+        tvMessage = findViewById(R.id.tooltip_message)
         val arrow = findViewById<View>(R.id.tooltip_arrow)
         animationDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
 
@@ -116,6 +118,8 @@ class WPTooltipView @JvmOverloads constructor (
     }
 
     fun show() {
+        if (visibility == View.VISIBLE) return
+
         this.postDelayed({
             this.apply {
                 alpha = 0f
@@ -140,5 +144,9 @@ class WPTooltipView @JvmOverloads constructor (
                         }
                     })
         }
+    }
+
+    fun setMessage(message: CharSequence) {
+        tvMessage.text = message
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainFabUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainFabUiState.kt
@@ -1,6 +1,9 @@
 package org.wordpress.android.ui.main
 
+import androidx.annotation.StringRes
+
 data class MainFabUiState(
     val isFabVisible: Boolean,
-    val isFabTooltipVisible: Boolean
+    val isFabTooltipVisible: Boolean,
+    @StringRes val CreateContentMessageId: Int
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -416,7 +416,12 @@ public class WPMainActivity extends AppCompatActivity implements
         });
 
         mFloatingActionButton.setOnClickListener(v -> {
-            mViewModel.setIsBottomSheetShowing(true);
+            SiteModel site = getSelectedSite();
+
+            mViewModel.onFabClicked(
+                    site != null
+                    && (site.isSelfHostedAdmin() || site.getHasCapabilityEditPages())
+            );
         });
 
         mFloatingActionButton.setOnLongClickListener(v -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -391,11 +391,17 @@ public class WPMainActivity extends AppCompatActivity implements
 
         // Setup Observers
         mViewModel.getFabUiState().observe(this, fabUiState -> {
+            String message = getResources().getString(fabUiState.getCreateContentMessageId());
+
+            mFabTooltip.setMessage(message);
+
             if (fabUiState.isFabTooltipVisible()) {
                 mFabTooltip.show();
             } else {
                 mFabTooltip.hide();
             }
+
+            mFloatingActionButton.setContentDescription(message);
 
             if (fabUiState.isFabVisible()) {
                 mFloatingActionButton.show();
@@ -416,27 +422,27 @@ public class WPMainActivity extends AppCompatActivity implements
         });
 
         mFloatingActionButton.setOnClickListener(v -> {
-            SiteModel site = getSelectedSite();
-
-            mViewModel.onFabClicked(
-                    site != null
-                    && (site.isSelfHostedAdmin() || site.getHasCapabilityEditPages())
-            );
+            mViewModel.onFabClicked(hasFullAccessToContent());
         });
 
         mFloatingActionButton.setOnLongClickListener(v -> {
             if (v.isHapticFeedbackEnabled()) {
                 v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
             }
-            mViewModel.onFabLongPressed();
-            Toast.makeText(v.getContext(), R.string.create_post_page_fab_tooltip, Toast.LENGTH_SHORT).show();
+            mViewModel.onFabLongPressed(hasFullAccessToContent());
+
+            int messageId = hasFullAccessToContent()
+                    ? R.string.create_post_page_fab_tooltip
+                    : R.string.create_post_page_fab_tooltip_contributors;
+
+            Toast.makeText(v.getContext(), messageId, Toast.LENGTH_SHORT).show();
             return true;
         });
 
         ViewUtilsKt.redirectContextClickToLongPressListener(mFloatingActionButton);
 
         mFabTooltip.setOnClickListener(v -> {
-            mViewModel.onTooltipTapped();
+            mViewModel.onTooltipTapped(hasFullAccessToContent());
         });
 
         mViewModel.isBottomSheetShowing().observe(this, event -> {
@@ -471,7 +477,10 @@ public class WPMainActivity extends AppCompatActivity implements
             });
         });
 
-        mViewModel.start(mSiteStore.hasSite() && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE);
+        mViewModel.start(
+                mSiteStore.hasSite() && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE,
+                hasFullAccessToContent()
+        );
     }
 
     private @Nullable String getAuthToken() {
@@ -702,6 +711,8 @@ public class WPMainActivity extends AppCompatActivity implements
         ProfilingUtils.dump();
         ProfilingUtils.stop();
 
+        mViewModel.onResume(hasFullAccessToContent());
+
         mFirstResume = false;
     }
 
@@ -765,7 +776,10 @@ public class WPMainActivity extends AppCompatActivity implements
             }
         }
 
-        mViewModel.onPageChanged(mSiteStore.hasSite() && pageType == PageType.MY_SITE);
+        mViewModel.onPageChanged(
+                mSiteStore.hasSite() && pageType == PageType.MY_SITE,
+                hasFullAccessToContent()
+        );
     }
 
     // user tapped the new post button in the bottom navbar
@@ -1383,6 +1397,10 @@ public class WPMainActivity extends AppCompatActivity implements
             mQuickStartSnackbar.dismiss();
             mQuickStartSnackbar = null;
         }
+    }
+
+    private boolean hasFullAccessToContent() {
+        return SiteUtils.hasFullAccessToContent(getSelectedSite());
     }
 
     // We dismiss the QuickStart SnackBar every time activity is paused because

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -301,4 +301,8 @@ public class SiteUtils {
     public static boolean hasCustomDomain(@NonNull SiteModel site) {
         return !site.getUrl().contains(".wordpress.com");
     }
+
+    public static boolean hasFullAccessToContent(@Nullable SiteModel site) {
+        return site != null && (site.isSelfHostedAdmin() || site.getHasCapabilityEditPages());
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -138,7 +138,7 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
         _fabUiState.value = newState
     }
 
-    private fun getCreateContentMessageId(hasFullAccessToContent: Boolean) : Int {
+    private fun getCreateContentMessageId(hasFullAccessToContent: Boolean): Int {
         return if (hasFullAccessToContent)
             R.string.create_post_page_fab_tooltip
         else

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -89,6 +89,10 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
         appPrefsWrapper.setMainFabTooltipDisabled(true)
         setMainFabUiState(true)
 
+        // Currently this bottom sheet has only 2 options.
+        // We should evaluate to re-introduce the bottom sheet also for users without full access to content
+        // if user has at least 2 options (eventually filtering the content not accessible like pages in this case)
+        // See p5T066-1cA-p2/#comment-4463
         if (hasFullAccessToContent) {
             _isBottomSheetShowing.value = Event(true)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -85,11 +85,15 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
         }
     }
 
-    fun setIsBottomSheetShowing(showing: Boolean) {
+    fun onFabClicked(hasFullAccessToContent: Boolean) {
         appPrefsWrapper.setMainFabTooltipDisabled(true)
         setMainFabUiState(true)
 
-        _isBottomSheetShowing.value = Event(showing)
+        if (hasFullAccessToContent) {
+            _isBottomSheetShowing.value = Event(true)
+        } else {
+            _createAction.postValue(CREATE_NEW_POST)
+        }
     }
 
     fun onPageChanged(showFab: Boolean) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2604,6 +2604,7 @@
     <string name="web_preview_desktop">Desktop</string>
 
     <string name="create_post_page_fab_tooltip">Create a post or page</string>
+    <string name="create_post_page_fab_tooltip_contributors">Create a post</string>
 
     <!-- News Card -->
     <!-- When announcing a new feature, add new strings and make sure to update LocalNewsItem.kt -->

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -64,9 +64,17 @@ class WPMainActivityViewModelTest {
     }
 
     @Test
+    fun `fab tooltip disabled when user without full access to content uses the fab`() {
+        whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(true)
+        viewModel.onFabClicked(false)
+        verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
+        assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
+    }
+
+    @Test
     fun `fab tooltip disabled when bottom sheet opened`() {
         whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(true)
-        viewModel.setIsBottomSheetShowing(true)
+        viewModel.onFabClicked(true)
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
@@ -92,6 +100,20 @@ class WPMainActivityViewModelTest {
         assertThat(action).isNotNull
         action.onClickAction?.invoke(CREATE_NEW_PAGE)
         assertThat(viewModel.createAction.value).isEqualTo(CREATE_NEW_PAGE)
+    }
+
+    @Test
+    fun `bottom sheet is visualized when user has full access to content`() {
+        viewModel.onFabClicked(hasFullAccessToContent = true)
+        assertThat(viewModel.createAction.value).isNull()
+        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isEqualTo(true)
+    }
+
+    @Test
+    fun `new post action is triggered from FAB when user has not full access to content`() {
+        viewModel.onFabClicked(hasFullAccessToContent = false)
+        assertThat(viewModel.isBottomSheetShowing.value).isNull()
+        assertThat(viewModel.createAction.value).isEqualTo(CREATE_NEW_POST)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -10,6 +10,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
@@ -29,36 +30,36 @@ class WPMainActivityViewModelTest {
     fun setUp() {
         whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(false)
         viewModel = WPMainActivityViewModel(appPrefsWrapper)
-        viewModel.start(true)
+        viewModel.start(isFabVisible = true, hasFullAccessToContent = true)
     }
 
     @Test
     fun `fab visible when asked`() {
-        viewModel.onPageChanged(true)
+        viewModel.onPageChanged(showFab = true, hasFullAccessToContent = true)
         assertThat(viewModel.fabUiState.value?.isFabVisible).isEqualTo(true)
     }
 
     @Test
     fun `fab hidden when asked`() {
-        viewModel.onPageChanged(false)
+        viewModel.onPageChanged(showFab = false, hasFullAccessToContent = true)
         assertThat(viewModel.fabUiState.value?.isFabVisible).isEqualTo(false)
     }
 
     @Test
     fun `fab tooltip visible when asked`() {
-        viewModel.onPageChanged(true)
+        viewModel.onPageChanged(showFab = true, hasFullAccessToContent = true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(true)
     }
 
     @Test
     fun `fab tooltip hidden when asked`() {
-        viewModel.onPageChanged(false)
+        viewModel.onPageChanged(showFab = false, hasFullAccessToContent = true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
 
     @Test
     fun `fab tooltip disabled when tapped`() {
-        viewModel.onTooltipTapped()
+        viewModel.onTooltipTapped(true)
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
@@ -81,7 +82,7 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `fab tooltip disabled when fab long pressed`() {
-        viewModel.onFabLongPressed()
+        viewModel.onFabLongPressed(true)
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
@@ -121,5 +122,18 @@ class WPMainActivityViewModelTest {
         viewModel.onOpenLoginPage()
 
         assertThat(viewModel.startLoginFlow.value!!.peekContent()).isEqualTo(true)
+    }
+
+    @Test
+    fun `onResume set expected content message when user has full access to content`() {
+        viewModel.onResume(true)
+        assertThat(viewModel.fabUiState.value!!.CreateContentMessageId).isEqualTo(R.string.create_post_page_fab_tooltip)
+    }
+
+    @Test
+    fun `onResume set expected content message when user has not full access to content`() {
+        viewModel.onResume(false)
+        assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
+                .isEqualTo(R.string.create_post_page_fab_tooltip_contributors)
     }
 }


### PR DESCRIPTION
Fixes #11388

When a user is an Author/Contributor of a site we already remove the access to pages in My Site screen (both Quick Action and List row item):

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/76911198-80a43780-68b0-11ea-9669-399819b6e370.png>
</p>

This PR extends that check also to the FAB opening directly the Editor for post creation when a user is a User/Contributor (or not a Self-Hosted site Admin).

cc FYI @rachelmcr and  @designsimply.

## To test:
In the following the test must be repeated both with a WP.com and a Self-Hosted site.

- Add a user with Author/Contributor role to a site (you can do it for example from the web)
- Login in the app with that user and switch to the site
- Note that pages access are removed like the image above
- Tap on the Fab and check you get the editor opened for post editing
- Create the post and publish it; note you get it published in the posts list
- Change the User role to be an Editor/Administrator (you can do it for example from the web)
- Restart the app and check the desired site is selected
- Note you now have access to pages content
- Tap on the Fab and check you get the bottom sheet for post/page creation
- Test you can create both post and page and get it uploaded and reported in the post/page lists
- Clean the app cache and login again to show the FAB tooltip. Check that on a site with Editor/Administrator rights you get `Create a post or page` message where on a site with Author/Contributor rights you get `Create a post` message.
- Long press on the FAB to get a toast. Check that on a site with Editor/Administrator rights you get `Create a post or page` message where on a site with Author/Contributor rights you get `Create a post` message.
- Use Talkback to get the description of the FAB. Check that on a site with Editor/Administrator rights you get `Create a post or page` message where on a site with Author/Contributor rights you get `Create a post` message.

Hi @osullivanchris 👋, if you want/can have a look into it I think you can use the apk generated in this PR for checking.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
