### PR TITLE
Fix and run WordPressUtils Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,11 @@ jobs:
       - android/restore-gradle-cache
       - copy-gradle-properties
       - run:
-          name: Test
+          name: Test WordPress
           command: ./gradlew --stacktrace testVanillaRelease
+      - run:
+          name: Test WordPressUtils
+          command: cd libs/utils && ./gradlew --stacktrace testReleaseUnitTest
       - android/save-gradle-cache
       - android/save-test-results
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,30 @@ jobs:
           include_job_number_field: false
           include_project_field: false
           failure_message: ':red_circle: WordPress Android connected tests failed on \`${CIRCLE_BRANCH}\` branch after merge by ${CIRCLE_USERNAME}. See <https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670|Firebase console test results> for details.'
+  WordPressUtils Connected Tests:
+    executor:
+      name: android/default
+      api-version: "28"
+    steps:
+      - git/shallow-checkout
+      - android/restore-gradle-cache
+      - copy-gradle-properties
+      - run:
+          name: Build
+          command: ./gradlew WordPress:assembleVanillaDebug && cd libs/utils && ./gradlew assembleAndroidTest --stacktrace
+      - run:
+          name: Decrypt credentials
+          command: openssl aes-256-cbc -md sha256 -d -in .circleci/.firebase.secrets.json.enc -out .circleci/.firebase.secrets.json -k "${FIREBASE_SECRETS_ENCRYPTION_KEY}"
+      - android/firebase-test:
+          key-file: .circleci/.firebase.secrets.json
+          type: instrumentation
+          apk-path: WordPress/build/outputs/apk/vanilla/debug/org.wordpress.android-vanilla-debug.apk
+          test-apk-path: libs/utils/WordPressUtils/build/outputs/apk/androidTest/debug/WordPressUtils-debug-androidTest.apk
+          device: model=Nexus5X,version=26,locale=en,orientation=portrait
+          project: api-project-108380595987
+          timeout: 10m
+          results-history-name: CircleCI WPUtils Connected Tests
+      - android/save-gradle-cache
   strings-check:
     docker:
       - image: circleci/ruby:2.5.5
