### PR TITLE
Show video player on long press on video item in media list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -271,7 +271,7 @@ public class MediaPreviewActivity extends LocaleAwareActivity implements MediaPr
         if (media != null) {
             fragment = MediaPreviewFragment.newInstance(mSite, media, true);
         } else {
-            fragment = MediaPreviewFragment.newInstance(mSite, mContentUri);
+            fragment = MediaPreviewFragment.newInstance(mSite, mContentUri, true);
         }
         getSupportFragmentManager().beginTransaction()
                 .replace(R.id.fragment_container, fragment, MediaPreviewFragment.TAG)
@@ -423,7 +423,7 @@ public class MediaPreviewActivity extends LocaleAwareActivity implements MediaPr
                     break;
                 case MULTI_IMAGE_URLS:
                     String imageUrl = mMediaIdOrUrlList.get(position);
-                    fragment = MediaPreviewFragment.newInstance(null, imageUrl);
+                    fragment = MediaPreviewFragment.newInstance(null, imageUrl, false);
                     break;
                 default:
                     // should never get here

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -83,9 +83,11 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
      */
     public static MediaPreviewFragment newInstance(
             @Nullable SiteModel site,
-            @NonNull String contentUri) {
+            @NonNull String contentUri,
+            boolean autoPlay) {
         Bundle args = new Bundle();
         args.putString(ARG_MEDIA_CONTENT_URI, contentUri);
+        args.putBoolean(ARG_AUTOPLAY, autoPlay);
         if (site != null) {
             args.putSerializable(WordPress.SITE, site);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -195,11 +195,15 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
 
         if (mFragmentWasPaused) {
             mFragmentWasPaused = false;
-        } else if (mIsAudio || mIsVideo) {
+        } else if (mIsAudio) {
             if (mAutoPlay) {
                 playMedia();
-            } else if (mIsVideo && !TextUtils.isEmpty(mVideoThumbnailUrl)) {
+            }
+        } else if (mIsVideo) {
+            if (!mAutoPlay && !TextUtils.isEmpty(mVideoThumbnailUrl)) {
                 loadImage(mVideoThumbnailUrl);
+            } else {
+                playMedia();
             }
         } else {
             loadImage(mContentUri);
@@ -347,7 +351,9 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
                 if (isAdded()) {
                     showProgress(false);
                     mImageView.setVisibility(View.GONE);
-                    mp.start();
+                    if (mAutoPlay) {
+                        mp.start();
+                    }
                     if (position > 0) {
                         mp.seekTo(position);
                     }


### PR DESCRIPTION
Fixes #11735

In the current code we're not doing anything in the `MediaPreviewFragment` when we receive a video URL as a parameter with `autoPlay` parameter set to false. This results in an empty screen when a user is trying to see a video preview. My solution opens the full screen player in this case but doesn't trigger auto play. I think this behaviour makes sense. Let me know what you think!

To test:
- Open a post in gutenberg
- Add a video block
- Click on "Add Video" 
- Click on "Choose from device"
- Long press on an item
- You see a full screen paused player (instead of blank screen visible previously)
- Start the video
- It starts playing

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
