### PR TITLE
Update FluxC version to 1.6.12-beta-3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.12-beta-2'
+    fluxCVersion = '1.6.12-beta-3'
 
     appCompatVersion = '1.0.2'
     constraintLayoutVersion = '1.1.3'


### PR DESCRIPTION
This PR updates FluxC version to 1.6.12-beta-3 including the revert https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1576

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
