### PR TITLE
Issue/11153 fix file loading error and other issues in PR #11695

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -691,7 +691,7 @@ public class PhotoPickerFragment extends Fragment {
             String stringUri = uri.toString();
             String outputFileExtension = MimeTypeMap.getFileExtensionFromUrl(stringUri);
             // TODO Add support for nullable lowResImgUrl
-            inputData.add(new EditImageData.InputData(stringUri, "", outputFileExtension));
+            inputData.add(new EditImageData.InputData(stringUri, null, outputFileExtension));
         }
         return inputData;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -12,7 +12,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.webkit.MimeTypeMap;
 import android.widget.PopupMenu;
 
 import androidx.annotation.NonNull;

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -690,7 +690,6 @@ public class PhotoPickerFragment extends Fragment {
         for (Uri uri : uris) {
             String stringUri = uri.toString();
             String outputFileExtension = MimeTypeMap.getFileExtensionFromUrl(stringUri);
-            // TODO Add support for nullable lowResImgUrl
             inputData.add(new EditImageData.InputData(stringUri, null, outputFileExtension));
         }
         return inputData;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorInitializer.kt
@@ -4,9 +4,7 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType
-import org.wordpress.android.WordPress
 import org.wordpress.android.imageeditor.ImageEditor
-import org.wordpress.android.util.MediaUtils
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageManager.RequestListener
 import org.wordpress.android.util.image.ImageType.IMAGE
@@ -60,22 +58,17 @@ class ImageEditorInitializer {
         }
 
         private fun <T : Any> onResourceReady(model: Any?, listener: ImageEditor.RequestListener<T>, resource: T) =
-                listener.onResourceReady(resource, getResourcePath(model))
-
-        private fun <T : Any> onLoadFailed(model: Any?, listener: ImageEditor.RequestListener<T>, e: Exception?) =
-                listener.onLoadFailed(e, getResourcePath(model))
-
-        private fun getResourcePath(model: Any?): String {
             if (model != null && (model is String || model is Uri)) {
-                return if (model is Uri) {
-                    val context = WordPress.getContext()
-                    MediaUtils.getRealPathFromURI(context, model)
-                } else {
-                    model as String
-                }
+                listener.onResourceReady(resource, model.toString())
             } else {
                 throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
             }
-        }
+
+        private fun <T : Any> onLoadFailed(model: Any?, listener: ImageEditor.RequestListener<T>, e: Exception?) =
+            if (model != null && (model is String || model is Uri)) {
+                listener.onLoadFailed(e, model.toString())
+            } else {
+                throw(IllegalArgumentException(IMAGE_STRING_URL_MSG))
+            }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorInitializer.kt
@@ -24,7 +24,7 @@ class ImageEditorInitializer {
 
         private fun loadIntoImageViewWithResultListener(
             imageManager: ImageManager
-        ): (String, ImageView, ScaleType, String, ImageEditor.RequestListener<Drawable>) -> Unit =
+        ): (String, ImageView, ScaleType, String?, ImageEditor.RequestListener<Drawable>) -> Unit =
                 { imageUrl, imageView, scaleType, thumbUrl, listener ->
                     imageManager.loadWithResultListener(
                         imageView,

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -208,20 +208,21 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
     }
 
     /**
-     * Loads a File from the Glide's disk cache for the provided imgUrl using asFile().
+     * Loads a File either using a file path obtained from the media store (for local images),
+     * or using Glide's disk cache (for remote images). Using Uri allows content and remote URIs to be interchangeable.
      *
      * We can use asFile() asynchronously on the ui thread or synchronously on a background thread.
      * This function uses the asynchronous api which takes a Target argument to invoke asFile().
      */
     fun loadIntoFileWithResultListener(
-        imgUrl: String,
+        imgUri: Uri,
         requestListener: RequestListener<File>
     ) {
         val context = WordPress.getContext()
         if (!context.isAvailable()) return
         GlideApp.with(context)
             .asFile()
-            .load(imgUrl)
+            .load(imgUri)
             .attachRequestListener(requestListener)
             .into(
                 // Used just to invoke asFile() and ignored thereafter.

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2740,6 +2740,7 @@
     <string name="preview_image_description">Preview Image</string>
     <string name="failed_to_load_image_tap_to_retry">Failed to load image.\nPlease tap to retry.</string>
     <string name="done">done</string>
+    <string name="error_failed_to_load_into_file">Failed to load into file, please try again.</string>
     <string name="error_failed_to_crop_and_save_image">Failed to crop and save image, please try again.</string>
     <string name="crop">crop</string>
     <string name="insert_label_with_count">Insert %d</string>

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/ImageEditor.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/ImageEditor.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.imageeditor
 
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType
 import java.io.File
@@ -9,7 +10,7 @@ class ImageEditor private constructor(
     private val loadIntoImageViewWithResultListener: (
         (String, ImageView, ScaleType, String, RequestListener<Drawable>) -> Unit
     ),
-    private val loadIntoFileWithResultListener: ((String, RequestListener<File>) -> Unit),
+    private val loadIntoFileWithResultListener: ((Uri, RequestListener<File>) -> Unit),
     private val loadIntoImageView: ((String, ImageView, ScaleType) -> Unit)
 ) {
     interface RequestListener<T> {
@@ -41,10 +42,10 @@ class ImageEditor private constructor(
     }
 
     fun loadIntoFileWithResultListener(
-        imageUrl: String,
+        imageUri: Uri,
         listener: RequestListener<File>
     ) {
-        loadIntoFileWithResultListener.invoke(imageUrl, listener)
+        loadIntoFileWithResultListener.invoke(imageUri, listener)
     }
 
     fun loadIntoImageView(imageUrl: String, imageView: ImageView, scaleType: ScaleType) {
@@ -60,7 +61,7 @@ class ImageEditor private constructor(
             loadIntoImageViewWithResultListener: (
                 (String, ImageView, ScaleType, String, RequestListener<Drawable>) -> Unit
             ),
-            loadIntoFileWithResultListener: ((String, RequestListener<File>) -> Unit),
+            loadIntoFileWithResultListener: ((Uri, RequestListener<File>) -> Unit),
             loadIntoImageView: ((String, ImageView, ScaleType) -> Unit)
         ) {
             INSTANCE = ImageEditor(

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/ImageEditor.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/ImageEditor.kt
@@ -8,7 +8,7 @@ import java.io.File
 
 class ImageEditor private constructor(
     private val loadIntoImageViewWithResultListener: (
-        (String, ImageView, ScaleType, String, RequestListener<Drawable>) -> Unit
+        (String, ImageView, ScaleType, String?, RequestListener<Drawable>) -> Unit
     ),
     private val loadIntoFileWithResultListener: ((Uri, RequestListener<File>) -> Unit),
     private val loadIntoImageView: ((String, ImageView, ScaleType) -> Unit)
@@ -35,7 +35,7 @@ class ImageEditor private constructor(
         imageUrl: String,
         imageView: ImageView,
         scaleType: ScaleType,
-        thumbUrl: String,
+        thumbUrl: String?,
         listener: RequestListener<Drawable>
     ) {
         loadIntoImageViewWithResultListener.invoke(imageUrl, imageView, scaleType, thumbUrl, listener)
@@ -59,7 +59,7 @@ class ImageEditor private constructor(
 
         fun init(
             loadIntoImageViewWithResultListener: (
-                (String, ImageView, ScaleType, String, RequestListener<Drawable>) -> Unit
+                (String, ImageView, ScaleType, String?, RequestListener<Drawable>) -> Unit
             ),
             loadIntoFileWithResultListener: ((Uri, RequestListener<File>) -> Unit),
             loadIntoImageView: ((String, ImageView, ScaleType) -> Unit)

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
@@ -31,7 +31,7 @@ class CropViewModel : ViewModel() {
     private val _navigateBackWithCropResult = MutableLiveData<CropResult>()
     val navigateBackWithCropResult: LiveData<CropResult> = _navigateBackWithCropResult
 
-    private lateinit var cacheDir: File
+    private lateinit var mediaEditingDirectory: File
     private lateinit var inputFilePath: String
     private lateinit var outputFileExtension: String
     private var isStarted = false
@@ -62,7 +62,7 @@ class CropViewModel : ViewModel() {
                 putParcelable(UCrop.EXTRA_INPUT_URI, Uri.fromFile(File(inputFilePath)))
 
                 putParcelable(UCrop.EXTRA_OUTPUT_URI, Uri.fromFile(
-                        File(cacheDir,
+                        File(mediaEditingDirectory,
                                 "$IMAGE_EDITOR_OUTPUT_IMAGE_FILE_NAME${inputFilePath.hashCode()}.$outputFileExtension"
                         )))
                 putAll(cropOptions.optionBundle)
@@ -74,7 +74,6 @@ class CropViewModel : ViewModel() {
         if (isStarted) {
             return
         }
-        this.cacheDir = cacheDir
         initMediaEditingDirectory(cacheDir)
         this.inputFilePath = inputFilePath
         this.outputFileExtension = outputFileExtension ?: DEFAULT_FILE_EXTENSION
@@ -84,8 +83,8 @@ class CropViewModel : ViewModel() {
     }
 
     private fun initMediaEditingDirectory(cacheDir: File) {
-        val directory = File(cacheDir, MEDIA_EDITING)
-        if (directory.mkdir()) {
+        mediaEditingDirectory = File(cacheDir, MEDIA_EDITING)
+        if (mediaEditingDirectory.mkdir()) {
             Log.d(TAG, "Cache directory created for media editing")
         }
     }

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -63,7 +63,7 @@ class PreviewImageFragment : Fragment() {
             @Parcelize
             data class InputData(
                 val highResImgUrl: String,
-                val lowResImgUrl: String,
+                val lowResImgUrl: String?,
                 val outputFileExtension: String
             ) : EditImageData()
 

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -53,8 +53,6 @@ class PreviewImageFragment : Fragment() {
     private lateinit var pageChangeCallback: OnPageChangeCallback
 
     private var cropActionMenu: MenuItem? = null
-    // TODO We might want to move this into the VM
-    private var numberOfImages = 0
 
     companion object {
         private val TAG = PreviewImageFragment::class.java.simpleName
@@ -151,7 +149,7 @@ class PreviewImageFragment : Fragment() {
     }
 
     private fun initializeInsertButton() {
-        insertButton.text = getString(string.insert_label_with_count, numberOfImages)
+        insertButton.text = getString(string.insert_label_with_count, viewModel.numberOfImages)
         insertButton.setOnClickListener {
             viewModel.onInsertClicked()
         }
@@ -161,7 +159,6 @@ class PreviewImageFragment : Fragment() {
         viewModel = ViewModelProvider(this).get(PreviewImageViewModel::class.java)
         setupObservers()
         val inputData = nonNullIntent.getParcelableArrayListExtra<EditImageData.InputData>(ARG_EDIT_IMAGE_DATA)
-        numberOfImages = inputData.size
 
         viewModel.onCreateView(inputData)
     }

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -14,7 +14,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.webkit.URLUtil
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType.CENTER
@@ -281,15 +280,9 @@ class PreviewImageFragment : Fragment() {
         // TODO: Temporarily added if check to fix this occasional crash
         // https://stackoverflow.com/q/51060762/193545
         if (navController.currentDestination?.id == R.id.preview_dest) {
-            val finalInputFilePath = if (URLUtil.isFileUrl(inputFilePath)) {
-                Uri.parse(inputFilePath).path as String
-            } else {
-                inputFilePath
-            }
-
             navController.navigate(
                 PreviewImageFragmentDirections.actionPreviewFragmentToCropFragment(
-                    finalInputFilePath,
+                    inputFilePath,
                     outputFileExtension,
                     shouldReturnToPreviewScreen
                 ),
@@ -305,17 +298,7 @@ class PreviewImageFragment : Fragment() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean = if (item.itemId == R.id.menu_crop) {
-        val highResImageUrl = viewModel.getHighResImageUrl(viewModel.selectedPosition)
-        val isFileUrl = URLUtil.isFileUrl(highResImageUrl)
-
-        val finalImageUrl = if (isFileUrl) {
-            Uri.parse(highResImageUrl).path as String
-        } else {
-            highResImageUrl
-        }
-
-        viewModel.onCropMenuClicked(isFileUrl, finalImageUrl)
-
+        viewModel.onCropMenuClicked()
         true
     } else {
         super.onOptionsItemSelected(item)

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -14,6 +14,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.URLUtil
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType.CENTER
@@ -280,9 +281,15 @@ class PreviewImageFragment : Fragment() {
         // TODO: Temporarily added if check to fix this occasional crash
         // https://stackoverflow.com/q/51060762/193545
         if (navController.currentDestination?.id == R.id.preview_dest) {
+            val finalInputFilePath = if (URLUtil.isFileUrl(inputFilePath)) {
+                Uri.parse(inputFilePath).path as String
+            } else {
+                inputFilePath
+            }
+
             navController.navigate(
                 PreviewImageFragmentDirections.actionPreviewFragmentToCropFragment(
-                    inputFilePath,
+                    finalInputFilePath,
                     outputFileExtension,
                     shouldReturnToPreviewScreen
                 ),
@@ -298,7 +305,17 @@ class PreviewImageFragment : Fragment() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean = if (item.itemId == R.id.menu_crop) {
-        viewModel.onCropMenuClicked(previewImageViewPager.currentItem)
+        val highResImageUrl = viewModel.getHighResImageUrl(viewModel.selectedPosition)
+        val isFileUrl = URLUtil.isFileUrl(highResImageUrl)
+
+        val finalImageUrl = if (isFileUrl) {
+            Uri.parse(highResImageUrl).path as String
+        } else {
+            highResImageUrl
+        }
+
+        viewModel.onCropMenuClicked(isFileUrl, finalImageUrl)
+
         true
     } else {
         super.onOptionsItemSelected(item)

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -246,7 +246,7 @@ class PreviewImageFragment : Fragment() {
 
     private fun loadIntoFile(url: String, position: Int) {
         ImageEditor.instance.loadIntoFileWithResultListener(
-            url,
+            Uri.parse(url),
             object : RequestListener<File> {
                 override fun onResourceReady(resource: File, url: String) {
                     viewModel.onLoadIntoFileSuccess(resource.path, position)

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -116,7 +116,7 @@ class PreviewImageFragment : Fragment() {
         val tabConfigurationStrategy = TabLayoutMediator.TabConfigurationStrategy { tab, position ->
             if (tab.customView == null) {
                 val customView = LayoutInflater.from(context)
-                        .inflate(R.layout.preview_image_thumbnail, thumbnailsTabLayout, false)
+                    .inflate(R.layout.preview_image_thumbnail, thumbnailsTabLayout, false)
                 tab.customView = customView
             }
             val imageView = (tab.customView as FrameLayout).findViewById<ImageView>(R.id.thumbnailImageView)
@@ -190,18 +190,18 @@ class PreviewImageFragment : Fragment() {
         })
 
         findNavController().currentBackStackEntry?.savedStateHandle
-                ?.getLiveData<CropResult>(CropFragment.CROP_RESULT)?.observe(
+            ?.getLiveData<CropResult>(CropFragment.CROP_RESULT)?.observe(
                 viewLifecycleOwner, Observer { result ->
-            if (result.resultCode == Activity.RESULT_OK) {
-                val data: Intent = result.data
-                if (data.hasExtra(UCrop.EXTRA_OUTPUT_URI)) {
-                    val imageUri = data.getParcelableExtra(UCrop.EXTRA_OUTPUT_URI) as? Uri
-                    imageUri?.let {
-                        viewModel.onCropResult(it.toString())
+                if (result.resultCode == Activity.RESULT_OK) {
+                    val data: Intent = result.data
+                    if (data.hasExtra(UCrop.EXTRA_OUTPUT_URI)) {
+                        val imageUri = data.getParcelableExtra(UCrop.EXTRA_OUTPUT_URI) as? Uri
+                        imageUri?.let {
+                            viewModel.onCropResult(it.toString())
+                        }
                     }
                 }
-            }
-        })
+            })
 
         viewModel.finishAction.observe(viewLifecycleOwner, Observer { event ->
             event.getContentIfNotHandled()?.let {

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiSt
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadFailedUiState
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageUiState.ImageInLowResLoadSuccessUiState
 import org.wordpress.android.imageeditor.viewmodel.Event
+import java.net.URI
 import java.util.UUID
 
 class PreviewImageViewModel : ViewModel() {
@@ -128,16 +129,18 @@ class PreviewImageViewModel : ViewModel() {
         )
     }
 
-    fun onCropMenuClicked(isFileUrl: Boolean, url: String) {
-        if (isFileUrl) {
+    fun onCropMenuClicked() {
+        val highResImageUrl = getHighResImageUrl(selectedPosition)
+
+        if (isFileUrl(highResImageUrl)) {
             onLoadIntoFileSuccess(
-                inputFilePathAtPosition = url,
+                inputFilePathAtPosition = URI(highResImageUrl).path as String,
                 position = selectedPosition
             )
         } else {
             updateLoadIntoFileState(
                 ImageStartLoadingToFileState(
-                    imageUrlAtPosition = url,
+                    imageUrlAtPosition = highResImageUrl,
                     position = selectedPosition
                 )
             )
@@ -289,8 +292,10 @@ class PreviewImageViewModel : ViewModel() {
         } ?: ""
     }
 
-    fun getHighResImageUrl(position: Int): String =
+    private fun getHighResImageUrl(position: Int): String =
         uiState.value?.viewPagerItemsStates?.get(position)?.data?.highResImageUrl ?: ""
+
+    private fun isFileUrl(url: String): Boolean = url.toLowerCase().startsWith(FILE_BASE)
 
     data class ImageData(
         val id: Long = UUID.randomUUID().hashCode().toLong(),
@@ -365,5 +370,9 @@ class PreviewImageViewModel : ViewModel() {
 
         data class ImageLoadToFileFailedState(val errorMsg: String?, val errorResId: Int) :
             ImageLoadToFileState()
+    }
+
+    companion object {
+        private const val FILE_BASE = "file:"
     }
 }

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -263,14 +263,6 @@ class PreviewImageViewModel : ViewModel() {
 
     private fun List<ImageUiState>.hasSingleElement() = this.size == 1
 
-    private fun ImageData.hasValidLowResImageUrlEqualTo(imageUrl: String): Boolean {
-        val hasValidLowResImageUrl = this.lowResImageUrl?.isNotEmpty() == true &&
-            this.lowResImageUrl != this.highResImageUrl
-        val isGivenUrlEqualToLowResImageUrl = imageUrl == this.lowResImageUrl
-
-        return hasValidLowResImageUrl && isGivenUrlEqualToLowResImageUrl
-    }
-
     fun onInsertClicked() {
         val outputData = uiState.value?.viewPagerItemsStates?.map { OutputData(it.data.highResImageUrl) }
                 ?: emptyList()
@@ -291,7 +283,15 @@ class PreviewImageViewModel : ViewModel() {
         val lowResImageUrl: String?,
         val highResImageUrl: String,
         val outputFileExtension: String
-    )
+    ) {
+        fun hasValidLowResImageUrlEqualTo(imageUrl: String): Boolean {
+            val hasValidLowResImageUrl = this.lowResImageUrl?.isNotEmpty() == true &&
+                this.lowResImageUrl != this.highResImageUrl
+            val isGivenUrlEqualToLowResImageUrl = imageUrl == this.lowResImageUrl
+
+            return hasValidLowResImageUrl && isGivenUrlEqualToLowResImageUrl
+        }
+    }
 
     data class UiState(
         val viewPagerItemsStates: List<ImageUiState>,

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -33,7 +33,8 @@ class PreviewImageViewModel : ViewModel() {
     private val _finishAction = MutableLiveData<Event<List<OutputData>>>()
     val finishAction: LiveData<Event<List<OutputData>>> = _finishAction
 
-    private var selectedPosition: Int = 0
+    var selectedPosition: Int = 0
+        private set
 
     var numberOfImages = 0
         private set
@@ -127,14 +128,20 @@ class PreviewImageViewModel : ViewModel() {
         )
     }
 
-    fun onCropMenuClicked(selectedPosition: Int) {
-        val selectedImageState = (uiState.value as UiState).viewPagerItemsStates[selectedPosition]
-        updateLoadIntoFileState(
-            ImageStartLoadingToFileState(
-                imageUrlAtPosition = selectedImageState.data.highResImageUrl,
+    fun onCropMenuClicked(isFileUrl: Boolean, url: String) {
+        if (isFileUrl) {
+            onLoadIntoFileSuccess(
+                inputFilePathAtPosition = url,
                 position = selectedPosition
             )
-        )
+        } else {
+            updateLoadIntoFileState(
+                ImageStartLoadingToFileState(
+                    imageUrlAtPosition = url,
+                    position = selectedPosition
+                )
+            )
+        }
     }
 
     fun onPageSelected(selectedPosition: Int) {
@@ -281,6 +288,9 @@ class PreviewImageViewModel : ViewModel() {
                 imageData.lowResImageUrl as String
         } ?: ""
     }
+
+    fun getHighResImageUrl(position: Int): String =
+        uiState.value?.viewPagerItemsStates?.get(position)?.data?.highResImageUrl ?: ""
 
     data class ImageData(
         val id: Long = UUID.randomUUID().hashCode().toLong(),

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -28,7 +28,7 @@ class PreviewImageViewModel : ViewModel() {
 
     private val _navigateToCropScreenWithFileInfo = MutableLiveData<Event<Triple<String, String?, Boolean>>>()
     val navigateToCropScreenWithFileInfo: LiveData<Event<Triple<String, String?, Boolean>>> =
-            _navigateToCropScreenWithFileInfo
+        _navigateToCropScreenWithFileInfo
 
     private val _finishAction = MutableLiveData<Event<List<OutputData>>>()
     val finishAction: LiveData<Event<List<OutputData>>> = _finishAction
@@ -43,7 +43,7 @@ class PreviewImageViewModel : ViewModel() {
 
         if (uiState.value == null) {
             val newImageUiStates = createViewPagerItemsInitialUiStates(
-                    convertInputDataToImageData(imageDataList)
+                convertInputDataToImageData(imageDataList)
             )
             val currentUiState = UiState(
                 newImageUiStates,
@@ -55,13 +55,13 @@ class PreviewImageViewModel : ViewModel() {
 
     private fun convertInputDataToImageData(imageDataList: List<InputData>): List<ImageData> {
         return imageDataList
-                .map { (highRes, lowRes, extension) ->
-                    ImageData(
-                            highResImageUrl = highRes,
-                            lowResImageUrl = lowRes,
-                            outputFileExtension = extension
-                    )
-                }
+            .map { (highRes, lowRes, extension) ->
+                ImageData(
+                    highResImageUrl = highRes,
+                    lowResImageUrl = lowRes,
+                    outputFileExtension = extension
+                )
+            }
     }
 
     fun onLoadIntoImageViewSuccess(imageUrlAtPosition: String, position: Int) {
@@ -86,7 +86,8 @@ class PreviewImageViewModel : ViewModel() {
             currentUiState.editActionsEnabled
         }
 
-        updateUiState(currentUiState.copy(
+        updateUiState(
+            currentUiState.copy(
                 viewPagerItemsStates = newImageUiStates,
                 editActionsEnabled = enableEditActions
             )
@@ -118,9 +119,11 @@ class PreviewImageViewModel : ViewModel() {
     }
 
     fun onLoadIntoFileFailed(exception: Exception?) {
-        updateLoadIntoFileState(ImageLoadToFileFailedState(
-            exception?.message,
-            R.string.error_failed_to_load_into_file)
+        updateLoadIntoFileState(
+            ImageLoadToFileFailedState(
+                exception?.message,
+                R.string.error_failed_to_load_into_file
+            )
         )
     }
 
@@ -139,7 +142,8 @@ class PreviewImageViewModel : ViewModel() {
         val currentUiState = uiState.value as UiState
         val imageStateAtPosition = currentUiState.viewPagerItemsStates[selectedPosition]
 
-        updateUiState(currentUiState.copy(
+        updateUiState(
+            currentUiState.copy(
                 editActionsEnabled = shouldEnableEditActionsForImageState(imageStateAtPosition)
             )
         )
@@ -256,7 +260,7 @@ class PreviewImageViewModel : ViewModel() {
     }
 
     private fun shouldEnableEditActionsForImageState(imageState: ImageUiState) =
-            imageState is ImageInHighResLoadSuccessUiState
+        imageState is ImageInHighResLoadSuccessUiState
 
     // TODO: revisit
     private fun canLoadToFile(imageState: ImageUiState) = imageState is ImageInHighResLoadSuccessUiState
@@ -265,7 +269,7 @@ class PreviewImageViewModel : ViewModel() {
 
     fun onInsertClicked() {
         val outputData = uiState.value?.viewPagerItemsStates?.map { OutputData(it.data.highResImageUrl) }
-                ?: emptyList()
+            ?: emptyList()
         _finishAction.value = Event(outputData)
     }
 
@@ -305,29 +309,34 @@ class PreviewImageViewModel : ViewModel() {
         val retryLayoutVisible: Boolean
     ) {
         var onItemTapped: (() -> Unit)? = null
+
         data class ImageDataStartLoadingUiState(val imageData: ImageData) : ImageUiState(
             data = imageData,
             progressBarVisible = true,
             retryLayoutVisible = false
         )
+
         // Continue displaying progress bar on low res image load success
-        data class ImageInLowResLoadSuccessUiState(val imageData: ImageData, val isRetryShown: Boolean = false)
-            : ImageUiState(
-            data = imageData,
-            progressBarVisible = !isRetryShown,
-            retryLayoutVisible = isRetryShown
-        )
+        data class ImageInLowResLoadSuccessUiState(val imageData: ImageData, val isRetryShown: Boolean = false) :
+            ImageUiState(
+                data = imageData,
+                progressBarVisible = !isRetryShown,
+                retryLayoutVisible = isRetryShown
+            )
+
         data class ImageInLowResLoadFailedUiState(val imageData: ImageData, val isRetryShown: Boolean = false) :
             ImageUiState(
-            data = imageData,
-            progressBarVisible = true,
-            retryLayoutVisible = false
-        )
+                data = imageData,
+                progressBarVisible = true,
+                retryLayoutVisible = false
+            )
+
         data class ImageInHighResLoadSuccessUiState(val imageData: ImageData) : ImageUiState(
             data = imageData,
             progressBarVisible = false,
             retryLayoutVisible = false
         )
+
         // Display retry only when high res image load failed
         data class ImageInHighResLoadFailedUiState(val imageData: ImageData) : ImageUiState(
             data = imageData,
@@ -339,10 +348,12 @@ class PreviewImageViewModel : ViewModel() {
     sealed class ImageLoadToFileState {
         object ImageLoadToFileIdleState : ImageLoadToFileState()
         data class ImageStartLoadingToFileState(val imageUrlAtPosition: String, val position: Int) :
-                ImageLoadToFileState()
+            ImageLoadToFileState()
+
         data class ImageLoadToFileSuccessState(val filePathAtPosition: String, val position: Int) :
-                ImageLoadToFileState()
+            ImageLoadToFileState()
+
         data class ImageLoadToFileFailedState(val errorMsg: String?, val errorResId: Int) :
-                ImageLoadToFileState()
+            ImageLoadToFileState()
     }
 }

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -4,6 +4,7 @@ import android.text.TextUtils
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.imageeditor.R
 import org.wordpress.android.imageeditor.preview.PreviewImageFragment.Companion.EditImageData.InputData
 import org.wordpress.android.imageeditor.preview.PreviewImageFragment.Companion.EditImageData.OutputData
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageLoadToFileState.ImageLoadToFileFailedState
@@ -111,9 +112,11 @@ class PreviewImageViewModel : ViewModel() {
         )
     }
 
-    fun onLoadIntoFileFailed() {
-        // TODO: Do we need to display any error message to the user?
-        updateLoadIntoFileState(ImageLoadToFileFailedState)
+    fun onLoadIntoFileFailed(exception: Exception?) {
+        updateLoadIntoFileState(ImageLoadToFileFailedState(
+            exception?.message,
+            R.string.error_failed_to_load_into_file)
+        )
     }
 
     fun onCropMenuClicked(selectedPosition: Int) {
@@ -323,6 +326,7 @@ class PreviewImageViewModel : ViewModel() {
                 ImageLoadToFileState()
         data class ImageLoadToFileSuccessState(val filePathAtPosition: String, val position: Int) :
                 ImageLoadToFileState()
-        object ImageLoadToFileFailedState : ImageLoadToFileState()
+        data class ImageLoadToFileFailedState(val errorMsg: String?, val errorResId: Int) :
+                ImageLoadToFileState()
     }
 }

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -197,9 +197,9 @@ class PreviewImageViewModel : ViewModel() {
         val imageStateAtPosition = currentUiState.viewPagerItemsStates[position]
         val imageDataAtPosition = imageStateAtPosition.data
         return when {
-            loadSuccess -> createImageLoadSuccessUiState(imageUrlAtPosition, imageDataAtPosition, imageStateAtPosition)
+            loadSuccess -> createImageLoadSuccessUiState(imageUrlAtPosition, imageStateAtPosition)
             retry -> createImageLoadStartUiState(imageDataAtPosition)
-            else -> createImageLoadFailedUiState(imageUrlAtPosition, imageDataAtPosition, position)
+            else -> createImageLoadFailedUiState(imageUrlAtPosition, imageStateAtPosition, position)
         }
     }
 
@@ -211,9 +211,9 @@ class PreviewImageViewModel : ViewModel() {
 
     private fun createImageLoadSuccessUiState(
         imageUrl: String,
-        imageData: ImageData,
         imageState: ImageUiState
     ): ImageUiState {
+        val imageData = imageState.data
         return if (imageData.hasValidLowResImageUrlEqualTo(imageUrl)) {
             val isHighResImageAlreadyLoaded = imageState is ImageInHighResLoadSuccessUiState
             if (!isHighResImageAlreadyLoaded) {
@@ -229,11 +229,13 @@ class PreviewImageViewModel : ViewModel() {
 
     private fun createImageLoadFailedUiState(
         imageUrlAtPosition: String,
-        imageDataAtPosition: ImageData,
+        imageStateAtPosition: ImageUiState,
         position: Int
     ): ImageUiState {
+        val imageDataAtPosition = imageStateAtPosition.data
         val imageUiState = if (imageDataAtPosition.hasValidLowResImageUrlEqualTo(imageUrlAtPosition)) {
-            ImageInLowResLoadFailedUiState(imageDataAtPosition)
+            val isRetryShown = imageStateAtPosition is ImageInHighResLoadFailedUiState
+            ImageInLowResLoadFailedUiState(imageDataAtPosition, isRetryShown)
         } else {
             ImageInHighResLoadFailedUiState(imageDataAtPosition)
         }
@@ -315,7 +317,8 @@ class PreviewImageViewModel : ViewModel() {
             progressBarVisible = !isRetryShown,
             retryLayoutVisible = isRetryShown
         )
-        data class ImageInLowResLoadFailedUiState(val imageData: ImageData) : ImageUiState(
+        data class ImageInLowResLoadFailedUiState(val imageData: ImageData, val isRetryShown: Boolean = false) :
+            ImageUiState(
             data = imageData,
             progressBarVisible = true,
             retryLayoutVisible = false

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -35,7 +35,12 @@ class PreviewImageViewModel : ViewModel() {
 
     private var selectedPosition: Int = 0
 
+    var numberOfImages = 0
+        private set
+
     fun onCreateView(imageDataList: List<InputData>) {
+        this.numberOfImages = imageDataList.size
+
         if (uiState.value == null) {
             val newImageUiStates = createViewPagerItemsInitialUiStates(
                     convertInputDataToImageData(imageDataList)

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageViewModel.kt
@@ -214,7 +214,7 @@ class PreviewImageViewModel : ViewModel() {
         imageData: ImageData,
         imageState: ImageUiState
     ): ImageUiState {
-        return if (imageUrl == imageData.lowResImageUrl) {
+        return if (imageData.hasValidLowResImageUrlEqualTo(imageUrl)) {
             val isHighResImageAlreadyLoaded = imageState is ImageInHighResLoadSuccessUiState
             if (!isHighResImageAlreadyLoaded) {
                 val isRetryShown = imageState is ImageInHighResLoadFailedUiState
@@ -232,7 +232,7 @@ class PreviewImageViewModel : ViewModel() {
         imageDataAtPosition: ImageData,
         position: Int
     ): ImageUiState {
-        val imageUiState = if (imageUrlAtPosition == imageDataAtPosition.lowResImageUrl) {
+        val imageUiState = if (imageDataAtPosition.hasValidLowResImageUrlEqualTo(imageUrlAtPosition)) {
             ImageInLowResLoadFailedUiState(imageDataAtPosition)
         } else {
             ImageInHighResLoadFailedUiState(imageDataAtPosition)
@@ -261,6 +261,14 @@ class PreviewImageViewModel : ViewModel() {
 
     private fun List<ImageUiState>.hasSingleElement() = this.size == 1
 
+    private fun ImageData.hasValidLowResImageUrlEqualTo(imageUrl: String): Boolean {
+        val hasValidLowResImageUrl = this.lowResImageUrl?.isNotEmpty() == true &&
+            this.lowResImageUrl != this.highResImageUrl
+        val isGivenUrlEqualToLowResImageUrl = imageUrl == this.lowResImageUrl
+
+        return hasValidLowResImageUrl && isGivenUrlEqualToLowResImageUrl
+    }
+
     fun onInsertClicked() {
         val outputData = uiState.value?.viewPagerItemsStates?.map { OutputData(it.data.highResImageUrl) }
                 ?: emptyList()
@@ -272,13 +280,13 @@ class PreviewImageViewModel : ViewModel() {
             return if (TextUtils.isEmpty(imageData.lowResImageUrl))
                 imageData.highResImageUrl
             else
-                imageData.lowResImageUrl
+                imageData.lowResImageUrl as String
         } ?: ""
     }
 
     data class ImageData(
         val id: Long = UUID.randomUUID().hashCode().toLong(),
-        val lowResImageUrl: String,
+        val lowResImageUrl: String?,
         val highResImageUrl: String,
         val outputFileExtension: String
     )

--- a/libs/image-editor/ImageEditor/src/main/res/values/strings.xml
+++ b/libs/image-editor/ImageEditor/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="retry">Retry</string>
     <string name="failed_to_load_image_tap_to_retry">Failed to load image.\nPlease tap to retry.</string>
     <string name="insert_label_with_count">Insert %d</string>
+    <string name="error_failed_to_load_into_file">Failed to load into file, please try again.</string>
 
     <!--crop screen-->
     <string name="crop">crop</string>


### PR DESCRIPTION
Merge instructions:

1. Review the code and test the changes
2. Make sure #11695 is merged to `feature/media-editing-phase-two `
3. Update target branch to `feature/media-editing-phase-two `
4. Merge the PR

This PR fixes below issues mentioned in #11695 as part of #11153

- [x] Fixes file loading error and displays the error mentioned in #11695 description:

> When the PreviewImage flow is started with images saved in local storage, Glide's asFile() method returns an error - nothing happens after you click on "Crop" action in the Toolbar. We probably shouldn't even call asFile() on local images, wdyt? Moreover, we probably should show a snackbar and show an error to the user when asFile fails.

- [x] Moves numberOfImages logic to VM as requested [here](https://github.com/wordpress-mobile/WordPress-Android/pull/11695#discussion_r410845460). cfe8cdf 
- [x] Supports null `lowResImageUrl` as asked [here](https://github.com/wordpress-mobile/WordPress-Android/pull/11695#discussion_r410844619). 94ca331

    Please consider making necessary changes here: 
    https://github.com/wordpress-mobile/WordPress-Android/commit/39074c2c389829057318343b297a3d7d364d469b#diff-681fa96c5b5159766b71b0b1aa778ca6R534-R536.    Changed here: 9d7452e


It also fixes these additional issues:
- [x] Crop result propagation issue (cropped result for "last selected image" was set on navigating back  from crop screen without cropping the "current selected image") 03bb133
- [x] Load to file issue on trying to crop an already cropped image 8c4ad7a

Note:
Tests are being included in another PR #11690.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
