### PR TITLE
Enable slack notifications for connected tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ workflows:
       - Connected Tests:
           requires:
             - gutenberg-bundle-build
-          post-to-slack: false
+          post-to-slack: true
           # Always run connected tests on develop and release branches
           filters:
             branches:


### PR DESCRIPTION
Since connected tests were fixed in https://github.com/wordpress-mobile/WordPress-Android/pull/12082, we are reverting the change from https://github.com/wordpress-mobile/WordPress-Android/pull/12067 to re-enable the slack notifications for connected tests.