### PR TITLE
Guard for nulls in processors and abort if necessary

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts.mediauploadcompletionprocessors;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import org.jsoup.nodes.Document;
@@ -50,7 +51,8 @@ public class CoverBlockProcessor extends BlockProcessor {
     }
 
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
-        if (jsonAttributes.get("id").getAsInt() == Integer.parseInt(mLocalId, 10)) {
+        JsonElement id = jsonAttributes.get("id");
+        if (id != null && id.getAsInt() == Integer.parseInt(mLocalId, 10)) {
             jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId, 10));
             jsonAttributes.addProperty("url", mRemoteUrl);
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/GalleryBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/GalleryBlockProcessor.java
@@ -68,6 +68,9 @@ public class GalleryBlockProcessor extends BlockProcessor {
 
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonArray ids = jsonAttributes.getAsJsonArray("ids");
+        if (ids == null) {
+            return false;
+        }
         JsonElement linkTo = jsonAttributes.get("linkTo");
         if (linkTo != null) {
             mLinkTo = linkTo.getAsString();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/ImageBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/ImageBlockProcessor.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts.mediauploadcompletionprocessors;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import org.jsoup.nodes.Document;
@@ -31,7 +32,8 @@ public class ImageBlockProcessor extends BlockProcessor {
     }
 
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
-        if (jsonAttributes.get("id").getAsString().equals(mLocalId)) {
+        JsonElement id = jsonAttributes.get("id");
+        if (id != null && id.getAsString().equals(mLocalId)) {
             jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId));
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaTextBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaTextBlockProcessor.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts.mediauploadcompletionprocessors;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import org.jsoup.nodes.Document;
@@ -44,7 +45,8 @@ public class MediaTextBlockProcessor extends BlockProcessor {
     }
 
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
-        if (jsonAttributes.get("mediaId").getAsString().equals(mLocalId)) {
+        JsonElement id = jsonAttributes.get("mediaId");
+        if (id != null && id.getAsString().equals(mLocalId)) {
             jsonAttributes.addProperty("mediaId", Integer.parseInt(mRemoteId));
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoBlockProcessor.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts.mediauploadcompletionprocessors;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import org.jsoup.nodes.Document;
@@ -28,7 +29,8 @@ public class VideoBlockProcessor extends BlockProcessor {
     }
 
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
-        if (jsonAttributes.get("id").getAsString().equals(mLocalId)) {
+        JsonElement id = jsonAttributes.get("id");
+        if (id != null && id.getAsString().equals(mLocalId)) {
             jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId));
             return true;
         }


### PR DESCRIPTION
Fixes: #12104

This PR guards for nulls in the processor Json handling. While it isn't clear why ids would not be present in parsed json from the block header, returning false will leave the content unchanged. Since no changes can be made to the parsed structure without matching the id, aborting should be the safest route.

I believe the reason why the id is missing is that it is not present in the templates, though I have not yet confirmed this.

### Steps to test

* Install and launch the application
* Tap on "Log In"
* Log in to the app using valid credentials
* Go to My site and tap on "Pages" icon
* Go to Drafts and tap on "CREATE A PAGE" button
* Select the Service template (observe template preview)
* Tap "Apply" option
* Insert Image block
* Add an image with "Choose from device"
* Leave the editor (tap back button) before the upload completes

**Expected:**

The app should not crash, and upload should complete successfully

* When upload has finished (observed in the notifications) reopen the page
* Switch to HTML view

**Expected:**

The url for the added image should be a remote URL (i.e. `https://` not `file://`)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
