### PR TITLE
Downgrade nav component to   2̶.̶2̶.̶0̶ 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
     ext.kotlin_coroutines_version = '1.3.3'
     ext.androidx_work_version = "2.0.1"
-    ext.navComponenVersion = '2.3.0-alpha05'
+    ext.navComponenVersion = '2.2.2'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
     ext.kotlin_coroutines_version = '1.3.3'
     ext.androidx_work_version = "2.0.1"
-    ext.navComponenVersion = '2.2.2'
+    ext.navComponenVersion = '2.2.0'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.61'
     ext.kotlin_coroutines_version = '1.3.3'
     ext.androidx_work_version = "2.0.1"
-    ext.navComponenVersion = '2.2.0'
+    ext.navComponenVersion = '2.0.0'
 
     repositories {
         google()

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageActivity.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.imageeditor
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
@@ -11,6 +12,7 @@ import androidx.navigation.ui.navigateUp
 import org.wordpress.android.imageeditor.ImageEditor.EditorAction.EditorCancelled
 
 class EditImageActivity : AppCompatActivity() {
+    private lateinit var viewModel: EditImageViewModel
     private lateinit var hostFragment: NavHostFragment
     private lateinit var appBarConfiguration: AppBarConfiguration
 
@@ -20,6 +22,7 @@ class EditImageActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        viewModel = ViewModelProvider(this).get(EditImageViewModel::class.java)
         setContentView(R.layout.activity_edit_image)
 
         hostFragment = supportFragmentManager

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/EditImageViewModel.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.imageeditor
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import org.wordpress.android.imageeditor.crop.CropViewModel.CropResult
+import org.wordpress.android.imageeditor.viewmodel.Event
+
+class EditImageViewModel : ViewModel() {
+    private val _cropResult = MutableLiveData<Event<CropResult>>()
+    val cropResult: LiveData<Event<CropResult>> = _cropResult
+
+    fun setCropResult(cropResult: CropResult) {
+        _cropResult.value = Event(cropResult)
+    }
+}

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropFragment.kt
@@ -17,6 +17,7 @@ import androidx.navigation.fragment.navArgs
 import com.yalantis.ucrop.UCropFragment
 import com.yalantis.ucrop.UCropFragment.UCropResult
 import com.yalantis.ucrop.UCropFragmentCallback
+import org.wordpress.android.imageeditor.EditImageViewModel
 import org.wordpress.android.imageeditor.ImageEditor
 import org.wordpress.android.imageeditor.R
 import org.wordpress.android.imageeditor.crop.CropViewModel.CropResult
@@ -159,10 +160,7 @@ class CropFragment : Fragment(), UCropFragmentCallback {
     private fun navigateBackWithCropResult(cropResult: CropResult) {
         if (navArgs.shouldReturnToPreviewScreen) {
             val navController = findNavController()
-
-            val saveStateHandle = navController.previousBackStackEntry?.savedStateHandle
-            saveStateHandle?.set(CROP_RESULT, cropResult)
-
+            ViewModelProvider(requireActivity()).get(EditImageViewModel::class.java).setCropResult(cropResult)
             navController.popBackStack()
         } else {
             val resultData = viewModel.getOutputData(cropResult)


### PR DESCRIPTION
Note: 
1. Review and merge - https://github.com/wordpress-mobile/WordPress-Android/pull/11786 
2. Merge `feature/media-editing-phase-two` into `media-editing-downgrade-nav-comp`
3. Make sure CircleCI passes all lint checks
4. Review this PR
5. Merge this PR


This PR downgrades NavComponent to v2.2.0 so we avoid using alpha. The main reason for introducing the alpha version was that we wanted to pass data from one fragment to another. This PR uses a parent viewModel as the mediator so we don't need to rely on the alpha version of the dependency.

To test:
1. Add an imageBlock into gutenberg
2. Select "Choose from device"
3. Pick an image and select "Edit"
4. Crop the image
5. Click on Done
6. Verify the image gets added to the editor
----------------
1. Add a gallery block into gutenberg
2. Select "Choose from device"
3. Pick multiple images and select "Edit"
4. Click on the crop icon in the toolbar
5. Crop the image
6. Click on done
7. Make sure both the thumbnail and image preview gets updated with the edited version
8. Click on Insert
9. Verify the images get added to the editor

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
