### PR TITLE
Updates the aztec version to v1.3.43

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = 'v1.3.42'
+        aztecVersion = 'v1.3.43'
     }
 
     dependencies {


### PR DESCRIPTION
Fixes #
The latest Aztec version includes a fix to the aztec toolbar where the "add" image icon is "x" even before the user clicks on it.

To test:
Verify that the "add" image icon in the Aztec toolbar is a "+" and animates to an "x" when selected.

**This PR should not be merged till the Aztec version is updated in gutenberg-mobile repository.**

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
