### PR TITLE
Offline Support : Post List - Fix Upload Status Cache issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -132,7 +132,6 @@ class PostListFragment : Fragment() {
         // since the MainViewModel has been already started, we need to manually update the authorFilterSelection value
         viewModel.start(
                 postListViewModelConnector,
-                mainViewModel.uploadStatusTracker,
                 mainViewModel.authorSelectionUpdated.value!!,
                 photonWidth = displayWidth - contentSpacing * 2,
                 photonHeight = nonNullActivity.resources.getDimensionPixelSize(R.dimen.reader_featured_image_height)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -132,6 +132,7 @@ class PostListFragment : Fragment() {
         // since the MainViewModel has been already started, we need to manually update the authorFilterSelection value
         viewModel.start(
                 postListViewModelConnector,
+                mainViewModel.uploadStatusTracker,
                 mainViewModel.authorSelectionUpdated.value!!,
                 photonWidth = displayWidth - contentSpacing * 2,
                 photonHeight = nonNullActivity.resources.getDimensionPixelSize(R.dimen.reader_featured_image_height)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -134,7 +134,7 @@ class PostListMainViewModel @Inject constructor(
     private val _searchQuery = MutableLiveData<String>()
     val searchQuery: LiveData<String> = _searchQuery
 
-    private val uploadStatusTracker = PostModelUploadStatusTracker(
+    val uploadStatusTracker = PostModelUploadStatusTracker(
             uploadStore = uploadStore,
             uploadActionUseCase = uploadActionUseCase
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -134,7 +134,7 @@ class PostListMainViewModel @Inject constructor(
     private val _searchQuery = MutableLiveData<String>()
     val searchQuery: LiveData<String> = _searchQuery
 
-    val uploadStatusTracker = PostModelUploadStatusTracker(
+    private val uploadStatusTracker = PostModelUploadStatusTracker(
             uploadStore = uploadStore,
             uploadActionUseCase = uploadActionUseCase
     )
@@ -272,7 +272,7 @@ class PostListMainViewModel @Inject constructor(
                 site = site,
                 postListType = postListType,
                 postActionHandler = postActionHandler,
-                getUploadStatus = uploadStatusTracker::getUploadStatus,
+                uploadStatusTracker = uploadStatusTracker,
                 doesPostHaveUnhandledConflict = postConflictResolver::doesPostHaveUnhandledConflict,
                 hasAutoSave = postConflictResolver::hasUnhandledAutoSave,
                 postFetcher = postFetcher,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -70,7 +70,6 @@ class PostListViewModel @Inject constructor(
     private val uploadStarter: UploadStarter,
     private val readerUtilsWrapper: ReaderUtilsWrapper,
     private val uploadUtilsWrapper: UploadUtilsWrapper,
-    private val uploadStatusTracker: PostModelUploadStatusTracker,
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     connectionStatus: LiveData<ConnectionStatus>
@@ -80,6 +79,7 @@ class PostListViewModel @Inject constructor(
     }
     private var isStarted: Boolean = false
     private lateinit var connector: PostListViewModelConnector
+    private lateinit var uploadStatusTracker: PostModelUploadStatusTracker
 
     private var photonWidth by Delegates.notNull<Int>()
     private var photonHeight by Delegates.notNull<Int>()
@@ -128,6 +128,7 @@ class PostListViewModel @Inject constructor(
 
     fun start(
         postListViewModelConnector: PostListViewModelConnector,
+        uploadStatusTracker: PostModelUploadStatusTracker,
         value: AuthorFilterSelection,
         photonWidth: Int,
         photonHeight: Int
@@ -138,6 +139,7 @@ class PostListViewModel @Inject constructor(
         this.photonHeight = photonHeight
         this.photonWidth = photonWidth
         connector = postListViewModelConnector
+        this.uploadStatusTracker = uploadStatusTracker
 
         isStarted = true
         lifecycleRegistry.markState(Lifecycle.State.STARTED)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -33,7 +33,6 @@ import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.ui.posts.PostListType.SEARCH
-import org.wordpress.android.ui.posts.PostModelUploadStatusTracker
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.posts.trackPostListAction
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
@@ -79,7 +78,6 @@ class PostListViewModel @Inject constructor(
     }
     private var isStarted: Boolean = false
     private lateinit var connector: PostListViewModelConnector
-    private lateinit var uploadStatusTracker: PostModelUploadStatusTracker
 
     private var photonWidth by Delegates.notNull<Int>()
     private var photonHeight by Delegates.notNull<Int>()
@@ -128,7 +126,6 @@ class PostListViewModel @Inject constructor(
 
     fun start(
         postListViewModelConnector: PostListViewModelConnector,
-        uploadStatusTracker: PostModelUploadStatusTracker,
         value: AuthorFilterSelection,
         photonWidth: Int,
         photonHeight: Int
@@ -139,7 +136,6 @@ class PostListViewModel @Inject constructor(
         this.photonHeight = photonHeight
         this.photonWidth = photonWidth
         connector = postListViewModelConnector
-        this.uploadStatusTracker = uploadStatusTracker
 
         isStarted = true
         lifecycleRegistry.markState(Lifecycle.State.STARTED)
@@ -375,7 +371,7 @@ class PostListViewModel @Inject constructor(
                         trackPostListAction(connector.site, buttonType, postModel, statEvent)
                         connector.postActionHandler.handlePostButton(buttonType, postModel)
                     },
-                    uploadStatusTracker = uploadStatusTracker
+                    uploadStatusTracker = connector.uploadStatusTracker
             )
 
     private fun retryOnConnectionAvailableAfterRefreshError() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModelConnector.kt
@@ -4,15 +4,16 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.PostActionHandler
 import org.wordpress.android.ui.posts.PostListType
+import org.wordpress.android.ui.posts.PostModelUploadStatusTracker
 
 class PostListViewModelConnector(
     val site: SiteModel,
     val postListType: PostListType,
     val postActionHandler: PostActionHandler,
-    val getUploadStatus: (PostModel, SiteModel) -> PostListItemUploadStatus,
     val doesPostHaveUnhandledConflict: (PostModel) -> Boolean,
     val hasAutoSave: (PostModel) -> Boolean,
     val postFetcher: PostFetcher,
+    val uploadStatusTracker: PostModelUploadStatusTracker,
     private val getFeaturedImageUrl: (site: SiteModel, featuredImageId: Long) -> String?
 ) {
     fun getFeaturedImageUrl(featuredImageId: Long): String? {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/AutoSavePostIfNotDraftUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/AutoSavePostIfNotDraftUseCaseTest.kt
@@ -160,7 +160,7 @@ class AutoSavePostIfNotDraftUseCaseTest {
     }
 
     private fun createOnPostChangedEvent(post: PostModel, error: PostError? = null): OnPostChanged {
-        val event = OnPostChanged(CauseOfOnPostChanged.RemoteAutoSavePost(post.id), 0)
+        val event = OnPostChanged(CauseOfOnPostChanged.RemoteAutoSavePost(post.id, post.remotePostId), 0)
         error?.let { event.error = it }
         return event
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -63,8 +63,7 @@ class PostListViewModelTest : BaseUnitTest() {
                 connectionStatus = mock(),
                 uploadUtilsWrapper = mock(),
                 uiDispatcher = TEST_DISPATCHER,
-                bgDispatcher = TEST_DISPATCHER,
-                uploadStatusTracker = uploadStatusTracker
+                bgDispatcher = TEST_DISPATCHER
         )
     }
 
@@ -72,6 +71,7 @@ class PostListViewModelTest : BaseUnitTest() {
     fun `when swiping to refresh, it uploads all local drafts`() {
         viewModel.start(
                 createPostListViewModelConnector(site = site, postListType = DRAFTS),
+                uploadStatusTracker,
                 DEFAULT_AUTHOR_FILTER,
                 DEFAULT_PHOTON_DIMENSIONS,
                 DEFAULT_PHOTON_DIMENSIONS
@@ -88,6 +88,7 @@ class PostListViewModelTest : BaseUnitTest() {
     fun `empty search query should show search prompt`() {
         viewModel.start(
                 createPostListViewModelConnector(site = site, postListType = SEARCH),
+                uploadStatusTracker,
                 DEFAULT_AUTHOR_FILTER,
                 DEFAULT_PHOTON_DIMENSIONS,
                 DEFAULT_PHOTON_DIMENSIONS

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListViewModelTest.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.PostListType
 import org.wordpress.android.ui.posts.PostListType.DRAFTS
 import org.wordpress.android.ui.posts.PostListType.SEARCH
-import org.wordpress.android.ui.posts.PostModelUploadStatusTracker
 import org.wordpress.android.ui.uploads.UploadStarter
 
 private const val DEFAULT_PHOTON_DIMENSIONS = -9
@@ -30,7 +29,6 @@ private val DEFAULT_AUTHOR_FILTER = AuthorFilterSelection.EVERYONE
 class PostListViewModelTest : BaseUnitTest() {
     @Mock private lateinit var site: SiteModel
     @Mock private lateinit var uploadStarter: UploadStarter
-    @Mock private lateinit var uploadStatusTracker: PostModelUploadStatusTracker
 
     private lateinit var viewModel: PostListViewModel
 
@@ -71,7 +69,6 @@ class PostListViewModelTest : BaseUnitTest() {
     fun `when swiping to refresh, it uploads all local drafts`() {
         viewModel.start(
                 createPostListViewModelConnector(site = site, postListType = DRAFTS),
-                uploadStatusTracker,
                 DEFAULT_AUTHOR_FILTER,
                 DEFAULT_PHOTON_DIMENSIONS,
                 DEFAULT_PHOTON_DIMENSIONS
@@ -88,7 +85,6 @@ class PostListViewModelTest : BaseUnitTest() {
     fun `empty search query should show search prompt`() {
         viewModel.start(
                 createPostListViewModelConnector(site = site, postListType = SEARCH),
-                uploadStatusTracker,
                 DEFAULT_AUTHOR_FILTER,
                 DEFAULT_PHOTON_DIMENSIONS,
                 DEFAULT_PHOTON_DIMENSIONS
@@ -111,7 +107,7 @@ class PostListViewModelTest : BaseUnitTest() {
                 site = site,
                 postListType = postListType,
                 postActionHandler = mock(),
-                getUploadStatus = mock(),
+                uploadStatusTracker = mock(),
                 doesPostHaveUnhandledConflict = mock(),
                 hasAutoSave = mock(),
                 getFeaturedImageUrl = mock(),


### PR DESCRIPTION
Fixes #11471

## Findings
A new instance of `PostModelUploadStatusTracker` was being created in multiple components which resulted in out of sync caches. 

## Solution

Similarly to #11315, A single instance of `PostModelUploadStatusTracker` is being injected into PostListMainViewModel and all child VMs are utilizing it. This resolves the scoping issue and ensures the cache for all components are up to date. 
## Testing

1. Open Post list
2. Turn on airplane mode
3. Open/Create a post and add a media item
4. Click on Update/Publish
5. Find the post in the post list
6. Turn airplane mode off. 
7. Ensure the media upload progress is being shown.

-------------
1. Open Post list
2. Turn on airplane mode
3. Open a post and make changes
4. Click on Update/Publish
5. Find the post in the post list
6. Click on the "Cancel" action
7. Make sure the Cancel action disappears

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 