### PR TITLE
Fix failed uploads being retried indefinitely

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 14.5
 -----
 * Removes sections from post search results
+* Fix a bug where failed post uploads were sometimes being retried indefinitely
  
 14.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 14.5
 -----
 * Removes sections from post search results
-* Fix a bug where failed post uploads were sometimes being retried indefinitely
+* Fixed a bug where failed post uploads were sometimes being retried indefinitely
  
 14.4
 -----
@@ -235,4 +235,3 @@
 * Updated Notifications with tabs
 * Add Posting activity block to the Stats/Insights
 * Fixed error notifications for failed uploads
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -1017,8 +1017,7 @@ public class UploadService extends Service {
                                 new PostEvents.PostUploadCanceled(postModel));
                     } else {
                         // Do not re-enqueue a post that has already failed
-                        if (isError != null && isError && post.getId() == updatedPost.getId() && mUploadStore
-                                .isFailedPost(post)) {
+                        if (isError != null && isError && mUploadStore.isFailedPost(updatedPost)) {
                             continue;
                         }
                         // TODO Should do some extra validation here


### PR DESCRIPTION
Fixes #11357

This is a bit tricky bug. I introduced it a few months ago in [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/10770). 

I'll start with explaining what is the method supposed to do. The `doFinalProcessingOfPosts` is called when a post upload completes (no matter the result). We pass reference to the post as a parameter. The method loads all posts registered for upload - both posts which were just enqueued but also posts for which the upload has already failed. Then we check if upload for the post hasn't failed yet and we start uploading it.
Howver, this piece of logic:
```
if (isError != null && isError && post.getId() == updatedPost.getId() && 
 mUploadStore.isFailedPost(post)) {
                            continue;
                        }
```
was supposed to skip posts for which the upload has already failed, so they are not enqueued again. However, `post.getId() == updatedPost.getId()` this part is wrong. I'll explain it on an example

Imagine we have two posts "PostA and PostB"
1. Both posts are enqueued
2. Upload for PostA fails and `doFinalProcessingOfPosts` gets called - PostA is passed as parameter
3. `mUploadStore.getAllRegisteredPosts()` returns both PostA and PostB
4. PostA gets skipped because the `if` statement copy-pasted above returns true
5. `mPostUploadHandler.upload(updatedPost);` for PostB is invoked (which is still correct, because it hasn't failed yet)
6. Upload for PostB fails and `doFinalProcessingOfPosts` gets called - PostB is passed as parameter
7. `mUploadStore.getAllRegisteredPosts()` returns both PostA and PostB
8. PostA should be skipped, however it won't get skipped since we are comparing "id of the parameter passed to `doFinalProcessingOfPosts` (PostB)" with "id of the `updatedPost` which is now `PostA`" -> `mPostUploadHandler.upload(updatedPost);` is invoked with PostA
9. This keeps happening indefinitely

The fix is pretty simple. I made a mistake in [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/10770/files) I created a few months ago. I was supposed to simply replace `mUploadStore.isFailedPost(post)` with `mUploadStore.isFailedPost(updatedPost)`. We don't need to be comparing any ids. We just want to ensure the post we are about to re-enqueue hasn't already failed and that's exactly what the `isFailedPost` method tells us.

It's a bit difficult to explain. Let me know if it makes sense or you want me to elaborate more.

To test:
1. Go to my site. 
2. Go to Post List. 
3. Create two posts in airplane mode and publish them. 
4. Turn off airplane mode so the upload can start and then turn it on quickly before the uploads finish.
5. Wait until the upload fails and make sure the UI is not flickering

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Props to Joel for finding the issue and finding the line which is causing the troubles.