### PR TITLE
Gutenberg Mobile 1.28.2 -> 14.9

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,6 @@
 14.9
 -----
 * [*] Fix issue with Preview post not working after switching to classic editor from inside the post
-* [***] Block Editor: New block: Pullquote
 * [**] Block Editor: Add support for changing background and text color in Buttons block
 * [*] Block Editor: Fix the icons and buttons in Gallery, Paragraph, List and MediaText block on RTL mode
 * [**] Block Editor: Remove Subscription Button from the Blog template since it didn't have an initial functionality and it is hard to configure for users.


### PR DESCRIPTION
Add the 1.28.2 Gutenberg mobile update to the 14.9 release to disable the pullquote block.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
