### PR TITLE
Gutenberg 1.28.1 updates to develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,6 @@
  
 14.9
 -----
-* [**] Block editor: Avoid crash when editor gets into invalid state
 * [*] Fix issue with Preview post not working after switching to classic editor from inside the post
 * [***] Block Editor: New block: Pullquote
 * [**] Block Editor: Add support for changing background and text color in Buttons block

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
  
 14.9
 -----
+* [**] Block editor: Avoid crash when editor gets into invalid state
 * [*] Fix issue with Preview post not working after switching to classic editor from inside the post
 * [***] Block Editor: New block: Pullquote
 * [**] Block Editor: Add support for changing background and text color in Buttons block

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3108,6 +3108,11 @@ public class EditPostActivity extends LocaleAwareActivity implements
         return (Exception e) -> CrashLoggingUtils.logException(e, T.EDITOR);
     }
 
+    @Override
+    public Consumer<String> getBreadcrumbLogger() {
+        return CrashLoggingUtils::log;
+    }
+
     private void updateAddingMediaToEditorProgressDialogState(ProgressDialogUiState uiState) {
         mAddingMediaToEditorProgressDialog = mProgressDialogHelper
                 .updateProgressDialogState(this, mAddingMediaToEditorProgressDialog, uiState, mUiHelpers);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -63,6 +63,7 @@ import org.wordpress.android.editor.EditorImagePreviewListener;
 import org.wordpress.android.editor.EditorImageSettingsListener;
 import org.wordpress.android.editor.EditorMediaUploadListener;
 import org.wordpress.android.editor.EditorMediaUtils;
+import org.wordpress.android.editor.ExceptionLogger;
 import org.wordpress.android.editor.GutenbergEditorFragment;
 import org.wordpress.android.editor.ImageSettingsDialogFragment;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -227,7 +228,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
         PostSettingsListDialogFragment.OnPostSettingsDialogFragmentListener,
         HistoryListFragment.HistoryItemClickInterface,
         EditPostSettingsCallback,
-        PrivateAtCookieProgressDialogOnDismissListener {
+        PrivateAtCookieProgressDialogOnDismissListener,
+        ExceptionLogger {
     public static final String ACTION_REBLOG = "reblogAction";
     public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
     public static final String EXTRA_LOAD_AUTO_SAVE_REVISION = "loadAutosaveRevision";
@@ -3099,6 +3101,11 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     @Override public void advertiseImageOptimization(@NotNull Function0<Unit> listener) {
         WPMediaUtils.advertiseImageOptimization(this, listener::invoke);
+    }
+
+    @Override
+    public Consumer<Exception> getExceptionLogger() {
+        return (Exception e) -> CrashLoggingUtils.logException(e, T.EDITOR);
     }
 
     private void updateAddingMediaToEditorProgressDialogState(ProgressDialogUiState uiState) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ExceptionLogger.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ExceptionLogger.java
@@ -1,0 +1,7 @@
+package org.wordpress.android.editor;
+
+import androidx.core.util.Consumer;
+
+public interface ExceptionLogger {
+    Consumer<Exception> getExceptionLogger();
+}

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ExceptionLogger.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ExceptionLogger.java
@@ -4,4 +4,5 @@ import androidx.core.util.Consumer;
 
 public interface ExceptionLogger {
     Consumer<Exception> getExceptionLogger();
+    Consumer<String> getBreadcrumbLogger();
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -3,6 +3,7 @@ package org.wordpress.android.editor;
 import android.os.Bundle;
 import android.view.ViewGroup;
 
+import androidx.core.util.Consumer;
 import androidx.fragment.app.Fragment;
 
 import org.wordpress.mobile.WPAndroidGlue.AddMentionUtil;
@@ -95,6 +96,11 @@ public class GutenbergContainerFragment extends Fragment {
         boolean isDarkMode = getArguments().getBoolean(ARG_PREFERRED_COLOR_SCHEME);
         boolean isSiteUsingWpComRestApi = getArguments().getBoolean(ARG_SITE_USING_WPCOM_REST_API);
 
+        Consumer<Exception> exceptionLogger = null;
+        if (getActivity() instanceof ExceptionLogger) {
+            exceptionLogger = ((ExceptionLogger) getActivity()).getExceptionLogger();
+        }
+
         mWPAndroidGlueCode = new WPAndroidGlueCode();
         mWPAndroidGlueCode.onCreate(getContext());
         mWPAndroidGlueCode.onCreateView(
@@ -109,8 +115,8 @@ public class GutenbergContainerFragment extends Fragment {
                 translations,
                 getContext().getResources().getColor(R.color.background_color),
                 isDarkMode,
-                isSiteUsingWpComRestApi
-        );
+                isSiteUsingWpComRestApi,
+                exceptionLogger);
 
         // clear the content initialization flag since a new ReactRootView has been created;
         mHasReceivedAnyContent = false;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -97,8 +97,11 @@ public class GutenbergContainerFragment extends Fragment {
         boolean isSiteUsingWpComRestApi = getArguments().getBoolean(ARG_SITE_USING_WPCOM_REST_API);
 
         Consumer<Exception> exceptionLogger = null;
+        Consumer<String> breadcrumbLogger = null;
         if (getActivity() instanceof ExceptionLogger) {
-            exceptionLogger = ((ExceptionLogger) getActivity()).getExceptionLogger();
+            ExceptionLogger exceptionLoggingActivity = ((ExceptionLogger) getActivity());
+            exceptionLogger = exceptionLoggingActivity.getExceptionLogger();
+            breadcrumbLogger = exceptionLoggingActivity.getBreadcrumbLogger();
         }
 
         mWPAndroidGlueCode = new WPAndroidGlueCode();
@@ -116,7 +119,8 @@ public class GutenbergContainerFragment extends Fragment {
                 getContext().getResources().getColor(R.color.background_color),
                 isDarkMode,
                 isSiteUsingWpComRestApi,
-                exceptionLogger);
+                exceptionLogger,
+                breadcrumbLogger);
 
         // clear the content initialization flag since a new ReactRootView has been created;
         mHasReceivedAnyContent = false;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -118,9 +118,9 @@ public class GutenbergContainerFragment extends Fragment {
                 translations,
                 getContext().getResources().getColor(R.color.background_color),
                 isDarkMode,
-                isSiteUsingWpComRestApi,
                 exceptionLogger,
-                breadcrumbLogger);
+                breadcrumbLogger,
+                isSiteUsingWpComRestApi);
 
         // clear the content initialization flag since a new ReactRootView has been created;
         mHasReceivedAnyContent = false;


### PR DESCRIPTION
Brings the updates in Gutenberg 1.28.1 (which has been merged to `release/14.9`) to `develop` branch before the `gutenberg/integrate_1.29.0` branch is created. I did this by setting `gutenberg/1.28.1_updates_to_develop` to be the same as `develop` and then cherry-picking the commits with the 1.28.1 changes onto it. I did this instead of just merging `release/14.9` into `develop` because I did not want to bring in changes that were not related to Gutenberg's 1.28.1 release.

As always, once the related gutenberg-mobile PR is merged, we need to update the submodule ref in this PR to point to gutenberg-mobile's "new" `develop` hash before merging this.

## To test

### 1. Verify that networking still works by adding an image from the media library and insuring you can change image's size.


### 2. Verify that invalid-span handling is working

Create a post with the following HTML:
```
<!-- wp:paragraph -->
<p><unknownhtmlelement>abc</unknownhtmlelement>D</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>E</p>
<!-- /wp:paragraph -->
```

1. Put your cursor at the beginning of the second paragraph block with the single `E`
2. Tap the backspace key to merge the two blocks
3. Confirm no crash and no red screen.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
