### PR TITLE
Fix copy string lint issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -141,7 +141,7 @@ public class AppLogViewerActivity extends LocaleAwareActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
         // Copy to clipboard button
-        MenuItem item = menu.add(Menu.NONE, ID_COPY_TO_CLIPBOARD, Menu.NONE, android.R.string.copy);
+        MenuItem item = menu.add(Menu.NONE, ID_COPY_TO_CLIPBOARD, Menu.NONE, R.string.copy_text);
         item.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
         item.setIcon(R.drawable.ic_copy_white_24dp);
         // Share button

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -349,7 +349,7 @@
                             android:layout_alignParentEnd="true"
                             android:layout_centerVertical="true"
                             android:layout_marginEnd="@dimen/margin_extra_large"
-                            android:text="@string/copy" />
+                            android:text="@string/copy_text" />
 
 
                     </RelativeLayout>

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -1288,7 +1288,7 @@ Language: ar
     <string name="media_edit_filename_caption">اسم الملف</string>
     <string name="media_edit_url_caption">عنوان URL</string>
     <string name="media_edit_alttext_text">النص البديل</string>
-    <string name="copy">نسخ</string>
+    <string name="copy_text">نسخ</string>
     <string name="connect_site">الاتصال بالموقع</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">ضوء وميض</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">جهاز الاهتزاز</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -693,7 +693,7 @@ Language: cs_CZ
     <string name="media_edit_filename_caption">Jméno souboru</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Alternativní text</string>
-    <string name="copy">Kopírovat</string>
+    <string name="copy_text">Kopírovat</string>
     <string name="connect_site">Web pro připojení</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Blikat světlem</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibrovat zařízením</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -1293,7 +1293,7 @@ Language: de
     <string name="media_edit_filetype_caption">Dateityp</string>
     <string name="media_edit_filename_caption">Dateiname</string>
     <string name="media_edit_alttext_text">Alternativtext</string>
-    <string name="copy">Kopieren</string>
+    <string name="copy_text">Kopieren</string>
     <string name="connect_site">Website verbinden</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Blinklicht</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Gerät vibrieren lassen</string>

--- a/WordPress/src/main/res/values-el/strings.xml
+++ b/WordPress/src/main/res/values-el/strings.xml
@@ -438,7 +438,7 @@ Language: el_GR
     <string name="media_edit_filename_caption">Όνομα Αρχείου</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Ενναλακτικό κείμενο</string>
-    <string name="copy">Αντιγραφή</string>
+    <string name="copy_text">Αντιγραφή</string>
     <string name="connect_site">Σύνδεση ιστότοπου</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Δόνηση συσκευής</string>
     <string name="notification_settings_item_sights_and_sounds_choose_sound">Επιλογή ήχου</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -1015,7 +1015,7 @@ Language: en_AU
     <string name="media_edit_filename_caption">File Name</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Alt text</string>
-    <string name="copy">Copy</string>
+    <string name="copy_text">Copy</string>
     <string name="connect_site">Connect Site</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Blink light</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibrate device</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -1110,7 +1110,7 @@ Language: en_CA
     <string name="media_edit_filename_caption">File Name</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Alt text</string>
-    <string name="copy">Copy</string>
+    <string name="copy_text">Copy</string>
     <string name="connect_site">Connect Site</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Blink light</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibrate device</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -1290,7 +1290,7 @@ Language: en_GB
     <string name="media_edit_filename_caption">File Name</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Alt text</string>
-    <string name="copy">Copy</string>
+    <string name="copy_text">Copy</string>
     <string name="connect_site">Connect Site</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Blink light</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibrate device</string>

--- a/WordPress/src/main/res/values-es-rCL/strings.xml
+++ b/WordPress/src/main/res/values-es-rCL/strings.xml
@@ -773,7 +773,7 @@ Language: es_CL
     <string name="media_edit_filename_caption">Nombre de Archivo</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Texto alternativo</string>
