### PR TITLE
Unified Login & Sign-Up: Create Sign-Up From Login functionality for Google Sign-In method

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -616,7 +616,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
         LoginGoogleFragment loginGoogleFragment;
         FragmentManager fragmentManager = getSupportFragmentManager();
         FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
-        loginGoogleFragment = new LoginGoogleFragment();
+        loginGoogleFragment = LoginGoogleFragment.newInstance(mIsSignupFromLoginEnabled);
         loginGoogleFragment.setRetainInstance(true);
         fragmentTransaction.add(loginGoogleFragment, LoginGoogleFragment.TAG);
         fragmentTransaction.commit();

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2402,6 +2402,7 @@
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>
     <string name="signup_with_google_progress">Signing up with Google…</string>
+    <string name="signin_with_google_progress">Signing in with Google…</string>
     <string name="content_description_add_avatar">Add avatar</string>
     <!-- Screen titles -->
     <string name="signup_email_screen_title">Email signup</string>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/GoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/GoogleFragment.java
@@ -22,6 +22,9 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.inject.Inject;
 
 import static android.app.Activity.RESULT_OK;
@@ -245,5 +248,14 @@ public class GoogleFragment extends Fragment implements ConnectionCallbacks, OnC
                 mIsResolvingError = false;
                 break;
         }
+    }
+
+    // Remove scale from photo URL path string. Current URL matches /s96-c, which returns a 96 x 96
+    // pixel image. Removing /s96-c from the string returns a 512 x 512 pixel image. Using regular
+    // expressions may help if the photo URL scale value in the returned path changes.
+    protected String removeScaleFromGooglePhotoUrl(String photoUrl) {
+        Pattern pattern = Pattern.compile("(/s[0-9]+-c)");
+        Matcher matcher = pattern.matcher(photoUrl);
+        return matcher.find() ? photoUrl.replace(matcher.group(1), "") : photoUrl;
     }
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -48,7 +48,8 @@ public class LoginGoogleFragment extends GoogleFragment {
         super.onAttach(context);
     }
 
-    @Override public void onCreate(Bundle savedInstanceState) {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         Bundle args = getArguments();
@@ -57,7 +58,8 @@ public class LoginGoogleFragment extends GoogleFragment {
         }
     }
 
