### PR TITLE
Issue/11976 fix snackbar position in Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1614,7 +1614,7 @@ public class ReaderPostListFragment extends Fragment
      * parent to be the main activity's CoordinatorLayout
      */
     private View getSnackbarParent() {
-        View coordinator = getActivity().findViewById(R.id.coordinator);
+        View coordinator = getActivity().findViewById(R.id.coordinator_layout);
         if (coordinator != null) {
             return coordinator;
         }


### PR DESCRIPTION
Fixes #11976 

This PR fixes snackbar position in Reader. Before this PR the snackbar would appear below the Bottom Navigation.

To test:
1. Open Reader
2. Click on the overflow menu on one of the items
3. Select "Block this site"
4. Notice the snackbar appears on top of the bottom navigation

Note:
- The "undo" button doesn't do anything. But it wasn't introduced in this PR. Moreover, we'll be changing the list items actions very soon anyway.


| Before | After |
| ----- | ----- |
| ![snackbar-msg-below](https://user-images.githubusercontent.com/2261188/82548621-e389a780-9b5b-11ea-8f11-e0c15913d9cd.gif) | ![snackbar-msg-on-top](https://user-images.githubusercontent.com/2261188/82548631-e6849800-9b5b-11ea-98c9-e97788af8807.gif) |



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
