### PR TITLE
Issue/11985 downgrade to viewpager1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -635,15 +635,6 @@ public class ReaderPostListFragment extends Fragment
             if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
                 return;
             }
-            ReaderTag discoverTag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
-            ReaderTag readerTag = AppPrefs.getReaderTag();
-
-            if (discoverTag != null && discoverTag.equals(readerTag)) {
-                setCurrentTag(readerTag);
-                updateCurrentTag();
-            } else if (discoverTag == null) {
-                AppLog.w(T.READER, "Discover tag not found; ReaderTagTable returned null");
-            }
         }
 
         if (shouldShowEmptyViewForSelfHostedCta()) {

--- a/WordPress/src/main/res/layout/reader_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_layout.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.viewpager2.widget.ViewPager2
+    <androidx.viewpager.widget.ViewPager
         android:id="@+id/view_pager"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes #11985 
Fixes #11957

This PR downgrades ViewPager2 in the ReaderFragment to ViewPager. The ViewPager2 causes issues when the user switches between tabs which are 2 tabs apart - more details in the issue description.

I also had to remove the manual `updateCurrentTag` in onResume - when the user switched from "discover" to "following" the "following tab" sometimes displayed "discover" content. (It was also causing a semi-related issue -> https://github.com/wordpress-mobile/WordPress-Android/issues/11957)

To test:
- it seems this scenario didn't work only when there were more than 4 tabs -> use `a8c` account to test this PR.
1. Open Reader on "Following"
2. Switched to "Saved"
3. Switch back to "Following" and notice the content is NOT empty



---------------
1 - Tap Reader
2 - Tap Discover
3 - Tap post on list
4 - Detail view is shown
5 - Tap on one of the tags (if there aren't any, just open a different post detail)
6 - List of posts related to that tag is shown (with title on view set to the tag)
7 - Tap on a post from the list
8 - Detail view is shown
9 - Tap Back and verify the list from step 6 is shown (before this fix the content of "discover" was shown)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
