### PR TITLE
Gutenberg/no jitpack updates to gutenberg 1.28 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
           name: Cache JS Bundle
           key: android-js-bundle-{{ checksum "gutenberg_submodule_hash" }}
           paths:
-            - libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets/index.android.bundle
+            - libs/gutenberg-mobile/react-native-gutenberg-bridge/android/build/assets/index.android.bundle
   restore-gutenberg-bundle-cache:
     steps:
       - run:
@@ -77,7 +77,7 @@ jobs:
       - run:
           name: Abort If JS Bundle Exists
           command: |
-            if [ -f "libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets/index.android.bundle" ]; then
+            if [ -f "libs/gutenberg-mobile/react-native-gutenberg-bridge/android/build/assets/index.android.bundle" ]; then
               echo "Gutenberg-Mobile bundle already in cache, no need to create a new one."
               circleci-agent step halt
             else
@@ -88,10 +88,10 @@ jobs:
       - yarn-bundle-android
       - run:
           name: Ensure assets folder exists
-          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/build/assets
       - run:
           name: Move bundle to assets folder
-          command: mv libs/gutenberg-mobile/bundle/android/App.js libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets/index.android.bundle
+          command: mv libs/gutenberg-mobile/bundle/android/App.js libs/gutenberg-mobile/react-native-gutenberg-bridge/android/build/assets/index.android.bundle
       - save-gutenberg-bundle-cache
   test:
     executor: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,28 @@ commands:
           name: Yarn bundle Android
           working_directory: libs/gutenberg-mobile
           command: yarn bundle:android
+  save-gutenberg-bundle-cache:
+    steps:
+      - run:
+          name: Save Gutenberg-Mobile Submodule Hash
+          command: |
+            git rev-parse @:./libs/gutenberg-mobile > gutenberg_submodule_hash
+            cat gutenberg_submodule_hash
+      - save_cache:
+          name: Cache JS Bundle
+          key: android-js-bundle-{{ checksum "gutenberg_submodule_hash" }}
+          paths:
+            - libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets/index.android.bundle
+  restore-gutenberg-bundle-cache:
+    steps:
+      - run:
+          name: Save Gutenberg-Mobile Submodule Hash
+          command: |
+            git rev-parse @:./libs/gutenberg-mobile > gutenberg_submodule_hash
+            cat gutenberg_submodule_hash
+      - restore_cache:
+          name: Restore JS Bundle From Cache
+          key: android-js-bundle-{{ checksum "gutenberg_submodule_hash" }}
 
 version: 2.1
 jobs:
@@ -51,17 +73,26 @@ jobs:
       - image: circleci/node:10
     steps:
       - git/shallow-checkout
+      - restore-gutenberg-bundle-cache
+      - run:
+          name: Abort If JS Bundle Exists
+          command: |
+            if [ -f "libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets/index.android.bundle" ]; then
+              echo "Gutenberg-Mobile bundle already in cache, no need to create a new one."
+              circleci-agent step halt
+            else
+              echo "Gutenberg-Mobile bundle not found in cache. Proceeding to generate new bundle"
+            fi
       - checkout-submodules
       - yarn-install
       - yarn-bundle-android
       - run:
-          name: Rename the JS bundle
-          working_directory: libs/gutenberg-mobile
-          command: mv bundle/android/App.js bundle/android/index.android.bundle
-      - persist_to_workspace:
-          root: libs/gutenberg-mobile/bundle/android
-          paths:
-            - index.android.bundle
+          name: Ensure assets folder exists
+          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+      - run:
+          name: Move bundle to assets folder
+          command: mv libs/gutenberg-mobile/bundle/android/App.js libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets/index.android.bundle
+      - save-gutenberg-bundle-cache
   test:
     executor: 
       name: android/default
@@ -71,11 +102,7 @@ jobs:
       - checkout-gutenberg-mobile-submodule-only
       - android/restore-gradle-cache
       - copy-gradle-properties
-      - run:
-          name: Ensure assets folder exists
-          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
-      - attach_workspace:
-          at: libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+      - restore-gutenberg-bundle-cache
       - run:
           name: Test WordPress
           environment:
@@ -97,11 +124,7 @@ jobs:
       - checkout-gutenberg-mobile-submodule-only
       - android/restore-gradle-cache
       - copy-gradle-properties
-      - run:
-          name: Ensure assets folder exists
-          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
-      - attach_workspace:
-          at: libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+      - restore-gutenberg-bundle-cache
       - run:
           name: Checkstyle
           environment:
@@ -143,11 +166,7 @@ jobs:
           name: Copy Secrets
           command: bundle exec fastlane run configure_apply
       - android/restore-gradle-cache
-      - run:
-          name: Ensure assets folder exists
-          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
-      - attach_workspace:
-          at: libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+      - restore-gutenberg-bundle-cache
       - run:
           name: Build APK
           environment:
