### PR TITLE
Add reblog to reader post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -119,6 +119,7 @@ import org.wordpress.android.ui.quickstart.QuickStartFullScreenDialogFragment;
 import org.wordpress.android.ui.quickstart.QuickStartReminderReceiver;
 import org.wordpress.android.ui.reader.ReaderCommentListActivity;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
+import org.wordpress.android.ui.reader.ReaderPostListActivity;
 import org.wordpress.android.ui.reader.ReaderPostListFragment;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
 import org.wordpress.android.ui.reader.SubfilterBottomSheetFragment;
@@ -373,6 +374,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(ReaderWebView object);
 
     void inject(ReaderPostPagerActivity object);
+
+    void inject(ReaderPostListActivity object);
 
     void inject(ReaderBlogAdapter object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1250,7 +1250,7 @@ public class WPMainActivity extends AppCompatActivity implements
         // it's visible. For more info see https://github.com/wordpress-mobile/WordPress-Android/issues/9604
         if (getLifecycle().getCurrentState().isAtLeast(STARTED)) {
             SiteModel site = getSelectedSite();
-            if (site != null && event.post != null && event.post.getLocalSiteId() == site.getId()) {
+            if (site != null && event.post != null) {
                 mUploadUtilsWrapper.onPostUploadedSnackbarHandler(
                         this,
                         findViewById(R.id.coordinator),

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -107,6 +107,8 @@ class AppPrefsWrapper @Inject constructor() {
         AppPrefs.setStatsWidgetHasData(hasData, appWidgetId)
     }
 
+    fun getSelectedSite(): Int = AppPrefs.getSelectedSite()
+
     fun removeAppWidgetHasData(appWidgetId: Int) = AppPrefs.removeStatsWidgetHasData(appWidgetId)
 
     fun isMainFabTooltipDisabled() = AppPrefs.isMainFabTooltipDisabled()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -107,7 +107,7 @@ class AppPrefsWrapper @Inject constructor() {
         AppPrefs.setStatsWidgetHasData(hasData, appWidgetId)
     }
 
-    fun getSelectedSite(): Int? = AppPrefs.getSelectedSite()
+    fun getSelectedSite(): Int = AppPrefs.getSelectedSite()
 
     fun removeAppWidgetHasData(appWidgetId: Int) = AppPrefs.removeStatsWidgetHasData(appWidgetId)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -107,7 +107,7 @@ class AppPrefsWrapper @Inject constructor() {
         AppPrefs.setStatsWidgetHasData(hasData, appWidgetId)
     }
 
-    fun getSelectedSite(): Int = AppPrefs.getSelectedSite()
+    fun getSelectedSite(): Int? = AppPrefs.getSelectedSite()
 
     fun removeAppWidgetHasData(appWidgetId: Int) = AppPrefs.removeStatsWidgetHasData(appWidgetId)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -14,6 +14,13 @@ public class ReaderInterfaces {
     }
 
     /*
+     * Called by the [ReaderPostAdapter] to trigger the reblog action
+     */
+    public interface ReblogActionListener {
+        void reblog(ReaderPost post);
+    }
+
+    /*
      * called from post detail fragment so toolbar can animate in/out when scrolling
      */
     public interface AutoHideToolbarListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader;
 
+import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
@@ -17,15 +18,33 @@ import androidx.fragment.app.Fragment;
 
 import com.google.android.material.appbar.AppBarLayout;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.datasets.ReaderBlogTable;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.PostStore;
+import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
+import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.ReaderBlog;
 import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.ui.RequestCodes;
+import org.wordpress.android.ui.posts.EditPostActivity;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
+import org.wordpress.android.ui.uploads.UploadActionUseCase;
+import org.wordpress.android.ui.uploads.UploadUtils;
+import org.wordpress.android.ui.uploads.UploadUtilsWrapper;
 import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.ToastUtils;
+
+import javax.inject.Inject;
 
 /*
  * serves as the host for ReaderPostListFragment when showing blog preview & tag preview
@@ -33,6 +52,12 @@ import org.wordpress.android.util.ToastUtils;
 public class ReaderPostListActivity extends AppCompatActivity {
     private ReaderPostListType mPostListType;
     private long mSiteId;
+
+    @Inject SiteStore mSiteStore;
+    @Inject PostStore mPostStore;
+    @Inject Dispatcher mDispatcher;
+    @Inject UploadActionUseCase mUploadActionUseCase;
+    @Inject UploadUtilsWrapper mUploadUtilsWrapper;
 
     @Override
     protected void attachBaseContext(Context newBase) {
@@ -42,6 +67,8 @@ public class ReaderPostListActivity extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        ((WordPress) getApplication()).component().inject(this);
+
         setContentView(R.layout.reader_activity_post_list);
 
         Toolbar toolbar = findViewById(R.id.toolbar);
@@ -105,6 +132,19 @@ public class ReaderPostListActivity extends AppCompatActivity {
         super.onResumeFragments();
         // this particular Activity doesn't show filtering, so we'll disable the FilteredRecyclerView toolbar here
         disableFilteredRecyclerViewToolbar();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        // We register the dispatcher in order to receive the OnPostUploaded event and show the snackbar
+        mDispatcher.register(this);
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        mDispatcher.unregister(this);
     }
 
     /*
@@ -263,5 +303,56 @@ public class ReaderPostListActivity extends AppCompatActivity {
             return null;
         }
         return ((ReaderPostListFragment) fragment);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == RequestCodes.EDIT_POST && resultCode == Activity.RESULT_OK
+            && data != null && !isFinishing()) {
+            int localId = data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0);
+            final SiteModel site = (SiteModel) data.getSerializableExtra(WordPress.SITE);
+            final PostModel post = mPostStore.getPostByLocalPostId(localId);
+
+            if (EditPostActivity.checkToRestart(data)) {
+                ActivityLauncher.editPostOrPageForResult(data, ReaderPostListActivity.this, site,
+                        data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0));
+                // a restart will happen so, no need to continue here
+                return;
+            }
+
+            if (site != null && post != null) {
+                mUploadUtilsWrapper.handleEditPostResultSnackbars(
+                        this,
+                        findViewById(R.id.coordinator),
+                        data,
+                        post,
+                        site,
+                        mUploadActionUseCase.getUploadAction(post),
+                        new View.OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                UploadUtils.publishPost(ReaderPostListActivity.this, post, site, mDispatcher);
+                            }
+                        });
+            }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onPostUploaded(OnPostUploaded event) {
+        int siteLocalId = AppPrefs.getSelectedSite();
+        SiteModel site = mSiteStore.getSiteByLocalId(siteLocalId);
+        if (site != null && event.post != null) {
+            mUploadUtilsWrapper.onPostUploadedSnackbarHandler(
+                    this,
+                    findViewById(R.id.coordinator),
+                    event.isError(),
+                    event.post,
+                    null,
+                    site);
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2901,16 +2901,18 @@ public class ReaderPostListFragment extends Fragment
     @Override
     public void reblog(ReaderPost post) {
         List<SiteModel> sites = mSiteStore.getVisibleSites();
+        int selectedSiteId = AppPrefs.getSelectedSite();
+        SiteModel selectedSite = mSiteStore.getSiteByLocalId(selectedSiteId);
         switch (sites.size()) {
             case 0:
                 ToastUtils.showToast(getActivity(), R.string.reader_no_site_to_reblog);
                 break;
             case 1:
-                ActivityLauncher.openEditorForReblog(getActivity(), getSelectedSite(), post);
+                ActivityLauncher.openEditorForReblog(getActivity(), selectedSite, post);
                 break;
             default:
                 this.mPostToReblog = post; // Stores the post to be handled in the onActivityResult after site selection
-                ActivityLauncher.showSitePickerForResult(this, getSelectedSite());
+                ActivityLauncher.showSitePickerForResult(this, selectedSite);
                 break;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2078,10 +2078,10 @@ public class ReaderPostListFragment extends Fragment
                     context,
                     getPostListType(),
                     mImageManager,
-                    mIsTopLevel,
-                    this
+                    mIsTopLevel
             );
             mPostAdapter.setOnFollowListener(this);
+            mPostAdapter.setReblogActionListener(this);
             mPostAdapter.setOnPostSelectedListener(this);
             mPostAdapter.setOnPostPopupListener(this);
             mPostAdapter.setOnDataLoadedListener(mDataLoadedListener);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2902,10 +2902,12 @@ public class ReaderPostListFragment extends Fragment
     public void reblog(ReaderPost post) {
         List<SiteModel> sites = mSiteStore.getVisibleSites();
         switch (sites.size()) {
+            case 0:
+                ToastUtils.showToast(getActivity(), R.string.reader_no_site_to_reblog);
+                break;
             case 1:
                 ActivityLauncher.openEditorForReblog(getActivity(), getSelectedSite(), this.mPostToReblog);
                 break;
-            case 0: // The no site case can be handled by the site picker for now
             default:
                 this.mPostToReblog = post; // Stores the post to be handled in the onActivityResult after site selection
                 ActivityLauncher.showSitePickerForResult(this, getSelectedSite());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2906,7 +2906,7 @@ public class ReaderPostListFragment extends Fragment
                 ToastUtils.showToast(getActivity(), R.string.reader_no_site_to_reblog);
                 break;
             case 1:
-                ActivityLauncher.openEditorForReblog(getActivity(), getSelectedSite(), this.mPostToReblog);
+                ActivityLauncher.openEditorForReblog(getActivity(), getSelectedSite(), post);
                 break;
             default:
                 this.mPostToReblog = post; // Stores the post to be handled in the onActivityResult after site selection

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2903,7 +2903,7 @@ public class ReaderPostListFragment extends Fragment
      * Handles reblog state changes and triggers reblog actions
      */
     private void handleReblogStateChanges() {
-        mViewModel.getReblogAction().observe(this, event -> {
+        mViewModel.getReblogState().observe(this, event -> {
             event.applyIfNotHandled(state -> {
                 if (state instanceof NoSite) {
                     ToastUtils.showToast(getActivity(), R.string.reader_no_site_to_reblog);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -74,7 +74,6 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
 import org.wordpress.android.fluxc.store.ReaderStore;
 import org.wordpress.android.fluxc.store.ReaderStore.OnReaderSitesSearched;
 import org.wordpress.android.fluxc.store.ReaderStore.ReaderSearchSitesPayload;
-import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.FilterCriteria;
 import org.wordpress.android.models.ReaderBlog;
 import org.wordpress.android.models.ReaderPost;
@@ -107,6 +106,9 @@ import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionRecyclerAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSiteSearchAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSiteSearchAdapter.SiteSearchAdapterListener;
+import org.wordpress.android.ui.reader.reblog.NoSite;
+import org.wordpress.android.ui.reader.reblog.PostEditor;
+import org.wordpress.android.ui.reader.reblog.SitePicker;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction;
 import org.wordpress.android.ui.reader.services.search.ReaderSearchServiceStarter;
@@ -199,8 +201,6 @@ public class ReaderPostListFragment extends Fragment
     private ReaderPostListType mPostListType;
     private ReaderSiteModel mLastTappedSiteSearchResult;
 
-    private ReaderPost mPostToReblog;
-
     private int mRestorePosition;
     private int mSiteSearchRestorePosition;
     private int mPostSearchAdapterPos;
@@ -237,7 +237,6 @@ public class ReaderPostListFragment extends Fragment
     @Inject QuickStartStore mQuickStartStore;
     @Inject UiHelpers mUiHelpers;
     @Inject TagUpdateClientUtilsProvider mTagUpdateClientUtilsProvider;
-    @Inject SiteStore mSiteStore;
 
     private enum ActionableEmptyViewButtonType {
         DISCOVER,
@@ -503,6 +502,8 @@ public class ReaderPostListFragment extends Fragment
                 mRecyclerView.setToolbarScrollFlags(0);
             }
         });
+
+        handleReblogStateChanges();
 
         mViewModel.start(
                 mCurrentTag,
@@ -2898,31 +2899,36 @@ public class ReaderPostListFragment extends Fragment
         }
     }
 
+    /**
+     * Handles reblog state changes and triggers reblog actions
+     */
+    private void handleReblogStateChanges() {
+        mViewModel.getReblogAction().observe(this, event -> {
+            event.applyIfNotHandled(state -> {
+                if (state instanceof NoSite) {
+                    ToastUtils.showToast(getActivity(), R.string.reader_no_site_to_reblog);
+                } else if (state instanceof SitePicker) {
+                    ActivityLauncher.showSitePickerForResult(this, state.getSite());
+                } else if (state instanceof PostEditor) {
+                    ActivityLauncher.openEditorForReblog(getActivity(), state.getSite(), state.getPost());
+                } else { // Error
+                    ToastUtils.showToast(getActivity(), R.string.reader_reblog_error);
+                }
+                return null;
+            });
+        });
+    }
+
     @Override
     public void reblog(ReaderPost post) {
-        List<SiteModel> sites = mSiteStore.getVisibleSites();
-        int selectedSiteId = AppPrefs.getSelectedSite();
-        SiteModel selectedSite = mSiteStore.getSiteByLocalId(selectedSiteId);
-        switch (sites.size()) {
-            case 0:
-                ToastUtils.showToast(getActivity(), R.string.reader_no_site_to_reblog);
-                break;
-            case 1:
-                ActivityLauncher.openEditorForReblog(getActivity(), selectedSite, post);
-                break;
-            default:
-                this.mPostToReblog = post; // Stores the post to be handled in the onActivityResult after site selection
-                ActivityLauncher.showSitePickerForResult(this, selectedSite);
-                break;
-        }
+        mViewModel.onReblogButtonClicked(post);
     }
 
     @Override public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == RequestCodes.SITE_PICKER && resultCode == Activity.RESULT_OK) {
             int siteLocalId = data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1);
-            SiteModel site = mSiteStore.getSiteByLocalId(siteLocalId);
-            ActivityLauncher.openEditorForReblog(getActivity(), site, this.mPostToReblog);
+            mViewModel.selectedSiteToReblog(siteLocalId);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2908,9 +2908,10 @@ public class ReaderPostListFragment extends Fragment
                 if (state instanceof NoSite) {
                     ToastUtils.showToast(getActivity(), R.string.reader_no_site_to_reblog);
                 } else if (state instanceof SitePicker) {
-                    ActivityLauncher.showSitePickerForResult(this, state.getSite());
+                    ActivityLauncher.showSitePickerForResult(this, ((SitePicker) state).getSite());
                 } else if (state instanceof PostEditor) {
-                    ActivityLauncher.openEditorForReblog(getActivity(), state.getSite(), state.getPost());
+                    PostEditor peState = (PostEditor) state;
+                    ActivityLauncher.openEditorForReblog(getActivity(), peState.getSite(), peState.getPost());
                 } else { // Error
                     ToastUtils.showToast(getActivity(), R.string.reader_reblog_error);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2928,7 +2928,7 @@ public class ReaderPostListFragment extends Fragment
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == RequestCodes.SITE_PICKER && resultCode == Activity.RESULT_OK) {
             int siteLocalId = data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1);
-            mViewModel.selectedSiteToReblog(siteLocalId);
+            mViewModel.onReblogSiteSelected(siteLocalId);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -1051,7 +1051,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
     public void onPostUploaded(OnPostUploaded event) {
         int siteLocalId = AppPrefs.getSelectedSite();
         SiteModel site = mSiteStore.getSiteByLocalId(siteLocalId);
-        if (site != null && event.post != null && event.post.getLocalSiteId() == site.getId()) {
+        if (site != null && event.post != null) {
             mUploadUtilsWrapper.onPostUploadedSnackbarHandler(
                     this,
                     findViewById(R.id.coordinator),

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -696,8 +696,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             Context context,
             ReaderPostListType postListType,
             ImageManager imageManager,
-            boolean isMainReader,
-            ReblogActionListener reblogActionListener
+            boolean isMainReader
     ) {
         super();
         ((WordPress) context.getApplicationContext()).component().inject(this);
@@ -708,7 +707,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mMarginLarge = context.getResources().getDimensionPixelSize(R.dimen.margin_large);
         mIsLoggedOutReader = !mAccountStore.hasAccessToken();
         mIsMainReader = isMainReader;
-        mReblogActionListener = reblogActionListener;
 
         int displayWidth = DisplayUtils.getDisplayPixelWidth(context);
         int cardMargin = context.getResources().getDimensionPixelSize(R.dimen.reader_card_margin);
@@ -736,6 +734,10 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     public void setOnFollowListener(OnFollowListener listener) {
         mFollowListener = listener;
+    }
+
+    public void setReblogActionListener(ReblogActionListener reblogActionListener) {
+        mReblogActionListener = reblogActionListener;
     }
 
     public void setOnPostSelectedListener(ReaderInterfaces.OnPostSelectedListener listener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.reader.ReaderAnim;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.ReaderInterfaces;
 import org.wordpress.android.ui.reader.ReaderInterfaces.OnFollowListener;
+import org.wordpress.android.ui.reader.ReaderInterfaces.ReblogActionListener;
 import org.wordpress.android.ui.reader.ReaderTypes;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
@@ -104,6 +105,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private ReaderInterfaces.OnPostBookmarkedListener mOnPostBookmarkedListener;
     private ReaderActions.DataRequestedListener mDataRequestedListener;
     private ReaderSiteHeaderView.OnBlogInfoLoadedListener mBlogInfoLoadedListener;
+    private ReblogActionListener mReblogActionListener;
 
     // the large "tbl_posts.text" column is unused here, so skip it when querying
     private static final boolean EXCLUDE_TEXT_COLUMN = true;
@@ -185,6 +187,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final TextView mTxtAuthorAndBlogName;
         private final TextView mTxtDateline;
 
+        private final ReaderIconCountView mReblog;
         private final ReaderIconCountView mCommentCount;
         private final ReaderIconCountView mLikeCount;
         private final ImageView mBtnBookmark;
@@ -218,6 +221,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             mTxtAuthorAndBlogName = itemView.findViewById(R.id.text_author_and_blog_name);
             mTxtDateline = itemView.findViewById(R.id.text_dateline);
 
+            mReblog = itemView.findViewById(R.id.reblog);
             mCommentCount = itemView.findViewById(R.id.count_comments);
             mLikeCount = itemView.findViewById(R.id.count_likes);
             mBtnBookmark = itemView.findViewById(R.id.bookmark);
@@ -553,6 +557,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         showLikes(holder, post);
         showComments(holder, post);
+        showReblogButton(holder, post);
         initBookmarkButton(position, holder, post);
 
         // more menu only shows for followed tags
@@ -691,7 +696,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             Context context,
             ReaderPostListType postListType,
             ImageManager imageManager,
-            boolean isMainReader
+            boolean isMainReader,
+            ReblogActionListener reblogActionListener
     ) {
         super();
         ((WordPress) context.getApplicationContext()).component().inject(this);
@@ -702,6 +708,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mMarginLarge = context.getResources().getDimensionPixelSize(R.dimen.margin_large);
         mIsLoggedOutReader = !mAccountStore.hasAccessToken();
         mIsMainReader = isMainReader;
+        mReblogActionListener = reblogActionListener;
 
         int displayWidth = DisplayUtils.getDisplayPixelWidth(context);
         int cardMargin = context.getResources().getDimensionPixelSize(R.dimen.reader_card_margin);
@@ -1003,6 +1010,24 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         } else {
             holder.mCommentCount.setVisibility(View.GONE);
             holder.mCommentCount.setOnClickListener(null);
+        }
+    }
+
+    /**
+     * Sets reblog button visibility and action
+     *
+     * @param holder the view holder
+     * @param post   the current reader post
+     */
+    private void showReblogButton(final ReaderPostViewHolder holder, final ReaderPost post) {
+        boolean canBeReblogged = !mIsLoggedOutReader && !post.isPrivate;
+        if (canBeReblogged) {
+            holder.mReblog.setCount(0);
+            holder.mReblog.setVisibility(View.VISIBLE);
+            holder.mReblog.setOnClickListener(v -> mReblogActionListener.reblog(post));
+        } else {
+            holder.mReblog.setVisibility(View.GONE);
+            holder.mReblog.setOnClickListener(null);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogState.kt
@@ -1,0 +1,38 @@
+package org.wordpress.android.ui.reader.reblog
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.models.ReaderPost
+
+/**
+ * Represents the Reblog View State
+ *
+ * @property site the site to reblog to
+ * @property post the post to be reblogged
+ */
+sealed class ReblogState(val site: SiteModel? = null, val post: ReaderPost? = null)
+
+/**
+ * Represents the Site Picker View State
+ *
+ * @property site the preselected site
+ * @property post the post to be reblogged (saved for later)
+ */
+class SitePicker(site: SiteModel, post: ReaderPost) : ReblogState(site, post)
+
+/**
+ * Represents the Post Editor View State
+ *
+ * @property site the site to reblog to
+ * @property post the post to be reblogged
+ */
+class PostEditor(site: SiteModel, post: ReaderPost) : ReblogState(site, post)
+
+/**
+ * Represents the No Site View State
+ */
+object NoSite : ReblogState()
+
+/**
+ * Represents the Error State
+ */
+object ReblogError : ReblogState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogState.kt
@@ -5,11 +5,8 @@ import org.wordpress.android.models.ReaderPost
 
 /**
  * Represents the Reblog View State
- *
- * @property site the site to reblog to
- * @property post the post to be reblogged
  */
-sealed class ReblogState(val site: SiteModel? = null, val post: ReaderPost? = null)
+sealed class ReblogState
 
 /**
  * Represents the Site Picker View State
@@ -17,7 +14,7 @@ sealed class ReblogState(val site: SiteModel? = null, val post: ReaderPost? = nu
  * @property site the preselected site
  * @property post the post to be reblogged (saved for later)
  */
-class SitePicker(site: SiteModel, post: ReaderPost) : ReblogState(site, post)
+class SitePicker(val site: SiteModel, val post: ReaderPost) : ReblogState()
 
 /**
  * Represents the Post Editor View State
@@ -25,7 +22,7 @@ class SitePicker(site: SiteModel, post: ReaderPost) : ReblogState(site, post)
  * @property site the site to reblog to
  * @property post the post to be reblogged
  */
-class PostEditor(site: SiteModel, post: ReaderPost) : ReblogState(site, post)
+class PostEditor(val site: SiteModel, val post: ReaderPost) : ReblogState()
 
 /**
  * Represents the No Site View State
@@ -33,6 +30,6 @@ class PostEditor(site: SiteModel, post: ReaderPost) : ReblogState(site, post)
 object NoSite : ReblogState()
 
 /**
- * Represents the Error State
+ * Represents the Unknown/Error State
  */
-object ReblogError : ReblogState()
+object Unknown : ReblogState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -97,8 +97,8 @@ class ReaderPostListViewModel @Inject constructor(
     private val _updateTagsAndSites = MutableLiveData<Event<EnumSet<UpdateTask>>>()
     val updateTagsAndSites: LiveData<Event<EnumSet<UpdateTask>>> = _updateTagsAndSites
 
-    private val _reblogAction = MutableLiveData<Event<ReblogState>>()
-    val reblogAction: LiveData<Event<ReblogState>> = _reblogAction
+    private val _reblogState = MutableLiveData<Event<ReblogState>>()
+    val reblogState: LiveData<Event<ReblogState>> = _reblogState
 
     /**
      * First tag for which the card was shown.
@@ -270,9 +270,9 @@ class ReaderPostListViewModel @Inject constructor(
         val selectedSiteId = appPrefsWrapper.getSelectedSite()
         val selectedSite: SiteModel = siteStore.getSiteByLocalId(selectedSiteId)
         when (siteStore.visibleSites.size) {
-            0 -> _reblogAction.value = Event(NoSite)
-            1 -> _reblogAction.value = Event(PostEditor(selectedSite, post))
-            else -> _reblogAction.value = Event(SitePicker(selectedSite, post))
+            0 -> _reblogState.value = Event(NoSite)
+            1 -> _reblogState.value = Event(PostEditor(selectedSite, post))
+            else -> _reblogState.value = Event(SitePicker(selectedSite, post))
         }
     }
 
@@ -282,13 +282,13 @@ class ReaderPostListViewModel @Inject constructor(
      * @param site selected site to reblog to
      */
     fun onReblogSiteSelected(siteLocalId: Int) {
-        val currentState = _reblogAction.value?.peekContent()
+        val currentState = _reblogState.value?.peekContent()
         val selectedPost = currentState?.post
         if (currentState is SitePicker && selectedPost != null) {
             val site = siteStore.getSiteByLocalId(siteLocalId)
-            _reblogAction.value = Event(PostEditor(site, selectedPost))
+            _reblogState.value = Event(PostEditor(site, selectedPost))
         } else {
-            _reblogAction.value = Event(ReblogError)
+            _reblogState.value = Event(ReblogError)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -11,7 +11,10 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.datasets.ReaderBlogTable
 import org.wordpress.android.datasets.ReaderTagTable
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.news.NewsItem
 import org.wordpress.android.modules.BG_THREAD
@@ -23,6 +26,11 @@ import org.wordpress.android.ui.news.NewsTrackerHelper
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.ReaderEvents
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
+import org.wordpress.android.ui.reader.reblog.NoSite
+import org.wordpress.android.ui.reader.reblog.PostEditor
+import org.wordpress.android.ui.reader.reblog.ReblogError
+import org.wordpress.android.ui.reader.reblog.ReblogState
+import org.wordpress.android.ui.reader.reblog.SitePicker
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask
 import org.wordpress.android.ui.reader.subfilter.ActionType
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory
@@ -54,7 +62,8 @@ class ReaderPostListViewModel @Inject constructor(
     private val subfilterListItemMapper: SubfilterListItemMapper,
     private val eventBusWrapper: EventBusWrapper,
     private val accountStore: AccountStore,
-    private val readerTracker: ReaderTracker
+    private val readerTracker: ReaderTracker,
+    private val siteStore: SiteStore
 ) : ScopedViewModel(bgDispatcher) {
     private val newsItemSource = newsManager.newsItemSource()
     private val _newsItemSourceMediator = MediatorLiveData<NewsItem>()
@@ -87,6 +96,9 @@ class ReaderPostListViewModel @Inject constructor(
 
     private val _updateTagsAndSites = MutableLiveData<Event<EnumSet<UpdateTask>>>()
     val updateTagsAndSites: LiveData<Event<EnumSet<UpdateTask>>> = _updateTagsAndSites
+
+    private val _reblogAction = MutableLiveData<Event<ReblogState>>()
+    val reblogAction: LiveData<Event<ReblogState>> = _reblogAction
 
     /**
      * First tag for which the card was shown.
@@ -247,6 +259,37 @@ class ReaderPostListViewModel @Inject constructor(
                         onClickAction = ::onSubfilterClicked,
                         isSelected = true
                 ))
+    }
+
+    /**
+     * Handles reblog button action
+     *
+     * @param post post to reblog
+     */
+    fun onReblogButtonClicked(post: ReaderPost) {
+        val selectedSiteId = appPrefsWrapper.getSelectedSite()
+        val selectedSite: SiteModel = siteStore.getSiteByLocalId(selectedSiteId)
+        when (siteStore.visibleSites.size) {
+            0 -> _reblogAction.value = Event(NoSite)
+            1 -> _reblogAction.value = Event(PostEditor(selectedSite, post))
+            else -> _reblogAction.value = Event(SitePicker(selectedSite, post))
+        }
+    }
+
+    /**
+     * Handles site selection
+     *
+     * @param site selected site to reblog to
+     */
+    fun selectedSiteToReblog(siteLocalId: Int) {
+        val currentState = _reblogAction.value?.peekContent()
+        val selectedPost = currentState?.post
+        if (currentState is SitePicker && selectedPost != null) {
+            val site = siteStore.getSiteByLocalId(siteLocalId)
+            _reblogAction.value = Event(PostEditor(site, selectedPost))
+        } else {
+            _reblogAction.value = Event(ReblogError)
+        }
     }
 
     fun onSubFiltersListButtonClicked() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -268,12 +268,12 @@ class ReaderPostListViewModel @Inject constructor(
      * @param post post to reblog
      */
     fun onReblogButtonClicked(post: ReaderPost) {
-        val selectedSiteId: Int? = appPrefsWrapper.getSelectedSite()
-        val selectedSite: SiteModel? = selectedSiteId?.let { siteStore.getSiteByLocalId(it) }
-        when (siteStore.visibleSites.size) {
-            0 -> _reblogState.value = Event(NoSite)
-            1 -> _reblogState.value = selectedSite?.let { Event(PostEditor(it, post)) } ?: Event(Unknown)
-            else -> _reblogState.value = selectedSite?.let { Event(SitePicker(it, post)) } ?: Event(Unknown)
+        val selectedSiteId: Int = appPrefsWrapper.getSelectedSite()
+        val selectedSite: SiteModel? = siteStore.getSiteByLocalId(selectedSiteId)
+        _reblogState.value = when (siteStore.visibleSites.size) {
+            0 -> Event(NoSite)
+            1 -> if (selectedSite != null) Event(PostEditor(selectedSite, post)) else Event(Unknown)
+            else -> if (selectedSite != null) Event(SitePicker(selectedSite, post)) else Event(Unknown)
         }
     }
 
@@ -283,10 +283,10 @@ class ReaderPostListViewModel @Inject constructor(
      * @param site selected site to reblog to
      */
     fun onReblogSiteSelected(siteLocalId: Int) {
-        val currentState = _reblogState.value?.peekContent()
+        val currentState: ReblogState? = _reblogState.value?.peekContent()
         if (currentState is SitePicker) {
-            val site = siteStore.getSiteByLocalId(siteLocalId)
-            _reblogState.value = Event(PostEditor(site, currentState.post))
+            val site: SiteModel? = siteStore.getSiteByLocalId(siteLocalId)
+            _reblogState.value = if (site != null) Event(PostEditor(site, currentState.post)) else Event(Unknown)
         } else if (BuildConfig.DEBUG) {
             throw IllegalStateException("Site Selected without passing the SitePicker state")
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -281,7 +281,7 @@ class ReaderPostListViewModel @Inject constructor(
      *
      * @param site selected site to reblog to
      */
-    fun selectedSiteToReblog(siteLocalId: Int) {
+    fun onReblogSiteSelected(siteLocalId: Int) {
         val currentState = _reblogAction.value?.peekContent()
         val selectedPost = currentState?.post
         if (currentState is SitePicker && selectedPost != null) {

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -257,11 +257,23 @@
                 android:layout_centerVertical="true"
                 android:layout_height="@dimen/reader_button_minimum_height"
                 android:layout_width="@dimen/reader_button_minimum_height"
-                android:layout_toStartOf="@id/count_comments"
+                android:layout_toStartOf="@id/reblog"
                 android:padding="@dimen/margin_medium"
                 android:src="@drawable/ic_bookmark_outline_bookmark_selector_24dp"
                 android:tint="@color/neutral_primary_40_neutral_40_selector" >
             </ImageView>
+
+            <org.wordpress.android.ui.reader.views.ReaderIconCountView
+                android:id="@+id/reblog"
+                android:contentDescription="@string/reader_view_reblog"
+                android:layout_alignWithParentIfMissing="true"
+                android:layout_centerVertical="true"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_medium"
+                android:layout_toStartOf="@+id/count_comments"
+                android:layout_width="wrap_content"
+                wp:readerIcon="reblog" >
+            </org.wordpress.android.ui.reader.views.ReaderIconCountView>
 
             <org.wordpress.android.ui.reader.views.ReaderIconCountView
                 android:id="@+id/count_comments"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -60,6 +60,7 @@
                 android:contentDescription="@string/reader_view_comments"
                 android:layout_gravity="center_vertical"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_medium"
                 android:layout_width="wrap_content"
                 wp:readerIcon="comment" >
             </org.wordpress.android.ui.reader.views.ReaderIconCountView>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1678,6 +1678,7 @@
 
     <!-- reblog -->
     <string name="reader_view_reblog">Reblog</string>
+    <string name="reader_reblog_error">Reblog failed</string>
     <string name="reader_no_site_to_reblog">You should have at least one site to be able to reblog</string>
 
     <!-- like counts -->

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -427,7 +427,7 @@ class ReaderPostListViewModelTest {
         whenever(siteStore.visibleSites).thenReturn(visibleSites)
 
         viewModel.onReblogButtonClicked(post)
-        viewModel.selectedSiteToReblog(siteId)
+        viewModel.onReblogSiteSelected(siteId)
 
         val state = viewModel.reblogAction.value?.peekContent()
         assert(state is PostEditor)
@@ -437,7 +437,7 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun `when user selects a site and no post is selected or the state is unexpected an error is thrown`() {
-        viewModel.selectedSiteToReblog(1)
+        viewModel.onReblogSiteSelected(1)
 
         val state = viewModel.reblogAction.value?.peekContent()
         assert(state == null || state !is SitePicker || state.post == null)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -445,11 +445,13 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun `when user has only one site but the selected site is not retrieved an error occurs`() {
+        val siteId = -1
         val site = SiteModel()
         val post = ReaderPost()
         val visibleSites = listOf(site) // One site
 
-        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(null) // failure
+        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
+        whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(null) // failure
         whenever(siteStore.visibleSites).thenReturn(visibleSites)
 
         viewModel.onReblogButtonClicked(post)
@@ -460,11 +462,13 @@ class ReaderPostListViewModelTest {
 
     @Test
     fun `when user has more than one sites but the selected site is not retrieved an error occurs`() {
+        val siteId = -1
         val site = SiteModel()
         val post = ReaderPost()
         val visibleSites = listOf(site, site) // More sites
 
-        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(null) // failure
+        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
+        whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(null) // failure
         whenever(siteStore.visibleSites).thenReturn(visibleSites)
 
         viewModel.onReblogButtonClicked(post)
@@ -474,7 +478,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `when user selects a site and no post is selected or the state is unexpected an error is thrown`() {
+    fun `when user selects a site and the state is unexpected an error is thrown`() {
         val reblog = { viewModel.onReblogSiteSelected(1) }
         if (BuildConfig.DEBUG) {
             assertThatIllegalStateException().isThrownBy(reblog)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -11,6 +11,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.ObjectAssert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -391,7 +392,7 @@ class ReaderPostListViewModelTest {
         viewModel.onReblogButtonClicked(post)
 
         val state = viewModel.reblogState.value?.peekContent()
-        assert(state is PostEditor)
+        assertThat(state).isInstanceOf(PostEditor::class.java)
         assertThat(state?.site).isEqualTo(site)
         assertThat(state?.post).isEqualTo(post)
     }
@@ -410,7 +411,7 @@ class ReaderPostListViewModelTest {
         viewModel.onReblogButtonClicked(post)
 
         val state = viewModel.reblogState.value?.peekContent()
-        assert(state is SitePicker)
+        assertThat(state).isInstanceOf(SitePicker::class.java)
         assertThat(state?.site).isEqualTo(site)
         assertThat(state?.post).isEqualTo(post)
     }
@@ -430,7 +431,7 @@ class ReaderPostListViewModelTest {
         viewModel.onReblogSiteSelected(siteId)
 
         val state = viewModel.reblogState.value?.peekContent()
-        assert(state is PostEditor)
+        assertThat(state).isInstanceOf(PostEditor::class.java)
         assertThat(state?.site).isEqualTo(site)
         assertThat(state?.post).isEqualTo(post)
     }
@@ -440,8 +441,7 @@ class ReaderPostListViewModelTest {
         viewModel.onReblogSiteSelected(1)
 
         val state = viewModel.reblogState.value?.peekContent()
-        assert(state == null || state !is SitePicker || state.post == null)
-        assert(state is ReblogError)
+        assertThat(state).isInstanceOf(ReblogError::class.java)
     }
 
     private fun onClickActionDummy(filter: SubfilterListItem) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -373,7 +373,7 @@ class ReaderPostListViewModelTest {
 
         viewModel.onReblogButtonClicked(post)
 
-        val state = viewModel.reblogAction.value?.peekContent()
+        val state = viewModel.reblogState.value?.peekContent()
         assertThat(state).isEqualTo(NoSite)
     }
 
@@ -390,7 +390,7 @@ class ReaderPostListViewModelTest {
 
         viewModel.onReblogButtonClicked(post)
 
-        val state = viewModel.reblogAction.value?.peekContent()
+        val state = viewModel.reblogState.value?.peekContent()
         assert(state is PostEditor)
         assertThat(state?.site).isEqualTo(site)
         assertThat(state?.post).isEqualTo(post)
@@ -409,7 +409,7 @@ class ReaderPostListViewModelTest {
 
         viewModel.onReblogButtonClicked(post)
 
-        val state = viewModel.reblogAction.value?.peekContent()
+        val state = viewModel.reblogState.value?.peekContent()
         assert(state is SitePicker)
         assertThat(state?.site).isEqualTo(site)
         assertThat(state?.post).isEqualTo(post)
@@ -429,7 +429,7 @@ class ReaderPostListViewModelTest {
         viewModel.onReblogButtonClicked(post)
         viewModel.onReblogSiteSelected(siteId)
 
-        val state = viewModel.reblogAction.value?.peekContent()
+        val state = viewModel.reblogState.value?.peekContent()
         assert(state is PostEditor)
         assertThat(state?.site).isEqualTo(site)
         assertThat(state?.post).isEqualTo(post)
@@ -439,7 +439,7 @@ class ReaderPostListViewModelTest {
     fun `when user selects a site and no post is selected or the state is unexpected an error is thrown`() {
         viewModel.onReblogSiteSelected(1)
 
-        val state = viewModel.reblogAction.value?.peekContent()
+        val state = viewModel.reblogState.value?.peekContent()
         assert(state == null || state !is SitePicker || state.post == null)
         assert(state is ReblogError)
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -11,7 +11,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.ObjectAssert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test


### PR DESCRIPTION
Fixes #11532 

## Description

This feature adds reblog action to post cards in stream view

A reblog button has been added in the actions of the post cards in stream view.
If the user has more that one sites the button triggers the existing Site Picker.

| Post Details |Site Picker (unchanged)|
|--- |---|
|![device-2020-03-27-082924](https://user-images.githubusercontent.com/304044/77728549-6b907c80-7005-11ea-925e-d361de9e894d.png)|![2020-03-19 22 05 33](https://user-images.githubusercontent.com/304044/77110683-9b041f80-6a2e-11ea-8f21-198d89d5ead1.png)|

If the user has only one site the editor is triggered directly.
At the moment handling users with no site is not supported.

When the users selects a site he is redirected to the editor with the following information prefilled:
* Title (with source)
* Image (if the post has a featured)
* Quote
* Citation

| Gutenberg editor with featured image| Gutenberg editor without image |
| --- | --- |
|![device-2020-03-22-114527](https://user-images.githubusercontent.com/304044/77246840-b8560b00-6c33-11ea-8b38-28dc15e7b888.png)|![2020-03-19 22 06 05](https://user-images.githubusercontent.com/304044/77110686-9c354c80-6a2e-11ea-858d-f09c597f6348.png)|

| Aztec editor with featured image| Aztec editor without image |
| --- | --- |
|![device-2020-03-22-114630](https://user-images.githubusercontent.com/304044/77246853-d459ac80-6c33-11ea-9059-40c0c62eb03f.png)|![device-2020-03-22-114609](https://user-images.githubusercontent.com/304044/77246855-d885ca00-6c33-11ea-8bea-9943adfebb79.png)|

When the user taps the Publish button and confirms he returns to the original context

| Uploading State| Post Published |
| --- | --- |
|![device-2020-03-27-083017](https://user-images.githubusercontent.com/304044/77728611-8531c400-7005-11ea-8091-14d377717765.png)|![device-2020-03-27-083046](https://user-images.githubusercontent.com/304044/77728603-82cf6a00-7005-11ea-8f5b-04b9d3914967.png)|

## Test

0. Open the App and Login if needed
1. Select the Reader tab
2. Notice the reblog button on the post cards actions
3. Tap on the reblog action on one of the post cards
4. If prompted select a site from the picker
5. Notice that the editor opens with content from the original post: Title (with source), Image (if the post has a featured), Quote and Citation link
6. Optionally edit the post
7. Press the Publish button
8. Confirm by pressing the Publish Now button in the dialog
9. Notice that you return to the original context (post list view)
10. Notice the snackbar with the VIEW button
11. Tap on the VIEW button
12. Examine the reblogged post in the browser

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.