### PR TITLE
Switch styles of the login and signup buttons

### DIFF
--- a/WordPress/src/main/res/layout-land/login_signup_screen.xml
+++ b/WordPress/src/main/res/layout-land/login_signup_screen.xml
@@ -47,7 +47,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/create_site_button"
-                style="@style/LoginTheme.Button.SignUp"
+                style="@style/LoginTheme.Button.Primary"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/margin_medium"
@@ -56,7 +56,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/login_button"
-                style="@style/LoginTheme.Button.Primary"
+                style="@style/LoginTheme.Button.SignUp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/margin_medium"

--- a/WordPress/src/main/res/layout/login_signup_screen.xml
+++ b/WordPress/src/main/res/layout/login_signup_screen.xml
@@ -48,7 +48,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/login_button"
-                style="@style/LoginTheme.Button.Primary"
+                style="@style/LoginTheme.Button.SignUp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_extra_small"
@@ -57,7 +57,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/create_site_button"
-                style="@style/LoginTheme.Button.SignUp"
+                style="@style/LoginTheme.Button.Primary"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/margin_extra_small"


### PR DESCRIPTION
Fixes #11659

This PR switches the styles of the "Sign up" and the "Login" buttons. This makes the "Sign up" action primary. I've decided to reuse the style called `SignUp` for Login because renaming it would require changing the login library and that feels like too much work for such a small change. 

To test:
- Open a fresh install of the app
- Notice that the "Sign up" action is primary 
- Notice that the "Login" action is secondary

![Screenshot_1586872924](https://user-images.githubusercontent.com/1079756/79235101-76536a00-7e6b-11ea-94d0-642bfadd57fe.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
