### PR TITLE
Media editing fix minor ui issues

### DIFF
--- a/libs/image-editor/ImageEditor/src/main/res/values/styles.xml
+++ b/libs/image-editor/ImageEditor/src/main/res/values/styles.xml
@@ -7,6 +7,7 @@
         <item name="colorAccent">@android:color/white</item>
         <item name="android:textColor">@android:color/white</item>
         <item name="colorOnPrimary">@android:color/white</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
     </style>
 
     <style name="ErrorTextStyle">

--- a/libs/image-editor/ImageEditor/src/main/res/values/styles.xml
+++ b/libs/image-editor/ImageEditor/src/main/res/values/styles.xml
@@ -20,5 +20,6 @@
         <item name="android:minWidth">0dp</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:padding">8dp</item>
+        <item name="android:foreground">?attr/selectableItemBackground</item>
     </style>
 </resources>


### PR DESCRIPTION
Note for the release manager: We'd ideally like to merge this PR into 14.8. I assume we'll merge it in time, but since it's thursday I thought it's better to leave a comment. In case we won't merge it in time, please feel free to bump it to 14.9 as neither of the issues is important.

This PR fixes two minor issues found during a final PR review of Media Editing Phase 2:
- The system navigation bar color in the Media Editor is explicitly set to `surfaceColor`. The previous implementation didn't work on some devices such as Samsung with Android 10. 
- Added selector for "insert" button in the Media Editor

To test:
1. Add a gallery clock to the Editor
2. Choose from device
3. Select 2+ images
4. Click on "Edit"
5. Notice the system navigation bar color is dark as the rest of the screen - in both light and dark mode
6. Hold a finger on the "insert" button and notice it has the default selector

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
