### PR TITLE
Do not translate dot separator

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1304,7 +1304,7 @@
     <string name="reader_filter_empty_sites_action">Follow a site</string>
     <string name="reader_filter_empty_tags_action">Add a tag</string>
     <string name="reader_filter_self_hosted_empty_sites_tags_action">Log in to WordPress.com</string>
-    <string name="reader_dot_separator">\u0020\u2022\u0020</string>
+    <string name="reader_dot_separator" translatable="false">\u0020\u2022\u0020</string>
 
     <!-- editor -->
     <string name="editor_post_saved_online">Post saved online</string>


### PR DESCRIPTION
This PR marks [dot separator string](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/res/values/strings.xml#L1307) as non translatable.

Targets `release/15.0`

To test:
Nothing to test.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
