### PR TITLE
Revert "Update media insertion to send caption information."

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -833,10 +833,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             int mediaId = isNetworkUrl ? Integer.valueOf(mediaEntry.getValue().getMediaId())
                     : mediaEntry.getValue().getId();
             String url = isNetworkUrl ? mediaEntry.getKey() : "file://" + mediaEntry.getKey();
-            rnMediaList.add(createRNMediaUsingMimeType(mediaId,
-                    url,
-                    mediaEntry.getValue().getMimeType(),
-                    mediaEntry.getValue().getCaption()));
+            rnMediaList.add(createRNMediaUsingMimeType(mediaId, url, mediaEntry.getValue().getMimeType()));
         }
 
         getGutenbergContainerFragment().appendUploadMediaFiles(rnMediaList);


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-Android#11670

We are reverting the change so that the 14.7 release branch has the correct gutenberg-mobile reference corresponding to the Gutenberg-Mobile v1.26.0 Editor release

Proper gb-mobile ref should be 315a213f1ae70e670213d2369933d2725f4a72f4
https://github.com/wordpress-mobile/gutenberg-mobile/commits/master