### PR TITLE
WPMainActivity: fix selected site being null when the ViewModel is started

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -483,11 +483,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 return null;
             });
         });
-
-        mViewModel.start(
-                mSiteStore.hasSite() && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE,
-                hasFullAccessToContent()
-        );
     }
 
     private @Nullable String getAuthToken() {
@@ -702,6 +697,11 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         // Load selected site
         initSelectedSite();
+
+        mViewModel.start(
+                mSiteStore.hasSite() && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE,
+                hasFullAccessToContent()
+        );
 
         // ensure the deep linking activity is enabled. We might be returning from the external-browser
         // viewing of a post


### PR DESCRIPTION

This fixes a **potential** bug, that is not apparent in the app (it's not really causing a problem right now but is latent there).  Found this out while making changes to introduce WP Stories in https://github.com/wordpress-mobile/WordPress-Android/pull/11930.

In `develop`, `initViewModel()` is getting called _before_ `initSelectedSite()`, we should only call `initViewModel` _after_ initializing the selected site, given the VM initialization depends on the data brought by the selected site.

Looking a bit `initViewModel()` has been introduced in this commit
https://github.com/wordpress-mobile/WordPress-Android/commit/c2591b47163be37aac6e4a0224b9a78c9ac555c0
in this PR https://github.com/wordpress-mobile/WordPress-Android/pull/10720/
In that PR it was all good, as initViewModel wasn't depending on the selected site :thumbsup:

But then in this other commit https://github.com/wordpress-mobile/WordPress-Android/commit/5b3d219e1f7b81bfee0fb16906b2c8ca936c362c
belonging to this PR https://github.com/wordpress-mobile/WordPress-Android/pull/11457  a dependency on `hasFullAccessToContent()` is introduced, which in turn calls `getSelectedSite()`. Being that `mSelectedSite` is still `null` in `onCreate()` (where the mViewModel.start() call is made) then the `hasFullAccessToContent()` method returns false, even when the user is an admin for the site. (this can be tried out with the debugger).

The checks for user rights are made _after_  the view model is initialized.

Look [here](https://github.com/wordpress-mobile/WordPress-Android/commit/5b3d219e1f7b81bfee0fb16906b2c8ca936c362c#diff-1cf6428dcfe0d429dfdcf7398ef4c056R480-R483
):


```
     mViewModel.start(
                mSiteStore.hasSite() && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE,
                hasFullAccessToContent()
        );
```

Given the initializer is called in `onResume()`, moving `mViewModel.start()` right after that call in `onResume` seems to be a solution we could use (this is what this PR does).
Also there shouldn't be a risk of running this several times given the `isStarted` flag in `start()`will be `true` but, let me know.

Pinging the writer / reviewer of such PR given they'll be more familiar with that @planarvoid @develric . Let me know your thoughts!

To test:
- follow the same instructions as described in https://github.com/wordpress-mobile/WordPress-Android/pull/11457 and verify this doesn't break the functionality introduced there.

1. create a new user with a new blog (or if you have one, you can use it)
2. add it to be a contributor on another blog of yours
3. the user should have now at least 2 blogs, one of which they're an admin of, and the other one where they're just contributor
4. tapping on the `switch site` button should show these 2 sites
5. switching between them should hide / show the Pages option as desired.
6. Verify the Page option is shown / hidden by re-starting the app with the selected site being the one your user is an admin of (Page option should show)
7. then switch the site to the site where your user is a contributor only, restart the app and verify the app doesn't show the Page option after restarting the app.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
