### PR TITLE
WP Stories integration - Activity launch (take 2)

### DIFF
--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -6,6 +6,7 @@
     <!-- WARNING -->
     <issue id="RtlSymmetry" severity="warning" />
     <issue id="UseSparseArrays" severity="warning" />
+    <issue id="UseRequireInsteadOfGet" severity="warning" />
 
     <issue id="NewApi">
         <warning path="src/main/res/values/reader_styles.xml" />

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -214,6 +214,15 @@
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>
         </activity>
+
+        <!-- Story composer activity -->
+        <activity
+            android:name=".ui.stories.StoryComposerActivity"
+            android:label="@string/app_name"
+            android:screenOrientation="portrait"
+            android:theme="@style/AppTheme.Immersive">
+        </activity>
+
         <!-- Workaround for old launcher icon pointing to .ui.posts.PostsActivity -->
         <activity-alias
             android:name=".ui.posts.PostsActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -13,6 +13,8 @@ import androidx.annotation.Nullable;
 import androidx.core.app.TaskStackBuilder;
 import androidx.fragment.app.Fragment;
 
+import com.wordpress.stories.compose.ComposeLoopFrameActivity;
+
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -638,6 +640,21 @@ public class ActivityLauncher {
         intent.putExtra(EditPostActivity.EXTRA_IS_PROMO, isPromo);
         intent.putExtra(EditPostActivity.EXTRA_CREATION_SOURCE_DETAIL, source);
         activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
+    }
+
+    public static void addNewStoryForResult(
+            Activity activity,
+            SiteModel site,
+            PagePostCreationSourcesDetail source
+    ) {
+        if (site == null) {
+            return;
+        }
+
+        Intent intent = new Intent(activity, ComposeLoopFrameActivity.class);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(EditPostActivity.EXTRA_CREATION_SOURCE_DETAIL, source);
+        activity.startActivityForResult(intent, RequestCodes.CREATE_STORY);
     }
 
     public static void editPostOrPageForResult(Activity activity, SiteModel site, PostModel post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -13,8 +13,6 @@ import androidx.annotation.Nullable;
 import androidx.core.app.TaskStackBuilder;
 import androidx.fragment.app.Fragment;
 
-import com.wordpress.stories.compose.ComposeLoopFrameActivity;
-
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -83,6 +83,7 @@ import org.wordpress.android.ui.stats.refresh.lists.detail.StatsDetailActivity;
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate;
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementActivity;
 import org.wordpress.android.ui.stockmedia.StockMediaPickerActivity;
+import org.wordpress.android.ui.stories.StoryComposerActivity;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -651,7 +652,7 @@ public class ActivityLauncher {
             return;
         }
 
-        Intent intent = new Intent(activity, ComposeLoopFrameActivity.class);
+        Intent intent = new Intent(activity, StoryComposerActivity.class);
         intent.putExtra(WordPress.SITE, site);
         intent.putExtra(EditPostActivity.EXTRA_CREATION_SOURCE_DETAIL, source);
         activity.startActivityForResult(intent, RequestCodes.CREATE_STORY);

--- a/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
@@ -49,7 +49,7 @@ class CommentFullScreenDialogFragment : Fragment(), CollapseFullScreenDialogCont
             }
         })
 
