### PR TITLE
Issue/11633 material placeholders

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -219,7 +219,7 @@ public class AddQuickPressShortcutActivity extends LocaleAwareActivity {
                     StringEscapeUtils.unescapeHtml4(blogNames[position]));
             blogUrl.setText(
                     StringEscapeUtils.unescapeHtml4(blogUrls[position]));
-            blavatar.setErrorImageResId(R.drawable.bg_rectangle_neutral_10_globe_32dp);
+            blavatar.setErrorImageResId(R.drawable.bg_rectangle_placeholder_globe_32dp);
             blavatar.setImageUrl(blavatars[position], mImageLoader);
 
             return view;

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -8,38 +8,38 @@ import javax.inject.Singleton
 class ImagePlaceholderManager @Inject constructor() {
     fun getErrorResource(imgType: ImageType): Int? {
         return when (imgType) {
-            ImageType.AVATAR -> R.drawable.bg_rectangle_neutral_10_user_32dp
-            ImageType.AVATAR_WITH_BACKGROUND -> R.drawable.bg_oval_neutral_30_user_32dp
+            ImageType.AVATAR -> R.drawable.bg_rectangle_placeholder_user_32dp
+            ImageType.AVATAR_WITH_BACKGROUND -> R.drawable.bg_oval_placeholder_user_32dp
             ImageType.AVATAR_WITHOUT_BACKGROUND -> R.drawable.ic_user_circle_grey_24dp
-            ImageType.BLAVATAR -> R.drawable.bg_rectangle_neutral_10_globe_32dp
+            ImageType.BLAVATAR -> R.drawable.bg_rectangle_placeholder_globe_32dp
             ImageType.IMAGE -> null // don't display any error drawable
-            ImageType.PHOTO -> R.color.neutral_0
-            ImageType.PLAN -> R.drawable.bg_oval_neutral_30_plans_32dp
+            ImageType.PHOTO -> R.color.placeholder
+            ImageType.PLAN -> R.drawable.bg_oval_placholder_plans_32dp
             ImageType.PLUGIN -> R.drawable.plugin_placeholder
-            ImageType.THEME -> R.color.neutral_0
+            ImageType.THEME -> R.color.placeholder
             ImageType.UNKNOWN -> R.drawable.ic_notice_white_24dp
             ImageType.USER -> R.drawable.ic_user_white_24dp
-            ImageType.VIDEO -> R.color.neutral_0
-            ImageType.ICON -> R.drawable.bg_rectangle_neutral_0_radius_2dp
+            ImageType.VIDEO -> R.color.placeholder
+            ImageType.ICON -> R.drawable.bg_rectangle_placeholder_radius_2dp
             ImageType.NO_PLACEHOLDER -> null
         }
     }
 
     fun getPlaceholderResource(imgType: ImageType): Int? {
         return when (imgType) {
-            ImageType.AVATAR -> R.drawable.bg_oval_neutral_0
-            ImageType.AVATAR_WITH_BACKGROUND -> R.drawable.bg_oval_neutral_30_user_32dp
+            ImageType.AVATAR -> R.drawable.bg_oval_placeholder
+            ImageType.AVATAR_WITH_BACKGROUND -> R.drawable.bg_oval_placeholder_user_32dp
             ImageType.AVATAR_WITHOUT_BACKGROUND -> R.drawable.ic_user_circle_grey_24dp
-            ImageType.BLAVATAR -> R.color.neutral_0
+            ImageType.BLAVATAR -> R.color.placeholder
             ImageType.IMAGE -> null // don't display any placeholder
-            ImageType.PHOTO -> R.color.neutral_0
-            ImageType.PLAN -> R.drawable.bg_oval_neutral_30_plans_32dp
+            ImageType.PHOTO -> R.color.placeholder
+            ImageType.PLAN -> R.drawable.bg_oval_placholder_plans_32dp
             ImageType.PLUGIN -> R.drawable.plugin_placeholder
-            ImageType.THEME -> R.drawable.bg_rectangle_neutral_10_themes_100dp
+            ImageType.THEME -> R.drawable.bg_rectangle_placeholder_themes_100dp
             ImageType.UNKNOWN -> R.drawable.legacy_dashicon_format_image_big_grey
             ImageType.USER -> R.drawable.ic_user_white_24dp
-            ImageType.VIDEO -> R.color.neutral_0
-            ImageType.ICON -> R.drawable.bg_rectangle_neutral_0_radius_2dp
+            ImageType.VIDEO -> R.color.placeholder
+            ImageType.ICON -> R.drawable.bg_rectangle_placeholder_radius_2dp
             ImageType.NO_PLACEHOLDER -> null
         }
     }

--- a/WordPress/src/main/res/drawable/bg_oval_placeholder.xml
+++ b/WordPress/src/main/res/drawable/bg_oval_placeholder.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval" >
-    <solid android:color="@color/neutral_0" />
+    <solid android:color="@color/placeholder" />
 </shape>

--- a/WordPress/src/main/res/drawable/bg_oval_placeholder_user_32dp.xml
+++ b/WordPress/src/main/res/drawable/bg_oval_placeholder_user_32dp.xml
@@ -5,10 +5,10 @@
     <item>
 
         <shape
-            android:shape="rectangle">
+            android:shape="oval">
 
             <solid
-                android:color="@color/neutral_10" >
+                android:color="@color/placeholder" >
             </solid>
 
         </shape>
@@ -16,7 +16,7 @@
     </item>
 
     <item
-        android:drawable="@drawable/ic_globe_white_24dp"
+        android:drawable="@drawable/ic_user_white_24dp"
         android:bottom="4dp"
         android:left="4dp"
         android:right="4dp"

--- a/WordPress/src/main/res/drawable/bg_oval_placholder_plans_32dp.xml
+++ b/WordPress/src/main/res/drawable/bg_oval_placholder_plans_32dp.xml
@@ -8,7 +8,7 @@
             android:shape="oval">
 
             <solid
-                android:color="@color/neutral_30" >
+                android:color="@color/placeholder" >
             </solid>
 
         </shape>
@@ -16,7 +16,7 @@
     </item>
 
     <item
-        android:drawable="@drawable/ic_user_white_24dp"
+        android:drawable="@drawable/ic_plans_white_24dp"
         android:bottom="4dp"
         android:left="4dp"
         android:right="4dp"

--- a/WordPress/src/main/res/drawable/bg_rectangle_placeholder_globe_32dp.xml
+++ b/WordPress/src/main/res/drawable/bg_rectangle_placeholder_globe_32dp.xml
@@ -5,10 +5,10 @@
     <item>
 
         <shape
-            android:shape="oval">
+            android:shape="rectangle">
 
             <solid
-                android:color="@color/neutral_30" >
+                android:color="@color/placeholder" >
             </solid>
 
         </shape>
@@ -16,7 +16,7 @@
     </item>
 
     <item
-        android:drawable="@drawable/ic_plans_white_24dp"
+        android:drawable="@drawable/ic_globe_white_24dp"
         android:bottom="4dp"
         android:left="4dp"
         android:right="4dp"

--- a/WordPress/src/main/res/drawable/bg_rectangle_placeholder_radius_2dp.xml
+++ b/WordPress/src/main/res/drawable/bg_rectangle_placeholder_radius_2dp.xml
@@ -5,7 +5,7 @@
     android:shape="rectangle">
 
     <solid
-        android:color="@color/neutral_0">
+        android:color="@color/placeholder">
     </solid>
 
     <corners

--- a/WordPress/src/main/res/drawable/bg_rectangle_placeholder_themes_100dp.xml
+++ b/WordPress/src/main/res/drawable/bg_rectangle_placeholder_themes_100dp.xml
@@ -9,7 +9,7 @@
             android:shape="rectangle" >
 
             <solid
-                android:color="@color/neutral_10" >
+                android:color="@color/placeholder" >
             </solid>
 
             <size

--- a/WordPress/src/main/res/drawable/bg_rectangle_placeholder_user_32dp.xml
+++ b/WordPress/src/main/res/drawable/bg_rectangle_placeholder_user_32dp.xml
@@ -8,7 +8,7 @@
             android:shape="rectangle">
 
             <solid
-                android:color="@color/neutral_10" >
+                android:color="@color/placeholder" >
             </solid>
 
         </shape>

--- a/WordPress/src/main/res/drawable/plugin_placeholder.xml
+++ b/WordPress/src/main/res/drawable/plugin_placeholder.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
-        <color android:color="@color/neutral_10" />
+        <color android:color="@color/placeholder" />
     </item>
     <item
         android:top="12dp"

--- a/WordPress/src/main/res/layout/activity_log_item_detail.xml
+++ b/WordPress/src/main/res/layout/activity_log_item_detail.xml
@@ -18,7 +18,7 @@
             android:layout_height="36dp"
             android:layout_marginEnd="12dp"
             android:contentDescription="@null"
-            android:src="@drawable/bg_rectangle_neutral_10_user_32dp" />
+            android:src="@drawable/bg_rectangle_placeholder_user_32dp" />
 
         <ImageView
             android:id="@+id/activityJetpackActorIcon"

--- a/WordPress/src/main/res/layout/history_list_item.xml
+++ b/WordPress/src/main/res/layout/history_list_item.xml
@@ -19,7 +19,7 @@
         android:layout_centerVertical="true"
         android:layout_margin="@dimen/activity_log_icon_margin"
         android:contentDescription="@string/description_user"
-        android:src="@drawable/bg_oval_neutral_30_user_32dp" />
+        android:src="@drawable/bg_oval_placeholder_user_32dp" />
 
     <LinearLayout
         android:id="@+id/diff_layout"

--- a/WordPress/src/main/res/layout/login_epilogue_sites_listitem.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_sites_listitem.xml
@@ -19,7 +19,7 @@
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:gravity="center_vertical"
         android:background="@drawable/blavatar_border"
-        android:src="@drawable/bg_rectangle_neutral_10_globe_32dp"
+        android:src="@drawable/bg_rectangle_placeholder_globe_32dp"
         android:contentDescription="@null"/>
 
     <LinearLayout

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -64,7 +64,7 @@
                             android:foreground="?attr/selectableItemBackgroundBorderless"
                             android:gravity="center_vertical"
                             tools:ignore="UnusedAttribute"
-                            tools:src="@drawable/bg_rectangle_neutral_10_globe_32dp" />
+                            tools:src="@drawable/bg_rectangle_placeholder_globe_32dp" />
                     </com.google.android.material.card.MaterialCardView>
 
                 </com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -58,7 +58,7 @@
                 app:badgeIconSize="@dimen/notifications_note_icon_size"
                 app:badgeVerticalOffset="@dimen/notifications_note_icon_vertical_offset"
                 tools:badgeIcon="@drawable/ic_star_white_24dp"
-                tools:src="@drawable/bg_oval_neutral_30_user_32dp" />
+                tools:src="@drawable/bg_oval_placeholder_user_32dp" />
 
             <FrameLayout
                 android:id="@+id/note_subject_container"

--- a/WordPress/src/main/res/layout/plan_details_fragment.xml
+++ b/WordPress/src/main/res/layout/plan_details_fragment.xml
@@ -22,7 +22,7 @@
             android:layout_height="@dimen/plan_icon_size"
             android:layout_gravity="center_horizontal"
             android:importantForAccessibility="no"
-            tools:src="@drawable/bg_oval_neutral_30_plans_32dp" />
+            tools:src="@drawable/bg_oval_placholder_plans_32dp" />
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/plans_list_item.xml
+++ b/WordPress/src/main/res/layout/plans_list_item.xml
@@ -15,7 +15,7 @@
         android:layout_centerVertical="true"
         android:layout_margin="@dimen/activity_log_icon_margin"
         android:importantForAccessibility="no"
-        tools:src="@drawable/bg_oval_neutral_30_plans_32dp" />
+        tools:src="@drawable/bg_oval_placholder_plans_32dp" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -32,7 +32,7 @@
                     android:id="@+id/image_banner"
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/plugin_banner_size"
-                    android:background="@color/neutral_10"
+                    android:background="@color/placeholder"
                     android:contentDescription="@string/plugin_detail_banner_desc" />
 
                 <ImageView

--- a/WordPress/src/main/res/layout/publicize_listitem_connection.xml
+++ b/WordPress/src/main/res/layout/publicize_listitem_connection.xml
@@ -13,7 +13,7 @@
         android:layout_centerVertical="true"
         android:layout_marginEnd="@dimen/margin_large"
         android:contentDescription="@null"
-        tools:src="@drawable/bg_rectangle_neutral_10_user_32dp" />
+        tools:src="@drawable/bg_rectangle_placeholder_user_32dp" />
 
     <View
         android:id="@+id/divider"

--- a/WordPress/src/main/res/layout/publicize_listitem_service.xml
+++ b/WordPress/src/main/res/layout/publicize_listitem_service.xml
@@ -13,7 +13,7 @@
         android:layout_centerVertical="true"
         android:layout_marginEnd="@dimen/margin_large"
         android:contentDescription="@null"
-        tools:src="@drawable/bg_rectangle_neutral_10_globe_32dp" />
+        tools:src="@drawable/bg_rectangle_placeholder_globe_32dp" />
 
     <View
         android:id="@+id/divider"

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -32,7 +32,7 @@
                 android:layout_centerVertical="true"
                 android:layout_marginEnd="@dimen/reader_card_avatar_margin_end"
                 android:importantForAccessibility="no"
-                android:src="@drawable/bg_rectangle_neutral_10_globe_32dp" />
+                android:src="@drawable/bg_rectangle_placeholder_globe_32dp" />
 
             <org.wordpress.android.ui.reader.views.ReaderFollowButton
                 android:id="@+id/follow_button"
@@ -169,7 +169,7 @@
                 android:layout_marginEnd="@dimen/margin_large"
                 android:background="?android:selectableItemBackground"
                 android:importantForAccessibility="no"
-                android:src="@drawable/bg_rectangle_neutral_10_user_32dp" />
+                android:src="@drawable/bg_rectangle_placeholder_user_32dp" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/text_discover"

--- a/WordPress/src/main/res/layout/reader_cardview_xpost.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_xpost.xml
@@ -29,9 +29,8 @@
                 android:layout_width="@dimen/blavatar_sz"
                 android:layout_height="@dimen/blavatar_sz"
                 android:layout_gravity="top|start"
-                android:background="@android:color/white"
                 android:importantForAccessibility="no"
-                android:src="@drawable/bg_rectangle_neutral_10_globe_32dp" />
+                android:src="@drawable/bg_rectangle_placeholder_globe_32dp" />
 
             <ImageView
                 android:id="@+id/image_avatar"
@@ -39,9 +38,8 @@
                 android:layout_gravity="bottom|end"
                 android:layout_marginStart="14dp"
                 android:layout_marginTop="14dp"
-                android:background="@android:color/white"
                 android:importantForAccessibility="no"
-                android:src="@drawable/bg_rectangle_neutral_10_user_32dp" />
+                android:src="@drawable/bg_rectangle_placeholder_user_32dp" />
         </FrameLayout>
 
         <LinearLayout

--- a/WordPress/src/main/res/layout/reader_comments_post_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_comments_post_header_view.xml
@@ -34,7 +34,7 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginEnd="@dimen/margin_medium"
                 android:contentDescription="@null"
-                tools:src="@drawable/bg_rectangle_neutral_10_user_32dp" />
+                tools:src="@drawable/bg_rectangle_placeholder_user_32dp" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/text_blog_name"

--- a/WordPress/src/main/res/layout/reader_listitem_blog.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_blog.xml
@@ -23,7 +23,7 @@
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_weight="0"
         android:contentDescription="@null"
-        tools:src="@drawable/bg_rectangle_neutral_10_globe_32dp" />
+        tools:src="@drawable/bg_rectangle_placeholder_globe_32dp" />
 
     <LinearLayout
         android:id="@+id/layout_content"

--- a/WordPress/src/main/res/layout/reader_listitem_comment.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment.xml
@@ -40,7 +40,7 @@
                 android:layout_height="@dimen/avatar_sz_extra_small"
                 android:layout_marginEnd="@dimen/margin_small"
                 android:importantForAccessibility="no"
-                tools:src="@drawable/bg_rectangle_neutral_10_user_32dp" />
+                tools:src="@drawable/bg_rectangle_placeholder_user_32dp" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/text_comment_author"

--- a/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
@@ -18,7 +18,7 @@
             android:layout_height="@dimen/reader_detail_header_blavatar"
             android:layout_gravity="top|start"
             android:contentDescription="@null"
-            tools:src="@drawable/bg_rectangle_neutral_10_globe_32dp" />
+            tools:src="@drawable/bg_rectangle_placeholder_globe_32dp" />
 
         <ImageView
             android:id="@+id/image_header_avatar"
@@ -28,7 +28,7 @@
             android:background="@drawable/bg_oval_neutral_0_stroke_white"
             android:contentDescription="@null"
             android:padding="2dp"
-            tools:src="@drawable/bg_rectangle_neutral_10_user_32dp" />
+            tools:src="@drawable/bg_rectangle_placeholder_user_32dp" />
     </FrameLayout>
 
 

--- a/WordPress/src/main/res/layout/reader_simple_post_view.xml
+++ b/WordPress/src/main/res/layout/reader_simple_post_view.xml
@@ -44,7 +44,7 @@
             android:layout_centerVertical="true"
             android:layout_marginEnd="@dimen/margin_medium"
             android:contentDescription="@null"
-            tools:src="@drawable/bg_rectangle_neutral_10_user_32dp" />
+            tools:src="@drawable/bg_rectangle_placeholder_user_32dp" />
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/reader_site_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_site_header_view.xml
@@ -23,7 +23,7 @@
             android:layout_centerVertical="true"
             android:layout_marginEnd="@dimen/reader_card_avatar_margin_end"
             android:contentDescription="@null"
-            android:src="@drawable/bg_rectangle_neutral_10_globe_32dp" />
+            android:src="@drawable/bg_rectangle_placeholder_globe_32dp" />
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/text_blog_name"

--- a/WordPress/src/main/res/layout/reader_site_search_result.xml
+++ b/WordPress/src/main/res/layout/reader_site_search_result.xml
@@ -21,7 +21,7 @@
             android:layout_width="@dimen/avatar_sz_small"
             android:layout_height="@dimen/avatar_sz_small"
             android:contentDescription="@null"
-            tools:src="@drawable/bg_rectangle_neutral_10_globe_32dp"/>
+            tools:src="@drawable/bg_rectangle_placeholder_globe_32dp"/>
 
         <RelativeLayout
             android:layout_width="0dp"

--- a/WordPress/src/main/res/layout/site_picker_listitem.xml
+++ b/WordPress/src/main/res/layout/site_picker_listitem.xml
@@ -18,11 +18,11 @@
             android:layout_height="@dimen/blavatar_sz"
             android:layout_marginStart="@dimen/site_picker_blavatar_margin_left"
             android:layout_marginEnd="@dimen/site_picker_blavatar_margin_right"
-            android:background="@android:color/white"
+            android:background="@color/placeholder"
             android:contentDescription="@string/blavatar_desc"
             android:gravity="center_vertical"
             android:padding="1dp"
-            android:src="@drawable/bg_rectangle_neutral_10_globe_32dp" />
+            android:src="@drawable/bg_rectangle_placeholder_globe_32dp" />
 
         <LinearLayout
             android:id="@+id/metadata_container"

--- a/WordPress/src/main/res/layout/stats_block_list_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_list_item.xml
@@ -77,7 +77,7 @@
             android:layout_height="@dimen/avatar_sz_small"
             android:contentDescription="@null"
             android:importantForAccessibility="no"
-            android:src="@drawable/bg_rectangle_neutral_10_globe_32dp"
+            android:src="@drawable/bg_rectangle_placeholder_globe_32dp"
             android:visibility="gone" />
     </LinearLayout>
 

--- a/WordPress/src/main/res/layout/theme_grid_item.xml
+++ b/WordPress/src/main/res/layout/theme_grid_item.xml
@@ -32,7 +32,7 @@
                     android:layout_height="wrap_content"
                     android:adjustViewBounds="true"
                     android:contentDescription="@string/theme_image_desc"
-                    tools:src="@drawable/bg_rectangle_neutral_10_themes_100dp" />
+                    tools:src="@drawable/bg_rectangle_placeholder_themes_100dp" />
 
             </FrameLayout>
 

--- a/WordPress/src/main/res/layout/wpwebview_activity.xml
+++ b/WordPress/src/main/res/layout/wpwebview_activity.xml
@@ -117,7 +117,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@+id/appbar"
-        android:background="@color/background_default"
         android:visibility="gone"
         app:aevButton="@string/retry"
         app:aevImage="@drawable/img_illustration_cloud_off_152dp"

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -17,6 +17,9 @@
         @color/primary_on_surface_disabled_selector
     </color>
 
+    <!-- Switch to attribute after dropping support for api 21-23 -->
+    <color name="placeholder">#1AFFFFFF</color>
+
     <!-- Stats -->
 
     <color name="stats_activity_very_low">@color/gray_80</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -15,6 +15,9 @@
     <color name="status_bar">@color/primary</color>
     <color name="status_bar_action_mode">@color/neutral</color>
 
+    <!-- Switch to attribute after dropping support for api 21-23 -->
+    <color name="placeholder">#1A000000</color>
+
     <!-- Stats -->
 
     <color name="stats_activity_very_low">@color/gray_0</color>


### PR DESCRIPTION
Fixes #11633

This PR updates the color of image placeholders, so they will look good in both light and dark themes.

They should look more like this:
<img width="953" alt="good" src="https://user-images.githubusercontent.com/728822/79499069-3ca37000-7fdf-11ea-97ea-bc89b7589f41.png">

And not like this:
![screenshot_20200407-130609_wordpress](https://user-images.githubusercontent.com/728822/78922979-51ff2400-7a4c-11ea-9074-4e31ff0b2150.jpg)

To test:
 I recommend downgrading network speed of your emulator and visiting following places:
- Media browser. Video placeholders are based on video, so we might not have any color there.
- Themes.
- Post list with featured images.
- Reader with featured images.
- Sites list.

Placeholders are used in a variety of places, but those are the main ones.

Technical note:
It's really hard to get themed attributes to work with Glide (and in general) on API 21-23. Because of this, we have to use regular color with alpha value baked in. This is gross, but can't be helped until we drop the support for API 21-23.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
