### PR TITLE
Merge 14.7 code freeze to develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,6 @@
+14.8
+-----
+ 
 14.7
 -----
 * Block editor: Disable ripple effect for Slider control

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -55,9 +55,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "alpha-216"
+            versionName "alpha-217"
         }
-        versionCode 849
+        versionCode 852
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
@@ -84,9 +84,9 @@ android {
             dimension "buildType"
             // Only set the release version if one isn't provided
             if (!project.hasProperty("versionName")) {
-                versionName "14.6"
+                versionName "14.7-rc-1"
             }
-            versionCode 850
+            versionCode 851
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "boolean", "TENOR_AVAILABLE", "false"
         }

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ ext {
     targetSdkVersion = 28
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.10-beta-2'
+    fluxCVersion = '1.6.10'
 
     appCompatVersion = '1.0.2'
     constraintLayoutVersion = '1.1.3'

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -833,7 +833,10 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             int mediaId = isNetworkUrl ? Integer.valueOf(mediaEntry.getValue().getMediaId())
                     : mediaEntry.getValue().getId();
             String url = isNetworkUrl ? mediaEntry.getKey() : "file://" + mediaEntry.getKey();
-            rnMediaList.add(createRNMediaUsingMimeType(mediaId, url, mediaEntry.getValue().getMimeType()));
+            rnMediaList.add(createRNMediaUsingMimeType(mediaId,
+                    url,
+                    mediaEntry.getValue().getMimeType(),
+                    mediaEntry.getValue().getCaption()));
         }
 
         getGutenbergContainerFragment().appendUploadMediaFiles(rnMediaList);


### PR DESCRIPTION
Aside from usual code freeze commits, we have merged #11706 into the `release/14.7` branch to revert a change that shouldn't have been included in `14.7` and then in this branch reverted that revert in dbef167a5f842be7d817404251735b7058652027. So, even though there are extra commits, this PR looks exactly like a regular code freeze merge, which was the goal.

cc @cameronvoell @mchowning 