### PR TITLE
Add dummy methods

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
@@ -1,3 +1,45 @@
 package org.wordpress.android.ui.reader.repository
 
-class ReaderTagRepository
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTagType
+import java.util.concurrent.TimeUnit
+
+/**
+ * ReaderTagRepository is middleware that encapsulates data related business related data logic
+ * Handle communicate with ReaderServices and Actions
+ */
+class ReaderTagRepository() {
+    private val mutableTopics = MutableLiveData<List<ReaderTag>>()
+    val topics: LiveData<List<ReaderTag>> = mutableTopics
+
+    suspend fun getInterests() {
+        // todo: full implementation needed
+        CoroutineScope(Dispatchers.IO).launch {
+            delay(TimeUnit.SECONDS.toMillis(5))
+            mutableTopics.postValue(getMockInterests())
+        }
+    }
+
+    // todo: remove method post implementation
+    private fun getMockInterests(): List<ReaderTag> {
+        return listOf<ReaderTag>().apply {
+            for (c in 'A'..'Z')
+                (ReaderTag(c.toString(), c.toString(), c.toString(),
+                        "https://public-api.wordpress.com/rest/v1.2/read/tags/$c/posts",
+                        ReaderTagType.DEFAULT))
+        }
+    }
+
+    // todo: full implementation needed
+    suspend fun saveInterests(tags: List<ReaderTag>) {
+        CoroutineScope(Dispatchers.IO).launch {
+            delay(TimeUnit.SECONDS.toMillis(3))
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
@@ -12,12 +12,13 @@ import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.models.ReaderTagType
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.SECONDS
+import javax.inject.Inject
 
 /**
  * ReaderTagRepository is middleware that encapsulates data related business related data logic
  * Handle communicate with ReaderServices and Actions
  */
-class ReaderTagRepository() {
+class ReaderTagRepository @Inject constructor() {
     private val mutableTopics = MutableLiveData<List<ReaderTag>>()
     val topics: LiveData<List<ReaderTag>> = mutableTopics
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
@@ -6,9 +6,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.models.ReaderTagType
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.SECONDS
 
 /**
  * ReaderTagRepository is middleware that encapsulates data related business related data logic
@@ -18,28 +21,27 @@ class ReaderTagRepository() {
     private val mutableTopics = MutableLiveData<List<ReaderTag>>()
     val topics: LiveData<List<ReaderTag>> = mutableTopics
 
-    suspend fun getInterests() {
-        // todo: full implementation needed
-        CoroutineScope(Dispatchers.IO).launch {
-            delay(TimeUnit.SECONDS.toMillis(5))
-            mutableTopics.postValue(getMockInterests())
-        }
+    suspend fun getInterests(): ReaderTagList =
+        withContext(Dispatchers.IO) {
+            delay(SECONDS.toMillis(5))
+            getMockInterests()
     }
 
     // todo: remove method post implementation
-    private fun getMockInterests(): List<ReaderTag> {
-        return listOf<ReaderTag>().apply {
-            for (c in 'A'..'Z')
-                (ReaderTag(c.toString(), c.toString(), c.toString(),
-                        "https://public-api.wordpress.com/rest/v1.2/read/tags/$c/posts",
-                        ReaderTagType.DEFAULT))
-        }
-    }
+    private fun getMockInterests() =
+            ReaderTagList().apply {
+                for (c in 'A'..'Z')
+                    (add(ReaderTag(
+                            c.toString(), c.toString(), c.toString(),
+                            "https://public-api.wordpress.com/rest/v1.2/read/tags/$c/posts",
+                            ReaderTagType.DEFAULT
+                    )))
+            }
 
     // todo: full implementation needed
     suspend fun saveInterests(tags: List<ReaderTag>) {
         CoroutineScope(Dispatchers.IO).launch {
-            delay(TimeUnit.SECONDS.toMillis(3))
+            delay(TimeUnit.SECONDS.toMillis(5))
         }
     }
 }


### PR DESCRIPTION
Part of #12039 

This PR adds two dummy methods to the ReaderTagRepository. 

Open Questions
1. Should a `List<ReaderTag>` be returned directly or will observers subscribe for changes. 
2. Should we using the `ReaderTagList` instead of `List<ReaderTag>`
3. Are there requirements for saving - even for a dummy - request params, etc

No tests needed, only contains stub methods.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
