### PR TITLE
Unified Login & Sign-Up: Add Signup Confirmation screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -168,6 +168,7 @@ class HelpActivity : LocaleAwareActivity() {
         RELEASE_NOTES("origin:release-notes"),
         SIGNUP_EMAIL("origin:signup-email"),
         SIGNUP_MAGIC_LINK("origin:signup-magic-link"),
+        SIGNUP_CONFIRMATION("origin:signup-confirmation"),
         SITE_CREATION_CREATING("origin:site-create-creating"),
         SITE_CREATION_SEGMENTS("origin:site-create-site-segments"),
         SITE_CREATION_VERTICALS("origin:site-create-site-verticals"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -645,6 +645,11 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     }
 
     @Override
+    public void helpSignupConfirmationScreen(String email) {
+        viewHelpAndSupport(Origin.SIGNUP_CONFIRMATION);
+    }
+
+    @Override
     public void helpSocialEmailScreen(String email) {
         viewHelpAndSupport(Origin.LOGIN_SOCIAL);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -41,6 +41,7 @@ import org.wordpress.android.login.LoginSiteAddressFragment;
 import org.wordpress.android.login.LoginUsernamePasswordFragment;
 import org.wordpress.android.login.SignupBottomSheetDialogFragment;
 import org.wordpress.android.login.SignupBottomSheetDialogFragment.SignupSheetListener;
+import org.wordpress.android.login.SignupConfirmationFragment;
 import org.wordpress.android.login.SignupEmailFragment;
 import org.wordpress.android.login.SignupGoogleFragment;
 import org.wordpress.android.login.SignupMagicLinkFragment;
@@ -455,6 +456,12 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                     LoginEmailPasswordFragment.newInstance(email, null, null, null, false);
             slideInFragment(loginEmailPasswordFragment, true, LoginEmailPasswordFragment.TAG);
         }
+    }
+
+    @Override
+    public void gotUnregisteredEmail(String email) {
+        SignupConfirmationFragment signupConfirmationFragment = SignupConfirmationFragment.newInstance(email);
+        slideInFragment(signupConfirmationFragment, true, SignupConfirmationFragment.TAG);
     }
 
     @Override

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2306,6 +2306,7 @@
     <string name="send_link" tools:ignore="UnusedResources">Send link</string>
     <string name="enter_your_password_instead" tools:ignore="UnusedResources">Enter your password instead</string>
     <string name="send_link_by_email">Send link by email</string>
+    <string name="create_account">Create account</string>
     <string name="or_type_your_password">Or type your password</string>
     <string name="alternatively">Alternatively:</string>
     <string name="enter_email_wordpress_com">Log in to WordPress.com using an email address to manage all your WordPress sites.</string>
@@ -2403,6 +2404,8 @@
     <string name="signup_magic_link_error_button_positive">Retry</string>
     <string name="signup_magic_link_message">We’ve emailed you a magic link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com.</string>
     <string name="signup_magic_link_progress">Sending email</string>
+    <string name="signup_confirmation_message">We’ll use this email address to create your new WordPress.com account.</string>
+    <string name="signup_confirmation_magic_link_message">We’ll email you a magic link to create your new WordPress.com account.</string>
     <string name="signup_terms_of_service_text">By signing up, you agree to our %1$sTerms of Service%2$s.</string>
     <string name="continue_terms_of_service_text">By continuing, you agree to our %1$sTerms of Service%2$s.</string>
     <string name="continue_with_google_terms_of_service_text">If you continue with Google and don\'t already have a WordPress.com account, you are creating an account and you agree to our %1$sTerms of Service%2$s.</string>
@@ -2411,11 +2414,11 @@
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>
     <string name="signup_with_google_progress">Signing up with Google…</string>
-    <string name="signin_with_google_progress">Signing in with Google…</string>
     <string name="content_description_add_avatar">Add avatar</string>
     <!-- Screen titles -->
     <string name="signup_email_screen_title">Email signup</string>
     <string name="signup_magic_link_title">Magic link sent</string>
+    <string name="signup_confirmation_title">Signup confirmation</string>
 
     <string name="continue_with_wpcom">Continue with WordPress.com</string>
     <string name="enter_your_site_address">Enter your site address</string>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/GoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/GoogleFragment.java
