### PR TITLE
Add delay to wait Gutenberg to load in connected tests

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/EditorTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/EditorTests.java
@@ -51,6 +51,13 @@ public class EditorTests extends BaseTest {
         new MySitesPage()
                 .startNewPost();
 
+        /*
+        Since gutenberg currently takes a long time to load this sleep is necessary. There are some improvements
+        in the works for improving the load time for Gutenberg. Once they land we could decrease the sleep duration,
+        but we probably should have a little bit of a delay here to avoid false negative tests.
+         */
+        sleep(8000);
+
         EditorPage editorPage = new EditorPage();
         editorPage.enterTitle(title);
         editorPage.enterContent(content);
@@ -71,6 +78,13 @@ public class EditorTests extends BaseTest {
         MasterbarComponent mb = new MasterbarComponent().goToMySitesTab();
         sleep();
         mb.clickBlogPosts();
+
+        /*
+        Since gutenberg currently takes a long time to load this sleep is necessary. There are some improvements
+        in the works for improving the load time for Gutenberg. Once they land we could decrease the sleep duration,
+        but we probably should have a little bit of a delay here to avoid false negative tests.
+         */
+        sleep(8000);
 
         new MySitesPage()
                 .startNewPost();

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/EditorTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/EditorTests.java
@@ -52,11 +52,11 @@ public class EditorTests extends BaseTest {
                 .startNewPost();
 
         /*
-        Since gutenberg currently takes a long time to load this sleep is necessary. There are some improvements
+        Since gutenberg currently takes a long time to load, this sleep is necessary. There are some improvements
         in the works for improving the load time for Gutenberg. Once they land we could decrease the sleep duration,
         but we probably should have a little bit of a delay here to avoid false negative tests.
          */
-        sleep(8000);
+        sleep(15000);
 
         EditorPage editorPage = new EditorPage();
         editorPage.enterTitle(title);
@@ -79,15 +79,15 @@ public class EditorTests extends BaseTest {
         sleep();
         mb.clickBlogPosts();
 
+        new MySitesPage()
+                .startNewPost();
+
         /*
-        Since gutenberg currently takes a long time to load this sleep is necessary. There are some improvements
+        Since gutenberg currently takes a long time to load, this sleep is necessary. There are some improvements
         in the works for improving the load time for Gutenberg. Once they land we could decrease the sleep duration,
         but we probably should have a little bit of a delay here to avoid false negative tests.
          */
-        sleep(8000);
-
-        new MySitesPage()
-                .startNewPost();
+        sleep(15000);
 
         EditorPage editorPage = new EditorPage();
         editorPage.enterTitle(title);


### PR DESCRIPTION
**To test:**

* CI should pass without a restart

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
