### PR TITLE
Media editing fix tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -230,7 +230,6 @@ public class PhotoPickerActivity extends LocaleAwareActivity
             case IMAGE_EDITOR_EDIT_IMAGE:
                 if (data != null && data.hasExtra(PreviewImageFragment.ARG_EDIT_IMAGE_DATA)) {
                     List<Uri> uris = WPMediaUtils.retrieveImageEditorResult(data);
-                    mImageEditorTracker.trackAddPhoto(uris);
                     doMediaUrisSelected(uris, PhotoPickerMediaSource.APP_PICKER);
                 }
                 break;


### PR DESCRIPTION
As per discussion with @leandroalonso, this PR slightly modifies when `editor_photo_added` is being tracked (originally implemented in https://github.com/wordpress-mobile/WordPress-Android/pull/11758).

- When the user is adding an image into the editor - using any of the pickers (stock_photos, device_library, wp_library, ..) we'll track `editor_photo_added` with property `via` set to the the corresponding source (no matter if the image was edited or not)
- When the user clicks on "edit" on an image which is already in the editor content - we'll track `editor_photo_added` with property `via` set to "media_editor"


To test:
Check that the events are tracked as per the description above.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
