### PR TITLE
Add Gutenberg specific checks to Code Freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,6 +58,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
   #####################################################################################
   desc "Creates a new release branch from the current develop"
   lane :code_freeze do | options |
+    gutenberg_dep_check()
     old_version = android_codefreeze_prechecks(options)
    
     android_bump_version_release()
@@ -388,6 +389,40 @@ ENV["HAS_ALPHA_VERSION"]="true"
       extract_universal_apk(bundle_path:"#{build_dir}#{name}", apk_path:"#{build_dir}#{apk_name}")
     end
     "#{build_dir}#{name}"
+  end
+
+  #####################################################################################
+  # gutenberg_dep_check
+  # -----------------------------------------------------------------------------------
+  # Verifies that Gutenberg is on the last released version 
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane gutenberg_dep_check
+  #####################################################################################
+  desc "Verifies that Gutenberg is on the last released version"
+  lane :gutenberg_dep_check do | options |
+    # Pull the latest develop
+    sh("git checkout develop")
+    sh("git pull")
+    sh("git submodule init")
+    sh("git submodule update")
+
+    Dir.chdir("../libs/gutenberg-mobile") do
+      sh("git fetch --tags")
+      last_tag_hash = sh("git rev-list --tags --max-count\=1")
+      submodule_hash = sh("git rev-parse HEAD")
+
+      if (last_tag_hash != submodule_hash)
+        error_message = "Gutenberg submodule hash is not on the last tag!\nSubmodule hash: #{submodule_hash}\nLast tag hash: #{last_tag_hash}"
+        UI.user_error!(error_message) unless UI.interactive? 
+        
+        if (!UI.confirm("#{error_message}\nDo you want to continue anyway?"))
+          UI.user_error!("Aborted by user request. Please fix Gutenberg reference and try again.")
+        end
+      else
+        UI.message("Gutenberg is on the last tag: #{last_tag_hash}.")  
+      end
+    end
   end
 
 #####################################################################################


### PR DESCRIPTION
This PR adds a step to the `code_freeze` lane that checks that mobile Gutenberg submodule hash matches the last tag.
If a different commit hash is found, the script fails on CI and ask the user if they want to continue or stop on local environments.

### To test:
1. Run `bundle exec fastlane code_freeze` and verify that the script shows a prompt about the Gutenberg reference and asks what to do. Agree to continue and verify that the script shows a prompt with its proposal for the next version number. **Abort** the execution.
2. Run `bundle exec fastlane code_freeze` and verify that the script shows a prompt about the Gutenberg reference and asks what to do. Respond _no_ and verify that the script is aborted.
3. Update the Gutenberg submodule in your `develop` branch to point to the last version. _Don't push it to GitHub_ :-) 
4. Run `bundle exec fastlane code_freeze` and verify that the script shows a prompt with its proposal for the next version number. **Abort** the execution.
5. Delete the last commit from your `develop` branch.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
