### PR TITLE
Add reblog to Reader Posts [DO NOT MERGE]

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 14.6
 -----
  
+* Added reblog functionality
+
 14.5
 -----
 * Block editor: New block: Latest Posts

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -257,7 +257,12 @@ public class ActivityLauncher {
         taskStackBuilder.startActivities();
     }
 
-    public static void openEditorForReblog(Context context, @NonNull SiteModel site, @NonNull ReaderPost post) {
+    public static void openEditorForReblog(Context context, @NonNull SiteModel site, @Nullable ReaderPost post) {
+        if (post == null) {
+            ToastUtils.showToast(context, R.string.post_not_found, ToastUtils.Duration.SHORT);
+            return;
+        }
+
         TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
         Intent mainActivityIntent = getMainActivityInNewStack(context);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -279,33 +279,23 @@ public class ActivityLauncher {
     /**
      * Opens the editor and passes the information needed for a reblog action
      *
-     * @param context the context
-     * @param site    the site on which the post should be reblogged
-     * @param post    the post to be reblogged
+     * @param activity the calling activity
+     * @param site     the site on which the post should be reblogged
+     * @param post     the post to be reblogged
      */
-    public static void openEditorForReblog(Context context, @NonNull SiteModel site, @Nullable ReaderPost post) {
+    public static void openEditorForReblog(Activity activity, @NonNull SiteModel site, @Nullable ReaderPost post) {
         if (post == null) {
-            ToastUtils.showToast(context, R.string.post_not_found, ToastUtils.Duration.SHORT);
+            ToastUtils.showToast(activity, R.string.post_not_found, ToastUtils.Duration.SHORT);
             return;
         }
-
-        TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
-        Intent mainActivityIntent = getMainActivityInNewStack(context);
-
-        Intent editorIntent = new Intent(context, EditPostActivity.class);
-        editorIntent.putExtra(WordPress.SITE, site);
-        editorIntent.putExtra(EditPostActivity.EXTRA_IS_PAGE, false);
-
+        Intent editorIntent = new Intent(activity, EditPostActivity.class);
         editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_TITLE, post.getTitle());
         editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_QUOTE, post.getExcerpt());
         editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_IMAGE, post.getFeaturedImage());
         editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_CITATION, post.getUrl());
-
         editorIntent.setAction(EditPostActivity.ACTION_REBLOG);
 
-        taskStackBuilder.addNextIntent(mainActivityIntent);
-        taskStackBuilder.addNextIntent(editorIntent);
-        taskStackBuilder.startActivities();
+        addNewPostForResult(editorIntent, activity, site, false, PagePostCreationSourcesDetail.POST_FROM_REBLOG);
     }
 
     public static void viewStatsInNewStack(Context context, SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -119,16 +119,35 @@ public class ActivityLauncher {
         activity.startActivity(intent);
     }
 
+    /**
+     * Presents the site picker and expects the selection result
+     *
+     * @param activity the activity that starts the site picker and expects the result
+     * @param site     the preselected site
+     */
     public static void showSitePickerForResult(Activity activity, SiteModel site) {
         Intent intent = createSitePickerIntent(activity, site);
         activity.startActivityForResult(intent, RequestCodes.SITE_PICKER);
     }
 
+    /**
+     * Presents the site picker and expects the selection result
+     *
+     * @param fragment the fragment that starts the site picker and expects the result
+     * @param site     the preselected site
+     */
     public static void showSitePickerForResult(Fragment fragment, SiteModel site) {
         Intent intent = createSitePickerIntent(fragment.getContext(), site);
         fragment.startActivityForResult(intent, RequestCodes.SITE_PICKER);
     }
 
+    /**
+     * Creates a site picker intent
+     *
+     * @param context the context to use for the intent creation
+     * @param site    the preselected site
+     * @return the site picker intent
+     */
     private static Intent createSitePickerIntent(Context context, SiteModel site) {
         Intent intent = new Intent(context, SitePickerActivity.class);
         intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, site.getId());
@@ -257,6 +276,13 @@ public class ActivityLauncher {
         taskStackBuilder.startActivities();
     }
 
+    /**
+     * Opens the editor and passes the information needed for a reblog action
+     *
+     * @param context the context
+     * @param site    the site on which the post should be reblogged
+     * @param post    the post to be reblogged
+     */
     public static void openEditorForReblog(Context context, @NonNull SiteModel site, @Nullable ReaderPost post) {
         if (post == null) {
             ToastUtils.showToast(context, R.string.post_not_found, ToastUtils.Duration.SHORT);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.page.PageModel;
 import org.wordpress.android.fluxc.network.utils.StatsGranularity;
 import org.wordpress.android.login.LoginMode;
+import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.networking.SSLCertsViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
@@ -119,9 +120,19 @@ public class ActivityLauncher {
     }
 
     public static void showSitePickerForResult(Activity activity, SiteModel site) {
-        Intent intent = new Intent(activity, SitePickerActivity.class);
-        intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, site.getId());
+        Intent intent = createSitePickerIntent(activity, site);
         activity.startActivityForResult(intent, RequestCodes.SITE_PICKER);
+    }
+
+    public static void showSitePickerForResult(Fragment fragment, SiteModel site) {
+        Intent intent = createSitePickerIntent(fragment.getContext(), site);
+        fragment.startActivityForResult(intent, RequestCodes.SITE_PICKER);
+    }
+
+    private static Intent createSitePickerIntent(Context context, SiteModel site) {
+        Intent intent = new Intent(context, SitePickerActivity.class);
+        intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, site.getId());
+        return intent;
     }
 
     public static void showPhotoPickerForResult(Activity activity,
@@ -240,6 +251,26 @@ public class ActivityLauncher {
         Intent editorIntent = new Intent(context, EditPostActivity.class);
         editorIntent.putExtra(WordPress.SITE, site);
         editorIntent.putExtra(EditPostActivity.EXTRA_IS_PAGE, false);
+
+        taskStackBuilder.addNextIntent(mainActivityIntent);
+        taskStackBuilder.addNextIntent(editorIntent);
+        taskStackBuilder.startActivities();
+    }
+
+    public static void openEditorForReblog(Context context, @NonNull SiteModel site, @NonNull ReaderPost post) {
+        TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
+        Intent mainActivityIntent = getMainActivityInNewStack(context);
+
+        Intent editorIntent = new Intent(context, EditPostActivity.class);
+        editorIntent.putExtra(WordPress.SITE, site);
+        editorIntent.putExtra(EditPostActivity.EXTRA_IS_PAGE, false);
+
+        editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_TITLE, post.getTitle());
+        editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_QUOTE, post.getExcerpt());
+        editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_IMAGE, post.getFeaturedImage());
+        editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_CITATION, post.getUrl());
+
+        editorIntent.setAction(EditPostActivity.ACTION_REBLOG);
 
         taskStackBuilder.addNextIntent(mainActivityIntent);
         taskStackBuilder.addNextIntent(editorIntent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/PagePostCreationSourcesDetail.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/PagePostCreationSourcesDetail.kt
@@ -17,6 +17,8 @@ enum class PagePostCreationSourcesDetail(val label: String) {
     POST_FROM_STATS("post-from-stats"),
     // post created from notifications unread page when empty
     POST_FROM_NOTIFS_EMPTY_VIEW("post-from-notif-empty-view"),
+    // post created from reader reblog action
+    POST_FROM_REBLOG("post-from-reader-reblog"),
     // all other cases container
     NO_DETAIL("no-detail");
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -152,6 +152,7 @@ import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.LocaleManagerWrapper;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.PermissionUtils;
+import org.wordpress.android.util.ReblogUtils;
 import org.wordpress.android.util.ShortcutUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
@@ -210,6 +211,7 @@ public class EditPostActivity extends AppCompatActivity implements
         PostSettingsListDialogFragment.OnPostSettingsDialogFragmentListener,
         HistoryListFragment.HistoryItemClickInterface,
         EditPostSettingsCallback {
+    public static final String ACTION_REBLOG = "reblogAction";
     public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
     public static final String EXTRA_LOAD_AUTO_SAVE_REVISION = "loadAutosaveRevision";
     public static final String EXTRA_POST_REMOTE_ID = "postModelRemoteId";
@@ -224,6 +226,10 @@ public class EditPostActivity extends AppCompatActivity implements
     public static final String EXTRA_INSERT_MEDIA = "insertMedia";
     public static final String EXTRA_IS_NEW_POST = "isNewPost";
     public static final String EXTRA_CREATION_SOURCE_DETAIL = "creationSourceDetail";
+    public static final String EXTRA_REBLOG_POST_TITLE = "reblogPostTitle";
+    public static final String EXTRA_REBLOG_POST_IMAGE = "reblogPostImage";
+    public static final String EXTRA_REBLOG_POST_QUOTE = "reblogPostQuote";
+    public static final String EXTRA_REBLOG_POST_CITATION = "reblogPostCitation";
     private static final String STATE_KEY_EDITOR_FRAGMENT = "editorFragment";
     private static final String STATE_KEY_DROPPED_MEDIA_URIS = "stateKeyDroppedMediaUri";
     private static final String STATE_KEY_POST_LOCAL_ID = "stateKeyPostModelLocalId";
@@ -2044,6 +2050,8 @@ public class EditPostActivity extends AppCompatActivity implements
             } else if (NEW_MEDIA_POST.equals(action)) {
                 mEditorMedia.addExistingMediaToEditorAsync(AddExistingMediaSource.WP_MEDIA_LIBRARY,
                         getIntent().getLongArrayExtra(NEW_MEDIA_POST_EXTRA_IDS));
+            } else if (ACTION_REBLOG.equals(action)) {
+                setPostContentFromReblogAction();
             }
         }
 
@@ -2139,6 +2147,30 @@ public class EditPostActivity extends AppCompatActivity implements
     private void setFeaturedImageId(final long mediaId) {
         if (mEditPostSettingsFragment != null) {
             mEditPostSettingsFragment.updateFeaturedImage(mediaId);
+        }
+    }
+
+    protected void setPostContentFromReblogAction() {
+        Intent intent = getIntent();
+        final String title = intent.getStringExtra(EXTRA_REBLOG_POST_TITLE);
+        final String quote = intent.getStringExtra(EXTRA_REBLOG_POST_QUOTE);
+        final String citation = intent.getStringExtra(EXTRA_REBLOG_POST_CITATION);
+        final String image = intent.getStringExtra(EXTRA_REBLOG_POST_IMAGE);
+        if (title != null && quote != null) {
+            mHasSetPostContent = true;
+            mEditPostRepository.updateAsync(postModel -> {
+                postModel.setTitle(title + "\n" + mSite.getDescription());
+                String content = ReblogUtils.reblogContent(image, quote, title, citation, mShowGutenbergEditor);
+                postModel.setContent(content);
+                mEditPostRepository.updatePublishDateIfShouldBePublishedImmediately(postModel);
+                return true;
+            }, (postModel, result) -> {
+                if (result == UpdatePostResult.Updated.INSTANCE) {
+                    mEditorFragment.setTitle(postModel.getTitle());
+                    mEditorFragment.setContent(postModel.getContent());
+                }
+                return null;
+            });
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2150,7 +2150,10 @@ public class EditPostActivity extends AppCompatActivity implements
         }
     }
 
-    protected void setPostContentFromReblogAction() {
+    /**
+     * Sets the content of the reblogged post
+     */
+    private void setPostContentFromReblogAction() {
         Intent intent = getIntent();
         final String title = intent.getStringExtra(EXTRA_REBLOG_POST_TITLE);
         final String quote = intent.getStringExtra(EXTRA_REBLOG_POST_QUOTE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -13,6 +13,10 @@ public class ReaderInterfaces {
         void onPostSelected(ReaderPost post);
     }
 
+    public interface ReblogActionListener {
+        void reblog(ReaderPost post);
+    }
+
     /*
      * called from post detail fragment so toolbar can animate in/out when scrolling
      */

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -13,6 +13,9 @@ public class ReaderInterfaces {
         void onPostSelected(ReaderPost post);
     }
 
+    /*
+     * Called by the [ReaderPostAdapter] to trigger the reblog action
+     */
     public interface ReblogActionListener {
         void reblog(ReaderPost post);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -863,7 +863,7 @@ class ReaderPostDetailFragment : Fragment(),
                 val sites = mSiteStore.visibleSites
                 when (sites.size) {
                     1 -> ActivityLauncher.openEditorForReblog(activity, sites.first(), this.post)
-                    else -> {  // The no site (0) case can be handled by the site picker for now
+                    else -> { // The no site (0) case can be handled by the site picker for now
                         val siteLocalId = AppPrefs.getSelectedSite()
                         val site = mSiteStore.getSiteByLocalId(siteLocalId)
                         ActivityLauncher.showSitePickerForResult(this, site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -854,19 +854,16 @@ class ReaderPostDetailFragment : Fragment(),
 
         val countLikes = view!!.findViewById<ReaderIconCountView>(R.id.count_likes)
         val countComments = view!!.findViewById<ReaderIconCountView>(R.id.count_comments)
-        val reblogButton = view!!.findViewById<ReaderIconCountView>(R.id.reblog)
+        val reblogButton = view?.findViewById<ReaderIconCountView>(R.id.reblog)
 
         if (canBeReblogged()) {
-            reblogButton.setCount(0)
-            reblogButton.visibility = View.VISIBLE
-            reblogButton.setOnClickListener {
+            reblogButton?.setCount(0)
+            reblogButton?.visibility = View.VISIBLE
+            reblogButton?.setOnClickListener {
                 val sites = mSiteStore.visibleSites
                 when (sites.size) {
-                    0 -> {
-                        // TODO: handle no site
-                    }
-                    1 -> ActivityLauncher.openEditorForReblog(activity, mSiteStore.visibleSites[0], this.post)
-                    else -> {
+                    1 -> ActivityLauncher.openEditorForReblog(activity, sites.first(), this.post)
+                    else -> {  // The no site (0) case can be handled by the site picker for now
                         val siteLocalId = AppPrefs.getSelectedSite()
                         val site = mSiteStore.getSiteByLocalId(siteLocalId)
                         ActivityLauncher.showSitePickerForResult(this, site)
@@ -874,8 +871,8 @@ class ReaderPostDetailFragment : Fragment(),
                 }
             }
         } else {
-            reblogButton.visibility = View.INVISIBLE
-            reblogButton.setOnClickListener(null)
+            reblogButton?.visibility = View.INVISIBLE
+            reblogButton?.setOnClickListener(null)
         }
 
         if (canShowCommentCount()) {
@@ -1516,8 +1513,13 @@ class ReaderPostDetailFragment : Fragment(),
         return canShowLikeCount() || canShowCommentCount() || canShowBookmarkButton()
     }
 
-    private fun canBeReblogged(): Boolean = true
-    // TODO: Check if special logic is needed, else remove condition
+    /**
+     * Returns true if the blog post can be reblogged
+     *
+     * TODO: Validate that no extra business logic is needed here
+     */
+    private fun canBeReblogged(): Boolean = this.post != null && accountStore.hasAccessToken()
+
     private fun canShowCommentCount(): Boolean {
         val post = this.post ?: return false
         return if (!accountStore.hasAccessToken()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -871,7 +871,7 @@ class ReaderPostDetailFragment : Fragment(),
                 }
             }
         } else {
-            reblogButton?.visibility = View.INVISIBLE
+            reblogButton?.visibility = View.GONE
             reblogButton?.setOnClickListener(null)
         }
 
@@ -886,7 +886,7 @@ class ReaderPostDetailFragment : Fragment(),
                 )
             }
         } else {
-            countComments.visibility = View.INVISIBLE
+            countComments.visibility = View.GONE
             countComments.setOnClickListener(null)
         }
 
@@ -912,7 +912,7 @@ class ReaderPostDetailFragment : Fragment(),
                 likingUsersLabel.visibility = View.INVISIBLE
             }
         } else {
-            countLikes.visibility = View.INVISIBLE
+            countLikes.visibility = View.GONE
             countLikes.setOnClickListener(null)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -860,10 +860,18 @@ class ReaderPostDetailFragment : Fragment(),
             reblogButton.setCount(0)
             reblogButton.visibility = View.VISIBLE
             reblogButton.setOnClickListener {
-                val siteLocalId = AppPrefs.getSelectedSite()
-                val site = mSiteStore.getSiteByLocalId(siteLocalId)
-                ActivityLauncher.showSitePickerForResult(this, site)
-                //TODO: Skip site picker when user has only one site and handle users without a site
+                val sites = mSiteStore.visibleSites
+                when (sites.size) {
+                    0 -> {
+                        // TODO: handle no site
+                    }
+                    1 -> ActivityLauncher.openEditorForReblog(activity, mSiteStore.visibleSites[0], this.post)
+                    else -> {
+                        val siteLocalId = AppPrefs.getSelectedSite()
+                        val site = mSiteStore.getSiteByLocalId(siteLocalId)
+                        ActivityLauncher.showSitePickerForResult(this, site)
+                    }
+                }
             }
         } else {
             reblogButton.visibility = View.INVISIBLE
@@ -940,9 +948,7 @@ class ReaderPostDetailFragment : Fragment(),
                 if (resultCode == Activity.RESULT_OK) {
                     val siteLocalId = data?.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1) ?: -1
                     val site = mSiteStore.getSiteByLocalId(siteLocalId)
-                    this.post?.let {
-                        ActivityLauncher.openEditorForReblog(activity, site, it)
-                    }
+                    ActivityLauncher.openEditorForReblog(activity, site, this.post)
                 }
             }
         }
@@ -1510,8 +1516,8 @@ class ReaderPostDetailFragment : Fragment(),
         return canShowLikeCount() || canShowCommentCount() || canShowBookmarkButton()
     }
 
-    private fun canBeReblogged(): Boolean = true //TODO: Check if special logic is needed, else remove condition
-
+    private fun canBeReblogged(): Boolean = true
+    // TODO: Check if special logic is needed, else remove condition
     private fun canShowCommentCount(): Boolean {
         val post = this.post ?: return false
         return if (!accountStore.hasAccessToken()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1515,10 +1515,15 @@ class ReaderPostDetailFragment : Fragment(),
 
     /**
      * Returns true if the blog post can be reblogged
-     *
-     * TODO: Validate that no extra business logic is needed here
      */
-    private fun canBeReblogged(): Boolean = this.post != null && accountStore.hasAccessToken()
+    private fun canBeReblogged(): Boolean {
+        this.post?.let {
+            if (!it.isPrivate && accountStore.hasAccessToken()) {
+                return true
+            }
+        }
+        return false
+    }
 
     private fun canShowCommentCount(): Boolean {
         val post = this.post ?: return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -86,6 +86,7 @@ import org.wordpress.android.ui.ActionableEmptyView;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.FilteredRecyclerView;
+import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.main.BottomNavController;
 import org.wordpress.android.ui.main.MainToolbarFragment;
@@ -93,6 +94,7 @@ import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.news.NewsViewHolder.NewsCardListener;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
+import org.wordpress.android.ui.reader.ReaderInterfaces.ReblogActionListener;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
@@ -154,7 +156,8 @@ public class ReaderPostListFragment extends Fragment
         ReaderInterfaces.OnFollowListener,
         WPMainActivity.OnActivityBackPressedListener,
         WPMainActivity.OnScrollToTopListener,
-        MainToolbarFragment {
+        MainToolbarFragment,
+        ReblogActionListener {
     private static final int TAB_POSTS = 0;
     private static final int TAB_SITES = 1;
     private static final int NO_POSITION = -1;
@@ -193,6 +196,8 @@ public class ReaderPostListFragment extends Fragment
     private String mCurrentSearchQuery;
     private ReaderPostListType mPostListType;
     private ReaderSiteModel mLastTappedSiteSearchResult;
+
+    private ReaderPost mPostToReblog;
 
     private int mRestorePosition;
     private int mSiteSearchRestorePosition;
@@ -2070,7 +2075,8 @@ public class ReaderPostListFragment extends Fragment
                     context,
                     getPostListType(),
                     mImageManager,
-                    mIsTopLevel
+                    mIsTopLevel,
+                    this
             );
             mPostAdapter.setOnFollowListener(this);
             mPostAdapter.setOnPostSelectedListener(this);
@@ -2886,6 +2892,19 @@ public class ReaderPostListFragment extends Fragment
                 //noinspection unchecked
                 mFilterCriteriaLoaderListener.onFilterCriteriasLoaded((List) tagList);
             }
+        }
+    }
+
+    @Override public void reblog(ReaderPost post) {
+        this.mPostToReblog = post;
+        ActivityLauncher.showSitePickerForResult(this, getSelectedSite());
+        //TODO: Skip site picker when user has only one site and handle users without a site
+    }
+
+    @Override public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == RequestCodes.SITE_PICKER && resultCode == Activity.RESULT_OK) {
+            ActivityLauncher.openEditorForReblog(getActivity(), getSelectedSite(), this.mPostToReblog);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2899,16 +2899,14 @@ public class ReaderPostListFragment extends Fragment
 
     @Override
     public void reblog(ReaderPost post) {
-        this.mPostToReblog = post;
         List<SiteModel> sites = mSiteStore.getVisibleSites();
         switch (sites.size()) {
-            case 0:
-                // TODO: handle no site
-                break;
             case 1:
                 ActivityLauncher.openEditorForReblog(getActivity(), getSelectedSite(), this.mPostToReblog);
                 break;
+            case 0: // The no site case can be handled by the site picker for now
             default:
+                this.mPostToReblog = post; // Stores the post to be handled in the onActivityResult after site selection
                 ActivityLauncher.showSitePickerForResult(this, getSelectedSite());
                 break;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -74,6 +74,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
 import org.wordpress.android.fluxc.store.ReaderStore;
 import org.wordpress.android.fluxc.store.ReaderStore.OnReaderSitesSearched;
 import org.wordpress.android.fluxc.store.ReaderStore.ReaderSearchSitesPayload;
+import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.FilterCriteria;
 import org.wordpress.android.models.ReaderBlog;
 import org.wordpress.android.models.ReaderPost;
@@ -235,6 +236,7 @@ public class ReaderPostListFragment extends Fragment
     @Inject QuickStartStore mQuickStartStore;
     @Inject UiHelpers mUiHelpers;
     @Inject TagUpdateClientUtilsProvider mTagUpdateClientUtilsProvider;
+    @Inject SiteStore mSiteStore;
 
     private enum ActionableEmptyViewButtonType {
         DISCOVER,
@@ -2895,10 +2897,21 @@ public class ReaderPostListFragment extends Fragment
         }
     }
 
-    @Override public void reblog(ReaderPost post) {
+    @Override
+    public void reblog(ReaderPost post) {
         this.mPostToReblog = post;
-        ActivityLauncher.showSitePickerForResult(this, getSelectedSite());
-        //TODO: Skip site picker when user has only one site and handle users without a site
+        List<SiteModel> sites = mSiteStore.getVisibleSites();
+        switch (sites.size()) {
+            case 0:
+                // TODO: handle no site
+                break;
+            case 1:
+                ActivityLauncher.openEditorForReblog(getActivity(), getSelectedSite(), this.mPostToReblog);
+                break;
+            default:
+                ActivityLauncher.showSitePickerForResult(this, getSelectedSite());
+                break;
+        }
     }
 
     @Override public void onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -91,6 +91,7 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.main.BottomNavController;
 import org.wordpress.android.ui.main.MainToolbarFragment;
+import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.news.NewsViewHolder.NewsCardListener;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -2915,7 +2916,9 @@ public class ReaderPostListFragment extends Fragment
     @Override public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == RequestCodes.SITE_PICKER && resultCode == Activity.RESULT_OK) {
-            ActivityLauncher.openEditorForReblog(getActivity(), getSelectedSite(), this.mPostToReblog);
+            int siteLocalId = data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1);
+            SiteModel site = mSiteStore.getSiteByLocalId(siteLocalId);
+            ActivityLauncher.openEditorForReblog(getActivity(), site, this.mPostToReblog);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -1014,7 +1014,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     private void showReblogButton(final ReaderPostViewHolder holder, final ReaderPost post) {
-        boolean canBeReblogged = true; //TODO: Check if special logic is needed, else remove condition
+        boolean canBeReblogged = true; // TODO: Check if special logic is needed, else remove condition
         if (canBeReblogged) {
             holder.mReblog.setCount(0);
             holder.mReblog.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.reader.ReaderAnim;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.ReaderInterfaces;
 import org.wordpress.android.ui.reader.ReaderInterfaces.OnFollowListener;
+import org.wordpress.android.ui.reader.ReaderInterfaces.ReblogActionListener;
 import org.wordpress.android.ui.reader.ReaderTypes;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
@@ -104,6 +105,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private ReaderInterfaces.OnPostBookmarkedListener mOnPostBookmarkedListener;
     private ReaderActions.DataRequestedListener mDataRequestedListener;
     private ReaderSiteHeaderView.OnBlogInfoLoadedListener mBlogInfoLoadedListener;
+    private ReblogActionListener mReblogActionListener;
 
     // the large "tbl_posts.text" column is unused here, so skip it when querying
     private static final boolean EXCLUDE_TEXT_COLUMN = true;
@@ -185,6 +187,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final TextView mTxtAuthorAndBlogName;
         private final TextView mTxtDateline;
 
+        private final ReaderIconCountView mReblog;
         private final ReaderIconCountView mCommentCount;
         private final ReaderIconCountView mLikeCount;
         private final ImageView mBtnBookmark;
@@ -218,6 +221,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             mTxtAuthorAndBlogName = itemView.findViewById(R.id.text_author_and_blog_name);
             mTxtDateline = itemView.findViewById(R.id.text_dateline);
 
+            mReblog = itemView.findViewById(R.id.reblog);
             mCommentCount = itemView.findViewById(R.id.count_comments);
             mLikeCount = itemView.findViewById(R.id.count_likes);
             mBtnBookmark = itemView.findViewById(R.id.bookmark);
@@ -553,6 +557,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         showLikes(holder, post);
         showComments(holder, post);
+        showReblogButton(holder, post);
         initBookmarkButton(position, holder, post);
 
         // more menu only shows for followed tags
@@ -691,7 +696,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             Context context,
             ReaderPostListType postListType,
             ImageManager imageManager,
-            boolean isMainReader
+            boolean isMainReader,
+            ReblogActionListener reblogActionListener
     ) {
         super();
         ((WordPress) context.getApplicationContext()).component().inject(this);
@@ -702,6 +708,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mMarginLarge = context.getResources().getDimensionPixelSize(R.dimen.margin_large);
         mIsLoggedOutReader = !mAccountStore.hasAccessToken();
         mIsMainReader = isMainReader;
+        mReblogActionListener = reblogActionListener;
 
         int displayWidth = DisplayUtils.getDisplayPixelWidth(context);
         int cardMargin = context.getResources().getDimensionPixelSize(R.dimen.reader_card_margin);
@@ -998,6 +1005,23 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 @Override
                 public void onClick(View v) {
                     ReaderActivityLauncher.showReaderComments(v.getContext(), post.blogId, post.postId);
+                }
+            });
+        } else {
+            holder.mCommentCount.setVisibility(View.GONE);
+            holder.mCommentCount.setOnClickListener(null);
+        }
+    }
+
+    private void showReblogButton(final ReaderPostViewHolder holder, final ReaderPost post) {
+        boolean canBeReblogged = true; //TODO: Check if special logic is needed, else remove condition
+        if (canBeReblogged) {
+            holder.mReblog.setCount(0);
+            holder.mReblog.setVisibility(View.VISIBLE);
+            holder.mReblog.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    mReblogActionListener.reblog(post);
                 }
             });
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -1021,19 +1021,14 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
      * @param post   the current reader post
      */
     private void showReblogButton(final ReaderPostViewHolder holder, final ReaderPost post) {
-        boolean canBeReblogged = mIsLoggedOutReader;
+        boolean canBeReblogged = !mIsLoggedOutReader;
         if (canBeReblogged) {
             holder.mReblog.setCount(0);
             holder.mReblog.setVisibility(View.VISIBLE);
-            holder.mReblog.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    mReblogActionListener.reblog(post);
-                }
-            });
+            holder.mReblog.setOnClickListener(v -> mReblogActionListener.reblog(post));
         } else {
-            holder.mCommentCount.setVisibility(View.GONE);
-            holder.mCommentCount.setOnClickListener(null);
+            holder.mReblog.setVisibility(View.GONE);
+            holder.mReblog.setOnClickListener(null);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -1013,8 +1013,15 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
     }
 
