### PR TITLE
Feature/multiple releasenotes versions 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: aa1997a9f798eb17a08023cbe502a8cdffdb34f1
-  tag: 0.9.5
+  revision: 6c1fa45f3beb216f4f5d03346f2981f1024b799e
+  tag: 0.9.6
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.5)
+    fastlane-plugin-wpmreleasetoolkit (0.9.6)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
       nokogiri (>= 1.10.4)
-      octokit (~> 4.13)
+      octokit (~> 4.18)
       parallel (~> 1.14)
       progress_bar (~> 1.3)
       rake (~> 12.3)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -294,7 +294,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
   lane :download_metadata_strings do |options| 
     values = options[:version].split('.')
     files = {
-      "release_note_#{values[0]}#{values[1]}" => {desc: "changelogs/#{options[:build_number]}.txt", max_size: 0},
+      "release_note_#{values[0]}#{values[1]}" => {desc: "changelogs/#{options[:build_number]}.txt", max_size: 500, alternate_key:"release_note_short_#{values[0]}#{values[1]}"},
       play_store_promo: {desc:"short_description.txt", max_size: 80},
       play_store_desc: {desc:"full_description.txt", max_size: 0},
       play_store_app_title: {desc:"title.txt", max_size: 50}

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.9.5'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.9.6'
 


### PR DESCRIPTION
This PR is a follow up of https://github.com/wordpress-mobile/WordPress-Android/pull/12017 and adds the logic to download the alternate release notes. 

To test:
1. Create a new branch out of this one.
2. `bundle install`
3. Run `bundle exec fastlane download_metadata_strings version:15.0 build_number:867`
4. Verify that the strings are downloaded and that the `short` version is picked when the standard one is too long (there should be a message about this in the console output).

Initially, I opted to skip the `short` version if it's still longer than 500 chars. After some rethinking, I've now changed it to save the `short` version in any case. This way, the release manager is aware that a translation is present and can try to work on it to make it fit the Play Store limit. 
If we skip the `short` version instead, the release manager should look on GlotPress to check if a translation is present, which is less than ideal. 

I have no strong opinions here tho, so let me know if you have other ideas. 
We can also just dismiss translations that are too long and use the English one... 

_Note_: This PR is based on changes in the https://github.com/wordpress-mobile/release-toolkit/pull/123.
Before merging this PR, a new version of the plugin should be released and the reference here updated.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
