### PR TITLE
NUX: Position scrollbar to the edge of the "Create Site" screen

### DIFF
--- a/WordPress/src/main/res/layout/site_creation_form_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_form_screen.xml
@@ -8,14 +8,22 @@
         android:id="@+id/toolbar"
         layout="@layout/toolbar_main"/>
 
-    <ViewStub
-        android:id="@+id/site_creation_form_content_stub"
+   <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_above="@+id/bottom_buttons"
         android:layout_below="@+id/toolbar"
-        android:layout_marginEnd="@dimen/site_creation_content_margin"
-        android:layout_marginStart="@dimen/site_creation_content_margin"/>
+        android:fillViewport="true"
+        android:scrollbars="vertical">
+
+        <ViewStub
+            android:id="@+id/site_creation_form_content_stub"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/site_creation_content_margin"
+            android:layout_marginStart="@dimen/site_creation_content_margin"/>
+
+   </androidx.core.widget.NestedScrollView>
 
     <View
         android:id="@+id/bottom_shadow"

--- a/WordPress/src/main/res/layout/site_creation_segments_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_segments_screen.xml
@@ -13,6 +13,5 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:scrollbars="vertical"/>
+        android:layout_height="match_parent"/>
 </LinearLayout>


### PR DESCRIPTION
Fixes #11632

To test:

1. Login to a valid account.
2. Change the device’s orientation to Landscape mode.
3. Navigate to “My Sites”.
4. Press the “+” button to create a new Site.
5. Select the “Create WordPress.com site”.
6. Notice that the scrollbar is shown at the edge of the "Create Site" screen

![device-2020-05-04-171024](https://user-images.githubusercontent.com/1405144/80962618-f8abca00-8e2a-11ea-9379-274b5e3cc822.png)


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
