### PR TITLE
Testing: Update mocks for screenshot test

### DIFF
--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/posts/posts-draft,pending.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/posts/posts-draft,pending.json
@@ -13,7 +13,7 @@
                 "equalTo": "date"
             },
             "fields": {
-                "equalTo": "ID,modified,status,meta,date"
+                "equalTo": "ID,modified,status,meta"
             },
             "order": {
                 "equalTo": "DESC"

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/posts/posts-first.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/posts/posts-first.json
@@ -7,7 +7,7 @@
                 "matches": "(.*)"
             },
             "fields": {
-                "equalTo": "ID, title, URL, discussion, like_count, date"
+                "equalTo": "ID,title,URL,discussion,like_count,date"
             },
             "number": {
                 "matches": "1"

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/posts/posts-private,publish.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/posts/posts-private,publish.json
@@ -13,7 +13,7 @@
                 "equalTo": "date"
             },
             "fields": {
-                "equalTo": "ID,modified,status,meta,date"
+                "equalTo": "ID,modified,status,meta"
             },
             "order": {
                 "equalTo": "DESC"

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_publicize.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_publicize.json
@@ -5,9 +5,6 @@
          "queryParameters": {
             "locale": {
                 "matches": "(.*)"
-            },
-            "max": {
-                "matches": "(.*)"
             }
         }
     },


### PR DESCRIPTION
As noted in https://github.com/wordpress-mobile/WordPress-Android/pull/11666 the screenshot test currently fails due to errors with the mocks. This PR updates the mocks to resolve those errors so the test passes.

Only one review is needed and anyone can review.

To test:

* Run `./gradlew :WordPress:connectedVanillaDebugAndroidTest` and confirm all tests pass.
* You can also run `WPScreenshotTest` (under `WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/`) individually to confirm it passes.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
