### PR TITLE
PhotoPicker: remove unused code paths for CHILD_REQUEST_CODE

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -53,7 +53,6 @@ public class PhotoPickerActivity extends LocaleAwareActivity
     public static final String EXTRA_MEDIA_URIS = "media_uris";
     public static final String EXTRA_MEDIA_ID = "media_id";
     public static final String EXTRA_MEDIA_QUEUED = "media_queued";
-    public static final String CHILD_REQUEST_CODE = "child_request_code";
 
     // the enum name of the source will be returned as a string in EXTRA_MEDIA_SOURCE
     public static final String EXTRA_MEDIA_SOURCE = "media_source";
@@ -193,12 +192,6 @@ public class PhotoPickerActivity extends LocaleAwareActivity
                 if (data != null) {
                     doMediaUrisSelected(WPMediaUtils.retrieveMediaUris(data), PhotoPickerMediaSource.ANDROID_PICKER);
                 }
-                break;
-            // user took a photo with the device camera
-            case RequestCodes.TAKE_VIDEO:
-                data.putExtra(CHILD_REQUEST_CODE, RequestCodes.TAKE_VIDEO);
-                setResult(RESULT_OK, data);
-                finish();
                 break;
             case RequestCodes.TAKE_PHOTO:
                 try {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2329,9 +2329,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         List<Uri> uris = convertStringArrayIntoUrisList(
                                 data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS));
                         mEditorMedia.addNewMediaItemsToEditorAsync(uris, false);
-                    } else if (data.getIntExtra(PhotoPickerActivity.CHILD_REQUEST_CODE, -1)
-                               == RequestCodes.TAKE_VIDEO) {
-                        mEditorMedia.addFreshlyTakenVideoToEditor();
                     }
                     break;
                 case RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK:


### PR DESCRIPTION
Title has it. This PR removes unused code introduced in #11611, whereas after discussion in such PR (as explained to me by @ashiagr and @malinajirka elsewhere) the UI entry point that would require this code to exist was then hidden as explained here https://github.com/wordpress-mobile/WordPress-Android/pull/11611#issuecomment-613320133 (commit https://github.com/wordpress-mobile/WordPress-Android/commit/ed6b137438685663619261e43d91c498a6cf1cc6) but then this unused code path wasn't removed.

To test:
- Verify the same steps provided in #11611


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
