### PR TITLE
Using Gravatar in me menu.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -48,6 +48,7 @@ import org.wordpress.android.networking.GravatarApi;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
+import org.wordpress.android.ui.main.utils.MeGravatarLoader;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource;
@@ -55,7 +56,6 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.FluxCUtils;
-import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
@@ -100,6 +100,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
     @Inject ImageManager mImageManager;
     @Inject AppPrefsWrapper mAppPrefsWrapper;
     @Inject PostStore mPostStore;
+    @Inject MeGravatarLoader mMeGravatarLoader;
 
     public static MeFragment newInstance() {
         return new MeFragment();
@@ -271,8 +272,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
             mAvatarCard.setVisibility(View.VISIBLE);
             mMyProfileView.setVisibility(View.VISIBLE);
 
-            final String avatarUrl = constructGravatarUrl(mAccountStore.getAccount());
-            loadAvatar(avatarUrl, null);
+            loadAvatar(null);
 
             mUsernameTextView.setText(getString(R.string.at_username, defaultAccount.getUserName()));
             mLoginLogoutTextView.setText(R.string.me_disconnect_from_wordpress_com);
@@ -299,57 +299,46 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
         mIsUpdatingGravatar = isUpdating;
     }
 
-    private String constructGravatarUrl(AccountModel account) {
-        int avatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_large);
-        return GravatarUtils.fixGravatarUrl(account.getAvatarUrl(), avatarSz);
-    }
-
-    private void loadAvatar(final String avatarUrl, String injectFilePath) {
+    private void loadAvatar(String injectFilePath) {
         final boolean newAvatarUploaded = injectFilePath != null && !injectFilePath.isEmpty();
-        if (newAvatarUploaded) {
-            // invalidate the specific gravatar entry from the bitmap cache. It will be updated via the injected
-            // request cache.
-            WordPress.getBitmapCache().removeSimilar(avatarUrl);
-            // Changing the signature invalidates Glide's cache
-            mAppPrefsWrapper.setAvatarVersion(mAppPrefsWrapper.getAvatarVersion() + 1);
-        }
+        final String rawAvatarUrl = mAccountStore.getAccount().getAvatarUrl();
 
-        Bitmap bitmap = WordPress.getBitmapCache().get(avatarUrl);
-        // Avatar's API doesn't synchronously update the image at avatarUrl. There is a replication lag
-        // (cca 5s), before the old avatar is replaced with the new avatar. Therefore we need to use this workaround,
-        // which temporary saves the new image into a local bitmap cache.
-        if (bitmap != null) {
-            mImageManager.load(mAvatarImageView, bitmap);
-        } else {
-            mImageManager.loadIntoCircle(mAvatarImageView, ImageType.AVATAR_WITHOUT_BACKGROUND,
-                    newAvatarUploaded ? injectFilePath : avatarUrl, new RequestListener<Drawable>() {
-                        @Override
-                        public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
-                            final String appLogMessage = "onLoadFailed while loading Gravatar image!";
-                            if (e == null) {
-                                AppLog.e(T.MAIN, appLogMessage + " e == null");
-                            } else {
-                                AppLog.e(T.MAIN, appLogMessage, e);
-                            }
-
-                            // For some reason, the Activity can be null so, guard for it. See #8590.
-                            if (getActivity() != null) {
-                                ToastUtils.showToast(getActivity(), R.string.error_refreshing_gravatar,
-                                        ToastUtils.Duration.SHORT);
-                            }
+        mMeGravatarLoader.load(
+                newAvatarUploaded,
+                rawAvatarUrl,
+                injectFilePath,
+                mAvatarImageView,
+                ImageType.AVATAR_WITHOUT_BACKGROUND,
+                new RequestListener<Drawable>() {
+                    @Override
+                    public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
+                        final String appLogMessage = "onLoadFailed while loading Gravatar image!";
+                        if (e == null) {
+                            AppLog.e(T.MAIN, appLogMessage + " e == null");
+                        } else {
+                            AppLog.e(T.MAIN, appLogMessage, e);
                         }
 
-                        @Override
-                        public void onResourceReady(@NotNull Drawable resource, @Nullable Object model) {
-                            if (newAvatarUploaded && resource instanceof BitmapDrawable) {
-                                Bitmap bitmap = ((BitmapDrawable) resource).getBitmap();
-                                // create a copy since the original bitmap may by automatically recycled
-                                bitmap = bitmap.copy(bitmap.getConfig(), true);
-                                WordPress.getBitmapCache().put(avatarUrl, bitmap);
-                            }
+                        // For some reason, the Activity can be null so, guard for it. See #8590.
+                        if (getActivity() != null) {
+                            ToastUtils.showToast(getActivity(), R.string.error_refreshing_gravatar,
+                                    ToastUtils.Duration.SHORT);
                         }
-                    }, mAppPrefsWrapper.getAvatarVersion());
-        }
+                    }
+
+                    @Override
+                    public void onResourceReady(@NotNull Drawable resource, @Nullable Object model) {
+                        if (newAvatarUploaded && resource instanceof BitmapDrawable) {
+                            Bitmap bitmap = ((BitmapDrawable) resource).getBitmap();
+                            // create a copy since the original bitmap may by automatically recycled
+                            bitmap = bitmap.copy(bitmap.getConfig(), true);
+                            WordPress.getBitmapCache().put(
+                                    mMeGravatarLoader.constructGravatarUrl(rawAvatarUrl),
+                                    bitmap
+                            );
+                        }
+                    }
+                });
     }
 
     private void signOutWordPressComWithConfirmation() {
@@ -512,8 +501,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
         showGravatarProgressBar(false);
         if (event.success) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.ME_GRAVATAR_UPLOADED);
-            final String avatarUrl = constructGravatarUrl(mAccountStore.getAccount());
-            loadAvatar(avatarUrl, event.filePath);
+            loadAvatar(event.filePath);
         } else {
             ToastUtils.showToast(getActivity(), R.string.error_updating_gravatar, ToastUtils.Duration.SHORT);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -60,6 +60,7 @@ import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose;
 import org.wordpress.android.ui.domains.DomainRegistrationResultFragment;
+import org.wordpress.android.ui.main.utils.MeGravatarLoader;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource;
@@ -131,6 +132,7 @@ public class MySiteFragment extends Fragment implements
     public static final String KEY_DOMAIN_CREDIT_CHECKED = "KEY_DOMAIN_CREDIT_CHECKED";
 
     private ImageView mBlavatarImageView;
+    private ImageView mAvatarImageView;
     private ProgressBar mBlavatarProgressBar;
     private WPTextView mBlogTitleTextView;
     private WPTextView mBlogSubtitleTextView;
@@ -180,6 +182,7 @@ public class MySiteFragment extends Fragment implements
     @Inject QuickStartStore mQuickStartStore;
     @Inject ImageManager mImageManager;
     @Inject UploadUtilsWrapper mUploadUtilsWrapper;
+    @Inject MeGravatarLoader mMeGravatarLoader;
 
     public static MySiteFragment newInstance() {
         return new MySiteFragment();
@@ -206,6 +209,19 @@ public class MySiteFragment extends Fragment implements
         }
     }
 
