### PR TITLE
Apply an unelevated card style to stats cards

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ManagementControlUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/ManagementControlUseCase.kt
@@ -41,6 +41,7 @@ class ManagementControlUseCase
                         icon = R.drawable.ic_plus_white_24dp,
                         textResource = R.string.stats_management_add_new_stats_card,
                         navigationAction = Companion.create(this::onClick),
+                        showDivider = false,
                         contentDescription = resourceProvider.getString(R.string.stats_management_add_new_stats_card)
                 )
         )

--- a/WordPress/src/main/res/color/on_surface_divider.xml
+++ b/WordPress/src/main/res/color/on_surface_divider.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.12" android:color="?attr/colorOnSurface" />
+</selector>

--- a/WordPress/src/main/res/layout/stats_list_block.xml
+++ b/WordPress/src/main/res/layout/stats_list_block.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/stats_block_list"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/WordPress.CardView.Unelevated"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" />
+    android:layout_height="wrap_content">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/stats_block_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/layout/stats_loading_view.xml
+++ b/WordPress/src/main/res/layout/stats_loading_view.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.facebook.shimmer.ShimmerFrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/StatsLoadingBlock"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/WordPress.CardView.Unelevated"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:animateLayoutChanges="false">
+    android:layout_height="wrap_content">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/stats_block_list"
-        android:contentDescription="@string/stats_loading_card"
+    <com.facebook.shimmer.ShimmerFrameLayout
+        style="@style/StatsLoadingBlock"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-</com.facebook.shimmer.ShimmerFrameLayout>
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="false">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/stats_block_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/stats_loading_card" />
+    </com.facebook.shimmer.ShimmerFrameLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/values-w528dp/dimens.xml
+++ b/WordPress/src/main/res/values-w528dp/dimens.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="stats_list_card_horizontal_spacing">8dp</dimen>
-    <dimen name="stats_list_card_top_spacing">4dp</dimen>
-    <dimen name="stats_list_card_bottom_spacing">4dp</dimen>
-    <dimen name="stats_list_card_first_spacing">8dp</dimen>
-    <dimen name="stats_list_card_last_spacing">8dp</dimen>
+    <dimen name="stats_list_card_top_spacing">8dp</dimen>
+    <dimen name="stats_list_card_bottom_spacing">8dp</dimen>
+    <dimen name="stats_list_card_first_spacing">16dp</dimen>
+    <dimen name="stats_list_card_last_spacing">16dp</dimen>
     <dimen name="stats_list_item_left_margin">48dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -476,4 +476,8 @@
     <dimen name="bottom_sheet_handle_width">32dp</dimen>
     <dimen name="bottom_sheet_handle_margin_top">4dp</dimen>
 
+    <!-- unelevated card -->
+    <dimen name="unelevated_card_elevation">0dp</dimen>
+    <dimen name="unelevated_card_stroke_width">1dp</dimen>
+
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -420,10 +420,10 @@
     <dimen name="stats_header_height">32dp</dimen>
     <dimen name="stats_bar_chart_height">180dp</dimen>
     <dimen name="stats_block_icon_size">24dp</dimen>
-    <dimen name="stats_list_card_horizontal_spacing">0dp</dimen>
-    <dimen name="stats_list_card_top_spacing">0dp</dimen>
-    <dimen name="stats_list_card_bottom_spacing">8dp</dimen>
-    <dimen name="stats_list_card_first_spacing">0dp</dimen>
+    <dimen name="stats_list_card_horizontal_spacing">4dp</dimen>
+    <dimen name="stats_list_card_top_spacing">4dp</dimen>
+    <dimen name="stats_list_card_bottom_spacing">4dp</dimen>
+    <dimen name="stats_list_card_first_spacing">8dp</dimen>
     <dimen name="stats_list_card_last_spacing">8dp</dimen>
     <dimen name="stats_list_item_left_margin">56dp</dimen>
     <dimen name="stats_activity_spacing">1dp</dimen>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -25,7 +25,7 @@
         <item name="appBarLayoutStyle">@style/WordPress.AppBarLayout</item>
 
         <!-- we can remove it after moving away from Bridge version of theme -->
-        <item name="materialCardViewStyle"> @style/Widget.MaterialComponents.CardView</item>
+        <item name="materialCardViewStyle">@style/Widget.MaterialComponents.CardView</item>
         <item name="floatingActionButtonStyle">@style/WordPress.FloatingActionButton</item>
 
         <item name="wpColorText">@color/neutral_70</item>
@@ -1096,6 +1096,14 @@
         <item name="android:paddingTop">@dimen/margin_large</item>
         <item name="android:paddingBottom">@dimen/margin_large</item>
         <item name="android:gravity">start</item>
+    </style>
+
+    <!-- Unelevated Card Style -->
+    <style name="WordPress.CardView.Unelevated" parent="@style/Widget.MaterialComponents.CardView">
+        <item name="cardElevation">@dimen/unelevated_card_elevation</item>
+        <item name="strokeColor">@color/on_surface_divider</item>
+        <item name="strokeWidth">@dimen/unelevated_card_stroke_width</item>
+        <item name="contentPadding">@dimen/unelevated_card_stroke_width</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Fixes #11468

This PR creates a new unelevated card style and applies it to the stats cards.

| Phone (Light) | Phone (Dark) |
|---|---|
|![phone-light](https://user-images.githubusercontent.com/830056/77019551-9fadd280-695f-11ea-92c3-0c00a62b1426.jpeg)|![phone-dark](https://user-images.githubusercontent.com/830056/77019548-9d4b7880-695f-11ea-9faa-df5f8062bd2e.jpeg)|

| Tablet (Light) | Tablet (Dark) |
|---|---|
|![tablet-light](https://user-images.githubusercontent.com/830056/77019681-10ed8580-6960-11ea-81f0-08d3092f164d.jpeg)|![tablet-dark](https://user-images.githubusercontent.com/830056/77019679-0f23c200-6960-11ea-81f0-d32e2224f66b.jpeg)|

## To test

Open the stats screen on a tablet and make sure it looks like the provided mockup (in the linked issue). Test on both light and dark modes.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.