### PR TITLE
Handle user with no site

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -451,7 +451,7 @@
             android:theme="@style/CalypsoTheme"
             android:windowSoftInputMode="adjustResize|stateHidden" />
         <activity
-            android:name=".ui.reader.ReaderPostNoSiteToReblogActivity"
+            android:name=".ui.reader.NoSiteToReblogActivity"
             android:theme="@style/CalypsoTheme" />
         <activity
             android:name=".ui.AppLogViewerActivity"

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -451,6 +451,9 @@
             android:theme="@style/CalypsoTheme"
             android:windowSoftInputMode="adjustResize|stateHidden" />
         <activity
+            android:name=".ui.reader.ReaderPostNoSiteToReblog"
+            android:theme="@style/CalypsoTheme" />
+        <activity
             android:name=".ui.AppLogViewerActivity"
             android:label="@string/reader_title_applog"
             android:theme="@style/CalypsoTheme" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -10,6 +10,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import androidx.appcompat.widget.AppCompatButton
 import org.wordpress.android.R
+import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.widgets.WPTextView
 
 /**
@@ -71,13 +72,19 @@ class ActionableEmptyView : LinearLayout {
                     R.styleable.ActionableEmptyView_aevImage,
                     0
             )
+            val hideImageInLandscape = typedArray.getBoolean(
+                    R.styleable.ActionableEmptyView_aevImageHiddenInLandscape,
+                    false
+            )
             val titleAttribute = typedArray.getString(R.styleable.ActionableEmptyView_aevTitle)
             val subtitleAttribute = typedArray.getString(R.styleable.ActionableEmptyView_aevSubtitle)
             val buttonAttribute = typedArray.getString(R.styleable.ActionableEmptyView_aevButton)
 
             if (imageResource != 0) {
                 image.setImageResource(imageResource)
-                image.visibility = View.VISIBLE
+                if (!hideImageInLandscape || !DisplayUtils.isLandscape(context)) {
+                    image.visibility = View.VISIBLE
+                }
             }
 
             if (!titleAttribute.isNullOrEmpty()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -12,6 +12,7 @@ public class RequestCodes {
     public static final int EDIT_POST = 800;
     public static final int PREVIEW_POST = 810;
     public static final int REMOTE_PREVIEW_POST = 820;
+    public static final int NO_REBLOG_SITE = 830;
     public static final int CREATE_SITE = 900;
     public static final int SITE_SETTINGS = 1000;
     public static final int DO_LOGIN = 1100;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -98,6 +98,7 @@ import org.wordpress.android.ui.posts.PromoDialog.PromoDialogClickInterface;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.AppSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsFragment;
+import org.wordpress.android.ui.reader.ReaderEvents;
 import org.wordpress.android.ui.reader.ReaderPostListFragment;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
 import org.wordpress.android.ui.uploads.UploadActionUseCase;
@@ -858,6 +859,19 @@ public class WPMainActivity extends AppCompatActivity implements
             AnalyticsUtils.trackWithDefaultInterceptor(AnalyticsTracker.Stat.DEEP_LINK_NOT_DEFAULT_HANDLER,
                     resolveInfo.activityInfo.name);
         }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onEventMainThread(ReaderEvents.SiteManagerTriggered event) {
+        setMySitePageActive();
+    }
+
+    /**
+     * Ste My Site page active
+     */
+    public void setMySitePageActive() {
+        mBottomNav.setCurrentSelectedPage(PageType.MY_SITE);
     }
 
     public void setReaderPageActive() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/NoSiteToReblogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/NoSiteToReblogActivity.kt
@@ -4,22 +4,24 @@ import android.R.id
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.reader_no_site_to_reblog.*
+import kotlinx.android.synthetic.main.reader_no_site_to_reblog.noSiteToReblogView
 import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.R
 
 /*
  * Serves as an intermediate screen where the user is informed that a site is needed for the reblog action
  */
-class ReaderPostNoSiteToReblogActivity : AppCompatActivity() {
+class NoSiteToReblogActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.reader_no_site_to_reblog)
 
-        supportActionBar?.setDisplayShowTitleEnabled(false)
-        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.apply {
+            setDisplayShowTitleEnabled(false)
+            setDisplayHomeAsUpEnabled(true)
+        }
 
