### PR TITLE
Set discover tab selection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -447,6 +447,8 @@ public class ReaderPostListFragment extends Fragment
             mSearchMenuItem.expandActionView();
             mRecyclerView.setToolbarScrollFlags(0);
         }
+
+        handleDefaultToDiscover();
     }
 
     private void initSubFilterViewModel() {
@@ -2812,5 +2814,19 @@ public class ReaderPostListFragment extends Fragment
 
     private boolean isFollowingScreen() {
         return mTagFragmentStartedWith != null && mTagFragmentStartedWith.isFollowedSites();
+    }
+
+    private void handleDefaultToDiscover() {
+        if (!mIsTopLevel) return;
+
+        if (AppPrefs.getReaderTag() == null) {
+            ReaderTag discoverTag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
+            String discoverLabel = requireActivity().getString(R.string.reader_discover_display_name);
+
+            if (discoverTag != null && discoverTag.getTagDisplayName().equals(discoverLabel)) {
+                setCurrentTag(discoverTag);
+                mReaderViewModel.selectedTabChange(discoverTag);
+            }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -447,8 +447,6 @@ public class ReaderPostListFragment extends Fragment
             mSearchMenuItem.expandActionView();
             mRecyclerView.setToolbarScrollFlags(0);
         }
-
-        handleDefaultToDiscover();
     }
 
     private void initSubFilterViewModel() {
@@ -2814,19 +2812,5 @@ public class ReaderPostListFragment extends Fragment
 
     private boolean isFollowingScreen() {
         return mTagFragmentStartedWith != null && mTagFragmentStartedWith.isFollowedSites();
-    }
-
-    private void handleDefaultToDiscover() {
-        if (!mIsTopLevel) return;
-
-        if (AppPrefs.getReaderTag() == null) {
-            ReaderTag discoverTag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
-            String discoverLabel = requireActivity().getString(R.string.reader_discover_display_name);
-
-            if (discoverTag != null && discoverTag.getTagDisplayName().equals(discoverLabel)) {
-                setCurrentTag(discoverTag);
-                mReaderViewModel.selectedTabChange(discoverTag);
-            }
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.ui.reader.usecases.LoadReaderTabsUseCase
 import org.wordpress.android.ui.reader.utils.DateProvider
 import org.wordpress.android.util.distinct
 import org.wordpress.android.viewmodel.Event
-import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -32,8 +31,7 @@ class ReaderViewModel @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val dateProvider: DateProvider,
-    private val loadReaderTabsUseCase: LoadReaderTabsUseCase,
-    private val resourceProvider: ResourceProvider
+    private val loadReaderTabsUseCase: LoadReaderTabsUseCase
 ) : ScopedViewModel(mainDispatcher) {
     private var initialized: Boolean = false
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -83,7 +83,7 @@ class ReaderViewModel @Inject constructor(
             }
             appPrefsWrapper.getReaderTag()?.let {
                 selectTab.invoke(it)
-            } ?: tagList.find { it.isDiscover }?.let {
+            } ?: tagList.find { it.isDefaultSelectedTab() }?.let {
                 selectTab.invoke(it)
             }
         }
@@ -117,6 +117,8 @@ class ReaderViewModel @Inject constructor(
     fun onSearchActionClicked() {
         _showSearch.value = Event(Unit)
     }
+
+    fun ReaderTag.isDefaultSelectedTab(): Boolean = this.isDiscover
 
     @Subscribe(threadMode = MAIN)
     fun onTagsUpdated(event: ReaderEvents.FollowedTagsChanged) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -118,7 +118,7 @@ class ReaderViewModel @Inject constructor(
         _showSearch.value = Event(Unit)
     }
 
-    fun ReaderTag.isDefaultSelectedTab(): Boolean = this.isDiscover
+    private fun ReaderTag.isDefaultSelectedTab(): Boolean = this.isDiscover
 
     @Subscribe(threadMode = MAIN)
     fun onTagsUpdated(event: ReaderEvents.FollowedTagsChanged) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -16,8 +16,11 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTag.DISCOVER_PATH
+import org.wordpress.android.models.ReaderTag.FOLLOWING_PATH
+import org.wordpress.android.models.ReaderTag.LIKED_PATH
 import org.wordpress.android.models.ReaderTagList
-import org.wordpress.android.models.ReaderTagType.FOLLOWED
+import org.wordpress.android.models.ReaderTagType
 import org.wordpress.android.test
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.usecases.LoadReaderTabsUseCase
@@ -154,10 +157,23 @@ class ReaderViewModelTest {
     }
 
     @Test
-    fun `SelectTab not invoked when last selected tab is null`() = testWithNonEmptyTags {
+    fun `SelectTab is invoked when last selected tab is null`() = testWithNonMockedNonEmptyTags {
         // Arrange
         whenever(appPrefsWrapper.getReaderTag()).thenReturn(null)
 
+        var tabPosition: TabPosition? = null
+        viewModel.selectTab.observeForever {
+            tabPosition = it.getContentIfNotHandled()
+        }
+        // Act
+        viewModel.start()
+        // Assert
+        assertThat(tabPosition).isGreaterThan(-1)
+    }
+
+    @Test
+    fun `SelectTab when tags are empty`() = testWithEmptyTags {
+        // Arrange
         var tabPosition: TabPosition? = null
         viewModel.selectTab.observeForever {
             tabPosition = it.getContentIfNotHandled()
@@ -219,12 +235,19 @@ class ReaderViewModelTest {
         }
     }
 
+    private fun <T> testWithNonMockedNonEmptyTags(block: suspend CoroutineScope.() -> T) {
+        test {
+            whenever(loadReaderTabsUseCase.loadTabs()).thenReturn(createNonMockedNonEmptyReaderTagList())
+            block()
+        }
+    }
+
     private fun createNonMockedNonEmptyReaderTagList(): ReaderTagList {
         return ReaderTagList().apply {
-            add(ReaderTag("Following", "Following", "Following", " ", FOLLOWED))
-            add(ReaderTag("Discover", "Discover", "Discover", " ", FOLLOWED))
-            add(ReaderTag("Like", "Like", "Like", " ", FOLLOWED))
-            add(ReaderTag("Saved", "Saved", "Saved", "Saved", FOLLOWED))
+            add(ReaderTag("Following", "Following", "Following", FOLLOWING_PATH, ReaderTagType.DEFAULT))
+            add(ReaderTag("Discover", "Discover", "Discover", DISCOVER_PATH, ReaderTagType.DEFAULT))
+            add(ReaderTag("Like", "Like", "Like", LIKED_PATH, ReaderTagType.DEFAULT))
+            add(ReaderTag("Saved", "Saved", "Saved", "Saved", ReaderTagType.DEFAULT))
         }
     }
 }


### PR DESCRIPTION
Fixes #11909 

This PR sets the selected tab to Discover when a reader tag is not available in app preferences and `isTopLevel=true`. This should only happen upon first entry into the reader. 

To test:

**Test that the discover tab is selected upon first entry into reader**

1. Login in to the app with an account that is not following any sites
2. Navigate to Reader
3. Ensure that “Discover” is the selected tab

**Test that the last selected tab remains selected upon app close** 

1. Tap on the "Followed Sites" tab
2. Close the app
3. Open the app
4. Ensure that “Followed Sites” is the selected tab
5. Repeat for My Likes & Saved Posts tabs

**Test that the last selected tab remains selected navigate away from Reader** 
1. Tap on the "Followed Sites" tab
2. Tap on My site from the navigation bar
3. Tap on the Reader tab
4. Ensure that “Followed Sites” is the selected tab
5. Repeat for My Likes & Saved Posts tabs

PR submission checklist:

- [X ] I have considered adding unit tests where possible.
- [X ] I have considered adding accessibility improvements for my changes.
- [X ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
