### PR TITLE
Fix ReaderPostListFragmnent consumes unrelated events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.reader;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;
@@ -45,14 +46,25 @@ public class ReaderEvents {
     }
 
     public static class UpdatePostsStarted {
+        private final ReaderTag mReaderTag;
         private final ReaderPostServiceStarter.UpdateAction mAction;
+
+        public UpdatePostsStarted(ReaderPostServiceStarter.UpdateAction action, final ReaderTag readerTag) {
+            mAction = action;
+            mReaderTag = readerTag;
+        }
 
         public UpdatePostsStarted(ReaderPostServiceStarter.UpdateAction action) {
             mAction = action;
+            mReaderTag = null;
         }
 
         public ReaderPostServiceStarter.UpdateAction getAction() {
             return mAction;
+        }
+
+        public @Nullable ReaderTag getReaderTag() {
+            return mReaderTag;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1250,7 +1250,7 @@ public class ReaderPostListFragment extends Fragment
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onReaderSitesSearched(OnReaderSitesSearched event) {
-        if (!isAdded()) {
+        if (!isAdded() || getPostListType() != ReaderPostListType.SEARCH_RESULTS) {
             return;
         }
 
@@ -1524,7 +1524,7 @@ public class ReaderPostListFragment extends Fragment
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(ReaderEvents.SearchPostsStarted event) {
-        if (!isAdded()) {
+        if (!isAdded() || getPostListType() != ReaderPostListType.SEARCH_RESULTS) {
             return;
         }
 
@@ -1536,7 +1536,7 @@ public class ReaderPostListFragment extends Fragment
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(ReaderEvents.SearchPostsEnded event) {
-        if (!isAdded()) {
+        if (!isAdded() || getPostListType() != ReaderPostListType.SEARCH_RESULTS) {
             return;
         }
 
@@ -2260,7 +2260,10 @@ public class ReaderPostListFragment extends Fragment
         if (!isAdded()) {
             return;
         }
-
+        // check if the event is related to this instance of the ReaderPostListFragment
+        if (event.getReaderTag() != null && !isCurrentTag(event.getReaderTag())) {
+            return;
+        }
         setIsUpdating(true, event.getAction());
         setEmptyTitleDescriptionAndButton(false);
     }
@@ -2271,11 +2274,11 @@ public class ReaderPostListFragment extends Fragment
         if (!isAdded()) {
             return;
         }
-
-        setIsUpdating(false, event.getAction());
+        // check if the event is related to this instance of the ReaderPostListFragment
         if (event.getReaderTag() != null && !isCurrentTag(event.getReaderTag())) {
             return;
         }
+        setIsUpdating(false, event.getAction());
 
         // don't show new posts if user is searching - posts will automatically
         // appear when search is exited

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
@@ -39,16 +39,18 @@ public class ReaderPostJobService extends JobService implements ServiceCompletio
                 action = UpdateAction.REQUEST_NEWER;
             }
 
-            EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
 
             if (params.getExtras().containsKey(ARG_TAG_PARAM_SLUG)) {
                 ReaderTag tag = getReaderTagFromBundleParams(params.getExtras());
+                EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action, tag));
                 mReaderPostLogic.performTask(params, action, tag, -1, -1);
             } else if (params.getExtras().containsKey(ARG_BLOG_ID)) {
                 long blogId = params.getExtras().getLong(ARG_BLOG_ID, 0);
+                EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
                 mReaderPostLogic.performTask(params, action, null, blogId, -1);
             } else if (params.getExtras().containsKey(ARG_FEED_ID)) {
                 long feedId = params.getExtras().getLong(ARG_FEED_ID, 0);
+                EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
                 mReaderPostLogic.performTask(params, action, null, -1, feedId);
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
@@ -37,7 +37,7 @@ public class ReaderPostLogic {
                             ReaderTag tag, long blogId, long feedId) {
         mListenerCompanion = companion;
 
-        EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
+        EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action, tag));
 
         if (tag != null) {
             updatePostsWithTag(tag, action);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
@@ -55,16 +55,18 @@ public class ReaderPostService extends Service implements ServiceCompletionListe
             action = UpdateAction.REQUEST_NEWER;
         }
 
-        EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
 
         if (intent.hasExtra(ARG_TAG)) {
             ReaderTag tag = (ReaderTag) intent.getSerializableExtra(ARG_TAG);
+            EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action, tag));
             mReaderPostLogic.performTask(null, action, tag, -1, -1);
         } else if (intent.hasExtra(ARG_BLOG_ID)) {
             long blogId = intent.getLongExtra(ARG_BLOG_ID, 0);
+            EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
             mReaderPostLogic.performTask(null, action, null, blogId, -1);
         } else if (intent.hasExtra(ARG_FEED_ID)) {
             long feedId = intent.getLongExtra(ARG_FEED_ID, 0);
+            EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
             mReaderPostLogic.performTask(null, action, null, -1, feedId);
         }
 


### PR DESCRIPTION
Fixes #11914

Fixes issue where an instance of ReaderPostListFragment would try to handle events not related to this instance. Eg."Following - ReaderPostListFragment" would try to handle "UpdatePostsStarted" for "Discover - ReaderPostListFragment" tab. This had some sideffects - eg. the "Following" tab changed it's loading state to "true", but it never switched it back to "false", so the loading state was shown indefinitely (https://user-images.githubusercontent.com/2261188/81922011-c55ffc80-95db-11ea-98dd-5abaf9575179.gif).

To test:
- unfortunately this PR touches code which is used in several parts of the Reader:(. But we plan to thoroughly test the Reader before we merge this refactoring into develop anyway.
1. Open Reader
2. Switch to "Discover"
3. Quickly switch to "Following"
4. Notice the "following" screen doesn't show "loading" indefinitely
-----------------------------
1. Open Reader
2. Smoke test search
------------------
1. Open Reader
2. Click on a title of one of the posts to open site detail
3. Smoke test "site detail"
-------------------
1. Open Reader
2. Click on one of the posts - opens post detail
3. Click on one of the tags at the top of the post (if the post doesn't have any tags, just open a different post)
4. Smoke test "tag detail"



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
