### PR TITLE
Update wiremock dependency and include jackson-core group

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -252,8 +252,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-v4'
         exclude module: 'recyclerview-v7'
     }
-    androidTestImplementation('com.github.tomakehurst:wiremock:2.23.2') {
-        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+    androidTestImplementation('com.github.tomakehurst:wiremock:2.26.3') {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
         exclude group: 'org.apache.commons', module: 'commons-lang3'
         exclude group: 'asm', module: 'asm'


### PR DESCRIPTION
It looks like we excluded the `jackson-core` group from the `wiremock` dependency in #9422, but with the latest Sentry SDK upgrade this has caused connected tests to fail with the following error:

```
java.lang.NoClassDefFoundError: Failed resolution of: Lcom/fasterxml/jackson/core/ObjectCodec;
```

This PR re-adds the `jackson-core` group and updates the `wiremock` dependency to the latest version.