### PR TITLE
Fix Crash InflateException Binary XML file

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
@@ -79,8 +79,8 @@ public class WPLoginInputRow extends RelativeLayout {
                     mEditText.setHintTextColor(getResources().getColor(android.R.color.transparent));
                 }
                 if (a.hasValue(R.styleable.wpLoginInputRow_passwordToggleEnabled)) {
-                    mTextInputLayout.setPasswordVisibilityToggleEnabled(
-                            a.getBoolean(R.styleable.wpLoginInputRow_passwordToggleEnabled, false));
+                    mTextInputLayout.setEndIconMode(TextInputLayout.END_ICON_PASSWORD_TOGGLE);
+                    mTextInputLayout.setEndIconDrawable(R.drawable.selector_password_visibility);
                 }
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/9905

To test: Go to the Login screen and check if the password icon has the correct asset when changing state.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
