### PR TITLE
[Fix] Gutenberg - honor allowMultipleSelection js flag in StockMediaPicker

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 14.9
 -----
 * Fix issue with Preview post not working after switching to classic editor from inside the post
+* [**] Block editor: Fix bug in Free Photo Library which allowed selecting multiple images but only inserted one
  
 14.8
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -19,6 +19,7 @@ public class RequestCodes {
     public static final int PHOTO_PICKER = 1200;
     public static final int STOCK_MEDIA_PICKER_MULTI_SELECT = 1201;
     public static final int STOCK_MEDIA_PICKER_SINGLE_SELECT = 1202;
+    public static final int STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK = 1203;
     public static final int SHOW_LOGIN_EPILOGUE_AND_RETURN = 1300;
     public static final int SHOW_SIGNUP_EPILOGUE_AND_RETURN = 1301;
     public static final int SMART_LOCK_SAVE = 1400;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -970,8 +970,10 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     ActivityLauncher.viewMediaPickerForResult(this, mSite, MediaBrowserType.EDITOR_PICKER);
                     break;
                 case STOCK_MEDIA:
-                    ActivityLauncher.showStockMediaPickerForResult(
-                            this, mSite, RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT);
+                    final int requestCode = allowMultipleSelection
+                            ? RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT
+                            : RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK;
+                    ActivityLauncher.showStockMediaPickerForResult(this, mSite, requestCode);
                     break;
                 case GIF:
                     ActivityLauncher.showGifPickerForResult(this, mSite, RequestCodes.GIF_PICKER);
@@ -2291,6 +2293,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 case RequestCodes.VIDEO_LIBRARY:
                 case RequestCodes.TAKE_VIDEO:
                 case RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT:
+                case RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK:
                     mEditorFragment.mediaSelectionCancelled();
                     return;
                 default:
@@ -2325,6 +2328,14 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     } else if (data.getIntExtra(PhotoPickerActivity.CHILD_REQUEST_CODE, -1)
                                == RequestCodes.TAKE_VIDEO) {
                         mEditorMedia.addFreshlyTakenVideoToEditor();
+                    }
+                    break;
+                case RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK:
+                    if (data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_ID)) {
+                        // pass array with single item
+                        long[] mediaIds = {data.getLongExtra(PhotoPickerActivity.EXTRA_MEDIA_ID, 0)};
+                        mEditorMedia
+                                .addExistingMediaToEditorAsync(AddExistingMediaSource.STOCK_PHOTO_LIBRARY, mediaIds);
                     }
                     break;
                 case RequestCodes.MEDIA_LIBRARY:

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -191,7 +191,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
             }
         });
 
-        if (enableMultiselect()) {
+        if (isMultiSelectEnabled()) {
             mTextPreview.setOnClickListener(new View.OnClickListener() {
                 @Override public void onClick(View v) {
                     previewSelection();
@@ -267,7 +267,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
         return super.onOptionsItemSelected(item);
     }
 
-    private boolean enableMultiselect() {
+    private boolean isMultiSelectEnabled() {
         return mRequestCode == RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT;
     }
 
@@ -444,7 +444,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
             }
 
             Intent intent = new Intent();
-            if (enableMultiselect()) {
+            if (isMultiSelectEnabled()) {
                 long[] idArray = new long[count];
                 for (int i = 0; i < count; i++) {
                     idArray[i] = event.mediaList.get(i).getMediaId();
@@ -501,7 +501,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
     private void notifySelectionCountChanged() {
         int numSelected = mAdapter.getSelectionCount();
         if (numSelected > 0) {
-            if (enableMultiselect()) {
+            if (isMultiSelectEnabled()) {
                 String labelAdd = String.format(getString(R.string.add_count), numSelected);
                 mTextAdd.setText(labelAdd);
 
@@ -601,7 +601,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
 
             boolean isSelected = isItemSelected(position);
             holder.mSelectionCountTextView.setSelected(isSelected);
-            if (enableMultiselect()) {
+            if (isMultiSelectEnabled()) {
                 if (isSelected) {
                     int count = mSelectedItems.indexOf(position) + 1;
                     String label = Integer.toString(count);
@@ -611,7 +611,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
                 }
             } else {
                 holder.mSelectionCountTextView.setVisibility(
-                        isSelected || enableMultiselect() ? View.VISIBLE : View.GONE);
+                        isSelected || isMultiSelectEnabled() ? View.VISIBLE : View.GONE);
             }
 
             float scale = isSelected ? SCALE_SELECTED : SCALE_NORMAL;
@@ -654,7 +654,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
             if (!isValidPosition(position)) return;
 
             // if this is single select, make sure to deselect any existing selection
-            if (selected && !enableMultiselect() && !mSelectedItems.isEmpty()) {
+            if (selected && !isMultiSelectEnabled() && !mSelectedItems.isEmpty()) {
                 int prevPosition = mSelectedItems.get(0);
                 StockViewHolder prevHolder = (StockViewHolder) mRecycler.findViewHolderForAdapterPosition(prevPosition);
                 if (prevHolder != null) {
@@ -676,7 +676,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
             }
 
             // show and animate the count bubble
-            if (enableMultiselect()) {
+            if (isMultiSelectEnabled()) {
                 if (selected) {
                     String label = Integer.toString(mSelectedItems.indexOf(position) + 1);
                     holder.mSelectionCountTextView.setText(label);


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2261

### Description
When the user selects "Free photos library" from the Cover block, it allows multiple photos to be selected. This is inconsistent with the other upload options (which only allow a single image to be selected). Additionally, these selected images are all uploaded to the media library upon confirmation, but only the first selected image is displayed in the post.

This PR adds a new request code for starting the StockMediaPicker activity for single select mode. This is necessary because the existing request code used for this purpose (`RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT`) is assumed to be used for the featured image picker.

**Edit:**

It turns out the issue that this PR fixes also exists for other blocks, and this PR fixes the issue for those blocks as well (e.g. Image, and Media & Text).

**To test:**

1. Create a new Gutenberg post
2. Add a cover block
3. Tap "Add image or video"
4. Tap "Choose from Free Photo Library" 
5. Type a search term

**Expected behavior:**

Only 1 image can be selected.

**Steps:**

6. Select an image
7. Tap "Use this photo"

**Expected behavior**
Selected image becomes the background of the Cover block

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
