### PR TITLE
Hide search in reader for self-hosted login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -77,7 +77,10 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.reader_home, menu)
-        searchMenuItem = menu.findItem(R.id.menu_search)
+        menu.findItem(R.id.menu_search).apply {
+            searchMenuItem = this
+            this.isVisible = viewModel.uiState.value?.searchIconVisible ?: false
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -35,6 +35,8 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
     private lateinit var viewModel: ReaderViewModel
     private lateinit var newsCardViewModel: NewsCardViewModel
 
+    private var searchMenuItem: MenuItem? = null
+
     private val viewPagerCallback = object : ViewPager2.OnPageChangeCallback() {
         override fun onPageSelected(position: Int) {
             super.onPageSelected(position)
@@ -58,6 +60,11 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
         initViewModel()
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        searchMenuItem = null
+    }
+
     override fun onResume() {
         super.onResume()
         viewModel.onScreenInForeground()
@@ -70,6 +77,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.reader_home, menu)
+        searchMenuItem = menu.findItem(R.id.menu_search)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -101,6 +109,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
         viewModel.uiState.observe(viewLifecycleOwner, Observer { uiState ->
             uiState?.let {
                 updateTabs(uiState)
+                searchMenuItem?.isVisible = uiState.searchIconVisible
             }
         })
 

--- a/WordPress/src/main/res/menu/reader_home.xml
+++ b/WordPress/src/main/res/menu/reader_home.xml
@@ -6,5 +6,6 @@
         android:id="@+id/menu_search"
         android:icon="@drawable/ic_search_white_24dp"
         android:title="@string/search"
+        android:visible="false"
         app:showAsAction="always" />
 </menu>


### PR DESCRIPTION
Fixes #11981 

Hides search icon in Reader for self-hosted login.

To test:
1. Login using the self-hosted login flow
2. Make sure the search icon in Reader is not visible
--------------
1. Login using the .com login flow
2. Make sure the search icon in Reader is visible and works


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
