### PR TITLE
Update gutenberg with new Aztec version

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,7 @@
 14.8
 -----
+* Block editor: Add alignment options for heading block on Android
+* Block editor: Update quote block to visually reflect selected alignment
  
 14.7
 -----

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = 'v1.3.40'
+        aztecVersion = 'v1.3.42'
     }
 
     dependencies {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -68,6 +68,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
+import org.wordpress.aztec.AlignmentRendering;
 import org.wordpress.aztec.Aztec;
 import org.wordpress.aztec.AztecAttributes;
 import org.wordpress.aztec.AztecContentChangeWatcher.AztecTextChangeObserver;
@@ -2331,7 +2332,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         plugins.add(new CaptionShortcodePlugin());
         plugins.add(new VideoShortcodePlugin());
         plugins.add(new AudioShortcodePlugin());
-        return new AztecParser(plugins);
+        return new AztecParser(AlignmentRendering.SPAN_LEVEL, plugins);
     }
 
     private Drawable getLoadingImagePlaceholder() {


### PR DESCRIPTION
See related gutenberg mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2006

⚠️  Before merging this PR, the `aztecVersion` needs to be updated from a hash to a tag

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
