### PR TITLE
Testing: Add optional connected tests on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - store_artifacts:
           path: Artifacts
           destination: Artifacts
-  connected-tests:
+  Connected Tests:
     executor:
       name: android/default
       api-version: "28"
@@ -176,11 +176,18 @@ workflows:
           filters:
             branches:
               ignore: /pull\/[0-9]+/
-  wordpress_android_connected_tests:
-    jobs:
-      - connected-tests:
+      - Connected Tests:
           filters:
             branches:
               only:
                 - develop
                 - /^release.*/ # Runs on any release branch
+      - Hold:
+          type: approval
+      - Connected Tests:
+          requires: [Hold] # Optionally run connected tests on PRs
+          filters:
+            branches:
+              ignore:
+                - develop
+                - /^release.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,32 @@ jobs:
           include_job_number_field: false
           include_project_field: false
           failure_message: ':red_circle: WordPress Android connected tests failed on \`${CIRCLE_BRANCH}\` branch after merge by ${CIRCLE_USERNAME}. See <https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670|Firebase console test results> for details.'
+  Optional Connected Tests:
+    executor:
+      name: android/default
+      api-version: "28"
+    steps:
+      - git/shallow-checkout
+      - android/restore-gradle-cache
+      - copy-gradle-properties
+      - run:
+          name: Build
+          command: ./gradlew WordPress:assembleVanillaDebug WordPress:assembleVanillaDebugAndroidTest --stacktrace
+      - run:
+          name: Decrypt credentials
+          command: openssl aes-256-cbc -md sha256 -d -in .circleci/.firebase.secrets.json.enc -out .circleci/.firebase.secrets.json -k "${FIREBASE_SECRETS_ENCRYPTION_KEY}"
+      - android/firebase-test:
+          key-file: .circleci/.firebase.secrets.json
+          type: instrumentation
+          apk-path: WordPress/build/outputs/apk/vanilla/debug/org.wordpress.android-vanilla-debug.apk
+          test-apk-path: WordPress/build/outputs/apk/androidTest/vanilla/debug/org.wordpress.android-vanilla-debug-androidTest.apk
+          test-targets: notPackage org.wordpress.android.ui.screenshots
+          device: model=Nexus5X,version=26,locale=en,orientation=portrait
+          project: api-project-108380595987
+          timeout: 10m
+          num-flaky-test-attempts: 2
+          results-history-name: CircleCI WordPress Connected Tests
+      - android/save-gradle-cache
   WordPressUtils Connected Tests:
     executor:
       name: android/default
@@ -194,5 +220,5 @@ workflows:
                 - develop
                 - /^release.*/
                 - /pull\/[0-9]+/
-      - Connected Tests:
+      - Optional Connected Tests:
           requires: [Hold]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,10 +193,6 @@ workflows:
               ignore:
                 - develop
                 - /^release.*/
+                - /pull\/[0-9]+/
       - Connected Tests:
           requires: [Hold]
-          filters:
-            branches:
-              ignore:
-                - develop
-                - /^release.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,15 +177,22 @@ workflows:
             branches:
               ignore: /pull\/[0-9]+/
       - Connected Tests:
+          # Always run connected tests on develop and release branches
           filters:
             branches:
               only:
                 - develop
-                - /^release.*/ # Runs on any release branch
+                - /^release.*/
       - Hold:
           type: approval
+          filters:
+            branches:
+              ignore:
+                - develop
+                - /^release.*/
       - Connected Tests:
-          requires: [Hold] # Optionally run connected tests on PRs
+          #Optionally run connected tests on PRs
+          requires: [Hold]
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
           fail_only: true
           include_job_number_field: false
           include_project_field: false
-          failure_message: ':red_circle: WordPress Android connected tests failed on \`${CIRCLE_BRANCH}\` branch after merge by ${CIRCLE_USERNAME}. See <https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670|Firebase console test results> for details.'
+          failure_message: ':red_circle: WordPress Android connected tests failed on \`${CIRCLE_BRANCH}\` branch after merge by ${CIRCLE_USERNAME}. See <https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670|Firebase console test results> for details.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'
   Optional Connected Tests:
     executor:
       name: android/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,9 @@ workflows:
               only:
                 - develop
                 - /^release.*/
+  Optional Tests:
+    #Optionally run connected tests on PRs
+    jobs:
       - Hold:
           type: approval
           filters:
@@ -191,7 +194,6 @@ workflows:
                 - develop
                 - /^release.*/
       - Connected Tests:
-          #Optionally run connected tests on PRs
           requires: [Hold]
           filters:
             branches:


### PR DESCRIPTION
This change sets up a CircleCI workflow to optionally run connected tests on PRs.

Here's how the setup works:
* The `Optional Tests/Hold` job puts the workflow on hold, so the tests will only run when they are manually triggered on CircleCI.
* Peril is now set up to force the `Optional Tests/Hold` check to have a `success` status on the PR, so it won't block merging if you choose not to run the tests.
* Peril comments on the PR with a link to the Optional Tests workflow on CircleCI. To run the tests, you can approve the Hold job on CircleCI and the Connected Tests results will be posted on the PR.
* Any new commits to the PR will trigger the Peril comment to be updated with the current link to run the connected tests.

Related changes to Peril settings:

* https://github.com/Automattic/peril-settings/pull/39
* https://github.com/Automattic/peril-settings/pull/40

To test:

* Confirm you see a `ci/circleci: Optional Tests/Hold` check on this PR with a `success` status.
* Confirm you see a Peril comment on this PR that says, "You can trigger optional UI/connected tests for these changes by visiting CircleCI here."
* Confirm the text "here" is a link to the `Optional Tests` workflow on CircleCI. On CircleCI, confirm you can manually approve it to start the connected tests.
* Confirm that when the connected tests finish, the test results are posted as an additional check on the PR.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
