### PR TITLE
Issue/11837 allow editing image media text block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -52,6 +52,8 @@ public class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.
         void onSelectedCountChanged(int count);
 
         void onAdapterLoaded(boolean isEmpty);
+
+        void onItemSelected(boolean isVideo);
     }
 
     private class PhotoPickerItem {
@@ -239,6 +241,9 @@ public class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.
 
         if (isSelected) {
             mSelectedPositions.add(position);
+            if (mListener != null) {
+                mListener.onItemSelected(item.mIsVideo);
+            }
         } else {
             int selectedIndex = mSelectedPositions.indexOf(position);
             if (selectedIndex > -1) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -52,8 +52,6 @@ public class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.
         void onSelectedCountChanged(int count);
 
         void onAdapterLoaded(boolean isEmpty);
-
-        void onItemSelected(boolean isVideo);
     }
 
     private class PhotoPickerItem {
@@ -241,9 +239,6 @@ public class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.
 
         if (isSelected) {
             mSelectedPositions.add(position);
-            if (mListener != null) {
-                mListener.onItemSelected(item.mIsVideo);
-            }
         } else {
             int selectedIndex = mSelectedPositions.indexOf(position);
             if (selectedIndex > -1) {
@@ -289,6 +284,16 @@ public class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.
             return null;
         }
         return (ThumbnailViewHolder) mRecycler.findViewHolderForAdapterPosition(position);
+    }
+
+    boolean isVideoFileSelected() {
+        for (Integer position : mSelectedPositions) {
+            PhotoPickerItem item = getItemAtPosition(position);
+            if (item != null && item.mIsVideo) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @NonNull

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -54,7 +54,6 @@ import java.util.Map;
 public class PhotoPickerFragment extends Fragment {
     private static final String KEY_LAST_TAPPED_ICON = "last_tapped_icon";
     private static final String KEY_SELECTED_POSITIONS = "selected_positions";
-    private static final String KEY_SELECTED_ITEM_IS_VIDEO = "selected_item_is_video";
 
     static final int NUM_COLUMNS = 3;
     public static final String ARG_BROWSER_TYPE = "browser_type";
@@ -102,7 +101,6 @@ public class PhotoPickerFragment extends Fragment {
     private MediaBrowserType mBrowserType;
     private SiteModel mSite;
     private ArrayList<Integer> mSelectedPositions;
-    private boolean mIsSelectedItemVideo;
 
     public static PhotoPickerFragment newInstance(@NonNull PhotoPickerListener listener,
                                                   @NonNull MediaBrowserType browserType,
@@ -131,9 +129,6 @@ public class PhotoPickerFragment extends Fragment {
             mLastTappedIcon = savedLastTappedIconName == null ? null : PhotoPickerIcon.valueOf(savedLastTappedIconName);
             if (savedInstanceState.containsKey(KEY_SELECTED_POSITIONS)) {
                 mSelectedPositions = savedInstanceState.getIntegerArrayList(KEY_SELECTED_POSITIONS);
-            }
-            if (savedInstanceState.containsKey(KEY_SELECTED_ITEM_IS_VIDEO)) {
-                mIsSelectedItemVideo = savedInstanceState.getBoolean(KEY_SELECTED_ITEM_IS_VIDEO);
             }
         }
     }
@@ -257,7 +252,6 @@ public class PhotoPickerFragment extends Fragment {
         if (hasAdapter() && getAdapter().getNumSelected() > 0) {
             ArrayList<Integer> selectedItems = getAdapter().getSelectedPositions();
             outState.putIntegerArrayList(KEY_SELECTED_POSITIONS, selectedItems);
-            outState.putBoolean(KEY_SELECTED_ITEM_IS_VIDEO, mIsSelectedItemVideo);
         }
     }
 
@@ -414,7 +408,8 @@ public class PhotoPickerFragment extends Fragment {
 
                 if (canShowInsertEditBottomBar()) {
                     TextView editView = mInsertEditBottomBar.findViewById(R.id.text_edit);
-                    editView.setVisibility(mIsSelectedItemVideo ? View.GONE : View.VISIBLE);
+                    boolean isVideoFileSelected = getAdapter().isVideoFileSelected();
+                    editView.setVisibility(isVideoFileSelected ? View.GONE : View.VISIBLE);
                 }
 
                 if (mActionMode == null) {
@@ -436,10 +431,6 @@ public class PhotoPickerFragment extends Fragment {
                 mGridManager.onRestoreInstanceState(mRestoreState);
                 mRestoreState = null;
             }
-        }
-
-        @Override public void onItemSelected(boolean isVideo) {
-            mIsSelectedItemVideo = isVideo;
         }
     };
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -13,6 +13,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.PopupMenu;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -53,6 +54,7 @@ import java.util.Map;
 public class PhotoPickerFragment extends Fragment {
     private static final String KEY_LAST_TAPPED_ICON = "last_tapped_icon";
     private static final String KEY_SELECTED_POSITIONS = "selected_positions";
+    private static final String KEY_SELECTED_ITEM_IS_VIDEO = "selected_item_is_video";
 
     static final int NUM_COLUMNS = 3;
     public static final String ARG_BROWSER_TYPE = "browser_type";
@@ -100,6 +102,7 @@ public class PhotoPickerFragment extends Fragment {
     private MediaBrowserType mBrowserType;
     private SiteModel mSite;
     private ArrayList<Integer> mSelectedPositions;
+    private boolean mIsSelectedItemVideo;
 
     public static PhotoPickerFragment newInstance(@NonNull PhotoPickerListener listener,
                                                   @NonNull MediaBrowserType browserType,
@@ -128,6 +131,9 @@ public class PhotoPickerFragment extends Fragment {
             mLastTappedIcon = savedLastTappedIconName == null ? null : PhotoPickerIcon.valueOf(savedLastTappedIconName);
             if (savedInstanceState.containsKey(KEY_SELECTED_POSITIONS)) {
                 mSelectedPositions = savedInstanceState.getIntegerArrayList(KEY_SELECTED_POSITIONS);
+            }
+            if (savedInstanceState.containsKey(KEY_SELECTED_ITEM_IS_VIDEO)) {
+                mIsSelectedItemVideo = savedInstanceState.getBoolean(KEY_SELECTED_ITEM_IS_VIDEO);
             }
         }
     }
@@ -239,7 +245,7 @@ public class PhotoPickerFragment extends Fragment {
     }
 
     private boolean canShowInsertEditBottomBar() {
-        return mBrowserType.isGutenbergPicker() && !mBrowserType.isVideoPicker();
+        return mBrowserType.isGutenbergPicker();
     }
 
     @Override
@@ -251,6 +257,7 @@ public class PhotoPickerFragment extends Fragment {
         if (hasAdapter() && getAdapter().getNumSelected() > 0) {
             ArrayList<Integer> selectedItems = getAdapter().getSelectedPositions();
             outState.putIntegerArrayList(KEY_SELECTED_POSITIONS, selectedItems);
+            outState.putBoolean(KEY_SELECTED_ITEM_IS_VIDEO, mIsSelectedItemVideo);
         }
     }
 
@@ -404,6 +411,12 @@ public class PhotoPickerFragment extends Fragment {
                 if (activity == null) {
                     return;
                 }
+
+                if (canShowInsertEditBottomBar()) {
+                    TextView editView = mInsertEditBottomBar.findViewById(R.id.text_edit);
+                    editView.setVisibility(mIsSelectedItemVideo ? View.GONE : View.VISIBLE);
+                }
+
                 if (mActionMode == null) {
                     ((AppCompatActivity) activity).startSupportActionMode(new ActionModeCallback());
                 }
@@ -423,6 +436,10 @@ public class PhotoPickerFragment extends Fragment {
                 mGridManager.onRestoreInstanceState(mRestoreState);
                 mRestoreState = null;
             }
+        }
+
+        @Override public void onItemSelected(boolean isVideo) {
+            mIsSelectedItemVideo = isVideo;
         }
     };
 


### PR DESCRIPTION
Fixes #11837

This PR allows users to edit an image in blocks which support both video and image files - eg Media&Text block.

To test:

1. Create a new post in gutenberg
2. Add **Media&Text** block
3. Select "Choose from device"
4. Select an image and notice a bottom bar with Edit/Insert is shown
5. Select a video and notice that image is deselected and Edit option is hidden in the bottom bar

| Photo | Video |
|----|----|
|![media_photo](https://user-images.githubusercontent.com/1405144/83600948-54ce4f00-a58d-11ea-9d6e-37a7a310ff70.png)| ![media_video](https://user-images.githubusercontent.com/1405144/83600972-5bf55d00-a58d-11ea-9f3f-39b8be986c11.png)|

Also test that _both Edit/ Insert option are shown_ in the bottom bar if an image is selected via **Image**, **Gallery** blocks and _only Insert option is shown_ if video is selected via **Video** block.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
