### PR TITLE
Testing: Re-enable and refactor login tests that don't use magic links

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -1,63 +1,69 @@
 package org.wordpress.android.e2e;
-// Disabled temporarily
-//import androidx.test.ext.junit.runners.AndroidJUnit4;
-//import androidx.test.rule.ActivityTestRule;
-//
-//import org.junit.After;
-//import org.junit.Before;
-//import org.junit.Rule;
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//import org.wordpress.android.e2e.flows.LoginFlow;
-//import org.wordpress.android.support.BaseTest;
-//import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
-//
-//import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
-//import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
-//import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_USERNAME;
-//import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
-//import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_SITE_ADDRESS;
-//import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_USERNAME;
-//
-//@RunWith(AndroidJUnit4.class)
-//public class LoginTests extends BaseTest {
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wordpress.android.e2e.flows.LoginFlow;
+import org.wordpress.android.support.BaseTest;
+import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
+
+import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
+import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
+import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_USERNAME;
+import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
+import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_SITE_ADDRESS;
+import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_USERNAME;
+
+@RunWith(AndroidJUnit4.class)
+public class LoginTests extends BaseTest {
 //    @Rule
 //    public ActivityTestRule<LoginMagicLinkInterceptActivity> mMagicLinkActivityTestRule =
 //            new ActivityTestRule<>(LoginMagicLinkInterceptActivity.class);
-//
-//    @Before
-//    public void setUp() {
-//        logoutIfNecessary();
-//    }
-//
-//    @Test
-//    public void loginWithEmailPassword() {
-//        wpLogin();
-//    }
-//
-//    @Test
-//    public void loginWithSiteAddress() {
-//        new LoginFlow().loginSiteAddress(
-//                E2E_WP_COM_USER_SITE_ADDRESS,
-//                E2E_WP_COM_USER_USERNAME,
-//                E2E_WP_COM_USER_PASSWORD);
-//    }
-//
+
+    @Before
+    public void setUp() {
+        logoutIfNecessary();
+    }
+
+    @Test
+    public void loginWithEmailPassword() {
+        new LoginFlow().chooseLogin()
+                 .enterEmailAddress()
+                 .enterPassword()
+                 .confirmLogin();
+    }
+
+    @Test
+    public void loginWithSiteAddress() {
+        new LoginFlow().chooseLogin()
+                 .chooseAndEnterSiteAddress(E2E_WP_COM_USER_SITE_ADDRESS)
+                 .enterUsernameAndPassword(E2E_WP_COM_USER_USERNAME, E2E_WP_COM_USER_PASSWORD)
+                 .confirmLogin();
+    }
+
+//    Disabled temporarily, see: https://github.com/wordpress-mobile/WordPress-Android/pull/11283
 //    @Test
 //    public void loginWithMagicLink() {
-//        new LoginFlow().loginMagicLink(mMagicLinkActivityTestRule);
+//        new LoginFlow().chooseLogin()
+//                 .enterEmailAddress()
+//                 .chooseMagicLink(mMagicLinkActivityTestRule)
+//                 .confirmLogin();
 //    }
-//
-//    @Test
-//    public void loginWithSelfHostedAccount() {
-//        new LoginFlow().loginSiteAddress(
-//                E2E_SELF_HOSTED_USER_SITE_ADDRESS,
-//                E2E_SELF_HOSTED_USER_USERNAME,
-//                E2E_SELF_HOSTED_USER_PASSWORD);
-//    }
-//
-//    @After
-//    public void tearDown() {
-//        logoutIfNecessary();
-//    }
-//}
+
+    @Test
+    public void loginWithSelfHostedAccount() {
+        new LoginFlow().chooseLogin()
+                .chooseAndEnterSiteAddress(E2E_SELF_HOSTED_USER_SITE_ADDRESS)
+                .enterUsernameAndPassword(E2E_SELF_HOSTED_USER_USERNAME, E2E_SELF_HOSTED_USER_PASSWORD)
+                .confirmLogin();
+    }
+
+    @After
+    public void tearDown() {
+        logoutIfNecessary();
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -1,15 +1,15 @@
 package org.wordpress.android.e2e;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.ActivityTestRule;
+//import androidx.test.rule.ActivityTestRule;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wordpress.android.e2e.flows.LoginFlow;
 import org.wordpress.android.support.BaseTest;
-import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
+//import org.junit.Rule;
+//import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -27,20 +27,22 @@ import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 
 public class LoginFlow {
-    private void chooseLogin() {
+    public LoginFlow chooseLogin() {
         // Login Prologue – We want to log in, not sign up
         // See LoginPrologueFragment
         clickOn(R.id.login_button);
+        return this;
     }
 
-    private void enterEmailAddress() {
+    public LoginFlow enterEmailAddress() {
         // Email Address Screen – Fill it in and click "Next"
         // See LoginEmailFragment
         populateTextField(R.id.input, E2E_WP_COM_USER_EMAIL);
         clickOn(R.id.primary_button);
+        return this;
     }
 
-    private void enterPassword() {
+    public LoginFlow enterPassword() {
         // Receive Magic Link or Enter Password Screen – Choose "Enter Password"
         // See LoginMagicLinkRequestFragment
         clickOn(R.id.login_enter_password);
@@ -49,9 +51,11 @@ public class LoginFlow {
         // See LoginEmailPasswordFragment
         populateTextField(R.id.input, E2E_WP_COM_USER_PASSWORD);
         clickOn(R.id.primary_button);
+
+        return this;
     }
 
-    private void confirmLogin() {
+    public void confirmLogin() {
         // If we get bumped to the "enter your username and password" screen, fill it in
         if (atLeastOneElementWithIdIsDisplayed(R.id.login_password_row)) {
             enterUsernameAndPassword(E2E_WP_COM_USER_USERNAME, E2E_WP_COM_USER_PASSWORD);
@@ -65,7 +69,7 @@ public class LoginFlow {
         waitForElementToBeDisplayed(R.id.nav_sites);
     }
 
-    private void chooseMagicLink(ActivityTestRule<LoginMagicLinkInterceptActivity> magicLinkActivityTestRule) {
+    public LoginFlow chooseMagicLink(ActivityTestRule<LoginMagicLinkInterceptActivity> magicLinkActivityTestRule) {
         // Receive Magic Link or Enter Password Screen – Choose "Send Link"
         // See LoginMagicLinkRequestFragment
         clickOn(R.id.login_request_magic_link);
@@ -78,9 +82,11 @@ public class LoginFlow {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("wordpress://magic-login?token=valid_token"))
                 .setPackage(getApplicationContext().getPackageName());
         magicLinkActivityTestRule.launchActivity(intent);
+
+        return this;
     }
 
-    private void enterUsernameAndPassword(String username, String password) {
+    public LoginFlow enterUsernameAndPassword(String username, String password) {
         ViewInteraction usernameElement = onView(allOf(isDescendantOfA(withId(R.id.login_username_row)),
                 Matchers.<View>instanceOf(EditText.class)));
         ViewInteraction passwordElement = onView(allOf(isDescendantOfA(withId(R.id.login_password_row)),
@@ -88,32 +94,13 @@ public class LoginFlow {
         populateTextField(usernameElement, username + "\n");
         populateTextField(passwordElement, password + "\n");
         clickOn(R.id.primary_button);
+        return this;
     }
 
-    private void chooseAndEnterSiteAddress(String siteAddress) {
+    public LoginFlow chooseAndEnterSiteAddress(String siteAddress) {
         clickOn(onView(withText(R.string.enter_site_address_instead)));
         populateTextField(R.id.input, siteAddress);
         clickOn(R.id.primary_button);
-    }
-
-    public void loginEmailPassword() {
-        chooseLogin();
-        enterEmailAddress();
-        enterPassword();
-        confirmLogin();
-    }
-
-    public void loginMagicLink(ActivityTestRule<LoginMagicLinkInterceptActivity> magicLinkActivityTestRule) {
-        chooseLogin();
-        enterEmailAddress();
-        chooseMagicLink(magicLinkActivityTestRule);
-        confirmLogin();
-    }
-
-    public void loginSiteAddress(String siteAddress, String username, String password) {
-        chooseLogin();
-        chooseAndEnterSiteAddress(siteAddress);
-        enterUsernameAndPassword(username, password);
-        confirmLogin();
+        return this;
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -95,7 +95,10 @@ public class BaseTest {
     }
     protected void wpLogin() {
         logoutIfNecessary();
-        new LoginFlow().loginEmailPassword();
+        new LoginFlow().chooseLogin()
+                       .enterEmailAddress()
+                       .enterPassword()
+                       .confirmLogin();
     }
 
     private void wpLogout() {


### PR DESCRIPTION
In https://github.com/wordpress-mobile/WordPress-Android/pull/11283 we temporarily disabled all login and signup connected tests.

This PR re-enables the login tests that don't use magic links, since they should not have any issues on their own. It also refactors these tests to make the test steps clearer for each test.

Background: These tests were sometimes failing because the magic link tests rely on an activity test rule to be able to invoke the magic link intent directly, and that intent can't always be launched. (The cause for that is still under investigation.) Because the test rule for that intent is launched before every test in the `LoginTests` class, it can sometimes cause unrelated tests to fail. This PR keeps that test rule and the magic link login test disabled, so it shouldn't cause any issues for the re-enabled tests.

As we work on the magic link issue, we could consider putting all tests that use magic links into their own class (rather than separating tests based on login and signup exclusively) so the test rule is only applied to tests that need it.

To test:

* Run the optional connected tests on CI and confirm they pass.
* You can also run the connected tests locally with `./gradlew :WordPress:connectedVanillaDebugAndroidTest`. (Note that local test runs include the WPScreenshotTest, which isn't included in the CI run. That test is currently failing, but it's also failing in `develop` and the failure is related to mocks, not login. We can fix that it a separate PR.)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
