### PR TITLE
Fallback to featured image url in case thumbnail url is empty.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.posts
 
 import android.net.Uri
+import android.text.TextUtils
 import dagger.Reusable
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -139,7 +140,14 @@ internal class FeaturedImageHelper @Inject constructor(
         // Get max width/height for photon thumbnail - we load a smaller image so it's loaded quickly
         val maxDimen = resourceProvider.getDimension(R.dimen.post_settings_featured_image_height_min).toInt()
 
-        val mediaUri = StringUtils.notNullStr(media.thumbnailUrl)
+        val mediaUri = StringUtils.notNullStr(
+                if (TextUtils.isEmpty(media.thumbnailUrl)) {
+                    media.url
+                } else {
+                    media.thumbnailUrl
+                }
+        )
+
         val photonUrl = readerUtilsWrapper.getResizedImageUrl(
                 mediaUri,
                 maxDimen,

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
@@ -330,7 +330,6 @@ class FeaturedImageHelperTest {
 
         val media: MediaModel = mock()
         whenever(media.thumbnailUrl).thenReturn("https://testing.com/thumbnail.jpg")
-        whenever(media.url).thenReturn("https://testing.com/url.jpg")
         whenever(mediaStore.getSiteMediaWithId(anyOrNull(), anyLong())).thenReturn(media)
 
         val site = createSiteModel().apply {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
@@ -12,6 +13,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.junit.MockitoJUnitRunner
@@ -292,6 +294,58 @@ class FeaturedImageHelperTest {
         val result = featuredImageHelper.createCurrentFeaturedImageState(createSiteModel(), post)
         // Assert
         assertThat(result).matches { it.uiState == FeaturedImageState.REMOTE_IMAGE_LOADING }
+    }
+
+    @Test
+    fun `createCurrent-State uses media url when thumbnailUrl is empty`() {
+        // Arrange
+        val post: PostImmutableModel = mock()
+        whenever(post.hasFeaturedImage()).thenReturn(true)
+
+        val media: MediaModel = mock()
+        whenever(media.thumbnailUrl).thenReturn(null)
+        whenever(media.url).thenReturn("https://testing.com/url.jpg")
+        whenever(mediaStore.getSiteMediaWithId(anyOrNull(), anyLong())).thenReturn(media)
+
+        val site = createSiteModel().apply {
+            origin = SiteModel.ORIGIN_WPCOM_REST
+        }
+
+        // Act
+        featuredImageHelper.createCurrentFeaturedImageState(site, post)
+        // Assert
+        verify(readerUtilsWrapper).getResizedImageUrl(
+                eq("https://testing.com/url.jpg"),
+                anyInt(),
+                anyInt(),
+                anyBoolean()
+        )
+    }
+
+    @Test
+    fun `createCurrent-State returns uses thumbnailUrl is not empty`() {
+        // Arrange
+        val post: PostImmutableModel = mock()
+        whenever(post.hasFeaturedImage()).thenReturn(true)
+
+        val media: MediaModel = mock()
+        whenever(media.thumbnailUrl).thenReturn("https://testing.com/thumbnail.jpg")
+        whenever(media.url).thenReturn("https://testing.com/url.jpg")
+        whenever(mediaStore.getSiteMediaWithId(anyOrNull(), anyLong())).thenReturn(media)
+
+        val site = createSiteModel().apply {
+            origin = SiteModel.ORIGIN_WPCOM_REST
+        }
+
+        // Act
+        featuredImageHelper.createCurrentFeaturedImageState(site, post)
+        // Assert
+        verify(readerUtilsWrapper).getResizedImageUrl(eq(
+                "https://testing.com/thumbnail.jpg"),
+                anyInt(),
+                anyInt(),
+                anyBoolean()
+        )
     }
 
     companion object Fixtures {


### PR DESCRIPTION
Fixes #11675

In the post settings, we want to fallback to featured image url in case thumbnail url is empty. Verified this is the same approach we use in `MediaGridAdapter > getBestImageUrl` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/03da46e4b10c4c592c9248135896bc58f13903b6/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java#L150) 

## To test
- The added Unit Test should pass
- Verify you can set and see the feature image in post settings in your test environment; check the thumbnail is visible also in the post preview and on the web
- Try to set as featured image an image that do not have a thumbnail url and check you can see it in the settings and in also in the post preview and on the web (Not sure how to create a setup with this scenario, I can share access to the site I have that presents the issue eventually).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
