### PR TITLE
Issue/Add touch feedback to attribution text and hide follow from posts for tags

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -208,7 +208,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final Group mFramePhoto;
         private final TextView mTxtPhotoTitle;
 
-        private final Group mLayoutDiscover;
+        private final View mLayoutDiscover;
         private final ImageView mImgDiscoverAvatar;
         private final TextView mTxtDiscover;
 
@@ -662,16 +662,14 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         GravatarUtils.fixGravatarUrl(discoverData.getAvatarUrl(), mAvatarSzSmall));
                 // tapping an editor pick opens the source post, which is handled by the existing
                 // post selection handler
-                for (int id : postHolder.mLayoutDiscover.getReferencedIds()) {
-                    postHolder.itemView.findViewById(id).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            if (mPostSelectedListener != null) {
-                                mPostSelectedListener.onPostSelected(post);
-                            }
+                postHolder.mLayoutDiscover.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        if (mPostSelectedListener != null) {
+                            mPostSelectedListener.onPostSelected(post);
                         }
-                    });
-                }
+                    }
+                });
                 break;
 
             case SITE_PICK:
@@ -680,18 +678,16 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         GravatarUtils.fixGravatarUrl(discoverData.getAvatarUrl(), mAvatarSzSmall));
                 // site picks show "Visit [BlogName]" link - tapping opens the blog preview if
                 // we have the blogId, if not show blog in internal webView
-                for (int id : postHolder.mLayoutDiscover.getReferencedIds()) {
-                    postHolder.itemView.findViewById(id).setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            if (discoverData.getBlogId() != 0) {
-                                ReaderActivityLauncher.showReaderBlogPreview(v.getContext(), discoverData.getBlogId());
-                            } else if (discoverData.hasBlogUrl()) {
-                                ReaderActivityLauncher.openUrl(v.getContext(), discoverData.getBlogUrl());
-                            }
+                postHolder.mLayoutDiscover.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        if (discoverData.getBlogId() != 0) {
+                            ReaderActivityLauncher.showReaderBlogPreview(v.getContext(), discoverData.getBlogId());
+                        } else if (discoverData.hasBlogUrl()) {
+                            ReaderActivityLauncher.openUrl(v.getContext(), discoverData.getBlogUrl());
                         }
-                    });
-                }
+                    }
+                });
                 break;
 
             case OTHER:

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -203,8 +203,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final ImageView mImgFeatured;
         private final ImageView mImgAvatarOrBlavatar;
 
-        private final ReaderFollowButton mFollowButton;
-
         private final Group mFramePhoto;
         private final TextView mTxtPhotoTitle;
 
@@ -248,7 +246,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             mThumbnailStrip = itemView.findViewById(R.id.thumbnail_strip);
 
             View postHeaderView = itemView.findViewById(R.id.layout_post_header);
-            mFollowButton = itemView.findViewById(R.id.follow_button);
 
             ViewUtilsKt.expandTouchTargetArea(mLayoutDiscover, R.dimen.reader_discover_layout_extra_padding, true);
             ViewUtilsKt.expandTouchTargetArea(mImgMore, R.dimen.reader_more_image_extra_padding, false);
@@ -585,19 +582,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             holder.mImgMore.setOnClickListener(null);
         }
 
-        if (shouldShowFollowButton()) {
-            holder.mFollowButton.setIsFollowed(post.isFollowedByCurrentUser);
-            holder.mFollowButton.setOnClickListener(new OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    toggleFollow(view.getContext(), view, post);
-                }
-            });
-            holder.mFollowButton.setVisibility(View.VISIBLE);
-        } else {
-            holder.mFollowButton.setVisibility(View.GONE);
-        }
-
         // attribution section for discover posts
         if (post.isDiscoverPost()) {
             showDiscoverData(holder, post);
@@ -622,16 +606,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             mRenderedIds.add(post.getPseudoId());
             AnalyticsUtils.trackRailcarRender(post.getRailcarJson());
         }
