### PR TITLE
Untangle http:// and wordpress:// deeplinking URLs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 14.6
 -----
 * Block editor: You can now crop, zoom in/out and rotate images that are already inserted in a post.
+* Fix a deeplinking issue that could lead to the app not being open after clicking on some special "wordpress://" URLs.
 
 14.5
 -----
@@ -14,11 +15,11 @@
 
 * Site Creation: faster site creation, removed intermediate steps. Just select what kind of site you'd like, enter the domain name and the site will be created.
 * Fixed a bug where failed post uploads were sometimes being retried indefinitely
- 
+
 14.4
 -----
 * Fix an issue where image is sometimes uploaded with a path to local storage
- 
+
 14.3
 -----
 * Added search to set page parent screen
@@ -31,7 +32,7 @@
 * Block editor: Fix issue where adding emojis to the post title added strong HTML elements to the title of the post
 * Block editor: We’ve introduced a new toolbar that floats above the block you’re editing, which makes navigating your blocks easier — especially complex ones.
 * Reader Information Architecture: added tab filtering; added bottom sheet to filter and navigate the followed sites/tags posts.
- 
+
 14.2
 -----
 * Block editor: Long-press Inserter icon to show options to add before/after
@@ -65,7 +66,7 @@
 * Block Editor: Add support for the Preformatted block.
 * Block Editor: Add support for changing Settings in the List Block.
 * Block Editor: Add support for Video block settings.
- 
+
 13.8
 -----
 * Modified Blog Post search to search for posts under all categories.
@@ -82,7 +83,7 @@
 * Fixed time displayed on Post Conflict Detected and Unpublished Revision dialogs
 * Block editor: Fix issue when removing image/page break block crashes the app
 * Fixed a crash on Samsung devices running Android 5 (Lollipop)
- 
+
 * Removed support for Giphy
 
 13.6

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -360,6 +360,13 @@
                 <data
                     android:host="notifications"
                     android:scheme="wordpress" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
                     android:host="public-api.wordpress.com"
@@ -376,6 +383,7 @@
                     android:pathPattern="/post/..*"
                     android:scheme="http" />
             </intent-filter>
+
         </activity>
 
         <!-- Reader Activities -->


### PR DESCRIPTION
Fixes an issue that made `wordpress://` URLs non-functional.

This was probably introduced in: https://github.com/wordpress-mobile/WordPress-Android/pull/9957

Note that I'm not sure why the issue is happening, according to the [documentation](https://developer.android.com/training/app-links/deep-linking) this should work fine, and other urls like: `http://viewpost` should also work as well (which is an unwanted side effect).

# Test

#### Before the patch, run:
```
adb shell am start \
 -W -a android.intent.action.VIEW \
 -c android.intent.category.BROWSABLE \
 -d "wordpress://viewpost?blogId=124661775\&postId=1194"
```

The app won't open.

#### After the patch, run the same command:

```
adb shell am start \
 -W -a android.intent.action.VIEW \
 -c android.intent.category.BROWSABLE \
 -d "wordpress://viewpost?blogId=124661775\&postId=1194"
```

The app will open and show the specified post in the reader.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. 
