### PR TITLE
Fix crash in onSaveInstanceState in Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -822,8 +822,10 @@ public class ReaderPostListFragment extends Fragment
         outState.putBoolean(ReaderConstants.KEY_WAS_PAUSED, mWasPaused);
         outState.putBoolean(ReaderConstants.KEY_ALREADY_UPDATED, mHasUpdatedPosts);
         outState.putBoolean(ReaderConstants.KEY_FIRST_LOAD, mFirstLoad);
-        outState.putBoolean(ReaderConstants.KEY_IS_REFRESHING, mRecyclerView.isRefreshing());
-        outState.putInt(ReaderConstants.KEY_RESTORE_POSITION, getCurrentPosition());
+        if (mRecyclerView != null) {
+            outState.putBoolean(ReaderConstants.KEY_IS_REFRESHING, mRecyclerView.isRefreshing());
+            outState.putInt(ReaderConstants.KEY_RESTORE_POSITION, getCurrentPosition());
+        }
         outState.putSerializable(ReaderConstants.ARG_POST_LIST_TYPE, getPostListType());
         outState.putBoolean(ReaderConstants.ARG_IS_TOP_LEVEL, mIsTopLevel);
         outState.putParcelable(QuickStartEvent.KEY, mQuickStartEvent);


### PR DESCRIPTION
Fixes #11992 

As explained [here](https://github.com/wordpress-mobile/WordPress-Android/issues/11992#issuecomment-633472384) this issue was introduced with [the changes](https://github.com/wordpress-mobile/WordPress-Android/pull/11927) to the BottomNavigation.

However, the root cause of this issue was introduced by Google in AppCompat 1.1.0. `onSaveInstanceState` is invoked even for fragments on back stack which views were never displayed/created.  More info [here](https://github.com/wordpress-mobile/WordPress-Android/pull/11292).

Downside is that we'll lose scroll position on double rotation, but I don't think it's a big deal. Especially since this will happen only when the user isn't on the Reader tab.

To test:
1. Open the App
2. Click on Reader
3. Click on "My Site"
4. Rotate your device **twice** -> make sure the app doesn't crash

------------------------------------

1. Enable "Don't keep activities" under Device Settings -> Systems -> Advanced -> Developer options -> Apps section
2. Open WordPress Android app and toggle from Reader tab to My site tab
4. Click Blog Posts on My site tab and return from it
6. Click Blog Posts again or Site Pages on My site tab -> make sure the app doesn't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

This crash was introduced in 14.9-rc-1, so this PR is targeting a frozen branch (cc @oguzkocer).
