### PR TITLE
Hide audio tab when the user has no audio

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -339,6 +339,14 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         }
     }
 
+    private void refreshTabs() {
+        boolean hasAudio = mMediaStore.getSiteAudio(mSite).size() > 0;
+        if (mShowAudioTab != hasAudio) {
+            mShowAudioTab = hasAudio;
+            setupTabs();
+        }
+    }
+
     private int getPositionForFilter(@NonNull MediaFilter filter) {
         return filter.getValue();
     }
@@ -471,6 +479,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
             case RequestCodes.MEDIA_SETTINGS:
                 if (resultCode == MediaSettingsActivity.RESULT_MEDIA_DELETED) {
                     reloadMediaGrid();
+                    refreshTabs();
                 }
                 break;
             case RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT:
@@ -757,11 +766,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         if (event.isError()) {
             return;
         }
-        boolean hasAudio = mMediaStore.getSiteAudio(mSite).size() > 0;
-        if (mShowAudioTab != hasAudio) {
-            mShowAudioTab = hasAudio;
-            setupTabs();
-        }
+        refreshTabs();
     }
 
     @Override


### PR DESCRIPTION
Fixes #11361 

This PR hides the audio tab in the Media activity when the user has no audio. The activity now listens to the event and refreshes the tab layout style if there is a change to the number of audio files.

To test:
- Go to a site without Audio media
- Go to the My Site/Media
- Check that the "Audio" tab is not visible
- Go to Calypso and add an audio file to the site media library
- Pull to refresh in the app
- The "Audio" appears
- Click on the "Audio" tab
- The audio file is visible on the screen
- Remote the audio file in Calypso
- Pull to refresh in the app
- The "Audio" tab disappears and the "All" tab is automatically selected

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
