### PR TITLE
Prepublishing Nudges : Change Publish to Publish Date

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1323,7 +1323,7 @@
     <string name="post_notification_error">Notification can\'t be created when the publish date is in the past.</string>
 
     <!-- post date selection -->
-    <string name="publish_date">Publish</string>
+    <string name="publish_date">Publish Date</string>
     <string name="immediately">Immediately</string>
     <string name="now">Now</string>
     <string name="scheduled_for">Scheduled for: %s</string>
@@ -2742,7 +2742,7 @@
     <string name="error_failed_to_crop_and_save_image">Failed to crop and save image, please try again.</string>
 
     <!-- Prepublishing Nudges -->
-    <string name="prepublishing_nudges_publish_action">Publish</string>
+    <string name="prepublishing_nudges_publish_action">Publish Date</string>
     <string name="prepublishing_nudges_visibility_action">Visibility</string>
     <string name="prepublishing_nudges_tags_action">Tags</string>
     <string name="prepublishing_nudges_back_button">Back</string>


### PR DESCRIPTION
Fixes #11776

This PR address the change of the `Publish` title in both the `Post Settings` and `Prepublishing Bottom sheet`

To test:

1. Create a new post. 
2. Click publish. 
3. You should see `Publish Date` instead of Publish in the bottom sheet.
(Ignore the UI below. It is being updated here https://github.com/wordpress-mobile/WordPress-Android/pull/11767

<kbd><img src="https://user-images.githubusercontent.com/1509205/80749109-96ca2800-8aeb-11ea-9f91-80a52d507d16.png" width="320"></kbd>

-------------------

1. Create a new post.
2. Click on the overflow/more icon in the Editor. 
3. Click Post Settings. 
4. You should see the `Publish Date` change. 
5. The word `Date` was capitalized for consistency. 

<kbd><img src="https://user-images.githubusercontent.com/1509205/80749235-c11be580-8aeb-11ea-864f-7d0e535e50f4.png" width="320"></kbd>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
