### PR TITLE
Reader move tab layout to parent part 3

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -10,6 +10,7 @@ import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel;
 import org.wordpress.android.ui.posts.PostListMainViewModel;
 import org.wordpress.android.ui.posts.editor.StorePostViewModel;
 import org.wordpress.android.ui.reader.ReaderCommentListViewModel;
+import org.wordpress.android.ui.reader.viewmodels.NewsCardViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel;
 import org.wordpress.android.ui.reader.viewmodels.SubfilterPageViewModel;
@@ -293,6 +294,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ReaderViewModel.class)
     abstract ViewModel readerParentPostListViewModel(ReaderViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(NewsCardViewModel.class)
+    abstract ViewModel newsCardViewModel(NewsCardViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -35,6 +35,15 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
     private fun initViewModel(view: View) {
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReaderViewModel::class.java)
         startObserving(view)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // TODO come up with a proper fix
+        /**
+         * We need to start the viewModel in onResume as when the user logs-in for the first time the tags
+         * aren't stored in the DB yet.
+         */
         viewModel.start()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader
 
+import android.app.Activity
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
@@ -13,7 +14,9 @@ import com.google.android.material.tabs.TabLayoutMediator
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.models.ReaderTagList
+import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
+import org.wordpress.android.ui.reader.viewmodels.NewsCardViewModel
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState
 import javax.inject.Inject
@@ -21,6 +24,7 @@ import javax.inject.Inject
 class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: ReaderViewModel
+    private lateinit var newsCardViewModel: NewsCardViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,6 +38,8 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
 
     private fun initViewModel(view: View) {
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReaderViewModel::class.java)
+        newsCardViewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+                .get(NewsCardViewModel::class.java)
         startObserving(view)
     }
 
@@ -53,6 +59,15 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
                 initViewPager(uiState, view)
             }
         })
+
+        newsCardViewModel.openUrlEvent.observe(viewLifecycleOwner, Observer {
+            it?.getContentIfNotHandled()?.let { url ->
+                val activity: Activity? = activity
+                if (activity != null) {
+                    WPWebViewActivity.openURL(activity, url)
+                }
+            }
+        })
     }
 
     private fun initViewPager(uiState: ReaderUiState, view: View) {
@@ -64,6 +79,14 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
         TabLayoutMediator(tabLayout, viewPager) { tab, position ->
             tab.text = uiState.tabTitles[position]
         }.attach()
+
+        val pageChangeCallback = object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                newsCardViewModel.onTagChanged(uiState.readerTagList[position])
+            }
+        }
+        viewPager.registerOnPageChangeCallback(pageChangeCallback)
     }
 
     private class TabsAdapter(parent: Fragment, private val tags: ReaderTagList) : FragmentStateAdapter(parent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2070,10 +2070,10 @@ public class ReaderPostListFragment extends Fragment
             if (getActivity() instanceof ReaderSiteHeaderView.OnBlogInfoLoadedListener) {
                 mPostAdapter.setOnBlogInfoLoadedListener((ReaderSiteHeaderView.OnBlogInfoLoadedListener) getActivity());
             }
-            mNewsCardViewModel.getNewsDataSource().removeObserver(mNewsItemObserver);
+            mNewsCardViewModel.getNewsDataSource(mCurrentTag).removeObserver(mNewsItemObserver);
             if (getPostListType().isTagType()) {
                 mPostAdapter.setCurrentTag(getCurrentTag());
-                mNewsCardViewModel.getNewsDataSource().observe(getViewLifecycleOwner(), mNewsItemObserver);
+                mNewsCardViewModel.getNewsDataSource(mCurrentTag).observe(getViewLifecycleOwner(), mNewsItemObserver);
             } else if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
                 mPostAdapter.setCurrentBlogAndFeed(mCurrentBlogId, mCurrentFeedId);
             } else if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -50,7 +50,6 @@ import com.google.android.material.tabs.TabLayout.Tab;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -87,12 +86,10 @@ import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.FilteredRecyclerView;
 import org.wordpress.android.ui.PagePostCreationSourcesDetail;
 import org.wordpress.android.ui.RequestCodes;
-import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.main.BottomNavController;
 import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode;
 import org.wordpress.android.ui.main.WPMainActivity;
-import org.wordpress.android.ui.news.NewsViewHolder.NewsCardListener;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
 import org.wordpress.android.ui.reader.ReaderInterfaces.ReblogActionListener;
