### PR TITLE
Issue/11739 whats new feature flag and link to what's new announcement

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -68,6 +68,7 @@ android {
 
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
         buildConfigField "boolean", "TENOR_AVAILABLE", "true"
+        buildConfigField "boolean", "FEATURE_ANNOUNCEMENT_AVAILABLE", "false"
     }
 
     // Gutenberg's dependency - react-native-video is using
@@ -100,6 +101,7 @@ android {
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             dimension "buildType"
+            buildConfigField "boolean", "FEATURE_ANNOUNCEMENT_AVAILABLE", "true"
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -167,9 +167,9 @@ public class AppSettingsFragment extends PreferenceFragment
         mWhatsNew = findPreference(getString(R.string.pref_key_whats_new));
 
         if (BuildConfig.FEATURE_ANNOUNCEMENT_AVAILABLE) {
-            mWhatsNew.setTitle(getString(R.string.whats_new_in_version, WordPress.versionName));
+            mWhatsNew.setSummary(getString(R.string.whats_new_in_version_summary, WordPress.versionName));
         } else {
-           removeWhatsNewPreference();
+            removeWhatsNewPreference();
         }
 
         if (!BuildConfig.OFFER_GUTENBERG) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -66,6 +66,8 @@ public class AppSettingsFragment extends PreferenceFragment
     private PreferenceScreen mPrivacySettings;
     private WPSwitchPreference mStripImageLocation;
 
+    private Preference mWhatsNew;
+
     @Inject SiteStore mSiteStore;
     @Inject AccountStore mAccountStore;
     @Inject Dispatcher mDispatcher;
@@ -162,6 +164,14 @@ public class AppSettingsFragment extends PreferenceFragment
 
         mStripImageLocation.setChecked(AppPrefs.isStripImageLocation());
 
+        mWhatsNew = findPreference(getString(R.string.pref_key_whats_new));
+
+        if (BuildConfig.FEATURE_ANNOUNCEMENT_AVAILABLE) {
+            mWhatsNew.setTitle(getString(R.string.whats_new_in_version, WordPress.versionName));
+        } else {
+           removeWhatsNewPreference();
+        }
+
         if (!BuildConfig.OFFER_GUTENBERG) {
             removeExperimentalCategory();
         }
@@ -173,6 +183,13 @@ public class AppSettingsFragment extends PreferenceFragment
         PreferenceScreen preferenceScreen =
                 (PreferenceScreen) findPreference(getString(R.string.pref_key_app_settings_root));
         preferenceScreen.removePreference(experimentalPreferenceCategory);
+    }
+
+
+    private void removeWhatsNewPreference() {
+        PreferenceCategory aboutTheAppPreferenceCategory =
+                (PreferenceCategory) findPreference(getString(R.string.pref_key_about_section));
+        aboutTheAppPreferenceCategory.removePreference(mWhatsNew);
     }
 
     @Override

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -22,6 +22,7 @@
     <string name="pref_key_app_theme" translatable="false">wp_pref_app_theme</string>
     <string name="pref_key_app_about" translatable="false">wp_pref_app_about</string>
     <string name="pref_key_oss_licenses" translatable="false">wp_pref_open_source_licenses</string>
+    <string name="pref_key_whats_new" translatable="false">wp_pref_whats_new</string>
     <string name="pref_notification_blogs" translatable="false">wp_pref_notification_blogs</string>
     <string name="pref_notification_blogs_followed" translatable="false">pref_notification_blogs_followed</string>
     <string name="pref_notification_other_category" translatable="false">wp_pref_notification_other_category</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -813,7 +813,8 @@
 
     <!-- preferences -->
     <string name="open_source_licenses">Open source licenses</string>
-    <string name="whats_new_in_version">What\'s New Version %s</string>
+    <string name="whats_new_in_version_title">What\'s New</string>
+    <string name="whats_new_in_version_summary">Version %s</string>
     <string name="preference_open_device_settings">Open device settings</string>
     <string name="preference_collect_information">Collect information</string>
     <string name="preference_crash_reports">Crash reports</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="share_intent_screen_title">Pick site</string>
     <string name="edit_photo_screen_title">Edit Photo</string>
     <string name="notif_detail_screen_title">Notification detail %s</string>
-    
+
     <!-- general strings -->
     <string name="posts">Posts</string>
     <string name="sites">Sites</string>
@@ -813,6 +813,7 @@
 
     <!-- preferences -->
     <string name="open_source_licenses">Open source licenses</string>
+    <string name="whats_new_in_version">What\'s New Version %s</string>
     <string name="preference_open_device_settings">Open device settings</string>
     <string name="preference_collect_information">Collect information</string>
     <string name="preference_crash_reports">Crash reports</string>

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -135,7 +135,7 @@
 
         <Preference
             android:key="@string/pref_key_whats_new"
-            android:title="@string/whats_new_in_version" />
+            android:title="@string/whats_new_in_version_title" />
 
     </PreferenceCategory>
 </PreferenceScreen>

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -133,5 +133,9 @@
             android:key="@string/pref_key_oss_licenses"
             android:title="@string/open_source_licenses" />
 
+        <Preference
+            android:key="@string/pref_key_whats_new"
+            android:title="@string/whats_new_in_version" />
+
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Fixes #11739

This PR adds a feature flag for What's New and adds a link to future announcement dialog from App Settings, so we can test it and make sure the flag is working :)

The app settings label also shows a current version number next to the title. I assume we would like to show a version that has an announcement, so this functionality will come later.

[![Image from Gyazo](https://i.gyazo.com/e87602c3e06b54e897b8bb6485d94949.png)](https://gyazo.com/e87602c3e06b54e897b8bb6485d94949)


Design mock:
[![Image from Gyazo](https://i.gyazo.com/71e3537807f63b3a047935a717e95f53.png)](https://gyazo.com/71e3537807f63b3a047935a717e95f53)


To test:
- Install the wasabi build.
- Navigate to app settings and make sure the What's New preference is there and that it displays the current version name next to it.
- Install vanilla build.
- Navigate to app settings and make sure the What's New preference is not there.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
