### PR TITLE
Fix crash on opening external url

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -980,6 +980,7 @@ public class ActivityLauncher {
     public static void openUrlExternal(Context context, @NonNull String url) {
         Uri uri = Uri.parse(url);
         Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
         try {
             // disable deeplinking activity so to not catch WP URLs


### PR DESCRIPTION
Fixes #11820

### To test

- Create a new post in the mobile app on a device with Android Lollipop OS.
- Add a link to the post.
- Preview the post.
- Click the link.
- Link should open properly without any crash.

| Before | After |
|-------|--------|
| ![link_not_ok](https://user-images.githubusercontent.com/1405144/81412191-1f3a6f80-9161-11ea-9367-4dda5b7592bb.gif) | ![link_ok_final](https://user-images.githubusercontent.com/1405144/81412266-3d07d480-9161-11ea-8d1c-193048e0b2c5.gif) |

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
