### PR TITLE
Issue/11799 show announcement on app upgrade

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -104,6 +104,7 @@ import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
 import org.wordpress.android.ui.uploads.UploadActionUseCase;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper;
+import org.wordpress.android.ui.whatsnew.FeatureAnnouncementDialogFragment;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -415,6 +416,11 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     handleNewPageAction(PagePostCreationSourcesDetail.PAGE_FROM_MY_SITE);
                     break;
             }
+        });
+
+        mViewModel.getOnFeatureAnnouncementRequested().observe(this, action -> {
+            new FeatureAnnouncementDialogFragment()
+                    .show(getSupportFragmentManager(), FeatureAnnouncementDialogFragment.TAG);
         });
 
         mFloatingActionButton.setOnClickListener(v -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -215,6 +215,9 @@ public class AppPrefs {
 
         // used to indicate that we do not need to show the main FAB tooltip
         IS_MAIN_FAB_TOOLTIP_DISABLED,
+
+        // Store a version of the last shown feature announcement
+        FEATURE_ANNOUNCEMENT_SHOWN_VERSION,
     }
 
     private static SharedPreferences prefs() {
@@ -1090,6 +1093,14 @@ public class AppPrefs {
     private static List<String> getPostWithHWAccelerationOff() {
         String idsAsString = getString(DeletablePrefKey.AZTEC_EDITOR_DISABLE_HW_ACC_KEYS, "");
         return Arrays.asList(idsAsString.split(","));
+    }
+
+    public static void setFeatureAnnouncementShownVersion(int version) {
+        setInt(UndeletablePrefKey.FEATURE_ANNOUNCEMENT_SHOWN_VERSION, version);
+    }
+
+    public static int getFeatureAnnouncementShownVersion() {
+        return getInt(UndeletablePrefKey.FEATURE_ANNOUNCEMENT_SHOWN_VERSION, -1);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -216,10 +216,10 @@ public class AppPrefs {
         // used to indicate that we do not need to show the main FAB tooltip
         IS_MAIN_FAB_TOOLTIP_DISABLED,
 
-        // Store a version of the last shown feature announcement
+        // version of the last shown feature announcement
         FEATURE_ANNOUNCEMENT_SHOWN_VERSION,
 
-        // version name of the last app version
+        // last app version code feature announcement was shown for
         LAST_FEATURE_ANNOUNCEMENT_APP_VERSION_CODE,
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -218,6 +218,9 @@ public class AppPrefs {
 
         // Store a version of the last shown feature announcement
         FEATURE_ANNOUNCEMENT_SHOWN_VERSION,
+
+        // version name of the last app version
+        LAST_FEATURE_ANNOUNCEMENT_APP_VERSION_CODE,
     }
 
     private static SharedPreferences prefs() {
@@ -1101,6 +1104,14 @@ public class AppPrefs {
 
     public static int getFeatureAnnouncementShownVersion() {
         return getInt(UndeletablePrefKey.FEATURE_ANNOUNCEMENT_SHOWN_VERSION, -1);
+    }
+
+    public static int getLastFeatureAnnouncementAppVersionCode() {
+        return getInt(UndeletablePrefKey.LAST_FEATURE_ANNOUNCEMENT_APP_VERSION_CODE);
+    }
+
+    public static void setLastFeatureAnnouncementAppVersionCode(int version) {
+        setInt(UndeletablePrefKey.LAST_FEATURE_ANNOUNCEMENT_APP_VERSION_CODE, version);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -34,6 +34,10 @@ class AppPrefsWrapper @Inject constructor() {
         get() = AppPrefs.getFeatureAnnouncementShownVersion()
         set(version) = AppPrefs.setFeatureAnnouncementShownVersion(version)
 
+    var lastFeatureAnnouncementAppVersionCode: Int
+        get() = AppPrefs.getLastFeatureAnnouncementAppVersionCode()
+        set(version) = AppPrefs.setLastFeatureAnnouncementAppVersionCode(version)
+
     var avatarVersion: Int
         get() = AppPrefs.getAvatarVersion()
         set(version) = AppPrefs.setAvatarVersion(version)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -126,6 +126,8 @@ class AppPrefsWrapper @Inject constructor() {
     fun getLastReaderKnownUserId() = AppPrefs.getLastReaderKnownUserId()
     fun setLastReaderKnownUserId(userId: Long) = AppPrefs.setLastReaderKnownUserId(userId)
 
+    fun getLastAppVersionCode() = AppPrefs.getLastAppVersionCode()
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -30,6 +30,10 @@ class AppPrefsWrapper @Inject constructor() {
         get() = AppPrefs.getNewsCardShownVersion()
         set(version) = AppPrefs.setNewsCardShownVersion(version)
 
+    var featureAnnouncementShownVersion: Int
+        get() = AppPrefs.getFeatureAnnouncementShownVersion()
+        set(version) = AppPrefs.setFeatureAnnouncementShownVersion(version)
+
     var avatarVersion: Int
         get() = AppPrefs.getAvatarVersion()
         set(version) = AppPrefs.setAvatarVersion(version)

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncement.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncement.kt
@@ -4,6 +4,7 @@ import androidx.annotation.DrawableRes
 
 data class FeatureAnnouncement(
     val version: String,
+    val versionCode : Int,
     val detailsUrl: String,
     val features: List<FeatureAnnouncementItem>
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncement.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncement.kt
@@ -4,7 +4,7 @@ import androidx.annotation.DrawableRes
 
 data class FeatureAnnouncement(
     val version: String,
-    val versionCode : Int,
+    val versionCode: Int,
     val detailsUrl: String,
     val features: List<FeatureAnnouncementItem>
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementProvider.kt
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 class FeatureAnnouncementProvider @Inject constructor() {
     private val localFeatureAnnouncement = FeatureAnnouncement(
-            "14.7", "https://wordpress.com/blog/2020/04/20/earth-day-live/", listOf(
+            "14.7", 857, "https://wordpress.com/blog/2020/04/20/earth-day-live/", listOf(
             FeatureAnnouncementItem(
                     "Super Publishing",
                     "Publish amazing articles using the power of your mind! Concentrate" +
@@ -27,7 +27,11 @@ class FeatureAnnouncementProvider @Inject constructor() {
     )
     )
 
-    fun getLatestFeatureAnnouncement(): FeatureAnnouncement {
+    fun getLatestFeatureAnnouncement(): FeatureAnnouncement? {
         return localFeatureAnnouncement
+    }
+
+    fun isFeatureAnnouncementAvailable(): Boolean {
+        return getLatestFeatureAnnouncement() != null
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.util
+
+import org.wordpress.android.BuildConfig
+import javax.inject.Inject
+
+class BuildConfigWrapper @Inject constructor() {
+    fun getAppVersionCode(): Int {
+        return BuildConfig.VERSION_CODE
+    }
+
+    fun isFeatureAnnouncementEnabled(): Boolean {
+        return BuildConfig.FEATURE_ANNOUNCEMENT_AVAILABLE
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/VersionCodeProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/VersionCodeProvider.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.util
+
+import javax.inject.Inject
+
+class VersionCodeProvider @Inject constructor() {
+    fun getVersionCode(): Int {
+        return BuildConfig.VERSION_CODE
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/VersionCodeProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/VersionCodeProvider.kt
@@ -1,9 +1,0 @@
-package org.wordpress.android.util
-
-import javax.inject.Inject
-
-class VersionCodeProvider @Inject constructor() {
-    fun getVersionCode(): Int {
-        return BuildConfig.VERSION_CODE
-    }
-}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.viewmodel.main
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
@@ -41,7 +42,12 @@ class WPMainActivityViewModel @Inject constructor(
     private val _onFeatureAnnouncementRequested = SingleLiveEvent<Unit>()
     val onFeatureAnnouncementRequested: LiveData<Unit> = _onFeatureAnnouncementRequested
 
-    fun start(isFabVisible: Boolean, hasFullAccessToContent: Boolean) {
+    @JvmOverloads
+    fun start(
+        isFabVisible: Boolean,
+        hasFullAccessToContent: Boolean,
+        isFeatureAnnouncementAvailable: Boolean = BuildConfig.FEATURE_ANNOUNCEMENT_AVAILABLE
+    ) {
         if (isStarted) return
         isStarted = true
 
@@ -49,7 +55,9 @@ class WPMainActivityViewModel @Inject constructor(
 
         loadMainActions()
 
-        checkForFeatureAnnouncements()
+        if (isFeatureAnnouncementAvailable) {
+            checkForFeatureAnnouncements()
+        }
     }
 
     private fun loadMainActions() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -13,14 +13,12 @@ import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.main.MainFabUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider
-import org.wordpress.android.util.VersionCodeProvider
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 
 class WPMainActivityViewModel @Inject constructor(
     private val featureAnnouncementProvider: FeatureAnnouncementProvider,
-    private val versionCodeProvider: VersionCodeProvider,
     private val appPrefsWrapper: AppPrefsWrapper
 ) : ViewModel() {
     private var isStarted = false
@@ -164,13 +162,12 @@ class WPMainActivityViewModel @Inject constructor(
 
     private fun checkForFeatureAnnouncements() {
         if (featureAnnouncementProvider.isFeatureAnnouncementAvailable()
-                && featureAnnouncementProvider.getLatestFeatureAnnouncement()?.versionCode == versionCodeProvider.getVersionCode()
                 && appPrefsWrapper.featureAnnouncementShownVersion < featureAnnouncementProvider.getLatestFeatureAnnouncement()?.versionCode!!) {
-            appPrefsWrapper.featureAnnouncementShownVersion = versionCodeProvider.getVersionCode()
+            appPrefsWrapper.featureAnnouncementShownVersion = featureAnnouncementProvider.getLatestFeatureAnnouncement()?.versionCode!!
             _onFeatureAnnouncementRequested.call()
         }
 //        else {
-//            // request feature announcement from endpoint
+//            // request feature announcement from endpoint to be used on next app start
 //        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -166,18 +166,21 @@ class WPMainActivityViewModel @Inject constructor(
 
     private fun checkForFeatureAnnouncements() {
         val currentVersionCode = buildConfigWrapper.getAppVersionCode()
-        val previousVersionCode = appPrefsWrapper.getLastAppVersionCode()
+        val previousVersionCode = appPrefsWrapper.lastFeatureAnnouncementAppVersionCode
 
         // only proceed to feature announcement logic if we are upgrading the app
         if (previousVersionCode != 0 && previousVersionCode < currentVersionCode) {
             if (canShowFeatureAnnouncement()) {
                 appPrefsWrapper.featureAnnouncementShownVersion =
                         featureAnnouncementProvider.getLatestFeatureAnnouncement()?.versionCode!!
+                appPrefsWrapper.lastFeatureAnnouncementAppVersionCode = currentVersionCode
                 _onFeatureAnnouncementRequested.call()
             }
 //          else {
 //              // request feature announcement from endpoint to be used on next app start
 //          }
+        } else {
+            appPrefsWrapper.lastFeatureAnnouncementAppVersionCode = currentVersionCode
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -12,11 +12,17 @@ import org.wordpress.android.ui.main.MainActionListItem.ActionType.NO_ACTION
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.main.MainFabUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider
+import org.wordpress.android.util.VersionCodeProvider
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 
-class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: AppPrefsWrapper) : ViewModel() {
+class WPMainActivityViewModel @Inject constructor(
+    private val featureAnnouncementProvider: FeatureAnnouncementProvider,
+    private val versionCodeProvider: VersionCodeProvider,
+    private val appPrefsWrapper: AppPrefsWrapper
+) : ViewModel() {
     private var isStarted = false
 
     private val _fabUiState = MutableLiveData<MainFabUiState>()
@@ -34,6 +40,9 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
     private val _startLoginFlow = MutableLiveData<Event<Boolean>>()
     val startLoginFlow: LiveData<Event<Boolean>> = _startLoginFlow
 
+    private val _onFeatureAnnouncementRequested = SingleLiveEvent<Unit>()
+    val onFeatureAnnouncementRequested: LiveData<Unit> = _onFeatureAnnouncementRequested
+
     fun start(isFabVisible: Boolean, hasFullAccessToContent: Boolean) {
         if (isStarted) return
         isStarted = true
@@ -41,29 +50,37 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
         setMainFabUiState(isFabVisible, hasFullAccessToContent)
 
         loadMainActions()
+
+        checkForFeatureAnnouncements()
     }
 
     private fun loadMainActions() {
         val actionsList = ArrayList<MainActionListItem>()
 
-        actionsList.add(CreateAction(
-                actionType = NO_ACTION,
-                iconRes = 0,
-                labelRes = R.string.my_site_bottom_sheet_title,
-                onClickAction = null
-        ))
-        actionsList.add(CreateAction(
-                actionType = CREATE_NEW_POST,
-                iconRes = R.drawable.ic_posts_white_24dp,
-                labelRes = R.string.my_site_bottom_sheet_add_post,
-                onClickAction = ::onCreateActionClicked
-        ))
-        actionsList.add(CreateAction(
-                actionType = CREATE_NEW_PAGE,
-                iconRes = R.drawable.ic_pages_white_24dp,
-                labelRes = R.string.my_site_bottom_sheet_add_page,
-                onClickAction = ::onCreateActionClicked
-        ))
+        actionsList.add(
+                CreateAction(
+                        actionType = NO_ACTION,
+                        iconRes = 0,
+                        labelRes = R.string.my_site_bottom_sheet_title,
+                        onClickAction = null
+                )
+        )
+        actionsList.add(
+                CreateAction(
+                        actionType = CREATE_NEW_POST,
+                        iconRes = R.drawable.ic_posts_white_24dp,
+                        labelRes = R.string.my_site_bottom_sheet_add_post,
+                        onClickAction = ::onCreateActionClicked
+                )
+        )
+        actionsList.add(
+                CreateAction(
+                        actionType = CREATE_NEW_PAGE,
+                        iconRes = R.drawable.ic_pages_white_24dp,
+                        labelRes = R.string.my_site_bottom_sheet_add_page,
+                        onClickAction = ::onCreateActionClicked
+                )
+        )
 
         _mainActions.postValue(actionsList)
     }
@@ -130,9 +147,9 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
 
     private fun setMainFabUiState(isFabVisible: Boolean, hasFullAccessToContent: Boolean) {
         val newState = MainFabUiState(
-                        isFabVisible = isFabVisible,
-                        isFabTooltipVisible = if (appPrefsWrapper.isMainFabTooltipDisabled()) false else isFabVisible,
-                        CreateContentMessageId = getCreateContentMessageId(hasFullAccessToContent)
+                isFabVisible = isFabVisible,
+                isFabTooltipVisible = if (appPrefsWrapper.isMainFabTooltipDisabled()) false else isFabVisible,
+                CreateContentMessageId = getCreateContentMessageId(hasFullAccessToContent)
         )
 
         _fabUiState.value = newState
@@ -143,5 +160,17 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
             R.string.create_post_page_fab_tooltip
         else
             R.string.create_post_page_fab_tooltip_contributors
+    }
+
+    private fun checkForFeatureAnnouncements() {
+        if (featureAnnouncementProvider.isFeatureAnnouncementAvailable()
+                && featureAnnouncementProvider.getLatestFeatureAnnouncement()?.versionCode == versionCodeProvider.getVersionCode()
+                && appPrefsWrapper.featureAnnouncementShownVersion < featureAnnouncementProvider.getLatestFeatureAnnouncement()?.versionCode!!) {
+            appPrefsWrapper.featureAnnouncementShownVersion = versionCodeProvider.getVersionCode()
+            _onFeatureAnnouncementRequested.call()
+        }
+//        else {
+//            // request feature announcement from endpoint
+//        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -161,13 +161,19 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     private fun checkForFeatureAnnouncements() {
-        if (featureAnnouncementProvider.isFeatureAnnouncementAvailable()
-                && appPrefsWrapper.featureAnnouncementShownVersion < featureAnnouncementProvider.getLatestFeatureAnnouncement()?.versionCode!!) {
-            appPrefsWrapper.featureAnnouncementShownVersion = featureAnnouncementProvider.getLatestFeatureAnnouncement()?.versionCode!!
+        if (canShowFeatureAnnouncement()) {
+            appPrefsWrapper.featureAnnouncementShownVersion =
+                    featureAnnouncementProvider.getLatestFeatureAnnouncement()?.versionCode!!
             _onFeatureAnnouncementRequested.call()
         }
 //        else {
 //            // request feature announcement from endpoint to be used on next app start
 //        }
+    }
+
+    private fun canShowFeatureAnnouncement(): Boolean {
+        return featureAnnouncementProvider.isFeatureAnnouncementAvailable() &&
+                appPrefsWrapper.featureAnnouncementShownVersion <
+                featureAnnouncementProvider.getLatestFeatureAnnouncement()?.versionCode!!
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -177,7 +177,7 @@ class WPMainActivityViewModelTest {
     }
 
     @Test
-    fun `show feature announcement on app upgrade, when it's available and no announcement was not shown before`() {
+    fun `show feature announcement when it's available and no announcement was not shown before`() {
         whenever(appPrefsWrapper.featureAnnouncementShownVersion).thenReturn(-1)
         whenever(appPrefsWrapper.getLastAppVersionCode()).thenReturn(840)
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(
@@ -191,7 +191,7 @@ class WPMainActivityViewModelTest {
     }
 
     @Test
-    fun `show feature announcement on app upgrade, when it's available and previous announcement targets older build`() {
+    fun `show feature announcement when it's available and previous announcement targets older build`() {
         whenever(appPrefsWrapper.featureAnnouncementShownVersion).thenReturn(849)
         whenever(appPrefsWrapper.getLastAppVersionCode()).thenReturn(840)
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -1,6 +1,9 @@
 package org.wordpress.android.viewmodel.main
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
@@ -15,6 +18,9 @@ import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PA
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.whatsnew.FeatureAnnouncement
+import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider
+import org.wordpress.android.util.VersionCodeProvider
 
 @RunWith(MockitoJUnitRunner::class)
 class WPMainActivityViewModelTest {
@@ -23,42 +29,51 @@ class WPMainActivityViewModelTest {
 
     private lateinit var viewModel: WPMainActivityViewModel
 
-    @Mock
-    private lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock lateinit var featureAnnouncementProvider: FeatureAnnouncementProvider
+    @Mock lateinit var onFeatureAnnouncementRequestedObserver: Observer<Unit>
+    @Mock lateinit var versionCodeProvider: VersionCodeProvider
+
+    private val featureAnnouncement = FeatureAnnouncement("14.7", 850, "https://wordpress.org/", emptyList())
 
     @Before
     fun setUp() {
         whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(false)
-        viewModel = WPMainActivityViewModel(appPrefsWrapper)
-        viewModel.start(isFabVisible = true, hasFullAccessToContent = true)
+        viewModel = WPMainActivityViewModel(featureAnnouncementProvider, versionCodeProvider, appPrefsWrapper)
+        viewModel.onFeatureAnnouncementRequested.observeForever(onFeatureAnnouncementRequestedObserver)
     }
 
     @Test
     fun `fab visible when asked`() {
+        startViewModelWithDefaultParameters()
         viewModel.onPageChanged(showFab = true, hasFullAccessToContent = true)
         assertThat(viewModel.fabUiState.value?.isFabVisible).isEqualTo(true)
     }
 
     @Test
     fun `fab hidden when asked`() {
+        startViewModelWithDefaultParameters()
         viewModel.onPageChanged(showFab = false, hasFullAccessToContent = true)
         assertThat(viewModel.fabUiState.value?.isFabVisible).isEqualTo(false)
     }
 
     @Test
     fun `fab tooltip visible when asked`() {
+        startViewModelWithDefaultParameters()
         viewModel.onPageChanged(showFab = true, hasFullAccessToContent = true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(true)
     }
 
     @Test
     fun `fab tooltip hidden when asked`() {
+        startViewModelWithDefaultParameters()
         viewModel.onPageChanged(showFab = false, hasFullAccessToContent = true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
 
     @Test
     fun `fab tooltip disabled when tapped`() {
+        startViewModelWithDefaultParameters()
         viewModel.onTooltipTapped(true)
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
@@ -66,6 +81,7 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `fab tooltip disabled when user without full access to content uses the fab`() {
+        startViewModelWithDefaultParameters()
         whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(true)
         viewModel.onFabClicked(false)
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
@@ -74,6 +90,7 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `fab tooltip disabled when bottom sheet opened`() {
+        startViewModelWithDefaultParameters()
         whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(true)
         viewModel.onFabClicked(true)
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
@@ -82,6 +99,7 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `fab tooltip disabled when fab long pressed`() {
+        startViewModelWithDefaultParameters()
         viewModel.onFabLongPressed(true)
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
@@ -89,6 +107,7 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `bottom sheet action is new post when new post is tapped`() {
+        startViewModelWithDefaultParameters()
         val action = viewModel.mainActions.value?.first { it.actionType == CREATE_NEW_POST } as CreateAction
         assertThat(action).isNotNull
         action.onClickAction?.invoke(CREATE_NEW_POST)
@@ -97,6 +116,7 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `bottom sheet action is new page when new page is tapped`() {
+        startViewModelWithDefaultParameters()
         val action = viewModel.mainActions.value?.first { it.actionType == CREATE_NEW_PAGE } as CreateAction
         assertThat(action).isNotNull
         action.onClickAction?.invoke(CREATE_NEW_PAGE)
@@ -105,6 +125,7 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `bottom sheet is visualized when user has full access to content`() {
+        startViewModelWithDefaultParameters()
         viewModel.onFabClicked(hasFullAccessToContent = true)
         assertThat(viewModel.createAction.value).isNull()
         assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isEqualTo(true)
@@ -112,6 +133,7 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `new post action is triggered from FAB when user has not full access to content`() {
+        startViewModelWithDefaultParameters()
         viewModel.onFabClicked(hasFullAccessToContent = false)
         assertThat(viewModel.isBottomSheetShowing.value).isNull()
         assertThat(viewModel.createAction.value).isEqualTo(CREATE_NEW_POST)
@@ -119,6 +141,7 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `when user taps to open the login page from the bottom sheet empty view cta the correct action is triggered`() {
+        startViewModelWithDefaultParameters()
         viewModel.onOpenLoginPage()
 
         assertThat(viewModel.startLoginFlow.value!!.peekContent()).isEqualTo(true)
@@ -126,14 +149,77 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `onResume set expected content message when user has full access to content`() {
+        startViewModelWithDefaultParameters()
         viewModel.onResume(true)
         assertThat(viewModel.fabUiState.value!!.CreateContentMessageId).isEqualTo(R.string.create_post_page_fab_tooltip)
     }
 
     @Test
     fun `onResume set expected content message when user has not full access to content`() {
+        startViewModelWithDefaultParameters()
         viewModel.onResume(false)
         assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
                 .isEqualTo(R.string.create_post_page_fab_tooltip_contributors)
+    }
+
+    @Test
+    fun `show feature announcement when it's available, no announcement was not shown before and current announcement version matches the app version code`() {
+        whenever(versionCodeProvider.getVersionCode()).thenReturn(850)
+        whenever(appPrefsWrapper.featureAnnouncementShownVersion).thenReturn(-1)
+        whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(featureAnnouncement)
+        whenever(featureAnnouncementProvider.isFeatureAnnouncementAvailable()).thenReturn(true)
+
+        startViewModelWithDefaultParameters()
+
+        verify(onFeatureAnnouncementRequestedObserver).onChanged(anyOrNull())
+    }
+
+    @Test
+    fun `show feature announcement when it's available, previous announcement is not current and current announcement version matches the app version code`() {
+        whenever(versionCodeProvider.getVersionCode()).thenReturn(850)
+        whenever(appPrefsWrapper.featureAnnouncementShownVersion).thenReturn(849)
+        whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(featureAnnouncement)
+        whenever(featureAnnouncementProvider.isFeatureAnnouncementAvailable()).thenReturn(true)
+
+        startViewModelWithDefaultParameters()
+
+        verify(onFeatureAnnouncementRequestedObserver).onChanged(anyOrNull())
+    }
+
+    @Test
+    fun `don't show feature announcement when it's not available`() {
+        whenever(featureAnnouncementProvider.isFeatureAnnouncementAvailable()).thenReturn(false)
+
+        startViewModelWithDefaultParameters()
+
+        verify(onFeatureAnnouncementRequestedObserver, never()).onChanged(anyOrNull())
+    }
+
+    @Test
+    fun `don't show feature announcement when it's available, previous announcement is current and current announcement version matches the app version code`() {
+        whenever(versionCodeProvider.getVersionCode()).thenReturn(850)
+        whenever(appPrefsWrapper.featureAnnouncementShownVersion).thenReturn(850)
+        whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(featureAnnouncement)
+        whenever(featureAnnouncementProvider.isFeatureAnnouncementAvailable()).thenReturn(true)
+
+        startViewModelWithDefaultParameters()
+
+        verify(onFeatureAnnouncementRequestedObserver, never()).onChanged(anyOrNull())
+    }
+
+    @Test
+    fun `don't show feature announcement when it's available, previous announcement is not current and current announcement version doesn't matches the app version code`() {
+        whenever(versionCodeProvider.getVersionCode()).thenReturn(851)
+        whenever(appPrefsWrapper.featureAnnouncementShownVersion).thenReturn(849)
+        whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(featureAnnouncement)
+        whenever(featureAnnouncementProvider.isFeatureAnnouncementAvailable()).thenReturn(true)
+
+        startViewModelWithDefaultParameters()
+
+        verify(onFeatureAnnouncementRequestedObserver, never()).onChanged(anyOrNull())
+    }
+
+    private fun startViewModelWithDefaultParameters() {
+        viewModel.start(isFabVisible = true, hasFullAccessToContent = true)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -234,6 +234,6 @@ class WPMainActivityViewModelTest {
     }
 
     private fun startViewModelWithDefaultParameters() {
-        viewModel.start(isFabVisible = true, hasFullAccessToContent = true)
+        viewModel.start(isFabVisible = true, hasFullAccessToContent = true, isFeatureAnnouncementAvailable = true)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -179,7 +179,7 @@ class WPMainActivityViewModelTest {
     @Test
     fun `show feature announcement when it's available and no announcement was not shown before`() {
         whenever(appPrefsWrapper.featureAnnouncementShownVersion).thenReturn(-1)
-        whenever(appPrefsWrapper.getLastAppVersionCode()).thenReturn(840)
+        whenever(appPrefsWrapper.lastFeatureAnnouncementAppVersionCode).thenReturn(840)
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(
                 featureAnnouncement
         )
@@ -191,9 +191,9 @@ class WPMainActivityViewModelTest {
     }
 
     @Test
-    fun `show feature announcement when it's available and previous announcement targets older build`() {
+    fun `show feature announcement when it's available and previous announcement was for older build`() {
         whenever(appPrefsWrapper.featureAnnouncementShownVersion).thenReturn(849)
-        whenever(appPrefsWrapper.getLastAppVersionCode()).thenReturn(840)
+        whenever(appPrefsWrapper.lastFeatureAnnouncementAppVersionCode).thenReturn(840)
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(
                 featureAnnouncement
         )
@@ -206,16 +206,17 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `don't show feature announcement on fresh app install`() {
-        whenever(appPrefsWrapper.getLastAppVersionCode()).thenReturn(0)
+        whenever(appPrefsWrapper.lastFeatureAnnouncementAppVersionCode).thenReturn(0)
 
         startViewModelWithDefaultParameters()
 
         verify(onFeatureAnnouncementRequestedObserver, never()).onChanged(anyOrNull())
+        verify(appPrefsWrapper).lastFeatureAnnouncementAppVersionCode = 850
     }
 
     @Test
     fun `don't show feature announcement when it's not available`() {
-        whenever(appPrefsWrapper.getLastAppVersionCode()).thenReturn(840)
+        whenever(appPrefsWrapper.lastFeatureAnnouncementAppVersionCode).thenReturn(840)
         whenever(featureAnnouncementProvider.isFeatureAnnouncementAvailable()).thenReturn(false)
 
         startViewModelWithDefaultParameters()
@@ -225,7 +226,7 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `don't show feature announcement when it's available but previous announcement is the same as current`() {
-        whenever(appPrefsWrapper.getLastAppVersionCode()).thenReturn(840)
+        whenever(appPrefsWrapper.lastFeatureAnnouncementAppVersionCode).thenReturn(840)
         whenever(appPrefsWrapper.featureAnnouncementShownVersion).thenReturn(850)
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(
                 featureAnnouncement
@@ -239,7 +240,7 @@ class WPMainActivityViewModelTest {
 
     @Test
     fun `don't show feature announcement after view model starts again`() {
-        whenever(appPrefsWrapper.getLastAppVersionCode()).thenReturn(840)
+        whenever(appPrefsWrapper.lastFeatureAnnouncementAppVersionCode).thenReturn(840)
         whenever(appPrefsWrapper.featureAnnouncementShownVersion).thenReturn(-1)
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(
                 featureAnnouncement

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
@@ -45,6 +45,7 @@ class FeatureAnnouncementViewModelTest : BaseUnitTest() {
 
     private val featureAnnouncement = FeatureAnnouncement(
             "14.7",
+            850,
             "https://wordpress.org/",
             testFeatures
     )

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
@@ -43,7 +43,7 @@ class FeatureAnnouncementViewModelTest : BaseUnitTest() {
             )
     )
 
-    private val featureAnnouncement = FeatureAnnouncement("14.7", "https://wordpress.org/", testFeatures)
+    private val featureAnnouncement = FeatureAnnouncement("14.7", 857, "https://wordpress.org/", testFeatures)
 
     @Before
     fun setUp() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
@@ -43,7 +43,11 @@ class FeatureAnnouncementViewModelTest : BaseUnitTest() {
             )
     )
 
-    private val featureAnnouncement = FeatureAnnouncement("14.7", 857, "https://wordpress.org/", testFeatures)
+    private val featureAnnouncement = FeatureAnnouncement(
+            "14.7",
+            "https://wordpress.org/",
+            testFeatures
+    )
 
     @Before
     fun setUp() {


### PR DESCRIPTION
Fixes #11799

This PR adds logic for displaying feature announcements on the app upgrade.

We decided to show announcements independent of app version - eg. if you are on v4 of the app, and there is an announcement in v5, you will see even if you skip v5 and upgrade straight to v6 or v7 (until we remove or replace announcement manually).

To test (using wasabi build):
- If you install this branch on top of develop - the announcement should be displayed when app starts.
- If you perform the fresh installation, an announcement will not be displayed.
- To trigger an announcement bump the [versionCode](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/11799-show-announcement-on-app-upgrade/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementProvider.kt#L8) number and restart the app.
- Make sure the announcement is not shown in vanilla version.



PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
