### PR TITLE
Post & Page List : Changed auto upload text from cancel to cancel upload

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -30,7 +30,7 @@ enum class PostListButtonType constructor(
             R.drawable.ic_trash_white_24dp,
             R.attr.colorOnSurface
     ),
-    BUTTON_CANCEL_PENDING_AUTO_UPLOAD(14, R.string.cancel, R.drawable.ic_undo_white_24dp, R.attr.wpColorWarningDark);
+    BUTTON_CANCEL_PENDING_AUTO_UPLOAD(14, R.string.pages_and_posts_cancel_auto_upload, R.drawable.ic_undo_white_24dp, R.attr.wpColorWarningDark);
 
     companion object {
         fun fromInt(value: Int): PostListButtonType? = values().firstOrNull { it.value == value }

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -30,7 +30,12 @@ enum class PostListButtonType constructor(
             R.drawable.ic_trash_white_24dp,
             R.attr.colorOnSurface
     ),
-    BUTTON_CANCEL_PENDING_AUTO_UPLOAD(14, R.string.pages_and_posts_cancel_auto_upload, R.drawable.ic_undo_white_24dp, R.attr.wpColorWarningDark);
+    BUTTON_CANCEL_PENDING_AUTO_UPLOAD(
+            14,
+            R.string.pages_and_posts_cancel_auto_upload,
+            R.drawable.ic_undo_white_24dp,
+            R.attr.wpColorWarningDark
+    );
 
     companion object {
         fun fromInt(value: Int): PostListButtonType? = values().firstOrNull { it.value == value }

--- a/WordPress/src/main/res/menu/page_more.xml
+++ b/WordPress/src/main/res/menu/page_more.xml
@@ -10,7 +10,7 @@
     <item
         android:id="@+id/cancel_auto_upload"
         android:orderInCategory="100"
-        android:title="@string/cancel"
+        android:title="@string/pages_and_posts_cancel_auto_upload"
         app:showAsAction="never"/>
     <item
         android:id="@+id/set_parent"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2617,6 +2617,7 @@
     <string name="pages_empty_scheduled">You don\'t have any scheduled pages</string>
     <string name="pages_empty_trashed">You don\'t have any trashed pages</string>
     <string name="pages_open_page_error">The selected page is not available</string>
+    <string name="pages_and_posts_cancel_auto_upload">Cancel Upload</string>
 
 
     <string name="page_status_pending_review" translatable="false">@string/post_status_pending_review</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2617,7 +2617,7 @@
     <string name="pages_empty_scheduled">You don\'t have any scheduled pages</string>
     <string name="pages_empty_trashed">You don\'t have any trashed pages</string>
     <string name="pages_open_page_error">The selected page is not available</string>
-    <string name="pages_and_posts_cancel_auto_upload">Cancel Upload</string>
+    <string name="pages_and_posts_cancel_auto_upload">Cancel upload</string>
 
 
     <string name="page_status_pending_review" translatable="false">@string/post_status_pending_review</string>


### PR DESCRIPTION
Fixes #11515

## Solution
Updates the `Cancel` action on the Page & Post list item to `Cancel upload`. 

## Testing
1. Turn on airplane mode.  
2. Create a post or page and publish it. 
3. An auto-upload label is displayed on the list item (eg. "We'll publish this post/page when your device is back online").
3. You will see that `Cancel upload` is shown on both the Page/Post List list item option menu. 

Page List (Compact)  | Post List (Compat)     | Post List (Normal) 
--------|-------  |  -------  
<img src="https://user-images.githubusercontent.com/1509205/79006050-e6858700-7b1d-11ea-8ddd-ef24dbd0a9f1.png" width="320">      | <img src="https://user-images.githubusercontent.com/1509205/79006052-e7b6b400-7b1d-11ea-9a95-9f261992fa5c.png" width="320">   |  <img src="https://user-images.githubusercontent.com/1509205/79006058-e84f4a80-7b1d-11ea-98a2-37d3bfe6c7a9.png" width="320">

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 