### PR TITLE
When upgrading from older version do not go through migration script steps.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -176,7 +176,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
         if (currentVersion <= DB_LAST_VERSION_WITHOUT_MIGRATION_SCRIPT) {
             // versions 0 - 136 didn't support migration scripts, so we can safely drop and recreate all tables
             reset(db);
-            currentVersion = DB_LAST_VERSION_WITHOUT_MIGRATION_SCRIPT;
+            currentVersion = newVersion;
         }
 
         switch (currentVersion) {


### PR DESCRIPTION
Fixes #11845 

This PR fixes the migration script for reader DB. When we encounter a migration attempt from the version before the migration scripts were introduced, we recreate the tables, and skip the individual migration steps.

To test:
- Checkout and do a fresh install of version 10.1 of the app (reader DB version 135). Since we were using HelpShipt back then, you might want to comment out the content of [this](https://github.com/wordpress-mobile/WordPress-Android/blob/10.1/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java#L114) and [this](https://github.com/wordpress-mobile/WordPress-Android/blob/10.1/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java#L238) methods.
- Install version from this branch on top of the 10.1. Notice the app does not crash.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
