### PR TITLE
Make app more resilient to empty post-formats.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -28,6 +28,8 @@ import org.wordpress.android.models.CategoryModel;
 import org.wordpress.android.models.JetpackSettingsModel;
 import org.wordpress.android.models.SiteSettingsModel;
 import org.wordpress.android.ui.plans.PlansConstants;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.LocaleManager;
@@ -1172,8 +1174,10 @@ public abstract class SiteSettingsInterface {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPostFormatsChanged(OnPostFormatsChanged event) {
         if (event.isError()) {
+            AppLog.e(T.SETTINGS, "An error occurred while updating the post formats with type: " + event.error.type);
             return;
         }
+        AppLog.v(T.SETTINGS, "Post formats successfully fetched!");
         notifyUpdatedOnUiThread();
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.11'
+    fluxCVersion = 'fd23cb74c0d68eaeb9856cbfe03114b788991b9e'
 
     appCompatVersion = '1.0.2'
     constraintLayoutVersion = '1.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = 'fd23cb74c0d68eaeb9856cbfe03114b788991b9e'
+    fluxCVersion = '1.6.12-beta-2'
 
     appCompatVersion = '1.0.2'
     constraintLayoutVersion = '1.1.3'


### PR DESCRIPTION
Fixes #11662 (and sorry, I ended up making a bit long description 🙃)

This PR is a companion to the real solution that is in the wordpress-mobile/WordPress-FluxC-Android#1575

Was able to reproduce the issue (with 14.5 and current develop) in a JN self-hosted site both adding it to the app as a JetPack or by site address.

I think the issue is due to the fact that the [post-formats we support](https://wordpress.org/support/article/post-formats/) ([and I'm not talking about the post types](https://wordpress.org/support/article/post-types/#custom-post-types)) are not meant to be customized but with some hack [like this](https://wordpress.stackexchange.com/questions/14444/is-it-possible-to-rename-a-post-format/41139#41139) you can get them renamed and if you do not do it well you can end up sending empty strings for some of the post-formats category. 

In the FluxC PR I added some check to consider not valid an empty post-format.

## Notes for reviewer
- placed in the steps a way to test using the debugger but if it comes handy I can share the JN site I already modified with the hack above for testing
- Probably useless to say, but after FluxC PR is merged I need to point the the newly created label before this can be merged
- For completeness, on the web the hack has UI effects with the classic editor and not with blocks but the effect on the API (with app crash) is always present

| Classic Editor with custom `Gallery` and `Aside` | Block Editor with standard `Gallery` and `Aside` |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/81193674-fcbb2180-8fbb-11ea-85c7-881be045eb20.png) | ![image](https://user-images.githubusercontent.com/47797566/81194069-7e12b400-8fbc-11ea-9a4c-eef4498c5bc8.png) |

also, we behave like the block editor (using default names) in the app Editor Post Settings but show the customized names in the Site Settings. Not sure if it's worth changing this since AFAIU post-formats customization is not a feature we support, so in my understanding to make the app more resilient to the eventual issue should be enough (let me know wdyt).

## To test
### Reproduce the issue
- Compile the develop branch and install it
- Open the FluxC project in AS and checkout the label pointed from develop (should be 1.6.11)
- Place an `Evaluate and Log` breakpoint as below for self-hosted and WPCOM API relevant code

| Self-Hosted XML-RPC (SiteXMLRPCClient) | WPCOM API (SiteRestClient) |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/81192293-528eca00-8fba-11ea-8c73-fac36a1b49bf.png) | ![image](https://user-images.githubusercontent.com/47797566/81192141-283d0c80-8fba-11ea-80ac-774f7afab729.png) | 
| `((Map)(response = (new java.util.HashMap<String, String>()))).put("Image", "")` | `(response.formats = new java.util.HashMap<String, String>()).put("image", "")`  |

- Be sure to clean the storage (should be done also in between checking self-hosted and wpcom api site) and open the app
- While in login screen attach debugger from the fluxc project
- Go into login flow adding the JN site by address
- Go to Site Settings (to create the cache entry)
- Come back to my site
- Go again to Site Settings -> BOOM 💥-> from now on if you open the app again you should get the app continues to crash
- Clean the app storage, restart the app attaching the debugger from fluxc, Login and select the JN site; then repeat the steps above to get the crash

### Check the fix
- Clean the app storage (or uninstall the app), repeat the steps above with the code from this PR (using the AS with the FluxC companion PR) and check the crash does not happen
- Also check you get the following message in the Logcat

```
An error occurred while updating the post formats with type: INVALID_RESPONSE
```

### Smoke test
As per title 😊, smoke test the app got from the current PR especially in Site Settings and Editor Post Settings sections.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
