### PR TITLE
Issue/11905 tab names reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -65,7 +65,7 @@ class ReaderViewModel @Inject constructor(
             val tagList = loadReaderTabsUseCase.loadTabs()
             if (tagList.isNotEmpty()) {
                 _uiState.value = ReaderUiState(
-                        tagList.map { it.tagTitle },
+                        tagList.map { it.tagDisplayName },
                         tagList
                 )
                 if (!initialized) {


### PR DESCRIPTION
Fixes #11905 

Revert back to using shorter `tagDisplayName` instead of `tagTitle`. I thought `tagDisplayName` doesn't work in other languages. But it seems it's just a missing translation for Czech. 

To test:
1. Open the Reader
2. Notice the tabs contain shorter version of the tags - eg "Following" instead of "Following sites"

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