-        viewModel.onKeyboardOpened.observe(this, Observer {
+        viewModel.onKeyboardOpened.observe(viewLifecycleOwner, Observer {
             it?.applyIfNotHandled {
                 GlobalScope.launch {
                     val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -44,7 +44,7 @@ class JetpackRemoteInstallFragment : Fragment() {
             val source = intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
             val retrievedState = savedInstanceState?.getSerializable(VIEW_STATE) as? JetpackRemoteInstallViewState.Type
             viewModel.start(site, retrievedState)
-            viewModel.liveViewState.observe(this, Observer { viewState ->
+            viewModel.liveViewState.observe(viewLifecycleOwner, Observer { viewState ->
                 if (viewState != null) {
                     if (viewState is JetpackRemoteInstallViewState.Error) {
                         AppLog.e(AppLog.T.JETPACK_REMOTE_INSTALL, "An error occurred while installing Jetpack")
@@ -68,7 +68,7 @@ class JetpackRemoteInstallFragment : Fragment() {
                     jetpack_install_progress.visibility = if (viewState.progressBarVisible) View.VISIBLE else View.GONE
                 }
             })
-            viewModel.liveActionOnResult.observe(this, Observer { result ->
+            viewModel.liveActionOnResult.observe(viewLifecycleOwner, Observer { result ->
                 if (result != null) {
                     when (result.action) {
                         MANUAL_INSTALL -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/PagePostCreationSourcesDetail.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/PagePostCreationSourcesDetail.kt
@@ -13,6 +13,8 @@ enum class PagePostCreationSourcesDetail(val label: String) {
     POST_FROM_MY_SITE("post-from-my-site"),
     // page created from bottom sheet in my site screen
     PAGE_FROM_MY_SITE("page-from-my-site"),
+    // story created from bottom sheet in my site screen
+    STORY_FROM_MY_SITE("story-from-my-site"),
     // post created from stats empty view when no stats/post available yet
     POST_FROM_STATS("post-from-stats"),
     // post created from notifications unread page when empty

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -55,4 +55,7 @@ public class RequestCodes {
 
     // ImageEditor
     public static final int IMAGE_EDITOR_EDIT_IMAGE = 6000;
+
+    // Story creator
+    public static final int CREATE_STORY = 7000;
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -67,7 +67,7 @@ class ActivityLogDetailFragment : Fragment() {
                 else -> throw Throwable("Couldn't initialize Activity Log view model")
             }
 
-            viewModel.activityLogItem.observe(this, Observer { activityLogModel ->
+            viewModel.activityLogItem.observe(viewLifecycleOwner, Observer { activityLogModel ->
                 setActorIcon(activityLogModel?.actorIconUrl, activityLogModel?.showJetpackIcon)
                 uiHelpers.setTextOrHide(activityActorName, activityLogModel?.actorName)
                 uiHelpers.setTextOrHide(activityActorRole, activityLogModel?.actorRole)
@@ -97,15 +97,15 @@ class ActivityLogDetailFragment : Fragment() {
                 }
             })
 
-            viewModel.rewindAvailable.observe(this, Observer { available ->
+            viewModel.rewindAvailable.observe(viewLifecycleOwner, Observer { available ->
                 activityRewindButton.visibility = if (available == true) View.VISIBLE else View.GONE
             })
 
-            viewModel.showRewindDialog.observe(this, Observer<ActivityLogDetailModel> { detailModel ->
+            viewModel.showRewindDialog.observe(viewLifecycleOwner, Observer<ActivityLogDetailModel> { detailModel ->
                 detailModel?.let { onRewindButtonClicked(it) }
             })
 
-            viewModel.handleFormattableRangeClick.observe(this, Observer<FormattableRange> { range ->
+            viewModel.handleFormattableRangeClick.observe(viewLifecycleOwner, Observer<FormattableRange> { range ->
                 if (range != null) {
                     formattableContentClickHandler.onClick(activity, range)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -86,27 +86,27 @@ class ActivityLogListFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.events.observe(this, Observer {
+        viewModel.events.observe(viewLifecycleOwner, Observer {
             reloadEvents(it ?: emptyList())
         })
 
-        viewModel.eventListStatus.observe(this, Observer { listStatus ->
+        viewModel.eventListStatus.observe(viewLifecycleOwner, Observer { listStatus ->
             refreshProgressBars(listStatus)
         })
 
-        viewModel.showItemDetail.observe(this, Observer {
+        viewModel.showItemDetail.observe(viewLifecycleOwner, Observer {
             if (it is ActivityLogListItem.Event) {
                 ActivityLauncher.viewActivityLogDetailForResult(activity, viewModel.site, it.activityId)
             }
         })
 
-        viewModel.showRewindDialog.observe(this, Observer {
+        viewModel.showRewindDialog.observe(viewLifecycleOwner, Observer {
             if (it is ActivityLogListItem.Event) {
                 displayRewindDialog(it)
             }
         })
 
-        viewModel.showSnackbarMessage.observe(this, Observer { message ->
+        viewModel.showSnackbarMessage.observe(viewLifecycleOwner, Observer { message ->
             val parent: View? = activity?.findViewById(android.R.id.content)
             if (message != null && parent != null) {
                 WPSnackbar.make(parent, message, Snackbar.LENGTH_LONG).show()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -168,7 +168,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.uiState.observe(this,
+        viewModel.uiState.observe(viewLifecycleOwner,
                 Observer { uiState ->
                     uiState?.let {
                         toggleFormProgressIndictor(uiState.isFormProgressIndicatorVisible)
@@ -196,7 +196,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
                 })
 
         viewModel.domainContactForm.observe(
-                this,
+                viewLifecycleOwner,
                 Observer<DomainContactFormModel> { domainContactFormModel ->
                     val currentModel = getDomainContactFormModel()
                     if (currentModel != domainContactFormModel) {
@@ -204,21 +204,21 @@ class DomainRegistrationDetailsFragment : Fragment() {
                     }
                 })
 
-        viewModel.showCountryPickerDialog.observe(this,
+        viewModel.showCountryPickerDialog.observe(viewLifecycleOwner,
                 Observer {
                     if (it != null && it.isNotEmpty()) {
                         showCountryPicker(it)
                     }
                 })
 
-        viewModel.showStatePickerDialog.observe(this,
+        viewModel.showStatePickerDialog.observe(viewLifecycleOwner,
                 Observer {
                     if (it != null && it.isNotEmpty()) {
                         showStatePicker(it)
                     }
                 })
 
-        viewModel.formError.observe(this,
+        viewModel.formError.observe(viewLifecycleOwner,
                 Observer { error ->
                     var affectedInputFields: Array<TextInputEditText>? = null
 
@@ -249,17 +249,17 @@ class DomainRegistrationDetailsFragment : Fragment() {
                     affectedInputFields?.firstOrNull { it.requestFocus() }
                 })
 
-        viewModel.showErrorMessage.observe(this,
+        viewModel.showErrorMessage.observe(viewLifecycleOwner,
                 Observer { errorMessage ->
                     ToastUtils.showToast(context, errorMessage)
                 })
 
-        viewModel.handleCompletedDomainRegistration.observe(this,
+        viewModel.handleCompletedDomainRegistration.observe(viewLifecycleOwner,
                 Observer { domainRegisteredEvent ->
                     mainViewModel.completeDomainRegistration(domainRegisteredEvent)
                 })
 
-        viewModel.showTos.observe(this,
+        viewModel.showTos.observe(viewLifecycleOwner,
                 Observer {
                     ActivityLauncher.openUrlExternal(
                             context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -93,12 +93,12 @@ class DomainSuggestionsFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.isIntroVisible.observe(this, Observer {
+        viewModel.isIntroVisible.observe(viewLifecycleOwner, Observer {
             it?.let { isIntroVisible ->
                 introduction_container.visibility = if (isIntroVisible) View.VISIBLE else View.GONE
             }
         })
-        viewModel.suggestionsLiveData.observe(this, Observer { listState ->
+        viewModel.suggestionsLiveData.observe(viewLifecycleOwner, Observer { listState ->
             if (listState != null) {
                 val isLoading = listState is ListState.Loading<*>
 
@@ -120,7 +120,7 @@ class DomainSuggestionsFragment : Fragment() {
                 }
             }
         })
-        viewModel.choseDomainButtonEnabledState.observe(this, Observer {
+        viewModel.choseDomainButtonEnabledState.observe(viewLifecycleOwner, Observer {
             chose_domain_button.isEnabled = it ?: false
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
@@ -9,7 +9,8 @@ sealed class MainActionListItem {
     enum class ActionType {
         NO_ACTION,
         CREATE_NEW_PAGE,
-        CREATE_NEW_POST
+        CREATE_NEW_POST,
+        CREATE_NEW_STORY
     }
 
     data class CreateAction(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -415,6 +415,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 case CREATE_NEW_PAGE:
                     handleNewPageAction(PagePostCreationSourcesDetail.PAGE_FROM_MY_SITE);
                     break;
+                case CREATE_NEW_STORY:
+                    handleNewStoryAction(PagePostCreationSourcesDetail.STORY_FROM_MY_SITE);
+                    break;
             }
         });
 
@@ -809,6 +812,20 @@ public class WPMainActivity extends LocaleAwareActivity implements
         }
 
         ActivityLauncher.addNewPostForResult(this, getSelectedSite(), false, source);
+    }
+
+    private void handleNewStoryAction(PagePostCreationSourcesDetail source) {
+        if (!mSiteStore.hasSite()) {
+            // No site yet - Move to My Sites fragment that shows the create new site screen
+            mBottomNav.setCurrentSelectedPage(PageType.MY_SITE);
+            return;
+        }
+
+        SiteModel site = getSelectedSite();
+        if (site != null) {
+            // TODO: evaluate to include the QuickStart logic like in the handleNewPostAction
+            ActivityLauncher.addNewStoryForResult(this, site, source);
+        }
     }
 
     private void trackLastVisiblePage(PageType pageType, boolean trackAnalytics) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -91,11 +91,11 @@ class PageListFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.pages.observe(this, Observer { data ->
+        viewModel.pages.observe(viewLifecycleOwner, Observer { data ->
             data?.let { setPages(data.first, data.second, data.third) }
         })
 
-        viewModel.scrollToPosition.observe(this, Observer { position ->
+        viewModel.scrollToPosition.observe(viewLifecycleOwner, Observer { position ->
             position?.let {
                 val smoothScroller = object : LinearSmoothScroller(context) {
                     override fun getVerticalSnapPreference(): Int {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
@@ -194,15 +194,15 @@ class PageParentFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.pages.observe(this, Observer { pages ->
+        viewModel.pages.observe(viewLifecycleOwner, Observer { pages ->
             pages?.let { setPages(pages) }
         })
 
-        viewModel.isSaveButtonVisible.observe(this, Observer { isVisible ->
+        viewModel.isSaveButtonVisible.observe(viewLifecycleOwner, Observer { isVisible ->
             isVisible?.let { saveButton?.isVisible = isVisible }
         })
 
-        viewModel.saveParent.observe(this, Observer {
+        viewModel.saveParent.observe(viewLifecycleOwner, Observer {
             returnParentChoiceAndExit()
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
@@ -85,7 +85,7 @@ class PageParentSearchFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.searchResult.observe(this, Observer { data ->
+        viewModel.searchResult.observe(viewLifecycleOwner, Observer { data ->
             data?.let { setSearchResult(data) }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -292,17 +292,17 @@ class PagesFragment : Fragment() {
     }
 
     private fun setupObservers(activity: FragmentActivity) {
-        viewModel.listState.observe(this, Observer {
+        viewModel.listState.observe(viewLifecycleOwner, Observer {
             refreshProgressBars(it)
         })
 
-        viewModel.createNewPage.observe(this, Observer {
+        viewModel.createNewPage.observe(viewLifecycleOwner, Observer {
             QuickStartUtils.completeTaskAndRemindNextOne(quickStartStore, QuickStartTask.CREATE_NEW_PAGE, dispatcher,
                     viewModel.site, quickStartEvent, context)
             ActivityLauncher.addNewPageForResult(this, viewModel.site, PAGE_FROM_PAGES_LIST)
         })
 
-        viewModel.showSnackbarMessage.observe(this, Observer { holder ->
+        viewModel.showSnackbarMessage.observe(viewLifecycleOwner, Observer { holder ->
             val parent = activity.findViewById<View>(R.id.coordinatorLayout)
             if (holder != null && parent != null) {
                 if (holder.buttonTitleRes == null) {
@@ -315,25 +315,25 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.editPage.observe(this, Observer { (site, page, loadAutoRevision) ->
+        viewModel.editPage.observe(viewLifecycleOwner, Observer { (site, page, loadAutoRevision) ->
             page?.let {
                 ActivityLauncher.editPageForResult(this, site, page.id, loadAutoRevision)
             }
         })
 
-        viewModel.previewPage.observe(this, Observer { post ->
+        viewModel.previewPage.observe(viewLifecycleOwner, Observer { post ->
             post?.let {
                 previewPage(activity, post)
             }
         })
 
-        viewModel.browsePreview.observe(this, Observer { preview ->
+        viewModel.browsePreview.observe(viewLifecycleOwner, Observer { preview ->
             preview?.let {
                 ActivityLauncher.previewPostOrPageForResult(activity, viewModel.site, preview.post, preview.previewType)
             }
         })
 
-        viewModel.previewState.observe(this, Observer {
+        viewModel.previewState.observe(viewLifecycleOwner, Observer {
             progressDialog = progressDialogHelper.updateProgressDialogState(
                     activity,
                     progressDialog,
@@ -342,11 +342,11 @@ class PagesFragment : Fragment() {
             )
         })
 
-        viewModel.setPageParent.observe(this, Observer { page ->
+        viewModel.setPageParent.observe(viewLifecycleOwner, Observer { page ->
             page?.let { ActivityLauncher.viewPageParentForResult(this, page) }
         })
 
-        viewModel.isNewPageButtonVisible.observe(this, Observer { isVisible ->
+        viewModel.isNewPageButtonVisible.observe(viewLifecycleOwner, Observer { isVisible ->
             isVisible?.let {
                 if (isVisible) {
                     newPageButton.show()
@@ -356,7 +356,7 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.scrollToPage.observe(this, Observer { requestedPage ->
+        viewModel.scrollToPage.observe(viewLifecycleOwner, Observer { requestedPage ->
             requestedPage?.let { page ->
                 val pagerIndex = PagesPagerAdapter.pageTypes.indexOf(PageListType.fromPageStatus(page.status))
                 pagesPager.currentItem = pagerIndex
@@ -364,11 +364,11 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.dialogAction.observe(this, Observer {
+        viewModel.dialogAction.observe(viewLifecycleOwner, Observer {
             it?.show(activity, activity.supportFragmentManager, uiHelpers)
         })
 
-        viewModel.postUploadAction.observe(this, Observer {
+        viewModel.postUploadAction.observe(viewLifecycleOwner, Observer {
             it?.let { (post, site, data) ->
                 uploadUtilsWrapper.handleEditPostResultSnackbars(
                         activity,
@@ -393,7 +393,7 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.uploadFinishedAction.observe(this, Observer {
+        viewModel.uploadFinishedAction.observe(viewLifecycleOwner, Observer {
             it?.let { (page, isError) ->
                 uploadUtilsWrapper.onPostUploadedSnackbarHandler(
                         activity,

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
@@ -78,7 +78,7 @@ class SearchListFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.searchResult.observe(this, Observer { data ->
+        viewModel.searchResult.observe(viewLifecycleOwner, Observer { data ->
             data?.let { setSearchResult(data) }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansListFragment.kt
@@ -81,11 +81,11 @@ class PlansListFragment : Fragment() {
     }
 
     private fun setObservers() {
-        viewModel.plans.observe(this, Observer {
+        viewModel.plans.observe(viewLifecycleOwner, Observer {
             reloadList(it ?: emptyList())
         })
 
-        viewModel.listStatus.observe(this, Observer { listStatus ->
+        viewModel.listStatus.observe(viewLifecycleOwner, Observer { listStatus ->
             if (isAdded && view != null) {
                 swipeToRefreshHelper.isRefreshing = listStatus == FETCHING
             }
@@ -118,7 +118,7 @@ class PlansListFragment : Fragment() {
             }
         })
 
-        viewModel.showDialog.observe(this, Observer {
+        viewModel.showDialog.observe(viewLifecycleOwner, Observer {
             if (it is PlanOffersModel && activity is PlansListInterface) {
                 (activity as PlansListInterface).onPlanItemClicked(it)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -93,35 +93,35 @@ public class PluginListFragment extends Fragment {
 
     private void setupObservers() {
         mViewModel.getSitePluginsLiveData()
-                  .observe(this, listState -> {
+                  .observe(getViewLifecycleOwner(), listState -> {
                       if (mListType == PluginListType.SITE) {
                           refreshPluginsAndProgressBars(listState);
                       }
                   });
 
         mViewModel.getFeaturedPluginsLiveData()
-                  .observe(this, listState -> {
+                  .observe(getViewLifecycleOwner(), listState -> {
                       if (mListType == PluginListType.FEATURED) {
                           refreshPluginsAndProgressBars(listState);
                       }
                   });
 
         mViewModel.getPopularPluginsLiveData()
-                  .observe(this, listState -> {
+                  .observe(getViewLifecycleOwner(), listState -> {
                       if (mListType == PluginListType.POPULAR) {
                           refreshPluginsAndProgressBars(listState);
                       }
                   });
 
         mViewModel.getNewPluginsLiveData()
-                  .observe(this, listState -> {
+                  .observe(getViewLifecycleOwner(), listState -> {
                       if (mListType == PluginListType.NEW) {
                           refreshPluginsAndProgressBars(listState);
                       }
                   });
 
         mViewModel.getSearchResultsLiveData()
-                  .observe(this, listState -> {
+                  .observe(getViewLifecycleOwner(), listState -> {
                       if (mListType == PluginListType.SEARCH) {
                           refreshPluginsAndProgressBars(listState);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
@@ -53,24 +53,24 @@ class EditPostPublishSettingsFragment : Fragment() {
 
         dateAndTimeContainer.setOnClickListener { showPostDateSelectionDialog() }
 
-        viewModel.onDatePicked.observe(this, Observer {
+        viewModel.onDatePicked.observe(viewLifecycleOwner, Observer {
             it?.applyIfNotHandled {
                 showPostTimeSelectionDialog()
             }
         })
-        viewModel.onPublishedDateChanged.observe(this, Observer {
+        viewModel.onPublishedDateChanged.observe(viewLifecycleOwner, Observer {
             it?.let { date ->
                 viewModel.updatePost(date, getPostRepository())
             }
         })
-        viewModel.onNotificationTime.observe(this, Observer {
+        viewModel.onNotificationTime.observe(viewLifecycleOwner, Observer {
             it?.let { notificationTime ->
                 getPostRepository()?.let { postRepository ->
                     viewModel.scheduleNotification(postRepository, notificationTime)
                 }
             }
         })
-        viewModel.onUiModel.observe(this, Observer {
+        viewModel.onUiModel.observe(viewLifecycleOwner, Observer {
             it?.let { uiModel ->
                 dateAndTime.text = uiModel.publishDateLabel
                 publishNotificationTitle.isEnabled = uiModel.notificationEnabled
@@ -98,12 +98,12 @@ class EditPostPublishSettingsFragment : Fragment() {
                 addToCalendarContainer.visibility = if (uiModel.notificationVisible) View.VISIBLE else View.GONE
             }
         })
-        viewModel.onShowNotificationDialog.observe(this, Observer {
+        viewModel.onShowNotificationDialog.observe(viewLifecycleOwner, Observer {
             it?.getContentIfNotHandled()?.let { notificationTime ->
                 showNotificationTimeSelectionDialog(notificationTime)
             }
         })
-        viewModel.onToast.observe(this, Observer {
+        viewModel.onToast.observe(viewLifecycleOwner, Observer {
             it?.applyIfNotHandled {
                 ToastUtils.showToast(
                         context,
@@ -113,7 +113,7 @@ class EditPostPublishSettingsFragment : Fragment() {
                 )
             }
         })
-        viewModel.onNotificationAdded.observe(this, Observer { event ->
+        viewModel.onNotificationAdded.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { notification ->
                 activity?.let {
                     NotificationManagerCompat.from(it).cancel(notification.id)
@@ -135,7 +135,7 @@ class EditPostPublishSettingsFragment : Fragment() {
                 }
             }
         })
-        viewModel.onAddToCalendar.observe(this, Observer {
+        viewModel.onAddToCalendar.observe(viewLifecycleOwner, Observer {
             it?.getContentIfNotHandled()?.let { calendarEvent ->
                 val calIntent = Intent(Intent.ACTION_INSERT)
                 calIntent.data = Events.CONTENT_URI

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -383,12 +383,12 @@ public class EditPostSettingsFragment extends Fragment {
             mFormatContainer.setVisibility(View.GONE);
         }
 
-        mPublishedViewModel.getOnUiModel().observe(this, new Observer<PublishUiModel>() {
+        mPublishedViewModel.getOnUiModel().observe(getViewLifecycleOwner(), new Observer<PublishUiModel>() {
             @Override public void onChanged(PublishUiModel uiModel) {
                 updatePublishDateTextView(uiModel.getPublishDateLabel());
             }
         });
-        mPublishedViewModel.getOnPostStatusChanged().observe(this, new Observer<PostStatus>() {
+        mPublishedViewModel.getOnPostStatusChanged().observe(getViewLifecycleOwner(), new Observer<PostStatus>() {
             @Override public void onChanged(PostStatus postStatus) {
                 updatePostStatus(postStatus);
             }
@@ -1087,7 +1087,7 @@ public class EditPostSettingsFragment extends Fragment {
                 return;
             }
             StringBuilder sb = new StringBuilder();
-            for (int i = 0;; ++i) {
+            for (int i = 0; ; ++i) {
                 sb.append(address.getAddressLine(i));
                 if (i == address.getMaxAddressLineIndex()) {
                     sb.append(".");
@@ -1123,7 +1123,7 @@ public class EditPostSettingsFragment extends Fragment {
             ToastUtils.showToast(getActivity(), R.string.post_settings_error_placepicker_missing_play_services);
         } catch (GooglePlayServicesRepairableException re) {
             GoogleApiAvailability.getInstance().getErrorDialog(getActivity(), re.getConnectionStatusCode(),
-                                                               ACTIVITY_REQUEST_PLAY_SERVICES_RESOLUTION);
+                    ACTIVITY_REQUEST_PLAY_SERVICES_RESOLUTION);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -122,11 +122,11 @@ class HistoryListFragment : Fragment() {
     }
 
     private fun setObservers() {
-        viewModel.revisions.observe(this, Observer {
+        viewModel.revisions.observe(viewLifecycleOwner, Observer {
             reloadList(it ?: emptyList())
         })
 
-        viewModel.listStatus.observe(this, Observer { listStatus ->
+        viewModel.listStatus.observe(viewLifecycleOwner, Observer { listStatus ->
             listStatus?.let {
                 if (isAdded && view != null) {
                     swipeToRefreshHelper.isRefreshing = listStatus == HistoryListStatus.FETCHING
@@ -156,7 +156,7 @@ class HistoryListFragment : Fragment() {
             }
         })
 
-        viewModel.showDialog.observe(this, Observer { showDialogItem ->
+        viewModel.showDialog.observe(viewLifecycleOwner, Observer { showDialogItem ->
             if (showDialogItem != null && showDialogItem.historyListItem is Revision) {
                 (activity as HistoryItemClickInterface).onHistoryItemClicked(
                         showDialogItem.historyListItem,
@@ -165,7 +165,7 @@ class HistoryListFragment : Fragment() {
             }
         })
 
-        viewModel.post.observe(this, Observer { post ->
+        viewModel.post.observe(viewLifecycleOwner, Observer { post ->
             actionable_empty_view.subtitle.text = if (post?.isPage == true) {
                 getString(R.string.history_empty_subtitle_page)
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -91,7 +91,7 @@ class PostListFragment : Fragment() {
         mainViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
                 .get(PostListMainViewModel::class.java)
 
-        mainViewModel.viewLayoutType.observe(this, Observer { optionaLayoutType ->
+        mainViewModel.viewLayoutType.observe(viewLifecycleOwner, Observer { optionaLayoutType ->
             optionaLayoutType?.let { layoutType ->
                 recyclerView?.removeItemDecoration(itemDecorationCompactLayout)
                 recyclerView?.removeItemDecoration(itemDecorationStandardLayout)
@@ -111,7 +111,7 @@ class PostListFragment : Fragment() {
             }
         })
 
-        mainViewModel.authorSelectionUpdated.observe(this, Observer {
+        mainViewModel.authorSelectionUpdated.observe(viewLifecycleOwner, Observer {
             if (it != null) {
                 if (viewModel.updateAuthorFilterIfNotSearch(it)) {
                     recyclerView?.scrollToPosition(0)
@@ -141,7 +141,7 @@ class PostListFragment : Fragment() {
 
     private fun initObservers() {
         if (postListType == SEARCH) {
-            mainViewModel.searchQuery.observe(this, Observer {
+            mainViewModel.searchQuery.observe(viewLifecycleOwner, Observer {
                 if (TextUtils.isEmpty(it)) {
                     postListAdapter.submitList(null)
                 }
@@ -149,22 +149,22 @@ class PostListFragment : Fragment() {
             })
         }
 
-        viewModel.emptyViewState.observe(this, Observer {
+        viewModel.emptyViewState.observe(viewLifecycleOwner, Observer {
             it?.let { emptyViewState -> updateEmptyViewForState(emptyViewState) }
         })
 
-        viewModel.isFetchingFirstPage.observe(this, Observer {
+        viewModel.isFetchingFirstPage.observe(viewLifecycleOwner, Observer {
             swipeRefreshLayout?.isRefreshing = it == true
         })
 
-        viewModel.pagedListData.observe(this, Observer {
+        viewModel.pagedListData.observe(viewLifecycleOwner, Observer {
             it?.let { pagedListData -> updatePagedListData(pagedListData) }
         })
 
-        viewModel.isLoadingMore.observe(this, Observer {
+        viewModel.isLoadingMore.observe(viewLifecycleOwner, Observer {
             progressLoadMore?.visibility = if (it == true) View.VISIBLE else View.GONE
         })
-        viewModel.scrollToPosition.observe(this, Observer {
+        viewModel.scrollToPosition.observe(viewLifecycleOwner, Observer {
             it?.let { index ->
                 recyclerView?.scrollToPosition(index)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -416,7 +416,7 @@ public class ReaderPostListFragment extends Fragment
             mWPMainActivityViewModel = ViewModelProviders.of((FragmentActivity) getActivity(), mViewModelFactory)
                                                          .get(WPMainActivityViewModel.class);
 
-            mViewModel.getCurrentSubFilter().observe(this, subfilterListItem -> {
+            mViewModel.getCurrentSubFilter().observe(getViewLifecycleOwner(), subfilterListItem -> {
                 if (isCurrentTagManagedInFollowingTab()
                     && getPostListType() != ReaderPostListType.SEARCH_RESULTS) {
                     mViewModel.onSubfilterSelected(subfilterListItem);
@@ -427,12 +427,12 @@ public class ReaderPostListFragment extends Fragment
                 }
             });
 
-            mViewModel.getShouldShowSubFilters().observe(this, show -> {
+            mViewModel.getShouldShowSubFilters().observe(getViewLifecycleOwner(), show -> {
                 mSubFilterComponent.setVisibility(show ? View.VISIBLE : View.GONE);
                 mSettingsButton.setVisibility(mAccountStore.hasAccessToken() ? View.VISIBLE : View.GONE);
             });
 
-            mViewModel.getReaderModeInfo().observe(this, readerModeInfo -> {
+            mViewModel.getReaderModeInfo().observe(getViewLifecycleOwner(), readerModeInfo -> {
                 if (readerModeInfo != null) {
                     changeReaderMode(readerModeInfo, true);
 
@@ -453,7 +453,7 @@ public class ReaderPostListFragment extends Fragment
                 }
             });
 
-            mViewModel.getChangeBottomSheetVisibility().observe(this, event -> {
+            mViewModel.getChangeBottomSheetVisibility().observe(getViewLifecycleOwner(), event -> {
                 event.applyIfNotHandled(isShowing -> {
                     FragmentManager fm = getFragmentManager();
                     if (fm != null) {
@@ -471,7 +471,7 @@ public class ReaderPostListFragment extends Fragment
                 });
             });
 
-            mViewModel.getBottomSheetEmptyViewAction().observe(this, event -> {
+            mViewModel.getBottomSheetEmptyViewAction().observe(getViewLifecycleOwner(), event -> {
                 event.applyIfNotHandled(action -> {
                     if (action instanceof OpenSubsAtPage) {
                         ReaderActivityLauncher.showReaderSubs(
@@ -486,7 +486,7 @@ public class ReaderPostListFragment extends Fragment
                 });
             });
 
-            mViewModel.getUpdateTagsAndSites().observe(this, event -> {
+            mViewModel.getUpdateTagsAndSites().observe(getViewLifecycleOwner(), event -> {
                 event.applyIfNotHandled(tasks -> {
                     if (NetworkUtils.isNetworkAvailable(getActivity())) {
                         ReaderUpdateServiceStarter.startService(getActivity(), tasks);
@@ -496,7 +496,7 @@ public class ReaderPostListFragment extends Fragment
             });
         }
 
-        mViewModel.getShouldCollapseToolbar().observe(this, collapse -> {
+        mViewModel.getShouldCollapseToolbar().observe(getViewLifecycleOwner(), collapse -> {
             if (collapse) {
                 mRecyclerView.setToolbarScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
                                                     | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
@@ -2909,7 +2909,7 @@ public class ReaderPostListFragment extends Fragment
      * Handles reblog state changes and triggers reblog actions
      */
     private void handleReblogStateChanges() {
-        mViewModel.getReblogState().observe(this, event -> {
+        mViewModel.getReblogState().observe(getViewLifecycleOwner(), event -> {
             event.applyIfNotHandled(state -> {
                 if (state instanceof NoSite) {
                     ReaderActivityLauncher.showNoSiteToReblog(getActivity());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -81,7 +81,7 @@ class SubfilterPageFragment : DaggerFragment() {
         readerViewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
                 .get(ReaderPostListViewModel::class.java)
 
-        readerViewModel.subFilters.observe(this, Observer {
+        readerViewModel.subFilters.observe(viewLifecycleOwner, Observer {
             (recyclerView.adapter as? SubfilterListAdapter)?.let { adapter ->
                 var items = it?.filter { it.type == category.type } ?: listOf()
 
@@ -100,7 +100,7 @@ class SubfilterPageFragment : DaggerFragment() {
             }
         })
 
-        viewModel.emptyState.observe(this, Observer { uiState ->
+        viewModel.emptyState.observe(viewLifecycleOwner, Observer { uiState ->
             if (isAdded) {
                 when (uiState) {
                     HiddenEmptyUiState -> emptyStateContainer.visibility = View.GONE

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -104,13 +104,13 @@ class StatsFragment : DaggerFragment() {
     }
 
     private fun setupObservers(activity: FragmentActivity) {
-        viewModel.isRefreshing.observe(this, Observer {
+        viewModel.isRefreshing.observe(viewLifecycleOwner, Observer {
             it?.let { isRefreshing ->
                 swipeToRefreshHelper.isRefreshing = isRefreshing
             }
         })
 
-        viewModel.showSnackbarMessage.observe(this, Observer { holder ->
+        viewModel.showSnackbarMessage.observe(viewLifecycleOwner, Observer { holder ->
             val parent = activity.findViewById<View>(R.id.coordinatorLayout)
             if (holder != null && parent != null) {
                 if (holder.buttonTitleRes == null) {
@@ -123,7 +123,7 @@ class StatsFragment : DaggerFragment() {
             }
         })
 
-        viewModel.toolbarHasShadow.observe(this, Observer { hasShadow ->
+        viewModel.toolbarHasShadow.observe(viewLifecycleOwner, Observer { hasShadow ->
             app_bar_layout.postDelayed(
                     {
                         if (app_bar_layout != null) {
@@ -139,7 +139,7 @@ class StatsFragment : DaggerFragment() {
             )
         })
 
-        viewModel.siteChanged.observe(this, Observer { siteChangedEvent ->
+        viewModel.siteChanged.observe(viewLifecycleOwner, Observer { siteChangedEvent ->
             siteChangedEvent?.applyIfNotHandled {
                 when (this) {
                     is SiteUpdateResult.SiteConnected -> viewModel.onSiteChanged()
@@ -148,13 +148,13 @@ class StatsFragment : DaggerFragment() {
             }
         })
 
-        viewModel.hideToolbar.observe(this, Observer { event ->
+        viewModel.hideToolbar.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { hideToolbar ->
                 app_bar_layout.setExpanded(!hideToolbar, true)
             }
         })
 
-        viewModel.selectedSection.observe(this, Observer { selectedSection ->
+        viewModel.selectedSection.observe(viewLifecycleOwner, Observer { selectedSection ->
             selectedSection?.let {
                 val position = when (selectedSection) {
                     INSIGHTS -> 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -156,13 +156,13 @@ class StatsViewAllFragment : DaggerFragment() {
     }
 
     private fun setupObservers(activity: FragmentActivity) {
-        viewModel.isRefreshing.observe(this, Observer {
+        viewModel.isRefreshing.observe(viewLifecycleOwner, Observer {
             it?.let { isRefreshing ->
                 swipeToRefreshHelper.isRefreshing = isRefreshing
             }
         })
 
-        viewModel.showSnackbarMessage.observe(this, Observer { event ->
+        viewModel.showSnackbarMessage.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { holder ->
                 val parent = activity.findViewById<View>(R.id.coordinatorLayout)
                 if (parent != null) {
@@ -177,7 +177,7 @@ class StatsViewAllFragment : DaggerFragment() {
             }
         })
 
-        viewModel.data.observe(this, Observer {
+        viewModel.data.observe(viewLifecycleOwner, Observer {
             if (it != null) {
                 recyclerView.visibility = if (it is StatsBlock.Success) View.VISIBLE else View.GONE
                 loadingContainer.visibility = if (it is StatsBlock.Loading) View.VISIBLE else View.GONE
@@ -198,29 +198,29 @@ class StatsViewAllFragment : DaggerFragment() {
                 }
             }
         })
-        viewModel.navigationTarget.observe(this, Observer { event ->
+        viewModel.navigationTarget.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { target ->
                 navigator.navigate(activity, target)
             }
         })
 
-        viewModel.dateSelectorData.observe(this, Observer { dateSelectorUiModel ->
+        viewModel.dateSelectorData.observe(viewLifecycleOwner, Observer { dateSelectorUiModel ->
             drawDateSelector(dateSelectorUiModel)
         })
 
-        viewModel.navigationTarget.observe(this, Observer { event ->
+        viewModel.navigationTarget.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { target ->
                 navigator.navigate(activity, target)
             }
         })
 
-        viewModel.selectedDate.observe(this, Observer { event ->
+        viewModel.selectedDate.observe(viewLifecycleOwner, Observer { event ->
             if (event != null) {
                 viewModel.onDateChanged()
             }
         })
 
-        viewModel.toolbarHasShadow.observe(this, Observer { hasShadow ->
+        viewModel.toolbarHasShadow.observe(viewLifecycleOwner, Observer { hasShadow ->
             app_bar_layout.postDelayed({
                 if (app_bar_layout != null) {
                     val elevation = if (hasShadow == true) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -147,7 +147,7 @@ class StatsListFragment : DaggerFragment() {
     }
 
     private fun setupObservers(activity: FragmentActivity) {
-        viewModel.uiModel.observe(this, Observer {
+        viewModel.uiModel.observe(viewLifecycleOwner, Observer {
             when (it) {
                 is UiModel.Success -> {
                     updateInsights(it.data)
@@ -177,33 +177,33 @@ class StatsListFragment : DaggerFragment() {
             }
         })
 
-        viewModel.dateSelectorData.observe(this, Observer { dateSelectorUiModel ->
+        viewModel.dateSelectorData.observe(viewLifecycleOwner, Observer { dateSelectorUiModel ->
             drawDateSelector(dateSelectorUiModel)
         })
 
-        viewModel.navigationTarget.observe(this, Observer { event ->
+        viewModel.navigationTarget.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { target ->
                 navigator.navigate(activity, target)
             }
         })
 
-        viewModel.selectedDate.observe(this, Observer { event ->
+        viewModel.selectedDate.observe(viewLifecycleOwner, Observer { event ->
             if (event != null) {
                 viewModel.onDateChanged(event.selectedSection)
             }
         })
 
-        viewModel.listSelected.observe(this, Observer {
+        viewModel.listSelected.observe(viewLifecycleOwner, Observer {
             viewModel.onListSelected()
         })
 
-        viewModel.typesChanged.observe(this, Observer { event ->
+        viewModel.typesChanged.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let {
                 viewModel.onTypesChanged()
             }
         })
 
-        viewModel.scrollTo?.observe(this, Observer { event ->
+        viewModel.scrollTo?.observe(viewLifecycleOwner, Observer { event ->
             if (event != null) {
                 (recyclerView.adapter as? StatsBlockAdapter)?.let { adapter ->
                     event.getContentIfNotHandled()?.let { statsType ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
@@ -71,19 +71,19 @@ class StatsDetailFragment : DaggerFragment() {
     }
 
     private fun setupObservers(viewModel: StatsDetailViewModel) {
-        viewModel.isRefreshing.observe(this, Observer {
+        viewModel.isRefreshing.observe(viewLifecycleOwner, Observer {
             it?.let { isRefreshing ->
                 swipeToRefreshHelper.isRefreshing = isRefreshing
             }
         })
 
-        viewModel.selectedDateChanged.observe(this, Observer { event ->
+        viewModel.selectedDateChanged.observe(viewLifecycleOwner, Observer { event ->
             if (event != null) {
                 viewModel.onDateChanged(event.selectedSection)
             }
         })
 
-        viewModel.showDateSelector.observe(this, Observer { dateSelectorUiModel ->
+        viewModel.showDateSelector.observe(viewLifecycleOwner, Observer { dateSelectorUiModel ->
             drawDateSelector(dateSelectorUiModel)
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
@@ -66,7 +66,7 @@ class InsightsManagementFragment : DaggerFragment() {
     }
 
     private fun setupObservers() {
-        viewModel.addedInsights.observe(this, Observer {
+        viewModel.addedInsights.observe(viewLifecycleOwner, Observer {
             it?.let { items ->
                 updateAddedInsights(items)
 
@@ -78,11 +78,11 @@ class InsightsManagementFragment : DaggerFragment() {
             }
         })
 
-        viewModel.closeInsightsManagement.observe(this, Observer {
+        viewModel.closeInsightsManagement.observe(viewLifecycleOwner, Observer {
             requireActivity().finish()
         })
 
-        viewModel.isMenuVisible.observe(this, Observer { isMenuVisible ->
+        viewModel.isMenuVisible.observe(viewLifecycleOwner, Observer { isMenuVisible ->
             isMenuVisible?.let {
                 menu?.findItem(R.id.save_insights)?.isVisible = isMenuVisible
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -100,13 +100,13 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
             viewModel.addWidget()
         }
 
-        siteSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+        siteSelectionViewModel.dialogOpened.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
                 StatsWidgetSiteSelectionDialogFragment().show(requireFragmentManager(), "stats_site_selection_fragment")
             }
         })
 
-        colorSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+        colorSelectionViewModel.dialogOpened.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
                 StatsWidgetColorSelectionDialogFragment().show(
                         requireFragmentManager(),
@@ -116,14 +116,14 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
         })
 
         merge(siteSelectionViewModel.notification, colorSelectionViewModel.notification).observe(
-                this,
+                viewLifecycleOwner,
                 Observer { event ->
                     event?.applyIfNotHandled {
                         ToastUtils.showToast(activity, this)
                     }
                 })
 
-        viewModel.settingsModel.observe(this, Observer { uiModel ->
+        viewModel.settingsModel.observe(viewLifecycleOwner, Observer { uiModel ->
             uiModel?.let {
                 if (uiModel.siteTitle != null) {
                     site_value.text = uiModel.siteTitle
@@ -133,7 +133,7 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
             }
         })
 
-        viewModel.widgetAdded.observe(this, Observer { event ->
+        viewModel.widgetAdded.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let {
                 analyticsTrackerWrapper.trackWithWidgetType(STATS_WIDGET_ADDED, it.widgetType)
                 when (it.widgetType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -85,13 +85,13 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
             viewModel.addWidget()
         }
 
-        siteSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+        siteSelectionViewModel.dialogOpened.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
                 StatsWidgetSiteSelectionDialogFragment().show(requireFragmentManager(), "stats_site_selection_fragment")
             }
         })
 
-        colorSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+        colorSelectionViewModel.dialogOpened.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
                 StatsWidgetColorSelectionDialogFragment().show(
                         requireFragmentManager(),
@@ -100,7 +100,7 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
             }
         })
 
-        dataTypeSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+        dataTypeSelectionViewModel.dialogOpened.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
                 StatsWidgetDataTypeSelectionDialogFragment().show(
                         requireFragmentManager(),
@@ -114,14 +114,14 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
                 colorSelectionViewModel.notification,
                 dataTypeSelectionViewModel.notification
         ).observe(
-                this,
+                viewLifecycleOwner,
                 Observer { event ->
                     event?.applyIfNotHandled {
                         ToastUtils.showToast(activity, this)
                     }
                 })
 
-        viewModel.settingsModel.observe(this, Observer { uiModel ->
+        viewModel.settingsModel.observe(viewLifecycleOwner, Observer { uiModel ->
             uiModel?.let {
                 if (uiModel.siteTitle != null) {
                     site_value.text = uiModel.siteTitle
@@ -132,7 +132,7 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
             }
         })
 
-        viewModel.widgetAdded.observe(this, Observer { event ->
+        viewModel.widgetAdded.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let {
                 analyticsTrackerWrapper.trackMinifiedWidget(STATS_WIDGET_ADDED)
                 minifiedWidgetUpdater.updateAppWidget(context!!, appWidgetId = appWidgetId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.ui.stories
+
+import android.os.Bundle
+import android.widget.Toast
+import com.wordpress.stories.compose.ComposeLoopFrameActivity
+import com.wordpress.stories.compose.MediaPickerProvider
+import com.wordpress.stories.compose.SnackbarProvider
+
+class StoryComposerActivity : ComposeLoopFrameActivity(), SnackbarProvider, MediaPickerProvider {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setSnackbarProvider(this)
+        setMediaPickerProvider(this)
+    }
+
+    override fun showProvidedSnackbar(message: String, actionLabel: String?, callback: () -> Unit) {
+        // TODO implement snackbar
+    }
+
+    override fun setupRequestCodes(requestCodes: ExternalMediaPickerRequestCodesAndExtraKeys) {
+        // TODO implement request codes
+    }
+
+    override fun showProvidedMediaPicker() {
+        // TODO implement show media picker
+        Toast.makeText(this, "picker not implemeneted yet", Toast.LENGTH_SHORT)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -67,7 +67,7 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
         ))
         actionsList.add(CreateAction(
                 actionType = CREATE_NEW_STORY,
-                iconRes = R.drawable.ic_pages_white_24dp,
+                iconRes = R.drawable.ic_story_icon_24dp,
                 labelRes = R.string.my_site_bottom_sheet_add_story,
                 onClickAction = ::onCreateActionClicked
         ))

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
+import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_STORY
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.NO_ACTION
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.main.MainFabUiState
@@ -62,6 +63,12 @@ class WPMainActivityViewModel @Inject constructor(private val appPrefsWrapper: A
                 actionType = CREATE_NEW_PAGE,
                 iconRes = R.drawable.ic_pages_white_24dp,
                 labelRes = R.string.my_site_bottom_sheet_add_page,
+                onClickAction = ::onCreateActionClicked
+        ))
+        actionsList.add(CreateAction(
+                actionType = CREATE_NEW_STORY,
+                iconRes = R.drawable.ic_pages_white_24dp,
+                labelRes = R.string.my_site_bottom_sheet_add_story,
                 onClickAction = ::onCreateActionClicked
         ))
 

--- a/WordPress/src/main/res/drawable/ic_story_icon_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_story_icon_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M6,3H14V17H6L6,3ZM4,3C4,1.8954 4.8954,1 6,1H14C15.1046,1 16,1.8954 16,3V17C16,18.1046 15.1046,19 14,19H6C4.8954,19 4,18.1046 4,17V3ZM18,5C19.1046,5 20,5.8954 20,7V21C20,22.1046 19.1046,23 18,23H10C8.8954,23 8,22.1046 8,21H18V5Z"
+      android:fillColor="#2C3338"
+      android:fillType="evenOdd"/>
+</vector>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1874,6 +1874,7 @@
     <string name="my_site_bottom_sheet_title">Add new</string>
     <string name="my_site_bottom_sheet_add_post">Blog post</string>
     <string name="my_site_bottom_sheet_add_page">Site page</string>
+    <string name="my_site_bottom_sheet_add_story">Story</string>
 
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -141,12 +141,12 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
         mLoginSiteAddressValidator = new LoginSiteAddressValidator();
 
-        mLoginSiteAddressValidator.getIsValid().observe(this, new Observer<Boolean>() {
+        mLoginSiteAddressValidator.getIsValid().observe(getViewLifecycleOwner(), new Observer<Boolean>() {
             @Override public void onChanged(Boolean enabled) {
                 getPrimaryButton().setEnabled(enabled);
             }
         });
-        mLoginSiteAddressValidator.getErrorMessageResId().observe(this, new Observer<Integer>() {
+        mLoginSiteAddressValidator.getErrorMessageResId().observe(getViewLifecycleOwner(), new Observer<Integer>() {
             @Override public void onChanged(Integer resId) {
                 if (resId != null) {
                     showError(resId);


### PR DESCRIPTION
This PR builds on top of #11920 

This PR adds the Activity launching code so it's accessible from the FAB.

The basic Activity linking functionality implemented also in this PR in this commit 02e7de8 , moved from the past PR and cherry picked here in 61316b8 (tapping on the main screen FAB should show a third option to create a Story and trigger the composing functionality in the Stories library).

#### Tracks
Tracking will be added on a later PR. 
`// TODO WPSTORIES add TRACKS`

#### To test:
1. checkout the branch and run 
```
git submodule init 
git submodule update
```
or for a fresh clone, you can also do `git clone --recurse-submodules git@github.com:wordpress-mobile/WordPress-Android.git`

2. build
3. run
4. once you land on the main screen and provided you have a site, tap on the FAB and then choose the third option (Story).
5. the camera capture mode from the Stories library should open up, and permissions will be requested accordingly.


To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
