### PR TITLE
WP Stories integration - setting the base error notification ID from the host app

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -1109,7 +1109,9 @@ public class MySiteFragment extends Fragment implements
                         // from tapping on MANAGE on the snackbar (otherwise they'll be able to discard the
                         // errored story but the error notification will remain existing in the system dashboard)
                         intent.setAction(
-                                FrameSaveNotifier.getNotificationIdForError(event.getStoryIndex()) + ""
+                                FrameSaveNotifier.getNotificationIdForError(
+                                        StoryComposerActivity.BASE_FRAME_MEDIA_ERROR_NOTIFICATION_ID,
+                                        event.getStoryIndex()) + ""
                         );
 
                         // TODO WPSTORIES add TRACKS: the putExtra described here below for NOTIFICATION_TYPE

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -82,6 +82,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         const val POST_FORMAT_WP_STORY_KEY = "wpstory"
         private const val STATE_KEY_POST_LOCAL_ID = "state_key_post_model_local_id"
         const val KEY_POST_LOCAL_ID = "key_post_model_local_id"
+        const val BASE_FRAME_MEDIA_ERROR_NOTIFICATION_ID: Int = 72300
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -171,6 +172,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         requestCodes.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED =
                 PhotoPickerActivity.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED
         requestCodes.EXTRA_MEDIA_URIS = PhotoPickerActivity.EXTRA_MEDIA_URIS
+        requestCodes.BASE_FRAME_MEDIA_ERROR_NOTIFICATION_ID = BASE_FRAME_MEDIA_ERROR_NOTIFICATION_ID
     }
 
     override fun showProvidedMediaPicker() {


### PR DESCRIPTION
Builds on top of #12045 

This PR sets the base error notification ID from the WPAndroid app to avoid collision with `PostUploadNotifier`.

To test:

0. setup some artificial error as we've been doing before in the stories library (use a counter so it fails only once)
1. create a story, add some text / emoji
2. save (tap publish)
3. observe the error notification appears.
4. tap retry to solve the issue
5. observe the error notification gets properly cancelled.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
