### PR TITLE
Make notifications list title static

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -78,7 +78,6 @@ public class NotificationsListFragment extends Fragment implements MainToolbarFr
 
     private static final String KEY_LAST_TAB_POSITION = "lastTabPosition";
 
-    private String mToolbarTitle;
     private TabLayout mTabLayout;
     private ViewGroup mConnectJetpackView;
     private boolean mShouldRefreshNotifications;
@@ -116,7 +115,7 @@ public class NotificationsListFragment extends Fragment implements MainToolbarFr
         mConnectJetpackView = view.findViewById(R.id.connect_jetpack);
 
         mToolbar = view.findViewById(R.id.toolbar_main);
-        mToolbar.setTitle(mToolbarTitle);
+        mToolbar.setTitle(R.string.notifications_screen_title);
         ((AppCompatActivity) getActivity()).setSupportActionBar(mToolbar);
 
         mTabLayout = view.findViewById(R.id.tab_layout);
@@ -214,11 +213,7 @@ public class NotificationsListFragment extends Fragment implements MainToolbarFr
 
     @Override
     public void setTitle(@NonNull String title) {
-        mToolbarTitle = title;
-
-        if (mToolbar != null) {
-            mToolbar.setTitle(mToolbarTitle);
-        }
+        // Do nothing since the title is static
     }
 
     private void clearToolbarScrollFlags() {


### PR DESCRIPTION
I think this was buggy even in previous versions. What is happening is that the static title (it's always the same string) is being set from the parent activity but it's not saved in the instance state. When you return back to the fragment, the title can't be restored. We're removing the option to set the fragment title from the activity in 14.8 so in this fix I'm simply using the static string (the one that's always used on this screen). The proper fix will come in 14.8. 

To test:
- Go to Notifications
- Press the back button
- Reopen the app
- Notice that the title hasn't disappeared

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
