### PR TITLE
Testing: Switch connected tests to develop and release branches only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   android: wordpress-mobile/android@1.0
   git: wordpress-mobile/git@1.0
   bundle-install: toshimaru/bundle-install@0.3.1
-  slack: circleci/slack@2.5.0
+  slack: circleci/slack@3.4.2
 
 commands:
   copy-gradle-properties:
@@ -113,8 +113,14 @@ jobs:
           device: model=Nexus5X,version=26,locale=en,orientation=portrait
           project: api-project-108380595987
           timeout: 10m
+          num-flaky-test-attempts: 2
           results-history-name: CircleCI WordPress Connected Tests
       - android/save-gradle-cache
+      - slack/status:
+          fail_only: true
+          include_job_number_field: false
+          include_project_field: false
+          failure_message: ':red_circle: WordPress Android connected tests failed on \`${CIRCLE_BRANCH}\` branch after merge by ${CIRCLE_USERNAME}. See <https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670|Firebase console test results> for details.'
   strings-check:
     docker:
       - image: circleci/ruby:2.5.5
@@ -139,7 +145,11 @@ workflows:
           filters:
             branches:
               ignore: /pull\/[0-9]+/
+  wordpress_android_connected_tests:
+    jobs:
       - connected-tests:
           filters:
             branches:
-              ignore: /pull\/[0-9]+/
+              only:
+                - develop
+                - /^release.*/ # Runs on any release branch


### PR DESCRIPTION
We're seeing flakiness in our connected tests, especially during peak times when CI is under heavy load. To mitigate that, this PR makes a few changes:

* Connected tests only run on commits to `develop` and `release/*` branches. That means tests will run once for each PR (when the PR is merged) instead of on every commit in a PR.
* Connected tests will be retried twice; the build will only fail if tests fail 3 times.
* When a build fails, a message will be sent to Slack with this format (note that in practice the branch name will only be `develop` or e.g. `release/14.5` in this message):

<img width="633" alt="Screenshot 2020-03-23 13 07 19" src="https://user-images.githubusercontent.com/8658164/77319776-523ab800-6d07-11ea-8b6e-90a094aaa5ec.png">


To test:

* Confirm the CI changes look reasonable.
* Confirm the results of a failed build look good: this [forced failure](https://circleci.com/gh/wordpress-mobile/WordPress-Android/41690) and the resulting Slack message above.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
