### PR TITLE
Don't show insert/edit for video in the custom media picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -239,7 +239,7 @@ public class PhotoPickerFragment extends Fragment {
     }
 
     private boolean canShowInsertPreviewBottomBar() {
-        return mBrowserType.isGutenbergPicker();
+        return mBrowserType.isGutenbergPicker() && !mBrowserType.isVideoPicker();
     }
 
     @Override


### PR DESCRIPTION
This PR hides "Edit" action for video from the bottom bar added in #11646 in the custom media picker.

**To test**

- Create a new post in gutenberg
- Add a video block
- Select "Choose from device"
- Select a video
- Notice that "checkmark" done action in the toolbar is visible and bottom bar with insert/ edit actions is not shown.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
