### PR TITLE
Add wordpress.com/stats/site deep link

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -384,6 +384,17 @@
                     android:host="wordpress.com"
                     android:pathPattern="/post/..*"
                     android:scheme="http" />
+
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/stats/..*"
+                    android:scheme="https" />
+
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/stats/..*"
+                    android:scheme="http" />
+
             </intent-filter>
 
         </activity>

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -104,6 +104,8 @@ import static org.wordpress.android.ui.pages.PagesActivityKt.EXTRA_PAGE_REMOTE_I
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_ID_KEY;
 
 public class ActivityLauncher {
+    private static final String TAG = ActivityLauncher.class.getSimpleName();
+
     public static void showMainActivityAndLoginEpilogue(Activity activity, ArrayList<Integer> oldSitesIds,
                                                         boolean doLoginUpdate) {
         Intent intent = new Intent(activity, WPMainActivity.class);
@@ -365,6 +367,12 @@ public class ActivityLauncher {
         taskStackBuilder.addNextIntent(mainActivityIntent);
         taskStackBuilder.addNextIntent(statsIntent);
         taskStackBuilder.startActivities();
+    }
+
+    public static void viewStatsInNewStack(Context context) {
+        Intent intent = getMainActivityInNewStack(context);
+        intent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_STATS);
+        context.startActivity(intent);
     }
 
     private static Intent getMainActivityInNewStack(Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -104,8 +104,6 @@ import static org.wordpress.android.ui.pages.PagesActivityKt.EXTRA_PAGE_REMOTE_I
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_ID_KEY;
 
 public class ActivityLauncher {
-    private static final String TAG = ActivityLauncher.class.getSimpleName();
-
     public static void showMainActivityAndLoginEpilogue(Activity activity, ArrayList<Integer> oldSitesIds,
                                                         boolean doLoginUpdate) {
         Intent intent = new Intent(activity, WPMainActivity.class);

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -48,8 +48,6 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
     private static final String REDIRECT_TO_PARAM = "redirect_to";
     private static final String STATS_PATH = "stats";
 
-    private static final String TAG = DeepLinkingIntentReceiverActivity.class.getSimpleName();
-
     private String mInterceptedUri;
     private String mBlogId;
     private String mPostId;

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -46,7 +46,9 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
     private static final String REGULAR_TRACKING_PATH = "bar";
     private static final String POST_PATH = "post";
     private static final String REDIRECT_TO_PARAM = "redirect_to";
+    private static final String STATS_PATH = "stats";
 
+    private static final String TAG = DeepLinkingIntentReceiverActivity.class.getSimpleName();
 
     private String mInterceptedUri;
     private String mBlogId;
@@ -71,7 +73,6 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
         // check if this intent is started via custom scheme link
         if (Intent.ACTION_VIEW.equals(action) && uri != null) {
             mInterceptedUri = uri.toString();
-
             if (shouldOpenEditor(uri)) {
                 handleOpenEditor(uri);
             } else if (shouldHandleTrackingUrl(uri)) {
@@ -81,6 +82,8 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
                 handleAppBanner(host);
             } else if (shouldViewPost(host)) {
                 handleViewPost(uri);
+            } else if (shouldShowStats(uri)) {
+                handleShowStats(uri);
             } else {
                 // not handled
                 finish();
@@ -131,17 +134,12 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
     }
 
     private void handleOpenEditor(@NonNull Uri uri) {
-        String urlPathSegment = uri.getLastPathSegment() == null ? "" : uri.getLastPathSegment();
-        openEditorForSite(urlPathSegment);
+        openEditorForSite(extractTargetHost(uri));
     }
 
     private void openEditorForSite(@NonNull String targetHost) {
-        List<SiteModel> matchedSites = mSiteStore.getSitesByNameOrUrlMatching(targetHost);
-        SiteModel site = matchedSites.isEmpty() ? null : matchedSites.get(0);
-        String host = null;
-        if (site != null && site.getUrl() != null) {
-            host = Uri.parse(site.getUrl()).getHost();
-        }
+        SiteModel site = extractSiteModelFromTargetHost(targetHost);
+        String host = extractHostFromSite(site);
         if (site != null && host != null && StringUtils.equals(host, targetHost)) {
             // if we found the site with the matching url, open the editor for this site.
             ActivityLauncher.openEditorForSiteInNewStack(getContext(), site);
@@ -169,6 +167,24 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
         }
     }
 
+    private boolean shouldShowStats(@NonNull Uri uri) {
+        // Match: https://wordpress.com/stats/
+        return StringUtils.equals(uri.getHost(), HOST_WORDPRESS_COM)
+               && (!uri.getPathSegments().isEmpty() && StringUtils.equals(uri.getPathSegments().get(0), STATS_PATH));
+    }
+
+    private void handleShowStats(@NonNull Uri uri) {
+        String targetHost = extractTargetHost(uri);
+        SiteModel site = extractSiteModelFromTargetHost(targetHost);
+        String host = extractHostFromSite(site);
+        if (site != null && host != null && StringUtils.equals(host, targetHost)) {
+            ActivityLauncher.viewStatsInNewStack(getContext(), site);
+        } else {
+            // In other cases, launch stats with the current selected site.
+            ActivityLauncher.viewStatsInNewStack(getContext());
+        }
+    }
+
     private void handleAppBanner(@NonNull String host) {
         switch (host) {
             case DEEP_LINK_HOST_NOTIFICATIONS:
@@ -191,9 +207,9 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
     private boolean isFromAppBanner(String host) {
         return (host != null
                 && (host.equals(DEEP_LINK_HOST_NOTIFICATIONS)
-                || host.equals(DEEP_LINK_HOST_POST)
-                || host.equals(DEEP_LINK_HOST_READ)
-                || host.equals(DEEP_LINK_HOST_STATS)));
+                    || host.equals(DEEP_LINK_HOST_POST)
+                    || host.equals(DEEP_LINK_HOST_READ)
+                    || host.equals(DEEP_LINK_HOST_STATS)));
     }
 
     @Override
@@ -214,10 +230,10 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
                 final long postId = Long.parseLong(mPostId);
 
                 AnalyticsUtils.trackWithBlogPostDetails(AnalyticsTracker.Stat.READER_VIEWPOST_INTERCEPTED,
-                                                        blogId, postId);
+                        blogId, postId);
 
                 ReaderActivityLauncher.showReaderPostDetail(this, false, blogId, postId, null, 0, false,
-                                                            mInterceptedUri);
+                        mInterceptedUri);
             } catch (NumberFormatException e) {
                 AppLog.e(T.READER, e);
             }
@@ -230,5 +246,22 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
     public void onBackPressed() {
         super.onBackPressed();
         finish();
+    }
+
+    // Helper Methods
+    private String extractTargetHost(@NonNull Uri uri) {
+        return uri.getLastPathSegment() == null ? "" : uri.getLastPathSegment();
+    }
+
+    private @Nullable SiteModel extractSiteModelFromTargetHost(String host) {
+        List<SiteModel> matchedSites = mSiteStore.getSitesByNameOrUrlMatching(host);
+        return matchedSites.isEmpty() ? null : matchedSites.get(0);
+    }
+
+    private @Nullable String extractHostFromSite(SiteModel site) {
+        if (site != null && site.getUrl() != null) {
+            return Uri.parse(site.getUrl()).getHost();
+        }
+        return null;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -181,6 +181,7 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
             // In other cases, launch stats with the current selected site.
             ActivityLauncher.viewStatsInNewStack(getContext());
         }
+        finish();
     }
 
     private void handleAppBanner(@NonNull String host) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -161,6 +161,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     public static final String ARG_READER = "show_reader";
     public static final String ARG_EDITOR = "show_editor";
     public static final String ARG_SHOW_ZENDESK_NOTIFICATIONS = "show_zendesk_notifications";
+    public static final String ARG_STATS = "show_stats";
 
     // Track the first `onResume` event for the current session so we can use it for Analytics tracking
     private static boolean mFirstResume = true;
@@ -522,6 +523,12 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         initSelectedSite();
                     }
                     onNewPostButtonClicked();
