### PR TITLE
Fix possible NPE for plugin removed snackbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -813,9 +813,9 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
                   .show();
     }
 
-    private void showSuccessfulPluginRemovedSnackbar() {
+    private void showSuccessfulPluginRemovedSnackbar(String pluginDisplayName) {
         WPSnackbar.make(mContainer,
-                getString(R.string.plugin_removed_successfully, mPlugin.getDisplayName()),
+                getString(R.string.plugin_removed_successfully, pluginDisplayName),
                 Snackbar.LENGTH_LONG)
                   .show();
     }
@@ -1130,13 +1130,14 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
             return;
         }
 
+        String pluginDisplayName = mPlugin.getDisplayName();
         mIsRemovingPlugin = false;
         cancelRemovePluginProgressDialog();
         if (event.isError()) {
             AppLog.e(T.PLUGINS, "An error occurred while removing the plugin with type: "
                                 + event.error.type + " and message: " + event.error.message);
             String toastMessage = getString(R.string.plugin_updated_failed_detailed,
-                    mPlugin.getDisplayName(), event.error.message);
+                    pluginDisplayName, event.error.message);
             ToastUtils.showToast(this, toastMessage, Duration.LONG);
             return;
         }
@@ -1151,7 +1152,7 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
             refreshViews();
             invalidateOptionsMenu();
         }
-        showSuccessfulPluginRemovedSnackbar();
+        showSuccessfulPluginRemovedSnackbar(pluginDisplayName);
     }
 
     // This check should only handle events for already installed plugins - onSitePluginConfigured,


### PR DESCRIPTION
Fixes #12101. This NPE happens because we are not calling `return` after the `finish()` statement [here](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/fix-npe-in-plugindetailactivity/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java#L1147-L1155). Although adding the `return` statement would have been a fine way to fix this, I think it's better to use an argument for the display name, so it surfaces the possible issue.

**To test:**
1. To reproduce the issue, start by adding `mPlugin = null;` statement just above [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/fix-npe-in-plugindetailactivity/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java#L1147).
2. Go to plugins page for a Jetpack site and select an installed plugin and remove it. (you can install a new plugin if you don't want to remove the ones you have)
3. Notice the crash
4. Retry the same steps after the change and verify it doesn't crash anymore.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
