### PR TITLE
Temporarily disable connected test notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ workflows:
             branches:
               ignore: /pull\/[0-9]+/
       - Connected Tests:
-          post-to-slack: true
+          post-to-slack: false
           # Always run connected tests on develop and release branches
           filters:
             branches:


### PR DESCRIPTION
Our tests currently can't login in Firebase due to a `Smart Lock` popup that needs to be dismissed. I've looked into dismissing it in the tests, but that makes the tests take a lot of extra time to run. We'll contact Firebase support to disable smart lock in their devices, which used to be the case and if that fails look into alternatives. Until we can do so, the Slack messages in #android-dev are annoying, so let's just disable the Slack notifications for now.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
