### PR TITLE
Init posts in ReaderPostListFragment in onStart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -607,9 +607,6 @@ public class ReaderPostListFragment extends Fragment
     @Override
     public void onResume() {
         super.onResume();
-
-        checkPostAdapter();
-
         if (mWasPaused) {
             AppLog.d(T.READER, "reader post list > resumed from paused state");
             mWasPaused = false;
@@ -743,6 +740,8 @@ public class ReaderPostListFragment extends Fragment
         if (getPostListType() == ReaderPostListType.TAG_FOLLOWED && NetworkUtils.isNetworkAvailable(getActivity())) {
             purgeDatabaseIfNeeded();
         }
+
+        checkPostAdapter();
     }
 
     @Override
@@ -758,7 +757,7 @@ public class ReaderPostListFragment extends Fragment
     private void checkPostAdapter() {
         if (isAdded() && mRecyclerView.getAdapter() == null) {
             mRecyclerView.setAdapter(getPostAdapter());
-
+            refreshPosts();
             if (!mHasUpdatedPosts && NetworkUtils.isNetworkAvailable(getActivity())) {
                 mHasUpdatedPosts = true;
                 if (getPostListType().isTagType()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
@@ -47,7 +47,7 @@ public class ReaderPostServiceStarter {
             PersistableBundle extras = new PersistableBundle();
             extras.putInt(ARG_ACTION, action.ordinal());
             putReaderTagExtras(extras, tag);
-            doScheduleJobWithBundle(context, extras, JOB_READER_POST_SERVICE_ID_TAG);
+            doScheduleJobWithBundle(context, extras, JOB_READER_POST_SERVICE_ID_TAG + tag.getTagSlug().hashCode());
         }
     }
 


### PR DESCRIPTION
Fixes #11907 

Merge Instructions:
1. Review and approve this PR
2. ~Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/11949 is merged~
3. ~Update the target branch to `master-feature-branch/move-reader-tablayout-to-parent`~
4. ~Remove the "Not ready for merge" tag~
5. Merge this PR

Goal of this PR is to fix a bug where fragments/tabs in Reader weren't getting preloaded.

| BEFORE | AFTER |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/2261188/82431805-6ee93700-9a8f-11ea-9f6b-1bb82f6fe2f2.gif) | ![after](https://user-images.githubusercontent.com/2261188/82431865-86282480-9a8f-11ea-94ac-bf513cd6f91a.gif) |


To test:
1. Open Reader
2. Half-swipe to the next tab - notice the content/UI is visible
3. Switch to My Site
4. Repeat steps 1-2
- Make sure the pre-loading works for both fragments with posts and fragments with an empty view

1. Clear app data
2. Log in
3. Open Reader
4. Make sure the discover tab contains posts (it shouldn't contain an empty view as discover is never empty when connection is available)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
