### PR TITLE
Remove crash when RecyclerView is already gone on view click

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -172,6 +172,9 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     @Override
                     public void onClick(View v) {
                         int clickedPosition = blogHolder.getAdapterPosition();
+                        if (clickedPosition == RecyclerView.NO_POSITION) {
+                            return;
+                        }
                         switch (getBlogType()) {
                             case RECOMMENDED:
                                 mClickListener.onBlogClicked(mRecommendedBlogs.get(clickedPosition));


### PR DESCRIPTION
Fixes #11511
I think this happens when the view performs a click but the underlying RecyclerView is already gone (race condition?). Another thing might be when the view holder is being recycled. 

To test:
* There is no way to test this, the crash is super rare. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
