### PR TITLE
[Gutenberg] Add stub result to Gutenberg Glue Class

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -123,7 +123,8 @@ public class GutenbergContainerFragment extends Fragment {
                 isDarkMode,
                 exceptionLogger,
                 breadcrumbLogger,
-                isSiteUsingWpComRestApi);
+                isSiteUsingWpComRestApi,
+                null);
 
         // clear the content initialization flag since a new ReactRootView has been created;
         mHasReceivedAnyContent = false;


### PR DESCRIPTION
To test:
- Open the editor Gutenberg Editor and expect to see the same default colors. 

Note: This is meant to unblock `develop` while https://github.com/wordpress-mobile/WordPress-Android/pull/12041 finishes its review process.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
