### PR TITLE
Update FluxC ver to 1.6.12-beta-4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.12-beta-3'
+    fluxCVersion = '1.6.12-beta-4'
 
     appCompatVersion = '1.0.2'
     constraintLayoutVersion = '1.1.3'


### PR DESCRIPTION
This PR updates FluxC version to 1.6.12-beta-4 including the location from metadata changes from https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1577

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
