### PR TITLE
Reader: Fix empty view illustration shown on Liked tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1693,6 +1693,9 @@ public class ReaderPostListFragment extends Fragment
         String description = null;
         ActionableEmptyViewButtonType button = null;
 
+        // Ensure the default image is reset for empty views before applying logic
+        mActionableEmptyView.image.setImageResource(R.drawable.img_illustration_empty_results_216dp);
+
         if (shouldShowEmptyViewForSelfHostedCta()) {
             setEmptyTitleAndDescriptionForSelfHostedCta();
             return;
@@ -1720,7 +1723,8 @@ public class ReaderPostListFragment extends Fragment
                             title = getString(R.string.reader_empty_followed_blogs_title);
                             description = getString(R.string.reader_empty_followed_blogs_description);
                         }
-
+                        mActionableEmptyView.image.setImageResource(
+                                R.drawable.img_illustration_following_empty_results_196dp);
                         button = ActionableEmptyViewButtonType.DISCOVER;
                     } else if (getCurrentTag().isPostsILike()) {
                         title = getString(R.string.reader_empty_posts_liked_title);
@@ -1772,7 +1776,6 @@ public class ReaderPostListFragment extends Fragment
         SpannableStringBuilder ssb = new SpannableStringBuilder(description);
         int imagePlaceholderPosition = description.indexOf("%s");
         addBookmarkImageSpan(ssb, imagePlaceholderPosition);
-        mActionableEmptyView.image.setImageResource(R.drawable.img_illustration_empty_results_216dp);
         mActionableEmptyView.image.setVisibility(View.VISIBLE);
         mActionableEmptyView.title.setText(R.string.reader_empty_saved_posts_title);
         mActionableEmptyView.subtitle.setText(ssb);


### PR DESCRIPTION
Fixes #11950

This PR ensures that the ‘Following’ empty view illustration does not show when viewing the ‘Liked’ tab empty view.

The code was adjusted to reset the illustration before any empty view is shown, therefore only an explicit empty following tab will see the updated one.


<kbd><img src="https://user-images.githubusercontent.com/506707/82347651-e6eb2a80-99c5-11ea-8ecc-c221ad77fed2.jpg" width="320"></kbd> 
**Testing Instructions**

-   Log into an account that is not following or liking any sites
-   Navigate to the reader tab
-   Tab on the Following tab
-   The empty view should be visible with the updated following illustration
-   Tab on the Liked tab
-   The empty view should be visible with the default illustration 
-   Tap on the Saves tab
-   The empty view should be visible with the default illustration 


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
