### PR TITLE
Issue/disabling battery saver theme change on older devices

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/AppThemeUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/AppThemeUtils.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.util
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.os.Build
 import android.text.TextUtils
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager

--- a/WordPress/src/main/java/org/wordpress/android/util/AppThemeUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/AppThemeUtils.kt
@@ -33,15 +33,9 @@ class AppThemeUtils {
                     AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
                 }
                 context.getString(R.string.app_theme_entry_value_default) -> {
-                    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
-                        AppCompatDelegate.setDefaultNightMode(
-                                AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-                        )
-                    } else {
-                        AppCompatDelegate.setDefaultNightMode(
-                                AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
-                        )
-                    }
+                    AppCompatDelegate.setDefaultNightMode(
+                            AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                    )
                 }
                 else -> AppLog.w(AppLog.T.UTILS, "Theme key $themeName is not recognized.")
             }

--- a/WordPress/src/main/res/values-v28/strings.xml
+++ b/WordPress/src/main/res/values-v28/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="app_theme_entry_value_default_key" translatable="false">@string/app_theme_entry_value_default</string>
+    <string-array name="app_theme_entries" tools:ignore="InconsistentArrays">
+        <item>@string/app_theme_light</item>
+        <item>@string/app_theme_dark</item>
+        <item>@string/app_theme_default</item>
+    </string-array>
+    <string-array name="app_theme_entry_values" tools:ignore="InconsistentArrays" translatable="false">
+        <item>@string/app_theme_entry_value_light</item>
+        <item>@string/app_theme_entry_value_dark</item>
+        <item>@string/app_theme_entry_value_default</item>
+    </string-array>
+</resources>

--- a/WordPress/src/main/res/values-v28/strings.xml
+++ b/WordPress/src/main/res/values-v28/strings.xml
@@ -6,7 +6,7 @@
         <item>@string/app_theme_dark</item>
         <item>@string/app_theme_default</item>
     </string-array>
-    <string-array name="app_theme_entry_values" tools:ignore="InconsistentArrays" translatable="false">
+    <string-array name="app_theme_entry_values" translatable="false" tools:ignore="InconsistentArrays">
         <item>@string/app_theme_entry_value_light</item>
         <item>@string/app_theme_entry_value_dark</item>
         <item>@string/app_theme_entry_value_default</item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -824,15 +824,14 @@
     <string name="app_theme_entry_value_light" translatable="false">light</string>
     <string name="app_theme_entry_value_dark" translatable="false">dark</string>
     <string name="app_theme_entry_value_default" translatable="false">default</string>
-    <string-array name="app_theme_entries">
+    <string name="app_theme_entry_value_default_key" translatable="false">@string/app_theme_entry_value_light</string>
+    <string-array name="app_theme_entries" tools:ignore="InconsistentArrays">
         <item>@string/app_theme_light</item>
         <item>@string/app_theme_dark</item>
-        <item>@string/app_theme_default</item>
     </string-array>
-    <string-array name="app_theme_entry_values" translatable="false">
+    <string-array name="app_theme_entry_values" translatable="false" tools:ignore="InconsistentArrays">
         <item>@string/app_theme_entry_value_light</item>
         <item>@string/app_theme_entry_value_dark</item>
-        <item>@string/app_theme_entry_value_default</item>
     </string-array>
 
     <!-- stats -->

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -9,7 +9,7 @@
         android:title="@string/interface_language" />
 
     <ListPreference
-        android:defaultValue="@string/app_theme_entry_value_default"
+        android:defaultValue="@string/app_theme_entry_value_default_key"
         android:dialogTitle="@string/app_theme"
         android:entries="@array/app_theme_entries"
         android:entryValues="@array/app_theme_entry_values"


### PR DESCRIPTION
Fixes [this](https://github.com/wordpress-mobile/WordPress-Android/pull/11469#issuecomment-601088062) issue.

On devices with API 27 and lower, when the app theme is set based on battery saver, toggling battery saver option twice causes activities to lose state (savedInstanceState will be null). This can result in all kinds of fun stuff that we do not want. This all happens on system level, and unless we decide to handle all UI configuration changes manually there is nothing we can do about this.

This PR removes `Set by Battery Saver` theme option from devices with API 27 and lower. For those devices `Light` will be the default option.

Battery saver theme switch on API 28 works as expected with the `MODE_NIGHT_FOLLOW_SYSTEM ` flag.

To test 1:
- Using a device with API <= 27 navigate to App Settings and open Appearance option.
- Notice that there are only two options Light and Dark. Light should be selected by default.
- Pick an option and notice that the app theme changes accordingly.
- Toggle battery saver on and off, and make sure that the app theme does not change.

To test 2:
- Using a device with API 28 navigate to App Settings and open Appearance option.
- Notice that there are three options Light and Dark and Set by Battery Saver. Set by Battery Saver should be selected by default.
- Toggle battery saver on and off, and make sure that the app theme changes.
- Pick any other option and notice that the app theme changes accordingly.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