-    <string name="copy">Copiar</string>
+    <string name="copy_text">Copiar</string>
     <string name="connect_site">Conectar Sitio</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Parpadeo de luz</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibrar dispositivo</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -48,7 +48,7 @@ Language: es_CO
     <string name="media_edit_filename_caption">Nombre del archivo</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Texto alternativo</string>
-    <string name="copy">Copiar</string>
+    <string name="copy_text">Copiar</string>
     <string name="connect_site">Conectar el sitio</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Luz parpadeante</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibración del dispositivo</string>

--- a/WordPress/src/main/res/values-es-rMX/strings.xml
+++ b/WordPress/src/main/res/values-es-rMX/strings.xml
@@ -1288,7 +1288,7 @@ Language: es_MX
     <string name="media_edit_filename_caption">Nombre del archivo</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Texto alternativo</string>
-    <string name="copy">Copiar</string>
+    <string name="copy_text">Copiar</string>
     <string name="connect_site">Conectar el sitio</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Luz parpadeante</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibración del dispositivo</string>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -1293,7 +1293,7 @@ Language: es_VE
     <string name="media_edit_filename_caption">Nombre del archivo</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Texto alternativo</string>
-    <string name="copy">Copiar</string>
+    <string name="copy_text">Copiar</string>
     <string name="connect_site">Conectar el sitio</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Luz parpadeante</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibración del dispositivo</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -1295,7 +1295,7 @@ Language: es
     <string name="media_edit_filename_caption">Nombre del archivo</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Texto alternativo</string>
-    <string name="copy">Copiar</string>
+    <string name="copy_text">Copiar</string>
     <string name="connect_site">Conectar el sitio</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Luz parpadeante</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibración del dispositivo</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -1295,7 +1295,7 @@ Language: fr
     <string name="media_edit_filename_caption">Nom du fichier</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Texte alternatif</string>
-    <string name="copy">Copier</string>
+    <string name="copy_text">Copier</string>
     <string name="connect_site">Connecter le site</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Faire clignoter la lumière</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Faire vibrer l\'appareil</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -1286,7 +1286,7 @@ Language: he_IL
     <string name="media_edit_filename_caption">שם קובץ</string>
     <string name="media_edit_url_caption">כתובת אתר</string>
     <string name="media_edit_alttext_text">טקסט חלופי</string>
-    <string name="copy">העתק</string>
+    <string name="copy_text">העתק</string>
     <string name="connect_site">חיבור האתר</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">הבהוב</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">מכשיר רוטט</string>

--- a/WordPress/src/main/res/values-hi/strings.xml
+++ b/WordPress/src/main/res/values-hi/strings.xml
@@ -23,7 +23,7 @@ Language: hi_IN
     <string name="media_edit_url_caption">यूआरएल</string>
     <string name="media_edit_filename_caption">फ़ाइल का नाम</string>
     <string name="media_edit_filetype_caption">फाइल का प्रकार</string>
-    <string name="copy">कापी</string>
+    <string name="copy_text">कापी</string>
     <string name="connect_site">साइट कनेक्ट करे</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">लाइट टिमटिमाये </string>
     <string name="notification_settings_item_sights_and_sounds_choose_sound">ध्वनि चुनें</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -1259,7 +1259,7 @@ Language: id
     <string name="media_edit_filename_caption">Nama File</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Teks alt</string>
-    <string name="copy">Salin</string>
+    <string name="copy_text">Salin</string>
     <string name="connect_site">Hubungkan Situs</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Kedipkan cahaya</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Getarkan perangkat</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -1270,7 +1270,7 @@ Language: it
     <string name="media_edit_filename_caption">Nome file</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Testo Alt</string>
-    <string name="copy">Copia</string>
+    <string name="copy_text">Copia</string>
     <string name="connect_site">Connetti un sito</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Luce lampeggiante</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibrazione dispositivo</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -1288,7 +1288,7 @@ Language: ja_JP
     <string name="media_edit_filename_caption">ファイル名</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">代替テキスト</string>
-    <string name="copy">コピー</string>
+    <string name="copy_text">コピー</string>
     <string name="connect_site">サイトを連携</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">点滅</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">端末をバイブレート</string>

