### PR TITLE
Adding reader_tag_loaded event when user selects a tag in subfilter.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -518,6 +518,10 @@ public class ReaderPostListFragment extends Fragment
                               || (mCurrentBlogId != readerModeInfo.getBlogId())
                               || (mCurrentFeedId != readerModeInfo.getFeedId())
                               || (readerModeInfo.isFirstLoad());
+
+            if (changesDetected && !readerModeInfo.isFirstLoad()) {
+                trackTagLoaded(readerModeInfo.getTag());
+            }
         }
 
         if (onlyOnChanges && !changesDetected) return;


### PR DESCRIPTION
Fixes #11496 

With IA reader changes (version 14.3) we moved the way we select tags from being a spinner in the action bar to being a list item in a bottom sheet. In this way we are not triggering the reader_tag_loaded.

This PR reintroduces that event when user select a tag from the bottom sheet.

## To test
Make sure events are enabled in the app settings. Then you can check the event is triggered or not looking in Logcat and filtering with `Tracked: ` string.

- Open the reader and remove any filter in Following
- Move between tabs and check the event is not triggered
- Select a Site from the subfilter and check the event is not triggered (also moving between Discover/Likes etc... tabs)
- Select a tag and check the event is triggered
- Move between tabs and check that the event is not triggered moving away from the Following tab but is triggered when coming back to Following (I think this is correct since you are accessing again to the posts of that stream, it is similar to selecting again that tag stream from the spinner as we were doing before)
- Remove the filter and check the event is not triggered
- Opening a post from a tag or another stream should not trigger the event

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
