### PR TITLE
Unified login tracking 1 - Screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 import org.wordpress.android.ui.accounts.PostSignupInterstitialActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
+import org.wordpress.android.ui.accounts.login.LoginPrologueFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailFragment;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
@@ -487,6 +488,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(AddContentAdapter object);
 
     void inject(PageParentSearchFragment object);
+
+    void inject(LoginPrologueFragment object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/modules/LoginAnalyticsModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/LoginAnalyticsModule.java
@@ -3,6 +3,7 @@ package org.wordpress.android.modules;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.login.LoginAnalyticsListener;
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker;
 import org.wordpress.android.ui.accounts.login.LoginAnalyticsTracker;
 
 import dagger.Module;
@@ -11,7 +12,8 @@ import dagger.Provides;
 @Module
 public class LoginAnalyticsModule {
     @Provides
-    public LoginAnalyticsListener provideAnalyticsListener(AccountStore accountStore, SiteStore siteStore) {
-        return new LoginAnalyticsTracker(accountStore, siteStore);
+    public LoginAnalyticsListener provideAnalyticsListener(AccountStore accountStore, SiteStore siteStore,
+                                                           UnifiedLoginTracker unifiedLoginTracker) {
+        return new LoginAnalyticsTracker(accountStore, siteStore, unifiedLoginTracker);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -52,6 +52,7 @@ import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.accounts.SmartLockHelper.Callback;
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Flow;
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Source;
 import org.wordpress.android.ui.accounts.login.LoginPrologueFragment;
 import org.wordpress.android.ui.accounts.login.LoginPrologueListener;
@@ -95,6 +96,8 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     private static final String KEY_SMARTLOCK_HELPER_STATE = "KEY_SMARTLOCK_HELPER_STATE";
     private static final String KEY_SIGNUP_FROM_LOGIN_ENABLED = "KEY_SIGNUP_FROM_LOGIN_ENABLED";
     private static final String KEY_SITE_LOGIN_AVAILABLE_FROM_PROLOGUE = "KEY_SITE_LOGIN_AVAILABLE_FROM_PROLOGUE";
+    private static final String KEY_UNIFIED_TRACKER_SOURCE = "KEY_UNIFIED_TRACKER_SOURCE";
+    private static final String KEY_UNIFIED_TRACKER_FLOW = "KEY_UNIFIED_TRACKER_FLOW";
 
     private static final String FORGOT_PASSWORD_URL_SUFFIX = "wp-login.php?action=lostpassword";
 
@@ -184,6 +187,11 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
             mIsSignupFromLoginEnabled = savedInstanceState.getBoolean(KEY_SIGNUP_FROM_LOGIN_ENABLED);
             mIsSiteLoginAvailableFromPrologue = savedInstanceState.getBoolean(KEY_SITE_LOGIN_AVAILABLE_FROM_PROLOGUE);
+            String source = savedInstanceState.getString(KEY_UNIFIED_TRACKER_SOURCE);
+            if (source != null) {
+                mUnifiedLoginTracker.setSource(source);
+            }
+            mUnifiedLoginTracker.setFlow(savedInstanceState.getString(KEY_UNIFIED_TRACKER_FLOW));
         }
     }
 
@@ -194,6 +202,11 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
         outState.putString(KEY_SMARTLOCK_HELPER_STATE, mSmartLockHelperState.name());
         outState.putBoolean(KEY_SIGNUP_FROM_LOGIN_ENABLED, mIsSignupFromLoginEnabled);
         outState.putBoolean(KEY_SITE_LOGIN_AVAILABLE_FROM_PROLOGUE, mIsSiteLoginAvailableFromPrologue);
+        outState.putString(KEY_UNIFIED_TRACKER_SOURCE, mUnifiedLoginTracker.getSource().getValue());
+        Flow flow = mUnifiedLoginTracker.getFlow();
+        if (flow != null) {
+            outState.putString(KEY_UNIFIED_TRACKER_FLOW, flow.getValue());
+        }
     }
 
     private void showFragment(Fragment fragment, String tag) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -52,6 +52,7 @@ import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.accounts.SmartLockHelper.Callback;
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Source;
 import org.wordpress.android.ui.accounts.login.LoginPrologueFragment;
 import org.wordpress.android.ui.accounts.login.LoginPrologueListener;
 import org.wordpress.android.ui.main.SitePickerActivity;
@@ -120,6 +121,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Inject DispatchingAndroidInjector<Fragment> mFragmentInjector;
     @Inject protected LoginAnalyticsListener mLoginAnalyticsListener;
     @Inject ZendeskHelper mZendeskHelper;
+    @Inject UnifiedLoginTracker mUnifiedLoginTracker;
     @Inject protected SiteStore mSiteStore;
 
     @Override
@@ -141,6 +143,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                 case FULL:
                 case WPCOM_LOGIN_ONLY:
                     mIsSignupFromLoginEnabled = true;
+                    mUnifiedLoginTracker.setSource(Source.DEFAULT);
                     showFragment(new LoginPrologueFragment(), LoginPrologueFragment.TAG);
                     if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
                         mIsSmartLockTriggeredFromPrologue = true;
@@ -149,15 +152,24 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                     }
                     break;
                 case SELFHOSTED_ONLY:
