### PR TITLE
Fix custom list in reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/LoadReaderTabsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/LoadReaderTabsUseCase.kt
@@ -23,6 +23,10 @@ class LoadReaderTabsUseCase @Inject constructor(
         return withContext(bgDispatcher) {
             val tagList = ReaderTagTable.getDefaultTags()
 
+            /* Creating custom tag lists isn't supported anymore. However, we need to keep the support here
+            for users who created custom lists in the past.*/
+            tagList.addAll(ReaderTagTable.getCustomListTags())
+
             tagList.addAll(ReaderTagTable.getBookmarkTags()) // Add "Saved" tab manually
 
             // Add "Following" tab manually when on self-hosted site


### PR DESCRIPTION
This PR fixes an issue introduced during the refactoring. Custom lists should be displayed as tabs in Reader. 

[This is the corresponding line](https://github.com/wordpress-mobile/WordPress-Android/blob/a9d79fd56d32ed9d2f541f47eb6d2767c97f4c91/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java#L2882) in `develop` which hasn't been [moved to LoadReaderTabsUseCase in this commit](https://github.com/wordpress-mobile/WordPress-Android/commit/48db3728b1b211118e06235a8b77e6c6541cf913).

To test:
1. Log in with an account with custom tag list
2. Make sure the lists are visible as tabs in Reader
3. Make sure the correct posts are displayed when you select the tabs

As we discussed I don't have an account with custom lists, so I can't test these changes. However, I think they are pretty simple and one tester should be enough.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
