### PR TITLE
Fix image transparency issue

### DIFF
--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropFragment.kt
@@ -56,7 +56,7 @@ class CropFragment : Fragment(), UCropFragmentCallback {
     private fun initializeViewModels() {
         viewModel = ViewModelProvider(this).get(CropViewModel::class.java)
         setupObservers()
-        viewModel.start(navArgs.inputFilePath, requireContext().cacheDir)
+        viewModel.start(navArgs.inputFilePath, navArgs.outputFileExtension, requireContext().cacheDir)
     }
 
     private fun setupObservers() {

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.imageeditor.crop
 
 import android.app.Activity.RESULT_OK
 import android.content.Intent
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Bundle
 import androidx.lifecycle.LiveData
@@ -40,6 +41,14 @@ class CropViewModel : ViewModel() {
                 setFreeStyleCropEnabled(true)
                 setShowCropFrame(true)
                 setHideBottomControls(false)
+                setCompressionFormat(  // If not set, uCrop takes its default compress format: JPEG
+                    when {
+                        outputFileExtension.equals(PNG, ignoreCase = true) -> Bitmap.CompressFormat.PNG
+                        outputFileExtension.equals(WEBP, ignoreCase = true) -> Bitmap.CompressFormat.WEBP
+                        else -> Bitmap.CompressFormat.JPEG
+                    }
+                )
+                setCompressionQuality(COMPRESS_QUALITY_100) // If not set, uCrop takes its default compress quality: 90
             }
         }
     }
@@ -125,7 +134,10 @@ class CropViewModel : ViewModel() {
     }
 
     companion object {
-        const val IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME = "image_editor_output_image"
-        const val DEFAULT_FILE_EXTENSION = "jpg"
+        private const val IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME = "image_editor_output_image"
+        private const val DEFAULT_FILE_EXTENSION = "jpg"
+        private const val COMPRESS_QUALITY_100 = 100
+        private const val PNG = "png"
+        private const val WEBP = "webp"
     }
 }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
