### PR TITLE
Editor: fix isRestarting flag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -445,7 +445,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         FragmentManager fragmentManager = getSupportFragmentManager();
         Bundle extras = getIntent().getExtras();
         String action = getIntent().getAction();
-        boolean isRestarting = !RestartEditorOptions.NO_RESTART.name().equals(extras.getString(EXTRA_RESTART_EDITOR));
+        boolean isRestarting = checkToRestart(getIntent());
         if (savedInstanceState == null) {
             if (!getIntent().hasExtra(EXTRA_POST_LOCAL_ID)
                 || Intent.ACTION_SEND.equals(action)


### PR DESCRIPTION

Fixes an issue with Analytics not being bumped for new posts, given `isRestarting` would always be `true` for new posts.

This line was introduced in this commit https://github.com/wordpress-mobile/WordPress-Android/commit/5ca1d7a4a67234b6ca556e4ba862de3da8690d5d
```
boolean isRestarting = !RestartEditorOptions.NO_RESTART.name().equals(extras.getString(EXTRA_RESTART_EDITOR));
```

but it's always TRUE the first time (new post), given `extras.getString(EXTRA_RESTART_EDITOR)`  is `null` (no such extra exists) and as such, the comparison returns false and the negation is `true`, making `isRestarting` then `==true`.

With this then, this other check here is never run!

```
        // Bump post created analytics only once, first time the editor is opened
        if (mIsNewPost && savedInstanceState == null && !isRestarting) {
```

See this change was introduced in this PR https://github.com/wordpress-mobile/WordPress-Android/pull/11649

To test:
1. create a new Post
2. verify the analytics get bumped

Summoning @hypest and @mchowning to make sure no other unintended behavior is introduced with this change

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
