### PR TITLE
Remove unnecessary log - gravatar api timeout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/networking/GravatarApi.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/GravatarApi.java
@@ -5,7 +5,6 @@ import android.os.Looper;
 
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.CrashLoggingUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -126,8 +125,6 @@ public class GravatarApi {
                             properties.put("network_exception_class", exceptionClass);
                             properties.put("network_exception_message", exceptionMessage);
                             AnalyticsTracker.track(AnalyticsTracker.Stat.ME_GRAVATAR_UPLOAD_EXCEPTION, properties);
-                            CrashLoggingUtils
-                                    .logException(e, AppLog.T.API, "Network call failure trying to upload Gravatar!");
                         }
 
                         new Handler(Looper.getMainLooper()).post(new Runnable() {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/9843

This PR removes unnecessary `Gravatar api timeout` log. The main reason we are removing this is that it's cluttering up Sentry with unimportant logs. Moreover, the error is being tracked into Tracks so we won't lose the data in case we ever need them.

To test:
- I don't think this PR needs any manual tests

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
