### PR TITLE
Add mobile Gutenberg localization to code freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,7 +67,9 @@ ENV["HAS_ALPHA_VERSION"]="true"
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
     
+    localize_gutenberg(skip_module_update: true)
     localize_libs()
+    ensure_git_status_clean()
     android_tag_build()
     get_prs_list(repository:GHHELPER_REPO, start_tag:"release/#{old_version}", report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{new_version}.txt")
   end
@@ -319,11 +321,37 @@ ENV["HAS_ALPHA_VERSION"]="true"
     {library: "Image Editor", strings_path: "./libs/image-editor/ImageEditor/src/main/res/values/strings.xml", exclusions: []}
   ]
 
+  private_lane :commit_strings do | options |
+    if (options[:auto_commit]) then
+       sh("cd .. && git add #{main_strings_path}")
+       sh("git commit -m 'Update strings for translation'")
+       sh("git push") 
+    else
+      UI.important("Your #{main_strings_path} has changed.")
+      UI.input("Please, review the changes, commit them and press return to continue.")
+    end
+  end
+
+  
   desc "Merge libraries strings files into the main app one"
   lane :localize_libs do | options |
     if (an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path)) then
-      UI.important("Your #{main_strings_path} has changed.")
-      UI.input("Please, review the changes, commit them and press return to continue.")
+      commit_strings(options)
+    end
+  end
+
+  desc "Import Gutenberg strings"
+  lane :localize_gutenberg do | options |
+    unless options[:skip_module_update] then
+      sh("git submodule init")
+      sh("git submodule update")
+    end
+
+    sh("cd .. && python ./tools/merge_strings_xml.py")
+    
+    is_repo_clean = ("git status --porcelain").empty?
+    unless is_repo_clean then
+      commit_strings(options)
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -325,7 +325,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
     if (options[:auto_commit]) then
        sh("cd .. && git add #{main_strings_path}")
        sh("git commit -m 'Update strings for translation'")
-       sh("git push") 
+       sh("git push origin HEAD") 
     else
       UI.important("Your #{main_strings_path} has changed.")
       UI.input("Please, review the changes, commit them and press return to continue.")


### PR DESCRIPTION
This PR adds a step in the `code_freeze` lane to import strings from the Gutenberg submodule into the main `strings.xml`.
As a first step, the script will stop and ask for a manual commit if any change to the main `strings.xml` is done (the script will modal-wait on the current terminal, but the changes can be reviewed and committed in another terminal). 
We can automate this step when we are confident that everything works as expected.  

To test:
1. Run `bundle install`.
2. Checkout a new test branch from this one.
3. Update the Gutenberg submodule in order to include some changes in the strings.
4. Run `bundle exec fastlane localize_gutenberg` (it's the same sub-lane called during the code freeze).
5. Verify that the strings have been imported. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