+                    mUnifiedLoginTracker.setSource(Source.SELF_HOSTED);
                     showFragment(new LoginSiteAddressFragment(), LoginSiteAddressFragment.TAG);
                     break;
                 case JETPACK_STATS:
                     mIsSignupFromLoginEnabled = true;
+                    mUnifiedLoginTracker.setSource(Source.JETPACK);
                     checkSmartLockPasswordAndStartLogin();
                     break;
                 case WPCOM_LOGIN_DEEPLINK:
+                    mUnifiedLoginTracker.setSource(Source.DEEPLINK);
+                    checkSmartLockPasswordAndStartLogin();
+                    break;
                 case WPCOM_REAUTHENTICATE:
+                    mUnifiedLoginTracker.setSource(Source.REAUTHENTICATION);
+                    checkSmartLockPasswordAndStartLogin();
+                    break;
                 case SHARE_INTENT:
+                    mUnifiedLoginTracker.setSource(Source.SHARE);
                     checkSmartLockPasswordAndStartLogin();
                     break;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -155,7 +155,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                     }
                     break;
                 case SELFHOSTED_ONLY:
-                    mUnifiedLoginTracker.setSource(Source.LOGIN_WITH_SITE);
+                    mUnifiedLoginTracker.setSource(Source.SELF_HOSTED);
                     showFragment(new LoginSiteAddressFragment(), LoginSiteAddressFragment.TAG);
                     break;
                 case JETPACK_STATS:

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -155,7 +155,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                     }
                     break;
                 case SELFHOSTED_ONLY:
-                    mUnifiedLoginTracker.setSource(Source.SELF_HOSTED);
+                    mUnifiedLoginTracker.setSource(Source.LOGIN_WITH_SITE);
                     showFragment(new LoginSiteAddressFragment(), LoginSiteAddressFragment.TAG);
                     break;
                 case JETPACK_STATS:

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -62,7 +62,7 @@ class UnifiedLoginTracker
         SHARE("share"),
         DEEPLINK("deeplink"),
         REAUTHENTICATION("reauthentication"),
-        SELF_HOSTED("self_hosted"),
+        LOGIN_WITH_SITE("login_with_site"),
         DEFAULT("default")
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -62,7 +62,7 @@ class UnifiedLoginTracker
         SHARE("share"),
         DEEPLINK("deeplink"),
         REAUTHENTICATION("reauthentication"),
