### PR TITLE
Issue/fix aztec gallery dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
@@ -1,8 +1,6 @@
 package org.wordpress.android.ui.posts;
 
-import android.content.Context;
 import android.os.Bundle;
-import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -84,7 +82,6 @@ public class InsertMediaDialog extends AppCompatDialogFragment {
 
     public static InsertMediaDialog newInstance(@NonNull InsertMediaCallback callback, @NonNull SiteModel site) {
         InsertMediaDialog dialog = new InsertMediaDialog();
-        dialog.setStyle(AppCompatDialogFragment.STYLE_NORMAL, R.style.Theme_AppCompat_Light_Dialog);
         dialog.setCallback(callback);
         Bundle args = new Bundle();
         args.putSerializable(WordPress.SITE, site);
@@ -108,9 +105,7 @@ public class InsertMediaDialog extends AppCompatDialogFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         getDialog().setTitle(R.string.media_insert_title);
 
-        Context themer = new ContextThemeWrapper(getActivity(), R.style.Calypso_SiteSettingsTheme);
-        LayoutInflater localInflater = inflater.cloneInContext(themer);
-        View view = localInflater.inflate(R.layout.insert_media_dialog, container, false);
+        View view = inflater.inflate(R.layout.insert_media_dialog, container, false);
 
         mInsertRadioGroup = (RadioGroup) view.findViewById(R.id.radio_group_insert_type);
         mGalleryRadioGroup = (RadioGroup) view.findViewById(R.id.radio_group_gallery_type);

--- a/WordPress/src/main/res/layout/insert_media_dialog.xml
+++ b/WordPress/src/main/res/layout/insert_media_dialog.xml
@@ -125,19 +125,19 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/button_cancel"
+                style="@style/Widget.MaterialComponents.Button.TextButton.Dialog"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                style="@style/Widget.MaterialComponents.Button.TextButton.Dialog"
-                android:text="@android:string/cancel"
-                android:layout_toStartOf="@+id/button_ok"/>
+                android:layout_toStartOf="@+id/button_ok"
+                android:text="@android:string/cancel" />
 
             <com.google.android.material.button.MaterialButton
-                style="@style/Widget.MaterialComponents.Button.TextButton.Dialog"
                 android:id="@+id/button_ok"
+                style="@style/Widget.MaterialComponents.Button.TextButton.Dialog"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@android:string/ok"
-                android:layout_alignParentEnd="true"/>
+                android:layout_alignParentEnd="true"
+                android:text="@android:string/ok" />
         </RelativeLayout>
     </LinearLayout>
 </ScrollView>

--- a/WordPress/src/main/res/layout/insert_media_dialog.xml
+++ b/WordPress/src/main/res/layout/insert_media_dialog.xml
@@ -17,14 +17,14 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_small">
 
-            <RadioButton
+            <com.google.android.material.radiobutton.MaterialRadioButton
                 android:id="@+id/radio_insert_individually"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/media_insert_individually"
                 android:textSize="@dimen/text_sz_large" />
 
-            <RadioButton
+            <com.google.android.material.radiobutton.MaterialRadioButton
                 android:id="@+id/radio_insert_as_gallery"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -49,31 +49,31 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content">
 
-                    <RadioButton
+                    <com.google.android.material.radiobutton.MaterialRadioButton
                         android:id="@+id/radio_thumbnail_grid"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/media_gallery_type_thumbnail_grid" />
 
-                    <RadioButton
+                    <com.google.android.material.radiobutton.MaterialRadioButton
                         android:id="@+id/radio_tiled"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/media_gallery_type_tiled" />
 
-                    <RadioButton
+                    <com.google.android.material.radiobutton.MaterialRadioButton
                         android:id="@+id/radio_squares"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/media_gallery_type_squares" />
 
-                    <RadioButton
+                    <com.google.android.material.radiobutton.MaterialRadioButton
                         android:id="@+id/radio_circles"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/media_gallery_type_circles" />
 
-                    <RadioButton
+                    <com.google.android.material.radiobutton.MaterialRadioButton
                         android:id="@+id/radio_slideshow"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -101,7 +101,7 @@
                 android:visibility="invisible"
                 tools:visibility="visible">
 
-                <TextView
+                <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/text_num_columns_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -123,14 +123,16 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_extra_large">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/button_cancel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                style="@style/Widget.MaterialComponents.Button.TextButton.Dialog"
                 android:text="@android:string/cancel"
                 android:layout_toStartOf="@+id/button_ok"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
+                style="@style/Widget.MaterialComponents.Button.TextButton.Dialog"
                 android:id="@+id/button_ok"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/WordPress/src/main/res/values/styles_calypso.xml
+++ b/WordPress/src/main/res/values/styles_calypso.xml
@@ -10,26 +10,6 @@
         <item name="android:textAppearanceLargePopupMenu">@style/Calypso.TextAppearance</item>
     </style>
 
-    <style name="Calypso.SiteSettingsTheme" parent="@style/CalypsoTheme">
-        <item name="android:windowActionModeOverlay">true</item>
-        <item name="android:actionModeCloseButtonStyle">@style/Calypso.ActionMode.Button</item>
-        <item name="android:actionModeStyle">@style/Calypso.ActionMode</item>
-        <item name="colorPrimaryDark">@color/neutral_40</item>
-
-        <item name="android:windowContentOverlay">@color/neutral_0</item>
-        <item name="android:alertDialogTheme">@style/Calypso.Dialog.Alert</item>
-        <item name="dialogTheme">@style/Calypso.Dialog.Alert</item>
-        <item name="colorControlActivated">@color/primary_40</item>
-        <item name="colorControlNormal">@color/neutral_10</item>
-        <item name="colorAccent">@color/accent</item>
-        <item name="android:listDivider">@drawable/bg_rectangle_divider</item>
-        <item name="android:dividerHeight">@dimen/site_settings_divider_height</item>
-    </style>
-
-    <style name="Calypso.ActionMode.Button" parent="ActionButton.CloseMode.WordPress">
-        <item name="android:background">@android:color/transparent</item>
-    </style>
-
     <style name="Calypso.ActionMode.Text">
         <item name="android:fontFamily" tools:ignore="NewApi">sans-serif-light</item>
         <item name="android:textColor">@android:color/white</item>


### PR DESCRIPTION
This PR updates the style of Aztec gallery dialog.

[![Image from Gyazo](https://i.gyazo.com/f060797e3ccbe3183bbdff84e1d62e6d.png)](https://gyazo.com/f060797e3ccbe3183bbdff84e1d62e6d)

To test:
- Using Aztec editor, open Add Media dialog and navigate to WordPress media library.
- Select multiple images and confirm your selection.
- Check that the resulting dialog looks good in both dark and light modes.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