@@ -119,6 +116,7 @@ import org.wordpress.android.ui.reader.subfilter.ActionType.OpenSubsAtPage;
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Site;
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.SiteAll;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
+import org.wordpress.android.ui.reader.viewmodels.NewsCardViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderModeInfo;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
@@ -222,6 +220,7 @@ public class ReaderPostListFragment extends Fragment
 
     private ReaderPostListViewModel mViewModel;
     private WPMainActivityViewModel mWPMainActivityViewModel;
+    private NewsCardViewModel mNewsCardViewModel;
 
     private Observer<NewsItem> mNewsItemObserver = new Observer<NewsItem>() {
         @Override public void onChanged(@Nullable NewsItem newsItem) {
@@ -407,6 +406,8 @@ public class ReaderPostListFragment extends Fragment
         super.onActivityCreated(savedInstanceState);
         mViewModel = ViewModelProviders.of(this, mViewModelFactory)
                                        .get(ReaderPostListViewModel.class);
+        mNewsCardViewModel = ViewModelProviders.of(requireActivity(), mViewModelFactory)
+                                               .get(NewsCardViewModel.class);
 
         if (mIsTopLevel) {
             mWPMainActivityViewModel = ViewModelProviders.of((FragmentActivity) getActivity(), mViewModelFactory)
@@ -2051,24 +2052,6 @@ public class ReaderPostListFragment extends Fragment
                 }
             };
 
-    private final NewsCardListener mNewsCardListener = new NewsCardListener() {
-        @Override public void onItemShown(@NotNull NewsItem item) {
-            mViewModel.onNewsCardShown(item, getCurrentTag());
-        }
-
-        @Override public void onItemClicked(@NotNull NewsItem item) {
-            mViewModel.onNewsCardExtendedInfoRequested(item);
-            Activity activity = getActivity();
-            if (activity != null) {
-                WPWebViewActivity.openURL(activity, item.getActionUrl());
-            }
-        }
-
-        @Override public void onDismissClicked(NewsItem item) {
-            mViewModel.onNewsCardDismissed(item);
-        }
-    };
-
     private ReaderPostAdapter getPostAdapter() {
         if (mPostAdapter == null) {
             AppLog.d(T.READER, "reader post list > creating post adapter");
@@ -2086,14 +2069,14 @@ public class ReaderPostListFragment extends Fragment
             mPostAdapter.setOnDataLoadedListener(mDataLoadedListener);
             mPostAdapter.setOnDataRequestedListener(mDataRequestedListener);
             mPostAdapter.setOnPostBookmarkedListener(mOnPostBookmarkedListener);
-            mPostAdapter.setOnNewsCardListener(mNewsCardListener);
+            mPostAdapter.setOnNewsCardListener(mNewsCardViewModel.getNewsCardListener());
             if (getActivity() instanceof ReaderSiteHeaderView.OnBlogInfoLoadedListener) {
                 mPostAdapter.setOnBlogInfoLoadedListener((ReaderSiteHeaderView.OnBlogInfoLoadedListener) getActivity());
             }
-            mViewModel.getNewsDataSource().removeObserver(mNewsItemObserver);
+            mNewsCardViewModel.getNewsDataSource().removeObserver(mNewsItemObserver);
             if (getPostListType().isTagType()) {
                 mPostAdapter.setCurrentTag(getCurrentTag());
-                mViewModel.getNewsDataSource().observe((FragmentActivity) getActivity(), mNewsItemObserver);
+                mNewsCardViewModel.getNewsDataSource().observe(getViewLifecycleOwner(), mNewsItemObserver);
             } else if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
                 mPostAdapter.setCurrentBlogAndFeed(mCurrentBlogId, mCurrentFeedId);
             } else if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
@@ -2187,8 +2170,6 @@ public class ReaderPostListFragment extends Fragment
                 );
             }
         }
-
-        mViewModel.onTagChanged(mCurrentTag);
 
         ReaderTag validTag;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/NewsCardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/NewsCardViewModel.kt
