### PR TITLE
Show dialog when the user clicks on a trashed post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.widgets.PostListButtonType.BUTTON_MOVE_TO_DRAFT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PREVIEW
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PUBLISH
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_RETRY
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_SHOW_MOVE_TRASHED_POST_TO_DRAFT_DIALOG
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_STATS
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_SUBMIT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_SYNC
@@ -111,6 +112,9 @@ class PostActionHandler(
             BUTTON_CANCEL_PENDING_AUTO_UPLOAD -> {
                 cancelPendingAutoUpload(post)
             }
+            BUTTON_SHOW_MOVE_TRASHED_POST_TO_DRAFT_DIALOG -> {
+                postListDialogHelper.showMoveTrashedPostToDraftDialog(post)
+            }
             BUTTON_MORE -> {
             } // do nothing - ui will show a popup window
         }
@@ -147,6 +151,13 @@ class PostActionHandler(
         val post = postStore.getPostByLocalPostId(localPostId)
         if (post != null) {
             triggerPostUploadAction.invoke(PublishPost(dispatcher, site, post))
+        }
+    }
+
+    fun moveTrashedPostToDraft(localPostId: Int) {
+        val post = postStore.getPostByLocalPostId(localPostId)
+        if (post != null) {
+            moveTrashedPostToDraft(post)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.widgets.PostListButtonType.BUTTON_MOVE_TO_DRAFT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PREVIEW
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PUBLISH
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_RETRY
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_SHOW_MOVE_TRASHED_POST_TO_DRAFT_DIALOG
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_STATS
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_SUBMIT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_SYNC
@@ -45,6 +46,7 @@ fun trackPostListAction(site: SiteModel, buttonType: PostListButtonType, postDat
         BUTTON_MORE -> "more"
         BUTTON_MOVE_TO_DRAFT -> "move_to_draft"
         BUTTON_CANCEL_PENDING_AUTO_UPLOAD -> "cancel_pending_auto_upload"
+        BUTTON_SHOW_MOVE_TRASHED_POST_TO_DRAFT_DIALOG -> "show_move_trashed_post_to_draft_post_dialog"
     }
 
     AnalyticsUtils.trackWithSiteDetails(statsEvent, site, properties)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.helpers.DialogHolder
 
 private const val CONFIRM_DELETE_POST_DIALOG_TAG = "CONFIRM_DELETE_POST_DIALOG_TAG"
+private const val CONFIRM_RESTORE_TRASHED_POST_DIALOG_TAG = "CONFIRM_RESTORE_TRASHED_POST_DIALOG_TAG"
 private const val CONFIRM_PUBLISH_POST_DIALOG_TAG = "CONFIRM_PUBLISH_POST_DIALOG_TAG"
 private const val CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG = "CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG"
 private const val CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG = "CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG"
@@ -30,10 +31,23 @@ class PostListDialogHelper(
     // Since we are using DialogFragments we need to hold onto which post will be published or trashed / resolved
     private var localPostIdForDeleteDialog: Int? = null
     private var localPostIdForPublishDialog: Int? = null
+    private var localPostIdForMoveTrashedPostToDraftDialog: Int? = null
     private var localPostIdForTrashPostWithLocalChangesDialog: Int? = null
     private var localPostIdForConflictResolutionDialog: Int? = null
     private var localPostIdForAutosaveRevisionResolutionDialog: Int? = null
     private var localPostIdForScheduledPostSyncDialog: Int? = null
+
+    fun showMoveTrashedPostToDraftDialog(post: PostModel) {
+        val dialogHolder = DialogHolder(
+                tag = CONFIRM_RESTORE_TRASHED_POST_DIALOG_TAG,
+                title = UiStringRes(R.string.post_list_move_trashed_post_to_draft_dialog_title),
+                message = UiStringRes(R.string.post_list_move_trashed_post_to_draft_dialog_message),
+                positiveButton = UiStringRes(R.string.post_list_move_trashed_post_to_draft_dialog_positive),
+                negativeButton = UiStringRes(R.string.post_list_move_trashed_post_to_draft_dialog_negative)
+        )
+        localPostIdForMoveTrashedPostToDraftDialog = post.id
+        showDialog.invoke(dialogHolder)
+    }
 
     fun showDeletePostConfirmationDialog(post: PostModel) {
         // We need network connection to delete a remote post, but not a local draft
@@ -129,7 +143,8 @@ class PostListDialogHelper(
         deletePost: (Int) -> Unit,
         publishPost: (Int) -> Unit,
         updateConflictedPostWithRemoteVersion: (Int) -> Unit,
-        editRestoredAutoSavePost: (Int) -> Unit
+        editRestoredAutoSavePost: (Int) -> Unit,
+        restoreTrashedPost: (Int) -> Unit
     ) {
         when (instanceTag) {
             CONFIRM_DELETE_POST_DIALOG_TAG -> localPostIdForDeleteDialog?.let {
@@ -152,6 +167,10 @@ class PostListDialogHelper(
             CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG -> localPostIdForTrashPostWithLocalChangesDialog?.let {
                 localPostIdForTrashPostWithLocalChangesDialog = null
                 trashPostWithLocalChanges(it)
+            }
+            CONFIRM_RESTORE_TRASHED_POST_DIALOG_TAG -> localPostIdForMoveTrashedPostToDraftDialog?.let {
+                localPostIdForMoveTrashedPostToDraftDialog = null
+                restoreTrashedPost(it)
             }
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPostIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the restored auto save
@@ -186,6 +205,7 @@ class PostListDialogHelper(
                         mapOf(POST_TYPE to "post")
                 )
             }
+            CONFIRM_RESTORE_TRASHED_POST_DIALOG_TAG -> localPostIdForMoveTrashedPostToDraftDialog = null
             else -> throw IllegalArgumentException("Dialog's negative button click is not handled: $instanceTag")
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
@@ -144,7 +144,7 @@ class PostListDialogHelper(
         publishPost: (Int) -> Unit,
         updateConflictedPostWithRemoteVersion: (Int) -> Unit,
         editRestoredAutoSavePost: (Int) -> Unit,
-        restoreTrashedPost: (Int) -> Unit
+        moveTrashedPostToDraft: (Int) -> Unit
     ) {
         when (instanceTag) {
             CONFIRM_DELETE_POST_DIALOG_TAG -> localPostIdForDeleteDialog?.let {
@@ -170,7 +170,7 @@ class PostListDialogHelper(
             }
             CONFIRM_RESTORE_TRASHED_POST_DIALOG_TAG -> localPostIdForMoveTrashedPostToDraftDialog?.let {
                 localPostIdForMoveTrashedPostToDraftDialog = null
-                restoreTrashedPost(it)
+                moveTrashedPostToDraft(it)
             }
             CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG -> localPostIdForAutosaveRevisionResolutionDialog?.let {
                 // open the editor with the restored auto save

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -392,7 +392,7 @@ class PostListMainViewModel @Inject constructor(
                 publishPost = postActionHandler::publishPost,
                 updateConflictedPostWithRemoteVersion = postConflictResolver::updateConflictedPostWithRemoteVersion,
                 editRestoredAutoSavePost = this::editRestoredAutoSavePost,
-                restoreTrashedPost = postActionHandler::moveTrashedPostToDraft
+                moveTrashedPostToDraft = postActionHandler::moveTrashedPostToDraft
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -391,7 +391,8 @@ class PostListMainViewModel @Inject constructor(
                 deletePost = postActionHandler::deletePost,
                 publishPost = postActionHandler::publishPost,
                 updateConflictedPostWithRemoteVersion = postConflictResolver::updateConflictedPostWithRemoteVersion,
-                editRestoredAutoSavePost = this::editRestoredAutoSavePost
+                editRestoredAutoSavePost = this::editRestoredAutoSavePost,
+                restoreTrashedPost = postActionHandler::moveTrashedPostToDraft
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.widgets.PostListButtonType.BUTTON_MOVE_TO_DRAFT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PREVIEW
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_PUBLISH
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_RETRY
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_SHOW_MOVE_TRASHED_POST_TO_DRAFT_DIALOG
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_STATS
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_SUBMIT
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_SYNC
@@ -116,7 +117,13 @@ class PostListItemUiStateHelper @Inject constructor(
         val statusesDelimeter = UiStringRes(R.string.multiple_status_label_delimiter)
         val onSelected = {
             when (postStatus) {
-                TRASHED -> {}
+                TRASHED -> {
+                    onAction.invoke(
+                            post,
+                            BUTTON_SHOW_MOVE_TRASHED_POST_TO_DRAFT_DIALOG,
+                            POST_LIST_ITEM_SELECTED
+                    )
+                }
                 UNKNOWN, PUBLISHED, DRAFT, PRIVATE, PENDING, SCHEDULED -> onAction.invoke(
                         post,
                         BUTTON_EDIT,

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -35,7 +35,8 @@ enum class PostListButtonType constructor(
             R.string.pages_and_posts_cancel_auto_upload,
             R.drawable.ic_undo_white_24dp,
             R.attr.wpColorWarningDark
-    );
+    ),
+    BUTTON_SHOW_MOVE_TRASHED_POST_TO_DRAFT_DIALOG(15, 0, 0, 0);
 
     companion object {
         fun fromInt(value: Int): PostListButtonType? = values().firstOrNull { it.value == value }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2716,6 +2716,10 @@
     <string name="post_list_tab_trashed_posts">Trashed</string>
     <string name="post_list_search_prompt">Search posts</string>
     <string name="post_list_search_nothing_found">No posts matching your search</string>
+    <string name="post_list_move_trashed_post_to_draft_dialog_title">Move Trashed Post To Draft</string>
+    <string name="post_list_move_trashed_post_to_draft_dialog_message">This is a trashed post, do you want to move it to drafts so you can edit its content?</string>
+    <string name="post_list_move_trashed_post_to_draft_dialog_positive">Move to Draft</string>
+    <string name="post_list_move_trashed_post_to_draft_dialog_negative">Cancel</string>
 
     <!-- Web Preview -->
     <string name="web_preview_default">Default</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2716,7 +2716,7 @@
     <string name="post_list_tab_trashed_posts">Trashed</string>
     <string name="post_list_search_prompt">Search posts</string>
     <string name="post_list_search_nothing_found">No posts matching your search</string>
-    <string name="post_list_move_trashed_post_to_draft_dialog_title">Move Trashed Post To Draft</string>
+    <string name="post_list_move_trashed_post_to_draft_dialog_title">Can\'t edit trashed post</string>
     <string name="post_list_move_trashed_post_to_draft_dialog_message">This is a trashed post, do you want to move it to drafts so you can edit its content?</string>
     <string name="post_list_move_trashed_post_to_draft_dialog_positive">Move to Draft</string>
     <string name="post_list_move_trashed_post_to_draft_dialog_negative">Cancel</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2716,8 +2716,8 @@
     <string name="post_list_tab_trashed_posts">Trashed</string>
     <string name="post_list_search_prompt">Search posts</string>
     <string name="post_list_search_nothing_found">No posts matching your search</string>
-    <string name="post_list_move_trashed_post_to_draft_dialog_title">Can\'t edit trashed post</string>
-    <string name="post_list_move_trashed_post_to_draft_dialog_message">This is a trashed post, do you want to move it to drafts so you can edit its content?</string>
+    <string name="post_list_move_trashed_post_to_draft_dialog_title">Move post to Drafts?</string>
+    <string name="post_list_move_trashed_post_to_draft_dialog_message">Trashed posts can\'t be edited. Do you want change the status of this post to "draft" so you can work on it?</string>
     <string name="post_list_move_trashed_post_to_draft_dialog_positive">Move to Draft</string>
     <string name="post_list_move_trashed_post_to_draft_dialog_negative">Cancel</string>
 


### PR DESCRIPTION
Shows a "move to draft" dialog when the user clicks on a trashed post - based on [this discussion](https://github.com/wordpress-mobile/WordPress-Android/pull/11291#issuecomment-589876505).

@oguzkocer You mentioned that you planned to do some refactoring related to tracking. I tried to implement the dialog, but I haven't encountered any real issues. The only thing I don't exactly like is the PostListButtonType with empty resource ids. But I'm not sure it's worth refactoring the structure because of it. Could you please elaborate if you remember what you had in mind or what issue did you encounter?

This PR is a draft until we resolve the discussion ☝️.

To test:
1. Open Post List
2. Trash a post
3. Search for that post
4. Click on the post in the search view
5. Notice a dialog is shown
6. Click on cancel and verify the dialog is dismissed
7. Click on the post again
6. Click on "Move to Draft" and notice the post is moved to drafts
7. Click on the post and start editing it
-----------------------
1. Open Post List
2. Trash a post
3. Select "Trashed" tab
4. Click on the post
5. Notice a dialog is shown
6. Click on "Move to Draft" and notice the post is moved to drafts


Note for editorial: We are introducing this dialog which appears when the user clicks on a trashed post. Trashed posts can't be edited.

<img src="https://user-images.githubusercontent.com/2261188/84145355-0243d580-aa5a-11ea-90c1-ff98c269ae01.png" width="300px" />




PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
