### PR TITLE
Testing: Re-enable magic link tests

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -118,6 +118,7 @@ android {
     }
 
     testOptions {
+        animationsDisabled = true
         unitTests {
             includeAndroidResources = true
             returnDefaultValues = true

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -1,15 +1,15 @@
 package org.wordpress.android.e2e;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-//import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.ActivityTestRule;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wordpress.android.e2e.flows.LoginFlow;
 import org.wordpress.android.support.BaseTest;
-//import org.junit.Rule;
-//import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
+import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
@@ -20,9 +20,9 @@ import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_USERNAME;
 
 @RunWith(AndroidJUnit4.class)
 public class LoginTests extends BaseTest {
-//    @Rule
-//    public ActivityTestRule<LoginMagicLinkInterceptActivity> mMagicLinkActivityTestRule =
-//            new ActivityTestRule<>(LoginMagicLinkInterceptActivity.class);
+    @Rule
+    public ActivityTestRule<LoginMagicLinkInterceptActivity> mMagicLinkActivityTestRule =
+            new ActivityTestRule<>(LoginMagicLinkInterceptActivity.class, true, false);
 
     @Before
     public void setUp() {
@@ -45,14 +45,13 @@ public class LoginTests extends BaseTest {
                  .confirmLogin();
     }
 
-//    Disabled temporarily, see: https://github.com/wordpress-mobile/WordPress-Android/pull/11283
-//    @Test
-//    public void loginWithMagicLink() {
-//        new LoginFlow().chooseLogin()
-//                 .enterEmailAddress()
-//                 .chooseMagicLink(mMagicLinkActivityTestRule)
-//                 .confirmLogin();
-//    }
+    @Test
+    public void loginWithMagicLink() {
+        new LoginFlow().chooseLogin()
+                       .enterEmailAddress()
+                       .chooseMagicLink(mMagicLinkActivityTestRule)
+                       .confirmLogin();
+    }
 
     @Test
     public void loginWithSelfHostedAccount() {

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -1,40 +1,39 @@
 package org.wordpress.android.e2e;
 
-// Disabled temporarily
-//import androidx.test.rule.ActivityTestRule;
-//
-//import org.junit.Before;
-//import org.junit.Rule;
-//import org.junit.Test;
-//import org.wordpress.android.e2e.flows.SignupFlow;
-//import org.wordpress.android.support.BaseTest;
-//import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
-//
-//import static org.wordpress.android.BuildConfig.E2E_SIGNUP_DISPLAY_NAME;
-//import static org.wordpress.android.BuildConfig.E2E_SIGNUP_EMAIL;
-//import static org.wordpress.android.BuildConfig.E2E_SIGNUP_PASSWORD;
-//import static org.wordpress.android.BuildConfig.E2E_SIGNUP_USERNAME;
-//
-//public class SignUpTests extends BaseTest {
-//    @Rule
-//    public ActivityTestRule<LoginMagicLinkInterceptActivity> mMagicLinkActivityTestRule =
-//            new ActivityTestRule<>(LoginMagicLinkInterceptActivity.class);
-//
-//    @Before
-//    public void setUp() {
-//        logoutIfNecessary();
-//    }
-//
-//    @Test
-//    public void signUpWithEmail() {
-//        SignupFlow signupFlow = new SignupFlow();
-//        signupFlow.chooseSignupWithEmail();
-//        signupFlow.enterEmail(E2E_SIGNUP_EMAIL, mMagicLinkActivityTestRule);
-//        signupFlow.checkEpilogue(
-//                E2E_SIGNUP_DISPLAY_NAME,
-//                E2E_SIGNUP_USERNAME);
-//        signupFlow.enterPassword(E2E_SIGNUP_PASSWORD);
-//        signupFlow.dismissInterstitial();
-//        signupFlow.confirmSignup();
-//    }
-//}
+import androidx.test.rule.ActivityTestRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.wordpress.android.e2e.flows.SignupFlow;
+import org.wordpress.android.support.BaseTest;
+import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
+
+import static org.wordpress.android.BuildConfig.E2E_SIGNUP_DISPLAY_NAME;
+import static org.wordpress.android.BuildConfig.E2E_SIGNUP_EMAIL;
+import static org.wordpress.android.BuildConfig.E2E_SIGNUP_PASSWORD;
+import static org.wordpress.android.BuildConfig.E2E_SIGNUP_USERNAME;
+
+public class SignUpTests extends BaseTest {
+    @Rule
+    public ActivityTestRule<LoginMagicLinkInterceptActivity> mMagicLinkActivityTestRule =
+            new ActivityTestRule<>(LoginMagicLinkInterceptActivity.class, true, false);
+
+    @Before
+    public void setUp() {
+        logoutIfNecessary();
+    }
+
+    @Test
+    public void signUpWithMagicLink() {
+        new SignupFlow().chooseSignupWithEmail()
+                        .enterEmail(E2E_SIGNUP_EMAIL)
+                        .openMagicLink(mMagicLinkActivityTestRule)
+                        .checkEpilogue(
+                                E2E_SIGNUP_DISPLAY_NAME,
+                                E2E_SIGNUP_USERNAME)
+                        .enterPassword(E2E_SIGNUP_PASSWORD)
+                        .dismissInterstitial()
+                        .confirmSignup();
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
@@ -20,17 +20,25 @@ import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 
 public class SignupFlow {
-    public void chooseSignupWithEmail() {
+    public SignupFlow chooseSignupWithEmail() {
         clickOn(onView(withId(R.id.create_site_button)));
         clickOn(onView(withId(R.id.signup_email)));
+
+        return this;
     }
 
-    public void enterEmail(String email,
-                           ActivityTestRule<LoginMagicLinkInterceptActivity> magicLinkActivityTestRule) {
+    public SignupFlow enterEmail(String email) {
         // Email file = id/input
         populateTextField(onView(withId(R.id.input)), email);
         clickOn(onView(withId(R.id.primary_button)));
 
+        // Should See Open Mail button
+        waitForElementToBeDisplayed(R.id.signup_magic_link_button);
+
+        return this;
+    }
+
+    public SignupFlow openMagicLink(ActivityTestRule<LoginMagicLinkInterceptActivity> magicLinkActivityTestRule) {
         // Follow the magic link to continue login
         // Intent is invoked directly rather than through a browser as WireMock is unavailable once in the background
         Intent intent = new Intent(
@@ -39,9 +47,11 @@ public class SignupFlow {
         ).setPackage(getApplicationContext().getPackageName());
 
         magicLinkActivityTestRule.launchActivity(intent);
+
+        return this;
     }
 
-    public void checkEpilogue(String displayName, String username) {
+    public SignupFlow checkEpilogue(String displayName, String username) {
         // Check Epilogue data
         ViewInteraction emailHeaderView = onView(withId(R.id.signup_epilogue_header_email));
         waitForElementToBeDisplayed(emailHeaderView);
@@ -51,9 +61,11 @@ public class SignupFlow {
 
         waitForElementToBeDisplayed(displayNameField);
         waitForElementToBeDisplayed(usernameField);
+
+        return this;
     }
 
-    public void enterPassword(String password) {
+    public SignupFlow enterPassword(String password) {
         // Enter Password
         ViewInteraction passwordField = onView(allOf(withId(R.id.input), withHint("Password (optional)")));
         waitForElementToBeDisplayed(passwordField);
@@ -61,11 +73,15 @@ public class SignupFlow {
 
         // Click continue
         clickOn(onView(withId(R.id.primary_button)));
+
+        return this;
     }
 
-    public void dismissInterstitial() {
+    public SignupFlow dismissInterstitial() {
         // Dismiss post-signup interstitial
         clickOn(onView(withId(R.id.dismiss_button)));
+
+        return this;
     }
 
     public void confirmSignup() {


### PR DESCRIPTION
This PR re-enables and updates the magic link tests that were disabled in https://github.com/wordpress-mobile/WordPress-Android/pull/11283.

Changes to the tests:

* The `ActivityTestRule` for login and signup tests was updated (per the [documentation](https://developer.android.com/reference/androidx/test/rule/ActivityTestRule#ActivityTestRule(java.lang.Class%3CT%3E,%20boolean,%20boolean))) so it does not launch the activity before every test. This makes sure it isn't launched until we explicitly launch the intent in the relevant test method.
* `build.gradle` was updated to disable animations for all test runs. This ensures that animations aren't slowing down or blocking the tests.
* The signup test was updated to use method chaining and separate the magic link step, for added clarity.

To test:

* Confirm the connected tests consistently pass on CI (where we primarily saw the flaky failures before). I ran the connected tests 5 times on this PR ([see the results on CircleCI](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android?branch=try%2Fenable-magic-link-tests)) and they passed each time with no flakiness.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