-        no_site_to_reblog_view.button.setOnClickListener {
+        noSiteToReblogView.button.setOnClickListener {
             EventBus.getDefault().post(ReaderEvents.SiteManagerTriggered())
             setResult(RESULT_OK)
             finish()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -188,7 +188,7 @@ public class ReaderActivityLauncher {
      * @param activity the calling activity
      */
     public static void showNoSiteToReblog(Activity activity) {
-        Intent intent = new Intent(activity, ReaderPostNoSiteToReblogActivity.class);
+        Intent intent = new Intent(activity, NoSiteToReblogActivity.class);
         activity.startActivityForResult(intent, RequestCodes.NO_REBLOG_SITE);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -14,6 +14,7 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity.DirectOperation;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
@@ -179,6 +180,16 @@ public class ReaderActivityLauncher {
         intent.putExtra(ReaderConstants.ARG_BLOG_ID, blogId);
         intent.putExtra(ReaderConstants.ARG_POST_ID, postId);
         context.startActivity(intent);
+    }
+
+    /**
+     * Presents the [ReaderPostNoSiteToReblog] activity
+     *
+     * @param activity the calling activity
+     */
+    public static void showNoSiteToReblog(Activity activity) {
+        Intent intent = new Intent(activity, ReaderPostNoSiteToReblog.class);
+        activity.startActivityForResult(intent, RequestCodes.NO_REBLOG_SITE);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -212,4 +212,10 @@ public class ReaderEvents {
 
     public static class DoSignIn {
     }
+
+    /**
+     * Shows the Site Manager (My site page)
+     */
+    public static class SiteManagerTriggered {
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -862,7 +862,7 @@ class ReaderPostDetailFragment : Fragment(),
             reblogButton.setOnClickListener {
                 val sites = mSiteStore.visibleSites
                 when (sites.size) {
-                    0 -> ToastUtils.showToast(activity, R.string.reader_no_site_to_reblog)
+                    0 -> ReaderActivityLauncher.showNoSiteToReblog(activity)
                     1 -> ActivityLauncher.openEditorForReblog(activity, sites.first(), this.post)
                     else -> {
                         val siteLocalId = AppPrefs.getSelectedSite()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2903,7 +2903,7 @@ public class ReaderPostListFragment extends Fragment
         List<SiteModel> sites = mSiteStore.getVisibleSites();
         switch (sites.size()) {
             case 0:
-                ToastUtils.showToast(getActivity(), R.string.reader_no_site_to_reblog);
+                ReaderActivityLauncher.showNoSiteToReblog(getActivity());
                 break;
             case 1:
                 ActivityLauncher.openEditorForReblog(getActivity(), getSelectedSite(), this.mPostToReblog);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostNoSiteToReblog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostNoSiteToReblog.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.ui.reader
+
+import android.R.id
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import kotlinx.android.synthetic.main.reader_no_site_to_reblog.*
+import org.greenrobot.eventbus.EventBus
+import org.wordpress.android.R
+
+/*
+ * Serves as an intermediate screen where the user is informed that a site is needed for the reblog action
+ */
+class ReaderPostNoSiteToReblog : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.reader_no_site_to_reblog)
+
+        supportActionBar?.setDisplayShowTitleEnabled(false)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        no_site_to_reblog_view.button.setOnClickListener {
+            setResult(RESULT_OK)
+            finish()
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
+        id.home -> {
+            finish()
+            true
+        }
+        else -> super.onOptionsItemSelected(item)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostNoSiteToReblog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostNoSiteToReblog.kt
@@ -20,6 +20,7 @@ class ReaderPostNoSiteToReblog : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         no_site_to_reblog_view.button.setOnClickListener {
+            EventBus.getDefault().post(ReaderEvents.SiteManagerTriggered())
             setResult(RESULT_OK)
             finish()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -1035,6 +1035,11 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                     mBackFromLogin = true;
                 }
                 break;
+            case RequestCodes.NO_REBLOG_SITE:
+                if (resultCode == Activity.RESULT_OK) {
+                    finish(); // Finish activity to make My Site page visible
+                }
+                break;
         }
     }
 

--- a/WordPress/src/main/res/layout/reader_no_site_to_reblog.xml
+++ b/WordPress/src/main/res/layout/reader_no_site_to_reblog.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent">
 
     <org.wordpress.android.ui.ActionableEmptyView
-        android:id="@+id/no_site_to_reblog_view"
+        android:id="@+id/noSiteToReblogView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="@dimen/toolbar_height"

--- a/WordPress/src/main/res/layout/reader_no_site_to_reblog.xml
+++ b/WordPress/src/main/res/layout/reader_no_site_to_reblog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <org.wordpress.android.ui.ActionableEmptyView
+        android:id="@+id/no_site_to_reblog_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/toolbar_height"
+        app:aevButton="@string/reader_no_site_to_reblog_action"
+        app:aevImage="@drawable/img_illustration_empty_results_216dp"
+        app:aevSubtitle="@string/reader_no_site_to_reblog_detail"
+        app:aevTitle="@string/reader_no_site_to_reblog_title" />
+
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_no_site_to_reblog.xml
+++ b/WordPress/src/main/res/layout/reader_no_site_to_reblog.xml
@@ -11,6 +11,7 @@
         android:layout_marginTop="@dimen/toolbar_height"
         app:aevButton="@string/reader_no_site_to_reblog_action"
         app:aevImage="@drawable/img_illustration_empty_results_216dp"
+        app:aevImageHiddenInLandscape="true"
         app:aevSubtitle="@string/reader_no_site_to_reblog_detail"
         app:aevTitle="@string/reader_no_site_to_reblog_title" />
 

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -174,6 +174,8 @@
         <attr name="aevButton" format="string"/>
         <!-- Optional: resource id of image -->
         <attr name="aevImage" format="reference"/>
+        <!-- Optional: defines if image should be hidden in landscape mode -->
+        <attr name="aevImageHiddenInLandscape" format="boolean" />
         <!-- Optional: string text of subtitle -->
         <attr name="aevSubtitle" format="string"/>
         <!-- Required: string text of title -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1678,7 +1678,9 @@
 
     <!-- reblog -->
     <string name="reader_view_reblog">Reblog</string>
-    <string name="reader_no_site_to_reblog">You should have at least one site to be able to reblog</string>
+    <string name="reader_no_site_to_reblog_title">No available sites</string>
+    <string name="reader_no_site_to_reblog_detail">Once you create a site, you can reblog content that you like to your own site.</string>
+    <string name="reader_no_site_to_reblog_action">Manage Sites</string>
 
     <!-- like counts -->
     <string name="reader_label_like">Like</string>


### PR DESCRIPTION
Fixes #11533 

## Description

This addition handles the case when the user has no site to reblog to.

A new screen appears when the user triggers the reblog action and has no sites. The screen design is in sync with the iOS implementation and has an actionable button directing the user to the _My site_ screen where the _Add New Site_ action is available.

The new screen is show when the reblog action is triggered in the post details or in the post cards stream view.

| Post details action | Stream view action |
| --- | --- |
|![detail](https://user-images.githubusercontent.com/304044/77844897-067a8980-71b3-11ea-9f0d-cebbfb493f70.gif)|![list](https://user-images.githubusercontent.com/304044/77844891-011d3f00-71b3-11ea-8345-a0e4b4698805.gif)|

## Test

### Reblog action on post cards actions in stream view

0. Open the App and Login with a user having no sites
1. Select the Reader tab
2. Notice the reblog button on the post cards actions
3. Tap on the reblog action on one of the post cards
4. Notice the no sites available screen
5. Press the _Manage Sites_ button
6. Verify that you are directed to the _My Sites_ page
7. Notice the _Add New Site_ button

### Reblog action on post details actions

0. Open the App and Login with a user having no sites
1. Select the Reader tab
2. Notice the reblog button on the post cards actions
3. Tap on the reblog action on one of the post cards
4. Notice the no sites available screen
5. Press the _Manage Sites_ button
6. Verify that you are directed to the _My Sites_ page
7. Notice the _Add New Site_ button

### Note

~~The **site creation flow** after redirection to the _My Sites_ page **has not been tested**. The default site creation flow fails with an HTTP 403/Forbidden error:
`Unexpected response code 403 for https://public-api.wordpress.com/rest/v1.1/sites/new/?locale=en_US`
This is error is probably related with the restrictions on credentials created with [applications manager](https://developer.wordpress.com/apps/)~~.
The site creation flow after redirection to the _My Sites_ page has been tested with credentials authorised to perform the site creation action.


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.