### PR TITLE
Show keyboard upon entry

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -193,7 +193,8 @@ class SiteCreationDomainsViewModel @Inject constructor(
                         searchInputUiState = createSearchInputUiState(
                                 showProgress = state is Loading,
                                 showClearButton = isNonEmptyUserQuery,
-                                showDivider = state.data.isNotEmpty()
+                                showDivider = state.data.isNotEmpty(),
+                                showKeyboard = true
                         ),
                         contentState = createDomainsUiContentState(query, state),
                         createSiteButtonContainerVisibility = selectedDomain != null
@@ -298,13 +299,15 @@ class SiteCreationDomainsViewModel @Inject constructor(
     private fun createSearchInputUiState(
         showProgress: Boolean,
         showClearButton: Boolean,
-        showDivider: Boolean
+        showDivider: Boolean,
+        showKeyboard: Boolean
     ): SiteCreationSearchInputUiState {
         return SiteCreationSearchInputUiState(
                 hint = UiStringRes(R.string.new_site_creation_search_domain_input_hint),
                 showProgress = showProgress,
                 showClearButton = showClearButton,
-                showDivider = showDivider
+                showDivider = showDivider,
+                showKeyboard = showKeyboard
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SearchInputWithHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SearchInputWithHeader.kt
@@ -9,6 +9,7 @@ import android.widget.EditText
 import android.widget.TextView
 import org.wordpress.android.R
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.ActivityUtils
 
 class SearchInputWithHeader(private val uiHelpers: UiHelpers, rootView: View, onClear: () -> Unit) {
     private val headerLayout = rootView.findViewById<ViewGroup>(R.id.header_layout)
@@ -61,5 +62,13 @@ class SearchInputWithHeader(private val uiHelpers: UiHelpers, rootView: View, on
         uiHelpers.updateVisibility(progressBar, uiState.showProgress)
         uiHelpers.updateVisibility(clearAllLayout, uiState.showClearButton)
         uiHelpers.updateVisibility(divider, uiState.showDivider)
+        showKeyboard(uiState.showKeyboard)
+    }
+
+    private fun showKeyboard(shouldShow: Boolean) {
+        if (shouldShow) {
+            searchInput.requestFocus()
+            ActivityUtils.showKeyboard(searchInput)
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationSearchInputUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationSearchInputUiState.kt
@@ -6,5 +6,6 @@ data class SiteCreationSearchInputUiState(
     val hint: UiString,
     val showProgress: Boolean,
     val showClearButton: Boolean,
-    val showDivider: Boolean
+    val showDivider: Boolean,
+    val showKeyboard: Boolean
 )


### PR DESCRIPTION
Fixes #12084 

This PR sets focus on the search input field and opens the keyboard upon entry to the search domain view. The `SiteCreationSearchInputUIState` now includes a showKeyboard field, so if for someone reason we don't want to show the keyboard on open we just need to set the field to false.

To test:
1. On "My site" choose "switch site"
2. Choose "Create WordPress.com site
3. Choose any kind of site
4. On entry to the domain search screen, the focus should be on the input text and the keyboard should be showing

NOTE: Existing behavior leaves keyboard open at all times incase the user wants to add or remove characters in the search field. If this changes, we can easily modify the code to close the keyboard as well.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
