### PR TITLE
WPMainActivity - Added comment to clarify functioning of hasFullAccessToContent()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1426,6 +1426,10 @@ public class WPMainActivity extends LocaleAwareActivity implements
         }
     }
 
+    // The first time this is called in onCreate -> initViewModel we still haven't initialized mSelectedSite,
+    // which hasFullAccessToContent depends on, and as such the state will be initialized with the most restrictive
+    // rights case (that is, will assume hasFullAccessToContent is false). This is OK and will be frequently checked
+    // to normalize the UI state whenever mSelectedSite changes.
     private boolean hasFullAccessToContent() {
         return SiteUtils.hasFullAccessToContent(getSelectedSite());
     }


### PR DESCRIPTION
Comes from https://github.com/wordpress-mobile/WordPress-Android/pull/12094

This PR just adds a clarifying comment on the use of the `hasFullAccessToContent()` method in the special case where mSelectedSite has not yet been initialized, to avoid confusions.

See discussion and plans in #12094 👍 

To test:
N/A

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