@@ -1,0 +1,111 @@
+package org.wordpress.android.ui.reader.viewmodels
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModel
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTagList
+import org.wordpress.android.models.news.NewsItem
+import org.wordpress.android.ui.news.NewsManager
+import org.wordpress.android.ui.news.NewsTracker
+import org.wordpress.android.ui.news.NewsTracker.NewsCardOrigin.READER
+import org.wordpress.android.ui.news.NewsTrackerHelper
+import org.wordpress.android.ui.news.NewsViewHolder.NewsCardListener
+import org.wordpress.android.viewmodel.Event
+import javax.inject.Inject
+
+/**
+ * This ViewModel encapsulates logic related to NewsCard. It's a card shown in order to promote a new app feature.
+ *
+ * The card is shown on the first tab which is selected when the user opens the Reader.
+ * The logic when and for how long is the card shown is encapsulated in the NewsManager.
+ */
+class NewsCardViewModel @Inject constructor(
+    private val newsTracker: NewsTracker,
+    private val newsTrackerHelper: NewsTrackerHelper,
+    private val newsManager: NewsManager
+) : ViewModel() {
+    /**
+     * First tag for which the news card was shown.
+     */
+    private var initialTag: ReaderTag? = null
+    private var selectedTag: ReaderTag? = null
+
+    private val onTagChanged: Observer<NewsItem?> = Observer { _newsItemSourceMediator.value = it }
+
+    private val newsItemSource = newsManager.newsItemSource()
+    private val _newsItemSourceMediator = MediatorLiveData<NewsItem>()
+
+    private var started: Boolean = false
+    private val _uiState = MutableLiveData<ReaderUiState>()
+    val uiState: LiveData<ReaderUiState> = _uiState
+
+    private val _openUrlEvent = MutableLiveData<Event<String>>()
+    val openUrlEvent: LiveData<Event<String>> = _openUrlEvent
+
+    val newsCardListener: NewsCardListener = object : NewsCardListener {
+        override fun onItemShown(item: NewsItem) {
+            onNewsCardShown(item)
+        }
+
+        override fun onItemClicked(item: NewsItem) {
+            onNewsCardExtendedInfoRequested(item)
+            _openUrlEvent.value = Event(item.actionUrl)
+        }
+
+        override fun onDismissClicked(item: NewsItem) {
+            onNewsCardDismissed(item)
+        }
+    }
+
+    fun start() {
+        if (started) return
+        started = true
+        newsManager.pull()
+    }
+
+    fun onTagChanged(tag: ReaderTag?) {
+        selectedTag = tag
+        newsTrackerHelper.reset()
+        tag?.let { newTag ->
+            // show the card only when the initial tag is selected in the filter
+            if (initialTag == null || newTag == initialTag) {
+                _newsItemSourceMediator.addSource(newsItemSource, onTagChanged)
+            } else {
+                _newsItemSourceMediator.removeSource(newsItemSource)
+                _newsItemSourceMediator.value = null
+            }
+        }
+    }
+
+    fun getNewsDataSource(): LiveData<NewsItem> {
+        return _newsItemSourceMediator
+    }
+
+    private fun onNewsCardShown(item: NewsItem) {
+        initialTag = selectedTag
+        if (newsTrackerHelper.shouldTrackNewsCardShown(item.version)) {
+            newsTracker.trackNewsCardShown(READER, item.version)
+            newsTrackerHelper.itemTracked(item.version)
+        }
+        newsManager.cardShown(item)
+    }
+
+    private fun onNewsCardDismissed(item: NewsItem) {
+        newsTracker.trackNewsCardDismissed(READER, item.version)
+        newsManager.dismiss(item)
+    }
+
+    private fun onNewsCardExtendedInfoRequested(item: NewsItem) {
+        newsTracker.trackNewsCardExtendedInfoRequested(READER, item.version)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        newsManager.stop()
+    }
+
+    data class ReaderUiState(val tabTitles: List<String>, val readerTagList: ReaderTagList)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -15,13 +15,12 @@ class ReaderViewModel @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val loadReaderTabsUseCase: LoadReaderTabsUseCase
 ) : ScopedViewModel(mainDispatcher) {
-    private var started: Boolean = false
+    private var initialized: Boolean = false
     private val _uiState = MutableLiveData<ReaderUiState>()
     val uiState: LiveData<ReaderUiState> = _uiState
 
     fun start() {
-        if (started) return
-        started = true
+        if (initialized) return
         loadTabs()
     }
 
@@ -32,6 +31,9 @@ class ReaderViewModel @Inject constructor(
                     tagList.map { it.tagDisplayName }, // TODO should we use displayname or title?
                     tagList
             )
+            if (tagList.isNotEmpty()) {
+                initialized = true
+            }
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/NewsCardViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/NewsCardViewModelTest.kt
@@ -1,0 +1,173 @@
+package org.wordpress.android.ui.reader.viewmodels
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.news.NewsItem
+import org.wordpress.android.ui.news.NewsManager
+import org.wordpress.android.ui.news.NewsTracker
+import org.wordpress.android.ui.news.NewsTracker.NewsCardOrigin
+import org.wordpress.android.ui.news.NewsTrackerHelper
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+
+@InternalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class NewsCardViewModelTest {
+    @Rule
+    @JvmField
+    val rule = InstantTaskExecutorRule()
+
+    @Mock private lateinit var newsManager: NewsManager
+    @Mock private lateinit var observer: Observer<NewsItem>
+    @Mock private lateinit var item: NewsItem
+
+    /**
+     * First tag for which the card was shown.
+     */
+    @Mock private lateinit var initialTag: ReaderTag
+    @Mock private lateinit var otherTag: ReaderTag
+    @Mock private lateinit var savedTag: ReaderTag
+    @Mock private lateinit var newsTracker: NewsTracker
+    @Mock private lateinit var newsTrackerHelper: NewsTrackerHelper
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock private lateinit var accountStore: AccountStore
+    @Mock private lateinit var siteStore: SiteStore
+
+    private lateinit var viewModel: NewsCardViewModel
+    private val liveData = MutableLiveData<NewsItem>()
+
+    @Before
+    fun setUp() {
+        whenever(newsManager.newsItemSource()).thenReturn(liveData)
+
+        viewModel = NewsCardViewModel(
+                newsTracker,
+                newsTrackerHelper,
+                newsManager
+        )
+        val observable = viewModel.getNewsDataSource()
+        observable.observeForever(observer)
+    }
+
+    @Test
+    fun `when view model starts pull is invoked`() {
+        viewModel.start()
+        verify(newsManager).pull(false)
+    }
+
+    @Test
+    fun `view model propagates news items`() {
+        viewModel.start()
+        viewModel.onTagChanged(initialTag)
+        liveData.postValue(item)
+        liveData.postValue(null)
+        liveData.postValue(item)
+
+        val inOrder = inOrder(observer)
+        inOrder.verify(observer).onChanged(item)
+        inOrder.verify(observer).onChanged(null)
+        inOrder.verify(observer).onChanged(item)
+    }
+
+    @Test
+    fun `view model propagates dismiss to NewsManager`() {
+        viewModel.newsCardListener.onDismissClicked(item)
+        verify(newsManager).dismiss(item)
+    }
+
+    @Test
+    fun `when view model starts emits null on first onTagChanged`() {
+        viewModel.start()
+        // propagates the item since the card hasn't been shown yet
+        liveData.postValue(item)
+        viewModel.onTagChanged(initialTag)
+        // the card has been shown for the initialTag
+        viewModel.newsCardListener.onItemShown(item)
+        // propagates null since the card should be visible only for initialTag
+        viewModel.onTagChanged(otherTag)
+        val inOrder = inOrder(observer)
+        inOrder.verify(observer).onChanged(item)
+        inOrder.verify(observer).onChanged(null)
+    }
+
+    @Test
+    fun `news item is available only for first tag for which card was shown`() {
+        viewModel.start()
+        // propagate the item since the card hasn't been shown yet
+        liveData.postValue(item)
+        viewModel.onTagChanged(initialTag)
+        // the card has been shown for the initialTag
+        viewModel.newsCardListener.onItemShown(item)
+        viewModel.onTagChanged(otherTag)
+        // do not propagate the item since the card should be visible only for initialTag
+        liveData.postValue(item)
+        // do not propagate the item since the card should be visible only for initialTag
+        liveData.postValue(item)
+        // do not propagate the item since the card should be visible only for initialTag
+        liveData.postValue(item)
+        // do not propagate the item since the card should be visible only for initialTag
+        liveData.postValue(item)
+        // propagate the item since the initialTag is selected
+        viewModel.onTagChanged(initialTag)
+        val inOrder = inOrder(observer)
+        inOrder.verify(observer).onChanged(item)
+        inOrder.verify(observer).onChanged(null)
+        inOrder.verify(observer).onChanged(item)
+    }
+
+    @Test
+    fun `view model propagates dismiss to NewsTracker`() {
+        viewModel.newsCardListener.onDismissClicked(item)
+        verify(newsTracker).trackNewsCardDismissed(
+                argThat { this == NewsCardOrigin.READER },
+                any()
+        )
+    }
+
+    @Test
+    fun `view model propagates CardShown to NewsTracker`() {
+        whenever(newsTrackerHelper.shouldTrackNewsCardShown(any())).thenReturn(true)
+        viewModel.newsCardListener.onItemShown(item)
+        verify(newsTracker).trackNewsCardShown(
+                argThat { this == NewsCardOrigin.READER },
+                any()
+        )
+        verify(newsTrackerHelper).itemTracked(any())
+    }
+
+    @Test
+    fun `view model does not propagates CardShown to NewsTracker`() {
+        whenever(newsTrackerHelper.shouldTrackNewsCardShown(any())).thenReturn(false)
+        viewModel.newsCardListener.onItemShown(item)
+        verify(
+                newsTracker,
+                times(0)
+        ).trackNewsCardShown(argThat { this == NewsCardOrigin.READER }, any())
+        verify(newsTrackerHelper, times(0)).itemTracked(any())
+    }
+
+    @Test
+    fun `view model propagates ExtendedInfoRequested to NewsTracker`() {
+        viewModel.newsCardListener.onItemClicked(item)
+        verify(newsTracker).trackNewsCardExtendedInfoRequested(
+                argThat { this == NewsCardOrigin.READER },
+                any()
+        )
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType.BOOKMARKED
 import org.wordpress.android.models.news.NewsItem
-import org.wordpress.android.ui.news.NewsManager
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.ReaderSubsActivity
 import org.wordpress.android.ui.reader.reblog.NoSite

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/ReaderPostListViewModelTest.kt
@@ -4,8 +4,6 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.argThat
-import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -28,15 +26,12 @@ import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType.BOOKMARKED
 import org.wordpress.android.models.news.NewsItem
 import org.wordpress.android.ui.news.NewsManager
-import org.wordpress.android.ui.news.NewsTracker
-import org.wordpress.android.ui.news.NewsTracker.NewsCardOrigin.READER
-import org.wordpress.android.ui.news.NewsTrackerHelper
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.ReaderSubsActivity
 import org.wordpress.android.ui.reader.reblog.NoSite
 import org.wordpress.android.ui.reader.reblog.PostEditor
-import org.wordpress.android.ui.reader.reblog.Unknown
 import org.wordpress.android.ui.reader.reblog.SitePicker
+import org.wordpress.android.ui.reader.reblog.Unknown
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask
 import org.wordpress.android.ui.reader.subfilter.ActionType.OpenLoginPage
 import org.wordpress.android.ui.reader.subfilter.ActionType.OpenSubsAtPage
@@ -59,17 +54,13 @@ class ReaderPostListViewModelTest {
     @JvmField
     val rule = InstantTaskExecutorRule()
 
-    @Mock private lateinit var newsManager: NewsManager
     @Mock private lateinit var observer: Observer<NewsItem>
     @Mock private lateinit var item: NewsItem
     /**
      * First tag for which the card was shown.
      */
     @Mock private lateinit var initialTag: ReaderTag
-    @Mock private lateinit var otherTag: ReaderTag
     @Mock private lateinit var savedTag: ReaderTag
-    @Mock private lateinit var newsTracker: NewsTracker
-    @Mock private lateinit var newsTrackerHelper: NewsTrackerHelper
     @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock private lateinit var subfilterListItemMapper: SubfilterListItemMapper
     @Mock private lateinit var eventBusWrapper: EventBusWrapper
@@ -82,7 +73,6 @@ class ReaderPostListViewModelTest {
 
     @Before
     fun setUp() {
-        whenever(newsManager.newsItemSource()).thenReturn(liveData)
         whenever(savedTag.tagTitle).thenReturn("tag-title")
         val tag = Tag(
                 tag = savedTag,
@@ -94,9 +84,6 @@ class ReaderPostListViewModelTest {
         whenever(subfilterListItemMapper.fromJson(any(), any(), any())).thenReturn(tag)
 
         viewModel = ReaderPostListViewModel(
-                newsManager,
-                newsTracker,
-                newsTrackerHelper,
                 TEST_DISPATCHER,
                 TEST_DISPATCHER,
                 appPrefsWrapper,
@@ -106,101 +93,6 @@ class ReaderPostListViewModelTest {
                 readerTracker,
                 siteStore
         )
-        val observable = viewModel.getNewsDataSource()
-        observable.observeForever(observer)
-    }
-
-    @Test
-    fun `when view model starts pull is invoked`() {
-        viewModel.start(initialTag, false, false)
-        verify(newsManager).pull(false)
-    }
-
-    @Test
-    fun `view model propagates news items`() {
-        viewModel.start(initialTag, false, false)
-        liveData.postValue(item)
-        liveData.postValue(null)
-        liveData.postValue(item)
-
-        val inOrder = inOrder(observer)
-        inOrder.verify(observer).onChanged(item)
-        inOrder.verify(observer).onChanged(null)
-        inOrder.verify(observer).onChanged(item)
-    }
-
-    @Test
-    fun `view model propagates dismiss to NewsManager`() {
-        viewModel.onNewsCardDismissed(item)
-        verify(newsManager).dismiss(item)
-    }
-
-    @Test
-    fun `when view model starts emits null on first onTagChanged`() {
-        viewModel.start(otherTag, false, false)
-        // propagates the item since the card hasn't been shown yet
-        liveData.postValue(item)
-        viewModel.onTagChanged(initialTag)
-        // the card has been shown for the initialTag
-        viewModel.onNewsCardShown(item, initialTag)
-        // propagates null since the card should be visible only for initialTag
-        viewModel.onTagChanged(otherTag)
-        val inOrder = inOrder(observer)
-        inOrder.verify(observer).onChanged(item)
-        inOrder.verify(observer).onChanged(null)
-    }
-
-    @Test
-    fun `news item is available only for first tag for which card was shown`() {
-        viewModel.start(otherTag, false, false)
-        // propagate the item since the card hasn't been shown yet
-        liveData.postValue(item)
-        viewModel.onTagChanged(initialTag)
-        // the card has been shown for the initialTag
-        viewModel.onNewsCardShown(item, initialTag)
-        viewModel.onTagChanged(otherTag)
-        // do not propagate the item since the card should be visible only for initialTag
-        liveData.postValue(item)
-        // do not propagate the item since the card should be visible only for initialTag
-        liveData.postValue(item)
-        // do not propagate the item since the card should be visible only for initialTag
-        liveData.postValue(item)
-        // do not propagate the item since the card should be visible only for initialTag
-        liveData.postValue(item)
-        // propagate the item since the initialTag is selected
-        viewModel.onTagChanged(initialTag)
-        val inOrder = inOrder(observer)
-        inOrder.verify(observer).onChanged(item)
-        inOrder.verify(observer).onChanged(null)
-        inOrder.verify(observer).onChanged(item)
-    }
-
-    @Test
-    fun `view model propagates dismiss to NewsTracker`() {
-        viewModel.onNewsCardDismissed(item)
-        verify(newsTracker).trackNewsCardDismissed(argThat { this == READER }, any())
-    }
-
-    @Test
-    fun `view model propagates CardShown to NewsTracker`() {
-        whenever(newsTrackerHelper.shouldTrackNewsCardShown(any())).thenReturn(true)
-        viewModel.onNewsCardShown(item, initialTag)
-        verify(newsTracker).trackNewsCardShown(argThat { this == READER }, any())
-        verify(newsTrackerHelper).itemTracked(any())
-    }
-
-    @Test
-    fun `view model does not propagates CardShown to NewsTracker`() {
-        whenever(newsTrackerHelper.shouldTrackNewsCardShown(any())).thenReturn(false)
-        viewModel.onNewsCardShown(item, initialTag)
-        verify(newsTracker, times(0)).trackNewsCardShown(argThat { this == READER }, any())
-        verify(newsTrackerHelper, times(0)).itemTracked(any())
-    }
-
-    @Test
-    fun `view model propagates ExtendedInfoRequested to NewsTracker`() {
-        viewModel.onNewsCardExtendedInfoRequested(item)
-        verify(newsTracker).trackNewsCardExtendedInfoRequested(argThat { this == READER }, any())
     }
 
     @Test


### PR DESCRIPTION
Partially fixes #11849

This is a third PR in a series of PRs which is trying to introduce a regular TabLayout+ViewPager2 in the main Reader view. The current implementation uses FilteredRecyclerView component (which is not a RecyclerView :P) that has some downsides (eg. swipe gesture doesn't work).

This PR moves NewsCard from the ReaderPostListViewModel to NewsCardViewModel.

To test:
Prerequisities
- Open LocalNewsItem.kt and increment the `version` field
- Build the app locally

1. Open the app on the Reader tab
2. Make sure the NewsCard is shown only on the firstly selected tab
3. Restart the App and make sure the card is still being shown
4. Click on the "Read More" button and verify it opens a webbrowser
5. Dismiss the card and make sure it disappears (it doesn't re-appear after rotation or restart)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
