### PR TITLE
Reblog feature: small customization of site picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -39,6 +39,7 @@ import org.wordpress.android.viewmodel.domains.DomainRegistrationDetailsViewMode
 import org.wordpress.android.viewmodel.domains.DomainSuggestionsViewModel;
 import org.wordpress.android.viewmodel.gif.GifPickerViewModel;
 import org.wordpress.android.viewmodel.history.HistoryViewModel;
+import org.wordpress.android.viewmodel.main.SitePickerViewModel;
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel;
 import org.wordpress.android.viewmodel.pages.PageListViewModel;
 import org.wordpress.android.viewmodel.pages.PageParentSearchViewModel;
@@ -275,6 +276,12 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(PageParentSearchViewModel.class)
     abstract ViewModel pageParentSearchViewModel(PageParentSearchViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(SitePickerViewModel.class)
+    abstract ViewModel sitePickerViewModel(SitePickerViewModel viewModel);
+
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -45,7 +45,7 @@ import org.wordpress.android.ui.history.HistoryDetailContainerFragment;
 import org.wordpress.android.ui.history.HistoryListItem.Revision;
 import org.wordpress.android.ui.main.MeActivity;
 import org.wordpress.android.ui.main.SitePickerActivity;
-import org.wordpress.android.ui.main.SitePickerActivity.SitePickerMode;
+import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
@@ -132,7 +132,7 @@ public class ActivityLauncher {
      * @param site     the preselected site
      */
     public static void showSitePickerForResult(Activity activity, SiteModel site) {
-        Intent intent = createSitePickerIntent(activity, site, SitePickerMode.NORMAL);
+        Intent intent = createSitePickerIntent(activity, site, SitePickerMode.DEFAULT_MODE);
         activity.startActivityForResult(intent, RequestCodes.SITE_PICKER);
     }
 
@@ -159,7 +159,7 @@ public class ActivityLauncher {
     private static Intent createSitePickerIntent(Context context, SiteModel site, SitePickerMode mode) {
         Intent intent = new Intent(context, SitePickerActivity.class);
         intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, site.getId());
-        intent.putExtra(SitePickerActivity.SITE_PICKER_MODE, mode);
+        intent.putExtra(SitePickerActivity.KEY_SITE_PICKER_MODE, mode);
         return intent;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -142,19 +142,16 @@ public class SitePickerActivity extends LocaleAwareActivity
                                 if (site != null) {
                                     mReblogActionMode.setTitle(site.getBlogNameOrHomeURL());
                                 }
-
                                 break;
                             case TO_NO_SITE_SELECTED:
                                 mSitePickerMode = SitePickerMode.REBLOG_SELECT_MODE;
                                 getAdapter().clearReblogSelection();
                                 break;
                         }
-
                         break;
                     case CONTINUE_REBLOG_TO:
                         SiteRecord siteToReblog = ((ContinueReblogTo) action).getSiteForReblog();
                         selectSiteAndFinish(siteToReblog);
-
                         break;
                     case ASK_FOR_SITE_SELECTION:
                         if (BuildConfig.DEBUG) {
@@ -168,7 +165,6 @@ public class SitePickerActivity extends LocaleAwareActivity
                             );
                             ToastUtils.showToast(this, R.string.site_picker_ask_site_select);
                         }
-
                         break;
                 }
                 return null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -401,6 +401,13 @@ public class SitePickerActivity extends LocaleAwareActivity
                     @Override
                     public void onAfterLoad() {
                         showProgress(false);
+                        if (mSitePickerMode == SitePickerMode.REBLOG_CONTINUE_MODE && !isInSearchMode) {
+                            mAdapter.findAndSelect(mCurrentLocalId);
+                            int scrollPos = mAdapter.getItemPosByLocalId(mCurrentLocalId);
+                            if (scrollPos > -1 && mRecycleView != null) {
+                                mRecycleView.scrollToPosition(scrollPos);
+                            }
+                        }
                     }
                 },
                 mSitePickerMode);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -5,6 +5,7 @@ import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -96,6 +97,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     private SitePickerMode mSitePickerMode;
     private Debouncer mDebouncer = new Debouncer();
     private SitePickerViewModel mViewModel;
