### PR TITLE
Remove leak canary

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -307,7 +307,6 @@ dependencies {
     // Debug
     debugImplementation 'com.facebook.stetho:stetho:1.5.1'
     debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.1'
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
 


### PR DESCRIPTION
Based on the feedback I'm removing leak canary for now and we'll keep it for the hackweek project. 

To test:
- There is nothing to test here

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
