### PR TITLE
Issue/11968 site pages deep link

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -395,6 +395,16 @@
                     android:pathPattern="/stats/..*"
                     android:scheme="http" />
 
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/pages/..*"
+                    android:scheme="https" />
+
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/pages/..*"
+                    android:scheme="http" />
+
             </intent-filter>
 
         </activity>

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1046,4 +1046,25 @@ public class ActivityLauncher {
         intent.putParcelableArrayListExtra(ARG_EDIT_IMAGE_DATA, input);
         activity.startActivityForResult(intent, RequestCodes.IMAGE_EDITOR_EDIT_IMAGE);
     }
+
+    public static void viewPagesInNewStack(Context context, SiteModel site) {
+        if (site == null) {
+            ToastUtils.showToast(context, R.string.pages_cannot_be_started, ToastUtils.Duration.SHORT);
+            return;
+        }
+
+        TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
+        Intent mainActivityIntent = getMainActivityInNewStack(context);
+        Intent pagesIntent = new Intent(context, PagesActivity.class);
+        pagesIntent.putExtra(WordPress.SITE, site);
+        taskStackBuilder.addNextIntent(mainActivityIntent);
+        taskStackBuilder.addNextIntent(pagesIntent);
+        taskStackBuilder.startActivities();
+    }
+
+    public static void viewPagesInNewStack(Context context) {
+        Intent intent = getMainActivityInNewStack(context);
+        intent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_PAGES);
+        context.startActivity(intent);
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -47,6 +47,7 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
     private static final String POST_PATH = "post";
     private static final String REDIRECT_TO_PARAM = "redirect_to";
     private static final String STATS_PATH = "stats";
+    private static final String PAGES_PATH = "pages";
 
     private String mInterceptedUri;
     private String mBlogId;
@@ -82,6 +83,8 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
                 handleViewPost(uri);
             } else if (shouldShowStats(uri)) {
                 handleShowStats(uri);
+            } else if (shouldShowPages(uri)) {
+                handleShowPages(uri);
             } else {
                 // not handled
                 finish();
@@ -93,8 +96,7 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
 
     private boolean shouldOpenEditor(@NonNull Uri uri) {
         // Match: https://wordpress.com/post/
-        return StringUtils.equals(uri.getHost(), HOST_WORDPRESS_COM)
-               && (!uri.getPathSegments().isEmpty() && StringUtils.equals(uri.getPathSegments().get(0), POST_PATH));
+        return shouldShow(uri, POST_PATH);
     }
 
     private @Nullable Uri getRedirectUri(@NonNull Uri uri) {
@@ -167,8 +169,7 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
 
     private boolean shouldShowStats(@NonNull Uri uri) {
         // Match: https://wordpress.com/stats/
-        return StringUtils.equals(uri.getHost(), HOST_WORDPRESS_COM)
-               && (!uri.getPathSegments().isEmpty() && StringUtils.equals(uri.getPathSegments().get(0), STATS_PATH));
+        return shouldShow(uri, STATS_PATH);
     }
 
     private void handleShowStats(@NonNull Uri uri) {
@@ -181,6 +182,25 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
             // In other cases, launch stats with the current selected site.
             ActivityLauncher.viewStatsInNewStack(getContext());
         }
+        finish();
+    }
+
+    private boolean shouldShowPages(@NonNull Uri uri) {
+        // Match: https://wordpress.com/pages/
+        return shouldShow(uri, PAGES_PATH);
+    }
+
+    private void handleShowPages(@NonNull Uri uri) {
+        String targetHost = extractTargetHost(uri);
+        SiteModel site = extractSiteModelFromTargetHost(targetHost);
+        String host = extractHostFromSite(site);
+        if (site != null && host != null && StringUtils.equals(host, targetHost)) {
+            ActivityLauncher.viewPagesInNewStack(getContext(), site);
+        } else {
+            // In other cases, launch pages with the current selected site.
+            ActivityLauncher.viewPagesInNewStack(getContext());
+        }
+        finish();
     }
 
     private void handleAppBanner(@NonNull String host) {
@@ -261,5 +281,10 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
             return Uri.parse(site.getUrl()).getHost();
         }
         return null;
+    }
+
+    private boolean shouldShow(@NonNull Uri uri, @NonNull String path) {
+        return StringUtils.equals(uri.getHost(), HOST_WORDPRESS_COM)
+               && (!uri.getPathSegments().isEmpty() && StringUtils.equals(uri.getPathSegments().get(0), path));
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.HapticFeedbackConstants;
 import android.view.View;
 import android.view.ViewGroup;
@@ -162,6 +163,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     public static final String ARG_EDITOR = "show_editor";
     public static final String ARG_SHOW_ZENDESK_NOTIFICATIONS = "show_zendesk_notifications";
     public static final String ARG_STATS = "show_stats";
+    public static final String ARG_PAGES = "show_pages";
 
     // Track the first `onResume` event for the current session so we can use it for Analytics tracking
     private static boolean mFirstResume = true;
@@ -529,6 +531,13 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         initSelectedSite();
                     }
                     ActivityLauncher.viewBlogStats(this, mSelectedSite);
