### PR TITLE
Remove init method from bottom nav

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -287,8 +287,7 @@ class WPMainNavigationView @JvmOverloads constructor(
             }
             fragmentManager.beginTransaction()
                     .add(R.id.fragment_container, fragment, getTagForPageType(pageType))
-                    .hide(fragment)
-                    .commit()
+                    .commitNow()
             return fragment
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -292,17 +292,15 @@ class WPMainNavigationView @JvmOverloads constructor(
         }
 
         internal fun getFragment(position: Int): Fragment? {
-            val pageType = pages().getOrElse(position) {
-                return null
+            return pages().getOrNull(position)?.let { pageType ->
+                fragmentManager.findFragmentByTag(getTagForPageType(pageType)) ?: createFragment(pageType)
             }
-            return fragmentManager.findFragmentByTag(getTagForPageType(pageType)) ?: createFragment(pageType)
         }
 
         internal fun getFragmentIfExists(position: Int): Fragment? {
-            val pageType = pages().getOrElse(position) {
-                return null
+            return pages().getOrNull(position)?.let { pageType ->
+                fragmentManager.findFragmentByTag(getTagForPageType(pageType))
             }
-            return fragmentManager.findFragmentByTag(getTagForPageType(pageType))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -94,7 +94,6 @@ class WPMainNavigationView @JvmOverloads constructor(
             itemView.addView(customView)
         }
 
-        navAdapter.init()
         currentPosition = AppPrefs.getMainPageIndex(numPages() - 1)
     }
 
@@ -291,14 +290,6 @@ class WPMainNavigationView @JvmOverloads constructor(
                     .hide(fragment)
                     .commit()
             return fragment
-        }
-
-        internal fun init() {
-            for (pageType in pages()) {
-                if (fragmentManager.findFragmentByTag(getTagForPageType(pageType)) == null) {
-                    createFragment(pageType)
-                }
-            }
         }
 
         internal fun getFragment(position: Int): Fragment? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -237,7 +237,7 @@ class WPMainNavigationView @JvmOverloads constructor(
         return itemView?.findViewById(R.id.nav_icon)
     }
 
-    fun getFragment(pageType: PageType) = navAdapter.getFragment(getPosition(pageType))
+    fun getFragment(pageType: PageType) = navAdapter.getFragmentIfExists(getPosition(pageType))
 
     private fun getItemView(position: Int): BottomNavigationItemView? {
         if (isValidPosition(position)) {
@@ -296,6 +296,13 @@ class WPMainNavigationView @JvmOverloads constructor(
                 return null
             }
             return fragmentManager.findFragmentByTag(getTagForPageType(pageType)) ?: createFragment(pageType)
+        }
+
+        internal fun getFragmentIfExists(position: Int): Fragment? {
+            val pageType = pages().getOrElse(position) {
+                return null
+            }
+            return fragmentManager.findFragmentByTag(getTagForPageType(pageType))
         }
     }
 


### PR DESCRIPTION
This PR removes the `init` method that was introduced to preload all the fragments on app start. This is actually not necessary and might introduce slight slowdown on the app start. 

To test:
- Open the app
- Click through all the bottom nav items
- Rotate the device
- Check that the fragments are always there

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
