### PR TITLE
Change parent style of NoDisplay activity to WordPress.NoActionBar

### DIFF
--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -129,8 +129,7 @@
         <item name="android:dropDownListViewStyle">@style/DropDownListView.Light.WordPress</item>
     </style>
 
-    <style name="NoDisplay" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="android:windowNoTitle">true</item>
+    <style name="NoDisplay" parent="WordPress.NoActionBar">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowIsTranslucent">true</item>


### PR DESCRIPTION
Fixes #11616
Fixes #11619

`NoDisplay`  theme was extending a wrong (non-material) theme, which caused a crash when you tried to render material widgets in `ShareIntentReceiverFragment`.


To test:
- Make sure you are logged in to the app.
- Try to share media from your device into WordPress app.
- You should see a site picker like this:
![Screenshot_1586365608](https://user-images.githubusercontent.com/728822/78812693-ac32b300-7980-11ea-9407-299a3fba7c86.png)
- Notice that it's not crashing.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
