### PR TITLE
Merge/14.4.1 to release/14.5

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,10 @@
 * Removes sections from post search results
 * Site Creation: faster site creation, removed intermediate steps. Just select what kind of site you'd like, enter the domain name and the site will be created.
 * Fixed a bug where failed post uploads were sometimes being retried indefinitely
+
+14.4.1
+-----
+* Block Editor: Fix crash when inserting a Button Block.
  
 14.4
 -----

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -85,7 +85,7 @@ android {
             if (!project.hasProperty("versionName")) {
                 versionName "14.5-rc-1"
             }
-            versionCode 840
+            versionCode 842
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
         }
 


### PR DESCRIPTION
This PR merges `hotfix/14.4.1` to `release/14.5`. Since we don't need the changes in the hotfix branch, we are only pulling the changes related to the release notes and the version number change. In order to do that, I manually discarded the changes in the merge commit.