### PR TITLE
Fix page upload directly from page list handled by PostUploadHandler

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -642,6 +642,10 @@ public class PostUploadHandler implements UploadHandler<PostModel>, OnAutoSavePo
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN, priority = 9)
     public void onPostUploaded(OnPostUploaded event) {
+        // check if the event is related to the PostModel that is being uploaded by PostUploadHandler
+        if (!isPostUploading(event.post)) {
+            return;
+        }
         SiteModel site = mSiteStore.getSiteByLocalId(event.post.getLocalSiteId());
 
         if (event.isError()) {


### PR DESCRIPTION
Fixes #11439

I failed to replicate this issue - more info about my "bet" what might be causing it can be found [here](https://github.com/wordpress-mobile/WordPress-Android/issues/11439#issuecomment-599529291). I tried to use proxy breakpoints and make the app crash, but I wasn't able to. However, I think this check should be in the PostUploadHandler anyway. In case the number of crashes won't decrease, we can look into this issue again.

To test:
Try to upload and remote auto save pages and posts. Try to enqueue multiple pages/post in offline. Basically test anything you can think of related to upload.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
