### PR TITLE
add isAdded() check to trashComment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -1385,7 +1385,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     }
 
     private void trashComment() {
-        if (mComment == null) {
+        if (!isAdded() && mComment == null) {
             return;
         }
 


### PR DESCRIPTION
Fixes #12022 

This PR addresses a NPE caused by a getActivity() == null situation. As a preventative measure I added a check for isAdded() which should not let the code execute if the fragment is not added to the activity.

**To test:**
- Launch the app
- Navigate to a site in which you have comments that are in trash status
- Tap Comments
- Select trashed from the dropdown filter
- Tap on the comment to open the comment detail view
- Tap on the more menu
- Tap on the Delete button to open the alert window
- Tap on Yes 
- The dialog should close and the snackbar shows that the comment has been deleted.
- You should not experience any crashes throughout this workflow

NOTE: I have not been able to recreate the NPE on multiple devices and emulators. Please let me know if you experience any NPE's and the steps you took to recreate. Thanks in advance.

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