+                    break;
+                case ARG_STATS:
+                    if (mSelectedSite == null) {
+                        initSelectedSite();
+                    }
+                    ActivityLauncher.viewBlogStats(this, mSelectedSite);
                     break;
             }
         } else {


### PR DESCRIPTION
Fixes #11967 

**Description**
This PR adds support for deep linking to the main (insights) stats tab from an external source/email. 

New `data` nodes were added to the manifest to handle https\http /stats paths. `DeepLinkingIntentReceiverActivity` was enhanced to handle the new stats deep link. A few helpers methods were added, as they are shared between existing handlers and stats, plus they can be reused as we add further deep links.

As with other deep links, if the user is not logged in when tapping on a stats link, they will be redirected to login. If a user is logged in, but the site doesn’t exist, the user will be taken to the stats tab for the current site. 

**To test:**

**Option A**
Using ADB
- Log into the app 
- Push the app to the background or close it
- Execute from a terminal
     ./adb shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d "https://wordpress.com/stats/annmarietestdomain.blog"

**Option B**
- Log into the app 
- Push the app to the background or close it
- Send yourself an email with a link to a site you have access to:https://wordpress.com/stats/{site url}
- Tap the link
- You may be prompted with a "open wordpress.com links with WordPress" dialog. If so, select an option. 
- The app should launch and you will be taken to the Insights stats tab
 
**Option C**
- Log into the app 
- Push the app to the background or close it
- Send yourself an email with a link to a site that is invalid: https://wordpress.com/stats/{fake site url}
- Tap the link
- You may be prompted with a "open wordpress.com links with WordPress" dialog. If so, select an option. 
- The app should take you to the current site Stats Insights tab

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