-    }
-
-    /*
-     * follow button only shows for tags and "Posts I Like" - it doesn't show for Followed Sites,
-     * Discover, lists, etc.
-     */
-    private boolean shouldShowFollowButton() {
-        return mCurrentTag != null
-               && mCurrentTag.isTagTopic()
-               && !mIsLoggedOutReader;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -51,7 +51,6 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils;
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils.VideoThumbnailUrlListener;
 import org.wordpress.android.ui.reader.utils.ReaderXPostUtils;
-import org.wordpress.android.ui.reader.views.ReaderFollowButton;
 import org.wordpress.android.ui.reader.views.ReaderGapMarkerView;
 import org.wordpress.android.ui.reader.views.ReaderIconCountView;
 import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -54,7 +54,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/margin_medium"
             app:layout_constraintStart_toEndOf="@id/image_avatar_or_blavatar"
-            app:layout_constraintEnd_toStartOf="@+id/follow_button"
+            app:layout_constraintEnd_toStartOf="@+id/image_more"
             app:layout_constraintTop_toTopOf="@id/guideline_top"
             tools:text="text_blog_nametext_blog_name text_blog_name" />
 
@@ -99,19 +99,10 @@
             android:layout_marginBottom="@dimen/margin_small"
             android:maxLines="1"
             app:layout_constraintStart_toEndOf="@id/dot_separator"
-            app:layout_constraintEnd_toStartOf="@id/follow_button"
+            app:layout_constraintEnd_toStartOf="@id/image_more"
             app:layout_constraintTop_toBottomOf="@id/text_author_and_blog_name"
             app:layout_constraintWidth_default="wrap"
             tools:text="text_dateline"/>
-
-        <org.wordpress.android.ui.reader.views.ReaderFollowButton
-            android:id="@+id/follow_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/reader_follow_button_padding"
-            android:layout_marginEnd="@dimen/reader_follow_button_padding"
-            app:layout_constraintEnd_toStartOf="@id/image_more"
-            app:layout_constraintTop_toTopOf="@id/guideline_top" />
 
         <ImageView
             android:id="@+id/image_more"
@@ -135,7 +126,7 @@
             android:visibility="visible"
             android:layout_marginEnd="@dimen/margin_medium"
             app:layout_constraintStart_toStartOf="@id/guideline_beginning"
-            app:layout_constraintEnd_toStartOf="@id/follow_button"
+            app:layout_constraintEnd_toStartOf="@id/image_more"
             app:layout_constraintTop_toTopOf="@id/guideline_top" />
         <!-- post header end -->
 

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -246,11 +246,11 @@
             android:background="?android:selectableItemBackground"
             android:importantForAccessibility="no"
             android:src="@drawable/bg_rectangle_placeholder_globe_32dp"
-            android:layout_marginTop="@dimen/margin_extra_large"
             android:layout_marginEnd="@dimen/margin_large"
             app:layout_constraintStart_toStartOf="@id/guideline_beginning"
             app:layout_constraintEnd_toStartOf="@id/text_discover"
-            app:layout_constraintTop_toBottomOf="@id/text_excerpt"
+            app:layout_constraintTop_toTopOf="@id/text_discover"
+            app:layout_constraintBottom_toBottomOf="@id/text_discover"
             tools:ignore="RtlSymmetry" />
 
         <org.wordpress.android.widgets.WPTextView
@@ -265,9 +265,10 @@
             android:textColor="?attr/wpColorOnSurfaceMedium"
             android:textAlignment="viewStart"
             android:gravity="center_vertical|start"
+            android:layout_marginTop="@dimen/margin_extra_large"
             app:layout_constraintStart_toEndOf="@id/image_discover_avatar"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
-            app:layout_constraintTop_toTopOf="@id/image_discover_avatar"
+            app:layout_constraintTop_toBottomOf="@id/text_excerpt"
             tools:text="text_attribution"
             tools:ignore="RtlSymmetry" />
 
@@ -276,9 +277,10 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:visibility="gone"
+            android:background="?android:selectableItemBackground"
             app:layout_constraintStart_toStartOf="@id/guideline_beginning"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
-            app:layout_constraintTop_toTopOf="@id/image_discover_avatar"
+            app:layout_constraintTop_toTopOf="@id/text_discover"
             app:layout_constraintBottom_toBottomOf="@id/text_discover"
             app:constraint_referenced_ids="image_discover_avatar,text_discover"
             tools:visibility="visible" />


### PR DESCRIPTION
This PR is a subpart of #11963 and

- Includes touch feedback for discover posts attribution text
- Hides Follow button from posts for tags (option already present in more options now present on the top of the card)

**Touch feedback** 

| Before (live app)| After |
|----| ---|
| ![before_attribution](https://user-images.githubusercontent.com/1405144/82664423-56277f80-9c4f-11ea-856b-07b43d618936.gif) | ![after_attribution](https://user-images.githubusercontent.com/1405144/82664562-9555d080-9c4f-11ea-860c-4ccaf9e3a02f.gif) |


**Hide Follow button**

| Before (live app) | After |
|----| ---|
| ![device-2020-05-22-165759](https://user-images.githubusercontent.com/1405144/82664636-c0d8bb00-9c4f-11ea-83cc-4778b5bfed05.png)| ![device-2020-05-22-165201](https://user-images.githubusercontent.com/1405144/82664620-b7e7e980-9c4f-11ea-8415-75a993b56f25.png) |

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
