### PR TITLE
Page List : Empty editor when loading more items

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * Block editor: You can now crop, zoom in/out and rotate images that are already inserted in a post.
 * Fix a deeplinking issue that could lead to the app not being open after clicking on some special "wordpress://" URLs.
+* Page List: Fixed an issue where opening a page would sometimes result in an empty editor.
 
 14.5
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -576,10 +576,13 @@ public class ActivityLauncher {
         activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
-    public static void editPageForResult(@NonNull Fragment fragment, @NonNull PageModel page,
-                                         boolean loadAutoSaveRevision) {
+    public static void editPageForResult(@NonNull Fragment fragment, @NonNull SiteModel site,
+                                         int pageLocalId, boolean loadAutoSaveRevision) {
         Intent intent = new Intent(fragment.getContext(), EditPostActivity.class);
-        editPageForResult(intent, fragment, page.getSite(), page.getPageId(), loadAutoSaveRevision);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, pageLocalId);
+        intent.putExtra(EditPostActivity.EXTRA_LOAD_AUTO_SAVE_REVISION, loadAutoSaveRevision);
+        fragment.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
     public static void editPageForResult(Intent intent, @NonNull Fragment fragment, @NonNull SiteModel site,

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -315,9 +315,9 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.editPage.observe(this, Observer { (page, loadAutoRevision) ->
+        viewModel.editPage.observe(this, Observer { (site, page, loadAutoRevision) ->
             page?.let {
-                ActivityLauncher.editPageForResult(this, page, loadAutoRevision)
+                ActivityLauncher.editPageForResult(this, site, page.id, loadAutoRevision)
             }
         })
 


### PR DESCRIPTION
Fixes #11339

## Solution
I fetch the latest page from the `PostStore` based on the `remote id` since the `local id` is out of sync. I am still checking to see if this solution will resolve the issue without any drawbacks since we are now running another query for the `PostModel` when we wanted to avoid that. 

## Testing
Ensure you have 20 or more pages or change [this](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7cf14c3b2b1001bf50ae46bc39b0d3f67533d13a/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java#L72) to 1.
1. My Site
2. Site Pages
3. Click on one of the existing pages
4. Notice the editor is not empty.

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