@@ -55,7 +55,7 @@ public class GoogleFragment extends Fragment implements ConnectionCallbacks, OnC
     protected String mIdToken;
     protected String mPhotoUrl;
 
-    protected static final String SERVICE_TYPE_GOOGLE = "google";
+    public static final String SERVICE_TYPE_GOOGLE = "google";
 
     @Inject protected Dispatcher mDispatcher;
     @Inject protected SiteStore mSiteStore;

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -579,11 +579,13 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         switch (event.type) {
             case EMAIL:
                 if (event.isAvailable) {
+                    ActivityUtils.hideKeyboardForced(mEmailInput);
                     if (mIsSignupFromLoginEnabled) {
-                        mLoginListener.showSignupMagicLink(event.value);
+                        if (mLoginListener != null) {
+                            mLoginListener.gotUnregisteredEmail(event.value);
+                        }
                     } else {
                         // email address is available on wpcom, so apparently the user can't login with that one.
-                        ActivityUtils.hideKeyboardForced(mEmailInput);
                         showEmailError(R.string.email_not_registered_wpcom);
                     }
                 } else if (mLoginListener != null) {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.login;
 
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -30,7 +29,6 @@ public class LoginGoogleFragment extends GoogleFragment {
     private static final int REQUEST_LOGIN = 1001;
     private boolean mLoginRequested = false;
     private boolean mIsSignupFromLoginEnabled;
-    private ProgressDialog mProgressDialog;
 
     public static final String TAG = "login_google_fragment_tag";
 
@@ -46,31 +44,10 @@ public class LoginGoogleFragment extends GoogleFragment {
     public void onAttach(Context context) {
         AndroidSupportInjection.inject(this);
         super.onAttach(context);
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
         Bundle args = getArguments();
         if (args != null) {
             mIsSignupFromLoginEnabled = args.getBoolean(ARG_SIGNUP_FROM_LOGIN_ENABLED, false);
         }
-    }
-
-    @Override
-    public void onStart() {
-        super.onStart();
-        if (mIsSignupFromLoginEnabled) {
-            mProgressDialog = ProgressDialog.show(
-                    getActivity(), null, getString(R.string.signin_with_google_progress), true, false, null);
-        }
-    }
-
-    @Override
-    public void onStop() {
-        dismissProgressDialog();
-        super.onStop();
     }
 
     @Override
@@ -196,12 +173,6 @@ public class LoginGoogleFragment extends GoogleFragment {
                     event.error.type.toString(), event.error.message);
 
             showError(getString(R.string.login_error_generic));
-        } else if (event.createdAccount) {
-            AppLog.d(T.MAIN,
-                    "GOOGLE LOGIN: onAuthenticationChanged - new wordpress account created");
-            mAnalyticsListener.trackCreatedAccount(event.userName, mGoogleEmail);
-            mAnalyticsListener.trackAnalyticsSignIn(true);
-            mGoogleListener.onGoogleSignupFinished(mDisplayName, mGoogleEmail, mPhotoUrl, event.userName);
         } else {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: onAuthenticationChanged - success");
             AppLog.i(T.NUX, "LoginGoogleFragment.onAuthenticationChanged: " + event.toString());
@@ -231,18 +202,14 @@ public class LoginGoogleFragment extends GoogleFragment {
                     AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - wordpress acount exists but not connected");
                     mAnalyticsListener.trackSocialAccountsNeedConnecting();
                     mLoginListener.loginViaSocialAccount(mGoogleEmail, mIdToken, SERVICE_TYPE_GOOGLE, true);
-                    finishFlow();
                     break;
                 // WordPress account does not exist with input email address.
                 case UNKNOWN_USER:
+                    AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - wordpress account doesn't exist");
                     if (mIsSignupFromLoginEnabled) {
-                        PushSocialPayload payload = new PushSocialPayload(mIdToken, SERVICE_TYPE_GOOGLE);
-                        AppLog.d(T.MAIN,
-                                "GOOGLE LOGIN: onSocialChanged - wordpress account doesn't exist - dispatching "
-                                + "SocialSignupAction");
-                        mDispatcher.dispatch(AccountActionBuilder.newPushSocialSignupAction(payload));
+                        mLoginListener.gotUnregisteredSocialAccount(mGoogleEmail, mDisplayName, mIdToken, mPhotoUrl,
+                                SERVICE_TYPE_GOOGLE);
                     } else {
-                        AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - wordpress account doesn't exist");
                         mAnalyticsListener.trackSocialErrorUnknownUser();
                         showError(getString(R.string.login_error_email_not_found_v2));
                     }
@@ -265,17 +232,10 @@ public class LoginGoogleFragment extends GoogleFragment {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - needs 2fa");
             mLoginListener.needs2faSocial(mGoogleEmail, event.userId, event.nonceAuthenticator, event.nonceBackup,
                     event.nonceSms);
-            finishFlow();
         } else {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: onSocialChanged - success");
             mGoogleListener.onGoogleLoginFinished();
-            finishFlow();
         }
-    }
-
-    private void dismissProgressDialog() {
-        if (mProgressDialog != null && mProgressDialog.isShowing()) {
-            mProgressDialog.dismiss();
-        }
+        finishFlow();
     }
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -19,6 +19,7 @@ public interface LoginListener {
 
     // Login Email input callbacks
     void gotWpcomEmail(String email, boolean verifyEmail);
+    void gotUnregisteredEmail(String email);
     void loginViaSiteAddress();
     void loginViaSocialAccount(String email, String idToken, String service, boolean isPasswordRequired);
     void loggedInViaSocialAccount(ArrayList<Integer> oldSiteIds, boolean doLoginUpdate);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -20,6 +20,8 @@ public interface LoginListener {
     // Login Email input callbacks
     void gotWpcomEmail(String email, boolean verifyEmail);
     void gotUnregisteredEmail(String email);
+    void gotUnregisteredSocialAccount(String email, String displayName, String idToken, String photoUrl,
+                                      String service);
     void loginViaSiteAddress();
     void loginViaSocialAccount(String email, String idToken, String service, boolean isPasswordRequired);
     void loggedInViaSocialAccount(ArrayList<Integer> oldSiteIds, boolean doLoginUpdate);
@@ -78,5 +80,6 @@ public interface LoginListener {
     void helpSignupEmailScreen(String email);
     void helpSignupMagicLinkScreen(String email);
     void showSignupMagicLink(String email);
+    void showSignupSocial(String email, String displayName, String idToken, String photoUrl, String service);
     void showSignupToLoginMessage();
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -79,6 +79,7 @@ public interface LoginListener {
     void doStartSignup();
     void helpSignupEmailScreen(String email);
     void helpSignupMagicLinkScreen(String email);
+    void helpSignupConfirmationScreen(String email);
     void showSignupMagicLink(String email);
     void showSignupSocial(String email, String displayName, String idToken, String photoUrl, String service);
     void showSignupToLoginMessage();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
@@ -153,8 +153,7 @@ class SignupConfirmationFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.help) {
             if (mLoginListener != null) {
-                // TODO Show help
-                // mLoginListener?.helpSignupConfirmationScreen(mEmail)
+                 mLoginListener?.helpSignupConfirmationScreen(mEmail)
             }
             return true
         }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
@@ -1,0 +1,126 @@
+package org.wordpress.android.login
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.android.synthetic.main.login_include_email_header.*
+import kotlinx.android.synthetic.main.signup_confirmation_screen.*
+import kotlinx.android.synthetic.main.toolbar_login.*
+import org.wordpress.android.login.util.AvatarHelper.AvatarRequestListener
+import org.wordpress.android.login.util.AvatarHelper.loadAvatarFromEmail
+
+class SignupConfirmationFragment : Fragment() {
+    private var mLoginListener: LoginListener? = null
+
+    private var mEmail: String? = null
+    private var mIsSocialSignup: Boolean = false
+
+    companion object {
+        const val TAG = "signup_confirmation_fragment_tag"
+
+        private const val ARG_EMAIL = "ARG_EMAIL"
+        private const val ARG_IS_SOCIAL_SIGNUP = "ARG_IS_SOCIAL_SIGNUP"
+
+        @JvmStatic fun newInstance(email: String?): SignupConfirmationFragment {
+            return SignupConfirmationFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_EMAIL, email)
+                    putBoolean(ARG_IS_SOCIAL_SIGNUP, false)
+                }
+            }
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+        if (context !is LoginListener) {
+            throw RuntimeException("$context must implement LoginListener")
+        }
+        mLoginListener = context
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            mEmail = it.getString(ARG_EMAIL)
+            mIsSocialSignup = it.getBoolean(ARG_IS_SOCIAL_SIGNUP)
+        }
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = inflater.inflate(R.layout.signup_confirmation_screen, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        (activity as AppCompatActivity?)?.apply {
+            setSupportActionBar(toolbar)
+            supportActionBar?.apply {
+                setTitle(R.string.sign_up_label)
+                setDisplayHomeAsUpEnabled(true)
+            }
+        }
+
+        email.text = mEmail
+
+        val avatarRequestListener = object : AvatarRequestListener {
+            override fun onRequestFinished() {
+                avatar_progress.visibility = View.GONE
+            }
+        }
+
+        if (mIsSocialSignup) {
+            // TODO Implement social signup confirmation
+        } else {
+            loadAvatarFromEmail(this, mEmail, gravatar, avatarRequestListener)
+            label.setText(R.string.signup_confirmation_magic_link_message)
+            signup_confirmation_button.setText(R.string.send_link_by_email)
+            signup_confirmation_button.setOnClickListener {
+                mLoginListener?.showSignupMagicLink(mEmail)
+            }
+        }
+
+        if (savedInstanceState == null) {
+            // TODO Track screen
+        }
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        // important for accessibility - talkback
+        activity?.setTitle(R.string.signup_confirmation_title)
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        mLoginListener = null
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.menu_login, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == R.id.help) {
+            if (mLoginListener != null) {
+                // TODO Show help
+                // mLoginListener?.helpSignupConfirmationScreen(mEmail)
+            }
+            return true
+        }
+        return false
+    }
+}

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
@@ -16,17 +16,26 @@ import kotlinx.android.synthetic.main.signup_confirmation_screen.*
 import kotlinx.android.synthetic.main.toolbar_login.*
 import org.wordpress.android.login.util.AvatarHelper.AvatarRequestListener
 import org.wordpress.android.login.util.AvatarHelper.loadAvatarFromEmail
+import org.wordpress.android.login.util.AvatarHelper.loadAvatarFromUrl
 
 class SignupConfirmationFragment : Fragment() {
     private var mLoginListener: LoginListener? = null
 
     private var mEmail: String? = null
+    private var mDisplayName: String? = null
+    private var mIdToken: String? = null
+    private var mPhotoUrl: String? = null
+    private var mService: String? = null
     private var mIsSocialSignup: Boolean = false
 
     companion object {
         const val TAG = "signup_confirmation_fragment_tag"
 
         private const val ARG_EMAIL = "ARG_EMAIL"
+        private const val ARG_SOCIAL_DISPLAY_NAME = "ARG_SOCIAL_DISPLAY_NAME"
+        private const val ARG_SOCIAL_ID_TOKEN = "ARG_SOCIAL_ID_TOKEN"
+        private const val ARG_SOCIAL_PHOTO_URL = "ARG_SOCIAL_PHOTO_URL"
+        private const val ARG_SOCIAL_SERVICE = "ARG_SOCIAL_SERVICE"
         private const val ARG_IS_SOCIAL_SIGNUP = "ARG_IS_SOCIAL_SIGNUP"
 
         @JvmStatic fun newInstance(email: String?): SignupConfirmationFragment {
@@ -34,6 +43,25 @@ class SignupConfirmationFragment : Fragment() {
                 arguments = Bundle().apply {
                     putString(ARG_EMAIL, email)
                     putBoolean(ARG_IS_SOCIAL_SIGNUP, false)
+                }
+            }
+        }
+
+        @JvmStatic fun newInstance(
+            email: String?,
+            displayName: String?,
+            idToken: String?,
+            photoUrl: String?,
+            service: String?
+        ): SignupConfirmationFragment {
+            return SignupConfirmationFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_EMAIL, email)
+                    putString(ARG_SOCIAL_DISPLAY_NAME, displayName)
+                    putString(ARG_SOCIAL_ID_TOKEN, idToken)
+                    putString(ARG_SOCIAL_PHOTO_URL, photoUrl)
+                    putString(ARG_SOCIAL_SERVICE, service)
+                    putBoolean(ARG_IS_SOCIAL_SIGNUP, true)
                 }
             }
         }
@@ -52,6 +80,10 @@ class SignupConfirmationFragment : Fragment() {
         super.onCreate(savedInstanceState)
         arguments?.let {
             mEmail = it.getString(ARG_EMAIL)
+            mDisplayName = it.getString(ARG_SOCIAL_DISPLAY_NAME)
+            mIdToken = it.getString(ARG_SOCIAL_ID_TOKEN)
+            mPhotoUrl = it.getString(ARG_SOCIAL_PHOTO_URL)
+            mService = it.getString(ARG_SOCIAL_SERVICE)
             mIsSocialSignup = it.getBoolean(ARG_IS_SOCIAL_SIGNUP)
         }
         setHasOptionsMenu(true)
@@ -83,7 +115,12 @@ class SignupConfirmationFragment : Fragment() {
         }
 
         if (mIsSocialSignup) {
-            // TODO Implement social signup confirmation
+            loadAvatarFromUrl(this, mPhotoUrl, gravatar, avatarRequestListener)
+            label.setText(R.string.signup_confirmation_message)
+            signup_confirmation_button.setText(R.string.create_account)
+            signup_confirmation_button.setOnClickListener {
+                mLoginListener?.showSignupSocial(mEmail, mDisplayName, mIdToken, mPhotoUrl, mService)
+            }
         } else {
             loadAvatarFromEmail(this, mEmail, gravatar, avatarRequestListener)
             label.setText(R.string.signup_confirmation_magic_link_message)

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
@@ -153,7 +153,7 @@ class SignupConfirmationFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.help) {
             if (mLoginListener != null) {
-                 mLoginListener?.helpSignupConfirmationScreen(mEmail)
+                mLoginListener?.helpSignupConfirmationScreen(mEmail)
             }
             return true
         }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/di/LoginFragmentModule.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/di/LoginFragmentModule.java
@@ -9,6 +9,7 @@ import org.wordpress.android.login.LoginMagicLinkSentFragment;
 import org.wordpress.android.login.LoginSiteAddressFragment;
 import org.wordpress.android.login.LoginSiteAddressHelpDialogFragment;
 import org.wordpress.android.login.LoginUsernamePasswordFragment;
+import org.wordpress.android.login.SignupConfirmationFragment;
 import org.wordpress.android.login.SignupEmailFragment;
 import org.wordpress.android.login.SignupGoogleFragment;
 import org.wordpress.android.login.SignupMagicLinkFragment;
@@ -53,4 +54,7 @@ public abstract class LoginFragmentModule {
 
     @ContributesAndroidInjector
     abstract SignupMagicLinkFragment signupMagicLinkFragment();
+
+    @ContributesAndroidInjector
+    abstract SignupConfirmationFragment signupConfirmationScreen();
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/AvatarHelper.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/AvatarHelper.kt
@@ -22,6 +22,15 @@ object AvatarHelper {
     ) {
         val avatarSize = fragment.resources.getDimensionPixelSize(R.dimen.avatar_sz_login)
         val avatarUrl = FakeGravatarUtils.gravatarFromEmail(email, avatarSize, STATUS_404)
+        loadAvatarFromUrl(fragment, avatarUrl, avatarView, listener)
+    }
+
+    @JvmStatic fun loadAvatarFromUrl(
+        fragment: Fragment,
+        avatarUrl: String?,
+        avatarView: ImageView,
+        listener: AvatarRequestListener
+    ) {
         Glide.with(fragment)
                 .load(avatarUrl)
                 .apply(RequestOptions.circleCropTransform())

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/signup_confirmation_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/signup_confirmation_screen.xml
@@ -1,0 +1,51 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical">
+
+    <include layout="@layout/toolbar_login" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:overScrollMode="never">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingEnd="@dimen/margin_extra_large"
+            android:paddingStart="@dimen/margin_extra_large">
+
+            <include
+                layout="@layout/login_include_email_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_large" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/label"
+                style="@style/Widget.LoginFlow.TextView.Label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_medium_large"
+                tools:text="@string/signup_confirmation_magic_link_message" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/signup_confirmation_button"
+        style="@style/Widget.LoginFlow.Button.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_medium_large"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_medium_large"
+        tools:text="@string/send_link_by_email" />
+
+</LinearLayout>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -81,6 +81,7 @@
     <string name="signup_magic_link_error_button_positive">Retry</string>
     <string name="signup_magic_link_message">We’ve emailed you a magic link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com.</string>
     <string name="signup_magic_link_progress">Sending email</string>
+    <string name="signup_confirmation_magic_link_message">We’ll email you a magic link to create your new WordPress.com account.</string>
     <string name="signup_terms_of_service_text">By signing up, you agree to our %1$sTerms of Service%2$s.</string>
     <string name="continue_terms_of_service_text">By continuing, you agree to our %1$sTerms of Service%2$s.</string>
     <string name="continue_with_google_terms_of_service_text">If you continue with Google and don\'t already have a WordPress.com account, you are creating an account and you agree to our %1$sTerms of Service%2$s.</string>
@@ -145,6 +146,7 @@
 
     <string name="signup_email_screen_title">Email signup</string>
     <string name="signup_magic_link_title">Magic link sent</string>
+    <string name="signup_confirmation_title">Signup confirmation</string>
 
 
     <!-- HTTP Authentication -->

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="invalid_verification_code">Invalid verification code</string>
     <string name="send_link">Send link</string>
     <string name="send_link_by_email">Send link by email</string>
+    <string name="create_account">Create account</string>
     <string name="send_verification_email">Send verification email</string>
     <string name="enter_your_password_instead">Enter your password instead</string>
     <string name="or_type_your_password">Or type your password</string>
@@ -81,6 +82,7 @@
     <string name="signup_magic_link_error_button_positive">Retry</string>
     <string name="signup_magic_link_message">We’ve emailed you a magic link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com.</string>
     <string name="signup_magic_link_progress">Sending email</string>
+    <string name="signup_confirmation_message">We’ll use this email address to create your new WordPress.com account.</string>
     <string name="signup_confirmation_magic_link_message">We’ll email you a magic link to create your new WordPress.com account.</string>
     <string name="signup_terms_of_service_text">By signing up, you agree to our %1$sTerms of Service%2$s.</string>
     <string name="continue_terms_of_service_text">By continuing, you agree to our %1$sTerms of Service%2$s.</string>
@@ -88,7 +90,6 @@
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>
     <string name="signup_with_google_progress">Signing up with Google&#8230;</string>
-    <string name="signin_with_google_progress">Signing in with Google&#8230;</string>
     <string name="continue_with_wpcom">Continue with WordPress.com</string>
     <string name="enter_your_site_address">Enter your site address</string>
 


### PR DESCRIPTION
Fixes #11785

Depends on #12048 

This PR adds a confirmation screen after a signup attempt is detected, for both email signups and social signups with Google.

| Email | Social |
|---|---|
| ![email](https://user-images.githubusercontent.com/830056/84966335-af1bf380-b0e7-11ea-952b-2e090b6964c5.jpeg) | ![social](https://user-images.githubusercontent.com/830056/84966338-b04d2080-b0e7-11ea-8248-f47b31d96e16.jpeg) |

## To test

**Email Signup**

0. Clear app data.
1. On the Prologue Screen, tap **Continue with WordPress.com**.
2. On the Email Screen, enter an email address that **_is not_** associated with a WordPress.com account.
3. Tap **Continue**.
4. Notice the Sign-Up Confirmation screen.
5. Notice that the keyboard is gone.
6. Notice the text matches the design spec.
7. Tap the **?** icon on the toolbar.
8. Notice the Help dialog.
9. Close the Help dialog.
10. Tap **Send link by email**.
11. Notice the Sign-Up Magic Link screen.
12. Verify the Magic Link email was sent correctly.
13. Complete the sign-up flow normally.

**Social Signup**

0. Clear app data.
1. On the Prologue Screen, tap **Continue with WordPress.com**.
2. On the Email Screen, tap **Continue with Google**.
3. Pick a Google account that **_is not_** associated with a WordPress.com account.
4. Notice the Sign-Up Confirmation screen.
5. Notice that the avatar was loaded.
6. Notice the text matches the design spec.
7. Tap the **?** icon on the toolbar.
8. Notice the Help dialog.
9. Close the Help dialog.
10. Tap **Create account**.
11. Complete the sign-up flow normally.

## Notes
- No tracking was added to this screen. This should be handled in a follow-up PR.
- With this PR, it was possible to revert some of the changes made in #11717, which resulted in `LoginGoogleFragment` becoming more similar to what it was originally.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.