@@ -142,6 +166,10 @@ workflows:
       - test
       - lint
       - Installable Build:
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
+      - WordPressUtils Connected Tests:
           filters:
             branches:
               ignore: /pull\/[0-9]+/

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.11.1'
 
     lintChecks 'org.wordpress:lint:1.0.1'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
 }
 
 android {
@@ -40,6 +43,8 @@ android {
         versionName "1.24"
         minSdkVersion 15
         targetSdkVersion 26
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 }
 

--- a/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/ImageUtilsTest.java
+++ b/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/ImageUtilsTest.java
@@ -1,9 +1,13 @@
 package org.wordpress.android.util;
 
 import android.graphics.BitmapFactory;
-import android.test.InstrumentationTestCase;
 
-public class ImageUtilsTest extends InstrumentationTestCase {
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ImageUtilsTest {
+    @Test
     public void testGetScaleForResizingReturnsOneWhenMaxSizeIsZero() {
         BitmapFactory.Options options = new BitmapFactory.Options();
         int scale = ImageUtils.getScaleForResizing(0, options);
@@ -11,6 +15,7 @@ public class ImageUtilsTest extends InstrumentationTestCase {
         assertEquals(1, scale);
     }
 
+    @Test
     public void testGetScaleForResizingSameSizeReturnsOne() {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.outHeight = 100;
@@ -22,6 +27,7 @@ public class ImageUtilsTest extends InstrumentationTestCase {
         assertEquals(1, scale);
     }
 
+    @Test
     public void testGetScaleForResizingPortraitMaxHeightSameAsMaxSizeReturnsOne() {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.outHeight = 100;
@@ -33,6 +39,7 @@ public class ImageUtilsTest extends InstrumentationTestCase {
         assertEquals(1, scale);
     }
 
+    @Test
     public void testGetScaleForResizingLandscapeMaxWidthSameAsMaxSizeReturnsOne() {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.outHeight = 1;
@@ -44,6 +51,7 @@ public class ImageUtilsTest extends InstrumentationTestCase {
         assertEquals(1, scale);
     }
 
+    @Test
     public void testGetScaleForResizingDoubleSizeReturnsTwo() {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.outHeight = 100;
@@ -55,6 +63,7 @@ public class ImageUtilsTest extends InstrumentationTestCase {
         assertEquals(2, scale);
     }
 
+    @Test
     public void testGetScaleForResizingThreeTimesSizeReturnsTwo() {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.outHeight = 100;
@@ -66,6 +75,7 @@ public class ImageUtilsTest extends InstrumentationTestCase {
         assertEquals(2, scale);
     }
 
+    @Test
     public void testGetScaleForResizingEightTimesSizeReturnsEight() {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.outHeight = 100;

--- a/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/JSONUtilsTest.java
+++ b/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/JSONUtilsTest.java
@@ -1,31 +1,36 @@
 package org.wordpress.android.util;
 
-import android.test.InstrumentationTestCase;
-
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.Test;
 
-public class JSONUtilsTest extends InstrumentationTestCase {
+public class JSONUtilsTest {
+    @Test
     public void testQueryJSONNullSource1() {
         JSONUtils.queryJSON((JSONObject) null, "", "");
     }
 
+    @Test
     public void testQueryJSONNullSource2() {
         JSONUtils.queryJSON((JSONArray) null, "", "");
     }
 
+    @Test
     public void testQueryJSONNullQuery1() {
         JSONUtils.queryJSON(new JSONObject(), null, "");
     }
 
+    @Test
     public void testQueryJSONNullQuery2() {
         JSONUtils.queryJSON(new JSONArray(), null, "");
     }
 
+    @Test
     public void testQueryJSONNullReturnValue1() {
         JSONUtils.queryJSON(new JSONObject(), "", null);
     }
 
+    @Test
     public void testQueryJSONNullReturnValue2() {
         JSONUtils.queryJSON(new JSONArray(), "", null);
     }

--- a/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/ShortcodeUtilsTest.java
+++ b/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/ShortcodeUtilsTest.java
@@ -1,24 +1,31 @@
 package org.wordpress.android.util;
 
-import android.test.InstrumentationTestCase;
+import org.junit.Test;
 
-public class ShortcodeUtilsTest extends InstrumentationTestCase {
+import static org.junit.Assert.assertEquals;
+
+public class ShortcodeUtilsTest {
+    @Test
     public void testGetVideoPressShortcodeFromId() {
         assertEquals("[wpvideo abcd1234]", ShortcodeUtils.getVideoPressShortcodeFromId("abcd1234"));
     }
 
+    @Test
     public void testGetVideoPressShortcodeFromNullId() {
         assertEquals("", ShortcodeUtils.getVideoPressShortcodeFromId(null));
     }
 
+    @Test
     public void testGetVideoPressIdFromCorrectShortcode() {
         assertEquals("abcd1234", ShortcodeUtils.getVideoPressIdFromShortCode("[wpvideo abcd1234]"));
     }
 
+    @Test
     public void testGetVideoPressIdFromInvalidShortcode() {
         assertEquals("", ShortcodeUtils.getVideoPressIdFromShortCode("[other abcd1234]"));
     }
 
+    @Test
     public void testGetVideoPressIdFromNullShortcode() {
         assertEquals("", ShortcodeUtils.getVideoPressIdFromShortCode(null));
     }

--- a/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/UrlUtilsTest.java
+++ b/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/UrlUtilsTest.java
@@ -1,21 +1,29 @@
 package org.wordpress.android.util;
 
-import android.test.InstrumentationTestCase;
+import org.junit.Test;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-public class UrlUtilsTest extends InstrumentationTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class UrlUtilsTest {
+    @Test
     public void testGetDomainFromUrlWithEmptyStringDoesNotReturnNull() {
         assertNotNull(UrlUtils.getHost(""));
     }
 
+    @Test
     public void testGetDomainFromUrlWithNoHostDoesNotReturnNull() {
         assertNotNull(UrlUtils.getHost("wordpress"));
     }
 
+    @Test
     public void testGetDomainFromUrlWithHostReturnsHost() {
         String url = "http://www.wordpress.com";
         String host = UrlUtils.getHost(url);
@@ -23,41 +31,49 @@ public class UrlUtilsTest extends InstrumentationTestCase {
         assertTrue(host.equals("www.wordpress.com"));
     }
 
+    @Test
     public void testAppendUrlParameter1() {
         String url = UrlUtils.appendUrlParameter("http://wp.com/test", "preview", "true");
         assertEquals("http://wp.com/test?preview=true", url);
     }
 
+    @Test
     public void testAppendUrlParameter2() {
         String url = UrlUtils.appendUrlParameter("http://wp.com/test?q=pony", "preview", "true");
         assertEquals("http://wp.com/test?q=pony&preview=true", url);
     }
 
+    @Test
     public void testAppendUrlParameter3() {
         String url = UrlUtils.appendUrlParameter("http://wp.com/test?q=pony#unicorn", "preview", "true");
         assertEquals("http://wp.com/test?q=pony&preview=true#unicorn", url);
     }
 
+    @Test
     public void testAppendUrlParameter4() {
         String url = UrlUtils.appendUrlParameter("/relative/test", "preview", "true");
         assertEquals("/relative/test?preview=true", url);
     }
 
+    @Test
     public void testAppendUrlParameter5() {
         String url = UrlUtils.appendUrlParameter("/relative/", "preview", "true");
         assertEquals("/relative/?preview=true", url);
     }
 
+    @Test
     public void testAppendUrlParameter6() {
         String url = UrlUtils.appendUrlParameter("http://wp.com/test/", "preview", "true");
         assertEquals("http://wp.com/test/?preview=true", url);
     }
 
+    @Test
     public void testAppendUrlParameter7() {
         String url = UrlUtils.appendUrlParameter("http://wp.com/test/?q=pony", "preview", "true");
         assertEquals("http://wp.com/test/?q=pony&preview=true", url);
     }
 
+    @Test
     public void testAppendUrlParameters1() {
         Map<String, String> params = new HashMap<>();
         params.put("w", "200");
@@ -68,6 +84,7 @@ public class UrlUtilsTest extends InstrumentationTestCase {
         }
     }
 
+    @Test
     public void testAppendUrlParameters2() {
         Map<String, String> params = new HashMap<>();
         params.put("h", "300");
@@ -78,22 +95,27 @@ public class UrlUtilsTest extends InstrumentationTestCase {
         }
     }
 
+    @Test
     public void testHttps1() {
         assertFalse(UrlUtils.isHttps(buildURL("http://wordpress.com/xmlrpc.php")));
     }
 
+    @Test
     public void testHttps2() {
         assertFalse(UrlUtils.isHttps(buildURL("http://wordpress.com#.b.com/test")));
     }
 
+    @Test
     public void testHttps3() {
         assertFalse(UrlUtils.isHttps(buildURL("http://wordpress.com/xmlrpc.php")));
     }
 
+    @Test
     public void testHttps4() {
         assertTrue(UrlUtils.isHttps(buildURL("https://wordpress.com")));
     }
 
+    @Test
     public void testHttps5() {
         assertTrue(UrlUtils.isHttps(buildURL("https://wordpress.com/test#test")));
     }


### PR DESCRIPTION
This PR fixes the outdated WordPressUtils test suite and allows it to be run in CI.

**To test:**
- Ensure the WordPressUtils tests are included in the list
- Ensure CI is passing

**PR submission checklist:**
- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
