### PR TITLE
Use boolean flag to determine whether there is a custom empty view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -54,7 +54,6 @@ public class FilteredRecyclerView extends RelativeLayout {
 
     private RecyclerView mRecyclerView;
     private TextView mEmptyView;
-    private View mCustomEmptyView;
     private Toolbar mToolbar;
     private AppBarLayout mAppBarLayout;
     private RecyclerView mSearchSuggestionsRecyclerView;
@@ -68,6 +67,7 @@ public class FilteredRecyclerView extends RelativeLayout {
     private int mSpinnerDrawableRight;
     private AppLog.T mTAG;
 
+    private boolean mShowEmptyView;
     private boolean mToolbarDisableScrollGestures = false;
     @LayoutRes private int mSpinnerItemView = 0;
     @LayoutRes private int mSpinnerDropDownItemView = 0;
@@ -137,8 +137,8 @@ public class FilteredRecyclerView extends RelativeLayout {
         mTAG = tag;
     }
 
-    public void setCustomEmptyView(View v) {
-        mCustomEmptyView = v;
+    public void setCustomEmptyView() {
+        mShowEmptyView = true;
     }
 
     private void init(@NonNull Context context, @Nullable AttributeSet attrs) {
@@ -310,7 +310,7 @@ public class FilteredRecyclerView extends RelativeLayout {
 
         if (!hasAdapter() || mAdapter.getItemCount() == 0) {
             if (mFilterListener != null) {
-                if (mCustomEmptyView == null) {
+                if (mShowEmptyView) {
                     String msg = mFilterListener.onShowEmptyViewMessage(emptyViewMessageType);
                     if (msg == null) {
                         msg = getContext().getString(R.string.empty_list_default);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -930,7 +930,7 @@ public class ReaderPostListFragment extends Fragment
         mActionableEmptyView = rootView.findViewById(R.id.empty_custom_view);
 
         mRecyclerView.setLogT(AppLog.T.READER);
-        mRecyclerView.setCustomEmptyView(mActionableEmptyView);
+        mRecyclerView.setCustomEmptyView();
         mRecyclerView.setFilterListener(new FilteredRecyclerView.FilterListener() {
             @Override
             public List<FilterCriteria> onLoadFilterCriteriaOptions(boolean refresh) {


### PR DESCRIPTION
We were previously passing the empty view into the FilteredRecyclerView only to check whether it's set. I've replaced the reference with a boolean flag that's true if there is a custom empty view. 

To test:
- Check that the reader still works
- Install Leak Canary
- Check that there are no leaks

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
