### PR TITLE
Unified Login & Sign-Up: Create Sign-Up From Login functionality for Email + Magic Link method

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -80,6 +80,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private String mRequestedEmail;
     private boolean mIsSocialLogin;
     private Integer mCurrentEmailErrorRes = null;
+    private boolean mIsSignupFromLoginEnabled = true;
 
     protected WPLoginInputRow mEmailInput;
     protected boolean mHasDismissedEmailHints;
@@ -227,7 +228,8 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
 
     @Override
     protected void setupBottomButtons(Button secondaryButton, Button primaryButton) {
-        if (mLoginListener.getLoginMode() == LoginMode.JETPACK_STATS) {
+        // Show Sign-Up button if login mode is Jetpack and signup from login is not enabled
+        if (mLoginListener.getLoginMode() == LoginMode.JETPACK_STATS && !mIsSignupFromLoginEnabled) {
             secondaryButton.setText(Html.fromHtml(String.format(getResources().getString(
                     R.string.login_email_button_signup), "<u>", "</u>")));
             secondaryButton.setOnClickListener(new OnClickListener() {
@@ -458,9 +460,13 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         switch (event.type) {
             case EMAIL:
                 if (event.isAvailable) {
-                    // email address is available on wpcom, so apparently the user can't login with that one.
-                    ActivityUtils.hideKeyboardForced(mEmailInput);
-                    showEmailError(R.string.email_not_registered_wpcom);
+                    if (mIsSignupFromLoginEnabled) {
+                        mLoginListener.showSignupMagicLink(event.value);
+                    } else {
+                        // email address is available on wpcom, so apparently the user can't login with that one.
+                        ActivityUtils.hideKeyboardForced(mEmailInput);
+                        showEmailError(R.string.email_not_registered_wpcom);
+                    }
                 } else if (mLoginListener != null) {
                     ActivityUtils.hideKeyboardForced(mEmailInput);
                     mLoginListener.gotWpcomEmail(event.value, false);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -70,6 +70,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private static final int EMAIL_CREDENTIALS_REQUEST_CODE = 25100;
 
     private static final String ARG_LOGIN_SITE_URL = "ARG_LOGIN_SITE_URL";
+    private static final String ARG_SIGNUP_FROM_LOGIN_ENABLED = "ARG_SIGNUP_FROM_LOGIN_ENABLED";
 
     public static final String TAG = "login_email_fragment_tag";
     public static final int MAX_EMAIL_LENGTH = 100;
@@ -80,7 +81,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private String mRequestedEmail;
     private boolean mIsSocialLogin;
     private Integer mCurrentEmailErrorRes = null;
-    private boolean mIsSignupFromLoginEnabled = true;
+    private boolean mIsSignupFromLoginEnabled;
 
     protected WPLoginInputRow mEmailInput;
     protected boolean mHasDismissedEmailHints;
@@ -91,6 +92,14 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         LoginEmailFragment fragment = new LoginEmailFragment();
         Bundle args = new Bundle();
         args.putString(ARG_LOGIN_SITE_URL, url);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    public static LoginEmailFragment newInstance(boolean isSignupFromLoginEnabled) {
+        LoginEmailFragment fragment = new LoginEmailFragment();
+        Bundle args = new Bundle();
+        args.putBoolean(ARG_SIGNUP_FROM_LOGIN_ENABLED, isSignupFromLoginEnabled);
         fragment.setArguments(args);
         return fragment;
     }
@@ -286,6 +295,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         Bundle args = getArguments();
         if (args != null) {
             mLoginSiteUrl = args.getString(ARG_LOGIN_SITE_URL, "");
+            mIsSignupFromLoginEnabled = args.getBoolean(ARG_SIGNUP_FROM_LOGIN_ENABLED, false);
         }
     }
 


### PR DESCRIPTION
Part of #11705

## To test

### Full Flow
0. Clear app data.
1. On the Prologue Screen, tap **Log In**.
2. If the Smart Lock dialog appears, dismiss it.
3. On the Email Screen, enter an email address that **_is not_** associated with a WordPress.com account.
4. Tap **Next**.
5. Notice the Sign-Up Magic Link screen.
6. Check email inbox of address used in Step 3.
7. Notice signup email from WordPress.com.
8. Complete the sign-up flow normally.

### Jetpack Flow
0. Log in with a self-hosted site that **_is not_** associated with a WordPress.com account.
1. Go to **My Site** tab and tap **Stats** (or go to **Notifications** tab).
2. Tap the **Install Jetpack** button.
3. If the Smart Lock dialog appears, dismiss it.
4. On the Email Screen, notice there's no **Don't have an account? Sign up** button.
5. Enter an email address that is not associated with a WordPress.com account.
6. Tap **Next**.
7. Notice the Sign-Up Magic Link screen.
8. Check email inbox of address used in Step 3.
9. Notice signup email from WordPress.com.
10. Complete the sign-up flow normally.

## Notes
- This doesn't add the Sign-Up From Login functionality for the Google Sign-In method just yet. This will be done in the following PR.
- This also doesn't remove the Sign-Up button from the Prologue screen. This will be addressed in a future task.
- Lastly, this also doesn't change the current labels used by the flows, so it may not always make sense.
- This PR make changes to the LoginFlow library. These changes will probably need to be merged to the LoginFlow library once our feature branch gets merged back to develop.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
