### PR TITLE
Introduce runtime feature flag for reader improvements phase 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -19,7 +19,6 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomnavigation.BottomNavigationView.OnNavigationItemReselectedListener
 import com.google.android.material.bottomnavigation.BottomNavigationView.OnNavigationItemSelectedListener
 import com.google.android.material.bottomnavigation.LabelVisibilityMode
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.main.WPMainActivity.OnScrollToTopListener
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType.MY_SITE

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -284,7 +284,7 @@ class WPMainNavigationView @JvmOverloads constructor(
         private fun createFragment(pageType: PageType): Fragment {
             val fragment = when (pageType) {
                 MY_SITE -> MySiteFragment.newInstance()
-                READER -> if (BuildConfig.READER_IMPROVEMENTS_PHASE_2) {
+                READER -> if (AppPrefs.isReaderImprovementsPhase2Enabled()) {
                     ReaderInterestsFragment() // TODO: Temporary entry point
                 } else {
                     ReaderFragment()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -223,6 +224,9 @@ public class AppPrefs {
 
         // last app version code feature announcement was shown for
         LAST_FEATURE_ANNOUNCEMENT_APP_VERSION_CODE,
+
+        // feature flag for Reader Improvements Phase 2
+        FF_READER_IMPROVEMENTS_PHASE_2
     }
 
     private static SharedPreferences prefs() {
@@ -1157,5 +1161,18 @@ public class AppPrefs {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Feature Flag for Reader Improvements Phase 2. Both BuildTime and RunTime feature flag is used.
+     *
+     * BuildTime feature flag is used to make sure we never enable the feature in production builds - even when the
+     * user manually overrides the shared preferences record using adb.
+     *
+     * RunTime feature flag is used for us to enable the feature during development and when testing PRs on CI builds.
+     */
+    public static boolean isReaderImprovementsPhase2Enabled() {
+        return BuildConfig.READER_IMPROVEMENTS_PHASE_2 && getBoolean(UndeletablePrefKey.FF_READER_IMPROVEMENTS_PHASE_2,
+                false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -1169,7 +1169,7 @@ public class AppPrefs {
      * BuildTime feature flag is used to make sure we never enable the feature in production builds - even when the
      * user manually overrides the shared preferences record using adb.
      *
-     * RunTime feature flag is used for us to enable the feature during development and when testing PRs on CI builds.
+     * RunTime feature flag is used for us to enable the feature during development.
      */
     public static boolean isReaderImprovementsPhase2Enabled() {
         return BuildConfig.READER_IMPROVEMENTS_PHASE_2 && getBoolean(UndeletablePrefKey.FF_READER_IMPROVEMENTS_PHASE_2,


### PR DESCRIPTION
This PR is a follow up of https://github.com/wordpress-mobile/WordPress-Android/pull/12038.

We realized that enabling the feature flag for everyone on `wasabi` and `jalapeno` builds isn't ideal.
1. It breaks UI tests on CI as the feature isn't finished yet
2. It breaks Reader for all developers as the feature isn't finished yet

This PR introduces run-time feature flag as an addition to the buildTime feature flag. Developers working on the project can set `FF_READER_IMPROVEMENTS_PHASE_2` shared preferences's value to "true".

To test:
1. Start the app
2. Click on Reader and notice it works
3. Set `FF_READER_IMPROVEMENTS_PHASE_2` to true
4. Restart the app
5. Notice the reader displays an empty fragment - the new "InterestFragment


There are more options how to change value in shared preferences during runtime. I've always used Stetho's dumpapp script. But feel free to use whatever works the best for you.

1. Clone this repo https://github.com/facebook/stetho (or copy "scripts" folder)
2. Run 
WASABI: 
<code>./stetho/scripts/dumpapp -p org.wordpress.android.beta prefs write org.wordpress.android.beta_preferences FF_READER_IMPROVEMENTS_PHASE_2 string true</code>
JALAPENO: 
<code>./stetho/scripts/dumpapp -p org.wordpress.android.prealpha prefs write org.wordpress.android.prealpha_preferences FF_READER_IMPROVEMENTS_PHASE_2 string true</code>
(you might need to set execute permissions to the `dumpapp` file using `chmod`)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
