### PR TITLE
Added a new icon for unknown file type.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -369,7 +369,7 @@ public class WPMediaUtils {
         } else if (MediaUtils.isAudio(url)) {
             return R.drawable.ic_audio_white_24dp;
         } else {
-            return 0;
+            return R.drawable.ic_image_multiple_white_24dp;
         }
     }
 

--- a/WordPress/src/main/res/drawable/ic_image_multiple_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_image_multiple_white_24dp.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15,7.5C15,6.672,15.672,6,16.5,6C17.328,6,18,6.672,18,7.5S17.328,9,16.5,9C15.672,9,15,8.328,15,7.5z M4,20h14v0c0,1.105-0.895,2-2,2H4c-1.1,0-2-0.9-2-2V8c0-1.105,0.895-2,2-2h0V20zM22,4v12c0,1.105-0.895,2-2,2H8c-1.105,0-2-0.895-2-2V4c0-1.105,0.895-2,2-2h12C21.105,2,22,2.895,22,4z M8,4v6.333L11,7l4.855,5.395l0.656-0.731c0.795-0.885,2.182-0.885,2.976,0L20,12.234V4H8z" />
+
+</vector>


### PR DESCRIPTION
Fixes #11617

We currently don't have an icon for the unknown file types in Media Browser, which might theoretically crash the app. This PR adds that icon.

I'm not 100% sure how it can happen, but the possibility is there, especially with self-hosted sites. We should handle unknown files gracefully, instead of crashing the app.

The icon will look like this:
[![Image from Gyazo](https://i.gyazo.com/1d99559d8102382df8f2be4d608a6809.png)](https://gyazo.com/1d99559d8102382df8f2be4d608a6809)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
