### PR TITLE
[DO NOT MERGE] Testing new peril settings for milestone checks (against develop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ it on [Google Play](https://play.google.com/store/apps/details?id=org.wordpress.
 1. `git submodule update --init --recursive`  to pull the submodules (optionally use `--depth=1 --recommend-shallow` flags to skip pulling full submodules' history).
 1. In Android Studio, open the project from the local repository. This will auto-generate `local.properties` with the SDK location.
 1. Go to Tools → AVD Manager and create an emulated device.
-1. Run.
+1. Run
 
 Notes:
 


### PR DESCRIPTION
This PR is used to verify that milestone checks are NOT disabled for PRs with `Part of a WIP feature` if it's against `develop`.