+    private float mDisabledOpacity;
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -121,6 +123,10 @@ public class SitePickerActivity extends LocaleAwareActivity
         }
 
         if (mSitePickerMode.isReblogMode()) {
+            TypedValue disabledAlpha = new TypedValue();
+            this.getResources().getValue(R.dimen.material_emphasis_disabled, disabledAlpha, true);
+            mDisabledOpacity = disabledAlpha.getFloat();
+
             mViewModel.getOnReblogActionTriggered().observe(
                     this,
                     unitEvent -> unitEvent.applyIfNotHandled(reblogAction -> {
@@ -210,6 +216,11 @@ public class SitePickerActivity extends LocaleAwareActivity
 
         mMenuContinue.setVisible(mSitePickerMode.isReblogMode() && !getAdapter().getIsInSearchMode());
         mMenuContinue.setEnabled(mViewModel.isReblogSiteSelected());
+
+
+        if (mSitePickerMode.isReblogMode()) {
+            mMenuContinue.getIcon().mutate().setAlpha(mSitePickerMode == SitePickerMode.REBLOG_SELECT_MODE ? (int) (mDisabledOpacity * 255) : 255);
+        }
 
         // no point showing search if there aren't multiple blogs
         mMenuSearch.setVisible(mSiteStore.getSitesCount() > 1);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -219,7 +219,9 @@ public class SitePickerActivity extends LocaleAwareActivity
 
 
         if (mSitePickerMode.isReblogMode()) {
-            mMenuContinue.getIcon().mutate().setAlpha(mSitePickerMode == SitePickerMode.REBLOG_SELECT_MODE ? (int) (mDisabledOpacity * 255) : 255);
+            mMenuContinue.getIcon().mutate().setAlpha(
+                    mSitePickerMode == SitePickerMode.REBLOG_SELECT_MODE ? (int) (mDisabledOpacity * 255) : 255
+            );
         }
 
         // no point showing search if there aren't multiple blogs

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -194,7 +194,8 @@ public class SitePickerActivity extends LocaleAwareActivity
     }
 
     private void updateMenuItemVisibility() {
-        if (mMenuAdd == null || mMenuEdit == null || mMenuSearch == null || mMenuContinue == null || mViewModel == null) {
+        if (mMenuAdd == null || mMenuEdit == null || mMenuSearch == null
+            || mMenuContinue == null || mViewModel == null) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -148,8 +148,8 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              OnDataLoadedListener dataLoadedListener,
                              SitePickerMode sitePickerMode
     ) {
-        this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener, null,
-                null, sitePickerMode);
+        this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener,
+                null, null, sitePickerMode);
     }
 
     public SitePickerAdapter(Context context,
@@ -161,8 +161,8 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              HeaderHandler headerHandler,
                              ArrayList<Integer> ignoreSitesIds
     ) {
-        this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener, null,
-                null, SitePickerMode.DEFAULT_MODE);
+        this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener,
+                headerHandler, ignoreSitesIds, SitePickerMode.DEFAULT_MODE);
     }
 
     public SitePickerAdapter(Context context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -516,6 +516,11 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
     }
 
+    void clearReblogSelection() {
+        mSitePickerMode = SitePickerMode.REBLOG_SELECT_MODE;
+        notifyDataSetChanged();
+    }
+
     private SiteList getSelectedSites() {
         SiteList sites = new SiteList();
         if (!mIsMultiSelectEnabled) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -387,6 +387,12 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         return mSites.size() != 0 ? getItem(mSelectedItemPos).mLocalId : -1;
     }
 
