### PR TITLE
Short release notes version handling - part 1: upload originals

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: ../release-toolkit
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit
+  revision: 116952d9044c2dbced95812a340ea43a47a50cc9
+  ref: 116952d9044c2dbced95812a340ea43a47a50cc9
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.9.4)
       activesupport (~> 4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 116952d9044c2dbced95812a340ea43a47a50cc9
-  ref: 116952d9044c2dbced95812a340ea43a47a50cc9
+  revision: aa1997a9f798eb17a08023cbe502a8cdffdb34f1
+  tag: 0.9.5
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.4)
+    fastlane-plugin-wpmreleasetoolkit (0.9.5)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,7 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 4ae6fbdc229d760e47c4b15faf2eb33f162170b3
-  tag: 0.9.3
+PATH
+  remote: ../release-toolkit
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.3)
+    fastlane-plugin-wpmreleasetoolkit (0.9.4)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -20,7 +18,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.2)
-    activesupport (4.2.11.1)
+    activesupport (4.2.11.3)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
@@ -154,7 +152,7 @@ GEM
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.0)
+    minitest (5.14.1)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -28,6 +28,12 @@ msgid ""
 msgstr ""
 
 #. translators: A shorter version of the Release notes to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_short_149"
+msgid ""
+"14.9:\n"
+"<b>Block editor enhancements:</b> New Pullquote block, Button block color options, updated page templates.\n"
+msgstr ""
+
 msgctxt "release_note_short_148"
 msgid ""
 "14.8:\n"

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -27,6 +27,15 @@ msgid ""
 "<b>General updates:</b> Added reblog functionality.\n"
 msgstr ""
 
+#. translators: A shorter version of the Release notes to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_short_148"
+msgid ""
+"14.8:\n"
+"<b>Block editor additions:</b> Buttons block displays multiple buttons in a single row; Image blocks prefill captions when available; Cover blocks allow uploading; inserted images can be cropped, zoomed, or rotated; Heading block includes alignment options.\n"
+"<b>Block editor improvements:</b> Relocated floating toolbar, fixed bug impact white space in Text blocks, fixed misaligned toolbar icons in RTL mode.\n"
+"<b>General updates:</b> Added reblog functionality.\n"
+msgstr ""
+
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
 msgctxt "sample_post_content"
 msgid "The best moment of any trip, for me, is when I first step foot off the plane. The whole of the trip is in front me, ripe with possibility."

--- a/WordPress/metadata/release_notes_short.txt
+++ b/WordPress/metadata/release_notes_short.txt
@@ -1,0 +1,1 @@
+<b>Block editor enhancements:</b> New Pullquote block, Button block color options, updated page templates.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,6 +91,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
 
     files = {
       release_note: prj_folder + "/WordPress/metadata/release_notes.txt",
+      release_note_short: prj_folder + "/WordPress/metadata/release_notes_short.txt",
       play_store_promo: prj_folder + "/WordPress/metadata/short_description.txt",
       play_store_desc: prj_folder + "/WordPress/metadata/full_description.txt",
       play_store_app_title: prj_folder + "/WordPress/metadata/title.txt",

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,6 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.9.3'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref:'116952d9044c2dbced95812a340ea43a47a50cc9'
 
-gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../wordpress-mobile/release-toolkit'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,6 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.9.3'
+#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.9.3'
 
+gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../wordpress-mobile/release-toolkit'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref:'116952d9044c2dbced95812a340ea43a47a50cc9'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.9.5'
 


### PR DESCRIPTION
We've had many cases where the translation of the release notes didn't fit the 500 chars limit in many languages. 
Because of this, this PR introduce the management of two different sets of release notes: the standard one and a short version that's used when the translation doesn't fit the App Store chars limit. 

To test:
1. `bundle install`
2. Run `bundle exec fastlane update_appstore_strings version:14.9` and verify that `PlayStoreStrings.po`  doesn't change. 
3. Checkout a new branch out of this one and push it to GitHub.
4. Apply some changes to `release_notes.txt` and `release_notes_short.txt`.
5. Run `bundle exec fastlane update_appstore_strings version:15.0` and verify that the changes are applied to `PlayStoreStrings.po` and the they are pushed to GitHub.
6. Delete the test branch from GitHub and your local repository.

_Note_: This PR is based on changes in the `release-toolkit`:https://github.com/wordpress-mobile/release-toolkit/pull/122.
Before merging this PR, a new version of the plugin should be released and the reference here updated. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
