### PR TITLE
Remove automated tagging from code_freeze lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,7 +70,6 @@ ENV["HAS_ALPHA_VERSION"]="true"
     localize_gutenberg(skip_module_update: true)
     localize_libs()
     ensure_git_status_clean()
-    android_tag_build()
     get_prs_list(repository:GHHELPER_REPO, start_tag:"release/#{old_version}", report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{new_version}.txt")
   end
 


### PR DESCRIPTION
I very frequently need to remove the tags created by the script and re-tag it which ends up hurting the workflow rather than helping it. This has been especially true since we started releasing FluxC and updating the tag in the release branch. So, I suggest removing this and instead adding a manual step in the release checklist.