### PR TITLE
Improve EventBus crash logging by removing top level exception

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
@@ -34,9 +34,9 @@ class CrashLoggingUtils {
                             // Remove the "Invoking subscriber failed" exception so that the main error will show up
                             // in Sentry. This error only means that an exception occurred during an EventBus event and
                             // it's not particularly useful for debugging.
-                            if (lastException.module == EVENT_BUS_MODULE
-                                    && lastException.type == EVENT_BUS_EXCEPTION
-                                    && lastException.value == EVENT_BUS_INVOKING_SUBSCRIBER_FAILED_ERROR) {
+                            if (lastException.module == EVENT_BUS_MODULE &&
+                                    lastException.type == EVENT_BUS_EXCEPTION &&
+                                    lastException.value == EVENT_BUS_INVOKING_SUBSCRIBER_FAILED_ERROR) {
                                 event.exceptions.remove(lastException)
                             }
                         }


### PR DESCRIPTION
We have a lot of `EventBusException org.greenrobot.eventbus.EventBus in handleSubscriberException` issues in Sentry most of which is pointing a different error. From the issue list, it's impossible to tell what the issue is about which makes monitoring these errors a very inefficient workflow. It's so bad that most of the time I feel like I have to ignore them unless the numbers are big enough.

With the recent Sentry SDK upgrade we are able to modify the events before they are sent to their servers. In this PR, I am removing this particular exception if it meets a very specific set of conditions - which should help us avoid accidentally modifying the exception list.

**To test:**
1. Apply the diff at the bottom.
2. Tap on the `switch site` button in the my site screen
3. Pull to refresh
4. This will create the following issue in Sentry: https://sentry.io/share/issue/59c9fae8616d473180cfcaff3a43de4b/ - it probably will just add to it since we already have an issue, but you can modify the error to create a different issue, just be sure to resolve it once you're done.
5. If you'd like to check what this PR changes, comment out the event modification changes from this PR and follow the same testing instructions. In this case this issue will be created: https://sentry.io/share/issue/72f4ba0af36f4c6893e6761fba806ea8/ - Notice the top level information after the change is much more descriptive and useful.

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

```
diff --git a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
index 0e3e093154..c875f08cdf 100644
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -304,10 +304,11 @@ public class SitePickerActivity extends LocaleAwareActivity
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
-        if (mSwipeToRefreshHelper.isRefreshing()) {
-            mSwipeToRefreshHelper.setRefreshing(false);
-        }
-        debounceLoadSites();
+        throw new IllegalStateException("Testing event bus crash logging changes");
+//        if (mSwipeToRefreshHelper.isRefreshing()) {
+//            mSwipeToRefreshHelper.setRefreshing(false);
+//        }
+//        debounceLoadSites();
     }
 
     private void debounceLoadSites() {
diff --git a/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt b/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
index aa1db8394c..602dc292c8 100644
--- a/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashLoggingUtils.kt
@@ -14,6 +14,7 @@ private const val EVENT_BUS_INVOKING_SUBSCRIBER_FAILED_ERROR = "Invoking subscri
 class CrashLoggingUtils {
     companion object {
         @JvmStatic fun shouldEnableCrashLogging(context: Context): Boolean {
+            return true
             if (PackageUtils.isDebugBuild()) {
                 return false
             }

```
