### PR TITLE
Issue/10726 site pages author picker phase I

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewState.kt
@@ -34,14 +34,14 @@ sealed class AuthorFilterListItemUIState(
     data class Everyone(override val isSelected: Boolean, @DrawableRes val imageRes: Int) :
             AuthorFilterListItemUIState(
                     id = EVERYONE.id,
-                    text = UiStringRes(R.string.post_list_author_everyone),
+                    text = UiStringRes(R.string.everyone),
                     isSelected = isSelected
             )
 
     data class Me(val avatarUrl: String?, override val isSelected: Boolean) :
             AuthorFilterListItemUIState(
                     id = ME.id,
-                    text = UiStringRes(R.string.post_list_author_me),
+                    text = UiStringRes(R.string.me),
                     isSelected = isSelected
             )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/AuthorSelectionAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/AuthorSelectionAdapter.kt
@@ -37,7 +37,7 @@ class AuthorSelectionAdapter(context: Context) : BaseAdapter() {
 
         if (view == null) {
             val inflater = LayoutInflater.from(parent.context)
-            view = inflater.inflate(R.layout.post_list_author_selection_dropdown, parent, false)
+            view = inflater.inflate(R.layout.author_selection_dropdown, parent, false)
             holder = DropdownViewHolder(view)
             view.tag = holder
         } else {
@@ -67,7 +67,7 @@ class AuthorSelectionAdapter(context: Context) : BaseAdapter() {
 
         if (view == null) {
             val inflater = LayoutInflater.from(parent.context)
-            view = inflater.inflate(R.layout.post_list_author_selection, parent, false)
+            view = inflater.inflate(R.layout.author_selection, parent, false)
             holder = NormalViewHolder(view)
             view.tag = holder
         } else {
@@ -92,7 +92,7 @@ class AuthorSelectionAdapter(context: Context) : BaseAdapter() {
     }
 
     private open class NormalViewHolder(protected val itemView: View) {
-        protected val image: AppCompatImageView = itemView.findViewById(R.id.post_list_author_selection_image)
+        protected val image: AppCompatImageView = itemView.findViewById(R.id.author_selection_image)
 
         @CallSuper
         open fun bind(
@@ -126,7 +126,7 @@ class AuthorSelectionAdapter(context: Context) : BaseAdapter() {
     }
 
     private class DropdownViewHolder(itemView: View) : NormalViewHolder(itemView) {
-        private val text: AppCompatTextView = itemView.findViewById(R.id.post_list_author_selection_text)
+        private val text: AppCompatTextView = itemView.findViewById(R.id.author_selection_text)
 
         override fun bind(
             state: AuthorFilterListItemUIState,

--- a/WordPress/src/main/res/drawable/bg_oval_transparent_stroke_white.xml
+++ b/WordPress/src/main/res/drawable/bg_oval_transparent_stroke_white.xml
@@ -6,7 +6,7 @@
 
     <stroke
         android:color="@android:color/white"
-        android:width="@dimen/posts_list_spinner_avatar_padding">
+        android:width="@dimen/me_avatar_width">
     </stroke>
 
 </shape>

--- a/WordPress/src/main/res/layout/author_selection.xml
+++ b/WordPress/src/main/res/layout/author_selection.xml
@@ -6,12 +6,12 @@
              android:layout_height="match_parent">
 
     <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/post_list_author_selection_image"
-        android:layout_width="@dimen/posts_list_spinner_avatar_size"
-        android:layout_height="@dimen/posts_list_spinner_avatar_size"
+        android:id="@+id/author_selection_image"
+        android:layout_width="@dimen/author_spinner_avatar_size"
+        android:layout_height="@dimen/author_spinner_avatar_size"
         android:layout_gravity="center"
         android:background="@drawable/bg_oval_transparent_stroke_white"
-        android:padding="@dimen/posts_list_spinner_avatar_padding"
+        android:padding="@dimen/author_spinner_avatar_padding"
         tools:src="@drawable/bg_oval_neutral_30_multiple_users_white_40dp"/>
 </FrameLayout>
 

--- a/WordPress/src/main/res/layout/author_selection_dropdown.xml
+++ b/WordPress/src/main/res/layout/author_selection_dropdown.xml
@@ -15,21 +15,21 @@
          on lower APIs will be minimal -->
 
     <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/post_list_author_selection_image"
-        android:layout_width="@dimen/posts_list_spinner_avatar_size"
-        android:layout_height="@dimen/posts_list_spinner_avatar_size"
-        android:layout_marginStart="@dimen/posts_list_spinner_dropdown_avatar_horizontal_margin"
-        android:layout_marginEnd="@dimen/posts_list_spinner_dropdown_avatar_horizontal_margin"
+        android:id="@+id/author_selection_image"
+        android:layout_width="@dimen/author_spinner_avatar_size"
+        android:layout_height="@dimen/author_spinner_avatar_size"
+        android:layout_marginStart="@dimen/author_spinner_dropdown_avatar_horizontal_margin"
+        android:layout_marginEnd="@dimen/author_spinner_dropdown_avatar_horizontal_margin"
         android:importantForAccessibility="no"
-        android:padding="@dimen/posts_list_spinner_avatar_padding"
+        android:padding="@dimen/author_spinner_avatar_padding"
         tools:src="@drawable/bg_oval_neutral_30_multiple_users_white_40dp"
         tools:tint="@color/neutral_50" />
 
     <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/post_list_author_selection_text"
+        android:id="@+id/author_selection_text"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:textAppearance="?attr/textAppearanceBody1"
-        tools:text="@string/post_list_author_everyone" />
+        tools:text="@string/everyone" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/me_action_layout.xml
+++ b/WordPress/src/main/res/layout/me_action_layout.xml
@@ -13,7 +13,7 @@
         android:layout_height="@dimen/avatar_sz_small"
         android:contentDescription="@null"
         android:background="@drawable/bg_oval_transparent_stroke_white"
-        android:padding="@dimen/posts_list_spinner_avatar_padding"
+        android:padding="@dimen/me_avatar_padding"
         android:src="@drawable/ic_user_white_24dp"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/pages_fragment.xml
+++ b/WordPress/src/main/res/layout/pages_fragment.xml
@@ -11,6 +11,20 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+            android:id="@+id/pullToRefresh"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_below="@id/toolbar"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+            <androidx.viewpager.widget.ViewPager
+                android:id="@+id/pagesPager"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
+
         <FrameLayout
             android:id="@+id/searchFrame"
             android:layout_width="match_parent"
@@ -86,20 +100,6 @@
             android:src="@drawable/ic_create_white_24dp"
             android:visibility="gone"
             app:borderWidth="0dp" />
-
-        <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
-            android:id="@+id/pullToRefresh"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_below="@id/toolbar"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-            <androidx.viewpager.widget.ViewPager
-                android:id="@+id/pagesPager"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-
-        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/WordPress/src/main/res/layout/pages_fragment.xml
+++ b/WordPress/src/main/res/layout/pages_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -9,6 +10,82 @@
         android:id="@+id/coordinatorLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+
+        <FrameLayout
+            android:id="@+id/searchFrame"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            app:layout_constraintTop_toBottomOf="@id/toolbar" />
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:animateLayoutChanges="true"
+            android:elevation="@dimen/appbar_elevation"
+            android:fitsSystemWindows="true">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:elevation="0dp"
+                app:layout_collapseMode="pin"
+                app:layout_scrollFlags="scroll|exitUntilCollapsed"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+                app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+            <RelativeLayout
+                android:id="@+id/tabContainer"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/tab_height"
+                android:elevation="0dp">
+
+                <com.google.android.material.tabs.TabLayout
+                    android:id="@+id/tabLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_alignStart="@+id/pages_tab_layout_fading_edge"
+                    android:layout_gravity="start"
+                    android:clipToPadding="false"
+                    android:elevation="0dp"
+                    app:tabGravity="fill"
+                    app:tabMode="scrollable"
+                    tools:paddingEnd="0dp"
+                    tools:paddingStart="@dimen/page_list_tab_layout_fading_edge_width" />
+
+                <View
+                    android:id="@+id/pages_tab_layout_fading_edge"
+                    android:layout_width="@dimen/page_list_tab_layout_fading_edge_width"
+                    android:layout_height="match_parent"
+                    android:layout_alignEnd="@+id/pages_author_selection"
+                    android:elevation="0dp" />
+
+                <androidx.appcompat.widget.AppCompatSpinner
+                    android:id="@+id/pages_author_selection"
+                    android:layout_width="@dimen/author_spinner_width"
+                    android:layout_height="match_parent"
+                    android:background="?attr/selectableItemBackground"
+                    android:contentDescription="@string/pages_list_author"
+                    android:elevation="0dp"
+                    android:paddingEnd="@dimen/margin_small"
+                    android:paddingStart="0dp" />
+            </RelativeLayout>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/newPageButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|bottom"
+            android:layout_marginBottom="@dimen/fab_margin"
+            android:layout_marginEnd="@dimen/fab_margin"
+            android:contentDescription="@string/fab_create_desc"
+            android:src="@drawable/ic_create_white_24dp"
+            android:visibility="gone"
+            app:borderWidth="0dp" />
 
         <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
             android:id="@+id/pullToRefresh"
@@ -23,52 +100,6 @@
                 android:layout_height="match_parent" />
 
         </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
-
-        <FrameLayout
-            android:id="@+id/searchFrame"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior"
-            app:layout_constraintTop_toBottomOf="@id/toolbar" />
-
-        <com.google.android.material.appbar.AppBarLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:animateLayoutChanges="true"
-            android:fitsSystemWindows="true">
-
-            <com.google.android.material.appbar.MaterialToolbar
-                android:id="@+id/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                app:layout_collapseMode="pin"
-                app:layout_scrollFlags="scroll|exitUntilCollapsed"
-                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-                app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
-
-            <com.google.android.material.tabs.TabLayout
-                android:id="@+id/tabLayout"
-                android:layout_width="match_parent"
-                android:layout_height="48dp"
-                android:layout_gravity="start"
-                app:tabContentStart="72dp"
-                app:tabGravity="fill"
-                app:tabMode="scrollable" />
-
-        </com.google.android.material.appbar.AppBarLayout>
-
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/newPageButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end|bottom"
-            android:layout_marginEnd="@dimen/fab_margin"
-            android:layout_marginBottom="@dimen/fab_margin"
-            android:contentDescription="@string/fab_create_desc"
-            android:src="@drawable/ic_create_white_24dp"
-            android:visibility="gone"
-            app:borderWidth="0dp" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/WordPress/src/main/res/layout/post_list_activity.xml
+++ b/WordPress/src/main/res/layout/post_list_activity.xml
@@ -49,7 +49,7 @@
 
             <androidx.appcompat.widget.AppCompatSpinner
                 android:id="@+id/post_list_author_selection"
-                android:layout_width="@dimen/posts_list_spinner_width"
+                android:layout_width="@dimen/author_spinner_width"
                 android:contentDescription="@string/post_list_author"
                 android:layout_height="match_parent"
                 android:background="?attr/selectableItemBackground"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -261,6 +261,8 @@
     <!--me-->
     <dimen name="me_list_row_icon_size">24dp</dimen>
     <dimen name="me_list_row_padding_horizontal">@dimen/content_margin</dimen>
+    <dimen name="me_avatar_padding">2dp</dimen>
+    <dimen name="me_avatar_width">2dp</dimen>
 
     <!--site picker-->
     <dimen name="site_picker_blavatar_margin_left">7dp</dimen>
@@ -383,7 +385,7 @@
     <dimen name="page_list_row_min_height">80dp</dimen>
     <dimen name="page_list_featured_image_size">40dp</dimen>
     <dimen name="page_list_menu_button_size">24dp</dimen>
-
+    <dimen name="page_list_tab_layout_fading_edge_width">16dp</dimen>
 
     <dimen name="quota_bar_text_minimum_height">36dp</dimen>
 
@@ -392,11 +394,13 @@
     <dimen name="post_list_row_skeleton_view_excerpt_height">16dp</dimen>
     <dimen name="post_list_row_skeleton_view_date_height">16dp</dimen>
 
+    <!-- author spinner for pages and posts lists -->
+    <dimen name="author_spinner_width">60dp</dimen>
+    <dimen name="author_spinner_avatar_size">32dp</dimen>
+    <dimen name="author_spinner_avatar_padding">2dp</dimen>
+    <dimen name="author_spinner_dropdown_avatar_horizontal_margin">13dp</dimen>
+
     <!--posts list-->
-    <dimen name="posts_list_spinner_width">60dp</dimen>
-    <dimen name="posts_list_spinner_avatar_size">32dp</dimen>
-    <dimen name="posts_list_spinner_avatar_padding">2dp</dimen>
-    <dimen name="posts_list_spinner_dropdown_avatar_horizontal_margin">13dp</dimen>
     <dimen name="posts_list_tab_layout_fading_edge_width">16dp</dimen>
     <dimen name="posts_list_compact_row_height">80dp</dimen>
     <dimen name="posts_list_compact_image_size">40dp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -116,6 +116,9 @@
     <string name="author_name_blog_name">%1$s, %2$s</string>
     <string name="at_username">\@%s</string>
 
+    <string name="me">Me</string>
+    <string name="everyone">Everyone</string>
+
     <!-- CAB -->
     <string name="cab_selected">%d selected</string>
 
@@ -2637,6 +2640,7 @@
     <string name="pages_empty_trashed">You don\'t have any trashed pages</string>
     <string name="pages_open_page_error">The selected page is not available</string>
     <string name="pages_and_posts_cancel_auto_upload">Cancel upload</string>
+    <string name="pages_list_author">Page author</string>
 
 
     <string name="page_status_pending_review" translatable="false">@string/post_status_pending_review</string>
@@ -2680,8 +2684,6 @@
 
     <!-- Posts -->
     <string name="post_list_author">Post author</string>
-    <string name="post_list_author_me">Me</string>
-    <string name="post_list_author_everyone">Everyone</string>
     <string name="post_list_tab_published_posts">Published</string>
     <string name="post_list_tab_drafts">Drafts</string>
     <string name="post_list_tab_scheduled_posts">Scheduled</string>


### PR DESCRIPTION
Phase I of #10726 

Description
This PR is requesting a merge into the feature branch. It generically renames layouts, drawables and dimension resources, so that the author selection spinner available in “posts” can be reused in site pages. 

**Implementation Details**

- `post_list_author_selection.xml` was renamed to `author_selection.xml`
- `post_list_author_selection_dropdown.xml` renamed to `author_selection_dropdown.xml` and removed “post_list” from ids
- Updated `post_list_activity` to reflect resource renaming
- Updated `AuthorSelectionAdapter` to reflect renamed author layout files
- Updated dimens.xml 
--Dropped the “posts_list” prefix in favor of “author”, so the author spinner can be used by pages and posts lists
--Added two dimens for use in `bg_oval_transparent_stroke_white.xml` (Note: this drawable is used for me, post and pages. I was going to drop the “me”, but felt it was important to keep the reference)
--Updated  `me_action_layout.xml`  to reflect the refactored `me_avatar_width` dimen
- Updated strings.xml
-- Added a separate resource `<string name="pages_list_author">Page author</string>`, so that content remains separate between posts and pages.
-- Added generic me and everyone strings
-- Updated `AuthorFilterListItemUIState` to reflect the use of generic strings
-- The `PostListMainViewState` file was updated because it houses `AuthorFilterListItemUIState`
- Prepped `pages_fragment` for author feature by adding the spinner and related views.

I had tossed around the idea of moving `AuthorFilterListItemUIState`, `getAuthorFilterItems()` , and `AuthorSelectionAdapter`  to some type of shared package, but noticed that there doesn’t seem to be a precedence for it. In fact, there are many references to ui.posts throughout the pages feature, so I am going to follow suit. I am open to suggestions on how to pull together a shared “posts/pages” area without messing with the existing structure.

**Testing Instructions**

Test Case (A) 

-Launch WPAndroid
-Open a site that has multiple post authors
-Navigate to Posts
-Tap on author selector, toggle through “everyone” and “me” 
-Ensure avatars show as expected
-Ensure “everyone” and “me” are spelled correctly

Test Case (B) 

-Launch WPAndroid
-Open a site 
-Tap on the “me” avatar 
-Ensure avatar shows as expected

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
