### PR TITLE
Post/Page compact cancel auto upload action improvement

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.widgets.PostListButtonType
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD_COMPACT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE_PERMANENTLY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
@@ -44,7 +45,7 @@ fun trackPostListAction(site: SiteModel, buttonType: PostListButtonType, postDat
         BUTTON_SYNC -> "sync"
         BUTTON_MORE -> "more"
         BUTTON_MOVE_TO_DRAFT -> "move_to_draft"
-        BUTTON_CANCEL_PENDING_AUTO_UPLOAD -> "cancel_pending_auto_upload"
+        BUTTON_CANCEL_PENDING_AUTO_UPLOAD, BUTTON_CANCEL_PENDING_AUTO_UPLOAD_COMPACT -> "cancel_pending_auto_upload"
     }
 
     AnalyticsUtils.trackWithSiteDetails(statsEvent, site, properties)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -46,6 +46,7 @@ import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiStat
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
 import org.wordpress.android.widgets.PostListButtonType
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD_COMPACT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE_PERMANENTLY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
@@ -89,16 +90,28 @@ class PostListItemUiStateHelper @Inject constructor(
         val onButtonClicked = { buttonType: PostListButtonType ->
             onAction.invoke(post, buttonType, POST_LIST_BUTTON_PRESSED)
         }
-        val buttonTypes = createButtonTypes(
+        val defaultButtonTypes = createButtonTypes(
                 postStatus = postStatus,
                 isLocalDraft = post.isLocalDraft,
                 isLocallyChanged = post.isLocallyChanged,
                 uploadUiState = uploadUiState,
                 siteHasCapabilitiesToPublish = capabilitiesToPublish,
-                statsSupported = statsSupported
+                statsSupported = statsSupported,
+                isCompactActions = false
         )
-        val defaultActions = createDefaultViewActions(buttonTypes, onButtonClicked)
-        val compactActions = createCompactViewActions(buttonTypes, onButtonClicked)
+
+        val compactButtonTypes = createButtonTypes(
+                postStatus = postStatus,
+                isLocalDraft = post.isLocalDraft,
+                isLocallyChanged = post.isLocallyChanged,
+                uploadUiState = uploadUiState,
+                siteHasCapabilitiesToPublish = capabilitiesToPublish,
+                statsSupported = statsSupported,
+                isCompactActions = true
+        )
+
+        val defaultActions = createDefaultViewActions(defaultButtonTypes, onButtonClicked)
+        val compactActions = createCompactViewActions(compactButtonTypes, onButtonClicked)
 
         val remotePostId = RemotePostId(RemoteId(post.remotePostId))
         val localPostId = LocalPostId(LocalId(post.id))
@@ -310,7 +323,8 @@ class PostListItemUiStateHelper @Inject constructor(
         isLocallyChanged: Boolean,
         uploadUiState: PostUploadUiState,
         siteHasCapabilitiesToPublish: Boolean,
-        statsSupported: Boolean
+        statsSupported: Boolean,
+        isCompactActions: Boolean
     ): List<PostListButtonType> {
         val canRetryUpload = uploadUiState is PostUploadUiState.UploadFailed
         val canCancelPendingAutoUpload = (uploadUiState is UploadWaitingForConnection ||
@@ -332,7 +346,11 @@ class PostListItemUiStateHelper @Inject constructor(
         }
 
         if (canCancelPendingAutoUpload) {
-            buttonTypes.add(BUTTON_CANCEL_PENDING_AUTO_UPLOAD)
+            if (isCompactActions) {
+                buttonTypes.add(BUTTON_CANCEL_PENDING_AUTO_UPLOAD_COMPACT)
+            } else {
+                buttonTypes.add(BUTTON_CANCEL_PENDING_AUTO_UPLOAD)
+            }
         }
 
         if (canShowPublishButton) {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -32,10 +32,17 @@ enum class PostListButtonType constructor(
     ),
     BUTTON_CANCEL_PENDING_AUTO_UPLOAD(
             14,
+            R.string.cancel,
+            R.drawable.ic_undo_white_24dp,
+            R.attr.wpColorWarningDark
+    ),
+    BUTTON_CANCEL_PENDING_AUTO_UPLOAD_COMPACT(
+            14,
             R.string.pages_and_posts_cancel_auto_upload,
             R.drawable.ic_undo_white_24dp,
             R.attr.wpColorWarningDark
-    );
+    )
+    ;
 
     companion object {
         fun fromInt(value: Int): PostListButtonType? = values().firstOrNull { it.value == value }

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -41,8 +41,7 @@ enum class PostListButtonType constructor(
             R.string.pages_and_posts_cancel_auto_upload,
             R.drawable.ic_undo_white_24dp,
             R.attr.wpColorWarningDark
-    )
-    ;
+    );
 
     companion object {
         fun fromInt(value: Int): PostListButtonType? = values().firstOrNull { it.value == value }


### PR DESCRIPTION
Fixes #11515
This PR is a continuation of https://github.com/wordpress-mobile/WordPress-Android/pull/11636 
It addresses the notion that`Cancel Upload` should only be visible on compact actions view of both the page and post list. 

To test:
1. Turn on airplane mode.
2. Create a post or page and publish it.
3. An auto-upload label is displayed on the list item (eg. "We'll publish this post/page when your device is back online").
4. You will see that Cancel upload is shown on both the compact Page/Post List list item option menu.
5. For the post list, the default/normal view will only contain "Cancel"

Default | Compact 
--------|-------
  <img src="https://user-images.githubusercontent.com/1509205/79140954-77f33400-7d7e-11ea-9cb3-706bf7e4b9ba.png" width="320">      |   <img src="https://user-images.githubusercontent.com/1509205/79140958-79246100-7d7e-11ea-8408-6180e9e4cacb.png" width="320">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
