### PR TITLE
Add log persistence

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -242,8 +242,10 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         sOAuthAuthenticator = mOAuthAuthenticator;
 
         ProfilingUtils.start("App Startup");
+
         // Enable log recording
         AppLog.enableRecording(true);
+        AppLog.enableLogFilePersistence(this.getBaseContext(), 3);
         AppLog.addListener(new AppLogListener() {
             @Override
             public void onLog(T tag, LogLevel logLevel, String message) {

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -1,15 +1,20 @@
 buildscript {
+    ext.kotlin_version = '1.3.61'
+
     repositories {
         google()
         jcenter()
     }
     dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.novoda:bintray-release:0.9'
     }
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.novoda.bintray-release'
 
 repositories {
@@ -24,13 +29,20 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'org.greenrobot:eventbus:3.0.0'
 
+    implementation "androidx.core:core-ktx:+"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:3.11.1'
+    testImplementation "org.robolectric:robolectric:4.3.1"
+    testImplementation 'androidx.test:core:1.0.0'
 
     lintChecks 'org.wordpress:lint:1.0.1'
     androidTestImplementation 'androidx.test:runner:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'
+    androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
+
 }
 
 android {
@@ -45,6 +57,15 @@ android {
         targetSdkVersion 26
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -53,7 +53,7 @@ android {
 
     defaultConfig {
         versionName "1.24"
-        minSdkVersion 15
+        minSdkVersion 18
         targetSdkVersion 26
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -277,16 +277,15 @@ public class AppLog {
             return sb.toString();
         }
 
-        @NonNull @Override public String toString() {
-            StringBuilder sb = new StringBuilder();
-            sb.append("[")
-              .append(this.formatLogDate()).append(" ")
-              .append(this.mLogTag.name())
-              .append("] ")
-              .append(this.mLogText)
-              .append("\n");
-
-            return sb.toString();
+        @Override
+        public @NonNull String toString() {
+            return "["
+            + formatLogDate()
+            + " "
+            + mLogTag.name()
+            + "] "
+            + mLogText
+            + "\n";
         }
     }
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -101,12 +101,12 @@ public class AppLog {
          LogFileProvider logFileProvider = LogFileProvider.fromContext(context);
          new LogFileCleaner(logFileProvider, maxLogCount).clean();
 
-         mLogFileWriter = new LogFileWriter(logFileProvider);
-         mLogFileWriter.write(getAppInfoHeaderText(context) + "\n");
-         mLogFileWriter.write(getDeviceInfoHeaderText(context) + "\n");
+         sLogFileWriter = new LogFileWriter(logFileProvider);
+         sLogFileWriter.write(getAppInfoHeaderText(context) + "\n");
+         sLogFileWriter.write(getDeviceInfoHeaderText(context) + "\n");
     }
 
-    private static LogFileWriter mLogFileWriter;
+    private static LogFileWriter sLogFileWriter;
 
     /**
      * Sends a VERBOSE log message
@@ -322,8 +322,8 @@ public class AppLog {
             LogEntry entry = new LogEntry(level, text, tag);
             mLogEntries.addEntry(entry);
 
-            if (mLogFileWriter != null) {
-                mLogFileWriter.write(entry.toString());
+            if (sLogFileWriter != null) {
+                sLogFileWriter.write(entry.toString());
             }
         }
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import org.wordpress.android.util.helpers.logfile.LogFileCleaner;
+import org.wordpress.android.util.helpers.logfile.LogFileProvider;
 import org.wordpress.android.util.helpers.logfile.LogFileWriter;
 
 import java.io.PrintWriter;
@@ -97,11 +98,12 @@ public class AppLog {
      * @param maxLogCount The maximum number of logs that should be stored
      */
      public static void enableLogFilePersistence(Context context, int maxLogCount) {
-        new LogFileCleaner(context, maxLogCount).clean();
+         LogFileProvider logFileProvider = LogFileProvider.fromContext(context);
+         new LogFileCleaner(logFileProvider, maxLogCount).clean();
 
-        mLogFileWriter = new LogFileWriter(context);
-        mLogFileWriter.write(getAppInfoHeaderText(context) + "\n");
-        mLogFileWriter.write(getDeviceInfoHeaderText(context) + "\n");
+         mLogFileWriter = new LogFileWriter(logFileProvider);
+         mLogFileWriter.write(getAppInfoHeaderText(context) + "\n");
+         mLogFileWriter.write(getDeviceInfoHeaderText(context) + "\n");
     }
 
     private static LogFileWriter mLogFileWriter;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileCleaner.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileCleaner.kt
@@ -1,0 +1,36 @@
+package org.wordpress.android.util.helpers.logfile
+
+import android.content.Context
+import java.io.File
+
+/**
+ * Prunes the Log File Store by retaining only the last `maxLogFileCount` log files.
+ */
+class LogFileCleaner {
+    private val maxLogFileCount: Int
+    private val logFiles: List<File>
+
+    /**
+     * Create a new LogFileCleaner.
+     *
+     * The file list is created upon instantiation – any files added
+     * afterwards won't be modified.
+     *
+     * @param context: The application context
+     * @param maxLogFileCount: The number of log files to retain
+     */
+    constructor(context: Context, maxLogFileCount: Int) {
+        this.maxLogFileCount = maxLogFileCount
+        this.logFiles = LogFileHelpers.logFiles(context)
+    }
+
+    /**
+     * Immediately removes all log files known to exist by this instance except for
+     * the most recent `maxLogFileCount` items.
+     */
+    fun clean() {
+        logFiles
+                .dropLast(maxLogFileCount)
+                .forEach { it.delete() }
+    }
+}

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileCleaner.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileCleaner.kt
@@ -1,35 +1,21 @@
 package org.wordpress.android.util.helpers.logfile
 
-import android.content.Context
-import java.io.File
-
 /**
  * Prunes the Log File Store by retaining only the last `maxLogFileCount` log files.
+ *
+ * The file list is created upon instantiation – any files added
+ * afterwards won't be modified.
+ *
+ * @param logFileProvider: An interface where the log files will be retrieved from
+ * @param maxLogFileCount: The number of log files to retain
  */
-class LogFileCleaner {
-    private val maxLogFileCount: Int
-    private val logFiles: List<File>
-
-    /**
-     * Create a new LogFileCleaner.
-     *
-     * The file list is created upon instantiation – any files added
-     * afterwards won't be modified.
-     *
-     * @param context: The application context
-     * @param maxLogFileCount: The number of log files to retain
-     */
-    constructor(context: Context, maxLogFileCount: Int) {
-        this.maxLogFileCount = maxLogFileCount
-        this.logFiles = LogFileHelpers.logFiles(context)
-    }
-
+class LogFileCleaner(private val logFileProvider: LogFileProvider, private val maxLogFileCount: Int) {
     /**
      * Immediately removes all log files known to exist by this instance except for
      * the most recent `maxLogFileCount` items.
      */
     fun clean() {
-        logFiles
+        logFileProvider.getLogFiles()
                 .dropLast(maxLogFileCount)
                 .forEach { it.delete() }
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileCleaner.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileCleaner.kt
@@ -9,7 +9,7 @@ package org.wordpress.android.util.helpers.logfile
  * @param logFileProvider: An interface where the log files will be retrieved from
  * @param maxLogFileCount: The number of log files to retain
  */
-class LogFileCleaner(private val logFileProvider: LogFileProvider, private val maxLogFileCount: Int) {
+class LogFileCleaner(private val logFileProvider: LogFileProviderInterface, private val maxLogFileCount: Int) {
     /**
      * Immediately removes all log files known to exist by this instance except for
      * the most recent `maxLogFileCount` items.

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileHelpers.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileHelpers.kt
@@ -3,41 +3,40 @@ package org.wordpress.android.util.helpers.logfile
 import android.content.Context
 import java.io.File
 
+private const val LOG_FILE_DIRECTORY = "logs"
+
 /**
  * A collection of helpers for Log Files.
  */
-class LogFileHelpers {
-    companion object {
-        private const val LOG_FILE_DIRECTORY = "logs"
+class LogFileProvider(private val logFileDirectoryPath: String) : LogFileProviderInterface {
+    /**
+     * Provides a {@link java.io.File} directory in which to store log files.
+     *
+     * If the directory doesn't already exist, it will be created.
+     */
+    override fun getLogFileDirectory(): File {
+        val logFileDirectory = File(logFileDirectoryPath, LOG_FILE_DIRECTORY)
 
-        /**
-         * Provides a {@link java.io.File} directory in which to store log files.
-         *
-         * If the directory doesn't already exist, it will be created.
-         *
-         * @param context: The application context
-         */
-        @JvmStatic
-        fun logFileDirectory(context: Context): File {
-            val logFileDirectory = File(context.applicationInfo.dataDir, LOG_FILE_DIRECTORY)
-
-            if (!logFileDirectory.exists()) {
-                logFileDirectory.mkdir()
-            }
-
-            return logFileDirectory
+        if (!logFileDirectory.exists()) {
+            logFileDirectory.mkdir()
         }
 
-        /**
-         * Provides a list of stored log files, ordered oldest to newest.
-         *
-         * @param context: The application context
-         */
+        return logFileDirectory
+    }
+
+    /**
+     * Provides a list of stored log files, ordered oldest to newest.
+     */
+    override fun getLogFiles(): List<File> {
+        return getLogFileDirectory()
+                .listFiles()
+                .sortedBy { it.lastModified() }
+    }
+
+    companion object {
         @JvmStatic
-        fun logFiles(context: Context): List<File> {
-            return logFileDirectory(context)
-                    .listFiles()
-                    .sortedBy { it.lastModified() }
+        fun fromContext(context: Context): LogFileProvider {
+            return LogFileProvider(context.applicationInfo.dataDir)
         }
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileHelpers.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileHelpers.kt
@@ -1,0 +1,43 @@
+package org.wordpress.android.util.helpers.logfile
+
+import android.content.Context
+import java.io.File
+
+/**
+ * A collection of helpers for Log Files.
+ */
+class LogFileHelpers {
+    companion object {
+        private const val LOG_FILE_DIRECTORY = "logs"
+
+        /**
+         * Provides a {@link java.io.File} directory in which to store log files.
+         *
+         * If the directory doesn't already exist, it will be created.
+         *
+         * @param context: The application context
+         */
+        @JvmStatic
+        fun logFileDirectory(context: Context): File {
+            val logFileDirectory = File(context.applicationInfo.dataDir, LOG_FILE_DIRECTORY)
+
+            if (!logFileDirectory.exists()) {
+                logFileDirectory.mkdir()
+            }
+
+            return logFileDirectory
+        }
+
+        /**
+         * Provides a list of stored log files, ordered oldest to newest.
+         *
+         * @param context: The application context
+         */
+        @JvmStatic
+        fun logFiles(context: Context): List<File> {
+            return logFileDirectory(context)
+                    .listFiles()
+                    .sortedBy { it.lastModified() }
+        }
+    }
+}

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileProvider.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileProvider.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.util.helpers.logfile
+
+import java.io.File
+
+/**
+ * An interface to retrieve log files
+ */
+interface LogFileProvider {
+    fun getLogFiles(): List<File>
+}

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileProvider.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileProvider.kt
@@ -7,4 +7,6 @@ import java.io.File
  */
 interface LogFileProvider {
     fun getLogFiles(): List<File>
+
+    fun getLogFileDirectory(): File
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileProviderInterface.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileProviderInterface.kt
@@ -5,7 +5,7 @@ import java.io.File
 /**
  * An interface to retrieve log files
  */
-interface LogFileProvider {
+interface LogFileProviderInterface {
     fun getLogFiles(): List<File>
 
     fun getLogFileDirectory(): File

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
@@ -22,9 +22,9 @@ class LogFileWriter @JvmOverloads constructor(
     private val fileWriter: FileWriter = FileWriter(file)
 
     /**
-     * An serial executor used to write to the file in a background thread
+     * A serial executor used to write to the file in a background thread
      */
-    val queue: ExecutorService = Executors.newSingleThreadExecutor()
+    private val queue: ExecutorService = Executors.newSingleThreadExecutor()
 
     /**
      * A reference to the underlying {@link Java.IO.File} file.

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.util.helpers.logfile
 
-import android.content.Context
 import org.jetbrains.annotations.TestOnly
 import java.io.File
 import java.io.FileWriter
@@ -13,15 +12,11 @@ import org.wordpress.android.util.DateTimeUtils
  * This class creates and writes to a log file, and will typically persist for the entire lifecycle
  * of its host application.
  */
-class LogFileWriter
-/**
- * General-purpose constructor – given a log file directory, creates and prepares a log file for writing.
- * @param context: The Android [context] object
- */ @JvmOverloads constructor(
-    context: Context,
-    id: String = DateTimeUtils.iso8601FromDate(Date())
+class LogFileWriter @JvmOverloads constructor(
+    logFileProvider: LogFileProvider,
+    fileId: String = DateTimeUtils.iso8601FromDate(Date())
 ) {
-    private val file = File(LogFileHelpers.logFileDirectory(context), "$id.log")
+    private val file = File(logFileProvider.getLogFileDirectory(), "$fileId.log")
     private val fileWriter: FileWriter = FileWriter(file)
 
     /**

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.util.DateTimeUtils
  * of its host application.
  */
 class LogFileWriter @JvmOverloads constructor(
-    logFileProvider: LogFileProvider,
+    logFileProvider: LogFileProviderInterface,
     fileId: String = DateTimeUtils.iso8601FromDate(Date())
 ) {
     private val file = File(logFileProvider.getLogFileDirectory(), "$fileId.log")

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.util.helpers.logfile
 
 import android.content.Context
+import org.jetbrains.annotations.TestOnly
 import java.io.File
 import java.io.FileWriter
 import java.util.Date
@@ -12,31 +13,29 @@ import org.wordpress.android.util.DateTimeUtils
  * This class creates and writes to a log file, and will typically persist for the entire lifecycle
  * of its host application.
  */
-class LogFileWriter {
-    private val fileWriter: FileWriter
+class LogFileWriter
+/**
+ * General-purpose constructor – given a log file directory, creates and prepares a log file for writing.
+ * @param context: The Android [context] object
+ */ @JvmOverloads constructor(
+    context: Context,
+    id: String = DateTimeUtils.iso8601FromDate(Date())
+) {
+    private val file = File(LogFileHelpers.logFileDirectory(context), "$id.log")
+    private val fileWriter: FileWriter = FileWriter(file)
 
     /**
      * A reference to the underlying {@link Java.IO.File} file.
      * Should only be used for testing.
      */
-    internal val file: File
-
-    /**
-     * General-purpose constructor – given a log file directory, creates and prepares a log file for writing.
-     * @param context: The Android [context] object
-     */
-    @JvmOverloads
-    constructor(context: Context, id: String = DateTimeUtils.iso8601FromDate(Date())) {
-        val logFileDirectory = LogFileHelpers.logFileDirectory(context)
-        this.file = File(logFileDirectory, "$id.log")
-        this.fileWriter = FileWriter(this.file)
-    }
+    @TestOnly
+    fun getFile(): File = file
 
     /**
      * Writes the provided string to the log file synchronously
      */
     fun write(data: String) {
-        this.fileWriter.write(data)
-        this.fileWriter.flush()
+        fileWriter.write(data)
+        fileWriter.flush()
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
@@ -1,0 +1,42 @@
+package org.wordpress.android.util.helpers.logfile
+
+import android.content.Context
+import java.io.File
+import java.io.FileWriter
+import java.util.Date
+import org.wordpress.android.util.DateTimeUtils
+
+/**
+ * A class that manages writing to a log file.
+ *
+ * This class creates and writes to a log file, and will typically persist for the entire lifecycle
+ * of its host application.
+ */
+class LogFileWriter {
+    private val fileWriter: FileWriter
+
+    /**
+     * A reference to the underlying {@link Java.IO.File} file.
+     * Should only be used for testing.
+     */
+    internal val file: File
+
+    /**
+     * General-purpose constructor – given a log file directory, creates and prepares a log file for writing.
+     * @param context: The Android [context] object
+     */
+    @JvmOverloads
+    constructor(context: Context, id: String = DateTimeUtils.iso8601FromDate(Date())) {
+        val logFileDirectory = LogFileHelpers.logFileDirectory(context)
+        this.file = File(logFileDirectory, "$id.log")
+        this.fileWriter = FileWriter(this.file)
+    }
+
+    /**
+     * Writes the provided string to the log file synchronously
+     */
+    fun write(data: String) {
+        this.fileWriter.write(data)
+        this.fileWriter.flush()
+    }
+}

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/logfile/LogFileWriter.kt
@@ -5,6 +5,8 @@ import java.io.File
 import java.io.FileWriter
 import java.util.Date
 import org.wordpress.android.util.DateTimeUtils
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 /**
  * A class that manages writing to a log file.
@@ -20,6 +22,11 @@ class LogFileWriter @JvmOverloads constructor(
     private val fileWriter: FileWriter = FileWriter(file)
 
     /**
+     * An serial executor used to write to the file in a background thread
+     */
+    val queue: ExecutorService = Executors.newSingleThreadExecutor()
+
+    /**
      * A reference to the underlying {@link Java.IO.File} file.
      * Should only be used for testing.
      */
@@ -30,7 +37,9 @@ class LogFileWriter @JvmOverloads constructor(
      * Writes the provided string to the log file synchronously
      */
     fun write(data: String) {
-        fileWriter.write(data)
-        fileWriter.flush()
+        queue.execute {
+            fileWriter.write(data)
+            fileWriter.flush()
+        }
     }
 }

--- a/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileCleanerTest.kt
+++ b/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileCleanerTest.kt
@@ -1,0 +1,72 @@
+package org.wordpress.android.util
+
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import java.io.File
+import java.io.FileReader
+import kotlin.random.Random
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.wordpress.android.util.helpers.logfile.LogFileCleaner
+import org.wordpress.android.util.helpers.logfile.LogFileHelpers
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
+class LogFileCleanerTest {
+    lateinit var testContext: Context
+    lateinit var logFileDirectory: File
+
+    private val maxFiles = 10
+
+    @Before
+    fun setup() {
+        testContext = ApplicationProvider.getApplicationContext()
+        logFileDirectory = LogFileHelpers.logFileDirectory(testContext)
+
+        repeat(maxFiles) {
+            val file = File(logFileDirectory, "$it.log")
+            file.writeText("$it")
+            file.setLastModified((it * 10_000L).toLong())
+        }
+
+        assert(logFileDirectory.listFiles().count() == maxFiles)
+    }
+
+    @After
+    fun tearDown() {
+        // Delete the test directory after each test
+        logFileDirectory.deleteRecursively()
+    }
+
+    @Test
+    fun testThatCleanerPreservesMostRecentlyCreatedFiles() {
+        LogFileCleaner(testContext, 3).clean()
+
+        val remainingFileIds = logFileDirectory.listFiles().map {
+            FileReader(it).readText()
+        }.joinToString(",") // Strings are easier to assert against than arrays
+
+        // This assertion is based on the fact that the initial list (pre-clean) would've
+        // been "0,1,2,3,4,5,6,7,8,9". Retaining the last 3 entries gives the following:
+        assertEquals("7,8,9", remainingFileIds)
+    }
+
+    @Test
+    fun testThatCleanerPreservesCorrectNumberOfFiles() {
+        val numberOfFiles = Random.nextInt(maxFiles)
+        LogFileCleaner(testContext, numberOfFiles).clean()
+        assertEquals(numberOfFiles, logFileDirectory.listFiles().count())
+    }
+
+    @Test
+    fun testThatCleanerErasesAllFilesIfGivenZero() {
+        LogFileCleaner(testContext, 0).clean()
+        assert(logFileDirectory.listFiles().isEmpty())
+    }
+}

--- a/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileCleanerTest.kt
+++ b/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileCleanerTest.kt
@@ -48,16 +48,16 @@ class LogFileCleanerTest {
 
     @Test
     fun testThatCleanerPreservesMostRecentlyCreatedFiles() {
-        LogFileCleaner(logFileProvider, 3).clean()
+        val maxLogFileCount = Random.nextInt(MAX_FILES)
+        LogFileCleaner(logFileProvider, maxLogFileCount).clean()
 
         // Strings are easier to assert against than arrays
-        val remainingFileIds = logFileProvider.getLogFileDirectory().listFiles().joinToString(",") {
+        val remainingFileIds = logFileProvider.getLogFiles().joinToString(",") {
             FileReader(it).readText()
         }
 
-        // This assertion is based on the fact that the initial list (pre-clean) would've
-        // been "0,1,2,3,4,5,6,7,8,9". Retaining the last 3 entries gives the following:
-        assertEquals("7,8,9", remainingFileIds)
+        val expectedValue = (MAX_FILES -1 downTo 0).take(maxLogFileCount).reversed().joinToString(",")
+        assertEquals(expectedValue, remainingFileIds)
     }
 
     @Test

--- a/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileCleanerTest.kt
+++ b/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileCleanerTest.kt
@@ -56,7 +56,7 @@ class LogFileCleanerTest {
             FileReader(it).readText()
         }
 
-        val expectedValue = (MAX_FILES -1 downTo 0).take(maxLogFileCount).reversed().joinToString(",")
+        val expectedValue = (MAX_FILES - 1 downTo 0).take(maxLogFileCount).reversed().joinToString(",")
         assertEquals(expectedValue, remainingFileIds)
     }
 

--- a/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileHelpersTest.kt
+++ b/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileHelpersTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.util.helpers.logfile.LogFileProvider
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
 class LogFileHelpersTest {
-    lateinit var testProvider: LogFileProvider
+    private lateinit var testProvider: LogFileProvider
 
     @Before
     fun setup() {
@@ -48,15 +48,15 @@ class LogFileHelpersTest {
     fun testThatLogFilesSortsFilesWithMostRecentFirst() {
         val directory = testProvider.getLogFileDirectory()
 
-        var oldFile = File(directory, UUID.randomUUID().toString())
-        oldFile.createNewFile()
-        oldFile.setLastModified(1_000L)
-        assert(oldFile.lastModified() == 1_000L)
-
-        var newFile = File(directory, UUID.randomUUID().toString())
-        newFile.createNewFile()
-        newFile.setLastModified(1_000_000L)
-        assert(newFile.lastModified() == 1_000_000L)
+        listOf(1_000L, 1_000_000L).shuffled().forEach { modifiedDate ->
+            File(directory, UUID.randomUUID().toString()).also { file ->
+                // Use timestamps in increments of 1000 to avoid issues from the File System's date precision
+                val date = modifiedDate * 1000
+                file.createNewFile()
+                file.setLastModified(date)
+                assert(file.lastModified() == date)
+            }
+        }
 
         val files = testProvider.getLogFiles()
         assert(files.first().lastModified() < files.last().lastModified())

--- a/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileHelpersTest.kt
+++ b/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileHelpersTest.kt
@@ -1,0 +1,63 @@
+package org.wordpress.android.util
+
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import java.io.File
+import java.util.UUID
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.wordpress.android.util.helpers.logfile.LogFileHelpers
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
+class LogFileHelpersTest {
+    lateinit var testContext: Context
+
+    @Before
+    fun setup() {
+        testContext = ApplicationProvider.getApplicationContext()
+    }
+
+    @After
+    fun tearDown() {
+        // Delete the test directory after each test
+        LogFileHelpers.logFileDirectory(testContext).deleteRecursively()
+    }
+
+    @Test
+    fun testThatLogFileDirectoryIsCreatedIfNotExists() {
+        val directory = LogFileHelpers.logFileDirectory(testContext)
+        assert(directory.exists())
+    }
+
+    @Test
+    fun testThatLogFilesListsAllFiles() {
+        val directory = LogFileHelpers.logFileDirectory(testContext)
+        File(directory, UUID.randomUUID().toString()).createNewFile()
+        Assert.assertEquals(LogFileHelpers.logFiles(testContext).count(), 1)
+    }
+
+    @Test
+    fun testThatLogFilesSortsFilesWithMostRecentFirst() {
+        val directory = LogFileHelpers.logFileDirectory(testContext)
+
+        var oldFile = File(directory, UUID.randomUUID().toString())
+        oldFile.createNewFile()
+        oldFile.setLastModified(1_000L)
+        assert(oldFile.lastModified() == 1_000L)
+
+        var newFile = File(directory, UUID.randomUUID().toString())
+        newFile.createNewFile()
+        newFile.setLastModified(1_000_000L)
+        assert(newFile.lastModified() == 1_000_000L)
+
+        val files = LogFileHelpers.logFiles(testContext)
+        assert(files.first().lastModified() < files.last().lastModified())
+    }
+}

--- a/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileHelpersTest.kt
+++ b/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileHelpersTest.kt
@@ -12,40 +12,41 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.wordpress.android.util.helpers.logfile.LogFileHelpers
+import org.wordpress.android.util.helpers.logfile.LogFileProvider
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
 class LogFileHelpersTest {
-    lateinit var testContext: Context
+    lateinit var testProvider: LogFileProvider
 
     @Before
     fun setup() {
-        testContext = ApplicationProvider.getApplicationContext()
+        val context: Context = ApplicationProvider.getApplicationContext()
+        testProvider = LogFileProvider.fromContext(context)
     }
 
     @After
     fun tearDown() {
         // Delete the test directory after each test
-        LogFileHelpers.logFileDirectory(testContext).deleteRecursively()
+        testProvider.getLogFileDirectory().deleteRecursively()
     }
 
     @Test
     fun testThatLogFileDirectoryIsCreatedIfNotExists() {
-        val directory = LogFileHelpers.logFileDirectory(testContext)
+        val directory = testProvider.getLogFileDirectory()
         assert(directory.exists())
     }
 
     @Test
     fun testThatLogFilesListsAllFiles() {
-        val directory = LogFileHelpers.logFileDirectory(testContext)
+        val directory = testProvider.getLogFileDirectory()
         File(directory, UUID.randomUUID().toString()).createNewFile()
-        Assert.assertEquals(LogFileHelpers.logFiles(testContext).count(), 1)
+        Assert.assertEquals(testProvider.getLogFiles().count(), 1)
     }
 
     @Test
     fun testThatLogFilesSortsFilesWithMostRecentFirst() {
-        val directory = LogFileHelpers.logFileDirectory(testContext)
+        val directory = testProvider.getLogFileDirectory()
 
         var oldFile = File(directory, UUID.randomUUID().toString())
         oldFile.createNewFile()
@@ -57,7 +58,7 @@ class LogFileHelpersTest {
         newFile.setLastModified(1_000_000L)
         assert(newFile.lastModified() == 1_000_000L)
 
-        val files = LogFileHelpers.logFiles(testContext)
+        val files = testProvider.getLogFiles()
         assert(files.first().lastModified() < files.last().lastModified())
     }
 }

--- a/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileWriterTest.kt
+++ b/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileWriterTest.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.util
+
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import java.io.FileReader
+import java.util.UUID
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.wordpress.android.util.helpers.logfile.LogFileHelpers
+import org.wordpress.android.util.helpers.logfile.LogFileWriter
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
+class LogFileWriterTest {
+    lateinit var testContext: Context
+
+    @Before
+    fun setup() {
+        testContext = ApplicationProvider.getApplicationContext()
+    }
+
+    @After
+    fun tearDown() {
+        // Delete the test directory after each test
+        LogFileHelpers.logFileDirectory(testContext).deleteRecursively()
+    }
+
+    @Test
+    fun testThatFileWriterCreatesLogFile() {
+        val writer = LogFileWriter(testContext)
+        assert(writer.file.exists())
+    }
+
+    @Test
+    fun testThatContentsAreWrittenToFile() {
+        val randomString = UUID.randomUUID().toString()
+        val writer = LogFileWriter(testContext)
+        writer.write(randomString)
+
+        val contents = FileReader(writer.file).readText()
+        assertEquals(randomString, contents)
+    }
+}

--- a/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileWriterTest.kt
+++ b/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileWriterTest.kt
@@ -18,7 +18,7 @@ import org.wordpress.android.util.helpers.logfile.LogFileWriter
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
 class LogFileWriterTest {
-    lateinit var testProvider: LogFileProvider
+    private lateinit var testProvider: LogFileProvider
 
     @Before
     fun setup() {

--- a/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileWriterTest.kt
+++ b/libs/utils/WordPressUtils/src/test/java/org/wordpress/android/util/LogFileWriterTest.kt
@@ -12,38 +12,42 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.wordpress.android.util.helpers.logfile.LogFileHelpers
+import org.wordpress.android.util.helpers.logfile.LogFileProvider
 import org.wordpress.android.util.helpers.logfile.LogFileWriter
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
 class LogFileWriterTest {
-    lateinit var testContext: Context
+    lateinit var testProvider: LogFileProvider
 
     @Before
     fun setup() {
-        testContext = ApplicationProvider.getApplicationContext()
+        val context: Context = ApplicationProvider.getApplicationContext()
+        testProvider = LogFileProvider.fromContext(context)
     }
 
     @After
     fun tearDown() {
         // Delete the test directory after each test
-        LogFileHelpers.logFileDirectory(testContext).deleteRecursively()
+        testProvider.getLogFileDirectory().deleteRecursively()
     }
 
     @Test
     fun testThatFileWriterCreatesLogFile() {
-        val writer = LogFileWriter(testContext)
-        assert(writer.file.exists())
+        val writer = LogFileWriter(testProvider)
+        assert(writer.getFile().exists())
     }
 
     @Test
     fun testThatContentsAreWrittenToFile() {
         val randomString = UUID.randomUUID().toString()
-        val writer = LogFileWriter(testContext)
+        val writer = LogFileWriter(testProvider)
         writer.write(randomString)
 
-        val contents = FileReader(writer.file).readText()
+        // Allow the async process to persist the file changes
+        Thread.sleep(1000)
+
+        val contents = FileReader(writer.getFile()).readText()
         assertEquals(randomString, contents)
     }
 }


### PR DESCRIPTION
**To test:**
- Ensure CI passes – this PR contains test coverage for all of its functionality.
- Run WPAndroid from Android Studio – sign into WP, and go through a few screens. Close the app.
- In Android Studio, under Device File Explorer, navigate to `data > user > 0 > org.wordpress.android > logs. View the content of the most recent log file and note that it contains appropriate information based on your actions.
- Stop and start the app four more times, and note that your first log file has been erased – this is to ensure we don't use an inordinate amount of the user's storage. In the future, this could be a user setting that can be customized when trying to debug a problem.
- Launch the app and ensure the existing logging functionality is the same as it was before – it's under Me > Help & Support > Application log.

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