+    public int getItemPosByLocalId(int localId) {
+        int positionInSitesArray = mSites.indexOfSiteId(localId);
+        
+        return mSites.size() != 0 && positionInSitesArray > -1 ? positionInSitesArray : -1;
+    }
+
     String getLastSearch() {
         return mLastSearch;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -64,7 +64,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     /**
-     * Represents the available modes to start SitePicker
+     * Represents the available SitePicker modes
      */
     public enum SitePickerMode {
         DEFAULT_MODE,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -63,12 +63,26 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         void onBindViewHolder(RecyclerView.ViewHolder holder, SiteList sites);
     }
 
+    /**
+     * Represents the available modes to start SitePicker
+     */
+    public enum SitePickerMode {
+        DEFAULT_MODE,
+        REBLOG_SELECT_MODE,
+        REBLOG_CONTINUE_MODE;
+
+        public boolean isReblogMode() {
+            return this == REBLOG_SELECT_MODE || this == REBLOG_CONTINUE_MODE;
+        }
+    }
+
     private final @LayoutRes int mItemLayoutReourceId;
 
     private static int mBlavatarSz;
 
     private SiteList mSites = new SiteList();
     private final int mCurrentLocalId;
+    private int mSelectedLocalId;
 
     private final int mSelectedItemBackground;
 
@@ -92,6 +106,8 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private boolean mIsSingleItemSelectionEnabled;
     private int mSelectedItemPos;
+
+    private SitePickerMode mSitePickerMode = SitePickerMode.DEFAULT_MODE;
 
     // show recently picked first if there are at least this many blogs
     private static final int RECENTLY_PICKED_THRESHOLD = 11;
@@ -129,9 +145,11 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              int currentLocalBlogId,
                              String lastSearch,
                              boolean isInSearchMode,
-                             OnDataLoadedListener dataLoadedListener) {
+                             OnDataLoadedListener dataLoadedListener,
+                             SitePickerMode sitePickerMode
+    ) {
         this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener, null,
-                null);
+                null, sitePickerMode);
     }
 
     public SitePickerAdapter(Context context,
@@ -141,7 +159,22 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              boolean isInSearchMode,
                              OnDataLoadedListener dataLoadedListener,
                              HeaderHandler headerHandler,
-                             ArrayList<Integer> ignoreSitesIds) {
+                             ArrayList<Integer> ignoreSitesIds
+    ) {
+        this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener, null,
+                null, SitePickerMode.DEFAULT_MODE);
+    }
+
+    public SitePickerAdapter(Context context,
+                             @LayoutRes int itemLayoutResourceId,
+                             int currentLocalBlogId,
+                             String lastSearch,
+                             boolean isInSearchMode,
+                             OnDataLoadedListener dataLoadedListener,
+                             HeaderHandler headerHandler,
+                             ArrayList<Integer> ignoreSitesIds,
+                             SitePickerMode sitePickerMode
+    ) {
         super();
         ((WordPress) context.getApplicationContext()).component().inject(this);
 
@@ -152,6 +185,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mIsInSearchMode = isInSearchMode;
         mItemLayoutReourceId = itemLayoutResourceId;
         mCurrentLocalId = currentLocalBlogId;
+        mSelectedLocalId = mCurrentLocalId;
         mInflater = LayoutInflater.from(context);
         mDataLoadedListener = dataLoadedListener;
 
@@ -168,6 +202,8 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mSelectedItemPos = getPositionOffset();
 
         mIgnoreSitesIds = ignoreSitesIds;
+
+        mSitePickerMode = sitePickerMode;
 
         loadSites();
     }
