### PR TITLE
Prepublishing Nudges : Refactored PostSettingsUtilsTest

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsUtils.kt
@@ -11,7 +11,8 @@ import javax.inject.Inject
 class PostSettingsUtils
 @Inject constructor(
     private val resourceProvider: ResourceProvider,
-    private val dateUtils: DateUtils
+    private val dateUtils: DateUtils,
+    private val postUtilsWrapper: PostUtilsWrapper
 ) {
     fun getPublishDateLabel(
         postModel: PostImmutableModel
@@ -27,19 +28,19 @@ class PostSettingsUtils
             } else if (status == PostStatus.PUBLISHED || status == PostStatus.PRIVATE) {
                 labelToUse = resourceProvider.getString(R.string.published_on, formattedDate)
             } else if (postModel.isLocalDraft) {
-                if (PostUtils.isPublishDateInThePast(postModel.dateCreated)) {
+                if (postUtilsWrapper.isPublishDateInThePast(postModel.dateCreated)) {
                     labelToUse = resourceProvider.getString(R.string.backdated_for, formattedDate)
-                } else if (PostUtils.shouldPublishImmediately(status, postModel.dateCreated)) {
+                } else if (postUtilsWrapper.shouldPublishImmediately(status, postModel.dateCreated)) {
                     labelToUse = resourceProvider.getString(R.string.immediately)
                 } else {
                     labelToUse = resourceProvider.getString(R.string.publish_on, formattedDate)
                 }
-            } else if (PostUtils.isPublishDateInTheFuture(postModel.dateCreated)) {
+            } else if (postUtilsWrapper.isPublishDateInTheFuture(postModel.dateCreated)) {
                 labelToUse = resourceProvider.getString(R.string.schedule_for, formattedDate)
             } else {
                 labelToUse = resourceProvider.getString(R.string.publish_on, formattedDate)
             }
-        } else if (PostUtils.shouldPublishImmediatelyOptionBeAvailable(status)) {
+        } else if (postUtilsWrapper.shouldPublishImmediatelyOptionBeAvailable(status)) {
             labelToUse = resourceProvider.getString(R.string.immediately)
         } else {
             // TODO: What should the label be if there is no specific date and this is not a DRAFT?

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -339,11 +339,12 @@ public class PostUtils {
         return pubDate != null && pubDate.after(currentDate);
     }
 
-    public static boolean isPublishDateInThePast(String dateCreated) {
+    public static boolean isPublishDateInThePast(String dateCreated, Date currentDate) {
         Date pubDate = DateTimeUtils.dateFromIso8601(dateCreated);
 
-        // just use half an hour before now as a threshold to make sure this is backdated, to avoid false positives
         Calendar cal = Calendar.getInstance();
+        cal.setTime(currentDate);
+        // just use half an hour before now as a threshold to make sure this is backdated, to avoid false positives
         cal.add(Calendar.MINUTE, -30);
         Date halfHourBack = cal.getTime();
         return pubDate != null && pubDate.before(halfHourBack);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
@@ -41,4 +41,10 @@ class PostUtilsWrapper @Inject constructor(private val dateProvider: DateProvide
 
     fun isPublishDateInTheFuture(dateCreated: String) =
             PostUtils.isPublishDateInTheFuture(dateCreated, dateProvider.getCurrentDate())
+
+    fun isPublishDateInThePast(dateCreated: String) =
+            PostUtils.isPublishDateInThePast(dateCreated, dateProvider.getCurrentDate())
+
+    fun shouldPublishImmediatelyOptionBeAvailable(status: PostStatus?) =
+            PostUtils.shouldPublishImmediatelyOptionBeAvailable(status)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.ui.stats.refresh.utils.DateUtils
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Calendar
-import java.util.Date
 
 class PostSettingsUtilsTest : BaseUnitTest() {
     @Mock lateinit var resourceProvider: ResourceProvider
@@ -26,6 +25,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     private lateinit var postUtilsWrapper: PostUtilsWrapper
 
     private val dateCreated = "2019-05-05T14:33:20+0200"
+    private val currentDate = "2019-05-05T20:33:20+0200"
     private val formattedDate = "5. 5. 2019"
     private lateinit var postModel: PostModel
 
@@ -34,6 +34,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
         postUtilsWrapper = PostUtilsWrapper(dateProvider)
         postSettingsUtils = PostSettingsUtils(resourceProvider, dateUtils, postUtilsWrapper)
         whenever(dateUtils.formatDateTime(any())).thenReturn(formattedDate)
+        whenever(dateProvider.getCurrentDate()).thenReturn(DateTimeUtils.dateUTCFromIso8601(currentDate))
         whenever(
                 resourceProvider.getString(
                         R.string.scheduled_for,
@@ -114,7 +115,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     fun `returns "immediately" for local draft when should publish immediately`() {
         postModel.setIsLocalDraft(true)
         postModel.setStatus(PostStatus.DRAFT.toString())
-        postModel.setDateCreated(DateTimeUtils.iso8601FromDate(Date()))
+        postModel.setDateCreated(currentDate)
 
         val publishedDate = postSettingsUtils.getPublishDateLabel(postModel)
 
@@ -124,9 +125,11 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     @Test
     fun `returns "published on" for local draft when date is not set`() {
         postModel.setIsLocalDraft(true)
-        val calendar = Calendar.getInstance()
-        calendar.add(Calendar.MINUTE, -5)
-        postModel.setDateCreated(DateTimeUtils.iso8601FromDate(calendar.time))
+
+        // This date is 5 minutes before the currentDate
+        val dateCreated = "2019-05-05T20:28:20+0200"
+
+        postModel.setDateCreated(dateCreated)
 
         val publishedDate = postSettingsUtils.getPublishDateLabel(postModel)
 
@@ -135,9 +138,10 @@ class PostSettingsUtilsTest : BaseUnitTest() {
 
     @Test
     fun `returns "schedule for" when post published in future`() {
-        val calendar = Calendar.getInstance()
-        calendar.add(Calendar.MINUTE, 100)
-        postModel.setDateCreated(DateTimeUtils.iso8601FromDate(calendar.time))
+        // two hours ahead of the currentDate
+        val futureDate = "2019-05-05T22:28:20+0200"
+
+        postModel.setDateCreated(futureDate)
 
         val publishedDate = postSettingsUtils.getPublishDateLabel(postModel)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.ui.reader.utils.DateProvider
 import org.wordpress.android.ui.stats.refresh.utils.DateUtils
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -20,14 +21,18 @@ import java.util.Date
 class PostSettingsUtilsTest : BaseUnitTest() {
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var dateUtils: DateUtils
+    @Mock lateinit var dateProvider: DateProvider
     private lateinit var postSettingsUtils: PostSettingsUtils
+    private lateinit var postUtilsWrapper: PostUtilsWrapper
 
     private val dateCreated = "2019-05-05T14:33:20+0200"
     private val formattedDate = "5. 5. 2019"
     private lateinit var postModel: PostModel
+
     @Before
     fun setUp() {
-        postSettingsUtils = PostSettingsUtils(resourceProvider, dateUtils)
+        postUtilsWrapper = PostUtilsWrapper(dateProvider)
+        postSettingsUtils = PostSettingsUtils(resourceProvider, dateUtils, postUtilsWrapper)
         whenever(dateUtils.formatDateTime(any())).thenReturn(formattedDate)
         whenever(
                 resourceProvider.getString(

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
@@ -122,7 +122,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `returns "published on" for local draft when date is not set`() {
+    fun `returns "publish on" for local draft when date within the next 30 minutes`() {
         postModel.setIsLocalDraft(true)
 
         // This date is 5 minutes before the currentDate

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.ui.reader.utils.DateProvider
 import org.wordpress.android.ui.stats.refresh.utils.DateUtils
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.viewmodel.ResourceProvider
-import java.util.Calendar
 
 class PostSettingsUtilsTest : BaseUnitTest() {
     @Mock lateinit var resourceProvider: ResourceProvider


### PR DESCRIPTION
Fixes #11884

## Solution
Remove the usage of `Calendar.getIntance()` and `Date()` from the tests so that mocked dates can be utilized. This allows the test to be deterministic; the dates will always be the same.

## Testing
1. Run the tests in `PostSettingsUtilsTest`.
2. Smoke test the `Status` and `Publish Date` functionality within `Post Settings` to ensure that they are still working as expected.

## Reviewing 
1. Only 1 reviewer is needed but anyone can review. 
2. Ensure that https://github.com/wordpress-mobile/WordPress-Android/pull/11805 is merged. 
3. Change the base branch to `feature/prepublishing_nudges` 
4. Remove the `Not Ready For Merge` label. 
5. Merge :) 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
