### PR TITLE
Prepublishing Nudges : Expand bottom sheet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -94,8 +94,7 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
 
             bottomSheet?.let {
                 val behavior = BottomSheetBehavior.from(it)
-                val metrics = resources.displayMetrics
-                behavior.peekHeight = metrics.heightPixels / 2
+                behavior.state = BottomSheetBehavior.STATE_EXPANDED
             }
         }
         setupMinimumHeightForFragmentContainer()


### PR DESCRIPTION
Fixes #11964

## Solution
Set the bottom sheet behavior to `Expanded` instead of peeking. 

## Testing
Use a phone for this test in landscape mode. 

1. Create a new post. 
2. Click Publish. 
3. See that it's expanded.

### Before
<kbd><img src="https://user-images.githubusercontent.com/1509205/82709741-e7462880-9c46-11ea-9941-9a6cff726225.png" ></kbd>

### After
<kbd><img src="https://user-images.githubusercontent.com/1509205/82709821-18265d80-9c47-11ea-8f34-fcc07ab2259a.png"></kbd>

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
