### PR TITLE
Testing: Make slack notification a parameter for connected tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,11 @@ jobs:
           path: Artifacts
           destination: Artifacts
   Connected Tests:
+    parameters:
+      post-to-slack:
+        description: Post to Slack when tests fail. SLACK_WEBHOOK ENV variable must be set.
+        type: boolean
+        default: false
     executor:
       name: android/default
       api-version: "28"
@@ -119,37 +124,14 @@ jobs:
           num-flaky-test-attempts: 2
           results-history-name: CircleCI WordPress Connected Tests
       - android/save-gradle-cache
-      - slack/status:
-          fail_only: true
-          include_job_number_field: false
-          include_project_field: false
-          failure_message: ':red_circle: WordPress Android connected tests failed on \`${CIRCLE_BRANCH}\` branch after merge by ${CIRCLE_USERNAME}. See <https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670|Firebase console test results> for details.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'
-  Optional Connected Tests:
-    executor:
-      name: android/default
-      api-version: "28"
-    steps:
-      - git/shallow-checkout
-      - android/restore-gradle-cache
-      - copy-gradle-properties
-      - run:
-          name: Build
-          command: ./gradlew WordPress:assembleVanillaDebug WordPress:assembleVanillaDebugAndroidTest --stacktrace
-      - run:
-          name: Decrypt credentials
-          command: openssl aes-256-cbc -md sha256 -d -in .circleci/.firebase.secrets.json.enc -out .circleci/.firebase.secrets.json -k "${FIREBASE_SECRETS_ENCRYPTION_KEY}"
-      - android/firebase-test:
-          key-file: .circleci/.firebase.secrets.json
-          type: instrumentation
-          apk-path: WordPress/build/outputs/apk/vanilla/debug/org.wordpress.android-vanilla-debug.apk
-          test-apk-path: WordPress/build/outputs/apk/androidTest/vanilla/debug/org.wordpress.android-vanilla-debug-androidTest.apk
-          test-targets: notPackage org.wordpress.android.ui.screenshots
-          device: model=Nexus5X,version=26,locale=en,orientation=portrait
-          project: api-project-108380595987
-          timeout: 10m
-          num-flaky-test-attempts: 2
-          results-history-name: CircleCI WordPress Connected Tests
-      - android/save-gradle-cache
+      - when:
+          condition: << parameters.post-to-slack >>
+          steps:
+            - slack/status:
+                fail_only: true
+                include_job_number_field: false
+                include_project_field: false
+                failure_message: ':red_circle: WordPress Android connected tests failed on \`${CIRCLE_BRANCH}\` branch after merge by ${CIRCLE_USERNAME}. See <https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670|Firebase console test results> for details.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'
   WordPressUtils Connected Tests:
     executor:
       name: android/default
@@ -203,6 +185,7 @@ workflows:
             branches:
               ignore: /pull\/[0-9]+/
       - Connected Tests:
+          post-to-slack: true
           # Always run connected tests on develop and release branches
           filters:
             branches:
@@ -220,5 +203,5 @@ workflows:
                 - develop
                 - /^release.*/
                 - /pull\/[0-9]+/
-      - Optional Connected Tests:
+      - Connected Tests:
           requires: [Hold]


### PR DESCRIPTION
This improves the CircleCI config for connected tests, as recommended in https://github.com/wordpress-mobile/WordPress-Android/pull/11535#issuecomment-607195054. It adds a boolean parameter `post-to-slack` to enable or disable the Slack failure notification. (I made it a boolean parameter here since at this point we only need the ability to suppress the notification for optional connected test runs.)

To test:

* Make sure config looks ok. (We could also test this by forcing a test failure and running the optional tests, to confirm the Slack notification isn't fired.)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