+    /**
+     * Sets reblog button visibility and action
+     * TODO: Validate that no extra business logic is needed for button visibility
+     *
+     * @param holder the view holder
+     * @param post   the current reader post
+     */
     private void showReblogButton(final ReaderPostViewHolder holder, final ReaderPost post) {
-        boolean canBeReblogged = true; // TODO: Check if special logic is needed, else remove condition
+        boolean canBeReblogged = mIsLoggedOutReader;
         if (canBeReblogged) {
             holder.mReblog.setCount(0);
             holder.mReblog.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -1015,13 +1015,12 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     /**
      * Sets reblog button visibility and action
-     * TODO: Validate that no extra business logic is needed for button visibility
      *
      * @param holder the view holder
      * @param post   the current reader post
      */
     private void showReblogButton(final ReaderPostViewHolder holder, final ReaderPost post) {
-        boolean canBeReblogged = !mIsLoggedOutReader;
+        boolean canBeReblogged = !mIsLoggedOutReader && !post.isPrivate;
         if (canBeReblogged) {
             holder.mReblog.setCount(0);
             holder.mReblog.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
@@ -22,6 +22,7 @@ public class ReaderIconCountView extends LinearLayout {
     // these must match the same values in attrs.xml
     private static final int ICON_LIKE = 0;
     private static final int ICON_COMMENT = 1;
+    private static final int ICON_REBLOG = 2;
 
     public ReaderIconCountView(Context context) {
         super(context);
@@ -61,6 +62,12 @@ public class ReaderIconCountView extends LinearLayout {
                     case ICON_COMMENT:
                         mImageView.setImageDrawable(ContextCompat.getDrawable(context,
                                 R.drawable.ic_comment_white_24dp));
+                        mImageView.setImageTintList(getResources().getColorStateList(
+                                R.color.neutral_primary_40_neutral_40_selector));
+                        break;
+                    case ICON_REBLOG:
+                        mImageView.setImageDrawable(ContextCompat.getDrawable(context,
+                                R.drawable.ic_reblog_white_24dp));
                         mImageView.setImageTintList(getResources().getColorStateList(
                                 R.color.neutral_primary_40_neutral_40_selector));
                         break;

--- a/WordPress/src/main/java/org/wordpress/android/util/ReblogUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ReblogUtils.kt
@@ -1,0 +1,89 @@
+@file:JvmName("ReblogUtils")
+
+package org.wordpress.android.util
+
+/**
+ * Returns the string embedded in a quote
+ */
+val String.embeddedQuote
+    get() = "<blockquote>$this</blockquote>"
+
+/**
+ * Returns the string embedded in a WordPress quote
+ */
+val String.embeddedWpQuote
+    get() = """<!-- wp:quote --><blockquote class="wp-block-quote">$this</blockquote><!-- /wp:quote -->"""
+
+/**
+ * Returns the string embedded in a citation
+ */
+val String.embeddedCitation
+    get() = "<cite>$this</cite>"
+
+/**
+ * Returns an html image from an image url string
+ */
+val String.htmlImage
+    get() = """<img src="$this">"""
+
+/**
+ * Returns an html WordPress image
+ */
+val String.htmlWpImage
+    get() = "<!-- wp:image -->${this.htmlImage}<!-- /wp:image -->"
+
+/**
+ * Returns an html paragraph
+ */
+val String.htmlParagraph
+    get() = "<p>$this</p>"
+
+/**
+ * Returns an html WordPress paragraph
+ */
+val String.htmlWpParagraph
+    get() = "<!-- wp:paragraph -->${this.htmlParagraph}<!-- /wp:paragraph -->"
+
+/**
+ * Creates a hyperlink from a URL
+ * @param url the url
+ * @param text the text to display. If not provided the [url] will be used
+ * @return the html of the hyperlink
+ */
+fun hyperLink(url: String, text: String? = null) = """<a href="$url">${text ?: url}</a>"""
+
+/**
+ * Provides an html containing the post [quote] followed by a link citation
+ * @param quote the post quote
+ * @param citationTitle the citation text
+ * @param citationUrl the citation link
+ * @return the html containing the post [quote] followed by a link citation
+ */
+fun quoteWithCitation(quote: String, citationTitle: String, citationUrl: String): String {
+    return quote.htmlParagraph + hyperLink(citationUrl, citationTitle).embeddedCitation
+}
+
+/**
+ * Provides the reblog post containing a featured image (if exists) followed by the quote and citation
+ * @param imageUrl the featured image url (might be null)
+ * @param quote the post quote
+ * @param citationTitle the citation text
+ * @param citationUrl the citation link
+ * @param isGutenberg if true
+ * @return the html containing the featured image (if exists) followed by the quote and citation
+ */
+fun reblogContent(
+    imageUrl: String?,
+    quote: String,
+    citationTitle: String,
+    citationUrl: String,
+    isGutenberg: Boolean = true
+): String {
+    val quoteWithCitation = quoteWithCitation(quote, citationTitle, citationUrl)
+    val html = if (isGutenberg) quoteWithCitation.embeddedWpQuote else quoteWithCitation.embeddedQuote
+    if (imageUrl != null && UrlUtils.isImageUrl(imageUrl)) {
+        val imageHtml = if (isGutenberg) imageUrl.htmlImage.htmlWpParagraph else imageUrl.htmlImage.htmlParagraph
+        return imageHtml + html
+    }
+    return html
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/ReblogUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ReblogUtils.kt
@@ -30,7 +30,7 @@ val String.htmlImage
  * Returns an html WordPress image
  */
 val String.htmlWpImage
-    get() = "<!-- wp:image -->${this.htmlImage}<!-- /wp:image -->"
+    get() = "<!-- wp:image --><figure class=\"wp-block-image\">${this.htmlImage}</figure><!-- /wp:image -->"
 
 /**
  * Returns an html paragraph
@@ -82,7 +82,7 @@ fun reblogContent(
     val quoteWithCitation = quoteWithCitation(quote, citationTitle, citationUrl)
     val html = if (isGutenberg) quoteWithCitation.embeddedWpQuote else quoteWithCitation.embeddedQuote
     if (imageUrl != null && UrlUtils.isImageUrl(imageUrl)) {
-        val imageHtml = if (isGutenberg) imageUrl.htmlImage.htmlWpParagraph else imageUrl.htmlImage.htmlParagraph
+        val imageHtml = if (isGutenberg) imageUrl.htmlWpImage else imageUrl.htmlImage.htmlParagraph
         return imageHtml + html
     }
     return html

--- a/WordPress/src/main/java/org/wordpress/android/util/UrlUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/UrlUtilsWrapper.kt
@@ -22,4 +22,12 @@ class UrlUtilsWrapper @Inject constructor() {
     fun getHost(urlString: String?): String {
         return UrlUtils.getHost(urlString)
     }
+
+    fun isValidUrlAndHostNotNull(urlString: String?): Boolean {
+        return UrlUtils.isValidUrlAndHostNotNull(urlString)
+    }
+
+    fun isImageUrl(urlString: String?): Boolean {
+        return UrlUtils.isImageUrl(urlString)
+    }
 }

--- a/WordPress/src/main/res/layout/reader_activity_post_pager.xml
+++ b/WordPress/src/main/res/layout/reader_activity_post_pager.xml
@@ -23,4 +23,11 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
+    <!-- this coordinator exists only for snackbars -->
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/coordinator"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="@dimen/reader_post_detail_snackbar_bottom_margin" />
+
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -257,11 +257,23 @@
                 android:layout_centerVertical="true"
                 android:layout_height="@dimen/reader_button_minimum_height"
                 android:layout_width="@dimen/reader_button_minimum_height"
-                android:layout_toStartOf="@id/count_comments"
+                android:layout_toStartOf="@id/reblog"
                 android:padding="@dimen/margin_medium"
                 android:src="@drawable/ic_bookmark_outline_bookmark_selector_24dp"
                 android:tint="@color/neutral_primary_40_neutral_40_selector" >
             </ImageView>
+
+            <org.wordpress.android.ui.reader.views.ReaderIconCountView
+                android:id="@+id/reblog"
+                android:contentDescription="@string/reader_view_reblog"
+                android:layout_alignWithParentIfMissing="true"
+                android:layout_centerVertical="true"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_medium"
+                android:layout_toStartOf="@+id/count_comments"
+                android:layout_width="wrap_content"
+                wp:readerIcon="reblog" >
+            </org.wordpress.android.ui.reader.views.ReaderIconCountView>
 
             <org.wordpress.android.ui.reader.views.ReaderIconCountView
                 android:id="@+id/count_comments"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -47,6 +47,15 @@
             tools:ignore="UselessParent" >
 
             <org.wordpress.android.ui.reader.views.ReaderIconCountView
+                android:id="@+id/reblog"
+                android:contentDescription="@string/reader_view_reblog"
+                android:layout_gravity="center_vertical"
+                android:layout_height="wrap_content"
+                android:layout_width="wrap_content"
+                wp:readerIcon="reblog" >
+            </org.wordpress.android.ui.reader.views.ReaderIconCountView>
+
+            <org.wordpress.android.ui.reader.views.ReaderIconCountView
                 android:id="@+id/count_comments"
                 android:contentDescription="@string/reader_view_comments"
                 android:layout_gravity="center_vertical"

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -80,6 +80,7 @@
         <attr name="readerIcon" format="enum">
             <enum name="like" value="0" />
             <enum name="comment" value="1" />
+            <enum name="reblog" value="2" />
         </attr>
     </declare-styleable>
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -484,4 +484,6 @@
     <dimen name="bottom_sheet_handle_width">32dp</dimen>
     <dimen name="bottom_sheet_handle_margin_top">4dp</dimen>
 
+    <!-- reader post detail snackbar bottom margin -->
+    <dimen name="reader_post_detail_snackbar_bottom_margin">56dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1682,6 +1682,9 @@
 
     <string name="reader_excerpt_link">Visit %s for more</string>
 
+    <!-- reblog -->
+    <string name="reader_view_reblog">Reblog</string> <!-- TODO: Add localizations -->
+
     <!-- like counts -->
     <string name="reader_label_like">Like</string>
     <string name="reader_likes_one">One person likes this</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1683,7 +1683,7 @@
     <string name="reader_excerpt_link">Visit %s for more</string>
 
     <!-- reblog -->
-    <string name="reader_view_reblog">Reblog</string> <!-- TODO: Add localizations -->
+    <string name="reader_view_reblog">Reblog</string>
 
     <!-- like counts -->
     <string name="reader_label_like">Like</string>

--- a/WordPress/src/test/java/org/wordpress/android/util/ReblogUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/ReblogUtilsTest.kt
@@ -1,0 +1,213 @@
+package org.wordpress.android.util
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+private const val VALID_URL = "VALID_URL"
+private const val INVALID_URL = "INVALID_URL"
+private const val VALID_IMAGE_URL = "VALID_IMAGE_URL"
+private const val INVALID_IMAGE_URL = "INVALID_IMAGE_URL"
+
+/**
+ * Implements tests for ReblogUtils
+ */
+@RunWith(MockitoJUnitRunner::class)
+class ReblogUtilsTest {
+    @Mock private lateinit var urlUtils: UrlUtilsWrapper
+
+    @Before
+    fun setup() {
+        whenever(urlUtils.isValidUrlAndHostNotNull(VALID_URL)).thenReturn(true)
+        whenever(urlUtils.isValidUrlAndHostNotNull(INVALID_URL)).thenReturn(false)
+        whenever(urlUtils.isImageUrl(VALID_IMAGE_URL)).thenReturn(true)
+        whenever(urlUtils.isImageUrl(INVALID_IMAGE_URL)).thenReturn(false)
+    }
+
+    @Test
+    fun `embedded quote`() {
+        val expected = "<blockquote>some quote</blockquote>"
+        val actual = "some quote".embeddedQuote
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded empty quote`() {
+        val expected = "<blockquote></blockquote>"
+        val actual = "".embeddedQuote
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded WP quote`() {
+        val expected = """<!-- wp:quote --><blockquote class="wp-block-quote">quote</blockquote><!-- /wp:quote -->"""
+        val actual = "quote".embeddedWpQuote
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded empty WP quote`() {
+        val expected = """<!-- wp:quote --><blockquote class="wp-block-quote"></blockquote><!-- /wp:quote -->"""
+        val actual = "".embeddedWpQuote
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded citation`() {
+        val expected = "<cite>some citation</cite>"
+        val actual = "some citation".embeddedCitation
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded empty citation`() {
+        val expected = "<cite></cite>"
+        val actual = "".embeddedCitation
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded image`() {
+        val expected = """<img src="$VALID_IMAGE_URL">"""
+        val actual = htmlImage(VALID_IMAGE_URL, urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded image with invalid image url`() {
+        assertNull(htmlImage(INVALID_IMAGE_URL, urlUtils))
+    }
+
+    @Test
+    fun `embedded WP image`() {
+        val expected = """<!-- wp:image --><figure class="wp-block-image"><img src="$VALID_IMAGE_URL">""" +
+                "</figure><!-- /wp:image -->"
+        val actual = htmlWpImage(VALID_IMAGE_URL, urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded WP image with invalid image url`() {
+        assertNull(htmlWpImage(INVALID_IMAGE_URL, urlUtils))
+    }
+
+    @Test
+    fun `embedded paragraph`() {
+        val expected = "<p>some paragraph</p>"
+        val actual = "some paragraph".htmlParagraph
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded empty paragraph`() {
+        val expected = "<p></p>"
+        val actual = "".htmlParagraph
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create hyperlink with valid url and text`() {
+        val expected = """<a href="$VALID_URL">some text</a>"""
+        val actual = hyperLink(VALID_URL, "some text", urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create hyperlink with valid url without a text`() {
+        val expected = """<a href="$VALID_URL">$VALID_URL</a>"""
+        val actual = hyperLink(VALID_URL, urlUtils = urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create hyperlink with invalid url`() {
+        assertNull(hyperLink(INVALID_URL, "not important", urlUtils))
+    }
+
+    @Test
+    fun `create quote without citation`() {
+        val expected = "<p>some quote</p>"
+        val actual = quoteWithCitation("some quote", urlUtils = urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create quote with citation having a valid url but no text`() {
+        val expected = """<p>some quote</p><cite><a href="$VALID_URL">$VALID_URL</a></cite>"""
+        val actual = quoteWithCitation("some quote", VALID_URL, urlUtils = urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create quote with citation having a valid url and text`() {
+        val expected = """<p>some quote</p><cite><a href="$VALID_URL">some text</a></cite>"""
+        val actual = quoteWithCitation("some quote", VALID_URL, "some text", urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create reblog content with quote, citation and a valid image for Gutenberg editor`() {
+        val expected = """<!-- wp:image --><figure class="wp-block-image">""" +
+                """<img src="$VALID_IMAGE_URL"></figure><!-- /wp:image -->""" +
+                """<!-- wp:quote --><blockquote class="wp-block-quote"><p>some quote</p>""" +
+                """<cite><a href="$VALID_URL">some text</a></cite></blockquote><!-- /wp:quote -->"""
+        val actual = reblogContent(
+                VALID_IMAGE_URL,
+                "some quote",
+                "some text",
+                VALID_URL,
+                true,
+                urlUtils
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create reblog content with quote, citation and an invalid image for Gutenberg editor`() {
+        val expected = """<!-- wp:quote --><blockquote class="wp-block-quote"><p>some quote</p>""" +
+                """<cite><a href="$VALID_URL">some text</a></cite></blockquote><!-- /wp:quote -->"""
+        val actual = reblogContent(
+                INVALID_IMAGE_URL,
+                "some quote",
+                "some text",
+                VALID_URL,
+                true,
+                urlUtils
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create reblog content with quote, citation and a valid image for Aztec editor`() {
+        val expected = """<p><img src="$VALID_IMAGE_URL"></p>""" +
+                """<blockquote><p>some quote</p><cite><a href="$VALID_URL">some text</a></cite></blockquote>"""
+        val actual = reblogContent(
+                VALID_IMAGE_URL,
+                "some quote",
+                "some text",
+                VALID_URL,
+                false,
+                urlUtils
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create reblog content with quote, citation and an invalid image for Aztec editor`() {
+        val expected = """<blockquote><p>some quote</p><cite><a href="$VALID_URL">some text</a></cite></blockquote>"""
+        val actual = reblogContent(
+                INVALID_IMAGE_URL,
+                "some quote",
+                "some text",
+                VALID_URL,
+                false,
+                urlUtils
+        )
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
Fixes #10934

**DO NOT MERGE: This is still Work In Progress**

## Description

This feature adds the reblog functionality in the reader

## Changes

A reblog button has been added in the Reader Post List and Post Details. 
If the user has more that one sites the button triggers the existing Site Picker.

| Posts List | Post Details |Site Picker (unchanged)|
| --- | --- |---|
|![2020-03-19 22 05 08](https://user-images.githubusercontent.com/304044/77110649-8b84d680-6a2e-11ea-84ce-85c3c635f315.png)|![2020-03-19 22 05 24](https://user-images.githubusercontent.com/304044/77110680-993a5c00-6a2e-11ea-8caf-e9f7b49b9903.png)|![2020-03-19 22 05 33](https://user-images.githubusercontent.com/304044/77110683-9b041f80-6a2e-11ea-8f21-198d89d5ead1.png)|

If the user has only one site the editor is triggered directly.

When the users selects a site he is redirected to the editor with the following information prefilled:
* Title (with source)
* Image (if the post has a featured)
* Quote
* Citation

| Gutenberg editor with featured image| Gutenberg editor without image |
| --- | --- |
|![device-2020-03-22-114527](https://user-images.githubusercontent.com/304044/77246840-b8560b00-6c33-11ea-8b38-28dc15e7b888.png)|![2020-03-19 22 06 05](https://user-images.githubusercontent.com/304044/77110686-9c354c80-6a2e-11ea-858d-f09c597f6348.png)|

| Aztec editor with featured image| Aztec editor without image |
| --- | --- |
|![device-2020-03-22-114630](https://user-images.githubusercontent.com/304044/77246853-d459ac80-6c33-11ea-9059-40c0c62eb03f.png)|![device-2020-03-22-114609](https://user-images.githubusercontent.com/304044/77246855-d885ca00-6c33-11ea-8bea-9943adfebb79.png)|

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
