### PR TITLE
Prepublishing Nudges : Navigate to editor before showing bottom sheet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1734,7 +1734,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     private void showPrepublishingNudgeBottomSheet() {
+        mViewPager.setCurrentItem(PAGE_CONTENT);
         ActivityUtils.hideKeyboard(this);
+
         Fragment fragment = getSupportFragmentManager().findFragmentByTag(
                 PrepublishingBottomSheetFragment.TAG);
         if (fragment == null) {


### PR DESCRIPTION
Fixes #12014

## Solution
the `viewPager` controls the content that is shown within the `Editor`. Setting it's `currentItem` before displaying the sheet creates the functionality we want. 

## Testing
1. Create a new post. 
2. Click More Icon. 
3. Click Post Settings. 
4. Press Publish. 
5. Realize the app navigated back to the Editor before showing bottom sheet. 

<kbd><img src="https://user-images.githubusercontent.com/1509205/82777745-adc31800-9e14-11ea-8bbd-c99f0f560d1e.gif" width="320"></kbd>

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 