### PR TITLE
Fix hide "take photo" on media custom picker in gutenberg merge

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -167,21 +167,26 @@ public class PhotoPickerFragment extends Fragment {
         if (!canShowMediaSourceBottomBar()) {
             mMediaSourceBottomBar.setVisibility(View.GONE);
         } else {
-            mMediaSourceBottomBar.findViewById(R.id.icon_camera).setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    if (mBrowserType.isImagePicker() && mBrowserType.isVideoPicker()) {
-                        showCameraPopupMenu(v);
-                    } else if (mBrowserType.isImagePicker()) {
-                        doIconClicked(PhotoPickerIcon.ANDROID_CAPTURE_PHOTO);
-                    } else if (mBrowserType.isVideoPicker()) {
-                        doIconClicked(PhotoPickerIcon.ANDROID_CAPTURE_VIDEO);
-                    } else {
-                        AppLog.e(T.MEDIA, "This code should be unreachable. If you see this message one of "
-                                          + "the MediaBrowserTypes isn't setup correctly.");
+            View camera = mMediaSourceBottomBar.findViewById(R.id.icon_camera);
+            if (mBrowserType.isGutenbergPicker()) {
+                camera.setVisibility(View.GONE);
+            } else {
+                camera.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        if (mBrowserType.isImagePicker() && mBrowserType.isVideoPicker()) {
+                            showCameraPopupMenu(v);
+                        } else if (mBrowserType.isImagePicker()) {
+                            doIconClicked(PhotoPickerIcon.ANDROID_CAPTURE_PHOTO);
+                        } else if (mBrowserType.isVideoPicker()) {
+                            doIconClicked(PhotoPickerIcon.ANDROID_CAPTURE_VIDEO);
+                        } else {
+                            AppLog.e(T.MEDIA, "This code should be unreachable. If you see this message one of "
+                                              + "the MediaBrowserTypes isn't setup correctly.");
+                        }
                     }
-                }
-            });
+                });
+            }
             mMediaSourceBottomBar.findViewById(R.id.icon_picker).setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {


### PR DESCRIPTION
This PR brings back [hide "take photo" changes](https://github.com/wordpress-mobile/WordPress-Android/pull/11611#issuecomment-613320133) lost in commit db738f7.

To test:

1. Create a new post in gutenberg
2. Add an image block
3. Select "Choose from device"
4. Notice that camera option is hidden in the bottom bar
5. Repeat steps 1-4 for "Gallery" and "Media & Text" blocks

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
