### PR TITLE
Issue/11386 is media in gutenberg body fix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -435,7 +435,7 @@ public class PostUtils {
                                             String localMediaId) {
         List<String> patterns = new ArrayList<>();
         // Regex for Image and Video blocks
-        patterns.add("<!-- wp:(?:image|video){1} \\{[^\\}]*\"id\":%s[^\\}]*\\} -->");
+        patterns.add("<!-- wp:(?:image|video){1} \\{[^\\}]*\"id\":%s([^\\d\\}][^\\}]*)*\\} -->");
         // Regex for Media&Text block
         patterns.add("<!-- wp:media-text \\{[^\\}]*\"mediaId\":%s[^\\}]*\\} -->");
         // Regex for Gallery block

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -437,7 +437,7 @@ public class PostUtils {
         // Regex for Image and Video blocks
         patterns.add("<!-- wp:(?:image|video){1} \\{[^\\}]*\"id\":%s([^\\d\\}][^\\}]*)*\\} -->");
         // Regex for Media&Text block
-        patterns.add("<!-- wp:media-text \\{[^\\}]*\"mediaId\":%s[^\\}]*\\} -->");
+        patterns.add("<!-- wp:media-text \\{[^\\}]*\"mediaId\":%s([^\\d\\}][^\\}]*)*\\} -->");
         // Regex for Gallery block
         patterns.add("<!-- wp:gallery \\{[^\\}]*\"ids\":\\[(?:\\d*,)*%s(?:,\\d*)*\\][^\\}]*\\} -->");
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -433,9 +433,9 @@ public class PostUtils {
     public static boolean isMediaInGutenbergPostBody(@NonNull String postContent,
                                             String localMediaId) {
         // check if media is in Gutenberg Post
-        String imgBlockHeaderToSearchFor =
-                String.format("<!-- wp:image \\{[^\\}]*\"id\":%s[^\\}]*\\} -->", localMediaId);
-        Pattern pattern = Pattern.compile(imgBlockHeaderToSearchFor);
+        String mediaBlockHeaderToSearchFor =
+                String.format("<!-- wp:(image|video) \\{[^\\}]*\"id\":%s[^\\}]*\\} -->", localMediaId);
+        Pattern pattern = Pattern.compile(mediaBlockHeaderToSearchFor);
         Matcher matcher = pattern.matcher(postContent);
         return matcher.find();
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
@@ -110,6 +110,13 @@ class PostUtilsUnitTest {
     }
 
     @Test
+    fun `isMediaInGutenberg returns false when only part of the id matches`() {
+        val imgId = "12345"
+        val postContent = "<!-- wp:image {\"id\":$imgId} --> ...... <!-- /wp:image -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "123")).isFalse()
+    }
+
+    @Test
     fun `isMediaInGutenberg works when the image tag has multiple attributes`() {
         val imgId = "999"
         val postContent = "<!-- wp:image {\"id\":$imgId,\"sizeSlug\":\"large\"} --> ...... <!-- /wp:image -->"

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
@@ -103,9 +103,44 @@ class PostUtilsUnitTest {
     }
 
     @Test
+    fun `isMediaInGutenberg returns true when a videoBlock is found in the post content`() {
+        val imgId = "999"
+        val postContent = "<!-- wp:video {\"id\":$imgId} --> ...... <!-- /wp:video -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()
+    }
+
+    @Test
+    fun `isMediaInGutenberg returns true when a Media&Text is found in the post content`() {
+        val imgId = "999"
+        val postContent = "<!-- wp:media-text {\"mediaId\":$imgId} --> ...... <!-- /wp:media-text -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()
+    }
+
+    @Test
+    fun `isMediaInGutenberg returns true when a galleryBlock is found in the post content`() {
+        val imgId = "999"
+        val postContent = "<!-- wp:gallery {\"ids\":[$imgId]} --> ...... <!-- /wp:gallery -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()
+    }
+
+    @Test
     fun `isMediaInGutenberg returns false when an imageBlock with provided id is NOT found in the post content`() {
         val imgId = "123"
         val postContent = "<!-- wp:image {\"id\":$imgId} --> ...... <!-- /wp:image -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "999")).isFalse()
+    }
+
+    @Test
+    fun `isMediaInGutenberg returns false when a videoBlock with provided id is NOT found in the post content`() {
+        val imgId = "123"
+        val postContent = "<!-- wp:video {\"id\":$imgId} --> ...... <!-- /wp:video -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "999")).isFalse()
+    }
+
+    @Test
+    fun `isMediaInGutenberg returns false when a Media&Text with provided id is NOT found in the post content`() {
+        val imgId = "123"
+        val postContent = "<!-- wp:media-text {\"mediaId\":$imgId} --> ...... <!-- /wp:media-text -->"
         assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "999")).isFalse()
     }
 
@@ -117,10 +152,24 @@ class PostUtilsUnitTest {
     }
 
     @Test
-    fun `isMediaInGutenberg returns false for an Media&Text when only part of the id matches`() {
+    fun `isMediaInGutenberg returns false for a videoBlock when only part of the id matches`() {
         val imgId = "12345"
-        val postContent = "<!-- wp:media-text {\"mediaId\":$imgId} --> ...... <!-- /wp:image -->"
+        val postContent = "<!-- wp:video {\"id\":$imgId} --> ...... <!-- /wp:video -->"
         assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "123")).isFalse()
+    }
+
+    @Test
+    fun `isMediaInGutenberg returns false for a Media&Text when only part of the id matches`() {
+        val imgId = "12345"
+        val postContent = "<!-- wp:media-text {\"mediaId\":$imgId} --> ...... <!-- /wp:media-text -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "123")).isFalse()
+    }
+
+    @Test
+    fun `isMediaInGutenberg returns false when a galleryBlock with provided id is NOT found in the post content`() {
+        val imgId = "123"
+        val postContent = "<!-- wp:gallery {\"ids\":[$imgId]} --> ...... <!-- /wp:gallery -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "999")).isFalse()
     }
 
     @Test
@@ -128,6 +177,42 @@ class PostUtilsUnitTest {
         val imgId = "999"
         val postContent = "<!-- wp:image {\"id\":$imgId,\"sizeSlug\":\"large\"} --> ...... <!-- /wp:image -->"
         assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()
+    }
+
+    @Test
+    fun `isMediaInGutenberg works when a videoBlock tag has multiple attributes`() {
+        val imgId = "999"
+        val postContent = "<!-- wp:video {\"id\":$imgId,\"sizeSlug\":\"large\"} --> ...... <!-- /wp:video -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()
+    }
+
+    @Test
+    fun `isMediaInGutenberg works when a Media&Text tag has multiple attributes`() {
+        val imgId = "999"
+        val postContent = "<!-- wp:media-text {\"mediaId\":$imgId,\"sizeSlug\":\"large\"} -->" +
+                " ...... <!-- /wp:media-text -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()
+    }
+
+    @Test
+    fun `isMediaInGutenberg works when a galleryBlock tag has multiple attributes`() {
+        val imgId = "999"
+        val postContent = "<!-- wp:gallery {\"ids\":[$imgId],\"sizeSlug\":\"large\"} --> ...... <!-- /wp:gallery -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()
+    }
+
+    @Test
+    fun `isMediaInGutenberg works when a galleryBlock tag has multiple ids`() {
+        val imgId = "999"
+        val postContent1 = "<!-- wp:gallery {\"ids\":[45,$imgId,123,345],\"sizeSlug\":\"large\"} -->" +
+                " ...... <!-- /wp:gallery -->"
+        val postContent2 = "<!-- wp:gallery {\"ids\":[$imgId,123,345],\"sizeSlug\":\"large\"} -->" +
+                " ...... <!-- /wp:gallery -->"
+        val postContent3 = "<!-- wp:gallery {\"ids\":[45,$imgId],\"sizeSlug\":\"large\"} -->" +
+                " ...... <!-- /wp:gallery -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent1, imgId)).isTrue()
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent2, imgId)).isTrue()
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent3, imgId)).isTrue()
     }
 
     private companion object Fixtures {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
@@ -96,28 +96,35 @@ class PostUtilsUnitTest {
     }
 
     @Test
-    fun `isMediaInGutenberg returns true when the image is found in the post content`() {
+    fun `isMediaInGutenberg returns true when an imageBlock is found in the post content`() {
         val imgId = "999"
         val postContent = "<!-- wp:image {\"id\":$imgId} --> ...... <!-- /wp:image -->"
         assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()
     }
 
     @Test
-    fun `isMediaInGutenberg returns false when the image with provided id is NOT found in the post content`() {
+    fun `isMediaInGutenberg returns false when an imageBlock with provided id is NOT found in the post content`() {
         val imgId = "123"
         val postContent = "<!-- wp:image {\"id\":$imgId} --> ...... <!-- /wp:image -->"
         assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "999")).isFalse()
     }
 
     @Test
-    fun `isMediaInGutenberg returns false when only part of the id matches`() {
+    fun `isMediaInGutenberg returns false for an imageBlock when only part of the id matches`() {
         val imgId = "12345"
         val postContent = "<!-- wp:image {\"id\":$imgId} --> ...... <!-- /wp:image -->"
         assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "123")).isFalse()
     }
 
     @Test