@@ -244,8 +280,10 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mImageManager.load(holder.mImgBlavatar, ImageType.BLAVATAR, site.mBlavatarUrl);
 
 
-        if ((site.mLocalId == mCurrentLocalId && !mIsMultiSelectEnabled)
-            || (mIsMultiSelectEnabled && isItemSelected(position))) {
+        if ((site.mLocalId == mCurrentLocalId && !mIsMultiSelectEnabled
+             && mSitePickerMode == SitePickerMode.DEFAULT_MODE)
+            || (mIsMultiSelectEnabled && isItemSelected(position))
+            || (mSitePickerMode == SitePickerMode.REBLOG_CONTINUE_MODE && mSelectedLocalId == site.mLocalId)) {
             holder.mLayoutContainer.setBackgroundColor(mSelectedItemBackground);
         } else {
             holder.mLayoutContainer.setBackground(null);
@@ -276,6 +314,12 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     if (mIsMultiSelectEnabled) {
                         toggleSelection(clickedPosition);
                     } else if (mSiteSelectedListener != null) {
+                        if (mSitePickerMode.isReblogMode()) {
+                            mSitePickerMode = SitePickerMode.REBLOG_CONTINUE_MODE;
+                            mSelectedLocalId = site.mLocalId;
+                            selectSingleItem(clickedPosition);
+                        }
+
                         mSiteSelectedListener.onSiteClick(getItem(clickedPosition));
                     }
                 } else {
@@ -283,21 +327,23 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 }
             });
 