@@ -187,11 +206,7 @@ jobs:
       - checkout-gutenberg-mobile-submodule-only
       - android/restore-gradle-cache
       - copy-gradle-properties
-      - run:
-          name: Ensure assets folder exists
-          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
-      - attach_workspace:
-          at: libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+      - restore-gutenberg-bundle-cache
       - run:
           name: Build
           environment:
@@ -229,11 +244,7 @@ jobs:
       - checkout-gutenberg-mobile-submodule-only
       - android/restore-gradle-cache
       - copy-gradle-properties
-      - run:
-          name: Ensure assets folder exists
-          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
-      - attach_workspace:
-          at: libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+      - restore-gutenberg-bundle-cache
       - run:
           name: Build
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       - copy-gradle-properties
       - run:
           name: Ensure assets folder exists
-          command: mkdir libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
       - attach_workspace:
           at: libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
       - run:
@@ -99,7 +99,7 @@ jobs:
       - copy-gradle-properties
       - run:
           name: Ensure assets folder exists
-          command: mkdir libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
       - attach_workspace:
           at: libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
       - run:
@@ -145,7 +145,7 @@ jobs:
       - android/restore-gradle-cache
       - run:
           name: Ensure assets folder exists
-          command: mkdir libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
       - attach_workspace:
           at: libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
       - run:
@@ -189,7 +189,7 @@ jobs:
       - copy-gradle-properties
       - run:
           name: Ensure assets folder exists
-          command: mkdir libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
       - attach_workspace:
           at: libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
       - run:
@@ -231,7 +231,7 @@ jobs:
       - copy-gradle-properties
       - run:
           name: Ensure assets folder exists
-          command: mkdir libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
       - attach_workspace:
           at: libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
       - run:

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ if (project.ext.buildGutenbergFromSource) {
     def nodeModulesDir = new File('libs/gutenberg-mobile/node_modules')
     if (!nodeModulesDir.exists()) {
         def message = "Attempting to build Gutenberg from source without a libs/gutenberg-mobile/node_modules directory. \
-Either run yarn install manually within libs/gutenberg-mobile or set wp.BUILD_GUTENBERG_FROM_SOURCE to false."
+Either run `yarn install` manually within libs/gutenberg-mobile or disable building Gutenberg from source by \
+setting wp.BUILD_GUTENBERG_FROM_SOURCE to false."
         throw new GradleException(message)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     ext.kotlinVersion = '1.3.61'
     ext.navComponenVersion = '2.0.0'
-    ext.buildGutenbergMobileJSBundle = 1
 
     repositories {
         google()
@@ -21,13 +20,20 @@ plugins {
     id 'com.gradle.build-scan' version '2.0.2'
 }
 
-ext {
-    buildGutenbergMobileJSBundle = 1
-}
-
 apply plugin: 'com.automattic.android.fetchstyle'
 
 project.ext.buildGutenbergFromSource = project.properties.getOrDefault('wp.BUILD_GUTENBERG_FROM_SOURCE', false).toBoolean()
+def suppressJSBundle =  System.getenv('SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD').asBoolean()
+project.ext.buildGutenbergMobileJSBundle = !(suppressJSBundle || project.ext.buildGutenbergFromSource)
+
+if (project.ext.buildGutenbergFromSource) {
+    def nodeModulesDir = new File('libs/gutenberg-mobile/node_modules')
+    if (!nodeModulesDir.exists()) {
+        def message = "Attempting to build Gutenberg from source without a libs/gutenberg-mobile/node_modules directory. \
+Either run yarn install manually within libs/gutenberg-mobile or set wp.BUILD_GUTENBERG_FROM_SOURCE to false."
+        throw new GradleException(message)
+    }
+}
 
 allprojects {
     apply plugin: 'checkstyle'


### PR DESCRIPTION
Related gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2264

Bringing the changes to not use jitpack for Gutenberg to `develop`.

### To test

Insure you can build the app successfully under these three scenarios:

wp.BUILD_GUTENBERG_FROM_SOURCE | build flavor
--- | ---
true | wasabiDebug
false | wasabiDebug
false | vanillaRelease

* Ensure that when `wp.BUILD_GUTENBERG_FROM_SOURCE` is false, changes to gutenberg's package.json file rerun the yarn task.
* We should also ensure that rebuilding the `wasabiDebug` flavor when `wp.BUILD_GUTENBERG_FROM_SOURCE` is `false` is reasonably fast since that is the build that will be generally used for development by non-Gutenberg Android devs.
* Lastly, we should insure that a `clean` regenerates the bundle:
  1. With `wp.BUILD_GUTENBERG_FROM_SOURCE` set to `false`, run `./gradlew installWasabiDebug` and verify that you can load the Gutenberg editor from resulting app
  2. Run that build again and observe that it runs much faster (~10 seconds)
  3. Run `./gradlew clean installWasabiDebug` and verify that you can load the Gutenberg editor from the resulting app. This build should take longer again because `clean` deletes the bundle so the build should detect that and rebuild it.

### PR submission checklist

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
