### PR TITLE
Default visibility of More and Edit to gone

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -408,6 +408,8 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         mBtnLikeComment.setOnClickListener(v -> likeComment(false));
 
         mBtnMoreComment.setOnClickListener(v -> showMoreMenu(v));
+        // hide more button until we know it can be enabled
+        mBtnMoreComment.setVisibility(View.GONE);
 
         setupSuggestionServiceAndAdapter();
 
@@ -1012,6 +1014,12 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             }
         }
 
+        if (canShowMore()) {
+            mBtnMoreComment.setVisibility(View.VISIBLE);
+        } else {
+            mBtnMoreComment.setVisibility(View.GONE);
+        }
+
         mLayoutButtons.setVisibility(View.VISIBLE);
     }
 
@@ -1082,6 +1090,13 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     private boolean canLike() {
         return (mEnabledActions != null && mEnabledActions.contains(EnabledActions.ACTION_LIKE)
                 && mSite != null && SiteUtils.isAccessedViaWPComRest(mSite));
+    }
+
+    /*
+    * The more button contains controls which only moderates can use
+     */
+    private boolean canShowMore() {
+        return canModerate();
     }
 
     /*
@@ -1378,6 +1393,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         }
 
         MenuItem editMenuItem = morePopupMenu.getMenu().findItem(R.id.action_edit);
+        editMenuItem.setVisible(false);
         if (canEdit()) {
             editMenuItem.setVisible(true);
         }


### PR DESCRIPTION
Fixes #12011 

**Description**
This PR fixes an issue that exposes the Edit option on Comment Detail view More menu. The underlying issue was that the More menu default visibility was set to visible, which caused it to show outside of moderation situations. 

**Details**
1. Default the visibility of the More menu to gone until moderation access has been explicitly granted 
2. Default the visibility of the Edit button (on the More menu) to gone until edit access has been explicitly granted.

**To test:**
**Scenario A - Do not show More menu**
- From a non-a8c account, log in
- Follow or comment on a site in which you are not a user
- From notifications, tap a comment alert
- The More menu should not be visible

**Scenario B - Do show More menu**
- From a non-a8c account, log in
- Follow or comment on a site in which you are a user
- From notifications, tap a comment alert
- The More menu should be visible


PR submission checklist:
- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
