### PR TITLE
Fix crash due to Uri support in ImageManager

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorInitializer.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.posts.editor
 
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType
 import org.wordpress.android.imageeditor.ImageEditor
@@ -51,15 +52,15 @@ class ImageEditorInitializer {
         }
 
         private fun <T : Any> onResourceReady(model: Any?, listener: ImageEditor.RequestListener<T>, resource: T) =
-            if (model != null && model is String) {
-                listener.onResourceReady(resource, model)
+            if (model != null && (model is String || model is Uri)) {
+                listener.onResourceReady(resource, model.toString())
             } else {
                 throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
             }
 
         private fun <T : Any> onLoadFailed(model: Any?, listener: ImageEditor.RequestListener<T>, e: Exception?) =
-            if (model != null && model is String) {
-                listener.onLoadFailed(e, model)
+            if (model != null && (model is String || model is Uri)) {
+                listener.onLoadFailed(e, model.toString())
             } else {
                 throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
             }


### PR DESCRIPTION
This PR fixes a crash when opening an image for editing because of `ImageManager` changes to support content URIs in this commit 0c024ad.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
