### PR TITLE
Add reblog to Reader Post Details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,8 @@
+14.6
+-----
+ 
+* Added reblog functionality
+
 14.5
 -----
 * Block editor: New block: Latest Posts

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.page.PageModel;
 import org.wordpress.android.fluxc.network.utils.StatsGranularity;
 import org.wordpress.android.login.LoginMode;
+import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.networking.SSLCertsViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
@@ -118,10 +119,39 @@ public class ActivityLauncher {
         activity.startActivity(intent);
     }
 
+    /**
+     * Presents the site picker and expects the selection result
+     *
+     * @param activity the activity that starts the site picker and expects the result
+     * @param site     the preselected site
+     */
     public static void showSitePickerForResult(Activity activity, SiteModel site) {
-        Intent intent = new Intent(activity, SitePickerActivity.class);
-        intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, site.getId());
+        Intent intent = createSitePickerIntent(activity, site);
         activity.startActivityForResult(intent, RequestCodes.SITE_PICKER);
+    }
+
+    /**
+     * Presents the site picker and expects the selection result
+     *
+     * @param fragment the fragment that starts the site picker and expects the result
+     * @param site     the preselected site
+     */
+    public static void showSitePickerForResult(Fragment fragment, SiteModel site) {
+        Intent intent = createSitePickerIntent(fragment.getContext(), site);
+        fragment.startActivityForResult(intent, RequestCodes.SITE_PICKER);
+    }
+
+    /**
+     * Creates a site picker intent
+     *
+     * @param context the context to use for the intent creation
+     * @param site    the preselected site
+     * @return the site picker intent
+     */
+    private static Intent createSitePickerIntent(Context context, SiteModel site) {
+        Intent intent = new Intent(context, SitePickerActivity.class);
+        intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, site.getId());
+        return intent;
     }
 
     public static void showPhotoPickerForResult(Activity activity,
@@ -244,6 +274,28 @@ public class ActivityLauncher {
         taskStackBuilder.addNextIntent(mainActivityIntent);
         taskStackBuilder.addNextIntent(editorIntent);
         taskStackBuilder.startActivities();
+    }
+
+    /**
+     * Opens the editor and passes the information needed for a reblog action
+     *
+     * @param activity the calling activity
+     * @param site     the site on which the post should be reblogged
+     * @param post     the post to be reblogged
+     */
+    public static void openEditorForReblog(Activity activity, @NonNull SiteModel site, @Nullable ReaderPost post) {
+        if (post == null) {
+            ToastUtils.showToast(activity, R.string.post_not_found, ToastUtils.Duration.SHORT);
+            return;
+        }
+        Intent editorIntent = new Intent(activity, EditPostActivity.class);
+        editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_TITLE, post.getTitle());
+        editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_QUOTE, post.getExcerpt());
+        editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_IMAGE, post.getFeaturedImage());
+        editorIntent.putExtra(EditPostActivity.EXTRA_REBLOG_POST_CITATION, post.getUrl());
+        editorIntent.setAction(EditPostActivity.ACTION_REBLOG);
+
+        addNewPostForResult(editorIntent, activity, site, false, PagePostCreationSourcesDetail.POST_FROM_REBLOG);
     }
 
     public static void viewStatsInNewStack(Context context, SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/PagePostCreationSourcesDetail.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/PagePostCreationSourcesDetail.kt
@@ -17,6 +17,8 @@ enum class PagePostCreationSourcesDetail(val label: String) {
     POST_FROM_STATS("post-from-stats"),
     // post created from notifications unread page when empty
     POST_FROM_NOTIFS_EMPTY_VIEW("post-from-notif-empty-view"),
+    // post created from reader reblog action
+    POST_FROM_REBLOG("post-from-reader-reblog"),
     // all other cases container
     NO_DETAIL("no-detail");
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -328,6 +328,7 @@ public class EditPostActivity extends AppCompatActivity implements
     @Inject EditorActionsProvider mEditorActionsProvider;
     @Inject DateTimeUtilsWrapper mDateTimeUtils;
     @Inject ViewModelProvider.Factory mViewModelFactory;
+    @Inject ReblogUtils mReblogUtils;
 
     private StorePostViewModel mViewModel;
 
@@ -2163,7 +2164,7 @@ public class EditPostActivity extends AppCompatActivity implements
             mHasSetPostContent = true;
             mEditPostRepository.updateAsync(postModel -> {
                 postModel.setTitle(title + "\n" + mSite.getDescription());
-                String content = ReblogUtils.reblogContent(image, quote, title, citation, mShowGutenbergEditor);
+                String content = mReblogUtils.reblogContent(image, quote, title, citation, mShowGutenbergEditor);
                 postModel.setContent(content);
                 mEditPostRepository.updatePublishDateIfShouldBePublishedImmediately(postModel);
                 return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -854,16 +854,17 @@ class ReaderPostDetailFragment : Fragment(),
 
         val countLikes = view!!.findViewById<ReaderIconCountView>(R.id.count_likes)
         val countComments = view!!.findViewById<ReaderIconCountView>(R.id.count_comments)
-        val reblogButton = view?.findViewById<ReaderIconCountView>(R.id.reblog)
+        val reblogButton = view!!.findViewById<ReaderIconCountView>(R.id.reblog)
 
         if (canBeReblogged()) {
-            reblogButton?.setCount(0)
-            reblogButton?.visibility = View.VISIBLE
-            reblogButton?.setOnClickListener {
+            reblogButton.setCount(0)
+            reblogButton.visibility = View.VISIBLE
+            reblogButton.setOnClickListener {
                 val sites = mSiteStore.visibleSites
                 when (sites.size) {
+                    0 -> ToastUtils.showToast(activity, R.string.reader_no_site_to_reblog)
                     1 -> ActivityLauncher.openEditorForReblog(activity, sites.first(), this.post)
-                    else -> { // The no site (0) case can be handled by the site picker for now
+                    else -> {
                         val siteLocalId = AppPrefs.getSelectedSite()
                         val site = mSiteStore.getSiteByLocalId(siteLocalId)
                         ActivityLauncher.showSitePickerForResult(this, site)
@@ -871,8 +872,8 @@ class ReaderPostDetailFragment : Fragment(),
                 }
             }
         } else {
-            reblogButton?.visibility = View.GONE
-            reblogButton?.setOnClickListener(null)
+            reblogButton.visibility = View.GONE
+            reblogButton.setOnClickListener(null)
         }
 
         if (canShowCommentCount()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -1051,18 +1051,16 @@ public class ReaderPostPagerActivity extends AppCompatActivity
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPostUploaded(OnPostUploaded event) {
-        if (getLifecycle().getCurrentState().isAtLeast(STARTED)) {
-            int siteLocalId = AppPrefs.getSelectedSite();
-            SiteModel site = mSiteStore.getSiteByLocalId(siteLocalId);
-            if (site != null && event.post != null && event.post.getLocalSiteId() == site.getId()) {
-                mUploadUtilsWrapper.onPostUploadedSnackbarHandler(
-                        this,
-                        findViewById(R.id.coordinator),
-                        event.isError(),
-                        event.post,
-                        null,
-                        site);
-            }
+        int siteLocalId = AppPrefs.getSelectedSite();
+        SiteModel site = mSiteStore.getSiteByLocalId(siteLocalId);
+        if (site != null && event.post != null && event.post.getLocalSiteId() == site.getId()) {
+            mUploadUtilsWrapper.onPostUploadedSnackbarHandler(
+                    this,
+                    findViewById(R.id.coordinator),
+                    event.isError(),
+                    event.post,
+                    null,
+                    site);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -77,8 +77,6 @@ import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
-import static androidx.lifecycle.Lifecycle.State.STARTED;
-
 /*
  * shows reader post detail fragments in a ViewPager - primarily used for easy swiping between
  * posts with a specific tag or in a specific blog, but can also be used to show a single

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
@@ -22,6 +22,7 @@ public class ReaderIconCountView extends LinearLayout {
     // these must match the same values in attrs.xml
     private static final int ICON_LIKE = 0;
     private static final int ICON_COMMENT = 1;
+    private static final int ICON_REBLOG = 2;
 
     public ReaderIconCountView(Context context) {
         super(context);
@@ -61,6 +62,12 @@ public class ReaderIconCountView extends LinearLayout {
                     case ICON_COMMENT:
                         mImageView.setImageDrawable(ContextCompat.getDrawable(context,
                                 R.drawable.ic_comment_white_24dp));
+                        mImageView.setImageTintList(getResources().getColorStateList(
+                                R.color.neutral_primary_40_neutral_40_selector));
+                        break;
+                    case ICON_REBLOG:
+                        mImageView.setImageDrawable(ContextCompat.getDrawable(context,
+                                R.drawable.ic_reblog_white_24dp));
                         mImageView.setImageTintList(getResources().getColorStateList(
                                 R.color.neutral_primary_40_neutral_40_selector));
                         break;

--- a/WordPress/src/main/java/org/wordpress/android/util/ReblogUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ReblogUtils.kt
@@ -1,0 +1,112 @@
+@file:JvmName("ReblogUtils")
+
+package org.wordpress.android.util
+
+/**
+ * Returns the string embedded in a quote
+ */
+val String.embeddedQuote
+    get() = "<blockquote>$this</blockquote>"
+
+/**
+ * Returns the string embedded in a WordPress quote
+ */
+val String.embeddedWpQuote
+    get() = """<!-- wp:quote --><blockquote class="wp-block-quote">$this</blockquote><!-- /wp:quote -->"""
+
+/**
+ * Returns the string embedded in a citation
+ */
+val String.embeddedCitation
+    get() = "<cite>$this</cite>"
+
+/**
+ * Creates an html image from an image url string or null if the url is not valid
+ * @param imageUrlString the image url string
+ * @param urlUtils optional UrlUtilsWrapper
+ * @return html image or null if the url is not valid
+ */
+@JvmOverloads
+fun htmlImage(imageUrlString: String?, urlUtils: UrlUtilsWrapper = UrlUtilsWrapper()): String? {
+    return if (urlUtils.isImageUrl(imageUrlString)) """<img src="$imageUrlString">""" else null
+}
+
+/**
+ * Returns an html WordPress image from an image url string or null if the url is not valid
+ * @param imageUrlString the image url string
+ * @param urlUtils optional UrlUtilsWrapper
+ * @return html image or null if the url is not valid
+ */
+@JvmOverloads
+fun htmlWpImage(imageUrlString: String?, urlUtils: UrlUtilsWrapper = UrlUtilsWrapper()): String? {
+    if (!urlUtils.isImageUrl(imageUrlString)) return null
+    return """<!-- wp:image --><figure class="wp-block-image">""" +
+            htmlImage(imageUrlString, urlUtils) + "</figure><!-- /wp:image -->"
+}
+
+/**
+ * Returns an html paragraph
+ */
+val String.htmlParagraph
+    get() = "<p>$this</p>"
+
+/**
+ * Creates a hyperlink from a url after validating the link
+ * @param url the url
+ * @param text the text to display. If not provided the [url] will be used
+ * @param urlUtils optional UrlUtilsWrapper
+ * @return the html of the hyperlink or null if the url is not valid
+ */
+@JvmOverloads
+fun hyperLink(url: String, text: String = url, urlUtils: UrlUtilsWrapper = UrlUtilsWrapper()): String? {
+    if (!urlUtils.isValidUrlAndHostNotNull(url)) return null
+    return """<a href="$url">$text</a>"""
+}
+
+/**
+ * Provides an html containing the post [quote] followed by a link citation if the later is valid
+ * @param quote the post quot
+ * @param citationUrl the citation link (optional)
+ * @param citationTitle the citation text (optional)
+ * @param urlUtils optional UrlUtilsWrapper
+ * @return the html containing the post [quote] followed by a link citation if the later is valid
+ */
+fun quoteWithCitation(
+    quote: String,
+    citationUrl: String? = null,
+    citationTitle: String? = null,
+    urlUtils: UrlUtilsWrapper = UrlUtilsWrapper()
+): String = when {
+    citationUrl == null -> quote.htmlParagraph
+    citationTitle == null -> quote.htmlParagraph + (hyperLink(citationUrl, urlUtils = urlUtils)?.embeddedCitation ?: "")
+    else -> quote.htmlParagraph + (hyperLink(citationUrl, citationTitle, urlUtils)?.embeddedCitation ?: "")
+}
+
+/**
+ * Provides the reblog post containing a featured image (if exists) followed by the quote and citation
+ * @param imageUrl the featured image url (might be null)
+ * @param quote the post quote
+ * @param citationTitle the citation text
+ * @param citationUrl the citation link
+ * @param isGutenberg if true
+ * @param urlUtils optional UrlUtilsWrapper instance
+ * @return the html containing the featured image (if exists) followed by the quote and citation
+ */
+@JvmOverloads
+fun reblogContent(
+    imageUrl: String?,
+    quote: String,
+    citationTitle: String?,
+    citationUrl: String?,
+    isGutenberg: Boolean = true,
+    urlUtils: UrlUtilsWrapper = UrlUtilsWrapper()
+): String {
+    val quoteWithCitation = quoteWithCitation(quote, citationUrl, citationTitle, urlUtils)
+    val html = if (isGutenberg) quoteWithCitation.embeddedWpQuote else quoteWithCitation.embeddedQuote
+    val imageHtml = if (isGutenberg) {
+        htmlWpImage(imageUrl, urlUtils)
+    } else {
+        htmlImage(imageUrl, urlUtils)?.htmlParagraph
+    }
+    return (imageHtml ?: "") + html
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/ReblogUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ReblogUtils.kt
@@ -1,112 +1,108 @@
-@file:JvmName("ReblogUtils")
-
 package org.wordpress.android.util
 
-/**
- * Returns the string embedded in a quote
- */
-val String.embeddedQuote
-    get() = "<blockquote>$this</blockquote>"
+import javax.inject.Inject
+import javax.inject.Singleton
 
-/**
- * Returns the string embedded in a WordPress quote
- */
-val String.embeddedWpQuote
-    get() = """<!-- wp:quote --><blockquote class="wp-block-quote">$this</blockquote><!-- /wp:quote -->"""
+@Singleton
+class ReblogUtils @Inject constructor(private val urlUtils: UrlUtilsWrapper) {
+    /**
+     * Returns the [string] embedded in a quote
+     */
+    fun embeddedQuote(string: String) = "<blockquote>$string</blockquote>"
 
-/**
- * Returns the string embedded in a citation
- */
-val String.embeddedCitation
-    get() = "<cite>$this</cite>"
-
-/**
- * Creates an html image from an image url string or null if the url is not valid
- * @param imageUrlString the image url string
- * @param urlUtils optional UrlUtilsWrapper
- * @return html image or null if the url is not valid
- */
-@JvmOverloads
-fun htmlImage(imageUrlString: String?, urlUtils: UrlUtilsWrapper = UrlUtilsWrapper()): String? {
-    return if (urlUtils.isImageUrl(imageUrlString)) """<img src="$imageUrlString">""" else null
-}
-
-/**
- * Returns an html WordPress image from an image url string or null if the url is not valid
- * @param imageUrlString the image url string
- * @param urlUtils optional UrlUtilsWrapper
- * @return html image or null if the url is not valid
- */
-@JvmOverloads
-fun htmlWpImage(imageUrlString: String?, urlUtils: UrlUtilsWrapper = UrlUtilsWrapper()): String? {
-    if (!urlUtils.isImageUrl(imageUrlString)) return null
-    return """<!-- wp:image --><figure class="wp-block-image">""" +
-            htmlImage(imageUrlString, urlUtils) + "</figure><!-- /wp:image -->"
-}
-
-/**
- * Returns an html paragraph
- */
-val String.htmlParagraph
-    get() = "<p>$this</p>"
-
-/**
- * Creates a hyperlink from a url after validating the link
- * @param url the url
- * @param text the text to display. If not provided the [url] will be used
- * @param urlUtils optional UrlUtilsWrapper
- * @return the html of the hyperlink or null if the url is not valid
- */
-@JvmOverloads
-fun hyperLink(url: String, text: String = url, urlUtils: UrlUtilsWrapper = UrlUtilsWrapper()): String? {
-    if (!urlUtils.isValidUrlAndHostNotNull(url)) return null
-    return """<a href="$url">$text</a>"""
-}
-
-/**
- * Provides an html containing the post [quote] followed by a link citation if the later is valid
- * @param quote the post quot
- * @param citationUrl the citation link (optional)
- * @param citationTitle the citation text (optional)
- * @param urlUtils optional UrlUtilsWrapper
- * @return the html containing the post [quote] followed by a link citation if the later is valid
- */
-fun quoteWithCitation(
-    quote: String,
-    citationUrl: String? = null,
-    citationTitle: String? = null,
-    urlUtils: UrlUtilsWrapper = UrlUtilsWrapper()
-): String = when {
-    citationUrl == null -> quote.htmlParagraph
-    citationTitle == null -> quote.htmlParagraph + (hyperLink(citationUrl, urlUtils = urlUtils)?.embeddedCitation ?: "")
-    else -> quote.htmlParagraph + (hyperLink(citationUrl, citationTitle, urlUtils)?.embeddedCitation ?: "")
-}
-
-/**
- * Provides the reblog post containing a featured image (if exists) followed by the quote and citation
- * @param imageUrl the featured image url (might be null)
- * @param quote the post quote
- * @param citationTitle the citation text
- * @param citationUrl the citation link
- * @param isGutenberg if true
- * @param urlUtils optional UrlUtilsWrapper instance
- * @return the html containing the featured image (if exists) followed by the quote and citation
- */
-@JvmOverloads
-fun reblogContent(
-    imageUrl: String?,
-    quote: String,
-    citationTitle: String?,
-    citationUrl: String?,
-    isGutenberg: Boolean = true,
-    urlUtils: UrlUtilsWrapper = UrlUtilsWrapper()
-): String {
-    val quoteWithCitation = quoteWithCitation(quote, citationUrl, citationTitle, urlUtils)
-    val html = if (isGutenberg) quoteWithCitation.embeddedWpQuote else quoteWithCitation.embeddedQuote
-    val imageHtml = if (isGutenberg) {
-        htmlWpImage(imageUrl, urlUtils)
-    } else {
-        htmlImage(imageUrl, urlUtils)?.htmlParagraph
+    /**
+     * Returns the [string] embedded in a WordPress quote
+     */
+    fun embeddedWpQuote(string: String): String {
+        return """<!-- wp:quote --><blockquote class="wp-block-quote">$string</blockquote><!-- /wp:quote -->"""
     }
-    return (imageHtml ?: "") + html
+
+    /**
+     * Returns the [string] embedded in a citation
+     */
+    fun embeddedCitation(string: String) = "<cite>$string</cite>"
+
+    /**
+     * Creates an html image from an image url string or null if the url is not valid
+     * @param imageUrlString the image url string
+     * @return html image or null if the url is not valid
+     */
+    fun htmlImage(imageUrlString: String?): String? {
+        return if (urlUtils.isImageUrl(imageUrlString)) """<img src="$imageUrlString">""" else null
+    }
+
+    /**
+     * Returns an html WordPress image from an image url string or null if the url is not valid
+     * @param imageUrlString the image url string
+     * @return html image or null if the url is not valid
+     */
+    fun htmlWpImage(imageUrlString: String?): String? {
+        if (!urlUtils.isImageUrl(imageUrlString)) return null
+        return """<!-- wp:image --><figure class="wp-block-image">""" +
+                htmlImage(imageUrlString) + "</figure><!-- /wp:image -->"
+    }
+
+    /**
+     * Returns the [string] in an html paragraph
+     */
+    fun htmlParagraph(string: String) = "<p>$string</p>"
+
+    /**
+     * Creates a hyperlink from a url after validating the link
+     * @param url the url
+     * @param text the text to display. If not provided the [url] will be used
+     * @return the html of the hyperlink or null if the url is not valid
+     */
+    @JvmOverloads
+    fun hyperLink(url: String, text: String = url): String? {
+        if (!urlUtils.isValidUrlAndHostNotNull(url)) return null
+        return """<a href="$url">$text</a>"""
+    }
+
+    /**
+     * Provides an html containing the post [quote] followed by a link citation if the later is valid
+     * @param quote the post quot
+     * @param citationUrl the citation link (optional)
+     * @param citationTitle the citation text (optional)
+     * @return the html containing the post [quote] followed by a link citation if the later is valid
+     */
+    fun quoteWithCitation(
+        quote: String,
+        citationUrl: String? = null,
+        citationTitle: String? = null
+    ): String = when {
+        citationUrl == null -> htmlParagraph(quote)
+        citationTitle == null -> htmlParagraph(quote) + embeddedCitation(
+                hyperLink(citationUrl)
+                        ?: ""
+        )
+        else -> htmlParagraph(quote) + (hyperLink(citationUrl, citationTitle)?.let { embeddedCitation(it) } ?: "")
+    }
+
+    /**
+     * Provides the reblog post containing a featured image (if exists) followed by the quote and citation
+     * @param imageUrl the featured image url (might be null)
+     * @param quote the post quote
+     * @param citationTitle the citation text
+     * @param citationUrl the citation link
+     * @param isGutenberg if true
+     * @return the html containing the featured image (if exists) followed by the quote and citation
+     */
+    @JvmOverloads
+    fun reblogContent(
+        imageUrl: String?,
+        quote: String,
+        citationTitle: String?,
+        citationUrl: String?,
+        isGutenberg: Boolean = true
+    ): String {
+        val quoteWithCitation = quoteWithCitation(quote, citationUrl, citationTitle)
+        val html = if (isGutenberg) embeddedWpQuote(quoteWithCitation) else embeddedQuote(quoteWithCitation)
+        val imageHtml = if (isGutenberg) {
+            htmlWpImage(imageUrl)
+        } else {
+            htmlImage(imageUrl)?.let { htmlParagraph(it) }
+        }
+        return (imageHtml ?: "") + html
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/UrlUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/UrlUtilsWrapper.kt
@@ -22,4 +22,12 @@ class UrlUtilsWrapper @Inject constructor() {
     fun getHost(urlString: String?): String {
         return UrlUtils.getHost(urlString)
     }
+
+    fun isValidUrlAndHostNotNull(urlString: String?): Boolean {
+        return UrlUtils.isValidUrlAndHostNotNull(urlString)
+    }
+
+    fun isImageUrl(urlString: String?): Boolean {
+        return UrlUtils.isImageUrl(urlString)
+    }
 }

--- a/WordPress/src/main/res/layout/reader_activity_post_pager.xml
+++ b/WordPress/src/main/res/layout/reader_activity_post_pager.xml
@@ -23,4 +23,11 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
+    <!-- this coordinator exists only for snackbars -->
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/coordinator"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="@dimen/reader_post_detail_snackbar_bottom_margin" />
+
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_activity_post_pager.xml
+++ b/WordPress/src/main/res/layout/reader_activity_post_pager.xml
@@ -27,7 +27,6 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/coordinator"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginBottom="@dimen/reader_post_detail_snackbar_bottom_margin" />
+        android:layout_height="match_parent" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -47,6 +47,15 @@
             tools:ignore="UselessParent" >
 
             <org.wordpress.android.ui.reader.views.ReaderIconCountView
+                android:id="@+id/reblog"
+                android:contentDescription="@string/reader_view_reblog"
+                android:layout_gravity="center_vertical"
+                android:layout_height="wrap_content"
+                android:layout_width="wrap_content"
+                wp:readerIcon="reblog" >
+            </org.wordpress.android.ui.reader.views.ReaderIconCountView>
+
+            <org.wordpress.android.ui.reader.views.ReaderIconCountView
                 android:id="@+id/count_comments"
                 android:contentDescription="@string/reader_view_comments"
                 android:layout_gravity="center_vertical"

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -80,6 +80,7 @@
         <attr name="readerIcon" format="enum">
             <enum name="like" value="0" />
             <enum name="comment" value="1" />
+            <enum name="reblog" value="2" />
         </attr>
     </declare-styleable>
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -479,4 +479,6 @@
     <dimen name="bottom_sheet_handle_width">32dp</dimen>
     <dimen name="bottom_sheet_handle_margin_top">4dp</dimen>
 
+    <!-- reader post detail snackbar bottom margin -->
+    <dimen name="reader_post_detail_snackbar_bottom_margin">56dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -479,6 +479,4 @@
     <dimen name="bottom_sheet_handle_width">32dp</dimen>
     <dimen name="bottom_sheet_handle_margin_top">4dp</dimen>
 
-    <!-- reader post detail snackbar bottom margin -->
-    <dimen name="reader_post_detail_snackbar_bottom_margin">56dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1678,6 +1678,7 @@
 
     <!-- reblog -->
     <string name="reader_view_reblog">Reblog</string>
+    <string name="reader_no_site_to_reblog">You should have at least one site to be able to reblog</string>
 
     <!-- like counts -->
     <string name="reader_label_like">Like</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1676,6 +1676,9 @@
 
     <string name="reader_excerpt_link">Visit %s for more</string>
 
+    <!-- reblog -->
+    <string name="reader_view_reblog">Reblog</string>
+
     <!-- like counts -->
     <string name="reader_label_like">Like</string>
     <string name="reader_likes_one">One person likes this</string>

--- a/WordPress/src/test/java/org/wordpress/android/util/ReblogUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/ReblogUtilsTest.kt
@@ -1,0 +1,213 @@
+package org.wordpress.android.util
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+private const val VALID_URL = "VALID_URL"
+private const val INVALID_URL = "INVALID_URL"
+private const val VALID_IMAGE_URL = "VALID_IMAGE_URL"
+private const val INVALID_IMAGE_URL = "INVALID_IMAGE_URL"
+
+/**
+ * Implements tests for ReblogUtils
+ */
+@RunWith(MockitoJUnitRunner::class)
+class ReblogUtilsTest {
+    @Mock private lateinit var urlUtils: UrlUtilsWrapper
+
+    @Before
+    fun setup() {
+        whenever(urlUtils.isValidUrlAndHostNotNull(VALID_URL)).thenReturn(true)
+        whenever(urlUtils.isValidUrlAndHostNotNull(INVALID_URL)).thenReturn(false)
+        whenever(urlUtils.isImageUrl(VALID_IMAGE_URL)).thenReturn(true)
+        whenever(urlUtils.isImageUrl(INVALID_IMAGE_URL)).thenReturn(false)
+    }
+
+    @Test
+    fun `embedded quote`() {
+        val expected = "<blockquote>some quote</blockquote>"
+        val actual = "some quote".embeddedQuote
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded empty quote`() {
+        val expected = "<blockquote></blockquote>"
+        val actual = "".embeddedQuote
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded WP quote`() {
+        val expected = """<!-- wp:quote --><blockquote class="wp-block-quote">quote</blockquote><!-- /wp:quote -->"""
+        val actual = "quote".embeddedWpQuote
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded empty WP quote`() {
+        val expected = """<!-- wp:quote --><blockquote class="wp-block-quote"></blockquote><!-- /wp:quote -->"""
+        val actual = "".embeddedWpQuote
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded citation`() {
+        val expected = "<cite>some citation</cite>"
+        val actual = "some citation".embeddedCitation
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded empty citation`() {
+        val expected = "<cite></cite>"
+        val actual = "".embeddedCitation
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded image`() {
+        val expected = """<img src="$VALID_IMAGE_URL">"""
+        val actual = htmlImage(VALID_IMAGE_URL, urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded image with invalid image url`() {
+        assertNull(htmlImage(INVALID_IMAGE_URL, urlUtils))
+    }
+
+    @Test
+    fun `embedded WP image`() {
+        val expected = """<!-- wp:image --><figure class="wp-block-image"><img src="$VALID_IMAGE_URL">""" +
+                "</figure><!-- /wp:image -->"
+        val actual = htmlWpImage(VALID_IMAGE_URL, urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded WP image with invalid image url`() {
+        assertNull(htmlWpImage(INVALID_IMAGE_URL, urlUtils))
+    }
+
+    @Test
+    fun `embedded paragraph`() {
+        val expected = "<p>some paragraph</p>"
+        val actual = "some paragraph".htmlParagraph
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `embedded empty paragraph`() {
+        val expected = "<p></p>"
+        val actual = "".htmlParagraph
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create hyperlink with valid url and text`() {
+        val expected = """<a href="$VALID_URL">some text</a>"""
+        val actual = hyperLink(VALID_URL, "some text", urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create hyperlink with valid url without a text`() {
+        val expected = """<a href="$VALID_URL">$VALID_URL</a>"""
+        val actual = hyperLink(VALID_URL, urlUtils = urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create hyperlink with invalid url`() {
+        assertNull(hyperLink(INVALID_URL, "not important", urlUtils))
+    }
+
+    @Test
+    fun `create quote without citation`() {
+        val expected = "<p>some quote</p>"
+        val actual = quoteWithCitation("some quote", urlUtils = urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create quote with citation having a valid url but no text`() {
+        val expected = """<p>some quote</p><cite><a href="$VALID_URL">$VALID_URL</a></cite>"""
+        val actual = quoteWithCitation("some quote", VALID_URL, urlUtils = urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create quote with citation having a valid url and text`() {
+        val expected = """<p>some quote</p><cite><a href="$VALID_URL">some text</a></cite>"""
+        val actual = quoteWithCitation("some quote", VALID_URL, "some text", urlUtils)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create reblog content with quote, citation and a valid image for Gutenberg editor`() {
+        val expected = """<!-- wp:image --><figure class="wp-block-image">""" +
+                """<img src="$VALID_IMAGE_URL"></figure><!-- /wp:image -->""" +
+                """<!-- wp:quote --><blockquote class="wp-block-quote"><p>some quote</p>""" +
+                """<cite><a href="$VALID_URL">some text</a></cite></blockquote><!-- /wp:quote -->"""
+        val actual = reblogContent(
+                VALID_IMAGE_URL,
+                "some quote",
+                "some text",
+                VALID_URL,
+                true,
+                urlUtils
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create reblog content with quote, citation and an invalid image for Gutenberg editor`() {
+        val expected = """<!-- wp:quote --><blockquote class="wp-block-quote"><p>some quote</p>""" +
+                """<cite><a href="$VALID_URL">some text</a></cite></blockquote><!-- /wp:quote -->"""
+        val actual = reblogContent(
+                INVALID_IMAGE_URL,
+                "some quote",
+                "some text",
+                VALID_URL,
+                true,
+                urlUtils
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create reblog content with quote, citation and a valid image for Aztec editor`() {
+        val expected = """<p><img src="$VALID_IMAGE_URL"></p>""" +
+                """<blockquote><p>some quote</p><cite><a href="$VALID_URL">some text</a></cite></blockquote>"""
+        val actual = reblogContent(
+                VALID_IMAGE_URL,
+                "some quote",
+                "some text",
+                VALID_URL,
+                false,
+                urlUtils
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `create reblog content with quote, citation and an invalid image for Aztec editor`() {
+        val expected = """<blockquote><p>some quote</p><cite><a href="$VALID_URL">some text</a></cite></blockquote>"""
+        val actual = reblogContent(
+                INVALID_IMAGE_URL,
+                "some quote",
+                "some text",
+                VALID_URL,
+                false,
+                urlUtils
+        )
+        assertEquals(expected, actual)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/util/ReblogUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/ReblogUtilsTest.kt
@@ -20,9 +20,11 @@ private const val INVALID_IMAGE_URL = "INVALID_IMAGE_URL"
 @RunWith(MockitoJUnitRunner::class)
 class ReblogUtilsTest {
     @Mock private lateinit var urlUtils: UrlUtilsWrapper
+    private lateinit var reblogUtils: ReblogUtils
 
     @Before
     fun setup() {
+        reblogUtils = ReblogUtils((urlUtils))
         whenever(urlUtils.isValidUrlAndHostNotNull(VALID_URL)).thenReturn(true)
         whenever(urlUtils.isValidUrlAndHostNotNull(INVALID_URL)).thenReturn(false)
         whenever(urlUtils.isImageUrl(VALID_IMAGE_URL)).thenReturn(true)
@@ -32,121 +34,121 @@ class ReblogUtilsTest {
     @Test
     fun `embedded quote`() {
         val expected = "<blockquote>some quote</blockquote>"
-        val actual = "some quote".embeddedQuote
+        val actual = reblogUtils.embeddedQuote("some quote")
         assertEquals(expected, actual)
     }
 
     @Test
     fun `embedded empty quote`() {
         val expected = "<blockquote></blockquote>"
-        val actual = "".embeddedQuote
+        val actual = reblogUtils.embeddedQuote("")
         assertEquals(expected, actual)
     }
 
     @Test
     fun `embedded WP quote`() {
         val expected = """<!-- wp:quote --><blockquote class="wp-block-quote">quote</blockquote><!-- /wp:quote -->"""
-        val actual = "quote".embeddedWpQuote
+        val actual = reblogUtils.embeddedWpQuote("quote")
         assertEquals(expected, actual)
     }
 
     @Test
     fun `embedded empty WP quote`() {
         val expected = """<!-- wp:quote --><blockquote class="wp-block-quote"></blockquote><!-- /wp:quote -->"""
-        val actual = "".embeddedWpQuote
+        val actual = reblogUtils.embeddedWpQuote("")
         assertEquals(expected, actual)
     }
 
     @Test
     fun `embedded citation`() {
         val expected = "<cite>some citation</cite>"
-        val actual = "some citation".embeddedCitation
+        val actual = reblogUtils.embeddedCitation("some citation")
         assertEquals(expected, actual)
     }
 
     @Test
     fun `embedded empty citation`() {
         val expected = "<cite></cite>"
-        val actual = "".embeddedCitation
+        val actual = reblogUtils.embeddedCitation("")
         assertEquals(expected, actual)
     }
 
     @Test
     fun `embedded image`() {
         val expected = """<img src="$VALID_IMAGE_URL">"""
-        val actual = htmlImage(VALID_IMAGE_URL, urlUtils)
+        val actual = reblogUtils.htmlImage(VALID_IMAGE_URL)
         assertEquals(expected, actual)
     }
 
     @Test
     fun `embedded image with invalid image url`() {
-        assertNull(htmlImage(INVALID_IMAGE_URL, urlUtils))
+        assertNull(reblogUtils.htmlImage(INVALID_IMAGE_URL))
     }
 
     @Test
     fun `embedded WP image`() {
         val expected = """<!-- wp:image --><figure class="wp-block-image"><img src="$VALID_IMAGE_URL">""" +
                 "</figure><!-- /wp:image -->"
-        val actual = htmlWpImage(VALID_IMAGE_URL, urlUtils)
+        val actual = reblogUtils.htmlWpImage(VALID_IMAGE_URL)
         assertEquals(expected, actual)
     }
 
     @Test
     fun `embedded WP image with invalid image url`() {
-        assertNull(htmlWpImage(INVALID_IMAGE_URL, urlUtils))
+        assertNull(reblogUtils.htmlWpImage(INVALID_IMAGE_URL))
     }
 
     @Test
     fun `embedded paragraph`() {
         val expected = "<p>some paragraph</p>"
-        val actual = "some paragraph".htmlParagraph
+        val actual = reblogUtils.htmlParagraph("some paragraph")
         assertEquals(expected, actual)
     }
 
     @Test
     fun `embedded empty paragraph`() {
         val expected = "<p></p>"
-        val actual = "".htmlParagraph
+        val actual = reblogUtils.htmlParagraph("")
         assertEquals(expected, actual)
     }
 
     @Test
     fun `create hyperlink with valid url and text`() {
         val expected = """<a href="$VALID_URL">some text</a>"""
-        val actual = hyperLink(VALID_URL, "some text", urlUtils)
+        val actual = reblogUtils.hyperLink(VALID_URL, "some text")
         assertEquals(expected, actual)
     }
 
     @Test
     fun `create hyperlink with valid url without a text`() {
         val expected = """<a href="$VALID_URL">$VALID_URL</a>"""
-        val actual = hyperLink(VALID_URL, urlUtils = urlUtils)
+        val actual = reblogUtils.hyperLink(VALID_URL)
         assertEquals(expected, actual)
     }
 
     @Test
     fun `create hyperlink with invalid url`() {
-        assertNull(hyperLink(INVALID_URL, "not important", urlUtils))
+        assertNull(reblogUtils.hyperLink(INVALID_URL, "not important"))
     }
 
     @Test
     fun `create quote without citation`() {
         val expected = "<p>some quote</p>"
-        val actual = quoteWithCitation("some quote", urlUtils = urlUtils)
+        val actual = reblogUtils.quoteWithCitation("some quote")
         assertEquals(expected, actual)
     }
 
     @Test
     fun `create quote with citation having a valid url but no text`() {
         val expected = """<p>some quote</p><cite><a href="$VALID_URL">$VALID_URL</a></cite>"""
-        val actual = quoteWithCitation("some quote", VALID_URL, urlUtils = urlUtils)
+        val actual = reblogUtils.quoteWithCitation("some quote", VALID_URL)
         assertEquals(expected, actual)
     }
 
     @Test
     fun `create quote with citation having a valid url and text`() {
         val expected = """<p>some quote</p><cite><a href="$VALID_URL">some text</a></cite>"""
-        val actual = quoteWithCitation("some quote", VALID_URL, "some text", urlUtils)
+        val actual = reblogUtils.quoteWithCitation("some quote", VALID_URL, "some text")
         assertEquals(expected, actual)
     }
 
@@ -156,13 +158,12 @@ class ReblogUtilsTest {
                 """<img src="$VALID_IMAGE_URL"></figure><!-- /wp:image -->""" +
                 """<!-- wp:quote --><blockquote class="wp-block-quote"><p>some quote</p>""" +
                 """<cite><a href="$VALID_URL">some text</a></cite></blockquote><!-- /wp:quote -->"""
-        val actual = reblogContent(
+        val actual = reblogUtils.reblogContent(
                 VALID_IMAGE_URL,
                 "some quote",
                 "some text",
                 VALID_URL,
-                true,
-                urlUtils
+                true
         )
         assertEquals(expected, actual)
     }
@@ -171,13 +172,12 @@ class ReblogUtilsTest {
     fun `create reblog content with quote, citation and an invalid image for Gutenberg editor`() {
         val expected = """<!-- wp:quote --><blockquote class="wp-block-quote"><p>some quote</p>""" +
                 """<cite><a href="$VALID_URL">some text</a></cite></blockquote><!-- /wp:quote -->"""
-        val actual = reblogContent(
+        val actual = reblogUtils.reblogContent(
                 INVALID_IMAGE_URL,
                 "some quote",
                 "some text",
                 VALID_URL,
-                true,
-                urlUtils
+                true
         )
         assertEquals(expected, actual)
     }
@@ -186,13 +186,12 @@ class ReblogUtilsTest {
     fun `create reblog content with quote, citation and a valid image for Aztec editor`() {
         val expected = """<p><img src="$VALID_IMAGE_URL"></p>""" +
                 """<blockquote><p>some quote</p><cite><a href="$VALID_URL">some text</a></cite></blockquote>"""
-        val actual = reblogContent(
+        val actual = reblogUtils.reblogContent(
                 VALID_IMAGE_URL,
                 "some quote",
                 "some text",
                 VALID_URL,
-                false,
-                urlUtils
+                false
         )
         assertEquals(expected, actual)
     }
@@ -200,13 +199,12 @@ class ReblogUtilsTest {
     @Test
     fun `create reblog content with quote, citation and an invalid image for Aztec editor`() {
         val expected = """<blockquote><p>some quote</p><cite><a href="$VALID_URL">some text</a></cite></blockquote>"""
-        val actual = reblogContent(
+        val actual = reblogUtils.reblogContent(
                 INVALID_IMAGE_URL,
                 "some quote",
                 "some text",
                 VALID_URL,
-                false,
-                urlUtils
+                false
         )
         assertEquals(expected, actual)
     }


### PR DESCRIPTION
Fixes #11531 

## Description

This feature adds the reblog functionality in the reader post details view

A reblog button has been added in the Reader Post Details. 
If the user has more that one sites the button triggers the existing Site Picker.

| Post Details |Site Picker (unchanged)|
|--- |---|
|![2020-03-19 22 05 24](https://user-images.githubusercontent.com/304044/77110680-993a5c00-6a2e-11ea-8caf-e9f7b49b9903.png)|![2020-03-19 22 05 33](https://user-images.githubusercontent.com/304044/77110683-9b041f80-6a2e-11ea-8f21-198d89d5ead1.png)|

If the user has only one site the editor is triggered directly.
At the moment handling users with no site is not supported.

When the users selects a site he is redirected to the editor with the following information prefilled:
* Title (with source)
* Image (if the post has a featured)
* Quote
* Citation

| Gutenberg editor with featured image| Gutenberg editor without image |
| --- | --- |
|![device-2020-03-22-114527](https://user-images.githubusercontent.com/304044/77246840-b8560b00-6c33-11ea-8b38-28dc15e7b888.png)|![2020-03-19 22 06 05](https://user-images.githubusercontent.com/304044/77110686-9c354c80-6a2e-11ea-858d-f09c597f6348.png)|

| Aztec editor with featured image| Aztec editor without image |
| --- | --- |
|![device-2020-03-22-114630](https://user-images.githubusercontent.com/304044/77246853-d459ac80-6c33-11ea-9059-40c0c62eb03f.png)|![device-2020-03-22-114609](https://user-images.githubusercontent.com/304044/77246855-d885ca00-6c33-11ea-8bea-9943adfebb79.png)|

When the user taps the Publish button and confirms he returns to the original context

| Uploading State| Post Published |
| --- | --- |
|![device-2020-03-25-220432](https://user-images.githubusercontent.com/304044/77580504-d1391780-6ee4-11ea-8eba-eeaf05132dad.png)|![device-2020-03-25-220329](https://user-images.githubusercontent.com/304044/77580509-d4cc9e80-6ee4-11ea-9bb5-455d412b5209.png)|

## Test

0. Open the App and Login if needed
1. Select the Reader tab
2. Tap on a post card
3. Notice the reblog action on the post detail view
4. Tap on the reblog action
5. If prompted select a site from the picker
6. Notice that the editor opens with content from the original post: Title (with source), Image (if the post has a featured), Quote and Citation link
7. Optionally edit the post
8. Press the Publish button
9. Confirm by pressing the Publish Now button in the dialog
10. Notice that you return to the original context (post detail view)
11. Notice the snackbar with the VIEW button
12. Tap on the VIEW button
13. Examine the reblogged post in the browser

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
