### PR TITLE
Merge 14.8 release notes to master

### DIFF
--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -11,6 +11,14 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_148"
+msgid ""
+"14.8:\n"
+"<b>Block editor additions:</b> Buttons block displays multiple buttons in a single row; Image blocks prefill captions when available; Cover blocks allow uploading; inserted images can be cropped, zoomed, or rotated; Heading block includes alignment options.\n"
+"<b>Block editor improvements:</b> Relocated floating toolbar, fixed bug impact white space in Text blocks, fixed misaligned toolbar icons in RTL mode.\n"
+"<b>General updates:</b> Added reblog functionality.\n"
+msgstr ""
+
 msgctxt "release_note_147"
 msgid ""
 "14.7:\n"
@@ -19,16 +27,6 @@ msgid ""
 "Bug fixes: A bug causing URL settings to appear when changing device orientation while previewing Starter Page Templates.\n"
 "\n"
 "UI improvements: Added your Gravatar to the Me menu in My Site.\n"
-msgstr ""
-
-msgctxt "release_note_146"
-msgid ""
-"14.6:\n"
-"Block editor enhancements: Added Cover block. Enabled crop, zoom, and rotate for images in posts. Tweaked “Take a Video” icon to differentiate from “Take a Photo.” Removed dimming effect on unselected blocks. Added toolbar for alignment options in Paragraph, Image, and MediaText blocks.\n"
-"\n"
-"Fixes: Issue where “wordpress://” links in a browser didn’t open the app, issue where opening a page opened an empty editor.\n"
-"\n"
-"General improvements: Dark Theme support.\n"
 msgstr ""
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,5 +1,3 @@
-Block editor: Added Column block and Starter Page template for blogs. Adjusted Starter Page Template buttons to avoid overlap with page content. “Choose media from device” opens a built-in WordPress media picker instead of your device’s default picker.
-
-Bug fixes: A bug causing URL settings to appear when changing device orientation while previewing Starter Page Templates.
-
-UI improvements: Added your Gravatar to the Me menu in My Site.
+<b>Block editor additions:</b> Buttons block displays multiple buttons in a single row; Image blocks prefill captions when available; Cover blocks allow uploading; inserted images can be cropped, zoomed, or rotated; Heading block includes alignment options.
+<b>Block editor improvements:</b> Relocated floating toolbar, fixed bug impact white space in Text blocks, fixed misaligned toolbar icons in RTL mode.
+<b>General updates:</b> Added reblog functionality.

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.11-beta-1'
+    fluxCVersion = '1.6.11'
 
     appCompatVersion = '1.0.2'
     constraintLayoutVersion = '1.1.3'


### PR DESCRIPTION
@loremattei I added the `bold` tags `<b` and `</b` to the release notes. It looks like that's available to us, which I thought wasn't: https://stackoverflow.com/a/18746972. Let me know if you prefer not to have them or if maybe they don't work.