### PR TITLE
Update release notes for offline pages

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,9 @@
 14.5
 -----
 * Removes sections from post search results
- 
+* Page List: Unsaved changes are automatically backed up on all devices. On page opening, the app will let you choose which version you prefer.
+* Page List: Minor design improvements
+
 14.4
 -----
 * Fix an issue where image is sometimes uploaded with a path to local storage

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/AutoSavePostIfNotDraftUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/AutoSavePostIfNotDraftUseCaseTest.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
 import org.wordpress.android.ui.uploads.AutoSavePostIfNotDraftResult
 import org.wordpress.android.ui.uploads.AutoSavePostIfNotDraftUseCase
 import org.wordpress.android.ui.uploads.OnAutoSavePostIfNotDraftCallback
-import java.lang.IllegalArgumentException
 import java.lang.reflect.Constructor
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -160,7 +159,7 @@ class AutoSavePostIfNotDraftUseCaseTest {
     }
 
     private fun createOnPostChangedEvent(post: PostModel, error: PostError? = null): OnPostChanged {
-        val event = OnPostChanged(CauseOfOnPostChanged.RemoteAutoSavePost(post.id), 0)
+        val event = OnPostChanged(CauseOfOnPostChanged.RemoteAutoSavePost(post.id, post.remotePostId), 0)
         error?.let { event.error = it }
         return event
     }


### PR DESCRIPTION
Updated release notes for offline pages. Feel free to modify the text anyway you like :). I basically just copied the release notes from "Offline posts".

To test:
- no need to test anything

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
