### PR TITLE
Extract weekdays to the main strings.xml file

### DIFF
--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -173,17 +173,17 @@
         <item>-1</item>
     </string-array>
 
-    <string-array name="weekdays">
-        <item>Sunday</item>
-        <item>Monday</item>
-        <item>Tuesday</item>
-        <item>Wednesday</item>
-        <item>Thursday</item>
-        <item>Friday</item>
-        <item>Saturday</item>
+    <string-array name="site_settings_weekdays" translatable="false">
+        <item>@string/weekday_sunday</item>
+        <item>@string/weekday_monday</item>
+        <item>@string/weekday_tuesday</item>
+        <item>@string/weekday_wednesday</item>
+        <item>@string/weekday_thursday</item>
+        <item>@string/weekday_friday</item>
+        <item>@string/weekday_saturday</item>
     </string-array>
 
-    <string-array name="weekday_values">
+    <string-array name="site_settings_weekday_values" translatable="false">
         <item>0</item>
         <item>1</item>
         <item>2</item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -679,6 +679,14 @@
     <string name="site_settings_optimize_images_summary">Enable to resize and compress pictures</string>
     <string name="site_settings_optimize_video_summary">Enable to resize and compress videos</string>
 
+    <string name="weekday_sunday">Sunday</string>
+    <string name="weekday_monday">Monday</string>
+    <string name="weekday_tuesday">Tuesday</string>
+    <string name="weekday_wednesday">Wednesday</string>
+    <string name="weekday_thursday">Thursday</string>
+    <string name="weekday_friday">Friday</string>
+    <string name="weekday_saturday">Saturday</string>
+
     <string name="detail_approve_manual">Require manual approval for everyone\'s comments.</string>
     <string name="detail_approve_auto_if_previously_approved">Automatically approve if the user has a previously approved comment</string>
     <string name="detail_approve_auto">Automatically approve everyone\'s comments.</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -141,8 +141,8 @@
 
         <org.wordpress.android.ui.prefs.DetailListPreference
             android:id="@+id/pref_week_starts"
-            android:entries="@array/weekdays"
-            android:entryValues="@array/weekday_values"
+            android:entries="@array/site_settings_weekdays"
+            android:entryValues="@array/site_settings_weekday_values"
             android:key="@string/pref_key_site_week_start"
             android:title="@string/site_settings_week_start_title" />
 


### PR DESCRIPTION
Some strings were untranslatable. I moved them from the `key_strings.xml` file to the main `strings.xml` file.


Before (French) | After (French)
-|-
![Screenshot_1586333902](https://user-images.githubusercontent.com/40213/78761180-8d352080-7982-11ea-85fe-c4438b098201.png) | ![Screenshot_1586333782](https://user-images.githubusercontent.com/40213/78761184-8e664d80-7982-11ea-890b-d0baab5a5bcc.png)

Note: I did the translation locally, so if you test yourself you'll not see any change unless you update the `values-XX/strings.xml` file.