### PR TITLE
Bump libraries to support remote config

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -194,9 +194,9 @@ dependencies {
     })
 
     implementation 'com.android.volley:volley:1.1.1'
-    implementation 'com.google.firebase:firebase-messaging:17.0.0'
-    implementation 'com.google.android.gms:play-services-auth:15.0.1'
-    implementation 'com.google.android.gms:play-services-places:15.0.1'
+    implementation 'com.google.android.gms:play-services-auth:18.0.0'
+    implementation 'com.google.android.gms:play-services-places:17.0.0'
+    implementation 'com.google.firebase:firebase-messaging:20.1.5'
     implementation 'com.android.installreferrer:installreferrer:1.0'
     implementation 'com.github.chrisbanes.photoview:library:1.2.4'
     implementation 'org.greenrobot:eventbus:3.1.1'

--- a/WordPress/src/main/java/org/wordpress/android/push/InstanceIDService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/InstanceIDService.java
@@ -2,9 +2,11 @@ package org.wordpress.android.push;
 
 import android.content.Intent;
 
-import com.google.firebase.iid.FirebaseInstanceIdService;
+import androidx.annotation.NonNull;
 
-public class InstanceIDService extends FirebaseInstanceIdService {
+import com.google.firebase.messaging.FirebaseMessagingService;
+
+public class InstanceIDService extends FirebaseMessagingService {
     /**
      * Called if InstanceID token is updated. This may occur if the security of
      * the previous token had been compromised. Note that this is also called
@@ -13,8 +15,8 @@ public class InstanceIDService extends FirebaseInstanceIdService {
      */
     // [START refresh_token]
     @Override
-    public void onTokenRefresh() {
-        // Register for Cloud messaging
+    public void onNewToken(@NonNull String s) {
+        super.onNewToken(s);
         GCMRegistrationIntentService.enqueueWork(this,
                 new Intent(this, GCMRegistrationIntentService.class));
     }


### PR DESCRIPTION
This PR bumps three libraries in order to implement firebase remote config library. I've checked the change log of these libraries and everything should be in order. The only breaking change was moving to AndroidX (which we did already) and a different way to handle InstanceID (which I implemented in this PR). 

To test:
- Smoke test the Google login and the app

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
