### PR TITLE
Fix bookmark crash in Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
@@ -8,11 +8,14 @@ import android.view.ViewGroup;
 import android.webkit.WebView;
 
 import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentManager;
 
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.ui.reader.utils.FeaturedImageUtils;
 import org.wordpress.android.ui.reader.views.ReaderWebView;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.UrlUtils;
 
@@ -80,10 +83,14 @@ public class ReaderPostWebViewCachingFragment extends DaggerFragment {
 
     private void selfRemoveFragment() {
         if (isAdded()) {
-            getActivity().getSupportFragmentManager()
-                         .beginTransaction()
-                         .remove(ReaderPostWebViewCachingFragment.this)
-                         .commitAllowingStateLoss(); // we don't care about state here
+            FragmentManager fm = getFragmentManager();
+            if (fm != null) {
+                fm.beginTransaction()
+                  .remove(ReaderPostWebViewCachingFragment.this)
+                  .commitAllowingStateLoss(); // we don't care about state here
+            } else {
+                AppLog.w(T.READER, "Fragment manager is null.");
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #11960 

The app crashes when the user clicks on the bookmark/saveForLater icon on one of the posts. This PR fixes the issue.

To test:
1. Clear app data
2. Log in
3. Open "Discover"
4. Find a post with the bookmark icon
5. Click on the icon
6. Turn on the airplane mode
7. Click on the post and notice the content and images are loaded even though you are offline

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
