### PR TITLE
Refactor to observe just one uistate for preview image and thumbnails

### DIFF
--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -17,8 +17,10 @@ import org.wordpress.android.imageeditor.ImageEditor.RequestListener
 import org.wordpress.android.imageeditor.R.layout
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ThumbnailsUiState.ThumbnailsContentUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState.ImageDataStartLoadingUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ThumbnailsUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ThumbnailsUiState.ThumbnailsContentUiState
 import org.wordpress.android.imageeditor.utils.UiHelpers
 import java.io.File
 
@@ -80,17 +82,8 @@ class PreviewImageFragment : Fragment() {
 
     private fun setupObservers() {
         viewModel.uiState.observe(this, Observer { uiState ->
-            if (uiState is ImageDataStartLoadingUiState) {
-                loadIntoImageView(uiState.imageData)
-            }
-            UiHelpers.updateVisibility(progressBar, uiState.progressBarVisible)
-            UiHelpers.updateVisibility(errorLayout, uiState.retryLayoutVisible)
-        })
-
-        viewModel.thumbnailsUiState.observe(this, Observer { state ->
-            if (state is ThumbnailsContentUiState) {
-                (thumbnailsRecyclerView.adapter as PreviewImageThumbnailAdapter).submitList(state.items)
-            }
+            updatePreviewImageView(uiState.imageUiState)
+            updateThumbnailsView(uiState.thumbnailsUiState)
         })
 
         viewModel.loadIntoFileState.observe(this, Observer { fileState ->
@@ -102,6 +95,20 @@ class PreviewImageFragment : Fragment() {
         viewModel.navigateToCropScreenWithFileInfo.observe(this, Observer { filePath ->
             navigateToCropScreenWithInputFilePath(filePath)
         })
+    }
+
+    private fun updatePreviewImageView(uiState: ImageUiState) {
+        if (uiState is ImageDataStartLoadingUiState) {
+            loadIntoImageView(uiState.imageData)
+        }
+        UiHelpers.updateVisibility(progressBar, uiState.progressBarVisible)
+        UiHelpers.updateVisibility(errorLayout, uiState.retryLayoutVisible)
+    }
+
+    private fun updateThumbnailsView(uiState: ThumbnailsUiState) {
+        if (uiState is ThumbnailsContentUiState) {
+            (thumbnailsRecyclerView.adapter as PreviewImageThumbnailAdapter).submitList(uiState.items)
+        }
     }
 
     private fun loadIntoImageView(imageData: ImageData) {

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -7,19 +7,16 @@ import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoad
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileIdleState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileSuccessState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadFailedUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadSuccessUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadFailedUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadSuccessUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ThumbnailsUiState.ThumbnailsContentUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState.ImageDataStartLoadingUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState.ImageInHighResLoadFailedUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState.ImageInHighResLoadSuccessUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState.ImageInLowResLoadFailedUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState.ImageInLowResLoadSuccessUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ThumbnailsUiState.ThumbnailsContentUiState
 
 class PreviewImageViewModel : ViewModel() {
-    private val _uiState: MutableLiveData<ImageUiState> = MutableLiveData()
-    val uiState: LiveData<ImageUiState> = _uiState
-
-    private val _thumbnailsUiState = MutableLiveData<ThumbnailsUiState>()
-    val thumbnailsUiState: LiveData<ThumbnailsUiState> = _thumbnailsUiState
+    private val _uiState: MutableLiveData<UiState> = MutableLiveData()
+    val uiState: LiveData<UiState> = _uiState
 
     private val _loadIntoFileState = MutableLiveData<ImageLoadToFileState>(ImageLoadToFileIdleState)
     val loadIntoFileState: LiveData<ImageLoadToFileState> = _loadIntoFileState
@@ -28,19 +25,8 @@ class PreviewImageViewModel : ViewModel() {
     val navigateToCropScreenWithFileInfo: LiveData<Pair<String, String?>> = _navigateToCropScreenWithFileInfo
 
     private var outputFileExtension: String? = null
-    private var isStarted = false
 
-    fun onCreateView(loResImageUrl: String, hiResImageUrl: String, outputFileExtension: String?) {
-        updateUiState(createImageDataStartLoadingUiState(loResImageUrl, hiResImageUrl))
-
-        if (isStarted) {
-            return
-        }
-
-        this.outputFileExtension = outputFileExtension
-
-        // TODO: Dummy data
-        val imageDataList = mutableListOf(
+    private val imageDataList = mutableListOf(
             ImageData(
                 lowResImageUrl = "https://testtravel123com.files.wordpress.com/2020/02/pexels-photo-1363876.jpg?w=268",
                 highResImageUrl = "https://testtravel123com.files.wordpress.com/2020/02/pexels-photo-1363876.jpg"
@@ -65,15 +51,23 @@ class PreviewImageViewModel : ViewModel() {
                 lowResImageUrl = "https://testtravel123com.files.wordpress.com/2019/11/books-1163695_1920.jpg?w=268",
                 highResImageUrl = "https://testtravel123com.files.wordpress.com/2019/11/books-1163695_1920.jpg"
             )
-        )
+    )
 
-        updateThumbnailsUiState(createThumbnailsContentUiState(imageDataList))
-        isStarted = true
+    fun onCreateView(loResImageUrl: String, hiResImageUrl: String, outputFileExtension: String?) {
+        val imageUiState = createImageDataStartLoadingUiState(
+            loResImageUrl,
+            hiResImageUrl
+        )
+        val thumbnailsUiState = uiState.value?.thumbnailsUiState ?: createThumbnailsContentUiState(imageDataList)
+
+        updateUiState(UiState(imageUiState, thumbnailsUiState))
+
+        this.outputFileExtension = outputFileExtension
     }
 
     fun onLoadIntoImageViewSuccess(currentUrl: String, imageData: ImageData) {
-        val currentState = uiState.value
-        val isHighResImageAlreadyLoaded = currentState == ImageInHighResLoadSuccessUiState
+        val currentState = uiState.value as UiState
+        val isHighResImageAlreadyLoaded = currentState.imageUiState == ImageInHighResLoadSuccessUiState
 
         val newState = if (currentUrl == imageData.lowResImageUrl) {
             if (!isHighResImageAlreadyLoaded) {
@@ -85,19 +79,23 @@ class PreviewImageViewModel : ViewModel() {
             ImageInHighResLoadSuccessUiState
         }
 
-        val highResImageJustLoadedIntoView = newState != currentState && newState == ImageInHighResLoadSuccessUiState
+        val highResImageJustLoadedIntoView = newState != currentState.imageUiState &&
+                newState == ImageInHighResLoadSuccessUiState
         val imageNotLoadedIntoFile = loadIntoFileState.value !is ImageLoadToFileSuccessState
         if (highResImageJustLoadedIntoView && imageNotLoadedIntoFile) {
             updateLoadIntoFileState(ImageStartLoadingToFileState(currentUrl))
         }
 
-        newState?.let { updateUiState(it) }
+        newState?.let {
+            updateUiState(currentState.copy(imageUiState = it))
+        }
     }
 
     fun onLoadIntoImageViewFailed(url: String) {
-        val newState = when (val currentState = uiState.value) {
+        val currentUiState = (uiState.value as UiState)
+        val newImageUiState = when (val currentImageUiState = currentUiState.imageUiState) {
             is ImageDataStartLoadingUiState -> {
-                val lowResImageUrl = currentState.imageData.lowResImageUrl
+                val lowResImageUrl = currentImageUiState.imageData.lowResImageUrl
                 if (url == lowResImageUrl) {
                     ImageInLowResLoadFailedUiState
                 } else {
@@ -107,7 +105,7 @@ class PreviewImageViewModel : ViewModel() {
             else -> ImageInHighResLoadFailedUiState
         }
 
-        updateUiState(newState)
+        updateUiState(currentUiState.copy(imageUiState = newImageUiState))
     }
 
     fun onLoadIntoFileSuccess(inputFilePath: String) {
@@ -121,16 +119,30 @@ class PreviewImageViewModel : ViewModel() {
     }
 
     fun onLoadIntoImageViewRetry(loResImageUrl: String, hiResImageUrl: String) {
-        updateUiState(createImageDataStartLoadingUiState(loResImageUrl, hiResImageUrl))
+        val currentState = uiState.value as UiState
+        updateUiState(
+            currentState.copy(imageUiState = createImageDataStartLoadingUiState(loResImageUrl, hiResImageUrl))
+        )
     }
 
     /*fun onThumbnailClick(position: Int) {
-        val thumbnailsContentUiState = (thumbnailsUiState.value as? ThumbnailsContentUiState)
-        val imageDataList = thumbnailsContentUiState?.items?.toMutableList() ?: mutableListOf()
+        val currentUiState = uiState.value as UiState
+        val thumbnailsUiState = currentUiState.thumbnailsUiState as ThumbnailsContentUiState
+        val imageDataList = thumbnailsUiState.items.toMutableList()
         imageDataList.forEachIndexed { index, image ->
             imageDataList[index] = image.copy(isSelected = index == position)
         }
-        updateThumbnailsUiState(createThumbnailsContentUiState(imageDataList))
+
+        val selectedItem = imageDataList[position]
+        updateUiState(
+            currentUiState.copy(
+                imageUiState = createImageDataStartLoadingUiState(
+                    selectedItem.lowResImageUrl,
+                    selectedItem.highResImageUrl
+                ),
+                thumbnailsUiState = createThumbnailsContentUiState(imageDataList)
+            )
+        )
     }*/
 
     private fun createImageDataStartLoadingUiState(
@@ -144,12 +156,8 @@ class PreviewImageViewModel : ViewModel() {
         imageDataList: MutableList<ImageData>
     ): ThumbnailsContentUiState = ThumbnailsContentUiState(imageDataList)
 
-    private fun updateUiState(uiState: ImageUiState) {
+    private fun updateUiState(uiState: UiState) {
         _uiState.value = uiState
-    }
-
-    private fun updateThumbnailsUiState(thumbnailsUiState: ThumbnailsUiState) {
-        _thumbnailsUiState.value = thumbnailsUiState
     }
 
     private fun updateLoadIntoFileState(fileState: ImageLoadToFileState) {
@@ -162,36 +170,40 @@ class PreviewImageViewModel : ViewModel() {
         var isSelected: Boolean = false
     )
 
-    sealed class ImageUiState(
-        val progressBarVisible: Boolean = false,
-        val retryLayoutVisible: Boolean
+    data class UiState(
+        val imageUiState: ImageUiState,
+        val thumbnailsUiState: ThumbnailsUiState
     ) {
-        data class ImageDataStartLoadingUiState(val imageData: ImageData) : ImageUiState(
-            progressBarVisible = true,
-            retryLayoutVisible = false
-        )
-        // Continue displaying progress bar on low res image load success
-        object ImageInLowResLoadSuccessUiState : ImageUiState(
-            progressBarVisible = true,
-            retryLayoutVisible = false
-        )
-        object ImageInLowResLoadFailedUiState : ImageUiState(
-            progressBarVisible = true,
-            retryLayoutVisible = false
-        )
-        object ImageInHighResLoadSuccessUiState : ImageUiState(
-            progressBarVisible = false,
-            retryLayoutVisible = false
-        )
-        // Display retry only when high res image load failed
-        object ImageInHighResLoadFailedUiState : ImageUiState(
-            progressBarVisible = false,
-            retryLayoutVisible = true
-        )
-    }
-
-    sealed class ThumbnailsUiState {
-        data class ThumbnailsContentUiState(val items: List<ImageData>) : ThumbnailsUiState()
+        sealed class ImageUiState(
+            val progressBarVisible: Boolean = false,
+            val retryLayoutVisible: Boolean
+        ) {
+            data class ImageDataStartLoadingUiState(val imageData: ImageData) : ImageUiState(
+                    progressBarVisible = true,
+                    retryLayoutVisible = false
+            )
+            // Continue displaying progress bar on low res image load success
+            object ImageInLowResLoadSuccessUiState : ImageUiState(
+                    progressBarVisible = true,
+                    retryLayoutVisible = false
+            )
+            object ImageInLowResLoadFailedUiState : ImageUiState(
+                    progressBarVisible = true,
+                    retryLayoutVisible = false
+            )
+            object ImageInHighResLoadSuccessUiState : ImageUiState(
+                    progressBarVisible = false,
+                    retryLayoutVisible = false
+            )
+            // Display retry only when high res image load failed
+            object ImageInHighResLoadFailedUiState : ImageUiState(
+                    progressBarVisible = false,
+                    retryLayoutVisible = true
+            )
+        }
+        sealed class ThumbnailsUiState {
+            data class ThumbnailsContentUiState(val items: List<ImageData>) : ThumbnailsUiState()
+        }
     }
 
     sealed class ImageLoadToFileState {

--- a/libs/image-editor/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/libs/image-editor/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -11,12 +11,12 @@ import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoad
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileIdleState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileSuccessState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadFailedUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadSuccessUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadFailedUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadSuccessUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ThumbnailsUiState.ThumbnailsContentUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState.ImageDataStartLoadingUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState.ImageInHighResLoadFailedUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState.ImageInHighResLoadSuccessUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState.ImageInLowResLoadFailedUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ImageUiState.ImageInLowResLoadSuccessUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState.ThumbnailsUiState.ThumbnailsContentUiState
 
 private const val TEST_LOW_RES_IMAGE_URL = "https://wordpress.com/low_res_image.png"
 private const val TEST_HIGH_RES_IMAGE_URL = "https://wordpress.com/image.png"
@@ -41,75 +41,81 @@ class PreviewImageViewModelTest {
     @Test
     fun `image loading started on view create`() {
         initViewModel()
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageDataStartLoadingUiState::class.java)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState)
+                .isInstanceOf(ImageDataStartLoadingUiState::class.java)
     }
 
     @Test
     fun `thumbnails ui content load triggered on view create`() {
         initViewModel()
-        assertThat(viewModel.thumbnailsUiState.value).isInstanceOf(ThumbnailsContentUiState::class.java)
+        assertThat(requireNotNull(viewModel.uiState.value).thumbnailsUiState)
+                .isInstanceOf(ThumbnailsContentUiState::class.java)
     }
 
     @Test
     fun `progress bar shown on view create`() {
         initViewModel()
-        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(true)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState.progressBarVisible).isEqualTo(true)
     }
 
     @Test
     fun `progress bar shown on low res image load success`() {
         initViewModel()
         viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL, imageData)
-        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(true)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState.progressBarVisible).isEqualTo(true)
     }
 
     @Test
     fun `progress bar shown on low res image load failed`() {
         initViewModel()
         viewModel.onLoadIntoImageViewFailed(TEST_LOW_RES_IMAGE_URL)
-        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(true)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState.progressBarVisible).isEqualTo(true)
     }
 
     @Test
     fun `low res image success ui shown on low res image load success`() {
         initViewModel()
         viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL, imageData)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageInLowResLoadSuccessUiState::class.java)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState)
+                .isInstanceOf(ImageInLowResLoadSuccessUiState::class.java)
     }
 
     @Test
     fun `low res image failed ui shown on low res image load failed`() {
         initViewModel()
         viewModel.onLoadIntoImageViewFailed(TEST_LOW_RES_IMAGE_URL)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageInLowResLoadFailedUiState::class.java)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState)
+                .isInstanceOf(ImageInLowResLoadFailedUiState::class.java)
     }
 
     @Test
     fun `progress bar hidden on high res image load success`() {
         initViewModel()
         viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL, imageData)
-        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState.progressBarVisible).isEqualTo(false)
     }
 
     @Test
     fun `progress bar hidden on high res image load failed`() {
         initViewModel()
         viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
-        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState.progressBarVisible).isEqualTo(false)
     }
 
     @Test
     fun `high res image success ui shown on high res image load success`() {
         initViewModel()
         viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL, imageData)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState)
+                .isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
     }
 
     @Test
     fun `high res image failed ui shown on high res image load failed`() {
         initViewModel()
         viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadFailedUiState::class.java)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState)
+                .isInstanceOf(ImageInHighResLoadFailedUiState::class.java)
     }
 
     @Test
@@ -117,7 +123,8 @@ class PreviewImageViewModelTest {
         initViewModel()
         viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL, imageData)
         viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL, imageData)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState)
+                .isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
     }
 
     @Test
@@ -193,7 +200,7 @@ class PreviewImageViewModelTest {
     fun `retry layout shown on high res image load failed`() {
         initViewModel()
         viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
-        assertThat(requireNotNull(viewModel.uiState.value).retryLayoutVisible).isEqualTo(true)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState.retryLayoutVisible).isEqualTo(true)
     }
 
     @Test
@@ -201,7 +208,7 @@ class PreviewImageViewModelTest {
         initViewModel()
         viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL, imageData)
         viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
-        assertThat(requireNotNull(viewModel.uiState.value).retryLayoutVisible).isEqualTo(true)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState.retryLayoutVisible).isEqualTo(true)
     }
 
     @Test
@@ -209,13 +216,15 @@ class PreviewImageViewModelTest {
         initViewModel()
         viewModel.onLoadIntoImageViewFailed(TEST_LOW_RES_IMAGE_URL)
         viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL, imageData)
-        assertThat(requireNotNull(viewModel.uiState.value).retryLayoutVisible).isEqualTo(false)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState.retryLayoutVisible).isEqualTo(false)
     }
 
     @Test
     fun `data loading start triggered on retry`() {
+        initViewModel()
         viewModel.onLoadIntoImageViewRetry(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageDataStartLoadingUiState::class.java)
+        assertThat(requireNotNull(viewModel.uiState.value).imageUiState)
+                .isInstanceOf(ImageDataStartLoadingUiState::class.java)
     }
 
     private fun initViewModel() = viewModel.onCreateView(


### PR DESCRIPTION
This PR passes `ImageUiState` and `ThumbnailsUIState` into one common `UiState` and observes all ui states through it as part of #11573. 

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
