### PR TITLE
Fix: show camera icon in media picker for Gutenberg media blocks

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 15.0
 -----
- 
+* [**] Block Editor: Fix bug in media picker, now you can add new pictures and videos directly to your video, image and media & text blocks.
+
 14.9
 -----
 * [*] Fix issue with Preview post not working after switching to classic editor from inside the post

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -168,7 +168,7 @@ public class PhotoPickerFragment extends Fragment {
             mMediaSourceBottomBar.setVisibility(View.GONE);
         } else {
             View camera = mMediaSourceBottomBar.findViewById(R.id.icon_camera);
-            if (mBrowserType.isGutenbergPicker()) {
+            if (!mBrowserType.isGutenbergPicker()) {
                 camera.setVisibility(View.GONE);
             } else {
                 camera.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
Fixes an issue where the path to adding media to Gutenberg media blocks (video, images, text & media, etc) doesn't have access to create a new video / image using the device's default camera app because the icon to access it is hidden.

The feature and the problem were introduced in this commit https://github.com/wordpress-mobile/WordPress-Android/commit/f6b8bac7cbaf4ccbd2a3e762a53d79b1b140d666, in PR #11611 

For example, take this video in particular https://cloudup.com/iQB35zbOIZQ linked in that PR, shows the user adding a video block, then tapping Add video, then tapping choose from device, and right there the picker shows two buttons at the bottom bar: the one on the right being the camera icon which should allow you to launch the device’s default camera app.

#### Before the fix
![beforefix](https://user-images.githubusercontent.com/6597771/82507641-3ec68600-9ad9-11ea-8e30-3cc62a649528.gif)

#### After the fix
![afterfix](https://user-images.githubusercontent.com/6597771/82507650-425a0d00-9ad9-11ea-8a7c-fe9a2d64673f.gif)


#### To test
0. make sure to have the Block Editor set as default for your test site.
1. create a new post
2. add a Video block
3. tap on the block's Add video
4. tap on "choose from device"
5. tap the camera button on the right, the device's camera app should fire up
6. record a new video with the camera app
7. once you're done tap on OK to use it
8. verify it gets loaded into the GB video block and uploads

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
