### PR TITLE
Reader : error inflating error textview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.graphics.Rect
+import android.graphics.drawable.Drawable
 import android.os.AsyncTask
 import android.os.Bundle
 import android.text.Html
@@ -22,8 +23,11 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.AppCompatDrawableManager
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.android.synthetic.main.reader_fragment_post_detail.*
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -1084,6 +1088,14 @@ class ReaderPostDetailFragment : Fragment(),
 
         val txtError = view!!.findViewById<TextView>(R.id.text_error)
         txtError.text = errorMessage
+
+        context?.let {
+            val icon: Drawable? = ContextCompat.getDrawable(it, R.drawable.ic_notice_48dp)
+            icon?.let {
+                txtError.setCompoundDrawablesRelativeWithIntrinsicBounds(null, icon, null, null)
+            }
+        }
+
         if (errorMessage == null) {
             txtError.visibility = View.GONE
         } else if (txtError.visibility != View.VISIBLE) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -24,11 +24,9 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.AppCompatDrawableManager
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.reader_fragment_post_detail.*
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -94,9 +92,7 @@ import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewUrlClick
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import org.wordpress.android.util.AppLog.T.MEDIA
 import org.wordpress.android.util.AppLog.T.READER
-import org.wordpress.android.util.AppLog.T.UTILS
 import org.wordpress.android.util.CrashLoggingUtils
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.HtmlUtils

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.content.res.Resources
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.os.AsyncTask
@@ -93,6 +94,10 @@ import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewUrlClick
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.AppLog.T.MEDIA
+import org.wordpress.android.util.AppLog.T.READER
+import org.wordpress.android.util.AppLog.T.UTILS
+import org.wordpress.android.util.CrashLoggingUtils
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.HtmlUtils
 import org.wordpress.android.util.NetworkUtils
@@ -1090,7 +1095,13 @@ class ReaderPostDetailFragment : Fragment(),
         txtError.text = errorMessage
 
         context?.let {
-            val icon: Drawable? = ContextCompat.getDrawable(it, R.drawable.ic_notice_48dp)
+            val icon: Drawable? = try {
+                ContextCompat.getDrawable(it, R.drawable.ic_notice_48dp)
+            } catch (e: Resources.NotFoundException) {
+                AppLog.e(READER, e)
+                CrashLoggingUtils.logException(e, READER, "Drawable not found. See issue #11576")
+                null
+            }
             icon?.let {
                 txtError.setCompoundDrawablesRelativeWithIntrinsicBounds(null, icon, null, null)
             }

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -111,7 +111,6 @@
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:drawablePadding="@dimen/margin_small"
-        android:drawableTop="@drawable/ic_notice_48dp"
         android:gravity="center"
         android:textColor="@color/neutral_30"
         android:textSize="@dimen/text_sz_extra_large"


### PR DESCRIPTION
Fixes #11576

## Findings
The app is crashing due to the app not inflating the drawable properly when an error occurs when a post is being viewed in the Reader. 

## Solution
To inflate the drawable programmatically and catch the exception because the app shouldn't crash if the icon can't be added to the `TextView` because the text can still communicate what error is taking place. This will be monitored since it shouldn't happen because the resource is present within the app. 

## Testing
1. Go to Reader. 
2. Click on a post. 
3. Simulate an error. One way is to put this function in `onCreate()` https://github.com/wordpress-mobile/WordPress-Android/blob/91fb9022cd28cb834c55c611d3dbe0be271919e4/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt#L1080

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
