### PR TITLE
Temporarily disable Slack notifications for failing connected tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ workflows:
       - Connected Tests:
           requires:
             - gutenberg-bundle-build
-          post-to-slack: true
+          post-to-slack: false
           # Always run connected tests on develop and release branches
           filters:
             branches:


### PR DESCRIPTION
While we are trying to figure out what the new connected test issue is, let's disable the slack notifications so it doesn't bother other developers.