### PR TITLE
Fix empty content in ReaderPostListTabs after horizontal scroll

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -606,6 +606,11 @@ public class ReaderPostListFragment extends Fragment
     @Override
     public void onResume() {
         super.onResume();
+        /*
+         * This is a workaround for https://github.com/wordpress-mobile/WordPress-Android/issues/11985.
+         * The RecyclerView doesn't get redrawn correctly when the adapter finishes its initialization in onStart.
+         */
+        getPostAdapter().notifyDataSetChanged();
         if (mWasPaused) {
             AppLog.d(T.READER, "reader post list > resumed from paused state");
             mWasPaused = false;


### PR DESCRIPTION
Fixes #11985

This PR fixes an issue where the content of ReaderPostListFragment could remain empty even when the adapter contained valid data.


To test:
1. swipe gestures
------------------
Use a8c account or an account which contains more than 4 tabs.
1. Open Reader on "Following"
2. Switched to "Saved"
3. Switch back to "Following" and notice the content is NOT empty

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
