### PR TITLE
Gutenberg/wpcom supported jetpack blocks api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.12-beta-3'
+    fluxCVersion = '6c8810c419e4c90c8f1372b52f13d96d8e79ad8a'
 
     appCompatVersion = '1.0.2'
     constraintLayoutVersion = '1.1.3'


### PR DESCRIPTION
Fixes (Part of) https://github.com/wordpress-mobile/gutenberg-mobile/issues/2166

### Description
Change enables us to reach endpoint "/wpcom/v2/gutenberg/available-extensions" which is used in WPAndroid for checking which jetpack blocks are enabled for a given site in the block editor

### Related PR's
FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1581
Gutenberg-Mobile branch: https://github.com/wordpress-mobile/gutenberg-mobile/compare/add/wpcom-api-supported-extensions-jetpack-blocks?expand=1

### To test: 
Create a new article and add a Contact Info block. 

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