-    @Override public void onStart() {
+    @Override
+    public void onStart() {
         super.onStart();
         if (mIsSignupFromLoginEnabled) {
             mProgressDialog = ProgressDialog.show(
@@ -65,7 +67,8 @@ public class LoginGoogleFragment extends GoogleFragment {
         }
     }
 
-    @Override public void onStop() {
+    @Override
+    public void onStop() {
         dismissProgressDialog();
         super.onStop();
     }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -3,6 +3,7 @@ package org.wordpress.android.login;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 
 import com.google.android.gms.auth.api.Auth;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
@@ -25,27 +26,45 @@ import static android.app.Activity.RESULT_OK;
 import dagger.android.support.AndroidSupportInjection;
 
 public class LoginGoogleFragment extends GoogleFragment {
+    private static final String ARG_SIGNUP_FROM_LOGIN_ENABLED = "ARG_SIGNUP_FROM_LOGIN_ENABLED";
     private static final int REQUEST_LOGIN = 1001;
     private boolean mLoginRequested = false;
-    private boolean mIsSignupFromLoginEnabled = true;
+    private boolean mIsSignupFromLoginEnabled;
     private ProgressDialog mProgressDialog;
 
     public static final String TAG = "login_google_fragment_tag";
 
+    public static LoginGoogleFragment newInstance(boolean isSignupFromLoginEnabled) {
+        LoginGoogleFragment fragment = new LoginGoogleFragment();
+        Bundle args = new Bundle();
+        args.putBoolean(ARG_SIGNUP_FROM_LOGIN_ENABLED, isSignupFromLoginEnabled);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
     @Override
     public void onAttach(Context context) {
         AndroidSupportInjection.inject(this);
+        super.onAttach(context);
+    }
+
+    @Override public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Bundle args = getArguments();
+        if (args != null) {
+            mIsSignupFromLoginEnabled = args.getBoolean(ARG_SIGNUP_FROM_LOGIN_ENABLED, false);
+        }
+
         if (mIsSignupFromLoginEnabled) {
             mProgressDialog = ProgressDialog.show(
                     getActivity(), null, getString(R.string.signin_with_google_progress), true, false, null);
         }
-        super.onAttach(context);
     }
 
-    @Override
-    public void onDetach() {
+    @Override public void onDestroy() {
         dismissProgressDialog();
-        super.onDetach();
+        super.onDestroy();
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -192,7 +192,7 @@ public class LoginGoogleFragment extends GoogleFragment {
             showError(getString(R.string.login_error_generic));
         } else if (event.createdAccount) {
             AppLog.d(T.MAIN,
-                    "GOOGLE SIGNUP: onAuthenticationChanged - new wordpress account created");
+                    "GOOGLE LOGIN: onAuthenticationChanged - new wordpress account created");
             mAnalyticsListener.trackCreatedAccount(event.userName, mGoogleEmail);
             mAnalyticsListener.trackAnalyticsSignIn(true);
             mGoogleListener.onGoogleSignupFinished(mDisplayName, mGoogleEmail, mPhotoUrl, event.userName);
@@ -231,10 +231,12 @@ public class LoginGoogleFragment extends GoogleFragment {
                 case UNKNOWN_USER:
                     if (mIsSignupFromLoginEnabled) {
                         PushSocialPayload payload = new PushSocialPayload(mIdToken, SERVICE_TYPE_GOOGLE);
-                        AppLog.d(T.MAIN, "GOOGLE SIGNUP: sign up result returned - dispatching SocialSignupAction");
+                        AppLog.d(T.MAIN,
+                                "GOOGLE LOGIN: onSocialChanged - wordpress account doesn't exist - dispatching "
+                                + "SocialSignupAction");
                         mDispatcher.dispatch(AccountActionBuilder.newPushSocialSignupAction(payload));
                     } else {
-                        AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - wordpress acount doesn't exist");
+                        AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - wordpress account doesn't exist");
                         mAnalyticsListener.trackSocialErrorUnknownUser();
                         showError(getString(R.string.login_error_email_not_found_v2));
                     }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.login;
 
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 
@@ -27,13 +28,24 @@ public class LoginGoogleFragment extends GoogleFragment {
     private static final int REQUEST_LOGIN = 1001;
     private boolean mLoginRequested = false;
     private boolean mIsSignupFromLoginEnabled = true;
+    private ProgressDialog mProgressDialog;
 
     public static final String TAG = "login_google_fragment_tag";
 
     @Override
     public void onAttach(Context context) {
         AndroidSupportInjection.inject(this);
+        if (mIsSignupFromLoginEnabled) {
+            mProgressDialog = ProgressDialog.show(
+                    getActivity(), null, getString(R.string.signin_with_google_progress), true, false, null);
+        }
         super.onAttach(context);
+    }
+
+    @Override
+    public void onDetach() {
+        dismissProgressDialog();
+        super.onDetach();
     }
 
     @Override
@@ -231,6 +243,12 @@ public class LoginGoogleFragment extends GoogleFragment {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - success");
             mGoogleListener.onGoogleLoginFinished();
             finishFlow();
+        }
+    }
+
+    private void dismissProgressDialog() {
+        if (mProgressDialog != null && mProgressDialog.isShowing()) {
+            mProgressDialog.dismiss();
         }
     }
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -55,16 +55,19 @@ public class LoginGoogleFragment extends GoogleFragment {
         if (args != null) {
             mIsSignupFromLoginEnabled = args.getBoolean(ARG_SIGNUP_FROM_LOGIN_ENABLED, false);
         }
+    }
 
+    @Override public void onStart() {
+        super.onStart();
         if (mIsSignupFromLoginEnabled) {
             mProgressDialog = ProgressDialog.show(
                     getActivity(), null, getString(R.string.signin_with_google_progress), true, false, null);
         }
     }
 
-    @Override public void onDestroy() {
+    @Override public void onStop() {
         dismissProgressDialog();
-        super.onDestroy();
+        super.onStop();
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
@@ -23,13 +23,11 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
 import java.util.ArrayList;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import dagger.android.support.AndroidSupportInjection;
 
 import static android.app.Activity.RESULT_CANCELED;
 import static android.app.Activity.RESULT_OK;
+
+import dagger.android.support.AndroidSupportInjection;
 
 public class SignupGoogleFragment extends GoogleFragment {
     private static final String OLD_SITES_IDS = "old_sites_ids";
@@ -181,15 +179,6 @@ public class SignupGoogleFragment extends GoogleFragment {
         if (mProgressDialog != null && mProgressDialog.isShowing()) {
             mProgressDialog.dismiss();
         }
-    }
-
-    // Remove scale from photo URL path string. Current URL matches /s96-c, which returns a 96 x 96
-    // pixel image. Removing /s96-c from the string returns a 512 x 512 pixel image. Using regular
-    // expressions may help if the photo URL scale value in the returned path changes.
-    private String removeScaleFromGooglePhotoUrl(String photoUrl) {
-        Pattern pattern = Pattern.compile("(/s[0-9]+-c)");
-        Matcher matcher = pattern.matcher(photoUrl);
-        return matcher.find() ? photoUrl.replace(matcher.group(1), "") : photoUrl;
     }
 
     @SuppressWarnings("unused")

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>
     <string name="signup_with_google_progress">Signing up with Google&#8230;</string>
+    <string name="signin_with_google_progress">Signing in with Google&#8230;</string>
 
     <string name="google_error_timeout">Google took too long to respond. You may need to wait until you have a stronger internet connection.</string>
 


### PR DESCRIPTION
Part of #11705

## To test

### Instructions

- To connect/disconnect a Google account, go to the [Social Login](https://wordpress.com/me/security/social-login) page. 
- To enable/disable two-factor authentication, go to the [Two-Step Authentication](https://wordpress.com/me/security/two-step) page.
- The scenarios described below are for the Full Flow, but they must work for the Jetpack flow as well.

### Scenarios

**New Account**

0. Clear app data.
1. On the Prologue Screen, tap **Log In**.
2. If the Smart Lock dialog appears, dismiss it.
3. On the Email Screen, tap **Log in with Google**.
4. Pick a Google account.
5. Complete the sign-up flow normally.

**Old Account / Social Connected / Two-Factor Disabled**

0. Clear app data.
1. On the Prologue Screen, tap **Log In**.
2. If the Smart Lock dialog appears, dismiss it.
3. On the Email Screen, tap **Log in with Google**.
4. Pick a Google account.
5. Complete the login flow normally.

**Old Account / Social Connected / Two-Factor Enabled**

0. Clear app data.
1. On the Prologue Screen, tap **Log In**.
2. If the Smart Lock dialog appears, dismiss it.
3. On the Email Screen, tap **Log in with Google**.
4. Pick a Google account.
5. Notice the 2FA Screen is shown.
6. Enter two-factor authentication code.
7. Tap **Next**.
8. Complete the login flow normally.

**Old Account / Social Disconnected / Two-Factor Disabled**

0. Clear app data.
1. On the Prologue Screen, tap **Log In**.
2. If the Smart Lock dialog appears, dismiss it.
3. On the Email Screen, tap **Log in with Google**.
4. Pick a Google account.
5. Notice the Email/Password Screen is shown.
6. Enter WordPress.com account password.
7. Tap **Next**.
8. Complete the login flow normally.

**Old Account / Social Disconnected / Two-Factor Enabled**

0. Clear app data.
1. On the Prologue Screen, tap **Log In**.
2. If the Smart Lock dialog appears, dismiss it.
3. On the Email Screen, tap **Log in with Google**.
4. Pick a Google account.
5. Notice the Email/Password Screen is shown.
6. Enter WordPress.com account password.
7. Tap **Next**.
8. Notice the 2FA Screen is shown.
9. Enter two-factor authentication code.
10. Tap **Next**.
11. Complete the login flow normally.

### Jetpack Flow

For each of the scenarios above, replace steps 0-3 with the steps below.

0. Log in with a self-hosted site that **_is not_** associated with a WordPress.com account.
1. Go to **My Site** tab and tap **Stats** (or go to **Notifications** tab).
2. Tap the **Install Jetpack** button.
3. If the Smart Lock dialog appears, dismiss it.
4. On the Email Screen, notice there's no **Don't have an account? Sign up** button.
6. Tap **Log in with Google**.
7. Continue with the flow described for each scenario.

## Notes
- The `LoginGoogleFragment` and `SignupGoogleFragment` should probably be merged into a single class once we don't have the need to support the old sign-up paths.
- If a user tries to login with Google but their WP.com account is currently disconnected from Google, we ask them to login with a password, even if their WP.com account is passwordless. In the future, we could probably make this work like on the web, where the user can log in with a Magic Link in case they haven't set a password (although their Google account will stay disconnected in this case).

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.