### PR TITLE
Issue/11917 center empty reader view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1639,20 +1639,6 @@ public class ReaderPostListFragment extends Fragment
         return getView();
     }
 
-    private int getEmptyViewTopMargin() {
-        int totalMargin = getActivity().getResources().getDimensionPixelSize(R.dimen.toolbar_height);
-
-        if (mIsTopLevel) {
-            totalMargin += getActivity().getResources().getDimensionPixelSize(R.dimen.tab_height);
-            if (isCurrentTagManagedInFollowingTab()) {
-                totalMargin += getActivity().getResources()
-                                            .getDimensionPixelSize(R.dimen.reader_subfilter_component_height);
-            }
-        }
-
-        return totalMargin;
-    }
-
     private void setEmptyTitleDescriptionAndButton(boolean requestFailed) {
         if (!isAdded()) {
             return;
@@ -1660,7 +1646,7 @@ public class ReaderPostListFragment extends Fragment
 
         int heightToolbar = getActivity().getResources().getDimensionPixelSize(R.dimen.toolbar_height);
         int heightTabs = getActivity().getResources().getDimensionPixelSize(R.dimen.tab_height);
-        mActionableEmptyView.updateLayoutForSearch(false, getEmptyViewTopMargin());
+        mActionableEmptyView.updateLayoutForSearch(false, 0);
         mActionableEmptyView.subtitle.setContentDescription(null);
         boolean isSearching = false;
         String title;


### PR DESCRIPTION
Fixes #11917 

Fixes centering of the empty view in the Reader.

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![Screenshot_1589890206](https://user-images.githubusercontent.com/2261188/82324800-87e3e080-99da-11ea-8d78-8daed76f6c75.png) | ![Screenshot_1589889437](https://user-images.githubusercontent.com/2261188/82323872-faec5780-99d8-11ea-9e11-e605bb7b34f9.png) |
| ![Screenshot_1589889404](https://user-images.githubusercontent.com/2261188/82323916-093a7380-99d9-11ea-9530-6ed4056a9ef4.png) | ![Screenshot_1589889435](https://user-images.githubusercontent.com/2261188/82323943-13f50880-99d9-11ea-877d-ed80bcc4e601.png) |
| ![Screenshot_1589889660](https://user-images.githubusercontent.com/2261188/82324823-9205df00-99da-11ea-9484-27a378da8921.png) | ![Screenshot_1589890217](https://user-images.githubusercontent.com/2261188/82324830-93cfa280-99da-11ea-93f3-5a890bea4156.png) |

To test:
1. Login with a user who doesn't follow any sites or unfollow all sites you are following
2. Switch to the "Following" tab
3. Notice the empty view looks ok
4. Switch to "Saved"
5. Notice the empty view looks ok
6. Switch to "Liked"
7. Notice the empty view looks ok
8. Start search and type some non-sense
9. Notice the empty view looks ok

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
