### PR TITLE
Support failed states for multiple images on preview screen

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2718,7 +2718,7 @@
     <string name="description_expand">Expand</string>
 
     <string name="preview_image_description">Preview Image</string>
-    <string name="failed_to_insert_image_tap_to_retry">Failed to insert image.\nPlease tap to retry.</string>
+    <string name="failed_to_load_image_tap_to_retry">Failed to load image.\nPlease tap to retry.</string>
     <string name="done">done</string>
     <string name="error_failed_to_crop_and_save_image">Failed to crop and save image, please try again.</string>
 

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -18,15 +18,76 @@ import kotlinx.android.synthetic.main.preview_image_fragment.*
 import org.wordpress.android.imageeditor.ImageEditor
 import org.wordpress.android.imageeditor.ImageEditor.RequestListener
 import org.wordpress.android.imageeditor.R
-import org.wordpress.android.imageeditor.R.layout
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
 import java.io.File
 
 class PreviewImageFragment : Fragment() {
     private lateinit var viewModel: PreviewImageViewModel
     private lateinit var tabLayoutMediator: TabLayoutMediator
     private var pagerAdapterObserver: PagerAdapterObserver? = null
+
+    private val imageDataList = listOf(
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/10/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/10/1000/1000.jpg",
+            outputFileExtension = "jpg"
+        ),
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/20/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/20/1000/1000.jpg",
+            outputFileExtension = "jpg"
+        ),
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/30/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/30/1000/1000.jpg",
+            outputFileExtension = "jpg"
+        ),
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/40/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/40/1000/1000.jpg",
+            outputFileExtension = "jpg"
+        ),
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/50/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/50/1000/1000.jpg",
+            outputFileExtension = "jpg"
+        ),
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/60/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/60/1000/1000.jpg",
+            outputFileExtension = "jpg"
+        ),
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/70/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/70/1000/1000.jpg",
+            outputFileExtension = "jpg"
+        ),
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/80/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/80/1000/1000.jpg",
+            outputFileExtension = "jpg"
+        ),
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/90/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/90/1000/1000.jpg",
+            outputFileExtension = "jpg"
+        ),
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/100/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/100/400/400.jpg",
+            outputFileExtension = "jpg"
+        ),
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/110/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/110/1000/1000.jpg",
+            outputFileExtension = "jpg"
+        ),
+        ImageData(
+            lowResImageUrl = "https://i.picsum.photos/id/120/200/200.jpg",
+            highResImageUrl = "https://i.picsum.photos/id/120/400/400.jpg",
+            outputFileExtension = "jpg"
+        )
+    )
 
     companion object {
         const val ARG_LOW_RES_IMAGE_URL = "arg_low_res_image_url"
@@ -64,7 +125,7 @@ class PreviewImageFragment : Fragment() {
         val tabConfigurationStrategy = TabLayoutMediator.TabConfigurationStrategy { tab, position ->
             if (tab.customView == null) {
                 val customView = LayoutInflater.from(context)
-                        .inflate(layout.preview_image_thumbnail, thumbnailsTabLayout, false)
+                        .inflate(R.layout.preview_image_thumbnail, thumbnailsTabLayout, false)
                 tab.customView = customView
             }
             val imageView = (tab.customView as FrameLayout).findViewById<ImageView>(R.id.thumbnailImageView)
@@ -94,13 +155,10 @@ class PreviewImageFragment : Fragment() {
     }
 
     private fun initializeViewModels(nonNullIntent: Intent) {
-        val lowResImageUrl = nonNullIntent.getStringExtra(ARG_LOW_RES_IMAGE_URL)
-        val highResImageUrl = nonNullIntent.getStringExtra(ARG_HIGH_RES_IMAGE_URL)
-        val outputFileExtension = nonNullIntent.getStringExtra(ARG_OUTPUT_FILE_EXTENSION)
-
         viewModel = ViewModelProvider(this).get(PreviewImageViewModel::class.java)
         setupObservers()
-        viewModel.onCreateView(lowResImageUrl, highResImageUrl, outputFileExtension)
+        // TODO: replace dummy list
+        viewModel.onCreateView(imageDataList)
     }
 
     private fun setupObservers() {
@@ -108,7 +166,7 @@ class PreviewImageFragment : Fragment() {
             (previewImageViewPager.adapter as PreviewImageAdapter).submitList(state.viewPagerItemsStates)
         })
 
-        viewModel.loadIntoFile.observe(this, Observer { fileState ->
+        /*viewModel.loadIntoFile.observe(this, Observer { fileState ->
             if (fileState is ImageStartLoadingToFileState) {
                 loadIntoFile(fileState.imageUrl)
             }
@@ -116,7 +174,7 @@ class PreviewImageFragment : Fragment() {
 
         viewModel.navigateToCropScreenWithFileInfo.observe(this, Observer { filePath ->
             navigateToCropScreenWithInputFilePath(filePath)
-        })
+        })*/
     }
 
     private fun loadIntoImageView(url: String, imageView: ImageView) {
@@ -146,11 +204,11 @@ class PreviewImageFragment : Fragment() {
             url,
             object : RequestListener<File> {
                 override fun onResourceReady(resource: File, url: String) {
-                    viewModel.onLoadIntoFileSuccess(resource.path)
+//                    viewModel.onLoadIntoFileSuccess(resource.path)
                 }
 
                 override fun onLoadFailed(e: Exception?, url: String) {
-                    viewModel.onLoadIntoFileFailed()
+//                    viewModel.onLoadIntoFileFailed()
                 }
             }
         )

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -90,6 +90,7 @@ class PreviewImageFragment : Fragment() {
     )
 
     companion object {
+        private const val PAGER_CURRENT_ITEM_INDEX = "pager_current_item_index"
         const val ARG_LOW_RES_IMAGE_URL = "arg_low_res_image_url"
         const val ARG_HIGH_RES_IMAGE_URL = "arg_high_res_image_url"
         const val ARG_OUTPUT_FILE_EXTENSION = "arg_output_file_extension"
@@ -107,20 +108,26 @@ class PreviewImageFragment : Fragment() {
 
         val nonNullIntent = checkNotNull(requireActivity().intent)
         initializeViewModels(nonNullIntent)
-        initializeViews()
+        initializeViews(savedInstanceState)
     }
 
-    private fun initializeViews() {
-        initializeViewPager()
+    private fun initializeViews(savedInstanceState: Bundle?) {
+        initializeViewPager(savedInstanceState)
     }
 
-    private fun initializeViewPager() {
+    private fun initializeViewPager(savedInstanceState: Bundle?) {
         val previewImageAdapter = PreviewImageAdapter(
             loadIntoImageViewWithResultListener = { imageData, imageView, position ->
                 loadIntoImageViewWithResultListener(imageData, imageView, position)
             }
         )
         previewImageViewPager.adapter = previewImageAdapter
+
+        if (savedInstanceState != null) {
+            previewImageViewPager.post{
+                previewImageViewPager.setCurrentItem(savedInstanceState.getInt(PAGER_CURRENT_ITEM_INDEX, 0), false)
+            }
+        }
 
         val tabConfigurationStrategy = TabLayoutMediator.TabConfigurationStrategy { tab, position ->
             if (tab.customView == null) {
@@ -221,6 +228,11 @@ class PreviewImageFragment : Fragment() {
 //        findNavController().navigate(
 //            PreviewImageFragmentDirections.actionPreviewFragmentToCropFragment(inputFilePath, outputFileExtension)
 //        )
+    }
+
+    override fun onSaveInstanceState(bundle: Bundle) {
+        super.onSaveInstanceState(bundle)
+        bundle.putInt(PAGER_CURRENT_ITEM_INDEX, previewImageViewPager.currentItem)
     }
 
     override fun onDestroyView() {

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -90,7 +90,6 @@ class PreviewImageFragment : Fragment() {
     )
 
     companion object {
-        private const val PAGER_CURRENT_ITEM_INDEX = "pager_current_item_index"
         const val ARG_LOW_RES_IMAGE_URL = "arg_low_res_image_url"
         const val ARG_HIGH_RES_IMAGE_URL = "arg_high_res_image_url"
         const val ARG_OUTPUT_FILE_EXTENSION = "arg_output_file_extension"
@@ -108,14 +107,14 @@ class PreviewImageFragment : Fragment() {
 
         val nonNullIntent = checkNotNull(requireActivity().intent)
         initializeViewModels(nonNullIntent)
-        initializeViews(savedInstanceState)
+        initializeViews()
     }
 
-    private fun initializeViews(savedInstanceState: Bundle?) {
-        initializeViewPager(savedInstanceState)
+    private fun initializeViews() {
+        initializeViewPager()
     }
 
-    private fun initializeViewPager(savedInstanceState: Bundle?) {
+    private fun initializeViewPager() {
         val previewImageAdapter = PreviewImageAdapter(
             loadIntoImageViewWithResultListener = { imageData, imageView, position ->
                 loadIntoImageViewWithResultListener(imageData, imageView, position)
@@ -154,6 +153,8 @@ class PreviewImageFragment : Fragment() {
         previewImageViewPager.setPageTransformer { _, _ ->
         }
 
+        // Set adapter data before the ViewPager2.restorePendingState gets called
+        // to avoid manual handling of the ViewPager2 state restoration.
         viewModel.uiState.value?.let {
             (previewImageViewPager.adapter as PreviewImageAdapter).submitList(it.viewPagerItemsStates)
         }

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -123,12 +123,6 @@ class PreviewImageFragment : Fragment() {
         )
         previewImageViewPager.adapter = previewImageAdapter
 
-        if (savedInstanceState != null) {
-            previewImageViewPager.post{
-                previewImageViewPager.setCurrentItem(savedInstanceState.getInt(PAGER_CURRENT_ITEM_INDEX, 0), false)
-            }
-        }
-
         val tabConfigurationStrategy = TabLayoutMediator.TabConfigurationStrategy { tab, position ->
             if (tab.customView == null) {
                 val customView = LayoutInflater.from(context)
@@ -158,6 +152,10 @@ class PreviewImageFragment : Fragment() {
         // Setting page transformer explicitly sets internal RecyclerView's itemAnimator to null
         // to fix this issue: https://issuetracker.google.com/issues/37034191
         previewImageViewPager.setPageTransformer { _, _ ->
+        }
+
+        viewModel.uiState.value?.let {
+            (previewImageViewPager.adapter as PreviewImageAdapter).submitList(it.viewPagerItemsStates)
         }
     }
 
@@ -228,11 +226,6 @@ class PreviewImageFragment : Fragment() {
 //        findNavController().navigate(
 //            PreviewImageFragmentDirections.actionPreviewFragmentToCropFragment(inputFilePath, outputFileExtension)
 //        )
-    }
-
-    override fun onSaveInstanceState(bundle: Bundle) {
-        super.onSaveInstanceState(bundle)
-        bundle.putInt(PAGER_CURRENT_ITEM_INDEX, previewImageViewPager.currentItem)
     }
 
     override fun onDestroyView() {

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewHolder.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewHolder.kt
@@ -9,11 +9,6 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.imageeditor.R
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadFailedUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadSuccessUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadFailedUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadSuccessUiState
 import org.wordpress.android.imageeditor.utils.UiHelpers
 
 class PreviewImageViewHolder(
@@ -33,17 +28,8 @@ class PreviewImageViewHolder(
     }
 
     fun onBind(uiState: ImageUiState) {
-        when (uiState) {
-            is ImageDataStartLoadingUiState,
-            is ImageInLowResLoadSuccessUiState,
-            is ImageInHighResLoadSuccessUiState -> {
-                loadIntoImageViewWithResultListener.invoke(uiState.data, previewImageView, adapterPosition)
-            }
-            is ImageInLowResLoadFailedUiState,
-            is ImageInHighResLoadFailedUiState -> {
-                onItemClicked = requireNotNull(uiState.onItemTapped) { "OnItemTapped is required." }
-            }
-        }
+        onItemClicked = uiState.onItemTapped
+        loadIntoImageViewWithResultListener.invoke(uiState.data, previewImageView, adapterPosition)
         UiHelpers.updateVisibility(progressBar, uiState.progressBarVisible)
         UiHelpers.updateVisibility(errorLayout, uiState.retryLayoutVisible)
     }

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewHolder.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewHolder.kt
@@ -10,18 +10,42 @@ import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.imageeditor.R
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadFailedUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadSuccessUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadFailedUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadSuccessUiState
 import org.wordpress.android.imageeditor.utils.UiHelpers
 
 class PreviewImageViewHolder(
     val view: View,
     private val loadIntoImageViewWithResultListener: (ImageData, ImageView, Int) -> Unit
 ) : RecyclerView.ViewHolder(view) {
+    private val container = itemView.findViewById<ConstraintLayout>(R.id.container)
     private val previewImageView = itemView.findViewById<ImageView>(R.id.previewImageView)
     private val progressBar = itemView.findViewById<ProgressBar>(R.id.progressBar)
     private val errorLayout = itemView.findViewById<ConstraintLayout>(R.id.errorLayout)
+    private var onItemClicked: (() -> Unit)? = null
+
+    init {
+        container.setOnClickListener {
+            onItemClicked?.invoke()
+        }
+    }
 
     fun onBind(uiState: ImageUiState) {
-        loadIntoImageViewWithResultListener.invoke(uiState.data, previewImageView, adapterPosition)
+        when (uiState) {
+            is ImageDataStartLoadingUiState,
+            is ImageInLowResLoadSuccessUiState,
+            is ImageInHighResLoadSuccessUiState -> {
+                loadIntoImageViewWithResultListener.invoke(uiState.data, previewImageView, adapterPosition)
+            }
+            is ImageInLowResLoadFailedUiState,
+            is ImageInHighResLoadFailedUiState -> {
+                onItemClicked = requireNotNull(uiState.onItemTapped) { "OnItemTapped is required." }
+            }
+        }
+
         UiHelpers.updateVisibility(progressBar, uiState.progressBarVisible)
         UiHelpers.updateVisibility(errorLayout, uiState.retryLayoutVisible)
     }

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -1,11 +1,9 @@
 package org.wordpress.android.imageeditor.preview
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileFailedState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileIdleState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileSuccessState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadFailedUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadSuccessUiState
@@ -16,73 +14,20 @@ class PreviewImageViewModel : ViewModel() {
     private val _uiState: MutableLiveData<UiState> = MutableLiveData()
     val uiState: LiveData<UiState> = _uiState
 
-    private val _loadIntoFile = MutableLiveData<ImageLoadToFileState>(ImageLoadToFileIdleState)
-    val loadIntoFile: LiveData<ImageLoadToFileState> = _loadIntoFile
+//    private val _loadIntoFile = MutableLiveData<ImageLoadToFileState>(ImageLoadToFileIdleState)
+//    val loadIntoFile: LiveData<ImageLoadToFileState> = _loadIntoFile
 
-    private val _navigateToCropScreenWithFileInfo = MutableLiveData<Pair<String, String?>>()
-    val navigateToCropScreenWithFileInfo: LiveData<Pair<String, String?>> = _navigateToCropScreenWithFileInfo
+//    private val _navigateToCropScreenWithFileInfo = MutableLiveData<Pair<String, String?>>()
+//    val navigateToCropScreenWithFileInfo: LiveData<Pair<String, String?>> = _navigateToCropScreenWithFileInfo
 
-    private var outputFileExtension: String? = null
-
-    // TODO: Dummy data
-    private val imageDataList = listOf(
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/10/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/10/1000/1000.jpg"
-        ),
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/20/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/20/1000/1000.jpg"
-        ),
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/30/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/30/1000/1000.jpg"
-        ),
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/40/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/40/1000/1000.jpg"
-        ),
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/50/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/50/1000/1000.jpg"
-        ),
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/60/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/60/1000/1000.jpg"
-        ),
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/70/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/70/1000/1000.jpg"
-        ),
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/80/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/80/1000/1000.jpg"
-        ),
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/90/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/90/1000/1000.jpg"
-        ),
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/100/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/100/400/400.jpg"
-        ),
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/110/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/110/1000/1000.jpg"
-        ),
-        ImageData(
-            lowResImageUrl = "https://i.picsum.photos/id/120/200/200.jpg",
-            highResImageUrl = "https://i.picsum.photos/id/120/400/400.jpg"
-        )
-    )
-
-    fun onCreateView(loResImageUrl: String, hiResImageUrl: String, outputFileExtension: String?) {
-        this.outputFileExtension = outputFileExtension
-
-        val newImageUiStates = createViewPagerItemsInitialUiStates(imageDataList)
-        val currentUiState = uiState.value?.copy(viewPagerItemsStates = newImageUiStates) ?: UiState(newImageUiStates)
-
-        updateUiState(currentUiState)
+    fun onCreateView(imageDataList: List<ImageData>) {
+        if (uiState.value == null) {
+            val newImageUiStates = createViewPagerItemsInitialUiStates(imageDataList)
+            val currentUiState = uiState.value?.copy(viewPagerItemsStates = newImageUiStates) ?: UiState(
+                newImageUiStates
+            )
+            updateUiState(currentUiState)
+        }
     }
 
     fun onLoadIntoImageViewSuccess(currentUrl: String, currentPosition: Int) {
@@ -111,7 +56,7 @@ class PreviewImageViewModel : ViewModel() {
         updateUiState(currentUiState.copy(viewPagerItemsStates = newImageUiStates))
     }
 
-    fun onLoadIntoFileSuccess(inputFilePath: String) {
+    /*fun onLoadIntoFileSuccess(inputFilePath: String) {
         updateLoadIntoFileState(ImageLoadToFileSuccessState(inputFilePath))
         _navigateToCropScreenWithFileInfo.value = Pair(inputFilePath, outputFileExtension)
     }
@@ -119,9 +64,10 @@ class PreviewImageViewModel : ViewModel() {
     fun onLoadIntoFileFailed() {
         // TODO: Do we need to display any error message to the user?
         updateLoadIntoFileState(ImageLoadToFileFailedState)
-    }
+    }*/
 
-    fun onLoadIntoImageViewRetry(currentUrl: String, currentPosition: Int) {
+    @VisibleForTesting
+    private fun onLoadIntoImageViewRetry(currentUrl: String, currentPosition: Int) {
         val newImageUiStates = updateViewPagerItemsUiStates(
             currentUrl = currentUrl,
             currentPosition = currentPosition,
@@ -200,11 +146,11 @@ class PreviewImageViewModel : ViewModel() {
         _uiState.value = state
     }
 
-    private fun updateLoadIntoFileState(fileState: ImageLoadToFileState) {
+    /*private fun updateLoadIntoFileState(fileState: ImageLoadToFileState) {
         _loadIntoFile.value = fileState
-    }
+    }*/
 
-    data class ImageData(val lowResImageUrl: String, val highResImageUrl: String)
+    data class ImageData(val lowResImageUrl: String, val highResImageUrl: String, val outputFileExtension: String)
 
     data class UiState(val viewPagerItemsStates: List<ImageUiState>)
 
@@ -243,10 +189,10 @@ class PreviewImageViewModel : ViewModel() {
         )
     }
 
-    sealed class ImageLoadToFileState {
+    /*sealed class ImageLoadToFileState {
         object ImageLoadToFileIdleState : ImageLoadToFileState()
         data class ImageStartLoadingToFileState(val imageUrl: String) : ImageLoadToFileState()
         data class ImageLoadToFileSuccessState(val filePath: String) : ImageLoadToFileState()
         object ImageLoadToFileFailedState : ImageLoadToFileState()
-    }
+    }*/
 }

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -115,7 +115,8 @@ class PreviewImageViewModel : ViewModel() {
         return if (currentUrl == currentImageData.lowResImageUrl) {
             val isHighResImageAlreadyLoaded = currentImageState is ImageInHighResLoadSuccessUiState
             if (!isHighResImageAlreadyLoaded) {
-                ImageInLowResLoadSuccessUiState(currentImageData)
+                val isRetryShown = currentImageState is ImageInHighResLoadFailedUiState
+                ImageInLowResLoadSuccessUiState(currentImageData, isRetryShown)
             } else {
                 currentImageState
             }
@@ -166,10 +167,11 @@ class PreviewImageViewModel : ViewModel() {
             retryLayoutVisible = false
         )
         // Continue displaying progress bar on low res image load success
-        data class ImageInLowResLoadSuccessUiState(val imageData: ImageData) : ImageUiState(
+        data class ImageInLowResLoadSuccessUiState(val imageData: ImageData, val isRetryShown: Boolean = false)
+            : ImageUiState(
             data = imageData,
-            progressBarVisible = true,
-            retryLayoutVisible = false
+            progressBarVisible = !isRetryShown,
+            retryLayoutVisible = isRetryShown
         )
         data class ImageInLowResLoadFailedUiState(val imageData: ImageData) : ImageUiState(
             data = imageData,

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.imageeditor.preview
 
-import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -66,7 +65,6 @@ class PreviewImageViewModel : ViewModel() {
         updateLoadIntoFileState(ImageLoadToFileFailedState)
     }*/
 
-    @VisibleForTesting
     private fun onLoadIntoImageViewRetry(currentUrl: String, currentPosition: Int) {
         val newImageUiStates = updateViewPagerItemsUiStates(
             currentUrl = currentUrl,

--- a/libs/image-editor/ImageEditor/src/main/res/layout/layout_retry.xml
+++ b/libs/image-editor/ImageEditor/src/main/res/layout/layout_retry.xml
@@ -28,7 +28,7 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:layout_marginTop="@dimen/retry_text_view_top_margin"
-        android:text="@string/failed_to_insert_image_tap_to_retry"
+        android:text="@string/failed_to_load_image_tap_to_retry"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"

--- a/libs/image-editor/ImageEditor/src/main/res/values/strings.xml
+++ b/libs/image-editor/ImageEditor/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="preview_image_description">Preview Image</string>
     <string name="preview_image_thumbnail_description">Preview Image Thumbnail</string>
     <string name="retry">Retry</string>
-    <string name="failed_to_insert_image_tap_to_retry">Failed to insert image.\nPlease tap to retry.</string>
+    <string name="failed_to_load_image_tap_to_retry">Failed to load image.\nPlease tap to retry.</string>
 
     <!--crop screen-->
     <string name="done">done</string>

--- a/libs/image-editor/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/libs/image-editor/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -250,6 +250,21 @@ class PreviewImageViewModelTest {
                 .isInstanceOf(ImageDataStartLoadingUiState::class.java)
     }
 
+    @Test
+    fun `progress bar not visible when retry layout is visible and low res image loaded at given item position`() {
+        initViewModel()
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewFailed(currentUrl = TEST_HIGH_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition]
+                .retryLayoutVisible).isEqualTo(true)
+
+        viewModel.onLoadIntoImageViewSuccess(currentUrl = TEST_LOW_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition]
+                .progressBarVisible).isEqualTo(false)
+    }
+
     private fun initViewModel() = viewModel.onCreateView(
         listOf(ImageData(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL, TEST_OUTPUT_FILE_EXTENSION))
     )

--- a/libs/image-editor/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
+++ b/libs/image-editor/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModelTest.kt
@@ -4,23 +4,19 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import org.junit.Before
 import org.junit.Test
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileFailedState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileIdleState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileSuccessState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageStartLoadingToFileState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadFailedUiState
-import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadSuccessUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageDataStartLoadingUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadFailedUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInHighResLoadSuccessUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadFailedUiState
+import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadSuccessUiState
 
 private const val TEST_LOW_RES_IMAGE_URL = "https://wordpress.com/low_res_image.png"
 private const val TEST_HIGH_RES_IMAGE_URL = "https://wordpress.com/image.png"
-private const val TEST_FILE_PATH = "/file/path"
+// private const val TEST_FILE_PATH = "/file/path"
 private const val TEST_OUTPUT_FILE_EXTENSION = ".jpg"
+private const val FIRST_ITEM_POSITION = 0
 
 class PreviewImageViewModelTest {
     @Rule
@@ -29,91 +25,120 @@ class PreviewImageViewModelTest {
     // Class under test
     private lateinit var viewModel: PreviewImageViewModel
 
-    private lateinit var imageData: ImageData
+    private lateinit var imageData: List<ImageData>
 
     @Before
     fun setUp() {
         viewModel = PreviewImageViewModel()
-        imageData = ImageData(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL)
+        imageData = listOf(ImageData(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL, TEST_OUTPUT_FILE_EXTENSION))
     }
 
     @Test
-    fun `data loading started on view create`() {
+    fun `first item data loading started on view create`() {
         initViewModel()
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageDataStartLoadingUiState::class.java)
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates.first())
+                .isInstanceOf(ImageDataStartLoadingUiState::class.java)
     }
 
     @Test
-    fun `progress bar shown on view create`() {
+    fun `first item progress bar shown on view create`() {
         initViewModel()
-        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(true)
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates.first()
+                .progressBarVisible).isEqualTo(true)
     }
 
     @Test
-    fun `progress bar shown on low res image load success`() {
+    fun `progress bar shown on low res image load success at given item position`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL, imageData)
-        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(true)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewSuccess(currentUrl = TEST_LOW_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition]
+                .progressBarVisible).isEqualTo(true)
     }
 
     @Test
-    fun `progress bar shown on low res image load failed`() {
+    fun `progress bar shown on low res image load failed at given item position`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewFailed(TEST_LOW_RES_IMAGE_URL)
-        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(true)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewFailed(currentUrl = TEST_LOW_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition]
+                .progressBarVisible).isEqualTo(true)
     }
 
     @Test
-    fun `low res image success ui shown on low res image load success`() {
+    fun `low res image success ui shown on low res image load success at given item position`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL, imageData)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageInLowResLoadSuccessUiState::class.java)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewSuccess(currentUrl = TEST_LOW_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition])
+                .isInstanceOf(ImageInLowResLoadSuccessUiState::class.java)
     }
 
     @Test
-    fun `low res image failed ui shown on low res image load failed`() {
+    fun `low res image failed ui shown on low res image load failed at given item position`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewFailed(TEST_LOW_RES_IMAGE_URL)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageInLowResLoadFailedUiState::class.java)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewFailed(currentUrl = TEST_LOW_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition])
+                .isInstanceOf(ImageInLowResLoadFailedUiState::class.java)
     }
 
     @Test
-    fun `progress bar hidden on high res image load success`() {
+    fun `progress bar hidden on high res image load success at given item position`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL, imageData)
-        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewSuccess(currentUrl = TEST_HIGH_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition]
+                .progressBarVisible).isEqualTo(false)
     }
 
     @Test
-    fun `progress bar hidden on high res image load failed`() {
+    fun `progress bar hidden on high res image load failed at given item position`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
-        assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewFailed(currentUrl = TEST_HIGH_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition]
+                .progressBarVisible).isEqualTo(false)
     }
 
     @Test
-    fun `high res image success ui shown on high res image load success`() {
+    fun `high res image success ui shown on high res image load success at given item position`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL, imageData)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewSuccess(currentUrl = TEST_HIGH_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition])
+                .isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
     }
 
     @Test
-    fun `high res image failed ui shown on high res image load failed`() {
+    fun `high res image failed ui shown on high res image load failed at given item position`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadFailedUiState::class.java)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewFailed(currentUrl = TEST_HIGH_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition])
+                .isInstanceOf(ImageInHighResLoadFailedUiState::class.java)
     }
 
     @Test
-    fun `high res image success ui shown when low res image loads after high res image`() {
+    fun `high res image success ui shown when low res image loads after high res image at given item position`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL, imageData)
-        viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL, imageData)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewSuccess(currentUrl = TEST_HIGH_RES_IMAGE_URL, currentPosition = itemPosition)
+        viewModel.onLoadIntoImageViewSuccess(currentUrl = TEST_LOW_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition])
+                .isInstanceOf(ImageInHighResLoadSuccessUiState::class.java)
     }
 
-    @Test
+    /*@Test
     fun `high res image file loading started when high res image shown`() {
         initViewModel()
         viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL, imageData)
@@ -180,40 +205,52 @@ class PreviewImageViewModelTest {
         initViewModel()
         viewModel.onLoadIntoFileFailed()
         assertNull(viewModel.navigateToCropScreenWithFileInfo.value)
-    }
+    }*/
 
     @Test
-    fun `retry layout shown on high res image load failed`() {
+    fun `retry layout shown on high res image load failed at given item position`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
-        assertThat(requireNotNull(viewModel.uiState.value).retryLayoutVisible).isEqualTo(true)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewFailed(currentUrl = TEST_HIGH_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition]
+                .retryLayoutVisible).isEqualTo(true)
     }
 
     @Test
-    fun `retry layout shown when low res image load succeeded but high res image load failed afterwards`() {
+    fun `retry layout shown when low res image load succeeded but high res image load failed at given item pos`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewSuccess(TEST_LOW_RES_IMAGE_URL, imageData)
-        viewModel.onLoadIntoImageViewFailed(TEST_HIGH_RES_IMAGE_URL)
-        assertThat(requireNotNull(viewModel.uiState.value).retryLayoutVisible).isEqualTo(true)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewSuccess(currentUrl = TEST_LOW_RES_IMAGE_URL, currentPosition = itemPosition)
+        viewModel.onLoadIntoImageViewFailed(currentUrl = TEST_HIGH_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition]
+                .retryLayoutVisible).isEqualTo(true)
     }
 
     @Test
-    fun `retry layout hidden when low res image load failed but high res image shown afterwards`() {
+    fun `retry layout hidden when low res image load failed but high res image shown at given item position`() {
         initViewModel()
-        viewModel.onLoadIntoImageViewFailed(TEST_LOW_RES_IMAGE_URL)
-        viewModel.onLoadIntoImageViewSuccess(TEST_HIGH_RES_IMAGE_URL, imageData)
-        assertThat(requireNotNull(viewModel.uiState.value).retryLayoutVisible).isEqualTo(false)
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewFailed(currentUrl = TEST_LOW_RES_IMAGE_URL, currentPosition = itemPosition)
+        viewModel.onLoadIntoImageViewSuccess(currentUrl = TEST_HIGH_RES_IMAGE_URL, currentPosition = itemPosition)
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition]
+                .retryLayoutVisible).isEqualTo(false)
     }
 
     @Test
-    fun `data loading start triggered on retry`() {
-        viewModel.onLoadIntoImageViewRetry(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL)
-        assertThat(viewModel.uiState.value).isInstanceOf(ImageDataStartLoadingUiState::class.java)
+    fun `data loading start triggered on retry at given item position`() {
+        initViewModel()
+        val itemPosition = FIRST_ITEM_POSITION
+        viewModel.onLoadIntoImageViewFailed(currentUrl = TEST_HIGH_RES_IMAGE_URL, currentPosition = itemPosition)
+        requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition].onItemTapped?.invoke()
+
+        assertThat(requireNotNull(viewModel.uiState.value).viewPagerItemsStates[itemPosition])
+                .isInstanceOf(ImageDataStartLoadingUiState::class.java)
     }
 
     private fun initViewModel() = viewModel.onCreateView(
-            TEST_LOW_RES_IMAGE_URL,
-            TEST_HIGH_RES_IMAGE_URL,
-            TEST_OUTPUT_FILE_EXTENSION
+        listOf(ImageData(TEST_LOW_RES_IMAGE_URL, TEST_HIGH_RES_IMAGE_URL, TEST_OUTPUT_FILE_EXTENSION))
     )
 }


### PR DESCRIPTION
Fixes #11152

This PR is continuation of https://github.com/wordpress-mobile/WordPress-Android/pull/11608. It

1. Refactors code to display retry layout when high res image fails to load in the pager and triggers selected image reload on tap to retry.

2. Fixes below pending action items:
    - [x] Thumbnails - manage select index (on fragment lifecycle changes)
    - [x] Existing test cases - update once changes are finalised (for image loading)

** Load to file logic is commented temporarily.

![device-2020-04-13-103803](https://user-images.githubusercontent.com/1405144/79093759-e9c58080-7d72-11ea-9840-081637dbc7a9.png)

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
