### PR TITLE
Gutenberg/shallow submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libs/gutenberg-mobile"]
 	path = libs/gutenberg-mobile
 	url = ../../wordpress-mobile/gutenberg-mobile.git
+	shallow = true


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/2182

gb-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2183

This PR turns the gutenberg-mobile git submodule to a shallow one by default, to minimize the size pulled when casually cloning gutenberg-mobile.

Note: This PR is targeting [another PR](https://github.com/wordpress-mobile/WordPress-Android/pull/11594), only because the gutenberg-mobile bridge changes that PR introduces are already merged to gutenberg-mobile develop, and targeting develop will result to build errors.

That said, the issue at hand (JitPack seemingly taking too long to clone the gutenberg-mobile repo and bailing) is plaguing this PR anyway, by failing many of its CI jobs.

### To test A
0. Prepare for a fresh clone of the repo by going into a folder that doesn't have the repo clone yet
1. Issue `git clone --single-branch --branch gutenberg/shallow-submodules git@github.com:wordpress-mobile/WordPress-Android.git` to pull the repo. Wait until that finishes.
2. `cd WordPress-Android` to go into the clone
3. Issue `git submodule update --init --recursive` and wait until it finishes
4. `cd libs/gutenberg-mobile` to go into the gb-mobile submodule
5. Issue `git rev-parse --is-shallow-repository` to verify it's a shallow clone. It should return `true`.
6. Check that the nested submodules are also shallow, namely the `gutenberg` and `jetpack` submodules.
7. Issue `git fetch --unshallow` to pull the whole submodule history, to verify that it can be done. `git rev-parse --is-shallow-repository` should return `false` after this.

### To test B
0. Prepare for a fresh clone of the repo by going into a folder that doesn't have the repo clone yet
1. Issue `git clone --single-branch --branch gutenberg/shallow-submodules git@github.com:wordpress-mobile/WordPress-Android.git` to pull the repo. Wait until that finishes.
2. `cd WordPress-Android` to go into the clone
3. Issue `git submodule update --init --recursive --no-recommend-shallow` and wait until it finishes
4. `cd libs/gutenberg-mobile` to go into the gbm-mobile submodule
5. Issue `git rev-parse --is-shallow-repository` to verify it's a **not** shallow clone. It should return `false`.
6. Verify that the nested submodules (namely the `gutenberg` and `jetpack` submodules) are also **not** shallow

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
