### PR TITLE
Bumped androidx core and fragment dependencies to latest

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -170,9 +170,9 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.6.2'
     implementation 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
 
-    implementation 'androidx.core:core:1.0.2'
+    implementation 'androidx.core:core:1.2.0'
     implementation 'androidx.legacy:legacy-support-core-ui:1.0.0'
-    implementation 'androidx.fragment:fragment:1.0.0'
+    implementation 'androidx.fragment:fragment:1.2.4'
 
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/CommentFullScreenDialogFragment.kt
@@ -51,7 +51,7 @@ class CommentFullScreenDialogFragment : Fragment(), CollapseFullScreenDialogCont
             }
         })
 
-        viewModel.onKeyboardOpened.observe(this, Observer {
+        viewModel.onKeyboardOpened.observe(viewLifecycleOwner, Observer {
             it?.applyIfNotHandled {
                 coroutineScope.launch {
                     val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -30,12 +30,12 @@ class JetpackRemoteInstallFragment : Fragment() {
     private lateinit var viewModel: JetpackRemoteInstallViewModel
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (activity!!.application as WordPress).component()!!.inject(this)
+        (requireActivity().application as WordPress).component()!!.inject(this)
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        activity!!.let { activity ->
+        requireActivity().let { activity ->
             viewModel = ViewModelProviders.of(this, viewModelFactory)
                     .get<JetpackRemoteInstallViewModel>(JetpackRemoteInstallViewModel::class.java)
 
@@ -104,7 +104,7 @@ class JetpackRemoteInstallFragment : Fragment() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == JETPACK_LOGIN && resultCode == Activity.RESULT_OK) {
-            val site = activity!!.intent!!.getSerializableExtra(WordPress.SITE) as SiteModel
+            val site = requireActivity().intent!!.getSerializableExtra(WordPress.SITE) as SiteModel
             viewModel.onLogin(site.id)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -44,7 +44,7 @@ class JetpackRemoteInstallFragment : Fragment() {
             val source = intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
             val retrievedState = savedInstanceState?.getSerializable(VIEW_STATE) as? JetpackRemoteInstallViewState.Type
             viewModel.start(site, retrievedState)
-            viewModel.liveViewState.observe(this, Observer { viewState ->
+            viewModel.liveViewState.observe(viewLifecycleOwner, Observer { viewState ->
                 if (viewState != null) {
                     if (viewState is JetpackRemoteInstallViewState.Error) {
                         AppLog.e(AppLog.T.JETPACK_REMOTE_INSTALL, "An error occurred while installing Jetpack")
@@ -68,7 +68,7 @@ class JetpackRemoteInstallFragment : Fragment() {
                     jetpack_install_progress.visibility = if (viewState.progressBarVisible) View.VISIBLE else View.GONE
                 }
             })
-            viewModel.liveActionOnResult.observe(this, Observer { result ->
+            viewModel.liveActionOnResult.observe(viewLifecycleOwner, Observer { result ->
                 if (result != null) {
                     when (result.action) {
                         MANUAL_INSTALL -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -67,7 +67,7 @@ class ActivityLogDetailFragment : Fragment() {
                 else -> throw Throwable("Couldn't initialize Activity Log view model")
             }
 
-            viewModel.activityLogItem.observe(this, Observer { activityLogModel ->
+            viewModel.activityLogItem.observe(viewLifecycleOwner, Observer { activityLogModel ->
                 setActorIcon(activityLogModel?.actorIconUrl, activityLogModel?.showJetpackIcon)
                 uiHelpers.setTextOrHide(activityActorName, activityLogModel?.actorName)
                 uiHelpers.setTextOrHide(activityActorRole, activityLogModel?.actorRole)
@@ -97,15 +97,15 @@ class ActivityLogDetailFragment : Fragment() {
                 }
             })
 
-            viewModel.rewindAvailable.observe(this, Observer { available ->
+            viewModel.rewindAvailable.observe(viewLifecycleOwner, Observer { available ->
                 activityRewindButton.visibility = if (available == true) View.VISIBLE else View.GONE
             })
 
-            viewModel.showRewindDialog.observe(this, Observer<ActivityLogDetailModel> { detailModel ->
+            viewModel.showRewindDialog.observe(viewLifecycleOwner, Observer<ActivityLogDetailModel> { detailModel ->
                 detailModel?.let { onRewindButtonClicked(it) }
             })
 
-            viewModel.handleFormattableRangeClick.observe(this, Observer<FormattableRange> { range ->
+            viewModel.handleFormattableRangeClick.observe(viewLifecycleOwner, Observer<FormattableRange> { range ->
                 if (range != null) {
                     formattableContentClickHandler.onClick(activity, range)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -39,7 +39,7 @@ class ActivityLogListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
 
         log_list_view.layoutManager = LinearLayoutManager(nonNullActivity, RecyclerView.VERTICAL, false)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -86,27 +86,27 @@ class ActivityLogListFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.events.observe(this, Observer {
+        viewModel.events.observe(viewLifecycleOwner, Observer {
             reloadEvents(it ?: emptyList())
         })
 
-        viewModel.eventListStatus.observe(this, Observer { listStatus ->
+        viewModel.eventListStatus.observe(viewLifecycleOwner, Observer { listStatus ->
             refreshProgressBars(listStatus)
         })
 
-        viewModel.showItemDetail.observe(this, Observer {
+        viewModel.showItemDetail.observe(viewLifecycleOwner, Observer {
             if (it is ActivityLogListItem.Event) {
                 ActivityLauncher.viewActivityLogDetailForResult(activity, viewModel.site, it.activityId)
             }
         })
 
-        viewModel.showRewindDialog.observe(this, Observer {
+        viewModel.showRewindDialog.observe(viewLifecycleOwner, Observer {
             if (it is ActivityLogListItem.Event) {
                 displayRewindDialog(it)
             }
         })
 
-        viewModel.showSnackbarMessage.observe(this, Observer { message ->
+        viewModel.showSnackbarMessage.observe(viewLifecycleOwner, Observer { message ->
             val parent: View? = activity?.findViewById(android.R.id.content)
             if (message != null && parent != null) {
                 WPSnackbar.make(parent, message, Snackbar.LENGTH_LONG).show()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -168,7 +168,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.uiState.observe(this,
+        viewModel.uiState.observe(viewLifecycleOwner,
                 Observer { uiState ->
                     uiState?.let {
                         toggleFormProgressIndictor(uiState.isFormProgressIndicatorVisible)
@@ -196,7 +196,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
                 })
 
         viewModel.domainContactForm.observe(
-                this,
+                viewLifecycleOwner,
                 Observer<DomainContactFormModel> { domainContactFormModel ->
                     val currentModel = getDomainContactFormModel()
                     if (currentModel != domainContactFormModel) {
@@ -204,21 +204,21 @@ class DomainRegistrationDetailsFragment : Fragment() {
                     }
                 })
 
-        viewModel.showCountryPickerDialog.observe(this,
+        viewModel.showCountryPickerDialog.observe(viewLifecycleOwner,
                 Observer {
                     if (it != null && it.isNotEmpty()) {
                         showCountryPicker(it)
                     }
                 })
 
-        viewModel.showStatePickerDialog.observe(this,
+        viewModel.showStatePickerDialog.observe(viewLifecycleOwner,
                 Observer {
                     if (it != null && it.isNotEmpty()) {
                         showStatePicker(it)
                     }
                 })
 
-        viewModel.formError.observe(this,
+        viewModel.formError.observe(viewLifecycleOwner,
                 Observer { error ->
                     var affectedInputFields: Array<TextInputEditText>? = null
 
@@ -249,17 +249,17 @@ class DomainRegistrationDetailsFragment : Fragment() {
                     affectedInputFields?.firstOrNull { it.requestFocus() }
                 })
 
-        viewModel.showErrorMessage.observe(this,
+        viewModel.showErrorMessage.observe(viewLifecycleOwner,
                 Observer { errorMessage ->
                     ToastUtils.showToast(context, errorMessage)
                 })
 
-        viewModel.handleCompletedDomainRegistration.observe(this,
+        viewModel.handleCompletedDomainRegistration.observe(viewLifecycleOwner,
                 Observer { domainRegisteredEvent ->
                     mainViewModel.completeDomainRegistration(domainRegisteredEvent)
                 })
 
-        viewModel.showTos.observe(this,
+        viewModel.showTos.observe(viewLifecycleOwner,
                 Observer {
                     ActivityLauncher.openUrlExternal(
                             context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -70,7 +70,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
         (nonNullActivity.application as WordPress).component()?.inject(this)
     }
 
@@ -85,14 +85,14 @@ class DomainRegistrationDetailsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        mainViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        mainViewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
                 .get(DomainRegistrationMainViewModel::class.java)
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(DomainRegistrationDetailsViewModel::class.java)
         setupObservers()
 
         val domainProductDetails = arguments?.getParcelable(EXTRA_DOMAIN_PRODUCT_DETAILS) as DomainProductDetails
-        val site = activity!!.intent?.getSerializableExtra(WordPress.SITE) as SiteModel
+        val site = requireActivity().intent?.getSerializableExtra(WordPress.SITE) as SiteModel
 
         viewModel.start(site, domainProductDetails)
 
@@ -440,7 +440,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
 
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
-            states = arguments!!.getParcelableArrayList<SupportedStateResponse>(EXTRA_STATES)
+            states = requireArguments().getParcelableArrayList<SupportedStateResponse>(EXTRA_STATES)
                     as ArrayList<SupportedStateResponse>
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationResultFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationResultFragment.kt
@@ -51,8 +51,9 @@ class DomainRegistrationResultFragment : Fragment() {
         continue_button.setOnClickListener {
             val intent = Intent()
             intent.putExtra(RESULT_REGISTERED_DOMAIN_EMAIL, email)
-            activity!!.setResult(RESULT_OK, intent)
-            activity!!.finish()
+            val nonNullActivity = requireActivity()
+            nonNullActivity.setResult(RESULT_OK, intent)
+            nonNullActivity.finish()
         }
 
         domain_registration_result_message.text = HtmlCompat.fromHtml(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -93,12 +93,12 @@ class DomainSuggestionsFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.isIntroVisible.observe(this, Observer {
+        viewModel.isIntroVisible.observe(viewLifecycleOwner, Observer {
             it?.let { isIntroVisible ->
                 introduction_container.visibility = if (isIntroVisible) View.VISIBLE else View.GONE
             }
         })
-        viewModel.suggestionsLiveData.observe(this, Observer { listState ->
+        viewModel.suggestionsLiveData.observe(viewLifecycleOwner, Observer { listState ->
             if (listState != null) {
                 val isLoading = listState is ListState.Loading<*>
 
@@ -120,7 +120,7 @@ class DomainSuggestionsFragment : Fragment() {
                 }
             }
         })
-        viewModel.choseDomainButtonEnabledState.observe(this, Observer {
+        viewModel.choseDomainButtonEnabledState.observe(viewLifecycleOwner, Observer {
             chose_domain_button.isEnabled = it ?: false
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -46,10 +46,10 @@ class DomainSuggestionsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
         (nonNullActivity.application as WordPress).component().inject(this)
 
-        mainViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        mainViewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
                 .get(DomainRegistrationMainViewModel::class.java)
 
         viewModel = ViewModelProviders.of(this, viewModelFactory)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -91,11 +91,11 @@ class PageListFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.pages.observe(this, Observer { data ->
+        viewModel.pages.observe(viewLifecycleOwner, Observer { data ->
             data?.let { setPages(data.first, data.second, data.third) }
         })
 
-        viewModel.scrollToPosition.observe(this, Observer { position ->
+        viewModel.scrollToPosition.observe(viewLifecycleOwner, Observer { position ->
             position?.let {
                 val smoothScroller = object : LinearSmoothScroller(context) {
                     override fun getVerticalSnapPreference(): Int {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -53,7 +53,7 @@ class PageListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
 
         initializeViews(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
@@ -149,7 +149,7 @@ class PageParentFragment : Fragment() {
         pageId = activity?.intent?.getLongExtra(EXTRA_PAGE_REMOTE_ID_KEY, 0)
 
         val nonNullPageId = checkNotNull(pageId)
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
 
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
@@ -194,15 +194,15 @@ class PageParentFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.pages.observe(this, Observer { pages ->
+        viewModel.pages.observe(viewLifecycleOwner, Observer { pages ->
             pages?.let { setPages(pages) }
         })
 
-        viewModel.isSaveButtonVisible.observe(this, Observer { isVisible ->
+        viewModel.isSaveButtonVisible.observe(viewLifecycleOwner, Observer { isVisible ->
             isVisible?.let { saveButton?.isVisible = isVisible }
         })
 
-        viewModel.saveParent.observe(this, Observer {
+        viewModel.saveParent.observe(viewLifecycleOwner, Observer {
             returnParentChoiceAndExit()
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
@@ -85,7 +85,7 @@ class PageParentSearchFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.searchResult.observe(this, Observer { data ->
+        viewModel.searchResult.observe(viewLifecycleOwner, Observer { data ->
             data?.let { setSearchResult(data) }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
@@ -48,7 +48,7 @@ class PageParentSearchFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
 
         initializeViews(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -292,17 +292,17 @@ class PagesFragment : Fragment() {
     }
 
     private fun setupObservers(activity: FragmentActivity) {
-        viewModel.listState.observe(this, Observer {
+        viewModel.listState.observe(viewLifecycleOwner, Observer {
             refreshProgressBars(it)
         })
 
-        viewModel.createNewPage.observe(this, Observer {
+        viewModel.createNewPage.observe(viewLifecycleOwner, Observer {
             QuickStartUtils.completeTaskAndRemindNextOne(quickStartStore, QuickStartTask.CREATE_NEW_PAGE, dispatcher,
                     viewModel.site, quickStartEvent, context)
             ActivityLauncher.addNewPageForResult(this, viewModel.site, PAGE_FROM_PAGES_LIST)
         })
 
-        viewModel.showSnackbarMessage.observe(this, Observer { holder ->
+        viewModel.showSnackbarMessage.observe(viewLifecycleOwner, Observer { holder ->
             val parent = activity.findViewById<View>(R.id.coordinatorLayout)
             if (holder != null && parent != null) {
                 if (holder.buttonTitleRes == null) {
@@ -315,25 +315,25 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.editPage.observe(this, Observer { (site, page, loadAutoRevision) ->
+        viewModel.editPage.observe(viewLifecycleOwner, Observer { (site, page, loadAutoRevision) ->
             page?.let {
                 ActivityLauncher.editPageForResult(this, site, page.id, loadAutoRevision)
             }
         })
 
-        viewModel.previewPage.observe(this, Observer { post ->
+        viewModel.previewPage.observe(viewLifecycleOwner, Observer { post ->
             post?.let {
                 previewPage(activity, post)
             }
         })
 
-        viewModel.browsePreview.observe(this, Observer { preview ->
+        viewModel.browsePreview.observe(viewLifecycleOwner, Observer { preview ->
             preview?.let {
                 ActivityLauncher.previewPostOrPageForResult(activity, viewModel.site, preview.post, preview.previewType)
             }
         })
 
-        viewModel.previewState.observe(this, Observer {
+        viewModel.previewState.observe(viewLifecycleOwner, Observer {
             progressDialog = progressDialogHelper.updateProgressDialogState(
                     activity,
                     progressDialog,
@@ -342,11 +342,11 @@ class PagesFragment : Fragment() {
             )
         })
 
-        viewModel.setPageParent.observe(this, Observer { page ->
+        viewModel.setPageParent.observe(viewLifecycleOwner, Observer { page ->
             page?.let { ActivityLauncher.viewPageParentForResult(this, page) }
         })
 
-        viewModel.isNewPageButtonVisible.observe(this, Observer { isVisible ->
+        viewModel.isNewPageButtonVisible.observe(viewLifecycleOwner, Observer { isVisible ->
             isVisible?.let {
                 if (isVisible) {
                     newPageButton.show()
@@ -356,7 +356,7 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.scrollToPage.observe(this, Observer { requestedPage ->
+        viewModel.scrollToPage.observe(viewLifecycleOwner, Observer { requestedPage ->
             requestedPage?.let { page ->
                 val pagerIndex = PagesPagerAdapter.pageTypes.indexOf(PageListType.fromPageStatus(page.status))
                 pagesPager.currentItem = pagerIndex
@@ -364,11 +364,11 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.dialogAction.observe(this, Observer {
+        viewModel.dialogAction.observe(viewLifecycleOwner, Observer {
             it?.show(activity, activity.supportFragmentManager, uiHelpers)
         })
 
-        viewModel.postUploadAction.observe(this, Observer {
+        viewModel.postUploadAction.observe(viewLifecycleOwner, Observer {
             it?.let { (post, site, data) ->
                 uploadUtilsWrapper.handleEditPostResultSnackbars(
                         activity,
@@ -393,7 +393,7 @@ class PagesFragment : Fragment() {
             }
         })
 
-        viewModel.uploadFinishedAction.observe(this, Observer {
+        viewModel.uploadFinishedAction.observe(viewLifecycleOwner, Observer {
             it?.let { (page, isError) ->
                 uploadUtilsWrapper.onPostUploadedSnackbarHandler(
                         activity,

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -114,7 +114,7 @@ class PagesFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
 
         initializeViews(nonNullActivity)
@@ -480,7 +480,7 @@ class PagesFragment : Fragment() {
                 )
 
                 WPDialogSnackbar.make(
-                        view!!.findViewById(R.id.coordinatorLayout), title,
+                        requireView().findViewById(R.id.coordinatorLayout), title,
                         resources.getInteger(R.integer.quick_start_snackbar_duration_ms)
                 ).show()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
@@ -78,7 +78,7 @@ class SearchListFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        viewModel.searchResult.observe(this, Observer { data ->
+        viewModel.searchResult.observe(viewLifecycleOwner, Observer { data ->
             data?.let { setSearchResult(data) }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
@@ -43,7 +43,7 @@ class SearchListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
 
         initializeViews(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansListFragment.kt
@@ -81,11 +81,11 @@ class PlansListFragment : Fragment() {
     }
 
     private fun setObservers() {
-        viewModel.plans.observe(this, Observer {
+        viewModel.plans.observe(viewLifecycleOwner, Observer {
             reloadList(it ?: emptyList())
         })
 
-        viewModel.listStatus.observe(this, Observer { listStatus ->
+        viewModel.listStatus.observe(viewLifecycleOwner, Observer { listStatus ->
             if (isAdded && view != null) {
                 swipeToRefreshHelper.isRefreshing = listStatus == FETCHING
             }
@@ -118,7 +118,7 @@ class PlansListFragment : Fragment() {
             }
         })
 
-        viewModel.showDialog.observe(this, Observer {
+        viewModel.showDialog.observe(viewLifecycleOwner, Observer {
             if (it is PlanOffersModel && activity is PlansListInterface) {
                 (activity as PlansListInterface).onPlanItemClicked(it)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansListFragment.kt
@@ -43,7 +43,7 @@ class PlansListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
 
         empty_recycler_view.layoutManager = LinearLayoutManager(nonNullActivity, RecyclerView.VERTICAL, false)
         empty_recycler_view.setEmptyView(actionable_empty_view)
@@ -71,7 +71,7 @@ class PlansListFragment : Fragment() {
         val adapter: PlansListAdapter
 
         if (empty_recycler_view.adapter == null) {
-            adapter = PlansListAdapter(checkNotNull(activity), this::onItemClicked)
+            adapter = PlansListAdapter(requireActivity(), this::onItemClicked)
             empty_recycler_view.adapter = adapter
         } else {
             adapter = empty_recycler_view.adapter as PlansListAdapter

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -93,35 +93,35 @@ public class PluginListFragment extends Fragment {
 
     private void setupObservers() {
         mViewModel.getSitePluginsLiveData()
-                  .observe(this, listState -> {
+                  .observe(getViewLifecycleOwner(), listState -> {
                       if (mListType == PluginListType.SITE) {
                           refreshPluginsAndProgressBars(listState);
                       }
                   });
 
         mViewModel.getFeaturedPluginsLiveData()
-                  .observe(this, listState -> {
+                  .observe(getViewLifecycleOwner(), listState -> {
                       if (mListType == PluginListType.FEATURED) {
                           refreshPluginsAndProgressBars(listState);
                       }
                   });
 
         mViewModel.getPopularPluginsLiveData()
-                  .observe(this, listState -> {
+                  .observe(getViewLifecycleOwner(), listState -> {
                       if (mListType == PluginListType.POPULAR) {
                           refreshPluginsAndProgressBars(listState);
                       }
                   });
 
         mViewModel.getNewPluginsLiveData()
-                  .observe(this, listState -> {
+                  .observe(getViewLifecycleOwner(), listState -> {
                       if (mListType == PluginListType.NEW) {
                           refreshPluginsAndProgressBars(listState);
                       }
                   });
 
         mViewModel.getSearchResultsLiveData()
-                  .observe(this, listState -> {
+                  .observe(getViewLifecycleOwner(), listState -> {
                       if (mListType == PluginListType.SEARCH) {
                           refreshPluginsAndProgressBars(listState);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
@@ -33,8 +33,8 @@ class EditPostPublishSettingsFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (activity!!.applicationContext as WordPress).component().inject(this)
-        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
+        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
                 .get(EditPostPublishSettingsViewModel::class.java)
     }
 
@@ -156,7 +156,7 @@ class EditPostPublishSettingsFragment : Fragment() {
         }
 
         val fragment = PostDatePickerDialogFragment.newInstance()
-        fragment.show(activity!!.supportFragmentManager, PostDatePickerDialogFragment.TAG)
+        fragment.show(requireActivity().supportFragmentManager, PostDatePickerDialogFragment.TAG)
     }
 
     private fun showPostTimeSelectionDialog() {
@@ -165,7 +165,7 @@ class EditPostPublishSettingsFragment : Fragment() {
         }
 
         val fragment = PostTimePickerDialogFragment.newInstance()
-        fragment.show(activity!!.supportFragmentManager, PostTimePickerDialogFragment.TAG)
+        fragment.show(requireActivity().supportFragmentManager, PostTimePickerDialogFragment.TAG)
     }
 
     private fun showNotificationTimeSelectionDialog(schedulingReminderPeriod: SchedulingReminderModel.Period?) {
@@ -174,7 +174,7 @@ class EditPostPublishSettingsFragment : Fragment() {
         }
 
         val fragment = PostNotificationScheduleTimeDialogFragment.newInstance(schedulingReminderPeriod)
-        fragment.show(activity!!.supportFragmentManager, PostNotificationScheduleTimeDialogFragment.TAG)
+        fragment.show(requireActivity().supportFragmentManager, PostNotificationScheduleTimeDialogFragment.TAG)
     }
 
     private fun getPostRepository(): EditPostRepository? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
@@ -53,24 +53,24 @@ class EditPostPublishSettingsFragment : Fragment() {
 
         dateAndTimeContainer.setOnClickListener { showPostDateSelectionDialog() }
 
-        viewModel.onDatePicked.observe(this, Observer {
+        viewModel.onDatePicked.observe(viewLifecycleOwner, Observer {
             it?.applyIfNotHandled {
                 showPostTimeSelectionDialog()
             }
         })
-        viewModel.onPublishedDateChanged.observe(this, Observer {
+        viewModel.onPublishedDateChanged.observe(viewLifecycleOwner, Observer {
             it?.let { date ->
                 viewModel.updatePost(date, getPostRepository())
             }
         })
-        viewModel.onNotificationTime.observe(this, Observer {
+        viewModel.onNotificationTime.observe(viewLifecycleOwner, Observer {
             it?.let { notificationTime ->
                 getPostRepository()?.let { postRepository ->
                     viewModel.scheduleNotification(postRepository, notificationTime)
                 }
             }
         })
-        viewModel.onUiModel.observe(this, Observer {
+        viewModel.onUiModel.observe(viewLifecycleOwner, Observer {
             it?.let { uiModel ->
                 dateAndTime.text = uiModel.publishDateLabel
                 publishNotificationTitle.isEnabled = uiModel.notificationEnabled
@@ -98,12 +98,12 @@ class EditPostPublishSettingsFragment : Fragment() {
                 addToCalendarContainer.visibility = if (uiModel.notificationVisible) View.VISIBLE else View.GONE
             }
         })
-        viewModel.onShowNotificationDialog.observe(this, Observer {
+        viewModel.onShowNotificationDialog.observe(viewLifecycleOwner, Observer {
             it?.getContentIfNotHandled()?.let { notificationTime ->
                 showNotificationTimeSelectionDialog(notificationTime)
             }
         })
-        viewModel.onToast.observe(this, Observer {
+        viewModel.onToast.observe(viewLifecycleOwner, Observer {
             it?.applyIfNotHandled {
                 ToastUtils.showToast(
                         context,
@@ -113,7 +113,7 @@ class EditPostPublishSettingsFragment : Fragment() {
                 )
             }
         })
-        viewModel.onNotificationAdded.observe(this, Observer { event ->
+        viewModel.onNotificationAdded.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { notification ->
                 activity?.let {
                     NotificationManagerCompat.from(it).cancel(notification.id)
@@ -135,7 +135,7 @@ class EditPostPublishSettingsFragment : Fragment() {
                 }
             }
         })
-        viewModel.onAddToCalendar.observe(this, Observer {
+        viewModel.onAddToCalendar.observe(viewLifecycleOwner, Observer {
             it?.getContentIfNotHandled()?.let { calendarEvent ->
                 val calIntent = Intent(Intent.ACTION_INSERT)
                 calIntent.data = Events.CONTENT_URI

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -383,12 +383,12 @@ public class EditPostSettingsFragment extends Fragment {
             mFormatContainer.setVisibility(View.GONE);
         }
 
-        mPublishedViewModel.getOnUiModel().observe(this, new Observer<PublishUiModel>() {
+        mPublishedViewModel.getOnUiModel().observe(getViewLifecycleOwner(), new Observer<PublishUiModel>() {
             @Override public void onChanged(PublishUiModel uiModel) {
                 updatePublishDateTextView(uiModel.getPublishDateLabel());
             }
         });
-        mPublishedViewModel.getOnPostStatusChanged().observe(this, new Observer<PostStatus>() {
+        mPublishedViewModel.getOnPostStatusChanged().observe(getViewLifecycleOwner(), new Observer<PostStatus>() {
             @Override public void onChanged(PostStatus postStatus) {
                 updatePostStatus(postStatus);
             }
@@ -1087,7 +1087,7 @@ public class EditPostSettingsFragment extends Fragment {
                 return;
             }
             StringBuilder sb = new StringBuilder();
-            for (int i = 0;; ++i) {
+            for (int i = 0; ; ++i) {
                 sb.append(address.getAddressLine(i));
                 if (i == address.getMaxAddressLineIndex()) {
                     sb.append(".");
@@ -1123,7 +1123,7 @@ public class EditPostSettingsFragment extends Fragment {
             ToastUtils.showToast(getActivity(), R.string.post_settings_error_placepicker_missing_play_services);
         } catch (GooglePlayServicesRepairableException re) {
             GoogleApiAvailability.getInstance().getErrorDialog(getActivity(), re.getConnectionStatusCode(),
-                                                               ACTIVITY_REQUEST_PLAY_SERVICES_RESOLUTION);
+                    ACTIVITY_REQUEST_PLAY_SERVICES_RESOLUTION);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -122,11 +122,11 @@ class HistoryListFragment : Fragment() {
     }
 
     private fun setObservers() {
-        viewModel.revisions.observe(this, Observer {
+        viewModel.revisions.observe(viewLifecycleOwner, Observer {
             reloadList(it ?: emptyList())
         })
 
-        viewModel.listStatus.observe(this, Observer { listStatus ->
+        viewModel.listStatus.observe(viewLifecycleOwner, Observer { listStatus ->
             listStatus?.let {
                 if (isAdded && view != null) {
                     swipeToRefreshHelper.isRefreshing = listStatus == HistoryListStatus.FETCHING
@@ -156,7 +156,7 @@ class HistoryListFragment : Fragment() {
             }
         })
 
-        viewModel.showDialog.observe(this, Observer { showDialogItem ->
+        viewModel.showDialog.observe(viewLifecycleOwner, Observer { showDialogItem ->
             if (showDialogItem != null && showDialogItem.historyListItem is Revision) {
                 (activity as HistoryItemClickInterface).onHistoryItemClicked(
                         showDialogItem.historyListItem,
@@ -165,7 +165,7 @@ class HistoryListFragment : Fragment() {
             }
         })
 
-        viewModel.post.observe(this, Observer { post ->
+        viewModel.post.observe(viewLifecycleOwner, Observer { post ->
             actionable_empty_view.subtitle.text = if (post?.isPage == true) {
                 getString(R.string.history_empty_subtitle_page)
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -59,7 +59,7 @@ class HistoryListFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        (checkNotNull(activity).application as WordPress).component()?.inject(this)
+        (requireActivity().application as WordPress).component()?.inject(this)
 
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(HistoryViewModel::class.java)
     }
@@ -74,7 +74,7 @@ class HistoryListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
 
         empty_recycler_view.layoutManager = LinearLayoutManager(nonNullActivity, RecyclerView.VERTICAL, false)
         empty_recycler_view.setEmptyView(actionable_empty_view)
@@ -112,7 +112,7 @@ class HistoryListFragment : Fragment() {
         val adapter: HistoryAdapter
 
         if (empty_recycler_view.adapter == null) {
-            adapter = HistoryAdapter(checkNotNull(activity), this::onItemClicked)
+            adapter = HistoryAdapter(requireActivity(), this::onItemClicked)
             empty_recycler_view.adapter = adapter
         } else {
             adapter = empty_recycler_view.adapter as HistoryAdapter

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
@@ -17,7 +17,7 @@ class PostDatePickerDialogFragment : DialogFragment() {
     private lateinit var viewModel: EditPostPublishSettingsViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
                 .get(EditPostPublishSettingsViewModel::class.java)
 
         val datePickerDialog = DatePickerDialog(activity,
@@ -51,7 +51,7 @@ class PostDatePickerDialogFragment : DialogFragment() {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        (activity!!.applicationContext as WordPress).component().inject(this)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -91,7 +91,7 @@ class PostListFragment : Fragment() {
         mainViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
                 .get(PostListMainViewModel::class.java)
 
-        mainViewModel.viewLayoutType.observe(this, Observer { optionaLayoutType ->
+        mainViewModel.viewLayoutType.observe(viewLifecycleOwner, Observer { optionaLayoutType ->
             optionaLayoutType?.let { layoutType ->
                 recyclerView?.removeItemDecoration(itemDecorationCompactLayout)
                 recyclerView?.removeItemDecoration(itemDecorationStandardLayout)
@@ -111,7 +111,7 @@ class PostListFragment : Fragment() {
             }
         })
 
-        mainViewModel.authorSelectionUpdated.observe(this, Observer {
+        mainViewModel.authorSelectionUpdated.observe(viewLifecycleOwner, Observer {
             if (it != null) {
                 if (viewModel.updateAuthorFilterIfNotSearch(it)) {
                     recyclerView?.scrollToPosition(0)
@@ -141,7 +141,7 @@ class PostListFragment : Fragment() {
 
     private fun initObservers() {
         if (postListType == SEARCH) {
-            mainViewModel.searchQuery.observe(this, Observer {
+            mainViewModel.searchQuery.observe(viewLifecycleOwner, Observer {
                 if (TextUtils.isEmpty(it)) {
                     postListAdapter.submitList(null)
                 }
@@ -149,22 +149,22 @@ class PostListFragment : Fragment() {
             })
         }
 
-        viewModel.emptyViewState.observe(this, Observer {
+        viewModel.emptyViewState.observe(viewLifecycleOwner, Observer {
             it?.let { emptyViewState -> updateEmptyViewForState(emptyViewState) }
         })
 
-        viewModel.isFetchingFirstPage.observe(this, Observer {
+        viewModel.isFetchingFirstPage.observe(viewLifecycleOwner, Observer {
             swipeRefreshLayout?.isRefreshing = it == true
         })
 
-        viewModel.pagedListData.observe(this, Observer {
+        viewModel.pagedListData.observe(viewLifecycleOwner, Observer {
             it?.let { pagedListData -> updatePagedListData(pagedListData) }
         })
 
-        viewModel.isLoadingMore.observe(this, Observer {
+        viewModel.isLoadingMore.observe(viewLifecycleOwner, Observer {
             progressLoadMore?.visibility = if (it == true) View.VISIBLE else View.GONE
         })
-        viewModel.scrollToPosition.observe(this, Observer {
+        viewModel.scrollToPosition.observe(viewLifecycleOwner, Observer {
             it?.let { index ->
                 recyclerView?.scrollToPosition(index)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -72,7 +72,7 @@ class PostListFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        nonNullActivity = checkNotNull(activity)
+        nonNullActivity = requireActivity()
         (nonNullActivity.application as WordPress).component().inject(this)
 
         val nonNullIntent = checkNotNull(nonNullActivity.intent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
@@ -25,7 +25,8 @@ class PostNotificationScheduleTimeDialogFragment : DialogFragment() {
         viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
                 .get(EditPostPublishSettingsViewModel::class.java)
         val alertDialogBuilder = MaterialAlertDialogBuilder(activity)
-        val view = requireActivity().layoutInflater.inflate(R.layout.post_notification_type_selector, null) as RadioGroup
+        val view = requireActivity().layoutInflater.inflate(R.layout.post_notification_type_selector, null)
+                as RadioGroup
         alertDialogBuilder.setView(view)
         val notificationTime = arguments?.getString(ARG_NOTIFICATION_SCHEDULE_TIME)?.let {
             SchedulingReminderModel.Period.valueOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
@@ -22,10 +22,10 @@ class PostNotificationScheduleTimeDialogFragment : DialogFragment() {
     private lateinit var viewModel: EditPostPublishSettingsViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
                 .get(EditPostPublishSettingsViewModel::class.java)
         val alertDialogBuilder = MaterialAlertDialogBuilder(activity)
-        val view = activity!!.layoutInflater.inflate(R.layout.post_notification_type_selector, null) as RadioGroup
+        val view = requireActivity().layoutInflater.inflate(R.layout.post_notification_type_selector, null) as RadioGroup
         alertDialogBuilder.setView(view)
         val notificationTime = arguments?.getString(ARG_NOTIFICATION_SCHEDULE_TIME)?.let {
             SchedulingReminderModel.Period.valueOf(
@@ -63,7 +63,7 @@ class PostNotificationScheduleTimeDialogFragment : DialogFragment() {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        (activity!!.applicationContext as WordPress).component().inject(this)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
@@ -17,7 +17,7 @@ class PostTimePickerDialogFragment : DialogFragment() {
     private lateinit var viewModel: EditPostPublishSettingsViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
                 .get(EditPostPublishSettingsViewModel::class.java)
 
         val is24HrFormat = DateFormat.is24HourFormat(activity)
@@ -34,7 +34,7 @@ class PostTimePickerDialogFragment : DialogFragment() {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        (activity!!.applicationContext as WordPress).component().inject(this)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -210,7 +210,7 @@ class ReaderPostDetailFragment : Fragment(),
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (activity!!.application as WordPress).component().inject(this)
+        (requireActivity().application as WordPress).component().inject(this)
         if (savedInstanceState != null) {
             postHistory.restoreInstance(savedInstanceState)
         }
@@ -353,7 +353,7 @@ class ReaderPostDetailFragment : Fragment(),
                             interceptedUri
                     )
                     ReaderActivityLauncher.openUrl(activity, interceptedUri, OpenUrlType.EXTERNAL)
-                    activity!!.finish()
+                    requireActivity().finish()
                 }
                 return true
             }
@@ -595,7 +595,7 @@ class ReaderPostDetailFragment : Fragment(),
             return
         }
 
-        WPSnackbar.make(view!!, R.string.reader_bookmark_snack_title, Snackbar.LENGTH_LONG)
+        WPSnackbar.make(requireView(), R.string.reader_bookmark_snack_title, Snackbar.LENGTH_LONG)
                 .setAction(
                         R.string.reader_bookmark_snack_btn
                 ) {
@@ -616,7 +616,7 @@ class ReaderPostDetailFragment : Fragment(),
         }
 
         if (isAskingToLike != ReaderPostTable.isPostLikedByCurrentUser(post)) {
-            val likeCount = view!!.findViewById<ReaderIconCountView>(R.id.count_likes)
+            val likeCount = requireView().findViewById<ReaderIconCountView>(R.id.count_likes)
             likeCount.isSelected = isAskingToLike
             ReaderAnim.animateLikeButton(likeCount.imageView, isAskingToLike)
 
@@ -878,9 +878,9 @@ class ReaderPostDetailFragment : Fragment(),
             return
         }
 
-        val countLikes = view!!.findViewById<ReaderIconCountView>(R.id.count_likes)
-        val countComments = view!!.findViewById<ReaderIconCountView>(R.id.count_comments)
-        val reblogButton = view!!.findViewById<ReaderIconCountView>(R.id.reblog)
+        val countLikes = requireView().findViewById<ReaderIconCountView>(R.id.count_likes)
+        val countComments = requireView().findViewById<ReaderIconCountView>(R.id.count_comments)
+        val reblogButton = requireView().findViewById<ReaderIconCountView>(R.id.reblog)
 
         if (canBeReblogged()) {
             reblogButton.setCount(0)
@@ -960,7 +960,7 @@ class ReaderPostDetailFragment : Fragment(),
 
         if (!accountStore.hasAccessToken()) {
             WPSnackbar.make(
-                    view!!, R.string.reader_snackbar_err_cannot_like_post_logged_out,
+                    requireView(), R.string.reader_snackbar_err_cannot_like_post_logged_out,
                     Snackbar.LENGTH_INDEFINITE
             ).setAction(R.string.sign_in, mSignInClickListener).show()
             return
@@ -1063,7 +1063,7 @@ class ReaderPostDetailFragment : Fragment(),
      * called when the post doesn't exist in local db, need to get it from server
      */
     private fun requestPost() {
-        val progress = view!!.findViewById<ProgressBar>(R.id.progress_loading)
+        val progress = requireView().findViewById<ProgressBar>(R.id.progress_loading)
         progress.visibility = View.VISIBLE
         progress.bringToFront()
 
@@ -1104,7 +1104,7 @@ class ReaderPostDetailFragment : Fragment(),
             return
         }
 
-        val progress = view!!.findViewById<ProgressBar>(R.id.progress_loading)
+        val progress = requireView().findViewById<ProgressBar>(R.id.progress_loading)
         progress.visibility = View.GONE
 
         if (event.statusCode == 200) {
@@ -1160,7 +1160,7 @@ class ReaderPostDetailFragment : Fragment(),
             return
         }
 
-        val txtError = view!!.findViewById<TextView>(R.id.text_error)
+        val txtError = requireView().findViewById<TextView>(R.id.text_error)
         txtError.text = errorMessage
 
         context?.let {
@@ -1210,7 +1210,7 @@ class ReaderPostDetailFragment : Fragment(),
                     "Failed to load private AT cookie. $event.error.type - $event.error.message"
             )
             WPSnackbar.make(
-                    view!!,
+                    requireView(),
                     string.media_accessing_failed,
                     Snackbar.LENGTH_LONG
             ).show()
@@ -1232,7 +1232,7 @@ class ReaderPostDetailFragment : Fragment(),
         }
 
         WPSnackbar.make(
-                view!!,
+                requireView(),
                 string.media_accessing_failed,
                 Snackbar.LENGTH_LONG
         ).show()
@@ -1450,7 +1450,7 @@ class ReaderPostDetailFragment : Fragment(),
      */
     override fun onRequestCustomView(): ViewGroup? {
         return if (isAdded) {
-            view!!.findViewById<View>(R.id.layout_custom_view_container) as ViewGroup
+            requireView().findViewById<View>(R.id.layout_custom_view_container) as ViewGroup
         } else {
             null
         }
@@ -1461,7 +1461,7 @@ class ReaderPostDetailFragment : Fragment(),
      */
     override fun onRequestContentView(): ViewGroup? {
         return if (isAdded) {
-            view!!.findViewById<View>(R.id.layout_post_detail_container) as ViewGroup
+            requireView().findViewById<View>(R.id.layout_post_detail_container) as ViewGroup
         } else {
             null
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -416,7 +416,7 @@ public class ReaderPostListFragment extends Fragment
             mWPMainActivityViewModel = ViewModelProviders.of((FragmentActivity) getActivity(), mViewModelFactory)
                                                          .get(WPMainActivityViewModel.class);
 
-            mViewModel.getCurrentSubFilter().observe(this, subfilterListItem -> {
+            mViewModel.getCurrentSubFilter().observe(getViewLifecycleOwner(), subfilterListItem -> {
                 if (isCurrentTagManagedInFollowingTab()
                     && getPostListType() != ReaderPostListType.SEARCH_RESULTS) {
                     mViewModel.onSubfilterSelected(subfilterListItem);
@@ -427,12 +427,12 @@ public class ReaderPostListFragment extends Fragment
                 }
             });
 
-            mViewModel.getShouldShowSubFilters().observe(this, show -> {
+            mViewModel.getShouldShowSubFilters().observe(getViewLifecycleOwner(), show -> {
                 mSubFilterComponent.setVisibility(show ? View.VISIBLE : View.GONE);
                 mSettingsButton.setVisibility(mAccountStore.hasAccessToken() ? View.VISIBLE : View.GONE);
             });
 
-            mViewModel.getReaderModeInfo().observe(this, readerModeInfo -> {
+            mViewModel.getReaderModeInfo().observe(getViewLifecycleOwner(), readerModeInfo -> {
                 if (readerModeInfo != null) {
                     changeReaderMode(readerModeInfo, true);
 
@@ -453,7 +453,7 @@ public class ReaderPostListFragment extends Fragment
                 }
             });
 
-            mViewModel.getChangeBottomSheetVisibility().observe(this, event -> {
+            mViewModel.getChangeBottomSheetVisibility().observe(getViewLifecycleOwner(), event -> {
                 event.applyIfNotHandled(isShowing -> {
                     FragmentManager fm = getFragmentManager();
                     if (fm != null) {
@@ -471,7 +471,7 @@ public class ReaderPostListFragment extends Fragment
                 });
             });
 
-            mViewModel.getBottomSheetEmptyViewAction().observe(this, event -> {
+            mViewModel.getBottomSheetEmptyViewAction().observe(getViewLifecycleOwner(), event -> {
                 event.applyIfNotHandled(action -> {
                     if (action instanceof OpenSubsAtPage) {
                         ReaderActivityLauncher.showReaderSubs(
@@ -486,7 +486,7 @@ public class ReaderPostListFragment extends Fragment
                 });
             });
 
-            mViewModel.getUpdateTagsAndSites().observe(this, event -> {
+            mViewModel.getUpdateTagsAndSites().observe(getViewLifecycleOwner(), event -> {
                 event.applyIfNotHandled(tasks -> {
                     if (NetworkUtils.isNetworkAvailable(getActivity())) {
                         ReaderUpdateServiceStarter.startService(getActivity(), tasks);
@@ -496,7 +496,7 @@ public class ReaderPostListFragment extends Fragment
             });
         }
 
-        mViewModel.getShouldCollapseToolbar().observe(this, collapse -> {
+        mViewModel.getShouldCollapseToolbar().observe(getViewLifecycleOwner(), collapse -> {
             if (collapse) {
                 mRecyclerView.setToolbarScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
                                                     | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
@@ -2909,7 +2909,7 @@ public class ReaderPostListFragment extends Fragment
      * Handles reblog state changes and triggers reblog actions
      */
     private void handleReblogStateChanges() {
-        mViewModel.getReblogState().observe(this, event -> {
+        mViewModel.getReblogState().observe(getViewLifecycleOwner(), event -> {
             event.applyIfNotHandled(state -> {
                 if (state instanceof NoSite) {
                     ReaderActivityLauncher.showNoSiteToReblog(getActivity());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -81,7 +81,7 @@ class SubfilterPageFragment : DaggerFragment() {
         readerViewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
                 .get(ReaderPostListViewModel::class.java)
 
-        readerViewModel.subFilters.observe(this, Observer {
+        readerViewModel.subFilters.observe(viewLifecycleOwner, Observer {
             (recyclerView.adapter as? SubfilterListAdapter)?.let { adapter ->
                 var items = it?.filter { it.type == category.type } ?: listOf()
 
@@ -100,7 +100,7 @@ class SubfilterPageFragment : DaggerFragment() {
             }
         })
 
-        viewModel.emptyState.observe(this, Observer { uiState ->
+        viewModel.emptyState.observe(viewLifecycleOwner, Observer { uiState ->
             if (isAdded) {
                 when (uiState) {
                     HiddenEmptyUiState -> emptyStateContainer.visibility = View.GONE

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -80,7 +80,7 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        nonNullActivity = activity!!
+        nonNullActivity = requireActivity()
         (nonNullActivity.application as WordPress).component().inject(this)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -178,7 +178,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
             }
         })
 
-        viewModel.start(arguments!![ARG_DATA] as SiteCreationState)
+        viewModel.start(requireArguments()[ARG_DATA] as SiteCreationState)
     }
 
     private fun initRetryButton() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/SiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/SiteCreationSegmentsFragment.kt
@@ -127,7 +127,7 @@ class SiteCreationSegmentsFragment : SiteCreationBaseFormFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (activity!!.application as WordPress).component().inject(this)
+        (requireActivity().application as WordPress).component().inject(this)
     }
 
     private fun updateContentLayout(segments: SegmentsContentUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -54,7 +54,7 @@ class StatsFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
 
         initializeViewModels(nonNullActivity, savedInstanceState == null, savedInstanceState)
         initializeViews(nonNullActivity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -104,13 +104,13 @@ class StatsFragment : DaggerFragment() {
     }
 
     private fun setupObservers(activity: FragmentActivity) {
-        viewModel.isRefreshing.observe(this, Observer {
+        viewModel.isRefreshing.observe(viewLifecycleOwner, Observer {
             it?.let { isRefreshing ->
                 swipeToRefreshHelper.isRefreshing = isRefreshing
             }
         })
 
-        viewModel.showSnackbarMessage.observe(this, Observer { holder ->
+        viewModel.showSnackbarMessage.observe(viewLifecycleOwner, Observer { holder ->
             val parent = activity.findViewById<View>(R.id.coordinatorLayout)
             if (holder != null && parent != null) {
                 if (holder.buttonTitleRes == null) {
@@ -123,7 +123,7 @@ class StatsFragment : DaggerFragment() {
             }
         })
 
-        viewModel.toolbarHasShadow.observe(this, Observer { hasShadow ->
+        viewModel.toolbarHasShadow.observe(viewLifecycleOwner, Observer { hasShadow ->
             app_bar_layout.postDelayed(
                     {
                         if (app_bar_layout != null) {
@@ -139,7 +139,7 @@ class StatsFragment : DaggerFragment() {
             )
         })
 
-        viewModel.siteChanged.observe(this, Observer { siteChangedEvent ->
+        viewModel.siteChanged.observe(viewLifecycleOwner, Observer { siteChangedEvent ->
             siteChangedEvent?.applyIfNotHandled {
                 when (this) {
                     is SiteUpdateResult.SiteConnected -> viewModel.onSiteChanged()
@@ -148,13 +148,13 @@ class StatsFragment : DaggerFragment() {
             }
         })
 
-        viewModel.hideToolbar.observe(this, Observer { event ->
+        viewModel.hideToolbar.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { hideToolbar ->
                 app_bar_layout.setExpanded(!hideToolbar, true)
             }
         })
 
-        viewModel.selectedSection.observe(this, Observer { selectedSection ->
+        viewModel.selectedSection.observe(viewLifecycleOwner, Observer { selectedSection ->
             selectedSection?.let {
                 val position = when (selectedSection) {
                     INSIGHTS -> 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -156,13 +156,13 @@ class StatsViewAllFragment : DaggerFragment() {
     }
 
     private fun setupObservers(activity: FragmentActivity) {
-        viewModel.isRefreshing.observe(this, Observer {
+        viewModel.isRefreshing.observe(viewLifecycleOwner, Observer {
             it?.let { isRefreshing ->
                 swipeToRefreshHelper.isRefreshing = isRefreshing
             }
         })
 
-        viewModel.showSnackbarMessage.observe(this, Observer { event ->
+        viewModel.showSnackbarMessage.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { holder ->
                 val parent = activity.findViewById<View>(R.id.coordinatorLayout)
                 if (parent != null) {
@@ -177,7 +177,7 @@ class StatsViewAllFragment : DaggerFragment() {
             }
         })
 
-        viewModel.data.observe(this, Observer {
+        viewModel.data.observe(viewLifecycleOwner, Observer {
             if (it != null) {
                 recyclerView.visibility = if (it is StatsBlock.Success) View.VISIBLE else View.GONE
                 loadingContainer.visibility = if (it is StatsBlock.Loading) View.VISIBLE else View.GONE
@@ -198,29 +198,29 @@ class StatsViewAllFragment : DaggerFragment() {
                 }
             }
         })
-        viewModel.navigationTarget.observe(this, Observer { event ->
+        viewModel.navigationTarget.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { target ->
                 navigator.navigate(activity, target)
             }
         })
 
-        viewModel.dateSelectorData.observe(this, Observer { dateSelectorUiModel ->
+        viewModel.dateSelectorData.observe(viewLifecycleOwner, Observer { dateSelectorUiModel ->
             drawDateSelector(dateSelectorUiModel)
         })
 
-        viewModel.navigationTarget.observe(this, Observer { event ->
+        viewModel.navigationTarget.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { target ->
                 navigator.navigate(activity, target)
             }
         })
 
-        viewModel.selectedDate.observe(this, Observer { event ->
+        viewModel.selectedDate.observe(viewLifecycleOwner, Observer { event ->
             if (event != null) {
                 viewModel.onDateChanged()
             }
         })
 
-        viewModel.toolbarHasShadow.observe(this, Observer { hasShadow ->
+        viewModel.toolbarHasShadow.observe(viewLifecycleOwner, Observer { hasShadow ->
             app_bar_layout.postDelayed({
                 if (app_bar_layout != null) {
                     val elevation = if (hasShadow == true) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -112,7 +112,7 @@ class StatsViewAllFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
 
         initializeViews(savedInstanceState)
         initializeViewModels(nonNullActivity, savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -147,7 +147,7 @@ class StatsListFragment : DaggerFragment() {
     }
 
     private fun setupObservers(activity: FragmentActivity) {
-        viewModel.uiModel.observe(this, Observer {
+        viewModel.uiModel.observe(viewLifecycleOwner, Observer {
             when (it) {
                 is UiModel.Success -> {
                     updateInsights(it.data)
@@ -177,33 +177,33 @@ class StatsListFragment : DaggerFragment() {
             }
         })
 
-        viewModel.dateSelectorData.observe(this, Observer { dateSelectorUiModel ->
+        viewModel.dateSelectorData.observe(viewLifecycleOwner, Observer { dateSelectorUiModel ->
             drawDateSelector(dateSelectorUiModel)
         })
 
-        viewModel.navigationTarget.observe(this, Observer { event ->
+        viewModel.navigationTarget.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { target ->
                 navigator.navigate(activity, target)
             }
         })
 
-        viewModel.selectedDate.observe(this, Observer { event ->
+        viewModel.selectedDate.observe(viewLifecycleOwner, Observer { event ->
             if (event != null) {
                 viewModel.onDateChanged(event.selectedSection)
             }
         })
 
-        viewModel.listSelected.observe(this, Observer {
+        viewModel.listSelected.observe(viewLifecycleOwner, Observer {
             viewModel.onListSelected()
         })
 
-        viewModel.typesChanged.observe(this, Observer { event ->
+        viewModel.typesChanged.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let {
                 viewModel.onTypesChanged()
             }
         })
 
-        viewModel.scrollTo?.observe(this, Observer { event ->
+        viewModel.scrollTo?.observe(viewLifecycleOwner, Observer { event ->
             if (event != null) {
                 (recyclerView.adapter as? StatsBlockAdapter)?.let { adapter ->
                     event.getContentIfNotHandled()?.let { statsType ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -118,7 +118,7 @@ class StatsListFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
 
         initializeViews(savedInstanceState)
         initializeViewModels(nonNullActivity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
@@ -37,7 +37,7 @@ class StatsDetailFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val nonNullActivity = checkNotNull(activity)
+        val nonNullActivity = requireActivity()
 
         initializeViewModels(nonNullActivity)
         initializeViews()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
@@ -71,19 +71,19 @@ class StatsDetailFragment : DaggerFragment() {
     }
 
     private fun setupObservers(viewModel: StatsDetailViewModel) {
-        viewModel.isRefreshing.observe(this, Observer {
+        viewModel.isRefreshing.observe(viewLifecycleOwner, Observer {
             it?.let { isRefreshing ->
                 swipeToRefreshHelper.isRefreshing = isRefreshing
             }
         })
 
-        viewModel.selectedDateChanged.observe(this, Observer { event ->
+        viewModel.selectedDateChanged.observe(viewLifecycleOwner, Observer { event ->
             if (event != null) {
                 viewModel.onDateChanged(event.selectedSection)
             }
         })
 
-        viewModel.showDateSelector.observe(this, Observer { dateSelectorUiModel ->
+        viewModel.showDateSelector.observe(viewLifecycleOwner, Observer { dateSelectorUiModel ->
             drawDateSelector(dateSelectorUiModel)
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
@@ -66,7 +66,7 @@ class InsightsManagementFragment : DaggerFragment() {
     }
 
     private fun setupObservers() {
-        viewModel.addedInsights.observe(this, Observer {
+        viewModel.addedInsights.observe(viewLifecycleOwner, Observer {
             it?.let { items ->
                 updateAddedInsights(items)
 
@@ -78,11 +78,11 @@ class InsightsManagementFragment : DaggerFragment() {
             }
         })
 
-        viewModel.closeInsightsManagement.observe(this, Observer {
+        viewModel.closeInsightsManagement.observe(viewLifecycleOwner, Observer {
             requireActivity().finish()
         })
 
-        viewModel.isMenuVisible.observe(this, Observer { isMenuVisible ->
+        viewModel.isMenuVisible.observe(viewLifecycleOwner, Observer { isMenuVisible ->
             isMenuVisible?.let {
                 menu?.findItem(R.id.save_insights)?.isVisible = isMenuVisible
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetColorSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetColorSelectionDialogFragment.kt
@@ -23,10 +23,10 @@ class StatsWidgetColorSelectionDialogFragment : AppCompatDialogFragment() {
     private lateinit var viewModel: StatsColorSelectionViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
                 .get(StatsColorSelectionViewModel::class.java)
         val alertDialogBuilder = MaterialAlertDialogBuilder(activity)
-        val view = activity!!.layoutInflater.inflate(R.layout.stats_color_selector, null) as RadioGroup
+        val view = requireActivity().layoutInflater.inflate(R.layout.stats_color_selector, null) as RadioGroup
         view.setOnCheckedChangeListener { _, checkedId ->
             checkedId.toColor()?.let { viewModel.selectColor(it) }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -69,21 +69,22 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        val nonNullActivity = requireActivity()
+        viewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
                 .get(StatsWidgetConfigureViewModel::class.java)
-        siteSelectionViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        siteSelectionViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
                 .get(StatsSiteSelectionViewModel::class.java)
-        colorSelectionViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        colorSelectionViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
                 .get(StatsColorSelectionViewModel::class.java)
-        activity?.setResult(AppCompatActivity.RESULT_CANCELED)
+        nonNullActivity.setResult(AppCompatActivity.RESULT_CANCELED)
 
-        val appWidgetId = activity?.intent?.extras?.getInt(
+        val appWidgetId = nonNullActivity.intent?.extras?.getInt(
                 AppWidgetManager.EXTRA_APPWIDGET_ID,
                 AppWidgetManager.INVALID_APPWIDGET_ID
         ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
 
         if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
-            activity?.finish()
+            nonNullActivity.finish()
             return
         }
 
@@ -138,13 +139,13 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
                 analyticsTrackerWrapper.trackWithWidgetType(STATS_WIDGET_ADDED, it.widgetType)
                 when (it.widgetType) {
                     WEEK_VIEWS -> {
-                        viewsWidgetUpdater.updateAppWidget(context!!, appWidgetId = it.appWidgetId)
+                        viewsWidgetUpdater.updateAppWidget(requireContext(), appWidgetId = it.appWidgetId)
                     }
                     ALL_TIME_VIEWS -> {
-                        allTimeWidgetUpdater.updateAppWidget(context!!, appWidgetId = it.appWidgetId)
+                        allTimeWidgetUpdater.updateAppWidget(requireContext(), appWidgetId = it.appWidgetId)
                     }
                     TODAY_VIEWS -> {
-                        todayWidgetUpdater.updateAppWidget(context!!, appWidgetId = it.appWidgetId)
+                        todayWidgetUpdater.updateAppWidget(requireContext(), appWidgetId = it.appWidgetId)
                     }
                 }
                 val resultValue = Intent()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -100,13 +100,13 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
             viewModel.addWidget()
         }
 
-        siteSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+        siteSelectionViewModel.dialogOpened.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
                 StatsWidgetSiteSelectionDialogFragment().show(requireFragmentManager(), "stats_site_selection_fragment")
             }
         })
 
-        colorSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+        colorSelectionViewModel.dialogOpened.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
                 StatsWidgetColorSelectionDialogFragment().show(
                         requireFragmentManager(),
@@ -116,14 +116,14 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
         })
 
         merge(siteSelectionViewModel.notification, colorSelectionViewModel.notification).observe(
-                this,
+                viewLifecycleOwner,
                 Observer { event ->
                     event?.applyIfNotHandled {
                         ToastUtils.showToast(activity, this)
                     }
                 })
 
-        viewModel.settingsModel.observe(this, Observer { uiModel ->
+        viewModel.settingsModel.observe(viewLifecycleOwner, Observer { uiModel ->
             uiModel?.let {
                 if (uiModel.siteTitle != null) {
                     site_value.text = uiModel.siteTitle
@@ -133,7 +133,7 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
             }
         })
 
-        viewModel.widgetAdded.observe(this, Observer { event ->
+        viewModel.widgetAdded.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let {
                 analyticsTrackerWrapper.trackWithWidgetType(STATS_WIDGET_ADDED, it.widgetType)
                 when (it.widgetType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetDataTypeSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetDataTypeSelectionDialogFragment.kt
@@ -25,10 +25,11 @@ class StatsWidgetDataTypeSelectionDialogFragment : AppCompatDialogFragment() {
     private lateinit var viewModel: StatsDataTypeSelectionViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        val nonNullActivity = requireActivity()
+        viewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
                 .get(StatsDataTypeSelectionViewModel::class.java)
-        val alertDialogBuilder = MaterialAlertDialogBuilder(activity)
-        val view = activity!!.layoutInflater.inflate(R.layout.stats_data_type_selector, null) as RadioGroup
+        val alertDialogBuilder = MaterialAlertDialogBuilder(nonNullActivity)
+        val view = nonNullActivity.layoutInflater.inflate(R.layout.stats_data_type_selector, null) as RadioGroup
         view.setOnCheckedChangeListener { _, checkedId ->
             checkedId.toDataType()?.let { viewModel.selectDataType(it) }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteSelectionDialogFragment.kt
@@ -22,7 +22,7 @@ class StatsWidgetSiteSelectionDialogFragment : AppCompatDialogFragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: StatsSiteSelectionViewModel
     private fun buildView(): View? {
-        val rootView = activity!!.layoutInflater.inflate(R.layout.stats_widget_site_selector, null)
+        val rootView = requireActivity().layoutInflater.inflate(R.layout.stats_widget_site_selector, null)
         val recyclerView = rootView.findViewById<RecyclerView>(R.id.recycler_view)
         recyclerView.layoutManager = LinearLayoutManager(activity)
         recyclerView.adapter = StatsWidgetSiteAdapter(imageManager)
@@ -36,7 +36,7 @@ class StatsWidgetSiteSelectionDialogFragment : AppCompatDialogFragment() {
         alertDialogBuilder.setNegativeButton(R.string.cancel) { _, _ -> }
         alertDialogBuilder.setCancelable(true)
 
-        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
                 .get(StatsSiteSelectionViewModel::class.java)
         viewModel.sites.observe(this, Observer {
             (requireDialog().recycler_view.adapter as? StatsWidgetSiteAdapter)?.update(it ?: listOf())

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -85,13 +85,13 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
             viewModel.addWidget()
         }
 
-        siteSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+        siteSelectionViewModel.dialogOpened.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
                 StatsWidgetSiteSelectionDialogFragment().show(requireFragmentManager(), "stats_site_selection_fragment")
             }
         })
 
-        colorSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+        colorSelectionViewModel.dialogOpened.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
                 StatsWidgetColorSelectionDialogFragment().show(
                         requireFragmentManager(),
@@ -100,7 +100,7 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
             }
         })
 
-        dataTypeSelectionViewModel.dialogOpened.observe(this, Observer { event ->
+        dataTypeSelectionViewModel.dialogOpened.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
                 StatsWidgetDataTypeSelectionDialogFragment().show(
                         requireFragmentManager(),
@@ -114,14 +114,14 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
                 colorSelectionViewModel.notification,
                 dataTypeSelectionViewModel.notification
         ).observe(
-                this,
+                viewLifecycleOwner,
                 Observer { event ->
                     event?.applyIfNotHandled {
                         ToastUtils.showToast(activity, this)
                     }
                 })
 
-        viewModel.settingsModel.observe(this, Observer { uiModel ->
+        viewModel.settingsModel.observe(viewLifecycleOwner, Observer { uiModel ->
             uiModel?.let {
                 if (uiModel.siteTitle != null) {
                     site_value.text = uiModel.siteTitle
@@ -132,7 +132,7 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
             }
         })
 
-        viewModel.widgetAdded.observe(this, Observer { event ->
+        viewModel.widgetAdded.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let {
                 analyticsTrackerWrapper.trackMinifiedWidget(STATS_WIDGET_ADDED)
                 minifiedWidgetUpdater.updateAppWidget(context!!, appWidgetId = appWidgetId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -48,23 +48,24 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        val nonNullActivity = requireActivity()
+        viewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
                 .get(StatsMinifiedWidgetConfigureViewModel::class.java)
-        siteSelectionViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        siteSelectionViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
                 .get(StatsSiteSelectionViewModel::class.java)
-        colorSelectionViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        colorSelectionViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
                 .get(StatsColorSelectionViewModel::class.java)
-        dataTypeSelectionViewModel = ViewModelProviders.of(activity!!, viewModelFactory)
+        dataTypeSelectionViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
                 .get(StatsDataTypeSelectionViewModel::class.java)
-        activity?.setResult(AppCompatActivity.RESULT_CANCELED)
+        nonNullActivity.setResult(AppCompatActivity.RESULT_CANCELED)
 
-        val appWidgetId = activity?.intent?.extras?.getInt(
+        val appWidgetId = nonNullActivity.intent?.extras?.getInt(
                 AppWidgetManager.EXTRA_APPWIDGET_ID,
                 AppWidgetManager.INVALID_APPWIDGET_ID
         ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
 
         if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
-            activity?.finish()
+            nonNullActivity.finish()
             return
         }
 
@@ -135,7 +136,7 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
         viewModel.widgetAdded.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let {
                 analyticsTrackerWrapper.trackMinifiedWidget(STATS_WIDGET_ADDED)
-                minifiedWidgetUpdater.updateAppWidget(context!!, appWidgetId = appWidgetId)
+                minifiedWidgetUpdater.updateAppWidget(requireContext(), appWidgetId = appWidgetId)
                 val resultValue = Intent()
                 resultValue.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
                 activity?.setResult(RESULT_OK, resultValue)

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
@@ -94,7 +94,7 @@ class FeatureAnnouncementDialogFragment : DialogFragment() {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        (activity!!.applicationContext as WordPress).component().inject(this)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
     }
 
     override fun onPause() {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -141,12 +141,12 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
         mLoginSiteAddressValidator = new LoginSiteAddressValidator();
 
-        mLoginSiteAddressValidator.getIsValid().observe(this, new Observer<Boolean>() {
+        mLoginSiteAddressValidator.getIsValid().observe(getViewLifecycleOwner(), new Observer<Boolean>() {
             @Override public void onChanged(Boolean enabled) {
                 getPrimaryButton().setEnabled(enabled);
             }
         });
-        mLoginSiteAddressValidator.getErrorMessageResId().observe(this, new Observer<Integer>() {
+        mLoginSiteAddressValidator.getErrorMessageResId().observe(getViewLifecycleOwner(), new Observer<Integer>() {
             @Override public void onChanged(Integer resId) {
                 if (resId != null) {
                     showError(resId);


### PR DESCRIPTION
Comes from https://github.com/wordpress-mobile/WordPress-Android/pull/11920#issuecomment-629101519

> As I mentioned on the p2 post I think we should also go through the release notes of fragments v1.2.0 and make sure none of the changes are breaking changes

This PR bumps the fragments and core dependencies to currently stable 1.2.4 and 1.2.0 versions respectively and fixes the lint errors coming with it,  namely:

- `UseRequireInsteadOfGet`, changed every `context!!` and `activity!!` declarations, fixed in c316368
- using `lifeCycleOwner` in all observe() calls where a Fragment or Activity was being added for `ViewModel` changes listening. Done in 92e6600

Note this PR does not implement some of the recommendations (i.e. use of FragmentContainerView), but only those that are enforced by the linter. Implementing the other recommendations would imply a more deep understanding of each feature and a different kind of effort so, leaving that for the future.

In the following section I copied the list of things impacted on each version of these dependencies and added a checkbox so people can review and test and mark it here if all looks good, and leaving those for which I haven't found to be used in our codebase (or related libraries) without a checkbox as we don't need to test those. If you see yourself as a candidate please add yourself to the list and mark the checkbox after having tested the related functionality you're familiar with, with this PR. 🙏 🙇 

#### Fragment checks
Have checked the release notes for 1.2.0 and subsequent .1....4[ here](https://developer.android.com/jetpack/androidx/releases/fragment#1.2.0)

- FragmentContainerView: The FragmentContainerView is the strongly recommended container for dynamically added Fragments, replacing usage of `FrameLayout` or other layouts. It also supports the same `class`, `android:name`, and optional `android:tag` as the `<fragment>` tag, but uses a normal FragmentTransaction to add this initial fragment, instead of the custom code path used by `<fragment>`.
- [x] onDestroyView() timing: Fragments now wait for exit animations, exit framework transitions, and exit AndroidX transitions (when using Transition 1.3.0) to complete before calling onDestroyView(). **Usages** of this in `LoginSiteAddressFragment`, `PreviewImageFragment`, `AztecEditorFragment`, `SiteSettingsFragment`, and `PeopleInvite`. 
- Class based add() and replace(): Added new overloads of add() and replace() on FragmentTransaction that take a Class<? extends Fragment> and optional Bundle of arguments. These methods use your FragmentFactory to construct an instance of the Fragment to add. Kotlin extensions that use reified types (i.e, fragmentTransaction.replace<YourFragment>(R.id.container)) have also been added to fragment-ktx.
- [x] Lifecycle ViewModel SavedState Integration: SavedStateViewModelFactory is now the default factory used when using by viewModels(), by activityViewModels(), the ViewModelProvider constructor, or ViewModelProviders.of() with a Fragment. **Usages** of this (`ViewModelProvider`) found in `EditImageActivity`, `PreviewImageFragment`, and `CropFragment. The `ViewModelProviders.of()` factory is [used extensively so](https://github.com/wordpress-mobile/WordPress-Android/search?q=ViewModelProviders.of&unscoped_q=ViewModelProviders.of), would need a few devs to test.
- [x] New Lint checks: Added a new Lint check that ensures you are using getViewLifecycleOwner() when observing LiveData from onCreateView(), onViewCreated(), or onActivityCreated(). **This is what this PR touches on the most**.
- [x] getFragmentManager() deprecation: The getFragmentManager() and requireFragmentManager() methods on Fragment have been deprecated and replaced with a single getParentFragmentManager() method, which returns the non-null FragmentManager the Fragment is added to (you can use isAdded() to determine if it is safe to call). **Haven't seen a problem with this one but again, it's used everywhere.**. EDIT: discussed elsewhere with @malinajirka , agreed this shouldn't be a problem
- FragmentManager.enableDebugLogging() deprecation: The static FragmentManager.enableDebugLogging method has been deprecated. FragmentManager now respects Log.isLoggable() for the tag FragmentManager, allowing you to enable either DEBUG or VERBOSE logging without re-compiling your app.

#### Core checks
As of [core here](https://developer.android.com/jetpack/androidx/releases/core#1.2.0 ) these things are described as major changes, marking here which ones are used / may have an impact in our codebase.

- [x] Added new APIs and bug fixes in NotificationCompat  (@mzorz to test)
- Added new APIs to work with BlendMode introduced in AndroidQ in backwards-compatible way
- Added new APIs and bug fixes in accessibility compat
- Added new APIs to work with ShortcutInfo (need test: `AddQuickPressShortcutActivity` and test here) EDITED: @mzorz checked, nothing is changed here (only added APIs)
- [x] Added new APIs to work with WindowInsets (@mzorz to test)
- Fixed backwards compatibility for bundle key strings between 28.0 (support library) and 1.1 (AndroidX) in EditorInfoCompat, ShareCompat, WakefulBroadcastReceiver and InputConnectionCompat

To test:
- build and smoke test the app.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
