### PR TITLE
Reader move tab layout to parent part 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -249,18 +249,16 @@ public class FilteredRecyclerView extends RelativeLayout {
         }
     }
 
-    private void manageFilterSelection(int position) {
+    private void onSpinnerItemSelected(int position) {
+        if (mHideAppBarLayout) {
+            throw new IllegalStateException("Developer error: Spinner shouldn't be visible when the appbar is hidden.");
+        }
         if (mSelectingRememberedFilterOnCreate) {
             mSelectingRememberedFilterOnCreate = false;
             return;
         }
 
-        FilterCriteria selectedCriteria;
-        if (mHideAppBarLayout) {
-            selectedCriteria = mFilterCriteriaOptions.get(position);
-        } else {
-            selectedCriteria = (FilterCriteria) mSpinnerAdapter.getItem(position);
-        }
+        FilterCriteria selectedCriteria = (FilterCriteria) mSpinnerAdapter.getItem(position);
 
         if (mCurrentFilter == selectedCriteria) {
             AppLog.d(mTAG, "The selected STATUS is already active: "
@@ -287,7 +285,7 @@ public class FilteredRecyclerView extends RelativeLayout {
         mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                manageFilterSelection(position);
+                onSpinnerItemSelected(position);
             }
 
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -27,9 +27,6 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.elevation.ElevationOverlayProvider;
-import com.google.android.material.tabs.TabLayout;
-import com.google.android.material.tabs.TabLayout.OnTabSelectedListener;
-import com.google.android.material.tabs.TabLayout.Tab;
 
 import org.wordpress.android.R;
 import org.wordpress.android.models.FilterCriteria;
@@ -53,7 +50,6 @@ public class FilteredRecyclerView extends RelativeLayout {
     private Spinner mSpinner;
     private boolean mSelectingRememberedFilterOnCreate = false;
 
-    private TabLayout mTabLayout;
     private boolean mUseTabsForFiltering = false;
 
     private RecyclerView mRecyclerView;
@@ -100,10 +96,7 @@ public class FilteredRecyclerView extends RelativeLayout {
     public void setCurrentFilter(FilterCriteria filter) {
         mCurrentFilter = filter;
 
-        if (mUseTabsForFiltering) {
-            int position = mFilterCriteriaOptions.indexOf(filter);
-            setSelectedTab(position);
-        } else {
+        if (!mUseTabsForFiltering) {
             int position = mSpinnerAdapter.getIndexOfCriteria(filter);
             if (position > -1 && position != mSpinner.getSelectedItemPosition()) {
                 mSpinner.setSelection(position);
@@ -113,15 +106,6 @@ public class FilteredRecyclerView extends RelativeLayout {
 
     public FilterCriteria getCurrentFilter() {
         return mCurrentFilter;
-    }
-
-    private void setSelectedTab(int position) {
-        if (mTabLayout != null) {
-            Tab tab = mTabLayout.getTabAt(position);
-            if (tab != null) {
-                tab.select();
-            }
-        }
     }
 
     public boolean isValidFilter(FilterCriteria filter) {
@@ -239,18 +223,10 @@ public class FilteredRecyclerView extends RelativeLayout {
             mSpinner = findViewById(R.id.filter_spinner);
         }
 
-        if (mTabLayout == null) {
-            mTabLayout = findViewById(R.id.tab_layout);
-            mTabLayout.addOnLayoutChangeListener(
-                    (v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) ->
-                            mTabLayout.setScrollPosition(mTabLayout.getSelectedTabPosition(), 0f, true));
-        }
 
         if (mUseTabsForFiltering) {
-            mTabLayout.setVisibility(View.VISIBLE);
             mSpinner.setVisibility(View.GONE);
         } else {
-            mTabLayout.setVisibility(View.GONE);
             mSpinner.setVisibility(View.VISIBLE);
         }
     }
@@ -309,53 +285,25 @@ public class FilteredRecyclerView extends RelativeLayout {
     private void initFilterAdapter() {
         mSelectingRememberedFilterOnCreate = true;
 
-        if (mUseTabsForFiltering) {
-            mTabLayout.clearOnTabSelectedListeners();
-            mTabLayout.removeAllTabs();
+        mSpinnerAdapter = new SpinnerAdapter(getContext(),
+                mFilterCriteriaOptions, mSpinnerItemView, mSpinnerDropDownItemView);
 
-            for (int i = 0; i < mFilterCriteriaOptions.size(); i++) {
-                FilterCriteria filterCriteria = mFilterCriteriaOptions.get(i);
-                Tab newTab = mTabLayout.newTab().setText(filterCriteria.getLabel());
-                mTabLayout.addTab(newTab, i);
+        mSpinner.setAdapter(mSpinnerAdapter);
+        mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                manageFilterSelection(position);
             }
 
-            mTabLayout.addOnTabSelectedListener(new OnTabSelectedListener() {
-                @Override public void onTabSelected(Tab tab) {
-                    manageFilterSelection(tab.getPosition());
-                }
-
-                @Override public void onTabUnselected(Tab tab) {
-                }
-
-                @Override public void onTabReselected(Tab tab) {
-                    mSelectingRememberedFilterOnCreate = false;
-                }
-            });
-        } else {
-            mSpinnerAdapter = new SpinnerAdapter(getContext(),
-                    mFilterCriteriaOptions, mSpinnerItemView, mSpinnerDropDownItemView);
-
-            mSpinner.setAdapter(mSpinnerAdapter);
-            mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-                @Override
-                public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                    manageFilterSelection(position);
-                }
-
-                @Override
-                public void onNothingSelected(AdapterView<?> parent) {
-                    // nop
-                }
-            });
-        }
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+                // nop
+            }
+        });
     }
 
     private boolean hasAdapter() {
         return (mAdapter != null);
-    }
-
-    public boolean emptyViewIsVisible() {
-        return (mEmptyView != null && mEmptyView.getVisibility() == View.VISIBLE);
     }
 
     public void hideEmptyView() {
@@ -408,10 +356,6 @@ public class FilteredRecyclerView extends RelativeLayout {
     public Menu addToolbarMenu(@MenuRes int menuResId) {
         mToolbar.inflateMenu(menuResId);
         return mToolbar.getMenu();
-    }
-
-    public void setTabLayoutVisibility(boolean mustShow) {
-        mTabLayout.setVisibility((mustShow && mUseTabsForFiltering) ? View.VISIBLE : View.GONE);
     }
 
     public void setToolbarBackgroundColor(int color) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -50,7 +50,7 @@ public class FilteredRecyclerView extends RelativeLayout {
     private Spinner mSpinner;
     private boolean mSelectingRememberedFilterOnCreate = false;
 
-    private boolean mUseTabsForFiltering = false;
+    private boolean mHideAppBarLayout = false;
 
     private RecyclerView mRecyclerView;
     private TextView mEmptyView;
@@ -96,7 +96,7 @@ public class FilteredRecyclerView extends RelativeLayout {
     public void setCurrentFilter(FilterCriteria filter) {
         mCurrentFilter = filter;
 
-        if (!mUseTabsForFiltering) {
+        if (!mHideAppBarLayout) {
             int position = mSpinnerAdapter.getIndexOfCriteria(filter);
             if (position > -1 && position != mSpinner.getSelectedItemPosition()) {
                 mSpinner.setSelection(position);
@@ -156,8 +156,8 @@ public class FilteredRecyclerView extends RelativeLayout {
                 mSpinnerDropDownItemView = a.getResourceId(
                         R.styleable.FilteredRecyclerView_wpSpinnerDropDownItemView, 0);
 
-                mUseTabsForFiltering = a.getBoolean(
-                        R.styleable.FilteredRecyclerView_wpUseTabsForFiltering, false);
+                mHideAppBarLayout = a.getBoolean(
+                        R.styleable.FilteredRecyclerView_wpHideAppBarLayout, false);
             } finally {
                 a.recycle();
             }
@@ -223,12 +223,7 @@ public class FilteredRecyclerView extends RelativeLayout {
             mSpinner = findViewById(R.id.filter_spinner);
         }
 
-
-        if (mUseTabsForFiltering) {
-            mSpinner.setVisibility(View.GONE);
-        } else {
-            mSpinner.setVisibility(View.VISIBLE);
-        }
+        mAppBarLayout.setVisibility(mHideAppBarLayout ? View.GONE : View.VISIBLE);
     }
 
     private void setup(boolean refresh) {
@@ -261,7 +256,7 @@ public class FilteredRecyclerView extends RelativeLayout {
         }
 
         FilterCriteria selectedCriteria;
-        if (mUseTabsForFiltering) {
+        if (mHideAppBarLayout) {
             selectedCriteria = mFilterCriteriaOptions.get(position);
         } else {
             selectedCriteria = (FilterCriteria) mSpinnerAdapter.getItem(position);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1100,7 +1100,6 @@ public class ReaderPostListFragment extends Fragment
                 populateSearchSuggestions(null);
                 showSearchMessageOrSuggestions();
                 mSettingsMenuItem.setVisible(false);
-                mRecyclerView.setTabLayoutVisibility(false);
                 mViewModel.changeSubfiltersVisibility(false);
                 if (mIsTopLevel) {
                     mViewModel.onSearchMenuCollapse(false);
@@ -1143,7 +1142,6 @@ public class ReaderPostListFragment extends Fragment
                         resetPostAdapter(ReaderPostListType.TAG_FOLLOWED);
                     }
 
-                    mRecyclerView.setTabLayoutVisibility(true);
                     mViewModel.changeSubfiltersVisibility(isCurrentTagManagedInFollowingTab());
                     mViewModel.onSearchMenuCollapse(true);
                 } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1024,7 +1024,7 @@ public class ReaderPostListFragment extends Fragment
         mSubFilterComponent.setBackgroundColor(elevatedCardColor);
 
         if (mIsTopLevel) {
-            mRecyclerView.getAppBarLayout().addView(mSubFilterComponent);
+            ((ViewGroup) rootView.findViewById(R.id.content_container)).addView(mSubFilterComponent);
 
             mSettingsButton = mSubFilterComponent.findViewById(R.id.filter_settings_button);
             mSettingsButton.setOnClickListener(v -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1018,14 +1018,11 @@ public class ReaderPostListFragment extends Fragment
             mRecyclerView.setRefreshing(true);
         }
 
-        mSubFilterComponent = inflater.inflate(R.layout.subfilter_component, rootView, false);
-        float cardElevation = getResources().getDimension(R.dimen.card_elevation);
-        int elevatedCardColor = elevationOverlayProvider.compositeOverlayWithThemeSurfaceColorIfNeeded(cardElevation);
-        mSubFilterComponent.setBackgroundColor(elevatedCardColor);
+
 
         if (mIsTopLevel) {
-            ((ViewGroup) rootView.findViewById(R.id.content_container)).addView(mSubFilterComponent);
-
+            mSubFilterComponent = inflater.inflate(R.layout.subfilter_component, rootView, false);
+            ((ViewGroup) rootView.findViewById(R.id.sub_filter_component_container)).addView(mSubFilterComponent);
             mSettingsButton = mSubFilterComponent.findViewById(R.id.filter_settings_button);
             mSettingsButton.setOnClickListener(v -> {
                 showSettings();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -29,7 +29,7 @@ class ReaderViewModel @Inject constructor(
         launch {
             val tagList = loadReaderTabsUseCase.loadTabs()
             _uiState.value = ReaderUiState(
-                    tagList.map { it.tagDisplayName }, // TODO should we use displayname or title?
+                    tagList.map { it.tagTitle },
                     tagList
             )
         }

--- a/WordPress/src/main/res/layout/filtered_list_component.xml
+++ b/WordPress/src/main/res/layout/filtered_list_component.xml
@@ -33,16 +33,6 @@
 
         </com.google.android.material.appbar.MaterialToolbar>
 
-        <com.google.android.material.tabs.TabLayout
-            android:id="@+id/tab_layout"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/tab_height"
-            android:layout_gravity="start"
-            android:visibility="gone"
-            app:tabGravity="fill"
-            app:tabMode="scrollable"
-            tools:visibility="visible" />
-
     </com.google.android.material.appbar.AppBarLayout>
 
     <RelativeLayout

--- a/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
@@ -2,6 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/content_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
@@ -11,7 +11,7 @@
         android:layout_height="match_parent"
         app:wpSpinnerItemView="@layout/toolbar_main_spinner_item"
         app:wpToolbarDisableScrollGestures="true"
-        app:wpUseTabsForFiltering="true" />
+        app:wpHideAppBarLayout="true" />
 
     <include
         android:id="@+id/empty_custom_view"

--- a/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
@@ -6,10 +6,18 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <FrameLayout
+        android:id="@+id/sub_filter_component_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        android:elevation="@dimen/card_elevation"/>
+
     <org.wordpress.android.ui.FilteredRecyclerView
         android:id="@+id/reader_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_below="@+id/sub_filter_component_container"
         app:wpSpinnerItemView="@layout/toolbar_main_spinner_item"
         app:wpToolbarDisableScrollGestures="true"
         app:wpHideAppBarLayout="true" />
@@ -21,6 +29,7 @@
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/layout_new_posts"
+        android:layout_below="@+id/sub_filter_component_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"

--- a/WordPress/src/main/res/layout/subfilter_component.xml
+++ b/WordPress/src/main/res/layout/subfilter_component.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/reader_subfilter_component_height"
-    android:background="@android:color/white"
-    android:elevation="@dimen/appbar_elevation">
+    android:background="@android:color/white">
 
     <View
         android:id="@+id/filter_selection"

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -148,8 +148,12 @@
 
         <!-- Optional: Default is false. Locks the toolbar and prevents scroll to hide/reveal functionality -->
         <attr name="wpToolbarDisableScrollGestures" format="boolean"/>
-        <!-- Optional: Default to false. Activate filtering by Tabs instead of Spinner -->
-        <attr name="wpUseTabsForFiltering" format="boolean"/>
+        <!-- Optional: Default to false. Hide the AppBarLayout. This flag was added as part of
+        ReaderPostListFragment refactoring. We don't need to use the FilteredRecyclerView in the
+        Reader anymore, but since it's planned to iteratively rewrite the ReaderPostListFragment
+        it's not worth replacing the FilteredRecyclerView with something else now. Therefore we
+        opted for a simple flag which hides the filtering options from the FilteredRecyclerView -->
+        <attr name="wpHideAppBarLayout" format="boolean"/>
     </declare-styleable>
 
     <!--


### PR DESCRIPTION
Partially fixes https://github.com/wordpress-mobile/WordPress-Android/issues/11849
This is a second PR in a series of PRs which is trying to introduce a regular TabLayout+ViewPager2 in the main Reader view. The current implementation uses FilteredRecyclerView component (which is not a RecyclerView :P) that has some downsides (eg. swipe gesture doesn't work).

- Removed the "loadTags" async task from the PostListFragment. The tags are loaded in the new ReaderFragment so it wasn't necessary anymore.
- Removed the TabLayout from the FilteredRecyclerView(FRV) component as it wasn't used anymore
- Removed "useTabsForFiltering" and introduced "HideTabLayout" in the FRV. We use it to hide the whole appbar layout as it'll now live in the ReaderFragment (will be introduced in future PRs)
- Fix bug where the SubFilterComponent wasn't being shown on the following tab (the component doesn't work yet, as we need to make some other changes in order to fix its behavior. Will be introduced in future PRs)


To test:
- This https://github.com/wordpress-mobile/WordPress-Android/pull/11840#pullrequestreview-407342819 bug should be fixed now.
- Make sure you can swipe left-right and that the correct content is shown on all the tabs
- This PR breaks search and following-subfilter component. This is expected and will be fixed later

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