-            holder.itemView.setOnLongClickListener(view -> {
-                int clickedPosition = holder.getAdapterPosition();
-                if (isValidPosition(clickedPosition)) {
-                    if (mIsMultiSelectEnabled) {
-                        toggleSelection(clickedPosition);
-                        return true;
-                    } else if (mSiteSelectedListener != null) {
-                        return mSiteSelectedListener.onSiteLongClick(getItem(clickedPosition));
+            if (!mSitePickerMode.isReblogMode()) {
+                holder.itemView.setOnLongClickListener(view -> {
+                    int clickedPosition = holder.getAdapterPosition();
+                    if (isValidPosition(clickedPosition)) {
+                        if (mIsMultiSelectEnabled) {
+                            toggleSelection(clickedPosition);
+                            return true;
+                        } else if (mSiteSelectedListener != null) {
+                            return mSiteSelectedListener.onSiteLongClick(getItem(clickedPosition));
+                        }
+                    } else {
+                        AppLog.w(AppLog.T.MAIN, "site picker > invalid clicked position " + clickedPosition);
                     }
-                } else {
-                    AppLog.w(AppLog.T.MAIN, "site picker > invalid clicked position " + clickedPosition);
-                }
-                return false;
-            });
-            ViewUtilsKt.redirectContextClickToLongPressListener(holder.itemView);
+                    return false;
+                });
+                ViewUtilsKt.redirectContextClickToLongPressListener(holder.itemView);
+            }
         }
 
         if (mIsSingleItemSelectionEnabled) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -226,7 +226,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         HistoryListFragment.HistoryItemClickInterface,
         EditPostSettingsCallback,
         PrivateAtCookieProgressDialogOnDismissListener {
-    public static final String ACTION_REBLOG = "reblogAction";		
+    public static final String ACTION_REBLOG = "reblogAction";
     public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
     public static final String EXTRA_LOAD_AUTO_SAVE_REVISION = "loadAutosaveRevision";
     public static final String EXTRA_POST_REMOTE_ID = "postModelRemoteId";
@@ -345,7 +345,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject ReaderUtilsWrapper mReaderUtilsWrapper;
     @Inject protected PrivateAtomicCookie mPrivateAtomicCookie;
-    @Inject ReblogUtils mReblogUtils;	
+    @Inject ReblogUtils mReblogUtils;
 
     private StorePostViewModel mViewModel;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -70,7 +70,7 @@ import org.wordpress.android.ui.PrivateAtCookieRefreshProgressDialog
 import org.wordpress.android.ui.PrivateAtCookieRefreshProgressDialog.PrivateAtCookieProgressDialogOnDismissListener
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.main.SitePickerActivity
-import org.wordpress.android.ui.main.SitePickerActivity.SitePickerMode.REBLOG
+import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode.REBLOG_SELECT_MODE
 import org.wordpress.android.ui.main.WPMainActivity
 import org.wordpress.android.ui.posts.BasicFragmentDialog
 import org.wordpress.android.ui.prefs.AppPrefs
@@ -893,7 +893,7 @@ class ReaderPostDetailFragment : Fragment(),
                     else -> {
                         val siteLocalId = AppPrefs.getSelectedSite()
                         val site = mSiteStore.getSiteByLocalId(siteLocalId)
-                        ActivityLauncher.showSitePickerForResult(this, site, REBLOG)
+                        ActivityLauncher.showSitePickerForResult(this, site, REBLOG_SELECT_MODE)
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -183,7 +183,7 @@ class ReaderPostDetailFragment : Fragment(),
     @Inject internal lateinit var readerFileDownloadManager: ReaderFileDownloadManager
     @Inject internal lateinit var featuredImageUtils: FeaturedImageUtils
     @Inject internal lateinit var privateAtomicCookie: PrivateAtomicCookie
-    @Inject internal lateinit var mSiteStore: SiteStore    
+    @Inject internal lateinit var mSiteStore: SiteStore
 
     private val mSignInClickListener = View.OnClickListener {
         EventBus.getDefault()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -92,7 +92,7 @@ import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.main.BottomNavController;
 import org.wordpress.android.ui.main.MainToolbarFragment;
 import org.wordpress.android.ui.main.SitePickerActivity;
-import org.wordpress.android.ui.main.SitePickerActivity.SitePickerMode;
+import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.news.NewsViewHolder.NewsCardListener;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -2921,7 +2921,11 @@ public class ReaderPostListFragment extends Fragment
                     ReaderActivityLauncher.showNoSiteToReblog(getActivity());
                 } else if (state instanceof SitePicker) {
                     SitePicker spState = (SitePicker) state;
-                    ActivityLauncher.showSitePickerForResult(this, spState.getSite(), SitePickerMode.REBLOG);
+                    ActivityLauncher.showSitePickerForResult(
+                            this,
+                            spState.getSite(),
+                            SitePickerMode.REBLOG_SELECT_MODE
+                    );
                 } else if (state instanceof PostEditor) {
                     PostEditor peState = (PostEditor) state;
                     ActivityLauncher.openEditorForReblog(getActivity(), peState.getSite(), peState.getPost());

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/SitePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/SitePickerViewModel.kt
@@ -1,0 +1,51 @@
+package org.wordpress.android.viewmodel.main
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogAction.AskForSiteSelection
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogAction.ContinueReblogTo
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogAction.UpdateMenuState
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogActionType.ASK_FOR_SITE_SELECTION
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogActionType.CONTINUE_REBLOG_FLOW
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogActionType.UPDATE_MENU_STATE
+import javax.inject.Inject
+
+class SitePickerViewModel @Inject constructor() : ViewModel() {
+    private val _onReblogActionTriggered = MutableLiveData<Event<ReblogAction>>()
+    val onReblogActionTriggered: LiveData<Event<ReblogAction>> = _onReblogActionTriggered
+
+    private var siteForReblog: SiteRecord? = null
+
+    enum class ReblogActionType {
+        UPDATE_MENU_STATE,
+        CONTINUE_REBLOG_FLOW,
+        ASK_FOR_SITE_SELECTION
+    }
+
+    sealed class ReblogAction(val actionType: ReblogActionType) {
+        object UpdateMenuState : ReblogAction(UPDATE_MENU_STATE)
+
+        data class ContinueReblogTo(val siteForReblog: SiteRecord?) : ReblogAction(CONTINUE_REBLOG_FLOW)
+
+        object AskForSiteSelection : ReblogAction(ASK_FOR_SITE_SELECTION)
+    }
+
+    fun onSiteForReblogSelected(siteRecord: SiteRecord?) {
+        siteForReblog = siteRecord
+        _onReblogActionTriggered.value = Event(UpdateMenuState)
+    }
+
+    fun onContinueFlowSelected() {
+        _onReblogActionTriggered.value = Event(
+                if (siteForReblog != null)
+                    ContinueReblogTo(siteForReblog)
+                else
+                    AskForSiteSelection
+        )
+    }
+
+    fun isReblogSiteSelected() = siteForReblog != null
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/SitePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/SitePickerViewModel.kt
@@ -5,41 +5,51 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord
 import org.wordpress.android.viewmodel.Event
-import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogAction.AskForSiteSelection
-import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogAction.ContinueReblogTo
-import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogAction.UpdateMenuState
-import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogActionType.ASK_FOR_SITE_SELECTION
-import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogActionType.CONTINUE_REBLOG_FLOW
-import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogActionType.UPDATE_MENU_STATE
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.Action.AskForSiteSelection
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.Action.ContinueReblogTo
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.Action.NavigateToState
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ActionType.ASK_FOR_SITE_SELECTION
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ActionType.CONTINUE_REBLOG_TO
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ActionType.NAVIGATE_TO_STATE
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.NavigateState.TO_NO_SITE_SELECTED
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.NavigateState.TO_SITE_SELECTED
 import javax.inject.Inject
 
 class SitePickerViewModel @Inject constructor() : ViewModel() {
-    private val _onReblogActionTriggered = MutableLiveData<Event<ReblogAction>>()
-    val onReblogActionTriggered: LiveData<Event<ReblogAction>> = _onReblogActionTriggered
+    private val _onActionTriggered = MutableLiveData<Event<Action>>()
+    val onActionTriggered: LiveData<Event<Action>> = _onActionTriggered
 
     private var siteForReblog: SiteRecord? = null
 
-    enum class ReblogActionType {
-        UPDATE_MENU_STATE,
-        CONTINUE_REBLOG_FLOW,
+    enum class ActionType {
+        NAVIGATE_TO_STATE,
+        CONTINUE_REBLOG_TO,
         ASK_FOR_SITE_SELECTION
     }
 
-    sealed class ReblogAction(val actionType: ReblogActionType) {
-        object UpdateMenuState : ReblogAction(UPDATE_MENU_STATE)
-
-        data class ContinueReblogTo(val siteForReblog: SiteRecord?) : ReblogAction(CONTINUE_REBLOG_FLOW)
-
-        object AskForSiteSelection : ReblogAction(ASK_FOR_SITE_SELECTION)
+    enum class NavigateState {
+        TO_SITE_SELECTED,
+        TO_NO_SITE_SELECTED
     }
 
-    fun onSiteForReblogSelected(siteRecord: SiteRecord?) {
-        siteForReblog = siteRecord
-        _onReblogActionTriggered.value = Event(UpdateMenuState)
+    sealed class Action(val actionType: ActionType) {
+        data class NavigateToState(val navigateState: NavigateState, val siteForReblog: SiteRecord? = null) : Action(
+                NAVIGATE_TO_STATE
+        )
+
+        data class ContinueReblogTo(val siteForReblog: SiteRecord?) : Action(
+                CONTINUE_REBLOG_TO
+        )
+
+        object AskForSiteSelection : Action(ASK_FOR_SITE_SELECTION)
+    }
+
+    fun onSiteForReblogSelected(siteRecord: SiteRecord) {
+        selectSite(siteRecord)
     }
 
     fun onContinueFlowSelected() {
-        _onReblogActionTriggered.value = Event(
+        _onActionTriggered.value = Event(
                 if (siteForReblog != null)
                     ContinueReblogTo(siteForReblog)
                 else
@@ -47,5 +57,19 @@ class SitePickerViewModel @Inject constructor() : ViewModel() {
         )
     }
 
-    fun isReblogSiteSelected() = siteForReblog != null
+    fun onReblogActionBackSelected() {
+        siteForReblog = null
+        _onActionTriggered.value = Event(NavigateToState(TO_NO_SITE_SELECTED))
+    }
+
+    fun onRefreshReblogActionMode() {
+        siteForReblog?.let {
+            selectSite(it)
+        }
+    }
+
+    private fun selectSite(siteRecord: SiteRecord) {
+        siteForReblog = siteRecord
+        _onActionTriggered.value = Event(NavigateToState(TO_SITE_SELECTED, siteRecord))
+    }
 }

--- a/WordPress/src/main/res/menu/site_picker.xml
+++ b/WordPress/src/main/res/menu/site_picker.xml
@@ -10,6 +10,11 @@
         app:showAsAction="collapseActionView|ifRoom" />
 
     <item
+        android:id="@+id/continue_flow"
+        android:title="@string/sitepicker_continue_flow"
+        app:showAsAction="always" />
+
+    <item
         android:id="@+id/menu_add"
         android:icon="@drawable/ic_plus_white_24dp"
         android:title="@string/site_picker_add_site"

--- a/WordPress/src/main/res/menu/site_picker.xml
+++ b/WordPress/src/main/res/menu/site_picker.xml
@@ -11,6 +11,7 @@
 
     <item
         android:id="@+id/continue_flow"
+        android:icon="@drawable/ic_checkmark_white_24dp"
         android:title="@string/sitepicker_continue_flow"
         app:showAsAction="always" />
 

--- a/WordPress/src/main/res/menu/site_picker.xml
+++ b/WordPress/src/main/res/menu/site_picker.xml
@@ -10,12 +10,6 @@
         app:showAsAction="collapseActionView|ifRoom" />
 
     <item
-        android:id="@+id/continue_flow"
-        android:icon="@drawable/ic_checkmark_white_24dp"
-        android:title="@string/sitepicker_continue_flow"
-        app:showAsAction="always" />
-
-    <item
         android:id="@+id/menu_add"
         android:icon="@drawable/ic_plus_white_24dp"
         android:title="@string/site_picker_add_site"

--- a/WordPress/src/main/res/menu/site_picker_reblog_action_mode.xml
+++ b/WordPress/src/main/res/menu/site_picker_reblog_action_mode.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/continue_flow"
+        android:icon="@drawable/ic_checkmark_white_24dp"
+        android:title="@string/sitepicker_continue_flow"
+        app:showAsAction="always" />
+
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1712,6 +1712,7 @@
     <string name="reader_no_site_to_reblog_detail">Once you create a site, you can reblog content that you like to your own site.</string>
     <string name="reader_no_site_to_reblog_action">Manage Sites</string>
     <string name="reader_reblog_error">Reblog failed</string>
+    <string name="sitepicker_continue_flow">Continue</string>
 
     <!-- like counts -->
     <string name="reader_label_like">Like</string>
@@ -1880,6 +1881,7 @@
     <string name="site_picker_remove_site_empty">No sites matching your search</string>
     <string name="site_picker_remove_site_error">Error removing site, try again later</string>
     <string name="site_picker_failed_selecting_added_site">Couldn\'t select newly added self-hosted site.</string>
+    <string name="site_picker_ask_site_select">Couldn\'t select site. Please try again.</string>
 
     <!-- Application logs view -->
     <string name="logs_copied_to_clipboard">Application logs have been copied to the clipboard</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/SitePickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/SitePickerViewModelTest.kt
@@ -1,0 +1,75 @@
+package org.wordpress.android.viewmodel.main
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogAction
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogAction.AskForSiteSelection
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogAction.ContinueReblogTo
+import org.wordpress.android.viewmodel.main.SitePickerViewModel.ReblogAction.UpdateMenuState
+
+@RunWith(MockitoJUnitRunner::class)
+class SitePickerViewModelTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    private lateinit var viewModel: SitePickerViewModel
+
+    @Mock
+    private lateinit var siteRecord: SiteRecord
+
+    @Before
+    fun setUp() {
+        viewModel = SitePickerViewModel()
+    }
+
+    @Test
+    fun `when a site is selected then siteForReblog is not null`() {
+        viewModel.onSiteForReblogSelected(siteRecord)
+        assertThat(viewModel.isReblogSiteSelected()).isEqualTo(true)
+    }
+
+    @Test
+    fun `when a site is not selected then siteForReblog is null`() {
+        assertThat(viewModel.isReblogSiteSelected()).isEqualTo(false)
+    }
+
+    @Test
+    fun `when a site is selected then UpdateMenuState is emitted`() {
+        var result: Event<ReblogAction>? = null
+
+        viewModel.onReblogActionTriggered.observeForever { result = it }
+        viewModel.onSiteForReblogSelected(siteRecord)
+
+        assertThat(result!!.peekContent()).isInstanceOf(UpdateMenuState::class.java)
+    }
+
+    @Test
+    fun `when continue is tapped then ContinueReblogTo is emitted`() {
+        var result: Event<ReblogAction>? = null
+
+        viewModel.onReblogActionTriggered.observeForever { result = it }
+        viewModel.onSiteForReblogSelected(siteRecord)
+        viewModel.onContinueFlowSelected()
+
+        assertThat(result!!.peekContent()).isInstanceOf(ContinueReblogTo::class.java)
+        assertThat((result!!.peekContent() as ContinueReblogTo).siteForReblog).isEqualTo(siteRecord)
+    }
+
+    @Test
+    fun `when continue is tapped but no site was selected then AskForSiteSelection is emitted`() {
+        var result: Event<ReblogAction>? = null
+
+        viewModel.onReblogActionTriggered.observeForever { result = it }
+        viewModel.onContinueFlowSelected()
+
+        assertThat(result!!.peekContent()).isInstanceOf(AskForSiteSelection::class.java)
+    }
+}


### PR DESCRIPTION
This PR tries to further enhance the #11555 by adding a little step in site picker selection before to continue the reblog flow when a user has more than one site.

| NOTE | IMAGE |
|---|---|
| Adding `CONTINUE` menu disabled at beginning | ![image](https://user-images.githubusercontent.com/47797566/79810282-fcdbe000-8372-11ea-950b-f28e9cc6cdc4.png) |
| Enabling `CONTINUE` menu after first site selection  | ![image](https://user-images.githubusercontent.com/47797566/79810457-6360fe00-8373-11ea-9af9-a02217be746e.png) |
| Search will allow site filtering and on filtered site selection user will be again in a  screen like the first one above  | ![image](https://user-images.githubusercontent.com/47797566/79810850-5abcf780-8374-11ea-8783-f59d591f747c.png)  |

cc @osullivanchris and @iamthomasbishop 

## To test
Be sure to be logged in with a WP.com account having more than one site (you should have enough sites to need to scroll in the site picker so to manual test the scroll to selected scenario)

### Feature Test
- From a reader post select the reblog button
- Check you get access to the site picker like below without any selected site

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/80132154-8ec63180-859b-11ea-9c7f-338fb36417d3.png>
</p>

- Check single site is selected if you tap on it, and you get an action bar like below

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/80132107-7fdf7f00-859b-11ea-9de5-aab7ce257b8e.png>
</p>

- Check you can select other sites and still remain in the same screen as above with an updated action bar title set to the site title
- Check you can go back and come to the initial screen with no site selected
- Long press on a site and check nothing happens (hiding sites capability should not be available)
- Activate search and type some search string to get a filtered list of sites
- Select a site that is at the lower end of the main list
- Check the search view is dismissed and the sites list is scrolled to the selected site
- Tap on the Checkmark icon and check you can complete the reblog flow.

### Smoke Test previous available scenarios
Site Picker is used in `My Site > Switch Site`, `Share to WP`, `Login Epilogue`; Smock test these scenarios to check for eventual regressions. In particular check the Site Hide feature in `Switch Site` picker works as usual.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
