### PR TITLE
Prepublishing Nudges : Requested focus for the TagsEditText 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/TagsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/TagsFragment.java
@@ -90,6 +90,8 @@ public abstract class TagsFragment extends Fragment implements TextWatcher, View
 
         mTagsEditText = (EditText) view.findViewById(R.id.tags_edit_text);
         mTagsEditText.setOnKeyListener(this);
+        mTagsEditText.requestFocus();
+        ActivityUtils.showKeyboard(mTagsEditText);
         mTagsEditText.post(() -> mTagsEditText.addTextChangedListener(TagsFragment.this));
 
         loadTags();


### PR DESCRIPTION
Fixes #11861 

## Solution

1. Requested focus on the `TagsFragment`'s tags `EditText`
2. Forced the keyboard to be shown because it wasn't showing in the bottom sheet. 

## Testing
1. Create a new post. 
2. Click publish. 
3. Click Tags. 
4. See that there's focus on the `EditText`. 

Before | After 
--------|-------
  <kbd><img src="https://user-images.githubusercontent.com/1509205/81338664-9e9d4580-9072-11ea-85fc-dfcefc14341f.png" width="320"></kbd>    |  <kbd><img src="https://user-images.githubusercontent.com/1509205/81338659-9d6c1880-9072-11ea-9452-45ca7ec00d93.png" width="320"></kbd>
------------
1. Create a new post. 
2. Click More and then click Post Settings. 
3. Click Tags. 
4. See that there's focus on the `EditText`.

Before | After 
--------|-------
  <kbd><img src="https://user-images.githubusercontent.com/1509205/81338287-fbe4c700-9071-11ea-816e-647de309c65e.png" width="320"></kbd>|       <kbd><img src="https://user-images.githubusercontent.com/1509205/81338302-043d0200-9072-11ea-8a85-8360c1efe2fb.png" width="320"></kbd>

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 