+                    break;
+                case ARG_PAGES:
+                    if (mSelectedSite == null) {
+                        initSelectedSite();
+                    }
+                    Log.d(WPMainActivity.class.getSimpleName(), "***=> ARGS PAGES");
+                    ActivityLauncher.viewCurrentBlogPages(this, mSelectedSite);
                     break;
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -10,7 +10,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.HapticFeedbackConstants;
 import android.view.View;
 import android.view.ViewGroup;
@@ -536,7 +535,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     if (mSelectedSite == null) {
                         initSelectedSite();
                     }
-                    Log.d(WPMainActivity.class.getSimpleName(), "***=> ARGS PAGES");
                     ActivityLauncher.viewCurrentBlogPages(this, mSelectedSite);
                     break;
             }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2639,7 +2639,7 @@
     <string name="pages_empty_trashed">You don\'t have any trashed pages</string>
     <string name="pages_open_page_error">The selected page is not available</string>
     <string name="pages_and_posts_cancel_auto_upload">Cancel upload</string>
-
+    <string name="pages_cannot_be_started">We cannot open pages at the moment. Please try again later</string>
 
     <string name="page_status_pending_review" translatable="false">@string/post_status_pending_review</string>
     <string name="page_status_page_private" translatable="false">@string/post_status_post_private</string>


### PR DESCRIPTION
Fixes #11968 

**Description**
This PR builds upon PR #11990 and adds support for deep linking to the site pages list from an external source/email.

**Merge Instructions**
- Ensure PR #11967 has been merged first
- Then merge this PR.
Note: A possible issue related to activity stack is still being researched. This PR can still be merged.


New `data` nodes were added to the manifest to handle https\http /pages paths. 

`DeepLinkingIntentReceiverActivity` was enhanced to handle the new pages deep link. Added a new helper method to be shared across other deep link handlers. As with other deep links, if the user is not logged in when tapping on a pages link, they will be redirected to login. If a user is logged in, but the site doesn’t exist, the user will be taken to the pages list for the current site.


**To test:**
**Option A**
Using ADB

- Log into the app
- Push the app to the background or close it
- Execute from a terminal
- ./adb shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d "https://wordpress.com/pages/annmarietestdomain.blog"

**Option B**

- Log into the app
- Push the app to the background or close it
- Send yourself an email with a link to a site you have access to:https://wordpress.com/pages/{site url}
- Tap the link
- You may be prompted with a "open wordpress.com links with WordPress" dialog. If so, select an option.
- The app should launch and you will be taken to the Site pages list

**Option C**

- Log into the app
- Push the app to the background or close it
- Send yourself an email with a link to a site that is invalid: https://wordpress.com/pages/{fake site url}
- Tap the link
- You may be prompted with a "open wordpress.com links with WordPress" dialog. If so, select an option.
- The app should take you to the current site Site Page list
PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
