### PR TITLE
Update quick start subtitle size.

### DIFF
--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -505,7 +505,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginEnd">@dimen/margin_extra_large</item>
         <item name="android:layout_width">wrap_content</item>
-        <item name="android:textAppearance">?attr/textAppearanceCaption</item>
+        <item name="android:textAppearance">?attr/textAppearanceBody2</item>
+        <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>
     </style>
 
     <style name="QuickStartDivider">
@@ -554,7 +555,8 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:maxLines">1</item>
         <item name="android:paddingEnd">@dimen/content_margin</item>
-        <item name="android:textAppearance">?attr/textAppearanceCaption</item>
+        <item name="android:textAppearance">?attr/textAppearanceBody2</item>
+        <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>
     </style>
 
     <!--People Management Styles-->


### PR DESCRIPTION
Updating the quick start subtitle on suggestion from @SylvesterWilmott 

From Caption (12sp) to Body2 (14sp).

![Screenshot_1587766651](https://user-images.githubusercontent.com/728822/80261346-039e7780-863f-11ea-80b2-163d3b6f80f9.png)

![Screenshot_1587766654](https://user-images.githubusercontent.com/728822/80261350-05683b00-863f-11ea-8601-814c188c86ac.png)

To test:
- Create a new site (or enable quick start programmatically).
- Make sure the quick start subtitle (one that says `x of 6 completed`) in the My Site card and subtitle inside the quick start tasks list look good.




PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