--- a/WordPress/src/main/res/values-kmr/strings.xml
+++ b/WordPress/src/main/res/values-kmr/strings.xml
@@ -944,7 +944,7 @@ Language: ku_TR
     <string name="media_edit_filename_caption">Navê Pelgeyê</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Nivîsa alternatîv</string>
-    <string name="copy">Kopî bike</string>
+    <string name="copy_text">Kopî bike</string>
     <string name="connect_site">Malper Girêde</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Şewqê veke - bigire</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Amûrê biricifîne</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -1246,7 +1246,7 @@ Language: ko_KR
     <string name="media_edit_filename_caption">파일 이름</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">대체 텍스트</string>
-    <string name="copy">복사</string>
+    <string name="copy_text">복사</string>
     <string name="connect_site">사이트 연결</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">표시등이 깜박임</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">기기 진동</string>

--- a/WordPress/src/main/res/values-ms/strings.xml
+++ b/WordPress/src/main/res/values-ms/strings.xml
@@ -80,7 +80,7 @@ Language: ms
     <string name="media_edit_filetype_caption">Jenis Fail</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Teks alt</string>
-    <string name="copy">Salin</string>
+    <string name="copy_text">Salin</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Lampu kelip</string>
     <string name="connect_site">Sambung Laman</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Gegarkan peranti</string>

--- a/WordPress/src/main/res/values-nb/strings.xml
+++ b/WordPress/src/main/res/values-nb/strings.xml
@@ -1144,7 +1144,7 @@ Language: nb_NO
     <string name="media_edit_filename_caption">Filnavn</string>
     <string name="media_edit_url_caption">Nettadresse</string>
     <string name="media_edit_alttext_text">Alternativ tekst</string>
-    <string name="copy">Kopier</string>
+    <string name="copy_text">Kopier</string>
     <string name="connect_site">Koble til nettsted</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Lysblink</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibreringer</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -1191,7 +1191,7 @@ Language: nl
     <string name="media_edit_filename_caption">Bestandsnaam</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Alt. tekst</string>
-    <string name="copy">Kopieer</string>
+    <string name="copy_text">Kopieer</string>
     <string name="connect_site">Site koppelen</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Lamp laten knipperen</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Apparaat laten trillen</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -1284,7 +1284,7 @@ Language: pl
     <string name="media_edit_filename_caption">Nazwa pliku</string>
     <string name="media_edit_url_caption">Adres URL </string>
     <string name="media_edit_alttext_text">Tekst alternatywny</string>
-    <string name="copy">Kopiuj</string>
+    <string name="copy_text">Kopiuj</string>
     <string name="connect_site">Połącz witrynę</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Zamigaj diodą</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Zawibruj urządzeniem</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -1197,7 +1197,7 @@ Language: pt_BR
     <string name="media_edit_filename_caption">Nome do arquivo</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Texto alternativo</string>
-    <string name="copy">Copiar</string>
+    <string name="copy_text">Copiar</string>
     <string name="connect_site">Conectar site</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Sinal luminoso</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibrar dispositivo</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -1290,7 +1290,7 @@ Language: ro
     <string name="media_edit_filename_caption">Nume fișier</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Text alternativ</string>
-    <string name="copy">Copiază</string>
+    <string name="copy_text">Copiază</string>
     <string name="connect_site">Conectează situl</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Luminează intermitent</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibrează dispozitivul</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -1290,7 +1290,7 @@ Language: ru
     <string name="media_edit_filename_caption">Имя файла</string>
     <string name="media_edit_url_caption">URL-адрес</string>
     <string name="media_edit_alttext_text">Атрибут Alt</string>
-    <string name="copy">Копировать</string>
+    <string name="copy_text">Копировать</string>
     <string name="connect_site">Подключить сайт</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Мигание светом</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Вибрация устройства</string>

--- a/WordPress/src/main/res/values-sk/strings.xml
+++ b/WordPress/src/main/res/values-sk/strings.xml
@@ -665,7 +665,7 @@ Language: sk
     <string name="media_edit_filename_caption">Názov súboru</string>
     <string name="media_edit_url_caption">URL adresa</string>
     <string name="media_edit_alttext_text">Celý text</string>
