### PR TITLE
Fix IndexOutOfBoundsException in ReaderPostAdapter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -59,6 +59,7 @@ import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderTagHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderThumbnailStrip;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ColorUtils;
 import org.wordpress.android.util.ContextExtensionsKt;
 import org.wordpress.android.util.DateTimeUtils;
@@ -844,6 +845,11 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         if (mGapMarkerPosition > -1 && position > mGapMarkerPosition) {
             arrayPos--;
+        }
+
+        if (mPosts.size() <= arrayPos) {
+            AppLog.d(T.READER, "Trying to read an element out of bounds of the posts list");
+            return null;
         }
 
         return mPosts.get(arrayPos);


### PR DESCRIPTION
Fixes #11513
I was trying to find out why it's actually crashing but I gave up. I think just catching the case is good enough in this case. The issue is super minor so I don't think it matters that much but I've added logging in case this gets worse.

To test:
* There is nothing to test here

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
