### PR TITLE
Issue/11635 fix sharing intent receiver in dark mode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -75,14 +75,6 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
         }
     }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // keep setBackground in the onResume, otherwise the transition between activities is visible to the user when
-        // sharing text with an account with one visible site
-        findViewById(R.id.main_view).setBackgroundResource(R.color.background_default);
-    }
-
     private void refreshContent() {
         if (FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
             List<SiteModel> visibleSites = mSiteStore.getVisibleSites();

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
@@ -24,8 +24,6 @@ import org.wordpress.android.ui.main.SitePickerAdapter.HeaderHandler;
 import org.wordpress.android.ui.main.SitePickerAdapter.SiteList;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
-import org.wordpress.android.util.ContextExtensionsKt;
-import org.wordpress.android.util.ViewUtils;
 import org.wordpress.android.util.image.ImageManager;
 
 import javax.inject.Inject;
@@ -171,20 +169,8 @@ public class ShareIntentReceiverFragment extends Fragment {
 
                                 if (mRecyclerView.computeVerticalScrollRange() > mRecyclerView.getHeight()) {
                                     mBottomButtonsShadow.setVisibility(View.VISIBLE);
-                                    mBottomButtonsContainer.setBackgroundResource(android.R.color.white);
-                                    mShareMediaBtn.setTextColor(getResources().getColor(R.color.primary_50));
-                                    ViewUtils.setButtonBackgroundColor(getContext(), mShareMediaBtn,
-                                            R.style.WordPress_Button_Grey,
-                                            R.attr.colorButtonNormal);
                                 } else {
                                     mBottomButtonsShadow.setVisibility(View.GONE);
-                                    mBottomButtonsContainer.setBackground(null);
-                                    mShareMediaBtn.setTextColor(
-                                            ContextExtensionsKt
-                                                    .getColorFromAttribute(getContext(), R.attr.wpColorText));
-                                    ViewUtils.setButtonBackgroundColor(getContext(), mShareMediaBtn,
-                                            R.style.WordPress_Button,
-                                            R.attr.colorButtonNormal);
                                 }
                             }
                         });

--- a/WordPress/src/main/res/layout/share_intent_receiver_activity.xml
+++ b/WordPress/src/main/res/layout/share_intent_receiver_activity.xml
@@ -1,15 +1,14 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:id="@+id/main_view"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:baselineAligned="true"
-  app:theme="@style/LoginTheme"
-  android:orientation="vertical">
-
-  <FrameLayout
-    android:id="@+id/fragment_container"
+    android:id="@+id/main_view"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:background="?android:colorBackground"
+    android:baselineAligned="true"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/share_intent_sites_listitem.xml
+++ b/WordPress/src/main/res/layout/share_intent_sites_listitem.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:id="@+id/layout_container"
-  android:layout_width="match_parent"
-  android:layout_height="wrap_content"
-  android:layout_marginTop="@dimen/margin_medium"
-  android:layout_marginBottom="@dimen/margin_medium"
-  android:layout_marginStart="@dimen/margin_extra_large"
-  android:layout_marginEnd="@dimen/margin_extra_large"
-  android:orientation="horizontal">
-
-  <include
-    tools:ignore="DuplicateIncludedIds"
-    layout="@layout/login_epilogue_sites_listitem"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_toStartOf="@+id/radio_selected"/>
+    android:layout_marginStart="@dimen/margin_extra_large"
+    android:layout_marginTop="@dimen/margin_medium"
+    android:layout_marginEnd="@dimen/margin_extra_large"
+    android:layout_marginBottom="@dimen/margin_medium"
+    android:orientation="horizontal">
 
-  <RadioButton
-    android:id="@+id/radio_selected"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/margin_small_medium"
-    android:layout_marginEnd="@dimen/margin_small_medium"
-    android:layout_alignParentEnd="true"
-    android:layout_centerVertical="true"
-    android:clickable="false"
-    android:focusableInTouchMode="false" />
+    <include
+        layout="@layout/login_epilogue_sites_listitem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_toStartOf="@+id/radio_selected"
+        tools:ignore="DuplicateIncludedIds" />
+
+    <com.google.android.material.radiobutton.MaterialRadioButton
+        android:id="@+id/radio_selected"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:layout_marginStart="@dimen/margin_small_medium"
+        android:layout_marginEnd="@dimen/margin_small_medium"
+        android:clickable="false"
+        android:focusableInTouchMode="false" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -129,8 +129,7 @@
         <item name="android:dropDownListViewStyle">@style/DropDownListView.Light.WordPress</item>
     </style>
 
-    <style name="NoDisplay" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="android:windowNoTitle">true</item>
+    <style name="NoDisplay" parent="WordPress.NoActionBar">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowIsTranslucent">true</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -254,17 +254,8 @@
         <item name="android:textColor">@color/neutral_40</item>
     </style>
 
-    <style name="WordPress.Button" parent="Widget.MaterialComponents.Button">
-        <item name="android:textColor">?attr/colorOnPrimarySurface</item>
-    </style>
-
     <style name="WordPress.Button.Primary" parent="Widget.MaterialComponents.Button">
         <item name="backgroundTint">@color/secondary_disabled_selector</item>
-    </style>
-
-    <style name="WordPress.Button.Grey" parent="Widget.AppCompat.Button.Colored">
-        <item name="colorButtonNormal">@color/neutral_0</item>
-        <item name="android:textColor">@color/primary_50</item>
     </style>
 
     <!-- NUX Styles -->


### PR DESCRIPTION
Fixes #11635 

Updates styling of Sharing Intent receiver to math material theme. 
![comparison_qp](https://user-images.githubusercontent.com/728822/79172611-0af59380-7daa-11ea-9f65-c06d2f896ab6.png)

To test:
- Try to share some media to the app.
- Notice that sharing intent receiver looks as expected in both light and dark modes.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