-        LOGIN_WITH_SITE("login_with_site"),
+        SELF_HOSTED("self_hosted"),
         DEFAULT("default")
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -1,0 +1,44 @@
+package org.wordpress.android.ui.accounts
+
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNIFIED_LOGIN_STEP
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UnifiedLoginTracker
+@Inject constructor(private val analyticsTracker: AnalyticsTrackerWrapper) {
+    private var currentFlow: Flow? = null
+    fun track(step: Step) {
+        track(requireNotNull(currentFlow), step)
+    }
+
+    fun track(flow: Flow, step: Step) {
+        currentFlow = flow
+        analyticsTracker.track(UNIFIED_LOGIN_STEP, mapOf("flow" to flow.value, "step" to step.value))
+    }
+
+    fun clear() {
+        currentFlow = null
+    }
+
+    enum class Flow(val value: String) {
+        GET_STARTED("get_started"),
+        LOGIN_MAGIC_LINK("login_magic_link"),
+        LOGIN_PASSWORD("login_password"),
+        LOGIN_SITE_ADDRESS("login_site_address"),
+        SIGNUP("signup")
+    }
+
+    enum class Step(val value: String) {
+        PROLOGUE("prologue"),
+        START("start"),
+        EMAIL_FILLED("email_filled"),
+        MAGIC_LINK_REQUESTED("magic_link_requested"),
+        EMAIL_OPENED("email_opened"),
+        USERNAME_PASSWORD("username_password"),
+        SUCCESS("success"),
+        HELP("help"),
+        TWO_FACTOR_AUTHENTICATION("2fa")
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -66,7 +66,6 @@ class UnifiedLoginTracker
     enum class Step(val value: String) {
         PROLOGUE("prologue"),
         START("start"),
-        EMAIL_FILLED("email_filled"),
         MAGIC_LINK_REQUESTED("magic_link_requested"),
         EMAIL_OPENED("email_opened"),
         USERNAME_PASSWORD("username_password"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -32,6 +32,19 @@ class UnifiedLoginTracker
         currentSource = source
     }
 
+    fun setSource(value: String) {
+        Source.values().find { it.value == value }?.let {
+            currentSource = it
+        }
+    }
+
+    fun setFlow(value: String?) {
+        currentFlow = Flow.values().find { it.value == value }
+    }
+
+    fun getSource(): Source = currentSource
+    fun getFlow(): Flow? = currentFlow
+
     enum class Source(val value: String) {
         JETPACK("jetpack"),
         SHARE("share"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts
 
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNIFIED_LOGIN_STEP
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Source.DEFAULT
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -8,6 +9,7 @@ import javax.inject.Singleton
 @Singleton
 class UnifiedLoginTracker
 @Inject constructor(private val analyticsTracker: AnalyticsTrackerWrapper) {
+    private var currentSource: Source = DEFAULT
     private var currentFlow: Flow? = null
     fun track(step: Step) {
         track(requireNotNull(currentFlow), step)
@@ -15,7 +17,14 @@ class UnifiedLoginTracker
 
     fun track(flow: Flow, step: Step) {
         currentFlow = flow
-        analyticsTracker.track(UNIFIED_LOGIN_STEP, mapOf("flow" to flow.value, "step" to step.value))
+        analyticsTracker.track(
+                UNIFIED_LOGIN_STEP,
+                mapOf("source" to currentSource.value, "flow" to flow.value, "step" to step.value)
+        )
+    }
+
+    fun setSource(source: Source) {
+        currentSource = source
     }
 
     fun clear() {
@@ -24,10 +33,20 @@ class UnifiedLoginTracker
 
     enum class Flow(val value: String) {
         GET_STARTED("get_started"),
+        LOGIN_SOCIAL("social_login"),
         LOGIN_MAGIC_LINK("login_magic_link"),
         LOGIN_PASSWORD("login_password"),
         LOGIN_SITE_ADDRESS("login_site_address"),
         SIGNUP("signup")
+    }
+
+    enum class Source(val value: String) {
+        JETPACK("jetpack"),
+        SHARE("share"),
+        DEEPLINK("deeplink"),
+        REAUTHENTICATION("reauthentication"),
+        SELF_HOSTED("self_hosted"),
+        DEFAULT("default")
     }
 
     enum class Step(val value: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.accounts
 
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.UNIFIED_LOGIN_STEP
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Source.DEFAULT
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -12,32 +13,23 @@ class UnifiedLoginTracker
     private var currentSource: Source = DEFAULT
     private var currentFlow: Flow? = null
     fun track(step: Step) {
-        track(requireNotNull(currentFlow), step)
+        track(step = step)
     }
 
-    fun track(flow: Flow, step: Step) {
+    fun track(flow: Flow? = null, step: Step) {
         currentFlow = flow
-        analyticsTracker.track(
-                UNIFIED_LOGIN_STEP,
-                mapOf("source" to currentSource.value, "flow" to flow.value, "step" to step.value)
-        )
+        if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
+            currentFlow?.let {
+                analyticsTracker.track(
+                        UNIFIED_LOGIN_STEP,
+                        mapOf("source" to currentSource.value, "flow" to it.value, "step" to step.value)
+                )
+            }
+        }
     }
 
     fun setSource(source: Source) {
         currentSource = source
-    }
-
-    fun clear() {
-        currentFlow = null
-    }
-
-    enum class Flow(val value: String) {
-        GET_STARTED("get_started"),
-        LOGIN_SOCIAL("social_login"),
-        LOGIN_MAGIC_LINK("login_magic_link"),
-        LOGIN_PASSWORD("login_password"),
-        LOGIN_SITE_ADDRESS("login_site_address"),
-        SIGNUP("signup")
     }
 
     enum class Source(val value: String) {
@@ -47,6 +39,15 @@ class UnifiedLoginTracker
         REAUTHENTICATION("reauthentication"),
         SELF_HOSTED("self_hosted"),
         DEFAULT("default")
+    }
+
+    enum class Flow(val value: String) {
+        GET_STARTED("get_started"),
+        LOGIN_SOCIAL("social_login"),
+        LOGIN_MAGIC_LINK("login_magic_link"),
+        LOGIN_PASSWORD("login_password"),
+        LOGIN_SITE_ADDRESS("login_site_address"),
+        SIGNUP("signup")
     }
 
     enum class Step(val value: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -284,8 +284,4 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override public void trackConnectedSiteInfoSucceeded(Map<String, ?> properties) {
         // Not used in WordPress app
     }
-
-    @Override public void trackEmailFilled() {
-        mUnifiedLoginTracker.track(Flow.GET_STARTED, Step.EMAIL_FILLED);
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -203,6 +203,11 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
+    public void trackSocialButtonStart() {
+        mUnifiedLoginTracker.track(Flow.LOGIN_SOCIAL, Step.START);
+    }
+
+    @Override
     public void trackSocialAccountsNeedConnecting() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_ACCOUNTS_NEED_CONNECTING);
     }
@@ -258,7 +263,7 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
     public void trackUsernamePasswordFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_USERNAME_PASSWORD_FORM_VIEWED);
-        mUnifiedLoginTracker.track(Flow.LOGIN_SITE_ADDRESS, Step.USERNAME_PASSWORD);
+        mUnifiedLoginTracker.track(Step.USERNAME_PASSWORD);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -19,7 +19,8 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     private SiteStore mSiteStore;
     private UnifiedLoginTracker mUnifiedLoginTracker;
 
-    public LoginAnalyticsTracker(AccountStore accountStore, SiteStore siteStore, UnifiedLoginTracker unifiedLoginTracker) {
+    public LoginAnalyticsTracker(AccountStore accountStore, SiteStore siteStore,
+                                 UnifiedLoginTracker unifiedLoginTracker) {
         this.mAccountStore = accountStore;
         this.mSiteStore = siteStore;
         mUnifiedLoginTracker = unifiedLoginTracker;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -4,6 +4,9 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.login.LoginAnalyticsListener;
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker;
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Flow;
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.util.Map;
@@ -14,9 +17,12 @@ import javax.inject.Singleton;
 public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     private AccountStore mAccountStore;
     private SiteStore mSiteStore;
-    public LoginAnalyticsTracker(AccountStore accountStore, SiteStore siteStore) {
+    private UnifiedLoginTracker mUnifiedLoginTracker;
+
+    public LoginAnalyticsTracker(AccountStore accountStore, SiteStore siteStore, UnifiedLoginTracker unifiedLoginTracker) {
         this.mAccountStore = accountStore;
         this.mSiteStore = siteStore;
+        mUnifiedLoginTracker = unifiedLoginTracker;
     }
 
     @Override
@@ -32,6 +38,7 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
     public void trackEmailFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_EMAIL_FORM_VIEWED);
+        mUnifiedLoginTracker.track(Flow.GET_STARTED, Step.START);
     }
 
     @Override
@@ -77,6 +84,7 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
     public void trackLoginMagicLinkOpenEmailClientClicked() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_OPEN_EMAIL_CLIENT_CLICKED);
+        mUnifiedLoginTracker.track(Flow.LOGIN_MAGIC_LINK, Step.EMAIL_OPENED);
     }
 
     @Override
@@ -100,8 +108,15 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
-    public void trackMagicLinkOpenEmailClientViewed() {
+    public void trackSignupMagicLinkOpenEmailClientViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_OPEN_EMAIL_CLIENT_VIEWED);
+        mUnifiedLoginTracker.track(Flow.SIGNUP, Step.MAGIC_LINK_REQUESTED);
+    }
+
+    @Override
+    public void trackLoginMagicLinkOpenEmailClientViewed() {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_OPEN_EMAIL_CLIENT_VIEWED);
+        mUnifiedLoginTracker.track(Flow.LOGIN_MAGIC_LINK, Step.MAGIC_LINK_REQUESTED);
     }
 
     @Override
@@ -112,11 +127,13 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
     public void trackMagicLinkRequestFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_REQUEST_FORM_VIEWED);
+        mUnifiedLoginTracker.track(Flow.LOGIN_MAGIC_LINK, Step.START);
     }
 
     @Override
     public void trackPasswordFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_PASSWORD_FORM_VIEWED);
+        mUnifiedLoginTracker.track(Flow.LOGIN_PASSWORD, Step.START);
     }
 
     @Override
@@ -152,6 +169,7 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
     public void trackSignupMagicLinkOpenEmailClientClicked() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_MAGIC_LINK_OPEN_EMAIL_CLIENT_CLICKED);