-    fun `isMediaInGutenberg works when the image tag has multiple attributes`() {
+    fun `isMediaInGutenberg returns false for an Media&Text when only part of the id matches`() {
+        val imgId = "12345"
+        val postContent = "<!-- wp:media-text {\"mediaId\":$imgId} --> ...... <!-- /wp:image -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "123")).isFalse()
+    }
+
+    @Test
+    fun `isMediaInGutenberg works when an imageBlock tag has multiple attributes`() {
         val imgId = "999"
         val postContent = "<!-- wp:image {\"id\":$imgId,\"sizeSlug\":\"large\"} --> ...... <!-- /wp:image -->"
         assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()


### PR DESCRIPTION
Fixes #11386

The previous implementation of isMediaInGutenbergPostBody wasn't taking into account any other blocks but `image` blocks. This PR adds support for `video, text&media and gallery` blocks.

This PR also fixes an issue in the regex for `image` block 51ca321. The previous implementation would match for example `id:12345` when we were looking for `id:123`.

To test:
1. Copy the regex into an online tool, such as https://regexr.com/ (remove the escape chars \ or copy it directly from the AS into the clipboard - the AS will automatically remove the \ before it saves the string into the clipboard)
2. Play with it and verify it works as intended
-------------------------------------------
* Image, Video, Gallery, Text&Media
1. Create a new post (in gutenberg)
2. Add * block and choose media from the device
3. Leave the post after the upload starts
4. Open the post while media are still uploading
5. Leave the post again, while the media are still uploading
6. Wait for upload to finish while you are on the post list
7. Open the post
8. Switch to HTML mode and verify the media doesn't use local path


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
