### PR TITLE
Show fragments correctly in bottom navigation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -280,15 +280,12 @@ class WPMainNavigationView @JvmOverloads constructor(
     }
 
     private inner class NavAdapter {
-        private val mFragments = mutableMapOf<PageType, Fragment>()
-
         private fun createFragment(pageType: PageType): Fragment {
             val fragment = when (pageType) {
                 MY_SITE -> MySiteFragment.newInstance()
                 READER -> ReaderPostListFragment.newInstance(true)
                 NOTIFS -> NotificationsListFragment.newInstance()
             }
-            mFragments[pageType] = fragment
             fragmentManager.beginTransaction()
                     .add(R.id.fragment_container, fragment, getTagForPageType(pageType))
                     .hide(fragment)
@@ -298,9 +295,8 @@ class WPMainNavigationView @JvmOverloads constructor(
 
         internal fun init() {
             for (pageType in pages()) {
-                if (mFragments[pageType] == null) {
-                    mFragments[pageType] = fragmentManager.findFragmentByTag(getTagForPageType(pageType))
-                            ?: createFragment(pageType)
+                if (fragmentManager.findFragmentByTag(getTagForPageType(pageType)) == null) {
+                    createFragment(pageType)
                 }
             }
         }
@@ -309,17 +305,7 @@ class WPMainNavigationView @JvmOverloads constructor(
             val pageType = pages().getOrElse(position) {
                 return null
             }
-            if (mFragments[pageType] != null) {
-                return mFragments[pageType]
-            }
-
-            val fragment = fragmentManager.findFragmentByTag(getTagForPageType(pageType))
-            return if (fragment != null) {
-                mFragments[pageType] = fragment
-                fragment
-            } else {
-                createFragment(pageType)
-            }
+            return fragmentManager.findFragmentByTag(getTagForPageType(pageType)) ?: createFragment(pageType)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -221,19 +221,11 @@ class WPMainNavigationView @JvmOverloads constructor(
         return getContentDescriptionForPosition(getPosition(pageType))
     }
 
-    private fun getTagForPosition(position: Int): String {
-        return when (getPageTypeOrNull(position)) {
-            MY_SITE -> TAG_MY_SITE
-            READER -> TAG_READER
-            else -> TAG_NOTIFS
-        }
-    }
-
     private fun getTagForPageType(pageType: PageType): String {
         return when (pageType) {
             MY_SITE -> TAG_MY_SITE
             READER -> TAG_READER
-            else -> TAG_NOTIFS
+            NOTIFS -> TAG_NOTIFS
         }
     }
 
@@ -321,7 +313,7 @@ class WPMainNavigationView @JvmOverloads constructor(
                 return mFragments[pageType]
             }
 
-            val fragment = fragmentManager.findFragmentByTag(getTagForPosition(position))
+            val fragment = fragmentManager.findFragmentByTag(getTagForPageType(pageType))
             return if (fragment != null) {
                 mFragments[pageType] = fragment
                 fragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.main
 
 import android.content.Context
 import android.util.AttributeSet
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
@@ -31,7 +30,6 @@ import org.wordpress.android.ui.reader.ReaderPostListFragment
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AniUtils.Duration
 import org.wordpress.android.util.getColorStateListFromAttribute
-import java.lang.IllegalArgumentException
 
 /*
  * Bottom navigation view and related adapter used by the main activity for the

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.main
 
 import android.content.Context
 import android.util.AttributeSet
-import android.util.SparseArray
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.reader.ReaderPostListFragment
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AniUtils.Duration
 import org.wordpress.android.util.getColorStateListFromAttribute
+import java.lang.IllegalArgumentException
 
 /*
  * Bottom navigation view and related adapter used by the main activity for the
@@ -95,6 +96,7 @@ class WPMainNavigationView @JvmOverloads constructor(
             itemView.addView(customView)
         }
 
+        navAdapter.init()
         currentPosition = AppPrefs.getMainPageIndex(numPages() - 1)
     }
 
@@ -154,7 +156,6 @@ class WPMainNavigationView @JvmOverloads constructor(
         setImageViewSelected(position, true)
 
         AppPrefs.setMainPageIndex(position)
-        prevPosition = position
 
         // temporarily disable the nav listeners so they don't fire when we change the selected page
         assignNavigationListeners(false)
@@ -165,15 +166,15 @@ class WPMainNavigationView @JvmOverloads constructor(
         }
 
         val fragment = navAdapter.getFragment(position)
+        val previousFragment = navAdapter.getFragment(prevPosition)
         if (fragment != null) {
-            fragmentManager
-                    .beginTransaction()
-                    .replace(R.id.fragment_container, fragment, getTagForPosition(position))
-                    // This is used because the main activity sometimes crashes because it's trying to switch fragments
-                    // after `onSaveInstanceState` was already called. This is the related issue
-                    // https://github.com/wordpress-mobile/WordPress-Android/issues/10852
-                    .commitAllowingStateLoss()
+            if (previousFragment != null) {
+                fragmentManager.beginTransaction().hide(previousFragment).show(fragment).commit()
+            } else {
+                fragmentManager.beginTransaction().show(fragment).commit()
+            }
         }
+        prevPosition = position
     }
 
     private fun setImageViewSelected(position: Int, isSelected: Boolean) {
@@ -224,6 +225,14 @@ class WPMainNavigationView @JvmOverloads constructor(
 
     private fun getTagForPosition(position: Int): String {
         return when (getPageTypeOrNull(position)) {
+            MY_SITE -> TAG_MY_SITE
+            READER -> TAG_READER
+            else -> TAG_NOTIFS
+        }
+    }
+
+    private fun getTagForPageType(pageType: PageType): String {
+        return when (pageType) {
             MY_SITE -> TAG_MY_SITE
             READER -> TAG_READER
             else -> TAG_NOTIFS
@@ -281,31 +290,45 @@ class WPMainNavigationView @JvmOverloads constructor(
     }
 
     private inner class NavAdapter {
-        private val mFragments = SparseArray<Fragment>(numPages())
+        private val mFragments = mutableMapOf<PageType, Fragment>()
 
-        private fun createFragment(position: Int): Fragment? {
-            val fragment: Fragment = when (pages().getOrNull(position)) {
+        private fun createFragment(pageType: PageType): Fragment {
+            val fragment = when (pageType) {
                 MY_SITE -> MySiteFragment.newInstance()
                 READER -> ReaderPostListFragment.newInstance(true)
                 NOTIFS -> NotificationsListFragment.newInstance()
-                else -> return null
             }
-
-            mFragments.put(position, fragment)
+            mFragments[pageType] = fragment
+            fragmentManager.beginTransaction()
+                    .add(R.id.fragment_container, fragment, getTagForPageType(pageType))
+                    .hide(fragment)
+                    .commit()
             return fragment
         }
 
+        internal fun init() {
+            for (pageType in pages()) {
+                if (mFragments[pageType] == null) {
+                    mFragments[pageType] = fragmentManager.findFragmentByTag(getTagForPageType(pageType))
+                            ?: createFragment(pageType)
+                }
+            }
+        }
+
         internal fun getFragment(position: Int): Fragment? {
-            if (isValidPosition(position) && mFragments.get(position) != null) {
-                return mFragments.get(position)
+            val pageType = pages().getOrElse(position) {
+                return null
+            }
+            if (mFragments[pageType] != null) {
+                return mFragments[pageType]
             }
 
             val fragment = fragmentManager.findFragmentByTag(getTagForPosition(position))
             return if (fragment != null) {
-                mFragments.put(position, fragment)
+                mFragments[pageType] = fragment
                 fragment
             } else {
-                createFragment(position)
+                createFragment(pageType)
             }
         }
     }


### PR DESCRIPTION
Fixes #11830 

Previously we were using `FragmentManager.replace` to replace fragments on bottom navigation change. This call sets the Fragment as not active. However, we were still keeping and using the fragments in the sparse array. Overall this approach works but it causes some unnecessary fragment recreation and it's buggy with child fragments. If the parent is not active, the child fragments are also not active (even if the parent is actually visible). I'm replacing this functionality with `show/hide` calls instead. The fragments get initialized the first time you open the app and when you switch the tabs (or rotate the device), the fragments are retrieved from the fragment manager and shown/hidden. 

To test:
- Smoke test the bottom navigation
- Rotate the device
- The scroll position is kept
- Debug the code to see that the fragments are not unnecessarily created

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
