### PR TITLE
Replace FragmentTransaction.show/hide with attach/detach - fix lifecycle

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -166,9 +166,9 @@ class WPMainNavigationView @JvmOverloads constructor(
         val previousFragment = navAdapter.getFragment(prevPosition)
         if (fragment != null) {
             if (previousFragment != null) {
-                fragmentManager.beginTransaction().hide(previousFragment).show(fragment).commit()
+                fragmentManager.beginTransaction().detach(previousFragment).attach(fragment).commit()
             } else {
-                fragmentManager.beginTransaction().show(fragment).commit()
+                fragmentManager.beginTransaction().attach(fragment).commit()
             }
         }
         prevPosition = position


### PR DESCRIPTION
The recent changes to the BottomNavigation component introduced an anticipated issue with the fragment lifecycle. When `show/hide` methods are used, even fragments which are not visible on the screen are still in the `RESUMED` state. This behavior has several downsides - it requires way more memory and also breaks tons of behavior which relies on `onPause` being invoked when the fragment goes to background. A couple of examples would be tracking and registration to an event bus.

To test:
- Make sure bottom navigation works
- Make sure only a single instance of each fragment lives in the memory
- Make sure onPause is called when you select a different tab

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
