### PR TITLE
Smart lock from prologue

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -68,6 +68,7 @@ android {
 
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
         buildConfigField "boolean", "TENOR_AVAILABLE", "true"
+        buildConfigField "boolean", "UNIFIED_LOGIN_AVAILABLE", "true"
     }
 
     // Gutenberg's dependency - react-native-video is using

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -177,7 +177,6 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
         outState.putString(KEY_SMARTLOCK_HELPER_STATE, mSmartLockHelperState.name());
         outState.putBoolean(KEY_SIGNUP_FROM_LOGIN_ENABLED, mIsSignupFromLoginEnabled);
-        outState.putBoolean(KEY_SIGNUP_FROM_LOGIN_ENABLED, mIsSignupFromLoginEnabled);
     }
 
     private void showFragment(Fragment fragment, String tag) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -111,6 +111,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     private boolean mIsJetpackConnect;
 
     private boolean mIsSignupFromLoginEnabled;
+    private boolean mIsSmartLockTriggeredFromPrologue;
 
     private LoginMode mLoginMode;
 
@@ -140,6 +141,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                     mIsSignupFromLoginEnabled = true;
                     showFragment(new LoginPrologueFragment(), LoginPrologueFragment.TAG);
                     if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
+                        mIsSmartLockTriggeredFromPrologue = true;
                         initSmartLockIfNotFinished(true);
                     }
                     break;
@@ -174,6 +176,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
         super.onSaveInstanceState(outState);
 
         outState.putString(KEY_SMARTLOCK_HELPER_STATE, mSmartLockHelperState.name());
+        outState.putBoolean(KEY_SIGNUP_FROM_LOGIN_ENABLED, mIsSignupFromLoginEnabled);
         outState.putBoolean(KEY_SIGNUP_FROM_LOGIN_ENABLED, mIsSignupFromLoginEnabled);
     }
 
@@ -738,9 +741,10 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Override
     public void onCredentialsUnavailable() {
         mSmartLockHelperState = SmartLockHelperState.FINISHED;
-        if (!BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
-            startLogin();
+        if (mIsSmartLockTriggeredFromPrologue) {
+            return;
         }
+        startLogin();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -138,6 +138,9 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                 case WPCOM_LOGIN_ONLY:
                     mIsSignupFromLoginEnabled = true;
                     showFragment(new LoginPrologueFragment(), LoginPrologueFragment.TAG);
+                    if (mIsSignupFromLoginEnabled) {
+                        initSmartLockIfNotFinished(true);
+                    }
                     break;
                 case SELFHOSTED_ONLY:
                     showFragment(new LoginSiteAddressFragment(), LoginSiteAddressFragment.TAG);
@@ -734,8 +737,9 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Override
     public void onCredentialsUnavailable() {
         mSmartLockHelperState = SmartLockHelperState.FINISHED;
-
-        startLogin();
+        if (!mIsSignupFromLoginEnabled) {
+            startLogin();
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -19,6 +19,7 @@ import com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListe
 import com.google.android.material.snackbar.Snackbar;
 
 import org.jetbrains.annotations.NotNull;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -138,7 +139,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                 case WPCOM_LOGIN_ONLY:
                     mIsSignupFromLoginEnabled = true;
                     showFragment(new LoginPrologueFragment(), LoginPrologueFragment.TAG);
-                    if (mIsSignupFromLoginEnabled) {
+                    if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
                         initSmartLockIfNotFinished(true);
                     }
                     break;
@@ -737,7 +738,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Override
     public void onCredentialsUnavailable() {
         mSmartLockHelperState = SmartLockHelperState.FINISHED;
-        if (!mIsSignupFromLoginEnabled) {
+        if (!BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
             startLogin();
         }
     }


### PR DESCRIPTION
Fixes #11712

This PR introduces smart lock from prologue.

I've created a flag in the BuildConfig file to hide the functionality. We can use this flag for our development. Right now it's enabled for all the versions but we should disable it once we decide to merge our code.

To test:
- Use a device that has smart lock set up
- Open the freshly installed app
- The smart lock is triggered automatically
- Select your account
- You're automatically logged in

To test:
- Use a device that has smart lock set up
- Open the freshly installed app
- The smart lock is triggered automatically
- Dismiss smart lock
- The app stays on the Prologue screen

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
