### PR TITLE
Reblog to wpcom sites only.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -282,7 +282,6 @@ abstract class ViewModelModule {
     @ViewModelKey(SitePickerViewModel.class)
     abstract ViewModel sitePickerViewModel(SitePickerViewModel viewModel);
 
-
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -265,6 +265,12 @@ public class ActivityLauncher {
         context.startActivity(intent);
     }
 
+    public static void viewMySiteInNewStack(Context context) {
+        Intent intent = getMainActivityInNewStack(context);
+        intent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_MY_SITE);
+        context.startActivity(intent);
+    }
+
     public static void viewReader(Context context) {
         Intent intent = new Intent(context, WPMainActivity.class);
         intent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_READER);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -626,12 +626,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         @Override
         protected SiteList[] doInBackground(Void... params) {
-            List<SiteModel> siteModels;
-            if (mIsInSearchMode) {
-                siteModels = mSiteStore.getSites();
-            } else {
-                siteModels = getBlogsForCurrentView();
-            }
+            List<SiteModel> siteModels = getBlogsForCurrentView();
 
             if (mIgnoreSitesIds != null) {
                 List<SiteModel> unignoredSiteModels = new ArrayList<>();
@@ -696,19 +691,26 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         private List<SiteModel> getBlogsForCurrentView() {
-            if (mShowHiddenSites) {
-                if (mShowSelfHostedSites) {
-                    return mSiteStore.getSites();
-                } else {
-                    return mSiteStore.getSitesAccessedViaWPComRest();
-                }
+            if (mSitePickerMode.isReblogMode()) {
+                // If we are reblogging we only want to select or search into the WPCom visible sites.
+                return mSiteStore.getVisibleSitesAccessedViaWPCom();
+            } else if (mIsInSearchMode) {
+                return mSiteStore.getSites();
             } else {
-                if (mShowSelfHostedSites) {
-                    List<SiteModel> out = mSiteStore.getVisibleSitesAccessedViaWPCom();
-                    out.addAll(mSiteStore.getSitesAccessedViaXMLRPC());
-                    return out;
+                if (mShowHiddenSites) {
+                    if (mShowSelfHostedSites) {
+                        return mSiteStore.getSites();
+                    } else {
+                        return mSiteStore.getSitesAccessedViaWPComRest();
+                    }
                 } else {
-                    return mSiteStore.getVisibleSitesAccessedViaWPCom();
+                    if (mShowSelfHostedSites) {
+                        List<SiteModel> out = mSiteStore.getVisibleSitesAccessedViaWPCom();
+                        out.addAll(mSiteStore.getSitesAccessedViaXMLRPC());
+                        return out;
+                    } else {
+                        return mSiteStore.getVisibleSitesAccessedViaWPCom();
+                    }
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -99,7 +99,6 @@ import org.wordpress.android.ui.posts.PromoDialog.PromoDialogClickInterface;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.AppSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsFragment;
-import org.wordpress.android.ui.reader.ReaderEvents;
 import org.wordpress.android.ui.reader.ReaderPostListFragment;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
 import org.wordpress.android.ui.uploads.UploadActionUseCase;
@@ -156,6 +155,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     public static final String ARG_SHOW_LOGIN_EPILOGUE = "show_login_epilogue";
     public static final String ARG_SHOW_SIGNUP_EPILOGUE = "show_signup_epilogue";
     public static final String ARG_OPEN_PAGE = "open_page";
+    public static final String ARG_MY_SITE = "show_my_site";
     public static final String ARG_NOTIFICATIONS = "show_notifications";
     public static final String ARG_READER = "show_reader";
     public static final String ARG_EDITOR = "show_editor";
@@ -502,6 +502,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
         String pagePosition = intent.getStringExtra(ARG_OPEN_PAGE);
         if (!TextUtils.isEmpty(pagePosition)) {
             switch (pagePosition) {
+                case ARG_MY_SITE:
+                    mBottomNav.setCurrentSelectedPage(PageType.MY_SITE);
+                    break;
                 case ARG_NOTIFICATIONS:
                     mBottomNav.setCurrentSelectedPage(PageType.NOTIFS);
                     break;
@@ -841,19 +844,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
             AnalyticsUtils.trackWithDefaultInterceptor(AnalyticsTracker.Stat.DEEP_LINK_NOT_DEFAULT_HANDLER,
                     resolveInfo.activityInfo.name);
         }
-    }
-
-    @SuppressWarnings("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onEventMainThread(ReaderEvents.SiteManagerTriggered event) {
-        setMySitePageActive();
-    }
-
-    /**
-     * Ste My Site page active
-     */
-    public void setMySitePageActive() {
-        mBottomNav.setCurrentSelectedPage(PageType.MY_SITE);
     }
 
     public void setReaderPageActive() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/NoSiteToReblogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/NoSiteToReblogActivity.kt
@@ -28,6 +28,7 @@ class NoSiteToReblogActivity : AppCompatActivity() {
             ActivityLauncher.viewMySiteInNewStack(this@NoSiteToReblogActivity)
             setResult(RESULT_OK)
             finish()
+            overridePendingTransition(0, 0)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/NoSiteToReblogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/NoSiteToReblogActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.reader_no_site_to_reblog.noSiteToReblogView
+import kotlinx.android.synthetic.main.toolbar_main.*
 import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.R
 
@@ -15,6 +16,8 @@ class NoSiteToReblogActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.reader_no_site_to_reblog)
+
+        setSupportActionBar(toolbar_main)
 
         supportActionBar?.apply {
             setDisplayShowTitleEnabled(false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/NoSiteToReblogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/NoSiteToReblogActivity.kt
@@ -6,8 +6,8 @@ import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.reader_no_site_to_reblog.noSiteToReblogView
 import kotlinx.android.synthetic.main.toolbar_main.*
-import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.R
+import org.wordpress.android.ui.ActivityLauncher
 
 /*
  * Serves as an intermediate screen where the user is informed that a site is needed for the reblog action
@@ -25,7 +25,7 @@ class NoSiteToReblogActivity : AppCompatActivity() {
         }
 
         noSiteToReblogView.button.setOnClickListener {
-            EventBus.getDefault().post(ReaderEvents.SiteManagerTriggered())
+            ActivityLauncher.viewMySiteInNewStack(this@NoSiteToReblogActivity)
             setResult(RESULT_OK)
             finish()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -212,10 +212,4 @@ public class ReaderEvents {
 
     public static class DoSignIn {
     }
-
-    /**
-     * Shows the Site Manager (My site page)
-     */
-    public static class SiteManagerTriggered {
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -886,19 +886,23 @@ class ReaderPostDetailFragment : Fragment(),
             reblogButton.setCount(0)
             reblogButton.visibility = View.VISIBLE
             reblogButton.setOnClickListener {
-                val sites = siteStore.visibleSites
-                when (sites.size) {
+                val sites = siteStore.visibleSitesAccessedViaWPCom
+                when (sites.count()) {
                     0 -> ReaderActivityLauncher.showNoSiteToReblog(activity)
-                    1 -> ActivityLauncher.openEditorForReblog(
-                            activity,
-                            sites.first(),
-                            this.post,
-                            PagePostCreationSourcesDetail.POST_FROM_DETAIL_REBLOG
-                    )
+                    1 -> {
+                        sites.firstOrNull()?.let {
+                            ActivityLauncher.openEditorForReblog(
+                                    activity,
+                                    it,
+                                    this.post,
+                                    PagePostCreationSourcesDetail.POST_FROM_DETAIL_REBLOG
+                            )
+                        } ?: ToastUtils.showToast(activity, R.string.reader_reblog_error)
+                    }
                     else -> {
-                        val siteLocalId = AppPrefs.getSelectedSite()
-                        val site = siteStore.getSiteByLocalId(siteLocalId)
-                        ActivityLauncher.showSitePickerForResult(this, site, REBLOG_SELECT_MODE)
+                        sites.firstOrNull()?.let {
+                            ActivityLauncher.showSitePickerForResult(this, it, REBLOG_SELECT_MODE)
+                        } ?: ToastUtils.showToast(activity, R.string.reader_reblog_error)
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2914,10 +2914,10 @@ public class ReaderPostListFragment extends Fragment
                 if (state instanceof NoSite) {
                     ReaderActivityLauncher.showNoSiteToReblog(getActivity());
                 } else if (state instanceof SitePicker) {
-                    SitePicker spState = (SitePicker) state;
+                    SitePicker sitePickerStateData = (SitePicker) state;
                     ActivityLauncher.showSitePickerForResult(
                             this,
-                            spState.getSite(),
+                            sitePickerStateData.getSite(),
                             SitePickerMode.REBLOG_SELECT_MODE
                     );
                 } else if (state instanceof PostEditor) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -268,12 +268,20 @@ class ReaderPostListViewModel @Inject constructor(
      * @param post post to reblog
      */
     fun onReblogButtonClicked(post: ReaderPost) {
-        val selectedSiteId: Int = appPrefsWrapper.getSelectedSite()
-        val selectedSite: SiteModel? = siteStore.getSiteByLocalId(selectedSiteId)
-        _reblogState.value = when (siteStore.visibleSites.size) {
+        val sites = siteStore.visibleSitesAccessedViaWPCom
+
+        _reblogState.value = when (sites.count()) {
             0 -> Event(NoSite)
-            1 -> if (selectedSite != null) Event(PostEditor(selectedSite, post)) else Event(Unknown)
-            else -> if (selectedSite != null) Event(SitePicker(selectedSite, post)) else Event(Unknown)
+            1 -> {
+                sites.firstOrNull()?.let {
+                    Event(PostEditor(it, post))
+                } ?: Event(Unknown)
+            }
+            else -> {
+                sites.firstOrNull()?.let {
+                    Event(SitePicker(it, post))
+                } ?: Event(Unknown)
+            }
         }
     }
 

--- a/WordPress/src/main/res/layout/reader_no_site_to_reblog.xml
+++ b/WordPress/src/main/res/layout/reader_no_site_to_reblog.xml
@@ -4,6 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <include layout="@layout/toolbar_main" />
+
     <org.wordpress.android.ui.ActionableEmptyView
         android:id="@+id/noSiteToReblogView"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1711,8 +1711,8 @@
 
     <!-- reblog -->
     <string name="reader_view_reblog">Reblog</string>
-    <string name="reader_no_site_to_reblog_title">No available sites</string>
-    <string name="reader_no_site_to_reblog_detail">Once you create a site, you can reblog content that you like to your own site.</string>
+    <string name="reader_no_site_to_reblog_title">No available WordPress.com sites</string>
+    <string name="reader_no_site_to_reblog_detail">Once you create a WordPress.com site, you can reblog content that you like to your own site.</string>
     <string name="reader_no_site_to_reblog_action">Manage Sites</string>
     <string name="reader_reblog_error">Reblog failed</string>
     <string name="sitepicker_continue_flow">Continue</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -363,15 +363,11 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `when user has no site the no site flow is triggered`() {
-        val siteId = 1
-        val site = SiteModel()
+    fun `when user has no visible WPCOM site the no site flow is triggered`() {
         val post = ReaderPost()
-        val visibleSites = listOf<SiteModel>() // No sites
+        val visibleWPComSites = listOf<SiteModel>() // No sites
 
-        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
-        whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(site)
-        whenever(siteStore.visibleSites).thenReturn(visibleSites)
+        whenever(siteStore.visibleSitesAccessedViaWPCom).thenReturn(visibleWPComSites)
 
         viewModel.onReblogButtonClicked(post)
 
@@ -380,15 +376,12 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `when user has only one site the post editor is triggered`() {
-        val siteId = 1
+    fun `when user has only one visible WPCOM site the post editor is triggered`() {
         val site = SiteModel()
         val post = ReaderPost()
-        val visibleSites = listOf(site) // One site
+        val visibleWPComSites = listOf(site) // One site
 
-        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
-        whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(site)
-        whenever(siteStore.visibleSites).thenReturn(visibleSites)
+        whenever(siteStore.visibleSitesAccessedViaWPCom).thenReturn(visibleWPComSites)
 
         viewModel.onReblogButtonClicked(post)
 
@@ -401,15 +394,12 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `when user has more than one sites the site picker is triggered`() {
-        val siteId = 1
+    fun `when user has more than one visible WPCOM sites the site picker is triggered`() {
         val site = SiteModel()
         val post = ReaderPost()
-        val visibleSites = listOf(site, site) // More sites
+        val visibleWPComSites = listOf(site, site) // More sites
 
-        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
-        whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(site)
-        whenever(siteStore.visibleSites).thenReturn(visibleSites)
+        whenever(siteStore.visibleSitesAccessedViaWPCom).thenReturn(visibleWPComSites)
 
         viewModel.onReblogButtonClicked(post)
 
@@ -422,15 +412,14 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `when user has more than one sites and selects the site to reblog the post editor is triggered`() {
+    fun `when user has more than one visible WPCOM sites and selects the site to reblog the post editor is triggered`() {
         val siteId = 1
         val site = SiteModel()
         val post = ReaderPost()
-        val visibleSites = listOf(site, site) // More sites
+        val visibleWPComSites = listOf(site, site) // More sites
 
-        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
         whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(site)
-        whenever(siteStore.visibleSites).thenReturn(visibleSites)
+        whenever(siteStore.visibleSitesAccessedViaWPCom).thenReturn(visibleWPComSites)
 
         viewModel.onReblogButtonClicked(post)
         viewModel.onReblogSiteSelected(siteId)
@@ -444,15 +433,11 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `when user has only one site but the selected site is not retrieved an error occurs`() {
-        val siteId = -1
-        val site = SiteModel()
+    fun `when user has only one visible WPCOM site but the selected site is not retrieved an error occurs`() {
         val post = ReaderPost()
-        val visibleSites = listOf(site) // One site
+        val visibleWPComSites = listOf(null) // One site
 
-        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
-        whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(null) // failure
-        whenever(siteStore.visibleSites).thenReturn(visibleSites)
+        whenever(siteStore.visibleSitesAccessedViaWPCom).thenReturn(visibleWPComSites)
 
         viewModel.onReblogButtonClicked(post)
 
@@ -461,15 +446,11 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `when user has more than one sites but the selected site is not retrieved an error occurs`() {
-        val siteId = -1
-        val site = SiteModel()
+    fun `when user has more than one visible WPCOM sites but the selected site is not retrieved an error occurs`() {
         val post = ReaderPost()
-        val visibleSites = listOf(site, site) // More sites
+        val visibleWPComSites = listOf(null, null) // More sites
 
-        whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
-        whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(null) // failure
-        whenever(siteStore.visibleSites).thenReturn(visibleSites)
+        whenever(siteStore.visibleSitesAccessedViaWPCom).thenReturn(visibleWPComSites)
 
         viewModel.onReblogButtonClicked(post)
 
@@ -478,7 +459,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `when user selects a site and the state is unexpected an error is thrown`() {
+    fun `when user selects a visible WPCOM site and the state is unexpected an error is thrown`() {
         val reblog = { viewModel.onReblogSiteSelected(1) }
         if (BuildConfig.DEBUG) {
             assertThatIllegalStateException().isThrownBy(reblog)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -412,7 +412,7 @@ class ReaderPostListViewModelTest {
     }
 
     @Test
-    fun `when user has more than one visible WPCOM sites and selects the site to reblog the post editor is triggered`() {
+    fun `when having more than one visible WPCOM sites and selecting site to reblog the post editor is triggered`() {
         val siteId = 1
         val site = SiteModel()
         val post = ReaderPost()


### PR DESCRIPTION
This PR does the following:

1. Limits the site that can be selected to reblog to and those that are presented and searchable in the site picker while reblogging to be those that are accessed through the WP.com API (WP.com/JP)
2. NoSiteToReblogActivity: adds back the toolbar wrongly missing after a merge from develop and aligns copy to iOS.


## To test
Setup an user that has in the visible sites at least 1 pure self-hosted site (added by address), at least 1 JP and at least 1 WP.com (also 1 Atomic could be good 😊)
Note: all the below reblog tests should be made from post lists (filtered or from main reader) and from a post details.

- keep all the sites available visible (let's assume something as below with the last one being the self-hosted)
<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/80736047-e3c0f500-8b11-11ea-96bb-3dbeff67ee4a.png>
</p>

- reblog and check the site picker is presented as below without the self-hosed

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/80736185-0eab4900-8b12-11ea-8907-9be166dcf19b.png>
</p>

- try to search and check the self-hosted is not present in the searched list

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/80736305-3b5f6080-8b12-11ea-8d39-96f8cd1fda47.png>
</p>

- select a site and check the reblog completes correctly.
- Now let's make not visible 1 of the not self-hosted sites

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/80736470-7b264800-8b12-11ea-8102-6dee33231d4e.png>
</p>

- Even if the self-hosted site is the currently selected one, when you reblog you should be brought in the editor reblogging to the only visible not self-hosted site. Complete the reblog and check it is processed correctly.

- Now let's keep visible only the self-hosted sites

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/80736758-d8ba9480-8b12-11ea-8369-8ef2fa1deac3.png>
</p>

- When you reblog you should be brought to the following screen

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/80736832-f7b92680-8b12-11ea-8ba2-34bc39e611f7.png>
</p>

- Check the screen has a working toolbar and the copy is as reported in the image
- Pressing the `Manage Sites` button you should be brought to the `My Site` page

### Test case 2 - Smoke test
Smoke test the Reblog functionality; also note the Site Picker is used in `My Site > Switch Site`, `Share to WP`, `Login Epilogue` so Smock test these scenarios to check for eventual regressions. In particular check the Site Hide feature and search in Switch Site picker work as usual.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