-    <string name="copy">Kopírovať</string>
+    <string name="copy_text">Kopírovať</string>
     <string name="connect_site">Pripojte webovú stránku</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Blikajúce svetlo</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vybračné zariadenie</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -1288,7 +1288,7 @@ Language: sq_AL
     <string name="media_edit_filename_caption">Emër Kartele</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Tekst alternativ</string>
-    <string name="copy">Kopjoje</string>
+    <string name="copy_text">Kopjoje</string>
     <string name="connect_site">Lidhe Sajtin</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Xixëllo dritëzë njoftimesh</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Dridhe pajisjen</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -1290,7 +1290,7 @@ Language: sv_SE
     <string name="media_edit_filename_caption">Filnamn</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Alt-text</string>
-    <string name="copy">Kopiera</string>
+    <string name="copy_text">Kopiera</string>
     <string name="connect_site">Anslut webbplats</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Blinksignal</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibrationssignal</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -1288,7 +1288,7 @@ Language: tr
     <string name="media_edit_filename_caption">Dosya adı</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">Alternatif metin</string>
-    <string name="copy">Kopyala</string>
+    <string name="copy_text">Kopyala</string>
     <string name="connect_site">Site bağla</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Işığı yakıp söndür</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Cihazı titreştir</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -1216,7 +1216,7 @@ Language: zh_CN
     <string name="media_edit_filename_caption">文件名</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">替代文本</string>
-    <string name="copy">复制</string>
+    <string name="copy_text">复制</string>
     <string name="connect_site">连接站点</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">让指示灯闪烁</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">让设备振动</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -1275,7 +1275,7 @@ Language: zh_TW
     <string name="media_edit_filename_caption">檔案名稱</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">替代文字</string>
-    <string name="copy">複製</string>
+    <string name="copy_text">複製</string>
     <string name="connect_site">連結網站</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">閃爍燈</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">震動裝置</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -1275,7 +1275,7 @@ Language: zh_TW
     <string name="media_edit_filename_caption">檔案名稱</string>
     <string name="media_edit_url_caption">URL</string>
     <string name="media_edit_alttext_text">替代文字</string>
-    <string name="copy">複製</string>
+    <string name="copy_text">複製</string>
     <string name="connect_site">連結網站</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">閃爍燈</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">震動裝置</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@
     <string name="cant_open_url">Unable to open the link</string>
     <string name="retry">Retry</string>
     <string name="invalid_ip_or_range">Invalid IP or IP range</string>
-    <string name="copy">Copy</string>
+    <string name="copy_text">Copy</string>
     <string name="error_please_choose_browser">Error opening the default web browser. Please choose another app:</string>
     <string name="delete_yes">Delete</string>
     <string name="add_count">Add %d</string>

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -32,7 +32,6 @@ import kotlinx.android.synthetic.main.preview_image_fragment.*
 import org.wordpress.android.imageeditor.ImageEditor
 import org.wordpress.android.imageeditor.ImageEditor.RequestListener
 import org.wordpress.android.imageeditor.R
-import org.wordpress.android.imageeditor.R.string
 import org.wordpress.android.imageeditor.crop.CropFragment
 import org.wordpress.android.imageeditor.crop.CropViewModel.CropResult
 import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.ImageData
@@ -149,7 +148,7 @@ class PreviewImageFragment : Fragment() {
     }
 
     private fun initializeInsertButton() {
-        insertButton.text = getString(string.insert_label_with_count, viewModel.numberOfImages)
+        insertButton.text = getString(R.string.insert_label_with_count, viewModel.numberOfImages)
         insertButton.setOnClickListener {
             viewModel.onInsertClicked()
         }


### PR DESCRIPTION
Fix lint issues caused by miss-use of a private string resource. I decided to change the name of the resource - this will have the negative impact that all the languages will need to be translated again, but I still think it's the only clean solution. Wdyt?

Note: This PR still contains some lint issues. These issues are fixed in https://github.com/wordpress-mobile/WordPress-Android/pull/11787.


To test:
- smoke test the app

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
