### PR TITLE
Remove dialog error when changing username

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
@@ -337,16 +337,15 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
             AppLog.e(T.API, "onUsernameSuggestionsFetched: " + event.error.type + " - " + event.error.message);
             showErrorDialog(new SpannedString(getString(R.string.username_changer_error_generic)));
         } else if (event.suggestions.size() == 0) {
-            showErrorDialog(
-                    Html.fromHtml(
-                            String.format(
-                                    getString(R.string.username_changer_error_none),
-                                    "<b>",
-                                    mUsernameSuggestionInput,
-                                    "</b>"
-                            )
-                    )
+            String error = String.format(
+                    getString(R.string.username_changer_error_none),
+                    "<b>",
+                    mUsernameSuggestionInput,
+                    "</b>"
             );
+            mUsernameView.setError(Html.fromHtml(
+                    error
+            ));
         } else {
             populateUsernameSuggestions(event.suggestions);
         }

--- a/WordPress/src/main/res/layout/username_changer_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/username_changer_dialog_fragment.xml
@@ -35,7 +35,6 @@
             android:id="@+id/username"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/textinputlayout_correction_margin_right"
             android:layout_toEndOf="@+id/icon"
             android:background="@android:color/transparent"
             android:digits="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"


### PR DESCRIPTION
Fixes #11407

Previously we were showing a dialog when there was an error with suggestions. Since the suggestions are fetched automatically on typing, this results in a bad user experience. I've replaced the error dialog with an error on the edit text. This error still gives the user the same information but doesn't disrupt the typing experience.

I've removed a negative right padding which made the error look bad. I'm wondering why it was added in the first place. I don't think it's necessary,

![Screenshot_1588774229](https://user-images.githubusercontent.com/1079756/81187285-1fe1d300-8fb4-11ea-800f-35ecc2da6bed.png)


To test:
- Go to "Account settings"
- Tap the username field
- Type one letter into the username field and wait
- You see an error on the EditText instead of a dialog

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