@@ -41,7 +41,8 @@ class CropViewModel : ViewModel() {
                 setFreeStyleCropEnabled(true)
                 setShowCropFrame(true)
                 setHideBottomControls(false)
-                setCompressionFormat(  // If not set, uCrop takes its default compress format: JPEG
+                // If not set, uCrop takes its default compress format: JPEG
+                setCompressionFormat(
                     when {
                         outputFileExtension.equals(PNG, ignoreCase = true) -> Bitmap.CompressFormat.PNG
                         outputFileExtension.equals(WEBP, ignoreCase = true) -> Bitmap.CompressFormat.WEBP

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
@@ -29,6 +29,7 @@ class CropViewModel : ViewModel() {
 
     private lateinit var cacheDir: File
     private lateinit var inputFilePath: String
+    private lateinit var outputFileExtension: String
     private var isStarted = false
 
     private val cropOptions by lazy {
@@ -46,18 +47,23 @@ class CropViewModel : ViewModel() {
         Bundle().also {
             with(it) {
                 putParcelable(UCrop.EXTRA_INPUT_URI, Uri.fromFile(File(inputFilePath)))
-                putParcelable(UCrop.EXTRA_OUTPUT_URI, Uri.fromFile(File(cacheDir, IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME)))
+                putParcelable(UCrop.EXTRA_OUTPUT_URI, Uri.fromFile(
+                            File(cacheDir,
+                            "$IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME.$outputFileExtension"
+                        )))
                 putAll(cropOptions.optionBundle)
             }
         }
     }
 
-    fun start(inputFilePath: String, cacheDir: File) {
+    fun start(inputFilePath: String, outputFileExtension: String?, cacheDir: File) {
         if (isStarted) {
             return
         }
         this.cacheDir = cacheDir
         this.inputFilePath = inputFilePath
+        this.outputFileExtension = outputFileExtension ?: DEFAULT_FILE_EXTENSION
+
         updateUiState(UiStartLoadingWithBundleState(cropOptionsBundleWithFilesInfo))
         isStarted = true
     }
@@ -118,6 +124,7 @@ class CropViewModel : ViewModel() {
     }
 
     companion object {
-        const val IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME = "image_editor_output_image.jpg"
+        const val IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME = "image_editor_output_image"
+        const val DEFAULT_FILE_EXTENSION = "jpg"
     }
 }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -27,6 +27,7 @@ class PreviewImageFragment : Fragment() {
     companion object {
         const val ARG_LOW_RES_IMAGE_URL = "arg_low_res_image_url"
         const val ARG_HIGH_RES_IMAGE_URL = "arg_high_res_image_url"
+        const val ARG_OUTPUT_FILE_EXTENSION = "arg_output_file_extension"
         const val PREVIEW_IMAGE_REDUCED_SIZE_FACTOR = 0.1
     }
 
@@ -46,10 +47,11 @@ class PreviewImageFragment : Fragment() {
     private fun initializeViewModels(nonNullIntent: Intent) {
         val lowResImageUrl = nonNullIntent.getStringExtra(ARG_LOW_RES_IMAGE_URL)
         val highResImageUrl = nonNullIntent.getStringExtra(ARG_HIGH_RES_IMAGE_URL)
+        val outputFileExtension = nonNullIntent.getStringExtra(ARG_OUTPUT_FILE_EXTENSION)
 
         viewModel = ViewModelProvider(this).get(PreviewImageViewModel::class.java)
         setupObservers()
-        viewModel.onCreateView(lowResImageUrl, highResImageUrl)
+        viewModel.onCreateView(lowResImageUrl, highResImageUrl, outputFileExtension)
     }
 
     private fun setupObservers() {
@@ -66,7 +68,7 @@ class PreviewImageFragment : Fragment() {
             }
         })
 
-        viewModel.navigateToCropScreenWithInputFilePath.observe(this, Observer { filePath ->
+        viewModel.navigateToCropScreenWithFileInfo.observe(this, Observer { filePath ->
             navigateToCropScreenWithInputFilePath(filePath)
         })
     }
@@ -104,9 +106,11 @@ class PreviewImageFragment : Fragment() {
         )
     }
 
-    private fun navigateToCropScreenWithInputFilePath(inputFilePath: String) {
+    private fun navigateToCropScreenWithInputFilePath(fileInfo: Pair<String, String?>) {
+        val inputFilePath = fileInfo.first
+        val outputFileExtension = fileInfo.second
         findNavController().navigate(
-            PreviewImageFragmentDirections.actionPreviewFragmentToCropFragment(inputFilePath)
+            PreviewImageFragmentDirections.actionPreviewFragmentToCropFragment(inputFilePath, outputFileExtension)
         )
     }
 }

--- a/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -20,10 +20,14 @@ class PreviewImageViewModel : ViewModel() {
     private val _loadIntoFile = MutableLiveData<ImageLoadToFileState>(ImageLoadToFileIdleState)
     val loadIntoFile: LiveData<ImageLoadToFileState> = _loadIntoFile
 
-    private val _navigateToCropScreenWithInputFilePath = MutableLiveData<String>()
-    val navigateToCropScreenWithInputFilePath: LiveData<String> = _navigateToCropScreenWithInputFilePath
+    private val _navigateToCropScreenWithFileInfo = MutableLiveData<Pair<String, String?>>()
+    val navigateToCropScreenWithFileInfo: LiveData<Pair<String, String?>> = _navigateToCropScreenWithFileInfo
 
-    fun onCreateView(loResImageUrl: String, hiResImageUrl: String) {
+    private var outputFileExtension: String? = null
+
+    fun onCreateView(loResImageUrl: String, hiResImageUrl: String, outputFileExtension: String?) {
+        this.outputFileExtension = outputFileExtension
+
         updateUiState(
             ImageDataStartLoadingUiState(
                 ImageData(loResImageUrl, hiResImageUrl)
@@ -70,7 +74,7 @@ class PreviewImageViewModel : ViewModel() {
 
     fun onLoadIntoFileSuccess(inputFilePath: String) {
         updateLoadIntoFileState(ImageLoadToFileSuccessState(inputFilePath))
-        _navigateToCropScreenWithInputFilePath.value = inputFilePath
+        _navigateToCropScreenWithFileInfo.value = Pair(inputFilePath, outputFileExtension)
     }
 
     fun onLoadIntoFileFailed() {

--- a/ImageEditor/src/main/res/navigation/nav_graph.xml
+++ b/ImageEditor/src/main/res/navigation/nav_graph.xml
@@ -17,6 +17,10 @@
                 android:name="inputFilePath"
                 app:argType="string"
                 android:defaultValue='""'/>
+            <argument
+                android:name="outputFileExtension"
+                app:argType="string"
+                app:nullable="true"/>
         </action>
     </fragment>
     <fragment
@@ -26,5 +30,9 @@
             android:name="inputFilePath"
             app:argType="string"
             android:defaultValue='""'/>
+        <argument
+            android:name="outputFileExtension"
+            app:argType="string"
+            app:nullable="true"/>
     </fragment>
 </navigation>

--- a/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/crop/CropViewModelTest.kt
+++ b/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/crop/CropViewModelTest.kt
@@ -16,6 +16,8 @@ import org.wordpress.android.imageeditor.crop.CropViewModel.UiState.UiStartLoadi
 import java.io.File
 
 private const val TEST_INPUT_IMAGE_PATH = "/input/file/path"
+private const val TEST_OUTPUT_FILE_EXTENSION = "jpg"
+
 class CropViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
@@ -89,5 +91,5 @@ class CropViewModelTest {
         assertThat(viewModel.cropAndSaveImageState.value).isInstanceOf(ImageCropAndSaveFailedState::class.java)
     }
 
-    private fun initViewModel() = viewModel.start(TEST_INPUT_IMAGE_PATH, cacheDir)
+    private fun initViewModel() = viewModel.start(TEST_INPUT_IMAGE_PATH, TEST_OUTPUT_FILE_EXTENSION, cacheDir)
 }

--- a/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiSt
 private const val TEST_LOW_RES_IMAGE_URL = "https://wordpress.com/low_res_image.png"
 private const val TEST_HIGH_RES_IMAGE_URL = "https://wordpress.com/image.png"
 private const val TEST_FILE_PATH = "/file/path"
+private const val TEST_OUTPUT_FILE_EXTENSION = ".jpg"
 
 class PreviewImageViewModelTest {
     @Rule
@@ -161,19 +162,25 @@ class PreviewImageViewModelTest {
     }
 
     @Test
-    fun `navigated to crop screen with input file path info on image load to file success`() {
+    fun `navigated to crop screen with file info on image load to file success`() {
         initViewModel()
         viewModel.onLoadIntoFileSuccess(TEST_FILE_PATH)
-        assertThat(requireNotNull(viewModel.navigateToCropScreenWithInputFilePath.value))
+        assertThat(requireNotNull(viewModel.navigateToCropScreenWithFileInfo.value).first)
                 .isEqualTo(TEST_FILE_PATH)
+        assertThat(requireNotNull(viewModel.navigateToCropScreenWithFileInfo.value).second)
+                .isEqualTo(TEST_OUTPUT_FILE_EXTENSION)
     }
 
     @Test
     fun `not navigated to crop screen on image load to file failure`() {
         initViewModel()
         viewModel.onLoadIntoFileFailed()
-        assertNull(viewModel.navigateToCropScreenWithInputFilePath.value)
+        assertNull(viewModel.navigateToCropScreenWithFileInfo.value)
     }
 
-    private fun initViewModel() = viewModel.onCreateView(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL)
+    private fun initViewModel() = viewModel.onCreateView(
+        TEST_LOW_RES_IMAGE_URL,
+        TEST_HIGH_RES_IMAGE_URL,
+        TEST_OUTPUT_FILE_EXTENSION
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -95,6 +95,7 @@ import static org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_AC
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_ACCESS_ERROR;
 import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG_HIGH_RES_IMAGE_URL;
 import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG_LOW_RES_IMAGE_URL;
+import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG_OUTPUT_FILE_EXTENSION;
 import static org.wordpress.android.ui.pages.PagesActivityKt.EXTRA_PAGE_REMOTE_ID_KEY;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_ID_KEY;
 
@@ -924,10 +925,16 @@ public class ActivityLauncher {
         }
     }
 
-    public static void openImageEditor(Activity activity, String loResImageUrl, String hiResImageUrl) {
+    public static void openImageEditor(
+        Activity activity,
+        String loResImageUrl,
+        String hiResImageUrl,
+        String outputFileExtension
+    ) {
         Intent intent = new Intent(activity, EditImageActivity.class);
         intent.putExtra(ARG_LOW_RES_IMAGE_URL, loResImageUrl);
         intent.putExtra(ARG_HIGH_RES_IMAGE_URL, hiResImageUrl);
+        intent.putExtra(ARG_OUTPUT_FILE_EXTENSION, outputFileExtension);
         activity.startActivityForResult(intent, RequestCodes.IMAGE_EDITOR_EDIT_IMAGE);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -21,6 +21,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.MimeTypeMap;
 import android.widget.RelativeLayout;
 
 import androidx.annotation.NonNull;
@@ -1676,7 +1677,8 @@ public class EditPostActivity extends AppCompatActivity implements
             !SiteUtils.isPhotonCapable(mSite)
         );
 
-        ActivityLauncher.openImageEditor(this, resizedImageUrl, imageUrl);
+        String outputFileExtension = MimeTypeMap.getFileExtensionFromUrl(imageUrl);
+        ActivityLauncher.openImageEditor(this, resizedImageUrl, imageUrl, outputFileExtension);
     }
 
     @Override


### PR DESCRIPTION
This PR fixes image transparency issue because of output file format(jpg) identified in https://github.com/wordpress-mobile/WordPress-Android/pull/11403#issue-382320852.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