+    private void refreshMeGravatar() {
+        String rawGravatarUrl = mMeGravatarLoader.constructGravatarUrl(mAccountStore.getAccount().getAvatarUrl());
+
+        mMeGravatarLoader.load(
+                false,
+                rawGravatarUrl,
+                null,
+                mAvatarImageView,
+                ImageType.USER,
+                null
+        );
+    }
+
     @Override
     public void onResume() {
         super.onResume();
@@ -216,6 +232,8 @@ public class MySiteFragment extends Fragment implements
 
         // Site details may have changed (e.g. via Settings and returning to this Fragment) so update the UI
         refreshSelectedSiteDetails(getSelectedSite());
+
+        refreshMeGravatar();
 
         SiteModel site = getSelectedSite();
         if (site != null) {
@@ -386,13 +404,12 @@ public class MySiteFragment extends Fragment implements
 
         mToolbar = rootView.findViewById(R.id.toolbar_main);
         mToolbar.setTitle(mToolbarTitle);
+
         mToolbar.inflateMenu(R.menu.my_site_menu);
-        mToolbar.setOnMenuItemClickListener(item -> {
-            if (item.getItemId() == R.id.me_item) {
+        View actionView = mToolbar.getMenu().findItem(R.id.me_item).getActionView();
+        mAvatarImageView = actionView.findViewById(R.id.avatar);
+        actionView.setOnClickListener(item -> {
                 ActivityLauncher.viewMeActivityForResult(getActivity());
-                return true;
-            }
-            return false;
         });
 
         return rootView;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/utils/MeGravatarLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/utils/MeGravatarLoader.kt
@@ -1,0 +1,65 @@
+package org.wordpress.android.ui.main.utils
+
+import android.graphics.drawable.Drawable
+import android.widget.ImageView
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.GravatarUtils
+import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.image.ImageManager.RequestListener
+import org.wordpress.android.util.image.ImageType
+import org.wordpress.android.viewmodel.ResourceProvider
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MeGravatarLoader @Inject constructor(
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val imageManager: ImageManager,
+    private val resourseProvider: ResourceProvider
+) {
+    fun load(
+        newAvatarUploaded: Boolean,
+        rawAvatarUrl: String,
+        injectFilePath: String?,
+        imageView: ImageView,
+        imageType: ImageType,
+        listener: RequestListener<Drawable>? = null
+    ) {
+        val avatarUrl = constructGravatarUrl(rawAvatarUrl)
+
+        if (newAvatarUploaded) {
+            // invalidate the specific gravatar entry from the bitmap cache. It will be updated via the injected
+            // request cache.
+            WordPress.getBitmapCache().removeSimilar(avatarUrl)
+            // Changing the signature invalidates Glide's cache
+            appPrefsWrapper.avatarVersion = appPrefsWrapper.avatarVersion + 1
+        }
+
+        val bitmap = WordPress.getBitmapCache().get(avatarUrl)
+        // Avatar's API doesn't synchronously update the image at avatarUrl. There is a replication lag
+        // (cca 5s), before the old avatar is replaced with the new avatar. Therefore we need to use this workaround,
+        // which temporary saves the new image into a local bitmap cache.
+        if (bitmap != null) {
+            imageManager.load(imageView, bitmap)
+        } else {
+            imageManager.loadIntoCircle(
+                    imageView,
+                    imageType,
+                    if (newAvatarUploaded && injectFilePath != null) {
+                        injectFilePath
+                    } else {
+                        avatarUrl
+                    },
+                    listener,
+                    appPrefsWrapper.avatarVersion
+            )
+        }
+    }
+
+    fun constructGravatarUrl(rawAvatarUrl: String): String {
+        val avatarSz = resourseProvider.getDimensionPixelSize(R.dimen.avatar_sz_large)
+        return GravatarUtils.fixGravatarUrl(rawAvatarUrl, avatarSz)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -18,6 +18,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.PLUGIN -> R.drawable.plugin_placeholder
             ImageType.THEME -> R.color.neutral_0
             ImageType.UNKNOWN -> R.drawable.ic_notice_white_24dp
+            ImageType.USER -> R.drawable.ic_user_white_24dp
             ImageType.VIDEO -> R.color.neutral_0
             ImageType.ICON -> R.drawable.bg_rectangle_neutral_0_radius_2dp
             ImageType.NO_PLACEHOLDER -> null
@@ -36,6 +37,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.PLUGIN -> R.drawable.plugin_placeholder
             ImageType.THEME -> R.drawable.bg_rectangle_neutral_10_themes_100dp
             ImageType.UNKNOWN -> R.drawable.legacy_dashicon_format_image_big_grey
+            ImageType.USER -> R.drawable.ic_user_white_24dp
             ImageType.VIDEO -> R.color.neutral_0
             ImageType.ICON -> R.drawable.bg_rectangle_neutral_0_radius_2dp
             ImageType.NO_PLACEHOLDER -> null

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
@@ -16,6 +16,7 @@ enum class ImageType {
     PLUGIN,
     THEME,
     UNKNOWN,
+    USER,
     VIDEO,
     ICON,
     NO_PLACEHOLDER

--- a/WordPress/src/main/res/layout/me_action_layout.xml
+++ b/WordPress/src/main/res/layout/me_action_layout.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:minWidth="@dimen/menu_width"
+    android:gravity="center"
+    android:background="?android:attr/actionBarItemBackground">
+
+    <ImageView
+        android:id="@+id/avatar"
+        android:layout_width="@dimen/avatar_sz_small"
+        android:layout_height="@dimen/avatar_sz_small"
+        android:contentDescription="@string/me_section_screen_title"
+        android:background="@drawable/bg_oval_transparent_stroke_white"
+        android:padding="@dimen/posts_list_spinner_avatar_padding"
+        android:src="@drawable/ic_user_white_24dp"/>
+
+</RelativeLayout>

--- a/WordPress/src/main/res/menu/my_site_menu.xml
+++ b/WordPress/src/main/res/menu/my_site_menu.xml
@@ -4,7 +4,7 @@
     <item
         android:id="@+id/me_item"
         android:title="@string/me_section_screen_title"
-        android:icon="@drawable/ic_user_circle_white_24dp"
+        app:actionLayout="@layout/me_action_layout"
         app:showAsAction="always">
     </item>
 </menu>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -8,6 +8,7 @@
     <dimen name="category_parent_spinner_row_height">40dp</dimen>
 
     <dimen name="tab_height">48dp</dimen>
+    <dimen name="menu_width">48dp</dimen>
     <dimen name="toolbar_height">56dp</dimen>
     <dimen name="toolbar_content_offset">72dp</dimen>
     <dimen name="toolbar_content_offset_end">0dp</dimen>


### PR DESCRIPTION
Fixes #10511

This PR adds the Gravatar to the Me menu.

**NOTE 1:** I opened a related issue #11599 documenting an accessibility issue I noticed while working on this; I think we can manage it in a dedicated task PR.

**Note 2:** working on this PR I saw some alignment issue we have in various places where we use/show the gravatar; when it is changed in the app not all places get updated if they were previously accessed (see for example the My Site > Comments section if you have commented on your site and visualized the comment with Gravatar before to change it). AFAIU and if I'm not missing something obvious (in that case there is not actual issue 😜) it is due to caching behaviours (at Glide level and at API side level; also tried to use the `signature` to invalidate the glide cache but many times one of the Glide cache level seems to be used anyway [see [here](https://bumptech.github.io/glide/doc/caching.html) for more glide caching details]). 
For now I tried to align the two gravatar behavior in Me section and in Me menu (also not sure it is only something limited to gravatar). 

**NOTE 3:** I think currently we are not robust in catching an update in the Gravatar from the web. So for example if the app is opened and already showed a section with the gravatar (so it is cached) an update of the gravatar is not triggered (at least this is what I got). If I'm not missing something and reviewer confirms the above, probably make sense to face all this wider task in dedicated PRs effort. Using something like the `MeGravatarLoader` maybe can help but does not manage the sync with a web Gravatar change (I needed to clean the cache to get it updated and synched along the app).

## To test

### WP.com and JP site
- check you get the `not set` or your set gravatar in the Me menu and Me section

| Not set Gravatar | Set Gravatar |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/78646602-94442c00-78b9-11ea-922a-3b5747f83bf2.png) | ![image](https://user-images.githubusercontent.com/47797566/78645928-922d9d80-78b8-11ea-8232-34f2e0084a87.png) |

- Change/set the gravatar and check you get the correct updated one in both Me menu and Me section

### Self-hosted site added by address
- Check you get the generic user icon like below in the menu

<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/47797566/78646902-0d438380-78ba-11ea-9e4b-a9567cfe8921.png">
</p>

### Smoke test
Smoke test the menu functionality to access the Me Section.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
