### PR TITLE
Issue/11724 app settings crash

### DIFF
--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -2237,8 +2237,4 @@ Language: ar
     <string name="save">حفظ </string>
     <string name="cancel">إلغاء</string>
     <string name="error">خطأ </string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -2237,8 +2237,4 @@ Language: de
     <string name="error">Fehler</string>
     <string name="category_refresh_error">Fehler beim Aktualisieren der Kategorien</string>
     <string name="notification_settings">Benachrichtigungs-Einstellungen</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -2239,8 +2239,4 @@ Language: en_GB
     <string name="save">Save</string>
     <string name="cancel">Cancel</string>
     <string name="error">Error</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-es-rMX/strings.xml
+++ b/WordPress/src/main/res/values-es-rMX/strings.xml
@@ -2237,8 +2237,4 @@ Language: es_MX
     <string name="save">Guardar</string>
     <string name="cancel">Cancelar</string>
     <string name="error">Error</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -2237,8 +2237,4 @@ Language: es_VE
     <string name="yes">Sí</string>
     <string name="no">No</string>
     <string name="notification_settings">Ajustes de avisos</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -2239,8 +2239,4 @@ Language: es
     <string name="save">Guardar</string>
     <string name="cancel">Cancelar</string>
     <string name="error">Error</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -2239,8 +2239,4 @@ Language: fr
     <string name="save">Enregistrer</string>
     <string name="cancel">Annuler</string>
     <string name="error">Erreur</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -2234,8 +2234,4 @@ Language: he_IL
     <string name="save">שמור</string>
     <string name="cancel">בטל</string>
     <string name="error">שגיאה</string>
-    <string-array name="app_theme_entries">
-        <item>‎@string/app_theme_light</item>
-        <item>‎@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -2194,8 +2194,4 @@ Language: id
     <string name="save">Simpan</string>
     <string name="cancel">Batal</string>
     <string name="error">Galat</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -2218,8 +2218,4 @@ Language: it
     <string name="save">Salva</string>
     <string name="cancel">Annulla</string>
     <string name="error">Errore</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -2237,8 +2237,4 @@ Language: ja_JP
     <string name="save">保存</string>
     <string name="cancel">キャンセル</string>
     <string name="error">エラー</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -2123,8 +2123,4 @@ Language: nl
     <string name="save">Bewaar</string>
     <string name="cancel">Annuleer </string>
     <string name="error">Fout</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -2233,8 +2233,4 @@ Language: pl
     <string name="save">Zapisz</string>
     <string name="cancel">Anuluj</string>
     <string name="error">Błąd</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -2239,8 +2239,4 @@ Language: ro
     <string name="save">Salvare</string>
     <string name="cancel">Anulare</string>
     <string name="error">Eroare</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -2239,8 +2239,4 @@ Language: ru
     <string name="save">Сохранить</string>
     <string name="cancel">Отмена</string>
     <string name="error">Ошибка</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -2237,8 +2237,4 @@ Language: sq_AL
     <string name="yes">Po</string>
     <string name="no">Jo</string>
     <string name="notification_settings">Rregullime Njoftimesh</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -2239,8 +2239,4 @@ Language: sv_SE
     <string name="save">Spara</string>
     <string name="cancel">Avbryt</string>
     <string name="error">Fel</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -2237,8 +2237,4 @@ Language: tr
     <string name="save">Kaydet</string>
     <string name="cancel">İptal</string>
     <string name="error">Hata</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-v28/strings.xml
+++ b/WordPress/src/main/res/values-v28/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_theme_entry_value_default_key" translatable="false">@string/app_theme_entry_value_default</string>
-    <string-array name="app_theme_entries" tools:ignore="InconsistentArrays">
+    <string-array name="app_theme_entries" translatable="false" tools:ignore="InconsistentArrays">
         <item>@string/app_theme_light</item>
         <item>@string/app_theme_dark</item>
         <item>@string/app_theme_default</item>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -2160,8 +2160,4 @@ Language: zh_CN
     <string name="no">否</string>
     <string name="preview">预览</string>
     <string name="notification_settings">通知设置</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -2215,8 +2215,4 @@ Language: zh_TW
     <string name="save">儲存</string>
     <string name="cancel">取消</string>
     <string name="error">錯誤</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -2215,8 +2215,4 @@ Language: zh_TW
     <string name="save">儲存</string>
     <string name="cancel">取消</string>
     <string name="error">錯誤</string>
-    <string-array name="app_theme_entries">
-        <item>\@string/app_theme_light</item>
-        <item>\@string/app_theme_dark</item>
-    </string-array>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -827,7 +827,7 @@
     <string name="app_theme_entry_value_dark" translatable="false">dark</string>
     <string name="app_theme_entry_value_default" translatable="false">default</string>
     <string name="app_theme_entry_value_default_key" translatable="false">@string/app_theme_entry_value_light</string>
-    <string-array name="app_theme_entries" tools:ignore="InconsistentArrays">
+    <string-array name="app_theme_entries" translatable="false" tools:ignore="InconsistentArrays">
         <item>@string/app_theme_light</item>
         <item>@string/app_theme_dark</item>
     </string-array>


### PR DESCRIPTION
Fixes #11724

The problem was related to the string array `app_theme_entries`. This array is used to present to the user the options they have for the app theme. On Android 8 and below, it has only two options: `light` and `dark`. For Android 9 and above, it has a third option: `default`.

This string array wasn't supposed to be translatable, but it wasn't marked as so at first, causing it to be [erroneously replicated](https://github.com/wordpress-mobile/WordPress-Android/commit/44869769b2ecd5c956ee12e6caf3326a405b8e9d) to the `strings.xml` file for the following languages:

- ar
- de
- en-gb
- es
- es-MX
- es-VE
- fr
- he
- id
- it
- ja
- nl
- pl
- ro
- ru
- sq
- sv
- tr
- zh-CN
- zh-HK
- zh-TW

Since the array was being "translated" in these files, the system was unable to replace that translation with the one for Android 9 and above, causing that preference to only have two options, even when it was supposed to have three, finally resulting in a `ArrayIndexOutOfBoundsException`, since the default option in those cases is the third one, which was missing.

**TL;DR:** The App Settings screen would crash for any user on Android 9 and above that was using one of those 20 languages.

This PR marks the string array `app_theme_entries` as not translatable and remove all the instances where it was erroneously replicated to those `strings.xml` files.

### To test

0. Make sure you're using a device with Android 9 and above and that the selected language is one of those listed above.
1. On the site screen, tap the profile icon in the header bar
2. Tap App Settings
3. The app shouldn't crash

### Notes
- If those translations were added by some automated process, we may need to make sure they won't be added by mistake again.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
