### PR TITLE
Made whole domain CTA clickable instead of just a row.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -398,7 +398,7 @@ public class MySiteFragment extends Fragment implements
 
         rootView.findViewById(R.id.row_view_site).setOnClickListener(v -> viewSite());
 
-        rootView.findViewById(R.id.row_register_domain).setOnClickListener(v -> registerDomain());
+        mDomainRegistrationCta.setOnClickListener(v -> registerDomain());
 
         rootView.findViewById(R.id.quick_action_stats_button).setOnClickListener(v -> {
             AnalyticsTracker.track(Stat.QUICK_ACTION_STATS_TAPPED);

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -309,8 +309,9 @@
                         android:orientation="vertical">
 
                         <LinearLayout
-                            android:id="@+id/row_register_domain"
-                            style="@style/MySiteListRowLayout">
+                            style="@style/MySiteListRowLayout"
+                            android:foreground="@null"
+                            tools:ignore="UnusedAttribute">
 
                             <ImageView
                                 android:id="@+id/my_site_register_domain_icon"


### PR DESCRIPTION
This PR makes whole Domain Credit CTA clickable instead of just a "Register Domain" row.

[![Image from Gyazo](https://i.gyazo.com/8ddb68e393fdff3c7e0d017162342a5d.gif)](https://gyazo.com/8ddb68e393fdff3c7e0d017162342a5d)

To test:
- Using a site with available domain credit tap at different areas of CTA (like in the gif above) and make sure you are navigated to domain registration flow.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
