### PR TITLE
Use HashMap instead of SparseArray

### DIFF
--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -5,6 +5,7 @@
 
     <!-- WARNING -->
     <issue id="RtlSymmetry" severity="warning" />
+    <issue id="UseSparseArrays" severity="warning" />
 
     <issue id="NewApi">
         <warning path="src/main/res/values/reader_styles.xml" />
@@ -46,7 +47,6 @@
     <issue id="ObsoleteSdkInt" severity="error" />
     <issue id="ViewHolder" severity="error" />
     <issue id="DuplicateDivider" severity="error" />
-    <issue id="UseSparseArrays" severity="error" />
     <issue id="InefficientWeight" severity="error" />
     <issue id="UnusedResources" severity="error" />
     <issue id="UselessParent" severity="error" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFeaturedImageTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFeaturedImageTracker.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.ui.posts
 
-import androidx.collection.LongSparseArray
+import android.annotation.SuppressLint
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.MediaModel
@@ -13,7 +13,16 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
  * you see fit.
  */
 class PostListFeaturedImageTracker(private val dispatcher: Dispatcher, private val mediaStore: MediaStore) {
-    private val featuredImageArray = LongSparseArray<String>()
+    /*
+    Using `SparseArray` is results in ArrayIndexOutOfBoundsException when we are trying to put a new item. Although
+    the reason for the crash is unclear, this defeats the whole purpose of using a `SparseArray`. Furthermore,
+    `SparseArray` is actually not objectively better than using a `HashMap` and in this case `HashMap` should perform
+    better due to higher number of items.
+
+    https://github.com/wordpress-mobile/WordPress-Android/issues/11487
+     */
+    @SuppressLint("UseSparseArrays")
+    private val featuredImageArray = HashMap<Long, String>()
 
     fun getFeaturedImageUrl(site: SiteModel, featuredImageId: Long): String? {
         if (featuredImageId == 0L) {
@@ -23,7 +32,7 @@ class PostListFeaturedImageTracker(private val dispatcher: Dispatcher, private v
         mediaStore.getSiteMediaWithId(site, featuredImageId)?.let { media ->
             // This should be a pretty rare case, but some media seems to be missing url
             return if (media.url != null) {
-                featuredImageArray.put(featuredImageId, media.url)
+                featuredImageArray[featuredImageId] = media.url
                 media.url
             } else null
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFeaturedImageTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFeaturedImageTracker.kt
@@ -22,17 +22,17 @@ class PostListFeaturedImageTracker(private val dispatcher: Dispatcher, private v
     https://github.com/wordpress-mobile/WordPress-Android/issues/11487
      */
     @SuppressLint("UseSparseArrays")
-    private val featuredImageArray = HashMap<Long, String>()
+    private val featuredImageMap = HashMap<Long, String>()
 
     fun getFeaturedImageUrl(site: SiteModel, featuredImageId: Long): String? {
         if (featuredImageId == 0L) {
             return null
         }
-        featuredImageArray[featuredImageId]?.let { return it }
+        featuredImageMap[featuredImageId]?.let { return it }
         mediaStore.getSiteMediaWithId(site, featuredImageId)?.let { media ->
             // This should be a pretty rare case, but some media seems to be missing url
             return if (media.url != null) {
-                featuredImageArray[featuredImageId] = media.url
+                featuredImageMap[featuredImageId] = media.url
                 media.url
             } else null
         }
@@ -46,6 +46,6 @@ class PostListFeaturedImageTracker(private val dispatcher: Dispatcher, private v
     }
 
     fun invalidateFeaturedMedia(featuredImageIds: List<Long>) {
-        featuredImageIds.forEach { featuredImageArray.remove(it) }
+        featuredImageIds.forEach { featuredImageMap.remove(it) }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListUploadStatusTracker.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.posts
 
 import android.annotation.SuppressLint
-import androidx.collection.SparseArrayCompat
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.UploadStore
@@ -27,10 +26,10 @@ class PostListUploadStatusTracker(
     https://github.com/wordpress-mobile/WordPress-Android/issues/11487
      */
     @SuppressLint("UseSparseArrays")
-    private val uploadStatusArray = HashMap<Int, PostListItemUploadStatus>()
+    private val uploadStatusMap = HashMap<Int, PostListItemUploadStatus>()
 
     fun getUploadStatus(post: PostModel, siteModel: SiteModel): PostListItemUploadStatus {
-        uploadStatusArray[post.id]?.let { return it }
+        uploadStatusMap[post.id]?.let { return it }
         val uploadError = uploadStore.getUploadErrorForPost(post)
         val isUploadingOrQueued = UploadService.isPostUploadingOrQueued(post)
         val hasInProgressMediaUpload = UploadService.hasInProgressMediaUploadsForPost(post)
@@ -46,11 +45,11 @@ class PostListUploadStatusTracker(
                 isEligibleForAutoUpload = uploadActionUseCase.isEligibleForAutoUpload(siteModel, post),
                 uploadWillPushChanges = uploadActionUseCase.uploadWillPushChanges(post)
         )
-        uploadStatusArray[post.id] = newStatus
+        uploadStatusMap[post.id] = newStatus
         return newStatus
     }
 
     fun invalidateUploadStatus(localPostIds: List<Int>) {
-        localPostIds.forEach { uploadStatusArray.remove(it) }
+        localPostIds.forEach { uploadStatusMap.remove(it) }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.viewmodel.posts
 
-import android.annotation.SuppressLint
 import android.text.TextUtils
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -58,7 +57,6 @@ private const val SEARCH_DELAY_MS = 500L
 private const val SEARCH_PROGRESS_INDICATOR_DELAY_MS = 500L
 private const val EMPTY_VIEW_THROTTLE = 250L
 
-@SuppressLint("UseSparseArrays")
 class PostListViewModel @Inject constructor(
     private val dispatcher: Dispatcher,
     private val listStore: ListStore,


### PR DESCRIPTION
Fixes #11487 & #11488 & #11490. I don't really understand why `SparseArray` is causing `ArrayIndexOutOfBoundsException`. I know that it's using an array as the underlying data structure, but the key should be flexible, that's kind of the whole point of it. The only thing I can think of is that when we call `put`, the first argument is treated as if it's an index rather than a `key`, but the [docs say otherwise](https://developer.android.com/reference/android/support/v4/util/SparseArrayCompat#put(int,%20E)). Am I missing something?

A quick search didn't show anything, so unless I am missing something, I don't see any value in going through the source code for `SparseArray` to figure out what's going on. Also, as explained in the code comments, I think `HashMap` should perform better due to the number of items, so I think we should just switch.

P.S: @malinajirka I remember us having a conversation about this in one of the PRs, but I can't remember what.

**To test:**
* Go to post list
* Create a new draft or update an existing post
* Add featured media
* Make sure the post list works as expected (showing post upload, featured image etc)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
