### PR TITLE
Issue/11935 localization of local announcements

### DIFF
--- a/WordPress/FEATURE_ANNOUNCEMENTS.json-example
+++ b/WordPress/FEATURE_ANNOUNCEMENTS.json-example
@@ -4,20 +4,20 @@
 {
   "announcements": [
     {
-      "appVersionName": "14.7", // app version name that announcement targets. Used for display purposes only.
-      "announceVersion": 1, // unique version of announcement. Used to track if the specific announcement was shown or not.
-      "detailsUrl": "http://wordpress.org",  // URL that "Find out more" button will open. If empty, "Find out more" button will not be shown.
+      "appVersionName": "14.7",  // app version name that announcement targets. Used for display purposes only.
+      "announceVersion": 1,  // unique version of announcement. Used to track if the specific announcement was shown or not.
+      "detailsUrl": "http://wordpress.org", // URL that "Find out more" button will open. If empty, "Find out more" button will not be shown.
       "features": [
         {
           "en": { // localized feature description for English language
             "title": "Super Publishing",
             "subtitle": "Super Publishing is here! Publish using the power of your mind."
           },
-          "it": { // localized feature description for Italian language
+          "it": {  // localized feature description for Italian language
             "title": "Super Pubblicazione",
             "subtitle": "Pubblicare articoli incredibili..."
           },
-          "iconBase64": "iVBORw0KGg", // icon data represented as base64 string without prefix (data:image/png;base64,).
+          "iconBase64": "iVBORw0KGg",  // icon data represented as base64 string without prefix (data:image/png;base64,).
           "iconUrl": "" // If icon is missing, we will try to load content of iconBase64
         },
         {
@@ -25,7 +25,7 @@
             "title": "Amazing Feature",
             "subtitle": "That's right! They are right in the app! They require pets right now. Are you going to look for them or what?"
           },
-          "it": {
+          "it": {  // localized feature description for Italian language
             "title": "Amazing Feature in Italian",
             "subtitle": "Description in Italian 2"
           },
@@ -37,7 +37,7 @@
             "title": "We like long feature announcements that why this one is going to be extra long and span multiple lines",
             "subtitle": "Here we run out of budget."
           },
-          "it": {
+          "it": {  // localized feature description for Italian language
             "title": "Long feature title in Italina",
             "subtitle": "Description in Italian 3"
           },

--- a/WordPress/FEATURE_ANNOUNCEMENTS.json-example
+++ b/WordPress/FEATURE_ANNOUNCEMENTS.json-example
@@ -4,26 +4,30 @@
 {
   "announcements": [
     {
-      "appVersionName": "14.7",  // app version name that announcement targets. Used for display purposes only.
-      "announceVersion": 1,  // unique version of announcement. Used to track if the specific announcement was shown or not.
-      "detailsUrl": "http://wordpress.org", // URL that "Find out more" button will open. If empty, "Find out more" button will not be shown.
+      "appVersionName": "14.7", // app version name that announcement targets. Used for display purposes only.
+      "announceVersion": 1, // unique version of announcement. Used to track if the specific announcement was shown or not.
+      "detailsUrl": "http://wordpress.org",  // URL that "Find out more" button will open. If empty, "Find out more" button will not be shown.
       "features": [
         {
           "en": { // localized feature description for English language
             "title": "Super Publishing",
             "subtitle": "Super Publishing is here! Publish using the power of your mind."
           },
-          "it": {  // localized feature description for Italian language
+          "it": { // localized feature description for Italian language
             "title": "Super Pubblicazione",
             "subtitle": "Pubblicare articoli incredibili..."
           },
-          "iconBase64": "iVBORw0KGg",  // icon data represented as base64 string without prefix (data:image/png;base64,).
+          "iconBase64": "iVBORw0KGg", // icon data represented as base64 string without prefix (data:image/png;base64,).
           "iconUrl": "" // If icon is missing, we will try to load content of iconBase64
         },
         {
           "en": {
             "title": "Amazing Feature",
             "subtitle": "That's right! They are right in the app! They require pets right now. Are you going to look for them or what?"
+          },
+          "it": {
+            "title": "Amazing Feature in Italian",
+            "subtitle": "Description in Italian 2"
           },
           "iconBase64": "",
           "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-personal.png"
@@ -32,6 +36,10 @@
           "en": {
             "title": "We like long feature announcements that why this one is going to be extra long and span multiple lines",
             "subtitle": "Here we run out of budget."
+          },
+          "it": {
+            "title": "Long feature title in Italina",
+            "subtitle": "Description in Italian 3"
           },
           "iconBase64": "",
           "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"

--- a/WordPress/FEATURE_ANNOUNCEMENTS.json-example
+++ b/WordPress/FEATURE_ANNOUNCEMENTS.json-example
@@ -4,43 +4,53 @@
 {
   "announcements": [
     {
-      "appVersionName": "14.7",  // app version name that announcement targets. Used for display purposes only.
-      "announcementVersion": 1,  // unique version of announcement. Used to track if the specific announcement was shown or not.
-      "detailsUrl": "http://wordpress.org", // URL that "Find out more" button will open. If empty, "Find out more" button will not be shown.
-      "features": [  // Features will appear in order they are in this list. Try to avoid using long subtitles.
+      "appVersionName": "14.7",
+      // app version name that announcement targets. Used for display purposes only.
+      "announcementVersion": 1,
+      // unique version of announcement. Used to track if the specific announcement was shown or not.
+      "detailsUrl": "http://wordpress.org",
+      // URL that "Find out more" button will open. If empty, "Find out more" button will not be shown.
+      "features": [
         {
-          "en": { // localized feature description for English language
-            "title": "Super Publishing",
-            "subtitle": "Super Publishing is here! Publish using the power of your mind."
-          },
-          "it": {  // localized feature description for Italian language
-            "title": "Super Pubblicazione",
-            "subtitle": "Pubblicare articoli incredibili..."
+          "localizedContent": {
+            "en": {
+              "title": "Super Publishing",
+              "subtitle": "Super Publishing is here! Publish using the power of your mind."
+            },
+            "it": {
+              "title": "Super Pubblicazione",
+              "subtitle": "Pubblicare articoli incredibili..."
+            }
           },
           // icon data represented as base64 string without prefix (data:image/png;base64,).
           "iconBase64": "iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAb1BMVEX///+ZzACTyQCRyQDi8MTk8cu+33f2+u3N5piczRSu2EnA4Hr+//rE4oTr9tXy+eOo1Dr1+unS6KOi0Sey2Fvt9tvd7ru322jb7bb6/PPE4oa73XHK5JLr9dfW6q32+uuo1DzQ6KC02mCv11LH4oz7JUSRAAAGUUlEQVR4nO2d63qiMBBASYK2eBcEReul6vs/4wJuEcJEg+Yy3Z3zc7fhyyEjl2TIBAFB/D/ELFmaOtZZrE0dyhy5YDwxdKytYGJj6Fjm+BCM8S8jh9oXh0JoGEx50a+5iSNFjDFT4WAUUx0zd6pMszcTp4YOYwUzJx9tjJaY6BzeGC0xEGCYY7Rk+/YAoI7Rknc7iDtGS6ogu77cfIY8RkuqOE07/5zPB+Hh+7qdlmyvn4dskH50W6OP0RKpk5PZYbtKuBBcpvin6DKNBw1R/DFakt7jdLkZJ6UaU1OasnW8r/6+itFPn53X42+chlMmHrm1PAVfb/KA/YYYLUmKjkbs4dCBlmU7/DFaEvZ0azL23XkN0vUbgowvMt8CT5ivxBt+JSLC7Jjv3vWrHBcz3yIq4r5XF6XjOvftArE8GfJj5W0S4TTNwUSA3hEr30Iya7OCxTAyVLfGPDEXoTUC0UV1bl6vUkTzjJpaGMCb4tS32g1rglgU5/YEC8XX5wuMkQP9Kt6GuPar0+MmIvYtWL0rSZ2NDsfiASDuJXhNi5OVLbqOYuBZsPsmweulv4v2MCY/Uxmf3dsqP3pSuwE8yTQeRka6hpO6yVf3rHh97V8Cp3zy8L8hRNg4JBD1Pi+op253W905axlGzSYH4Kfo720qBoaw9agFdBdg2GwyB8Y9CjyRA/3nrfOtNWXTnuSeAIbephiHkGHr4r7RMtw2m3xAv13h540YiifpdE+1ovTUbAIOO9+5FKuBLyOt34yOXzFCy6dHFcZSdXoADmFxuhuPWVfNW/7l3mSmuMH4GEToV1id7vrupj2xcb/jKd80BbBSZZlc2X0xra4Lxx5Ti3x0W5D7VjZ5Y1HyVWJ1BHIxGu4W/SZuRLIbXx7ORjo37D5d2YW7nrVJTc+tPcX19KLuZdIcYvK8VyaJXAsyx9PgipuhVdwm1T64ktrDqaHei59ZgCQWi3gQbD0PWsfHz9Dts2nm42fo9FUfmBFzgMs74tqHoNNLzcKLoctHUy+CLi+m0HyYC0N374hpN5fSBcLd7SIP/YA2k4ggCIL4L5mEAy+Yf/JOs/gzzro5gkc8zzT7TdnF11amZjt+ExFsLEmCq5gOnkuHUhfDc93Fa2/J+ahhwcW5tQiLw3CftLo47Pd+vJEceGv1GoWhnFzUL+UWWPlrZl9hMLwCeSD6intwhf6+RonAMAO7oG0IrpzxMyZD+A90s6cGsICoU+j8GypSkbimoSJHhB/wGCpWFXgICnW4KJrXMeDfULECzb/1DBVJk7z+dM6/oWL5Ujc9jAzJ0BZkSIZkSIb2IUMyJEMytA8ZkiEZkqF9yJAMyZAM7UOGZEiGZGgfMiRDMiRD+5AhGZIhGdqHDMmQDMnQPmRIhmRIhvYhQzIkQzK0DxmSIRmSoX3IUN9wpWhe79ns31D1ZZfmLkSKfS0xfZ2n2IpLt5CCYrfi+6ba/g3hj2S1v7CEtstnzT21/RsqvpLVLmEKbxp4/94dgSH4JW+PTfmAIOCNTSkQGEJVC1ifWh+htC1z+3N+DIbdTRGSflt+5+tGXRsuVSVCYRgsL80uvlBGeH6N/m6rkXxKpQlwGAZBWlZzLXsoTvFru0Z+DDabbNatvIDFsOBYdnFvfFNMRIaWIEMyJEMyJEMyJEMyJMPfYKiuhGTXcPy8a6bwsq1+j2mY9/Ei6LTSjKfKAQ5rkWvVNTSPO0E/P0SXP8Mg2HpQdFvIcuLe0HX1PHm20j7OC8ruHI9ij+1XTbFyquil6vHQXaBy5rReV03GHA2jWDmuDFgz+WLCuiQXI82VXTuE4xMXP6gHAUZ5dhqHXH37KAUsM7mhKgPFpz9/0SZIFYp8Vh8SGWpDGFWBOo62ZA4ZypAhPshQhgzxQYYyZIgPMpQhQ3yQoQwZ4oMMZcgQH2QoQ4b4IEMZMsQHGcqQIT7IUIYM8UGGMr/PUFXAVPWVvCoT12USYj++4FVroazwCgu6TULshSrqlA3gL/9dZjv3BcyTEuoStnACoOjzxbJjcmhETg8aQAmAQnPrBz/MO4PCk4cpI3IN+EJQt7i2J45J21GsnjTYSN/F4x7Bivie7cZF8rxQdr4TjQZrDBlQT8l2UZWxlUz1EtLy+FLlhbERigwvPSbHZc8dDpZLp2nc/xJ/AMM4nGaREA01AAAAAElFTkSuQmCC",
-          "iconUrl": "" // If icon is missing, we will try to load content of iconBase64
+          "iconUrl": ""
+          // If icon is missing, we will try to load content of iconBase64
         },
         {
-          "en": {
-            "title": "Amazing Feature",
-            "subtitle": "That's right! They are right in the app! They require pets right now. Are you going to look for them or what?"
-          },
-          "it": {  // localized feature description for Italian language
-            "title": "Amazing Feature in Italian",
-            "subtitle": "Description in Italian 2"
+          "localizedContent": {
+            "en": {
+              "title": "Amazing Feature",
+              "subtitle": "That's right! They are right in the app! They require pets right now. Are you going to look for them or what?"
+            },
+            "it": { // localized feature description for Italian language
+              "title": "Amazing Feature in Italian",
+              "subtitle": "Description in Italian 2"
+            }
           },
           "iconBase64": "",
           "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-personal.png"
         },
         {
-          "en": {
-            "title": "We like long feature announcements that why this one is going to be extra long and span multiple lines",
-            "subtitle": "Here we run out of budget."
-          },
-          "it": {  // localized feature description for Italian language
-            "title": "Long feature title in Italina",
-            "subtitle": "Description in Italian 3"
+          "localizedContent": {
+            "en": {
+              "title": "We like long feature announcements that why this one is going to be extra long and span multiple lines",
+              "subtitle": "Here we run out of budget."
+            },
+            "it": { // localized feature description for Italian language
+              "title": "Long feature title in Italina",
+              "subtitle": "Description in Italian 3"
+            }
           },
           "iconBase64": "",
           "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"

--- a/WordPress/FEATURE_ANNOUNCEMENTS.json-example
+++ b/WordPress/FEATURE_ANNOUNCEMENTS.json-example
@@ -5,9 +5,9 @@
   "announcements": [
     {
       "appVersionName": "14.7",  // app version name that announcement targets. Used for display purposes only.
-      "announceVersion": 1,  // unique version of announcement. Used to track if the specific announcement was shown or not.
+      "announcementVersion": 1,  // unique version of announcement. Used to track if the specific announcement was shown or not.
       "detailsUrl": "http://wordpress.org", // URL that "Find out more" button will open. If empty, "Find out more" button will not be shown.
-      "features": [
+      "features": [  // Features will appear in order they are in this list. Try to avoid using long subtitles.
         {
           "en": { // localized feature description for English language
             "title": "Super Publishing",
@@ -17,7 +17,8 @@
             "title": "Super Pubblicazione",
             "subtitle": "Pubblicare articoli incredibili..."
           },
-          "iconBase64": "iVBORw0KGg",  // icon data represented as base64 string without prefix (data:image/png;base64,).
+          // icon data represented as base64 string without prefix (data:image/png;base64,).
+          "iconBase64": "iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAb1BMVEX///+ZzACTyQCRyQDi8MTk8cu+33f2+u3N5piczRSu2EnA4Hr+//rE4oTr9tXy+eOo1Dr1+unS6KOi0Sey2Fvt9tvd7ru322jb7bb6/PPE4oa73XHK5JLr9dfW6q32+uuo1DzQ6KC02mCv11LH4oz7JUSRAAAGUUlEQVR4nO2d63qiMBBASYK2eBcEReul6vs/4wJuEcJEg+Yy3Z3zc7fhyyEjl2TIBAFB/D/ELFmaOtZZrE0dyhy5YDwxdKytYGJj6Fjm+BCM8S8jh9oXh0JoGEx50a+5iSNFjDFT4WAUUx0zd6pMszcTp4YOYwUzJx9tjJaY6BzeGC0xEGCYY7Rk+/YAoI7Rknc7iDtGS6ogu77cfIY8RkuqOE07/5zPB+Hh+7qdlmyvn4dskH50W6OP0RKpk5PZYbtKuBBcpvin6DKNBw1R/DFakt7jdLkZJ6UaU1OasnW8r/6+itFPn53X42+chlMmHrm1PAVfb/KA/YYYLUmKjkbs4dCBlmU7/DFaEvZ0azL23XkN0vUbgowvMt8CT5ivxBt+JSLC7Jjv3vWrHBcz3yIq4r5XF6XjOvftArE8GfJj5W0S4TTNwUSA3hEr30Iya7OCxTAyVLfGPDEXoTUC0UV1bl6vUkTzjJpaGMCb4tS32g1rglgU5/YEC8XX5wuMkQP9Kt6GuPar0+MmIvYtWL0rSZ2NDsfiASDuJXhNi5OVLbqOYuBZsPsmweulv4v2MCY/Uxmf3dsqP3pSuwE8yTQeRka6hpO6yVf3rHh97V8Cp3zy8L8hRNg4JBD1Pi+op253W905axlGzSYH4Kfo720qBoaw9agFdBdg2GwyB8Y9CjyRA/3nrfOtNWXTnuSeAIbephiHkGHr4r7RMtw2m3xAv13h540YiifpdE+1ovTUbAIOO9+5FKuBLyOt34yOXzFCy6dHFcZSdXoADmFxuhuPWVfNW/7l3mSmuMH4GEToV1id7vrupj2xcb/jKd80BbBSZZlc2X0xra4Lxx5Ti3x0W5D7VjZ5Y1HyVWJ1BHIxGu4W/SZuRLIbXx7ORjo37D5d2YW7nrVJTc+tPcX19KLuZdIcYvK8VyaJXAsyx9PgipuhVdwm1T64ktrDqaHei59ZgCQWi3gQbD0PWsfHz9Dts2nm42fo9FUfmBFzgMs74tqHoNNLzcKLoctHUy+CLi+m0HyYC0N374hpN5fSBcLd7SIP/YA2k4ggCIL4L5mEAy+Yf/JOs/gzzro5gkc8zzT7TdnF11amZjt+ExFsLEmCq5gOnkuHUhfDc93Fa2/J+ahhwcW5tQiLw3CftLo47Pd+vJEceGv1GoWhnFzUL+UWWPlrZl9hMLwCeSD6intwhf6+RonAMAO7oG0IrpzxMyZD+A90s6cGsICoU+j8GypSkbimoSJHhB/wGCpWFXgICnW4KJrXMeDfULECzb/1DBVJk7z+dM6/oWL5Ujc9jAzJ0BZkSIZkSIb2IUMyJEMytA8ZkiEZkqF9yJAMyZAM7UOGZEiGZGgfMiRDMiRD+5AhGZIhGdqHDMmQDMnQPmRIhmRIhvYhQzIkQzK0DxmSIRmSoX3IUN9wpWhe79ns31D1ZZfmLkSKfS0xfZ2n2IpLt5CCYrfi+6ba/g3hj2S1v7CEtstnzT21/RsqvpLVLmEKbxp4/94dgSH4JW+PTfmAIOCNTSkQGEJVC1ifWh+htC1z+3N+DIbdTRGSflt+5+tGXRsuVSVCYRgsL80uvlBGeH6N/m6rkXxKpQlwGAZBWlZzLXsoTvFru0Z+DDabbNatvIDFsOBYdnFvfFNMRIaWIEMyJEMyJEMyJEMyJMPfYKiuhGTXcPy8a6bwsq1+j2mY9/Ei6LTSjKfKAQ5rkWvVNTSPO0E/P0SXP8Mg2HpQdFvIcuLe0HX1PHm20j7OC8ruHI9ij+1XTbFyquil6vHQXaBy5rReV03GHA2jWDmuDFgz+WLCuiQXI82VXTuE4xMXP6gHAUZ5dhqHXH37KAUsM7mhKgPFpz9/0SZIFYp8Vh8SGWpDGFWBOo62ZA4ZypAhPshQhgzxQYYyZIgPMpQhQ3yQoQwZ4oMMZcgQH2QoQ4b4IEMZMsQHGcqQIT7IUIYM8UGGMr/PUFXAVPWVvCoT12USYj++4FVroazwCgu6TULshSrqlA3gL/9dZjv3BcyTEuoStnACoOjzxbJjcmhETg8aQAmAQnPrBz/MO4PCk4cpI3IN+EJQt7i2J45J21GsnjTYSN/F4x7Bivie7cZF8rxQdr4TjQZrDBlQT8l2UZWxlUz1EtLy+FLlhbERigwvPSbHZc8dDpZLp2nc/xJ/AMM4nGaREA01AAAAAElFTkSuQmCC",
           "iconUrl": "" // If icon is missing, we will try to load content of iconBase64
         },
         {

--- a/WordPress/FEATURE_ANNOUNCEMENTS.json-example
+++ b/WordPress/FEATURE_ANNOUNCEMENTS.json-example
@@ -5,22 +5,35 @@
   "announcements": [
     {
       "appVersionName": "14.7",  // app version name that announcement targets. Used for display purposes only.
-      "announcementVersion": 1, // unique version of announcement. Used to track if the specific announcement was shown or not.
-      "detailsUrl": "http://wordpress.org",  // URL that "Find out more" button will open. If empty, "Find out more" button will not be shown.
-      "features": [ // Features will appear in order they are in this list. Try to avoid using long subtitles.
+      "announceVersion": 1,  // unique version of announcement. Used to track if the specific announcement was shown or not.
+      "detailsUrl": "http://wordpress.org", // URL that "Find out more" button will open. If empty, "Find out more" button will not be shown.
+      "features": [
         {
-          "title": "Super Publishing",
-          "subtitle": "Super Publishing is here! Publish using the power of your mind.",
-          "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-free.png"
+          "en": { // localized feature description for English language
+            "title": "Super Publishing",
+            "subtitle": "Super Publishing is here! Publish using the power of your mind."
+          },
+          "it": {  // localized feature description for Italian language
+            "title": "Super Pubblicazione",
+            "subtitle": "Pubblicare articoli incredibili..."
+          },
+          "iconBase64": "iVBORw0KGg",  // icon data represented as base64 string without prefix (data:image/png;base64,).
+          "iconUrl": "" // If icon is missing, we will try to load content of iconBase64
         },
         {
-          "title": "Amazing Feature",
-          "subtitle": "Equally amazing but unfortunately, very long and winded text that is supposed to be a brief description of the Amazing Feature that we are trying to promote.",
+          "en": {
+            "title": "Amazing Feature",
+            "subtitle": "That's right! They are right in the app! They require pets right now. Are you going to look for them or what?"
+          },
+          "iconBase64": "",
           "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-personal.png"
         },
         {
-          "title": "Small but important feature",
-          "subtitle": "We don't have much to say about it.",
+          "en": {
+            "title": "We like long feature announcements that why this one is going to be extra long and span multiple lines",
+            "subtitle": "Here we run out of budget."
+          },
+          "iconBase64": "",
           "iconUrl": "https://s0.wordpress.com/i/store/mobile/plans-premium.png"
         }
       ]

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -33,6 +33,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
+import org.wordpress.android.ui.whatsnew.FeatureAnnouncement;
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementDialogFragment;
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider;
 import org.wordpress.android.util.AppLog;
@@ -171,9 +172,9 @@ public class AppSettingsFragment extends PreferenceFragment
 
         mWhatsNew = findPreference(getString(R.string.pref_key_whats_new));
 
-        if (mFeatureAnnouncementProvider.isFeatureAnnouncementAvailable()) {
-            mWhatsNew.setSummary(getString(R.string.version_with_name_param,
-                    mFeatureAnnouncementProvider.getLatestFeatureAnnouncement().getAppVersionName()));
+        FeatureAnnouncement featureAnnouncement = mFeatureAnnouncementProvider.getLatestFeatureAnnouncement();
+        if (featureAnnouncement != null) {
+            mWhatsNew.setSummary(getString(R.string.version_with_name_param, featureAnnouncement.getAppVersionName()));
             mWhatsNew.setOnPreferenceClickListener(this);
         } else {
             removeWhatsNewPreference();

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementListAdapter.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.whatsnew
 
+import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.ImageView
@@ -95,10 +96,17 @@ class FeatureAnnouncementListAdapter(
             title.text = featureAnnouncementItem.title
             subtitle.text = featureAnnouncementItem.subtitle
 
-            imageManager.loadIntoCircle(
-                    featureIcon, ImageType.PLAN,
-                    StringUtils.notNullStr(featureAnnouncementItem.iconUrl)
-            )
+            if (!TextUtils.isEmpty(featureAnnouncementItem.iconUrl)) {
+                imageManager.loadIntoCircle(
+                        featureIcon, ImageType.PLAN,
+                        StringUtils.notNullStr(featureAnnouncementItem.iconUrl)
+                )
+            } else {
+                imageManager.loadBase64IntoCircle(
+                        featureIcon, ImageType.PLAN,
+                        StringUtils.notNullStr(featureAnnouncementItem.iconBase64)
+                )
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementProvider.kt
@@ -1,25 +1,23 @@
 package org.wordpress.android.ui.whatsnew
 
 import android.text.TextUtils
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
+import com.google.gson.JsonParser
 import org.wordpress.android.WordPress
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.LocaleManagerWrapper
 import java.io.FileNotFoundException
 import javax.inject.Inject
 
-class FeatureAnnouncementProvider @Inject constructor() {
-    private val gson: Gson by lazy {
-        val builder = GsonBuilder()
-        builder.create()
-    }
-
+class FeatureAnnouncementProvider @Inject constructor(val localeManagerWrapper: LocaleManagerWrapper) {
     fun getLatestFeatureAnnouncement(): FeatureAnnouncement? {
         return getFeatureAnnouncements().firstOrNull()
     }
 
     fun getFeatureAnnouncements(): List<FeatureAnnouncement> {
+        val defaultLanguage = "en"
+        val currentLanguage = localeManagerWrapper.getLanguage()
+
         val featureAnnouncements = arrayListOf<FeatureAnnouncement>()
 
         var featureAnnouncementFileContent: String? = null
@@ -37,12 +35,42 @@ class FeatureAnnouncementProvider @Inject constructor() {
             return featureAnnouncements
         }
 
-        val featureAnnouncement: FeatureAnnouncements = gson.fromJson(
-                featureAnnouncementFileContent,
-                FeatureAnnouncements::class.java
-        )
+        val rootAnnouncementObject = JsonParser().parse(featureAnnouncementFileContent).asJsonObject
+        val announcementsArray = rootAnnouncementObject["announcements"].asJsonArray
 
-        featureAnnouncements.addAll(featureAnnouncement.announcements)
+        for (announcementElement in announcementsArray) {
+            val announcementObject = announcementElement.asJsonObject
+
+            val features = arrayListOf<FeatureAnnouncementItem>()
+
+            val featuresArray = announcementObject.get("features").asJsonArray
+            for (featureElement in featuresArray) {
+                val featureObject = featureElement.asJsonObject
+
+                val localizedDataObject = if (featureObject.has(currentLanguage)) {
+                    featureObject.get(currentLanguage).asJsonObject
+                } else {
+                    featureObject.get(defaultLanguage).asJsonObject
+                }
+
+                val title = localizedDataObject.get("title").asString
+                val subtitle = localizedDataObject.get("subtitle").asString
+
+                val iconBase64 = featureObject.get("iconBase64").asString
+                val iconUrl = featureObject.get("iconUrl").asString
+
+                features.add(FeatureAnnouncementItem(title, subtitle, iconBase64, iconUrl))
+            }
+
+            val featureAnnouncement = FeatureAnnouncement(
+                    announcementObject.get("appVersionName").asString,
+                    announcementObject.get("announceVersion").asInt,
+                    announcementObject.get("detailsUrl").asString,
+                    features
+            )
+
+            featureAnnouncements.add(featureAnnouncement)
+        }
 
         return featureAnnouncements
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncements.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncements.kt
@@ -6,6 +6,7 @@ data class FeatureAnnouncement(
     val appVersionName: String,
     val announcementVersion: Int,
     val detailsUrl: String,
+    val isLocalized: Boolean = false,
     val features: List<FeatureAnnouncementItem>
 )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncements.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncements.kt
@@ -12,5 +12,6 @@ data class FeatureAnnouncement(
 data class FeatureAnnouncementItem(
     val title: String,
     val subtitle: String,
+    val iconBase64: String,
     val iconUrl: String
 )

--- a/WordPress/src/main/java/org/wordpress/android/util/LocaleManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LocaleManagerWrapper.kt
@@ -1,13 +1,15 @@
 package org.wordpress.android.util
 
+import android.content.Context
 import java.util.Calendar
 import java.util.Locale
 import java.util.TimeZone
 import javax.inject.Inject
 
 class LocaleManagerWrapper
-@Inject constructor() {
+@Inject constructor(val context: Context) {
     fun getLocale(): Locale = Locale.getDefault()
     fun getTimeZone(): TimeZone = TimeZone.getDefault()
     fun getCurrentCalendar(): Calendar = Calendar.getInstance(getLocale())
+    fun getLanguage(): String = LocaleManager.getLanguage(context)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -7,6 +7,7 @@ import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.text.TextUtils
+import android.util.Base64
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType
 import android.widget.ImageView.ScaleType.CENTER
@@ -139,6 +140,31 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
         if (!context.isAvailable()) return
         GlideApp.with(context)
                 .load(imgUrl)
+                .addFallback(imageType)
+                .addPlaceholder(imageType)
+                .circleCrop()
+                .attachRequestListener(requestListener)
+                .addSignature(version)
+                .into(imageView)
+                .clearOnDetach()
+    }
+
+    /**
+     * Loads a base64 string without prefix (data:image/png;base64,) into the ImageView and applies circle
+     * transformation. Adds placeholder and error placeholder depending on the ImageType.
+     */
+    @JvmOverloads
+    fun loadBase64IntoCircle(
+        imageView: ImageView,
+        imageType: ImageType,
+        base64ImageData: String,
+        requestListener: RequestListener<Drawable>? = null,
+        version: Int? = null
+    ) {
+        val context = imageView.context
+        if (!context.isAvailable()) return
+        GlideApp.with(context)
+                .load(Base64.decode(base64ImageData, Base64.DEFAULT))
                 .addFallback(imageType)
                 .addPlaceholder(imageType)
                 .circleCrop()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -187,7 +187,7 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     private fun canShowFeatureAnnouncement(): Boolean {
-        return featureAnnouncementProvider.isFeatureAnnouncementAvailable() &&
+        return featureAnnouncementProvider.isAnnouncementOnUpgradeAvailable() &&
                 appPrefsWrapper.featureAnnouncementShownVersion <
                 featureAnnouncementProvider.getLatestFeatureAnnouncement()?.announcementVersion!!
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -42,6 +42,7 @@ class WPMainActivityViewModelTest {
             "14.7",
             2,
             "https://wordpress.org/",
+            true,
             emptyList()
     )
 
@@ -186,7 +187,7 @@ class WPMainActivityViewModelTest {
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(
                 featureAnnouncement
         )
-        whenever(featureAnnouncementProvider.isFeatureAnnouncementAvailable()).thenReturn(true)
+        whenever(featureAnnouncementProvider.isAnnouncementOnUpgradeAvailable()).thenReturn(true)
 
         startViewModelWithDefaultParameters()
 
@@ -201,7 +202,7 @@ class WPMainActivityViewModelTest {
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(
                 featureAnnouncement
         )
-        whenever(featureAnnouncementProvider.isFeatureAnnouncementAvailable()).thenReturn(true)
+        whenever(featureAnnouncementProvider.isAnnouncementOnUpgradeAvailable()).thenReturn(true)
 
         startViewModelWithDefaultParameters()
 
@@ -222,7 +223,7 @@ class WPMainActivityViewModelTest {
     @Test
     fun `don't show feature announcement when it's not available`() {
         whenever(appPrefsWrapper.lastFeatureAnnouncementAppVersionCode).thenReturn(840)
-        whenever(featureAnnouncementProvider.isFeatureAnnouncementAvailable()).thenReturn(false)
+        whenever(featureAnnouncementProvider.isAnnouncementOnUpgradeAvailable()).thenReturn(false)
 
         startViewModelWithDefaultParameters()
 
@@ -236,7 +237,7 @@ class WPMainActivityViewModelTest {
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(
                 featureAnnouncement
         )
-        whenever(featureAnnouncementProvider.isFeatureAnnouncementAvailable()).thenReturn(true)
+        whenever(featureAnnouncementProvider.isAnnouncementOnUpgradeAvailable()).thenReturn(true)
 
         startViewModelWithDefaultParameters()
 
@@ -250,7 +251,7 @@ class WPMainActivityViewModelTest {
         whenever(featureAnnouncementProvider.getLatestFeatureAnnouncement()).thenReturn(
                 featureAnnouncement
         )
-        whenever(featureAnnouncementProvider.isFeatureAnnouncementAvailable()).thenReturn(true)
+        whenever(featureAnnouncementProvider.isAnnouncementOnUpgradeAvailable()).thenReturn(true)
 
         startViewModelWithDefaultParameters()
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
@@ -34,16 +34,19 @@ class FeatureAnnouncementViewModelTest : BaseUnitTest() {
             FeatureAnnouncementItem(
                     "Test Feature 1",
                     "Test Description 1",
+                    "",
                     "https://wordpress.org/icon1.png"
             ),
             FeatureAnnouncementItem(
                     "Test Feature 2",
                     "Test Description 1",
+                    "",
                     "https://wordpress.org/icon2.png"
             ),
             FeatureAnnouncementItem(
                     "Test Feature 3",
                     "Test Description 3",
+                    "",
                     "https://wordpress.org/icon3.png"
             )
     )

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
@@ -55,6 +55,7 @@ class FeatureAnnouncementViewModelTest : BaseUnitTest() {
             "14.7",
             1,
             "https://wordpress.org/",
+            true,
             testFeatures
     )
 


### PR DESCRIPTION
Fixes #11935 

This PR adds support for localized local announcements.

To test:
Before testing I do recommend commenting modifying logic of [this](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/11935-localization-of-local-announcements/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt#L168) method, so the feature announcement will be shown every time on app start.

It should look something like this:
  ```
  private fun checkForFeatureAnnouncements() {
        val currentVersionCode = buildConfigWrapper.getAppVersionCode()

        if (featureAnnouncementProvider.isAnnouncementOnUpgradeAvailable()) {
            appPrefsWrapper.featureAnnouncementShownVersion =
                    featureAnnouncementProvider.getLatestFeatureAnnouncement()?.announcementVersion!!
            _onFeatureAnnouncementRequested.call()
        }
    }
```

Start by copying the content of `FEATURE_ANNOUNCEMENTS.json-example` into `FEATURE_ANNOUNCEMENTS.json`.

- While App language set to English, launch the app and confirm that the feature announcement is displayed. 
- Change app language to a different variation of English, like Canadian or UK, launch the app and confirm that the feature announcement is displayed. 
- Change app language to Italian, launch the app, and confirm that the feature announcement is displayed features Italian content.
- Open `FEATURE_ANNOUNCEMENTS.json` and remove Italian translation from one of the features. Launch the app and confirm that the feature announcement is not displayed. Change language to English, and confirm that feature announcement IS displayed when you restart the app.
- This PR also adds support for base64 image loading, so confirm that you see a green android icon for in the first feature.

Local announcements are temporary, and I don't want to overengineer them, so I assume that announcement will always have an `en` locale.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
