### PR TITLE
Commenting out the override method shouldOverrideUrlLoading() fixes the issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
@@ -213,11 +213,11 @@ public class LearnMorePreference extends Preference implements View.OnClickListe
     }
 
     private class LearnMoreClient extends WebViewClient {
-        @Override
-        public boolean shouldOverrideUrlLoading(WebView webView, String url) {
-            // prevent loading clicked links
-            return !mUrl.equals(url) && !SUPPORT_CONTENT_JS.equals(url) && !CONTENT_PADDING_JS.equals(url);
-        }
+//        @Override
+//        public boolean shouldOverrideUrlLoading(WebView webView, String url) {
+//            // prevent loading clicked links
+//            return !mUrl.equals(url) && !SUPPORT_CONTENT_JS.equals(url) && !CONTENT_PADDING_JS.equals(url);
+//        }
 
         @Override
         public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
@@ -213,11 +213,11 @@ public class LearnMorePreference extends Preference implements View.OnClickListe
     }
 
     private class LearnMoreClient extends WebViewClient {
-//        @Override
-//        public boolean shouldOverrideUrlLoading(WebView webView, String url) {
-//            // prevent loading clicked links
-//            return !mUrl.equals(url) && !SUPPORT_CONTENT_JS.equals(url) && !CONTENT_PADDING_JS.equals(url);
-//        }
+        @Override
+        public boolean shouldOverrideUrlLoading(WebView webView, String url) {
+            // prevent loading clicked links
+            return !mUrl.equals(url) && !SUPPORT_CONTENT_JS.equals(url) && !CONTENT_PADDING_JS.equals(url);
+        }
 
         @Override
         public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -363,7 +363,7 @@
                     app:caption="@string/site_settings_learn_more_caption"
                     app:layout="@layout/learn_more_pref_old"
                     app:openInDialog="true"
-                    app:url="https://en.support.wordpress.com/settings/discussion-settings/#default-article-settings"
+                    app:url="https://wordpress.com/support/settings/discussion-settings/#default-article-settings"
                     app:useCustomJsFormatting="true" />
 
             </PreferenceCategory>


### PR DESCRIPTION
Fixes #
Fixed issue where the URL for the popup does not load due to shouldOverrideUrlLoading()

To test:
In the WordPress app, go to My Sites > Settings > More > Learn More > Website loads correctly

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
