### PR TITLE
Issue/12026 ri phase 2 init

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -68,6 +68,7 @@ android {
 
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
         buildConfigField "boolean", "TENOR_AVAILABLE", "true"
+        buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "true"
     }
 
     // Gutenberg's dependency - react-native-video is using
@@ -89,12 +90,14 @@ android {
             versionCode 869
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "boolean", "TENOR_AVAILABLE", "false"
+            buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "false"
         }
 
         zalpha { // alpha version - enable experimental features
             applicationId "org.wordpress.android"
             dimension "buildType"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
+            buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "false"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -1,4 +1,3 @@
 package org.wordpress.android.ui.reader.discover
 
-class ReaderDiscoverFragment {
-}
+class ReaderDiscoverFragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -1,0 +1,4 @@
+package org.wordpress.android.ui.reader.discover
+
+class ReaderDiscoverFragment {
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -1,4 +1,3 @@
 package org.wordpress.android.ui.reader.discover
 
-class ReaderDiscoverViewModel {
-}
+class ReaderDiscoverViewModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -1,0 +1,4 @@
+package org.wordpress.android.ui.reader.discover
+
+class ReaderDiscoverViewModel {
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
@@ -1,0 +1,4 @@
+package org.wordpress.android.ui.reader.repository
+
+class ReaderPostRepository {
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
@@ -1,4 +1,3 @@
 package org.wordpress.android.ui.reader.repository
 
-class ReaderPostRepository {
-}
+class ReaderPostRepository

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
@@ -1,4 +1,3 @@
 package org.wordpress.android.ui.reader.repository
 
-class ReaderTagRepository {
-}
+class ReaderTagRepository

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
@@ -1,0 +1,4 @@
+package org.wordpress.android.ui.reader.repository
+
+class ReaderTagRepository {
+}


### PR DESCRIPTION
This PR introduces a build time feature flag for the second phase of "Reader Improvements" project. It also adds empty classes/packages for the discover tab and repositories.

To test:
No need to test anything.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
