### PR TITLE
Add downsample strategy to thumbnails.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -23,6 +23,7 @@ import androidx.fragment.app.FragmentActivity
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
+import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.target.AppWidgetTarget
 import com.bumptech.glide.request.target.BaseTarget
@@ -448,6 +449,7 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
             val thumbnailRequest = GlideApp
                     .with(context)
                     .load(thumbnailUrl)
+                    .downsample(DownsampleStrategy.AT_MOST)
                     .attachRequestListener(listener)
             return this.thumbnail(thumbnailRequest)
         }


### PR DESCRIPTION
Fixes #5701 

This PR fixes an issue with the rendering of large images in the reader image viewer.

It was a bit surprising, but a good number of people post text posts in the form of images, and they are reaaaaaly long. I assume this is done to prevent people from copying the content.

This issue was relatively easy to reproduce, but it took me some time to pinpoint the actual problem. The issue happens when we load thumbnails with really large resolutions (file size does not matter), on devices with limited memory. Glide is pretty good at handling large images unless we are loading them as thumbnails. We need to explicitly specify the downsample strategy when loading thumbnails, for Glide to know what to do.

To test:

First, confirm the issue with the current develop branch:
- Create an emulator with a custom hardware profile, and set the available internal memory to 128MB. Here is my config for reference:
<details><summary>CLICK TO SHOW</summary>

[![Image from Gyazo](https://i.gyazo.com/7fe5067302c6ce86d9887b866bea50ea.png)](https://gyazo.com/7fe5067302c6ce86d9887b866bea50ea)

</details>

- Create and publish a post with the following image:
<details><summary>CLICK TO SHOW</summary>

![long](https://user-images.githubusercontent.com/728822/83713128-29268580-a5dc-11ea-9cf8-eb4f8972d111.png)

</details>

- Open this post in Reader (you might need to follow the blog with the post first).

- Tap on the image in the post.

- Observer the crash.

Test the fix:
Repeat the abovementioned steps with this PR, and notice the crash is not happening.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