+        mUnifiedLoginTracker.track(Flow.SIGNUP, Step.EMAIL_OPENED);
     }
 
     @Override
@@ -222,21 +240,25 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
     public void trackTwoFactorFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_TWO_FACTOR_FORM_VIEWED);
+        mUnifiedLoginTracker.track(Step.TWO_FACTOR_AUTHENTICATION);
     }
 
     @Override
     public void trackUrlFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_URL_FORM_VIEWED);
+        mUnifiedLoginTracker.track(Flow.LOGIN_SITE_ADDRESS, Step.START);
     }
 
     @Override
     public void trackUrlHelpScreenViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_URL_HELP_SCREEN_VIEWED);
+        mUnifiedLoginTracker.track(Step.HELP);
     }
 
     @Override
     public void trackUsernamePasswordFormViewed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_USERNAME_PASSWORD_FORM_VIEWED);
+        mUnifiedLoginTracker.track(Flow.LOGIN_SITE_ADDRESS, Step.USERNAME_PASSWORD);
     }
 
     @Override
@@ -256,5 +278,9 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
 
     @Override public void trackConnectedSiteInfoSucceeded(Map<String, ?> properties) {
         // Not used in WordPress app
+    }
+
+    @Override public void trackEmailFilled() {
+        mUnifiedLoginTracker.track(Flow.GET_STARTED, Step.EMAIL_FILLED);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -20,6 +20,8 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.login.LoginBaseFormFragment;
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker;
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step;
 import org.wordpress.android.ui.main.SitePickerAdapter;
 import org.wordpress.android.ui.main.SitePickerAdapter.SiteList;
 import org.wordpress.android.util.GravatarUtils;
@@ -51,6 +53,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     private LoginEpilogueListener mLoginEpilogueListener;
 
     @Inject ImageManager mImageManager;
+    @Inject UnifiedLoginTracker mUnifiedLoginTracker;
 
     public static LoginEpilogueFragment newInstance(boolean doLoginUpdate, boolean showAndReturn,
                                                     ArrayList<Integer> oldSitesIds) {
@@ -140,6 +143,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
         if (savedInstanceState == null) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_EPILOGUE_VIEWED);
+            mUnifiedLoginTracker.track(Step.SUCCESS);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.kt
@@ -11,12 +11,19 @@ import kotlinx.android.synthetic.main.login_prologue_bottom_buttons_container_de
 import kotlinx.android.synthetic.main.login_signup_screen.*
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
+import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.LOGIN_PROLOGUE_PAGED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.LOGIN_PROLOGUE_VIEWED
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Flow
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step.PROLOGUE
+import javax.inject.Inject
 
 class LoginPrologueFragment : Fragment() {
     private lateinit var loginPrologueListener: LoginPrologueListener
+
+    @Inject lateinit var unifiedLoginTracker: UnifiedLoginTracker
 
     companion object {
         const val TAG = "login_prologue_fragment_tag"
@@ -38,6 +45,9 @@ class LoginPrologueFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val nonNullActivity = checkNotNull(activity)
+        (nonNullActivity.application as? WordPress)?.component()?.inject(this)
 
         if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
             bottom_buttons.removeAllViews()
@@ -75,6 +85,7 @@ class LoginPrologueFragment : Fragment() {
 
         if (savedInstanceState == null) {
             AnalyticsTracker.track(LOGIN_PROLOGUE_VIEWED)
+            unifiedLoginTracker.track(Flow.GET_STARTED, PROLOGUE)
         }
     }
 

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -319,6 +319,7 @@ public final class AnalyticsTracker {
         CONNECT_JETPACK_FAILED,
         PUSH_NOTIFICATION_RECEIVED,
         PUSH_NOTIFICATION_TAPPED, // Same of opened
+        UNIFIED_LOGIN_STEP,
         LOGIN_ACCESSED,
         LOGIN_MAGIC_LINK_EXITED,
         LOGIN_MAGIC_LINK_FAILED,

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1136,6 +1136,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "push_notification_received";
             case PUSH_NOTIFICATION_TAPPED:
                 return "push_notification_alert_tapped";
+            case UNIFIED_LOGIN_STEP:
+                return "unified_login_step";
             case LOGIN_ACCESSED:
                 return "login_accessed";
             case LOGIN_MAGIC_LINK_EXITED:

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -19,7 +19,8 @@ public interface LoginAnalyticsListener {
     void trackLoginSocial2faNeeded();
     void trackLoginSocialSuccess();
     void trackMagicLinkFailed(Map<String, ?> properties);
-    void trackMagicLinkOpenEmailClientViewed();
+    void trackSignupMagicLinkOpenEmailClientViewed();
+    void trackLoginMagicLinkOpenEmailClientViewed();
     void trackMagicLinkRequested();
     void trackMagicLinkRequestFormViewed();
     void trackPasswordFormViewed();
@@ -51,4 +52,5 @@ public interface LoginAnalyticsListener {
     void trackConnectedSiteInfoRequested(String url);
     void trackConnectedSiteInfoFailed(String url, String errorContext, String errorType, String errorDescription);
     void trackConnectedSiteInfoSucceeded(Map<String, ?> properties);
+    void trackEmailFilled();
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -37,6 +37,7 @@ public interface LoginAnalyticsListener {
     void trackSignupSocialButtonFailure();
     void trackSignupSocialToLogin();
     void trackSignupTermsOfServiceTapped();
+    void trackSocialButtonStart();
     void trackSocialAccountsNeedConnecting();
     void trackSocialButtonClick();
     void trackSocialButtonFailure();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -53,5 +53,4 @@ public interface LoginAnalyticsListener {
     void trackConnectedSiteInfoRequested(String url);
     void trackConnectedSiteInfoFailed(String url, String errorContext, String errorType, String errorDescription);
     void trackConnectedSiteInfoSucceeded(Map<String, ?> properties);
-    void trackEmailFilled();
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -369,6 +369,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             startProgress();
             mRequestedEmail = email;
             mDispatcher.dispatch(AccountActionBuilder.newIsAvailableEmailAction(email));
+            mAnalyticsListener.trackEmailFilled();
         } else {
             showEmailError(R.string.email_invalid);
         }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -369,7 +369,6 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             startProgress();
             mRequestedEmail = email;
             mDispatcher.dispatch(AccountActionBuilder.newIsAvailableEmailAction(email));
-            mAnalyticsListener.trackEmailFilled();
         } else {
             showEmailError(R.string.email_invalid);
         }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -79,6 +79,7 @@ public class LoginGoogleFragment extends GoogleFragment {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: startFlow");
             mLoginRequested = true;
             Intent loginIntent = Auth.GoogleSignInApi.getSignInIntent(mGoogleApiClient);
+            mAnalyticsListener.trackSocialButtonStart();
             startActivityForResult(loginIntent, REQUEST_LOGIN);
         } else {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: startFlow called, but is already in progress");

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
@@ -87,7 +87,7 @@ public class LoginMagicLinkSentFragment extends Fragment {
         }
 
         if (savedInstanceState == null) {
-            mAnalyticsListener.trackMagicLinkOpenEmailClientViewed();
+            mAnalyticsListener.trackLoginMagicLinkOpenEmailClientViewed();
         }
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
@@ -118,7 +118,7 @@ public class SignupMagicLinkFragment extends Fragment {
         }
 
         if (savedInstanceState == null) {
-            mAnalyticsListener.trackMagicLinkOpenEmailClientViewed();
+            mAnalyticsListener.trackSignupMagicLinkOpenEmailClientViewed();
         }
     }
 


### PR DESCRIPTION
Fixes #11797

This PR adds screen tracking based on the definition. If you agree, I'll write down the logic later. I've created one event `unified_login_step` which defines every single screen shown during the login/signup. This event has 3 properties. The first one is `source` (which wasn't defined in the requirements but I think it makes sense). It tracks the source of the login flow (whether it comes from a share action/Jetpack and so on). The second one is `flow` which defines whether the flow is login, signup, login with magic link or password and so on. All of these flows have the third property - `step`. Step is a single screen in the flow. 
There were a few steps/flows missing from the requirements, for example Social login. 
Let me know if these properties make sense!

I've created a singleton that behaves like a state machine and keeps the current flow. My thinking behind this is that some of the steps are shared between the flows and to know which flow we're in would require some heavy logic changes (pass the flow around between the fragments). My approach seems like much cleaner solution. Let me know what you think.

To test (the steps are not well defined because we need to track everything):
- Add filter for `unified_login_step` to `LogCat`
- Go through all the login/signup flows you can imagine
- Check that every screen view emits an event that makes sense
- Try a login through Jetpack 
- Check that the source is changed to `jetpack`
- Try a login through other sources (share/deeplink)
- Check that the source is correct

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
