### PR TITLE
Customise Site Picker for Reblog Action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -43,6 +43,7 @@ import org.wordpress.android.ui.history.HistoryDetailContainerFragment;
 import org.wordpress.android.ui.history.HistoryListItem.Revision;
 import org.wordpress.android.ui.main.MeActivity;
 import org.wordpress.android.ui.main.SitePickerActivity;
+import org.wordpress.android.ui.main.SitePickerActivity.SitePickerMode;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
@@ -126,34 +127,34 @@ public class ActivityLauncher {
      * @param site     the preselected site
      */
     public static void showSitePickerForResult(Activity activity, SiteModel site) {
-        Intent intent = createSitePickerIntent(activity, site, false);
+        Intent intent = createSitePickerIntent(activity, site, SitePickerMode.NORMAL);
         activity.startActivityForResult(intent, RequestCodes.SITE_PICKER);
     }
 
     /**
      * Presents the site picker and expects the selection result
      *
-     * @param fragment         the fragment that starts the site picker and expects the result
-     * @param site             the preselected site
-     * @param searchOnlyAction when true only the search and back actions are shown
+     * @param fragment the fragment that starts the site picker and expects the result
+     * @param site     the preselected site
+     * @param mode     site picker mode
      */
-    public static void showSitePickerForResult(Fragment fragment, SiteModel site, boolean searchOnlyAction) {
-        Intent intent = createSitePickerIntent(fragment.getContext(), site, searchOnlyAction);
+    public static void showSitePickerForResult(Fragment fragment, SiteModel site, SitePickerMode mode) {
+        Intent intent = createSitePickerIntent(fragment.getContext(), site, mode);
         fragment.startActivityForResult(intent, RequestCodes.SITE_PICKER);
     }
 
     /**
      * Creates a site picker intent
      *
-     * @param context          the context to use for the intent creation
-     * @param site             the preselected site
-     * @param searchOnlyAction when true only the search and back actions are shown
+     * @param context the context to use for the intent creation
+     * @param site    the preselected site
+     * @param mode    site picker mode
      * @return the site picker intent
      */
-    private static Intent createSitePickerIntent(Context context, SiteModel site, boolean searchOnlyAction) {
+    private static Intent createSitePickerIntent(Context context, SiteModel site, SitePickerMode mode) {
         Intent intent = new Intent(context, SitePickerActivity.class);
         intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, site.getId());
-        intent.putExtra(SitePickerActivity.KEY_ONLY_SEARCH_MODE, searchOnlyAction);
+        intent.putExtra(SitePickerActivity.SITE_PICKER_MODE, mode);
         return intent;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -126,31 +126,34 @@ public class ActivityLauncher {
      * @param site     the preselected site
      */
     public static void showSitePickerForResult(Activity activity, SiteModel site) {
-        Intent intent = createSitePickerIntent(activity, site);
+        Intent intent = createSitePickerIntent(activity, site, false);
         activity.startActivityForResult(intent, RequestCodes.SITE_PICKER);
     }
 
     /**
      * Presents the site picker and expects the selection result
      *
-     * @param fragment the fragment that starts the site picker and expects the result
-     * @param site     the preselected site
+     * @param fragment         the fragment that starts the site picker and expects the result
+     * @param site             the preselected site
+     * @param searchOnlyAction when true only the search and back actions are shown
      */
-    public static void showSitePickerForResult(Fragment fragment, SiteModel site) {
-        Intent intent = createSitePickerIntent(fragment.getContext(), site);
+    public static void showSitePickerForResult(Fragment fragment, SiteModel site, boolean searchOnlyAction) {
+        Intent intent = createSitePickerIntent(fragment.getContext(), site, searchOnlyAction);
         fragment.startActivityForResult(intent, RequestCodes.SITE_PICKER);
     }
 
     /**
      * Creates a site picker intent
      *
-     * @param context the context to use for the intent creation
-     * @param site    the preselected site
+     * @param context          the context to use for the intent creation
+     * @param site             the preselected site
+     * @param searchOnlyAction when true only the search and back actions are shown
      * @return the site picker intent
      */
-    private static Intent createSitePickerIntent(Context context, SiteModel site) {
+    private static Intent createSitePickerIntent(Context context, SiteModel site, boolean searchOnlyAction) {
         Intent intent = new Intent(context, SitePickerActivity.class);
         intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, site.getId());
+        intent.putExtra(SitePickerActivity.KEY_ONLY_SEARCH_MODE, searchOnlyAction);
         return intent;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -80,6 +80,7 @@ public class SitePickerActivity extends AppCompatActivity
     private static final String KEY_IS_IN_SEARCH_MODE = "is_in_search_mode";
     private static final String KEY_LAST_SEARCH = "last_search";
     private static final String KEY_REFRESHING = "refreshing_sites";
+    public static final String KEY_ONLY_SEARCH_MODE = "only_search";
 
     private ActionableEmptyView mActionableEmptyView;
     private SitePickerAdapter mAdapter;
@@ -91,6 +92,7 @@ public class SitePickerActivity extends AppCompatActivity
     private MenuItem mMenuSearch;
     private SearchView mSearchView;
     private int mCurrentLocalId;
+    private boolean mSearchOnlyMode;
     private Debouncer mDebouncer = new Debouncer();
 
     @Inject AccountStore mAccountStore;
@@ -132,6 +134,7 @@ public class SitePickerActivity extends AppCompatActivity
         outState.putBoolean(KEY_IS_IN_SEARCH_MODE, getAdapter().getIsInSearchMode());
         outState.putString(KEY_LAST_SEARCH, getAdapter().getLastSearch());
         outState.putBoolean(KEY_REFRESHING, mSwipeToRefreshHelper.isRefreshing());
+        outState.putBoolean(KEY_ONLY_SEARCH_MODE, mSearchOnlyMode);
         super.onSaveInstanceState(outState);
     }
 
@@ -158,7 +161,7 @@ public class SitePickerActivity extends AppCompatActivity
             return;
         }
 
-        if (getAdapter().getIsInSearchMode()) {
+        if (getAdapter().getIsInSearchMode() || mSearchOnlyMode) {
             mMenuEdit.setVisible(false);
             mMenuAdd.setVisible(false);
         } else {
@@ -313,8 +316,10 @@ public class SitePickerActivity extends AppCompatActivity
             mCurrentLocalId = savedInstanceState.getInt(KEY_LOCAL_ID);
             isInSearchMode = savedInstanceState.getBoolean(KEY_IS_IN_SEARCH_MODE);
             lastSearch = savedInstanceState.getString(KEY_LAST_SEARCH);
+            mSearchOnlyMode = savedInstanceState.getBoolean(KEY_ONLY_SEARCH_MODE);
         } else if (getIntent() != null) {
             mCurrentLocalId = getIntent().getIntExtra(KEY_LOCAL_ID, 0);
+            mSearchOnlyMode = getIntent().getBooleanExtra(KEY_ONLY_SEARCH_MODE, false);
         }
 
         setNewAdapter(lastSearch, isInSearchMode);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -77,10 +77,11 @@ public class SitePickerActivity extends AppCompatActivity
         SearchView.OnQueryTextListener {
     public static final String KEY_LOCAL_ID = "local_id";
     public static final String KEY_SITE_CREATED_BUT_NOT_FETCHED = "key_site_created_but_not_fetched";
+    public static final String KEY_ONLY_SEARCH_MODE = "only_search";
+
     private static final String KEY_IS_IN_SEARCH_MODE = "is_in_search_mode";
     private static final String KEY_LAST_SEARCH = "last_search";
     private static final String KEY_REFRESHING = "refreshing_sites";
-    public static final String KEY_ONLY_SEARCH_MODE = "only_search";
 
     private ActionableEmptyView mActionableEmptyView;
     private SitePickerAdapter mAdapter;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -520,6 +520,7 @@ public class SitePickerActivity extends AppCompatActivity
 
     @Override
     public boolean onSiteLongClick(final SiteRecord siteRecord) {
+        if (mSearchOnlyMode) return false;
         final SiteModel site = mSiteStore.getSiteByLocalId(siteRecord.getLocalId());
         if (site == null) {
             return false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -58,6 +58,7 @@ import org.wordpress.android.models.ReaderPostDiscoverData
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.main.SitePickerActivity
+import org.wordpress.android.ui.main.SitePickerActivity.SitePickerMode.REBLOG
 import org.wordpress.android.ui.main.WPMainActivity
 import org.wordpress.android.ui.posts.BasicFragmentDialog
 import org.wordpress.android.ui.prefs.AppPrefs
@@ -867,7 +868,7 @@ class ReaderPostDetailFragment : Fragment(),
                     else -> {
                         val siteLocalId = AppPrefs.getSelectedSite()
                         val site = mSiteStore.getSiteByLocalId(siteLocalId)
-                        ActivityLauncher.showSitePickerForResult(this, site, true)
+                        ActivityLauncher.showSitePickerForResult(this, site, REBLOG)
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -867,7 +867,7 @@ class ReaderPostDetailFragment : Fragment(),
                     else -> {
                         val siteLocalId = AppPrefs.getSelectedSite()
                         val site = mSiteStore.getSiteByLocalId(siteLocalId)
-                        ActivityLauncher.showSitePickerForResult(this, site)
+                        ActivityLauncher.showSitePickerForResult(this, site, true)
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -91,6 +91,7 @@ import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.main.BottomNavController;
 import org.wordpress.android.ui.main.MainToolbarFragment;
 import org.wordpress.android.ui.main.SitePickerActivity;
+import org.wordpress.android.ui.main.SitePickerActivity.SitePickerMode;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.news.NewsViewHolder.NewsCardListener;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -2909,7 +2910,7 @@ public class ReaderPostListFragment extends Fragment
                     ReaderActivityLauncher.showNoSiteToReblog(getActivity());
                 } else if (state instanceof SitePicker) {
                     SitePicker spState = (SitePicker) state;
-                    ActivityLauncher.showSitePickerForResult(this, spState.getSite(), true);
+                    ActivityLauncher.showSitePickerForResult(this, spState.getSite(), SitePickerMode.REBLOG);
                 } else if (state instanceof PostEditor) {
                     PostEditor peState = (PostEditor) state;
                     ActivityLauncher.openEditorForReblog(getActivity(), peState.getSite(), peState.getPost());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2910,7 +2910,7 @@ public class ReaderPostListFragment extends Fragment
                 break;
             default:
                 this.mPostToReblog = post; // Stores the post to be handled in the onActivityResult after site selection
-                ActivityLauncher.showSitePickerForResult(this, getSelectedSite());
+                ActivityLauncher.showSitePickerForResult(this, getSelectedSite(), true);
                 break;
         }
     }


### PR DESCRIPTION
Fixes #11554

## Description

Displays only the Search and Back action on the top toolbar when site picker is opened for reblog

The custom sitepicker is show when the reblog action is triggered in the post details or in the post cards stream view.

| Post details action | Stream view action |
| --- | --- |
|![detail](https://user-images.githubusercontent.com/304044/77846031-d71c4a80-71bb-11ea-97a6-4fa111cc1767.gif)|![list](https://user-images.githubusercontent.com/304044/77846026-cf5ca600-71bb-11ea-9639-b7dff5a9aae5.gif)|

## Test

### Reblog action on post cards actions in stream view

0. Open the App and Login with a user that has more than one sites
1. Select the Reader tab
2. Notice the reblog button on the post cards actions
3. Tap on the reblog action on one of the post cards
4. Verify that the site picker opens
5. Verify that the site picker top toolbar has only the search action
6. Long tap on any list item and verify that no action is triggered

### Reblog action on post details actions

0. Open the App and Login with a user that has more than one sites
1. Select the Reader tab
2. Notice the reblog button on the post cards actions
3. Tap on the reblog action on one of the post cards
4. Verify that the site picker opens
5. Verify that the site picker top toolbar has only the search action
6. Long tap on any list item and verify that no action is triggered

### Default site picker without customization

0. Open the App and Login with a user that has more than one sites
1. Press the _Switch Site_ button on the My Sites page
2. Verify that all the actions are displayed in the top toolbar: Search, Add and Edit
3. Long tap on any list item and verify that the list enters edit mode


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.