### PR TITLE
Gutenberg: update to v1.27.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,8 +8,6 @@
 * Block editor: Fix the icons in FloatingToolbar on RTL mode
 * Block editor: Add alignment options for heading block
 * Block editor: Fix titles in the media picker
-
-* Block editor: Add alignment options for heading block on Android
 * Block editor: Update quote block to visually reflect selected alignment
 * Block editor: Fix bug where buttons in page templates were not rendering correctly on web
  

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,12 @@
 14.8
 -----
-* Block editor: Add alignment options for heading block on Android
+* Block editor: Prefill caption for image blocks when available on the Media library
+* Block editor: New block: Buttons. From now you’ll be able to add the individual Button block only inside the Buttons block
+* Block editor: Fix bug where whitespaces at start of text blocks were being removed
+* Block editor: Add support for upload options in Cover block
+* Block editor: Floating toolbar, previously located above nested blocks, is now placed at the top of the screen
+* Block editor: Fix the icons in FloatingToolbar on RTL mode
+* Block editor: Add alignment options for heading block
 * Block editor: Update quote block to visually reflect selected alignment
  
 14.7

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * Block editor: Fix the icons in FloatingToolbar on RTL mode
 * Block editor: Add alignment options for heading block
 * Block editor: Update quote block to visually reflect selected alignment
+* Block editor: Fix bug where buttons in page templates were not rendering correctly on web
  
 14.7
 -----


### PR DESCRIPTION
## Related PRs

gutenberg-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2186
WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/14002

To test:


**Bug fix**

- [x] Issue/1966 Disable whitespace collapse in Aztec https://github.com/wordpress-mobile/gutenberg-mobile/pull/2127
- [x] Revert "Add prop to force fullscreen preview for videos. (#20436)" https://github.com/wordpress-mobile/gutenberg-mobile/pull/2173
- [x] Block list - Autoscroll to text components within InnerBlocks https://github.com/wordpress-mobile/gutenberg-mobile/pull/2171
- [x] Issue/1851 insert captions https://github.com/wordpress-mobile/gutenberg-mobile/pull/2156
- [x] [FIX] Cover block background when there's a video is totally black https://github.com/wordpress-mobile/gutenberg-mobile/pull/2146
- [x]  Correct colors usage in Button https://github.com/wordpress-mobile/gutenberg-mobile/issues/2155
- [x] Correct slider step value https://github.com/wordpress-mobile/gutenberg-mobile/issues/2119
- [x] Refactor: Fixed position of `FloatingToolbar` on the bottom of the screen https://github.com/wordpress-mobile/gutenberg-mobile/issues/2118

**New feature & Improvement**

- [x] Update Aztec-Android for alignment handling https://github.com/wordpress-mobile/gutenberg-mobile/pull/2006
- [x] ~Video block - don't force full screen on iOS https://github.com/wordpress-mobile/gutenberg-mobile/pull/1952~ This was reverted
- [x] Adjust RangeControl to add the stepper control and allow type selection https://github.com/wordpress-mobile/gutenberg-mobile/pull/2125
- [x] Cover block - enable upload options in production https://github.com/wordpress-mobile/gutenberg-mobile/issues/2174
- [x] Cover block uploads failure UI https://github.com/wordpress-mobile/gutenberg-mobile/issues/2150
- [x] Add Buttons block https://github.com/wordpress-mobile/gutenberg-mobile/issues/1933


**Note:** including this to ensure we don't see the block in production yet:
- [x] Contact Info jetpack native blocks behind DEV flag https://github.com/wordpress-mobile/gutenberg-mobile/issues/1934

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.