### PR TITLE
Fix logout for connected tests and re-enable Slack notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ workflows:
             branches:
               ignore: /pull\/[0-9]+/
       - Connected Tests:
-          post-to-slack: false
+          post-to-slack: true
           # Always run connected tests on develop and release branches
           filters:
             branches:

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MePage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MePage.java
@@ -2,7 +2,6 @@ package org.wordpress.android.e2e.pages;
 
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.ViewInteraction;
-import androidx.test.espresso.matcher.ViewMatchers.Visibility;
 
 import org.wordpress.android.R;
 
@@ -10,7 +9,6 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
@@ -35,7 +33,7 @@ public class MePage {
         // Using the settings button as a marker for successfully navigating to the page
         while (!isElementDisplayed(appSettings)) {
             clickOn(R.id.nav_sites);
-            clickOn(onView(allOf(withId(R.id.me_item), withEffectiveVisibility(Visibility.VISIBLE))));
+            clickOn(R.id.me_item);
         }
 
         if (!isSelfHosted()) {

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MePage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MePage.java
@@ -2,6 +2,7 @@ package org.wordpress.android.e2e.pages;
 
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.ViewInteraction;
+import androidx.test.espresso.matcher.ViewMatchers.Visibility;
 
 import org.wordpress.android.R;
 
@@ -9,6 +10,7 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
@@ -33,7 +35,7 @@ public class MePage {
         // Using the settings button as a marker for successfully navigating to the page
         while (!isElementDisplayed(appSettings)) {
             clickOn(R.id.nav_sites);
-            clickOn(R.id.me_item);
+            clickOn(onView(allOf(withId(R.id.me_item), withEffectiveVisibility(Visibility.VISIBLE))));
         }
 
         if (!isSelfHosted()) {

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -16,6 +16,7 @@ import androidx.test.espresso.action.GeneralClickAction;
 import androidx.test.espresso.action.GeneralLocation;
 import androidx.test.espresso.action.Press;
 import androidx.test.espresso.action.Tap;
+import androidx.test.espresso.matcher.ViewMatchers.Visibility;
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObjectNotFoundException;
@@ -46,6 +47,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
@@ -58,8 +60,12 @@ import static org.hamcrest.Matchers.is;
 public class WPSupportUtils {
     // HIGH-LEVEL METHODS
 
+    public static ViewInteraction visibleElementWithId(Integer elementID) {
+        return onView(allOf(withId(elementID), withEffectiveVisibility(Visibility.VISIBLE)));
+    }
+
     public static boolean isElementDisplayed(Integer elementID) {
-        return isElementDisplayed(onView(withId(elementID)));
+        return isElementDisplayed(visibleElementWithId(elementID));
     }
 
     public static boolean isElementDisplayed(ViewInteraction element) {
@@ -82,7 +88,7 @@ public class WPSupportUtils {
 
     public static void scrollToThenClickOn(Integer elementID) {
         waitForElementToBeDisplayed(elementID);
-        onView(withId(elementID))
+        visibleElementWithId(elementID)
                 .perform(scrollTo());
         clickOn(elementID);
     }
@@ -95,7 +101,7 @@ public class WPSupportUtils {
 
     public static void clickOn(Integer elementID) {
         waitForElementToBeDisplayed(elementID);
-        clickOn(onView(withId(elementID)));
+        clickOn(visibleElementWithId(elementID));
         idleFor(500); // allow for transitions
     }
 
@@ -154,7 +160,7 @@ public class WPSupportUtils {
 
     public static void longClickOn(Integer elementID) {
         waitForElementToBeDisplayed(elementID);
-        onView(withId(elementID)).perform(longClick());
+        visibleElementWithId(elementID).perform(longClick());
     }
 
     public static void longClickOn(ViewInteraction element) {
@@ -186,7 +192,7 @@ public class WPSupportUtils {
 
     public static void populateTextField(Integer elementID, String text) {
         waitForElementToBeDisplayed(elementID);
-        onView(withId(elementID))
+        visibleElementWithId(elementID)
                 .perform(replaceText(text))
                 .perform(closeSoftKeyboard());
     }
@@ -311,11 +317,11 @@ public class WPSupportUtils {
         Integer maxTries = 10;
 
         for (Integer i = 0; i < 10; i++) {
-            onView(withId(elementID)).perform(swipeRight());
+            visibleElementWithId(elementID).perform(swipeRight());
         }
 
         while (!tabLayoutHasTextDisplayed(elementID, string) && tries < maxTries) {
-            onView(withId(elementID)).perform(swipeLeft());
+            visibleElementWithId(elementID).perform(swipeLeft());
             tries++;
         }
 


### PR DESCRIPTION
This PR adds an extra visibility matcher to `me_item` menu button in the "My Site" screen so the tests can logout. I couldn't figure out what caused the matcher to stop working since there doesn't seem to be a change to the `MySiteFragment` when the tests started to fail. Regardless, this matcher change is working locally, so hopefully it'll fix the ones in Firebase as well.

I've also re-enabled to Slack notifications since the tests were consistently passing before this issue, so assuming this PR fixes the issue, I don't think we need to keep that disabled anymore.

To test:
* Run the optional connected tests and verify all of them passes

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
