### PR TITLE
Fix automattic tab in Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -65,7 +65,7 @@ class ReaderViewModel @Inject constructor(
             val tagList = loadReaderTabsUseCase.loadTabs()
             if (tagList.isNotEmpty()) {
                 _uiState.value = ReaderUiState(
-                        tagList.map { it.tagDisplayName },
+                        tagList.map { it.label },
                         tagList
                 )
                 if (!initialized) {


### PR DESCRIPTION
Fixes #11979 
Fixes title of the Automattic tab in Reader.


To test:
1. Log in with a8c account
2. Open Reader
3. Notice tha last tab has title ("Automattic").

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
