### PR TITLE
Issue/example feature announcement

### DIFF
--- a/WordPress/FEATURE_ANNOUNCEMENTS.json-example
+++ b/WordPress/FEATURE_ANNOUNCEMENTS.json-example
@@ -1,4 +1,5 @@
-// remove comments from actual announcements
+// FEATURE_ANNOUNCEMENT.json file should be located in WordPress/src/main/assets
+// comments in this file are ignored by Gson, so you can either remove or leave them
 
 {
   "announcements": [

--- a/WordPress/FEATURE_ANNOUNCEMENTS.json-example
+++ b/WordPress/FEATURE_ANNOUNCEMENTS.json-example
@@ -1,0 +1,28 @@
+// remove comments from actual announcements
+
+{
+  "announcements": [
+    {
+      "appVersionName": "14.7",  // app version name that announcement targets. Used for display purposes only.
+      "announceVersion": 1, // unique version of announcement. Used to track if the specific announcement was shown or not.
+      "detailsUrl": "http://wordpress.org",  // URL that "Find out more" button will open. If empty, "Find out more" button will not be shown.
+      "features": [ // Features will appear in order they are in this list. Try to avoid using long subtitles.
+        {
+          "title": "Super Publishing",
+          "subtitle": "Publish amazing articles using the power of your mind! Concentrate on what you want to post, and we will do the rest!",
+          "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-free.png"
+        },
+        {
+          "title": "Great cats and superb dogs are right behind you!",
+          "subtitle": "That's right! They are right in the app! They require pets right now. Are you going to look for them or what?",
+          "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-personal.png"
+        },
+        {
+          "title": "We like long feature announcements that why this one is going to be extra long and span multiple lines",
+          "subtitle": "Here we run out of budget.",
+          "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"
+        }
+      ]
+    }
+  ]
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
@@ -72,6 +72,7 @@ class FeatureAnnouncementDialogFragment : DialogFragment() {
             it?.let { uiModel ->
                 progressIndicator.visibility = if (uiModel.isProgressVisible) View.VISIBLE else View.GONE
                 versionLabel.text = getString(R.string.version_with_name_param, uiModel.appVersion)
+                featureAdapter.toggleFooterVisibility(uiModel.isFindOutMoreVisible)
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementListAdapter.kt
@@ -23,6 +23,7 @@ class FeatureAnnouncementListAdapter(
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private var viewModel: FeatureAnnouncementViewModel
     private val list = mutableListOf<FeatureAnnouncementItem>()
+    private var isFindOutMoreVisible = true
 
     init {
         (activity.applicationContext as WordPress).component().inject(this)
@@ -36,7 +37,7 @@ class FeatureAnnouncementListAdapter(
     }
 
     override fun getItemViewType(position: Int): Int {
-        if (position == itemCount - 1) {
+        if (isFindOutMoreVisible && position == itemCount - 1) {
             return VIEW_TYPE_FOOTER
         }
         return VIEW_TYPE_FEATURE
@@ -50,9 +51,16 @@ class FeatureAnnouncementListAdapter(
         }
     }
 
+    fun toggleFooterVisibility(isVisible: Boolean) {
+        isFindOutMoreVisible = isVisible
+        notifyDataSetChanged()
+    }
+
     override fun getItemCount(): Int {
-        if (list.isNotEmpty()) {
+        if (list.isNotEmpty() && isFindOutMoreVisible) {
             return list.size + 1
+        } else if (list.isNotEmpty() && !isFindOutMoreVisible) {
+            return list.size
         }
 
         return 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.whatsnew
 
+import android.text.TextUtils
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -35,7 +36,8 @@ class FeatureAnnouncementViewModel @Inject constructor(
     init {
         _uiModel.addSource(_currentFeatureAnnouncement) { featureAnnouncement ->
             _uiModel.value = _uiModel.value?.copy(
-                    appVersion = featureAnnouncement.appVersionName, isProgressVisible = false
+                    appVersion = featureAnnouncement.appVersionName, isProgressVisible = false,
+                    isFindOutMoreVisible = !TextUtils.isEmpty(featureAnnouncement.detailsUrl)
             )
         }
 
@@ -70,6 +72,7 @@ class FeatureAnnouncementViewModel @Inject constructor(
 
     data class FeatureAnnouncementUiModel(
         val appVersion: String = "",
-        val isProgressVisible: Boolean = false
+        val isProgressVisible: Boolean = false,
+        val isFindOutMoreVisible: Boolean = true
     )
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
@@ -61,18 +61,18 @@ class FeatureAnnouncementViewModelTest : BaseUnitTest() {
         viewModel.onDialogClosed.observeForever(onDialogClosedObserver)
         viewModel.onAnnouncementDetailsRequested.observeForever(onAnnouncementDetailsRequestedObserver)
         viewModel.featureItems.observeForever(featuresObserver)
-
-        viewModel.start()
     }
 
     @Test
-    fun `progress is visible after start`() {
+    fun `progress and find out more is visible after start`() {
+        viewModel.start()
         assertThat(uiModelResults.isNotEmpty()).isEqualTo(true)
         assertThat(uiModelResults[0].isProgressVisible).isEqualTo(true)
     }
 
     @Test
     fun `announcement details are loaded after start`() {
+        viewModel.start()
         assertThat(uiModelResults.isNotEmpty()).isEqualTo(true)
         assertThat(uiModelResults[1].isProgressVisible).isEqualTo(false)
         assertThat(uiModelResults[1].appVersion).isEqualTo("14.7")
@@ -81,13 +81,31 @@ class FeatureAnnouncementViewModelTest : BaseUnitTest() {
 
     @Test
     fun `pressing close button closes the dialog`() {
+        viewModel.start()
         viewModel.onCloseDialogButtonPressed()
         verify(onDialogClosedObserver).onChanged(anyOrNull())
     }
 
     @Test
     fun `pressing Find Out More triggers request for announcement details with specific URL`() {
+        viewModel.start()
         viewModel.onFindMoreButtonPressed()
         verify(onAnnouncementDetailsRequestedObserver).onChanged("https://wordpress.org/")
+    }
+
+    @Test
+    fun `find Out More is  visible when detailsUrl is present`() {
+        viewModel.start()
+        assertThat(uiModelResults[1].isFindOutMoreVisible).isEqualTo(true)
+    }
+
+    @Test
+    fun `find Out More is not visible when detailsUrl is missing`() {
+        whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(
+                featureAnnouncement.copy(detailsUrl = "")
+        )
+
+        viewModel.start()
+        assertThat(uiModelResults[1].isFindOutMoreVisible).isEqualTo(false)
     }
 }


### PR DESCRIPTION
This PR adds an example feature announcement file.

In addition, I also made a detailed URL option, and when it's missing the Find Out More button will not be shown.


To test:
- Remove `detailsUrl` from `FEATURE_ANNOUNCEMENTS.json` or set it to an empty string.
- Open feature announcements from App Settings. Confirm that the Find Out More button is not visible.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
