### PR TITLE
Speed up suggestion insertion by using a single transaction

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/SuggestionTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/SuggestionTable.java
@@ -56,11 +56,16 @@ public class SuggestionTable {
         // we want to delete the current suggestions, so that removed users will not show up as a suggestion
         deleteSuggestionsForSite(siteId);
 
+        // Including the insertion of all suggestions in a single transaction dramatically improves insertion
+        // performance when there are a lot of suggestions
+        getWritableDb().beginTransaction();
         if (suggestions != null) {
             for (Suggestion suggestion : suggestions) {
                 addSuggestion(suggestion);
             }
         }
+        getWritableDb().setTransactionSuccessful();
+        getWritableDb().endTransaction();
     }
 
     public static void addSuggestion(final Suggestion suggestion) {


### PR DESCRIPTION
When adding @-mention support [for Gutenberg](https://github.com/wordpress-mobile/WordPress-Android/pull/11693), I noticed that it was taking a really long time for mentions to appear the first time for a site. Part of this is due to the API call taking 3-6 seconds when there are 1500+ users on the site (a site with only a single user responded in around 300ms).

Most of the delay was due to the time it took for the data to be inserted in the database one entry at a time. On my device, inserting 1500+ suggestions for a site took ~16 seconds after the API call returned the data. This PR wraps all those insertions into a single transaction which reduced the insertion time down to under 300 milliseconds in my tests. 

This change is important for Gutenberg because we are going to be using this for a UI that is only used for providing suggestions. Having that UI not work for >20 seconds the first time it is loaded is obviously an awful user experience.

### Testing
1. Switch to a site you have not used on your device before (or wipe the app data).
2. Open the comments for that site
3. Tap on a comment
4. Tap on the field for replying to a comment
5. Note that the suggestions API call is initiated and that once it completes you almost immediately (< 300ms) see autocomplete suggestions when you type `@` immediately followed by a single letter (until that point there won't be any suggestions available). Given how long the API call itself can take, I would suggest watching it using Stetho, Charles, or adding a log message to `SuggestionService::handleSuggestionsUpdatedResponse` so you know exactly when suggestions should be available.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
