### PR TITLE
Fix empty stats in post detail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
@@ -60,7 +60,7 @@ class PostAverageViewsPerDayUseCase(
 
         return when {
             error != null -> State.Error(error.message ?: error.type.name)
-            model != null && model.yearsAverage.isNotEmpty() -> State.Data(model)
+            model != null && model.hasData() -> State.Data(model)
             else -> State.Empty()
         }
     }
@@ -95,6 +95,10 @@ class PostAverageViewsPerDayUseCase(
             )
         }
         return items
+    }
+
+    private fun PostDetailStatsModel?.hasData(): Boolean {
+        return this != null && this.yearsAverage.isNotEmpty() && this.yearsAverage.any { it.value > 0 }
     }
 
     private fun onLinkClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsUseCase.kt
@@ -62,7 +62,7 @@ class PostDayViewsUseCase
                 selectedDateProvider.onDateLoadingFailed(DETAIL)
                 State.Error(error.message ?: error.type.name)
             }
-            model != null && model.dayViews.isNotEmpty() -> {
+            model != null && model.hasData() -> {
                 selectedDateProvider.onDateLoadingSucceeded(DETAIL)
                 State.Data(model)
             }
@@ -77,7 +77,7 @@ class PostDayViewsUseCase
         val items = mutableListOf<BlockListItem>()
         val visibleBarCount = uiState.visibleBarCount ?: domainModel.dayViews.size
 
-        if (domainModel.dayViews.isNotEmpty() && visibleBarCount > 0) {
+        if (domainModel.hasData() && visibleBarCount > 0) {
             val periodFromProvider = selectedDateProvider.getSelectedDate(DETAIL)
             val availablePeriods = domainModel.dayViews.takeLast(visibleBarCount)
             val availableDates = availablePeriods.map { statsDateFormatter.parseStatsDate(DAYS, it.period) }
@@ -136,6 +136,10 @@ class PostDayViewsUseCase
 
     private fun onBarChartDrawn(visibleBarCount: Int) {
         updateUiState { it.copy(visibleBarCount = visibleBarCount) }
+    }
+
+    private fun PostDetailStatsModel?.hasData(): Boolean {
+        return this != null && this.dayViews.isNotEmpty() && this.dayViews.any { it.count > 0 }
     }
 
     data class UiState(val visibleBarCount: Int? = null)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
@@ -60,7 +60,7 @@ class PostMonthsAndYearsUseCase(
 
         return when {
             error != null -> State.Error(error.message ?: error.type.name)
-            model != null && model.yearsTotal.isNotEmpty() -> State.Data(model)
+            model != null && model.hasData() -> State.Data(model)
             else -> State.Empty()
         }
     }
@@ -95,6 +95,10 @@ class PostMonthsAndYearsUseCase(
             )
         }
         return items
+    }
+
+    private fun PostDetailStatsModel?.hasData(): Boolean {
+        return this != null && this.yearsTotal.isNotEmpty() && this.yearsTotal.any { it.value > 0 }
     }
 
     private fun onLinkClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCase.kt
@@ -60,7 +60,7 @@ class PostRecentWeeksUseCase(
 
         return when {
             error != null -> State.Error(error.message ?: error.type.name)
-            model != null && model.weekViews.isNotEmpty() -> State.Data(model)
+            model != null && model.hasData() -> State.Data(model)
             else -> State.Empty()
         }
     }
@@ -103,6 +103,10 @@ class PostRecentWeeksUseCase(
 
     override fun buildLoadingItem(): List<BlockListItem> {
         return listOf(Title(R.string.stats_detail_recent_weeks))
+    }
+
+    private fun PostDetailStatsModel?.hasData(): Boolean {
+        return this != null && this.weekViews.isNotEmpty() && this.weekViews.any { it.total > 0 }
     }
 
     class PostRecentWeeksUseCaseFactory

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
@@ -16,7 +16,9 @@ import org.wordpress.android.R
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel
+import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Day
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Month
+import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Week
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Year
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
@@ -26,6 +28,7 @@ import org.wordpress.android.test
 import org.wordpress.android.ui.stats.refresh.lists.detail.PostDetailMapper.ExpandedYearUiState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.EMPTY
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.ERROR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -56,6 +59,7 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
     private lateinit var expandCaptor: KArgumentCaptor<(ExpandedYearUiState) -> Unit>
     private val postId: Long = 1L
     private val year = Year(2010, listOf(Month(1, 100)), 150)
+
     @InternalCoroutinesApi
     @Before
     fun setUp() {
@@ -206,6 +210,26 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
         val result = loadData(true, forced)
 
         assertThat(result.state).isEqualTo(ERROR)
+    }
+
+    @Test
+    fun `maps list of empty items to empty UI model`() = test {
+        val forced = false
+        whenever(store.fetchPostDetail(site, postId, forced)).thenReturn(
+                OnStatsFetched(
+                        model = PostDetailStatsModel(
+                                0,
+                                listOf(Day("1970", 0), Day("1970", 1)),
+                                listOf(Week(listOf(), 10, 10)),
+                                listOf(Year(2020, listOf(), 100)),
+                                listOf(Year(2020, listOf(), 0))
+                        )
+                )
+        )
+
+        val result = loadData(true, forced)
+
+        assertThat(result.state).isEqualTo(EMPTY)
     }
 
     private fun assertTitle(item: BlockListItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.*
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -15,6 +16,8 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Day
+import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Week
+import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Year
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.PostDetailType
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
@@ -22,6 +25,7 @@ import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.stats.PostDetailStore
 import org.wordpress.android.test
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.EMPTY
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.ERROR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.BarChartItem
@@ -82,11 +86,11 @@ class PostDayViewsUseCaseTest : BaseUnitTest() {
 
         val result = loadData(true, forced)
 
-        Assertions.assertThat(result.type).isEqualTo(PostDetailType.POST_OVERVIEW)
-        Assertions.assertThat(result.state).isEqualTo(SUCCESS)
+        assertThat(result.type).isEqualTo(PostDetailType.POST_OVERVIEW)
+        assertThat(result.state).isEqualTo(SUCCESS)
         result.data!!.apply {
-            Assertions.assertThat(this[0]).isEqualTo(title)
-            Assertions.assertThat(this[1]).isEqualTo(barChartItem)
+            assertThat(this[0]).isEqualTo(title)
+            assertThat(this[1]).isEqualTo(barChartItem)
         }
     }
 
@@ -102,7 +106,7 @@ class PostDayViewsUseCaseTest : BaseUnitTest() {
 
         val result = loadData(true, forced)
 
-        Assertions.assertThat(result.state).isEqualTo(ERROR)
+        assertThat(result.state).isEqualTo(ERROR)
     }
 
     /**
@@ -126,8 +130,28 @@ class PostDayViewsUseCaseTest : BaseUnitTest() {
 
         val result = loadData(true, forced)
 
-        Assertions.assertThat(result.state).isEqualTo(SUCCESS)
-        Assertions.assertThat(result.data).isEmpty()
+        assertThat(result.state).isEqualTo(SUCCESS)
+        assertThat(result.data).isEmpty()
+    }
+
+    @Test
+    fun `maps list of empty items to empty UI model`() = test {
+        val forced = false
+        whenever(store.fetchPostDetail(site, postId, forced)).thenReturn(
+                OnStatsFetched(
+                        model = PostDetailStatsModel(
+                                0,
+                                listOf(Day("1970", 0), Day("1975", 0)),
+                                listOf(Week(listOf(), 10, 10)),
+                                listOf(Year(2020, listOf(), 100)),
+                                listOf(Year(2020, listOf(), 100))
+                        )
+                )
+        )
+
+        val result = loadData(true, forced)
+
+        assertThat(result.state).isEqualTo(EMPTY)
     }
 
     private suspend fun loadData(refresh: Boolean, forced: Boolean): UseCaseModel {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostDayViewsUseCaseTest.kt
@@ -5,8 +5,7 @@ import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.InternalCoroutinesApi
-import org.assertj.core.api.Assertions
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCaseTest.kt
@@ -16,7 +16,9 @@ import org.wordpress.android.R
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel
+import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Day
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Month
+import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Week
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Year
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
@@ -26,6 +28,7 @@ import org.wordpress.android.test
 import org.wordpress.android.ui.stats.refresh.lists.detail.PostDetailMapper.ExpandedYearUiState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.EMPTY
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.ERROR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -206,6 +209,26 @@ class PostMonthsAndYearsUseCaseTest : BaseUnitTest() {
         val result = loadData(true, forced)
 
         assertThat(result.state).isEqualTo(ERROR)
+    }
+
+    @Test
+    fun `maps list of empty items to empty UI model`() = test {
+        val forced = false
+        whenever(store.fetchPostDetail(site, postId, forced)).thenReturn(
+                OnStatsFetched(
+                        model = PostDetailStatsModel(
+                                0,
+                                listOf(Day("1970", 0), Day("1970", 1)),
+                                listOf(Week(listOf(Day("Monday", 10)), 10, 10)),
+                                listOf(Year(2020, listOf(Month(1, 0)), 0)),
+                                listOf(Year(2020, listOf(), 10))
+                        )
+                )
+        )
+
+        val result = loadData(true, forced)
+
+        assertThat(result.state).isEqualTo(EMPTY)
     }
 
     private fun assertTitle(item: BlockListItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostRecentWeeksUseCaseTest.kt
@@ -17,7 +17,9 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Day
+import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Month
 import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Week
+import org.wordpress.android.fluxc.model.stats.PostDetailStatsModel.Year
 import org.wordpress.android.fluxc.store.StatsStore.OnStatsFetched
 import org.wordpress.android.fluxc.store.StatsStore.StatsError
 import org.wordpress.android.fluxc.store.StatsStore.StatsErrorType.GENERIC_ERROR
@@ -26,6 +28,7 @@ import org.wordpress.android.test
 import org.wordpress.android.ui.stats.refresh.lists.detail.PostDetailMapper.ExpandedWeekUiState
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.BLOCK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.EMPTY
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.ERROR
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel.UseCaseState.SUCCESS
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
@@ -222,6 +225,26 @@ class PostRecentWeeksUseCaseTest : BaseUnitTest() {
         val result = loadData(true, forced)
 
         assertThat(result.state).isEqualTo(ERROR)
+    }
+
+    @Test
+    fun `maps list of empty items to empty UI model`() = test {
+        val forced = false
+        whenever(store.fetchPostDetail(site, postId, forced)).thenReturn(
+                OnStatsFetched(
+                        model = PostDetailStatsModel(
+                                0,
+                                listOf(Day("1970", 0), Day("1970", 1)),
+                                listOf(Week(listOf(Day("Monday", 0)), 0, 0)),
+                                listOf(Year(2020, listOf(Month(1, 55)), 10)),
+                                listOf(Year(2020, listOf(), 10))
+                        )
+                )
+        )
+
+        val result = loadData(true, forced)
+
+        assertThat(result.state).isEqualTo(EMPTY)
     }
 
     private fun assertTitle(item: BlockListItem) {


### PR DESCRIPTION
Fixes #11546

We haven't been properly checking whether the model is empty. What we were receiving from the backend is a list of items (years, months) with value 0 instead of an empty list. This PR introduces a check to properly see if models are empty.

To test:
* Go to a site with a post without any views
* Go to Blog Posts
* Click on the overflow menu/Stats on the Post without views
* Notice that the blocks now show the message "No data yet" instead of previously visible lines with empty data

![Screenshot_1585559959](https://user-images.githubusercontent.com/1079756/77896276-52433680-7278-11ea-8570-4d776784e606.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
