### PR TITLE
Issue/11518 enable custom picker for video and Text&Media blocks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
@@ -11,7 +11,8 @@ public enum MediaBrowserType {
     GUTENBERG_SINGLE_IMAGE_PICKER, // select image from Gutenberg editor
     GUTENBERG_VIDEO_PICKER, // select one or multiple videos from Gutenberg editor
     GUTENBERG_SINGLE_VIDEO_PICKER, // select video from Gutenberg editor
-    GUTENBERG_SINGLE_MEDIA_PICKER; // select multiple images or videos to insert into a post
+    GUTENBERG_SINGLE_MEDIA_PICKER, // select a single image or video to insert into a post
+    GUTENBERG_MEDIA_PICKER; // select multiple images or videos to insert into a post
 
     public boolean isPicker() {
         return this != BROWSER;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
@@ -9,7 +9,8 @@ public enum MediaBrowserType {
     SITE_ICON_PICKER, // select a single image as a site icon
     GUTENBERG_IMAGE_PICKER, // select one or multiple images from Gutenberg editor
     GUTENBERG_SINGLE_IMAGE_PICKER, // select image from Gutenberg editor
-    GUTENBERG_VIDEO_PICKER, // select video from Gutenberg editor
+    GUTENBERG_VIDEO_PICKER, // select one or multiple videos from Gutenberg editor
+    GUTENBERG_SINGLE_VIDEO_PICKER, // select video from Gutenberg editor
     GUTENBERG_SINGLE_MEDIA_PICKER; // select multiple images or videos to insert into a post
 
     public boolean isPicker() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserType.java
@@ -27,6 +27,19 @@ public enum MediaBrowserType {
                || this == GUTENBERG_SINGLE_IMAGE_PICKER;
     }
 
+    public boolean isImagePicker() {
+        return this == EDITOR_PICKER || this == AZTEC_EDITOR_PICKER || this == FEATURED_IMAGE_PICKER
+               || this == GRAVATAR_IMAGE_PICKER || this == SITE_ICON_PICKER || this == GUTENBERG_IMAGE_PICKER
+               || this == GUTENBERG_SINGLE_IMAGE_PICKER || this == GUTENBERG_SINGLE_MEDIA_PICKER
+               || this == GUTENBERG_MEDIA_PICKER;
+    }
+
+    public boolean isVideoPicker() {
+        return this == EDITOR_PICKER || this == AZTEC_EDITOR_PICKER || this == GUTENBERG_VIDEO_PICKER
+               || this == GUTENBERG_SINGLE_VIDEO_PICKER || this == GUTENBERG_SINGLE_MEDIA_PICKER
+               || this == GUTENBERG_MEDIA_PICKER;
+    }
+
     public boolean isSingleMediaPicker() {
         return this == GUTENBERG_SINGLE_MEDIA_PICKER;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -450,10 +450,12 @@ public class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.
         @Override
         protected Boolean doInBackground(Void... params) {
             // images
-            addMedia(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, false);
+            if (mBrowserType.isImagePicker()) {
+                addMedia(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, false);
+            }
 
             // videos
-            if (!mBrowserType.isSingleImagePicker()) {
+            if (mBrowserType.isVideoPicker()) {
                 addMedia(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, true);
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2454,7 +2454,13 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onAddVideoClicked(boolean allowMultipleSelection) {
-        onPhotoPickerIconClicked(PhotoPickerIcon.ANDROID_CHOOSE_VIDEO, allowMultipleSelection);
+        if (allowMultipleSelection) {
+            ActivityLauncher.showPhotoPickerForResult(this, MediaBrowserType.GUTENBERG_VIDEO_PICKER, mSite,
+                    mEditPostRepository.getId());
+        } else {
+            ActivityLauncher.showPhotoPickerForResult(this, MediaBrowserType.GUTENBERG_SINGLE_VIDEO_PICKER, mSite,
+                    mEditPostRepository.getId());
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2465,7 +2465,13 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onAddDeviceMediaClicked(boolean allowMultipleSelection) {
-        onPhotoPickerIconClicked(PhotoPickerIcon.ANDROID_CHOOSE_PHOTO_OR_VIDEO, allowMultipleSelection);
+        if (allowMultipleSelection) {
+            ActivityLauncher.showPhotoPickerForResult(this, MediaBrowserType.GUTENBERG_MEDIA_PICKER, mSite,
+                    mEditPostRepository.getId());
+        } else {
+            ActivityLauncher.showPhotoPickerForResult(this, MediaBrowserType.GUTENBERG_SINGLE_MEDIA_PICKER, mSite,
+                    mEditPostRepository.getId());
+        }
     }
 
     @Override


### PR DESCRIPTION
Partially fixes #11518

Goal of this PR is to show our custom media picker instead of the OS default picker after the user clicks on "Choose from device" button when working with Video/Text&Media blocks. 
The app displays:
- only image files for image and gallery blocks
- only video files for video block
- both image and video files for Text&Media block.

This PR targets a feature branch and the behavior still has the following issues
- The custom image picker has a bottom navigation bar with "LocalStorage/UseCamera/WPMediaLibrary" options. We'll want to hide that before we merge these changes into develop.


To test:

1. Create a new post
2. Insert a Video Block
3. Select "Choose from device"
4. Notice our custom media picker is shown
5. Select an video file (make sure you can't select more than one and that only video files are available)
6. Click on done

Repeat these steps for Text&Media block (make sure you can't select more than one and that both image and video files are available).

-----------------------------------------

1. Create a new post
2. Insert an Image Block
3. Select "Choose from device"
4. Verify only image files are available

Repeat these steps for the Gallery block.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
