### PR TITLE
Set My site fragment title to 'My site' instead of using site title

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * Block editor: Fix a bug which caused to show URL settings modal randomly when changing the device orientation multiple times during the time Starter Page Template Preview is open
 * Block editor: "Choose media from device" now opens our built-in media picker instead of the OS default media picker.
 * Added user Gravatar to the Me menu in My Site.
+* Updated site details screen title to "My site", to avoid duplicating the title of the current site which is displayed in the screen's header area. 
 
 14.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -377,7 +377,7 @@ public class MySiteFragment extends Fragment implements
         setupClickListeners(rootView);
 
         mToolbar = rootView.findViewById(R.id.toolbar_main);
-        mToolbar.setTitle(mToolbarTitle);
+        mToolbar.setTitle(R.string.my_site_section_screen_title);
 
         mToolbar.inflateMenu(R.menu.my_site_menu);
 
@@ -955,9 +955,6 @@ public class MySiteFragment extends Fragment implements
         } else {
             mQuickActionButtonsContainer.setWeightSum(75f);
         }
-
-        // Refresh the title
-        setTitle(site.getName());
     }
 
     private void toggleAdminVisibility(@Nullable final SiteModel site) {
@@ -1009,12 +1006,9 @@ public class MySiteFragment extends Fragment implements
 
     @Override
     public void setTitle(@NonNull final String title) {
-        if (isAdded()) {
-            mToolbarTitle = (title.isEmpty()) ? getString(R.string.wordpress) : title;
-
-            if (mToolbar != null) {
-                mToolbar.setTitle(mToolbarTitle);
-            }
+        mToolbarTitle = title;
+        if (mToolbar != null) {
+            mToolbar.setTitle(title);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -813,12 +813,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
     }
 
     private void updateTitle(PageType pageType) {
-        if (pageType == PageType.MY_SITE && mSelectedSite != null) {
-            ((MainToolbarFragment) mBottomNav.getActiveFragment()).setTitle(mSelectedSite.getName());
-        } else {
-            ((MainToolbarFragment) mBottomNav.getActiveFragment())
-                    .setTitle(mBottomNav.getTitleForPageType(pageType).toString());
-        }
+        ((MainToolbarFragment) mBottomNav.getActiveFragment())
+                .setTitle(mBottomNav.getTitleForPageType(pageType).toString());
     }
 
     private void trackLastVisiblePage(PageType pageType, boolean trackAnalytics) {
@@ -1192,8 +1188,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
         // Make selected site visible
         selectedSite.setIsVisible(true);
         AppPrefs.setSelectedSite(selectedSite.getId());
-
-        updateTitle();
     }
 
     /**
@@ -1209,7 +1203,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
             mSelectedSite = mSiteStore.getSiteByLocalId(siteLocalId);
             // If saved site exist, then return, else (site has been removed?) try to select another site
             if (mSelectedSite != null) {
-                updateTitle();
                 return;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -808,10 +808,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
         ActivityLauncher.addNewPostForResult(this, getSelectedSite(), false, source);
     }
 
-    private void updateTitle() {
-        updateTitle(mBottomNav.getCurrentSelectedPage());
-    }
-
     private void updateTitle(PageType pageType) {
         ((MainToolbarFragment) mBottomNav.getActiveFragment())
                 .setTitle(mBottomNav.getTitleForPageType(pageType).toString());

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -45,10 +45,7 @@
     <string name="share_intent_screen_title">Pick site</string>
     <string name="edit_photo_screen_title">Edit Photo</string>
     <string name="notif_detail_screen_title">Notification detail %s</string>
-
-    <!-- default strings -->
-    <string name="wordpress" translatable="false">WordPress</string>
-
+    
     <!-- general strings -->
     <string name="posts">Posts</string>
     <string name="sites">Sites</string>


### PR DESCRIPTION
IANAAD (I Am Not An Android Developer), so please let me know if I did anything wrong! This PR is a small tweak the title of the My Site screen to always read "My site" instead of duplicating the site name, which is shown in the screen header anyway.

![site-title-android](https://user-images.githubusercontent.com/4780/79573268-44821380-80b6-11ea-8636-c63d78cb5b86.png)

To test:

* Build and run, and ensure the My Site fragment has the title "My site"
* Try selecting a different site and ensure the title stays the same

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
