### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ it on [Google Play](https://play.google.com/store/apps/details?id=org.wordpress.
 Notes:
 
 * To use WordPress.com features (login to WordPress.com, access Reader and Stats, etc) you need a WordPress.com OAuth2 ID and secret. Please read the [OAuth2 Authentication](#oauth2-authentication) section.
+* While building the app in Android Studio ignore all the update plugin prompts (updating plugins may resulted in plugin conflicts and interrupt the build process).
 
 
 ## OAuth2 Authentication ##

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ it on [Google Play](https://play.google.com/store/apps/details?id=org.wordpress.
 Notes:
 
 * To use WordPress.com features (login to WordPress.com, access Reader and Stats, etc) you need a WordPress.com OAuth2 ID and secret. Please read the [OAuth2 Authentication](#oauth2-authentication) section.
-* While building the app in Android Studio ignore all the update plugin prompts (updating plugins may resulted in plugin conflicts and interrupt the build process).
+* While loading/building the app in Android Studio ignore the prompt to update the gradle plugin version as that will probably introduce build errors. On the other hand, feel free to update if you are planning to work on ensuring the compatibility of the newer version.
 
 
 ## OAuth2 Authentication ##


### PR DESCRIPTION
added notes about avoiding update plugins while building app on Android Studio. Which might cause interrupting the build process due to plugin conflict. 

Fixes #
```
FAILURE: Build failed with an exception.

* Where:
Build file '[...]/WordPress-Android/build.gradle' line: 21

* What went wrong:
An exception occurred applying plugin request [id: 'com.gradle.build-scan', version: '2.0.2']
> Failed to apply plugin [id 'com.gradle.build-scan']
   > The build scan plugin is not compatible with this version of Gradle.
     Please see https://gradle.com/help/gradle-6-build-scan-plugin for more information.

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.
```

build-scan plugin is not compatible with Gradle > 6.0.1. This project require 5.4.1 so avoid update Gradle since it might cause plugin conflicts and interrupt build process in android studio

To test:
N/A

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.