### PR TITLE
Use custom image picker in gutenberg

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -331,9 +331,10 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                     switch (requestCode) {
                         case RequestCodes.PHOTO_PICKER:
                             if (data != null) {
-                                String mediaUriString = data.getStringExtra(PhotoPickerActivity.EXTRA_MEDIA_URI);
+                                String[] mediaUriStringsArray =
+                                        data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS);
 
-                                if (mediaUriString != null) {
+                                if (mediaUriStringsArray != null && mediaUriStringsArray.length > 0) {
                                     PhotoPickerMediaSource source = PhotoPickerMediaSource.fromString(
                                             data.getStringExtra(PhotoPickerActivity.EXTRA_MEDIA_SOURCE));
                                     AnalyticsTracker.Stat stat =
@@ -341,7 +342,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                                                 ? AnalyticsTracker.Stat.SIGNUP_EMAIL_EPILOGUE_GRAVATAR_SHOT_NEW
                                                 : AnalyticsTracker.Stat.SIGNUP_EMAIL_EPILOGUE_GRAVATAR_GALLERY_PICKED;
                                     AnalyticsTracker.track(stat);
-                                    Uri imageUri = Uri.parse(mediaUriString);
+                                    Uri imageUri = Uri.parse(mediaUriStringsArray[0]);
 
                                     if (imageUri != null) {
                                         boolean wasSuccess = WPMediaUtils.fetchMediaAndDoNext(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -397,8 +397,8 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
         switch (requestCode) {
             case RequestCodes.PHOTO_PICKER:
                 if (resultCode == Activity.RESULT_OK && data != null) {
-                    String strMediaUri = data.getStringExtra(PhotoPickerActivity.EXTRA_MEDIA_URI);
-                    if (strMediaUri == null) {
+                    String[] mediaUriStringsArray = data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS);
+                    if (mediaUriStringsArray == null || mediaUriStringsArray.length == 0) {
                         AppLog.e(AppLog.T.UTILS, "Can't resolve picked or captured image");
                         return;
                     }
@@ -409,7 +409,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
                                     ? AnalyticsTracker.Stat.ME_GRAVATAR_SHOT_NEW
                                     : AnalyticsTracker.Stat.ME_GRAVATAR_GALLERY_PICKED;
                     AnalyticsTracker.track(stat);
-                    Uri imageUri = Uri.parse(strMediaUri);
+                    Uri imageUri = Uri.parse(mediaUriStringsArray[0]);
                     if (imageUri != null) {
                         boolean didGoWell = WPMediaUtils.fetchMediaAndDoNext(getActivity(), imageUri,
                                                                              new WPMediaUtils.MediaFetchDoNext() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -849,8 +849,8 @@ public class MySiteFragment extends Fragment implements
                         showSiteIconProgressBar(true);
                         updateSiteIconMediaId(mediaId);
                     } else {
-                        String strMediaUri = data.getStringExtra(PhotoPickerActivity.EXTRA_MEDIA_URI);
-                        if (strMediaUri == null) {
+                        String[] mediaUriStringsArray = data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS);
+                        if (mediaUriStringsArray == null || mediaUriStringsArray.length == 0) {
                             AppLog.e(AppLog.T.UTILS, "Can't resolve picked or captured image");
                             return;
                         }
@@ -864,7 +864,7 @@ public class MySiteFragment extends Fragment implements
                                         : AnalyticsTracker.Stat.MY_SITE_ICON_GALLERY_PICKED;
                         AnalyticsTracker.track(stat);
 
-                        Uri imageUri = Uri.parse(strMediaUri);
+                        Uri imageUri = Uri.parse(mediaUriStringsArray[0]);
                         if (imageUri != null) {
                             boolean didGoWell = WPMediaUtils.fetchMediaAndDoNext(getActivity(), imageUri,
                                     new WPMediaUtils.MediaFetchDoNext() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
@@ -7,7 +7,8 @@ public enum MediaBrowserType {
     FEATURED_IMAGE_PICKER, // select a single image as a featured image
     GRAVATAR_IMAGE_PICKER, // select a single image as a gravatar
     SITE_ICON_PICKER, // select a single image as a site icon
-    GUTENBERG_IMAGE_PICKER, // select image from Gutenberg editor
+    GUTENBERG_IMAGE_PICKER, // select one or multiple images from Gutenberg editor
+    GUTENBERG_SINGLE_IMAGE_PICKER, // select image from Gutenberg editor
     GUTENBERG_VIDEO_PICKER, // select video from Gutenberg editor
     GUTENBERG_SINGLE_MEDIA_PICKER; // select multiple images or videos to insert into a post
 
@@ -20,7 +21,8 @@ public enum MediaBrowserType {
     }
 
     public boolean isSingleImagePicker() {
-        return this == FEATURED_IMAGE_PICKER || this == GRAVATAR_IMAGE_PICKER || this == SITE_ICON_PICKER;
+        return this == FEATURED_IMAGE_PICKER || this == GRAVATAR_IMAGE_PICKER || this == SITE_ICON_PICKER
+               || this == GUTENBERG_SINGLE_IMAGE_PICKER;
     }
 
     public boolean isSingleMediaPicker() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2193,9 +2193,13 @@ public class EditPostActivity extends AppCompatActivity implements
                         if (mEditPostSettingsFragment != null) {
                             mEditPostSettingsFragment.refreshViews();
                         }
-                    } else if (data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_URI)) {
-                        mEditorMedia.addNewMediaToEditorAsync(
-                                Uri.parse(data.getStringExtra(PhotoPickerActivity.EXTRA_MEDIA_URI)), false);
+                    } else if (data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)) {
+                        String[] mediaUrisArray = data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS);
+                        List<Uri> uris = new ArrayList<>(mediaUrisArray.length);
+                        for (String stringUri : mediaUrisArray) {
+                            uris.add(Uri.parse(stringUri));
+                        }
+                        mEditorMedia.addNewMediaItemsToEditorAsync(uris, false);
                     }
                     break;
                 case RequestCodes.MEDIA_LIBRARY:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2193,6 +2193,9 @@ public class EditPostActivity extends AppCompatActivity implements
                         if (mEditPostSettingsFragment != null) {
                             mEditPostSettingsFragment.refreshViews();
                         }
+                    } else if (data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_URI)) {
+                        mEditorMedia.addNewMediaToEditorAsync(
+                                Uri.parse(data.getStringExtra(PhotoPickerActivity.EXTRA_MEDIA_URI)), false);
                     }
                     break;
                 case RequestCodes.MEDIA_LIBRARY:
@@ -2426,7 +2429,13 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onAddPhotoClicked(boolean allowMultipleSelection) {
-        onPhotoPickerIconClicked(PhotoPickerIcon.ANDROID_CHOOSE_PHOTO, allowMultipleSelection);
+        if (allowMultipleSelection) {
+            ActivityLauncher.showPhotoPickerForResult(this, MediaBrowserType.GUTENBERG_IMAGE_PICKER, mSite,
+                    mEditPostRepository.getId());
+        } else {
+            ActivityLauncher.showPhotoPickerForResult(this, MediaBrowserType.GUTENBERG_SINGLE_IMAGE_PICKER, mSite,
+                    mEditPostRepository.getId());
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2194,11 +2194,8 @@ public class EditPostActivity extends AppCompatActivity implements
                             mEditPostSettingsFragment.refreshViews();
                         }
                     } else if (data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)) {
-                        String[] mediaUrisArray = data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS);
-                        List<Uri> uris = new ArrayList<>(mediaUrisArray.length);
-                        for (String stringUri : mediaUrisArray) {
-                            uris.add(Uri.parse(stringUri));
-                        }
+                        List<Uri> uris = convertStringArrayIntoUrisList(
+                                data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS));
                         mEditorMedia.addNewMediaItemsToEditorAsync(uris, false);
                     }
                     break;
@@ -2257,6 +2254,14 @@ public class EditPostActivity extends AppCompatActivity implements
             uriList.add(data.getData());
         }
         return uriList;
+    }
+
+    private List<Uri> convertStringArrayIntoUrisList(String[] stringArray) {
+        List<Uri> uris = new ArrayList<>(stringArray.length);
+        for (String stringUri : stringArray) {
+            uris.add(Uri.parse(stringUri));
+        }
+        return uris;
     }
 
     private void addLastTakenPicture() {


### PR DESCRIPTION
Partially fixes #11518 

Goal of this PR is to show our custom media picker instead of the OS default picker after the user clicks on "Choose from device" button when working with Image/Video/Gallery/Media&Text blocks. This PR also adds support to the custom media picker for selecting multiple images from the local storage.

This PR targets a feature branch and the behavior still has the following issues
- The custom picker displays both images and video files for all blocks. When you select a video file on an image block, gutenberg isn't able to deal with it.
- The custom image picker has a bottom navigation bar with "LocalStorage/UseCamera/WPMediaLibrary" options. We'll want to hide that before we merge these changes into develop.

To test:
1. Create a new post
2. Insert in Image block
3. Select "Choose from device"
4. Notice our custom media picker is shown
5. Select an image (make sure you can't select more than one)
6. Click on done


Repeat these steps for ~Video, Text&Media (make sure it works with both image and video) and~ Gallery block (make sure you can select more than one image).

------------------------------
1. Go to MySite
2. Click on the site's avatar
3.  Select "Change"
4. Verify the picker works and select an image
5. Click on done
6. Make sure the selected image gets uploaded

Repeat the same steps for user avatar - you can access it in `my site -> "me" action in the toolbar -> Change photo`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
