### PR TITLE
Use remoteId instead of localId in AutoSavePostIfNotDraftUseCase

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/AutoSavePostIfNotDraftUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/AutoSavePostIfNotDraftUseCaseTest.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
 import org.wordpress.android.ui.uploads.AutoSavePostIfNotDraftResult
 import org.wordpress.android.ui.uploads.AutoSavePostIfNotDraftUseCase
 import org.wordpress.android.ui.uploads.OnAutoSavePostIfNotDraftCallback
-import java.lang.IllegalArgumentException
 import java.lang.reflect.Constructor
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -105,7 +104,7 @@ class AutoSavePostIfNotDraftUseCaseTest {
 
     @Test
     fun `post auto-saved`() {
-        whenever(postStore.getPostByLocalPostId(any())).thenReturn(PostModel())
+        whenever(postStore.getPostByRemotePostId(any(), any())).thenReturn(PostModel())
         val remotePostPayload = createRemotePostPayload()
         val onPostStatusFetched = createOnPostStatusFetchedEvent(
                 post = remotePostPayload.post,
@@ -160,7 +159,7 @@ class AutoSavePostIfNotDraftUseCaseTest {
     }
 
     private fun createOnPostChangedEvent(post: PostModel, error: PostError? = null): OnPostChanged {
-        val event = OnPostChanged(CauseOfOnPostChanged.RemoteAutoSavePost(post.id), 0)
+        val event = OnPostChanged(CauseOfOnPostChanged.RemoteAutoSavePost(post.id, post.remotePostId), 0)
         error?.let { event.error = it }
         return event
     }

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'eb5f375bccbefdba7c0c5e0b4bca15b5ad21bbf8'
+    fluxCVersion = '1.6.8-beta-2'
 }
 
 // Onboarding and dev env setup tasks

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.7'
+    fluxCVersion = 'd0d86ffaca87e920bc1da9ba13741452d6e2139c'
 }
 
 // Onboarding and dev env setup tasks

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ buildScan {
 
 ext {
     daggerVersion = '2.22.1'
-    fluxCVersion = 'd0d86ffaca87e920bc1da9ba13741452d6e2139c'
+    fluxCVersion = 'eb5f375bccbefdba7c0c5e0b4bca15b5ad21bbf8'
 }
 
 // Onboarding and dev env setup tasks


### PR DESCRIPTION
Fixes #11467

Note: This is just a draft PR at the moment, since [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1520) needs to be merged first.

This is a very rare crash and I wasn't able to reproduce it. However, I have a guess what is causing the issue. 
1. User edits a page
1. Someone invokes fetchPages (either pull to refresh or automatic refresh)
1. User edits a post and the changes get enqueued for upload
2. AutoSavePostIfNotDraftUseCase initiates remote-auto-save
4. [Fetch pages request completes and all the pages are deleted and re-insterted ](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7cf14c3b2b1001bf50ae46bc39b0d3f67533d13a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java#L904)(their localId is changed)
5. Remote-auto-save completes and we try to load the page from the db using local id. However, the page is not there anymore since it was removed in step 4.
6. Boom

I had this theory before checking the logs and the logs seem to confirm it. 
- Dispatching action: PostAction-REMOTE_AUTO_SAVE_POST
- Dispatching action: PostAction-FETCHED_POSTS 
- Dispatching action: UploadAction-REMOTE_AUTO_SAVED_POST
- IllegalStateException: updatedPost must not be null

This PR is trying to fix the issue by using remoteId instead of localId. RemoteId should never change and we can be sure we always have it at this point, since we wouldn't be able to remote-auto-save the post otherwise.

To test:
1. Modify an existing published post and leave the editor without explicitly confirming the changes
2. Go to calypso, open the post and make sure unpublished-revision dialog is displayed and you can access the changes you made in the app in step 1
----------------------------
1. Turn on airplane mode
2. Modify an existing published post and leave the editor without explicitly confirming the changes
3. Go to calypso and move the post back to drafts
4. Turn off airplane mode and make sure pushPost is invoked and remote-auto-save isn't invoked (eg. check logs/stetho)
---------------------------
1. Modify an existing draft and leave the editor without explicitly confirming the changes
2. Make sure pushPost is invoked and remote-auto-save isn't invoked (eg. check logs/stetho)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
