### PR TITLE
Better manage OnPostUploaded event for reblog in WPMainActivity.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1263,15 +1263,35 @@ public class WPMainActivity extends LocaleAwareActivity implements
         // WPMainActivity invokes show(). This condition makes sure, the WPMainActivity invokes show() only when
         // it's visible. For more info see https://github.com/wordpress-mobile/WordPress-Android/issues/9604
         if (getLifecycle().getCurrentState().isAtLeast(STARTED)) {
-            SiteModel site = getSelectedSite();
-            if (site != null && event.post != null) {
+            SiteModel selectedSite = getSelectedSite();
+
+            if (selectedSite != null && event.post != null) {
+                SiteModel targetSite;
+
+                if (event.post.getLocalSiteId() == selectedSite.getId()) {
+                    targetSite = selectedSite;
+                } else {
+                    SiteModel postSite = mSiteStore.getSiteByLocalId(event.post.getLocalSiteId());
+
+                    if (postSite != null) {
+                        targetSite = postSite;
+                    } else {
+                        AppLog.d(
+                                T.MAIN,
+                                "WPMainActivity >  onPostUploaded: got an event from a not found site ["
+                                + event.post.getLocalSiteId() + "]."
+                        );
+                        return;
+                    }
+                }
+
                 mUploadUtilsWrapper.onPostUploadedSnackbarHandler(
                         this,
                         findViewById(R.id.coordinator),
                         event.isError(),
                         event.post,
                         null,
-                        site);
+                        targetSite);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -226,7 +226,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         HistoryListFragment.HistoryItemClickInterface,
         EditPostSettingsCallback,
         PrivateAtCookieProgressDialogOnDismissListener {
-    public static final String ACTION_REBLOG = "reblogAction";		
+    public static final String ACTION_REBLOG = "reblogAction";
     public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
     public static final String EXTRA_LOAD_AUTO_SAVE_REVISION = "loadAutosaveRevision";
     public static final String EXTRA_POST_REMOTE_ID = "postModelRemoteId";
@@ -345,7 +345,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject ReaderUtilsWrapper mReaderUtilsWrapper;
     @Inject protected PrivateAtomicCookie mPrivateAtomicCookie;
-    @Inject ReblogUtils mReblogUtils;	
+    @Inject ReblogUtils mReblogUtils;
 
     private StorePostViewModel mViewModel;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -183,7 +183,7 @@ class ReaderPostDetailFragment : Fragment(),
     @Inject internal lateinit var readerFileDownloadManager: ReaderFileDownloadManager
     @Inject internal lateinit var featuredImageUtils: FeaturedImageUtils
     @Inject internal lateinit var privateAtomicCookie: PrivateAtomicCookie
-    @Inject internal lateinit var mSiteStore: SiteStore    
+    @Inject internal lateinit var mSiteStore: SiteStore
 
     private val mSignInClickListener = View.OnClickListener {
         EventBus.getDefault()


### PR DESCRIPTION
This is a follow up PR to the #11540 

In that PR we removed a check in the OnPostUploaded event handler to allow snackbar management for when reblogging to sites different from the selected one

![image](https://user-images.githubusercontent.com/47797566/80069218-4712bc00-8541-11ea-927a-34853ad9d011.png)

This PR reintroduce the check and allows the event management for posts belonging to a different site than the selected one if we have the site in the sites store.

This also fixes a bug since we were actually possibly passing the wrong site (the selected one) to the `onPostUploadedSnackbarHandler` even when reblogging to a site different from the selected one. This could lead to odd behaviours especially when dealing with pairs of sites (the selected one and the reblogged-to one) where the user has/has not rights to publish given the `boolean userCanPublish = userCanPublish(site);` check in the `onPostUploadedSnackbarHandler`.

## To test
Create a scenario where the logged in user has two sites in his list of sites. One where has publish rights and one where has not publish rights (Contributor rights).

- Switch Site to where you have publish rights
- Go to reader and reblog a post to the site you do not have publish rights and check you get no PUBLISH action 

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/80071295-a7572d00-8544-11ea-90d0-d6a782489988.png>
</p>

- Reblog (in Editor save the post as Draft) to the site where you have publish rights and check you get the snackbar with Publish action

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/80071361-c48bfb80-8544-11ea-9e7d-089f5fc1b877.png>
</p>

- Publish from snackbar action and check you get the snackbar with View action
- View from snackbar action and check you get the right view screen on the right site you selected for reblog
- Smoke test the `OnPostUpload` event/snackbar handler: publish/draft to your site post/page from FAB, from Post/Page list coming back to My Site to check the snackbar appears as expected (whatever else you can think of 😊)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
