### PR TITLE
Integrate gutenberg 1.29.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,6 @@
 * [**] Block Editor: Add support for changing overlay color settings in Cover block
 * [**] Block Editor: Add enter/exit animation in FloatingToolbar
 * [**] Block Editor: Block toolbar can now collapse when the block width is smaller than the toolbar content
-* [**] Block Editor: Creating undo levels less frequently
 * [**] Block Editor: Tooltip for page template selection buttons
 * [*] Block Editor: Fix merging of text blocks when text had active formatting (bold, italic, strike, link)
 * [*] Block Editor: Fix button alignment in page templates and make strings consistent


### PR DESCRIPTION
Integrate the 1.29.1 release into the 15.0 release.

To test:

1. Open an empty gutenberg post with an paragraph block.
2. Type maybe 50-70 letters in the paragraph block as quickly as possible and without pausing.
3. Wait a 1-2 seconds (to make sure you don't encounter a separate issue not resolved in this fix - [relevant comment](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2349#issuecomment-639527592))
4. Publish the post
5. Insure that the published post is not missing any content.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
