### PR TITLE
End progress when the login fragment is destroyed

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -246,8 +246,9 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
             mProgressDialog.setOnCancelListener(null);
             mProgressDialog = null;
         }
-
-        mPrimaryButton.setEnabled(true);
+        if (mPrimaryButton != null) {
+            mPrimaryButton.setEnabled(true);
+        }
 
         if (mSecondaryButton != null) {
             mSecondaryButton.setEnabled(true);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -207,6 +207,12 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
         return false;
     }
 
+    @Override
+    public void onDestroy() {
+        endProgress();
+        super.onDestroy();
+    }
+
     protected void startProgress() {
         startProgress(true);
     }


### PR DESCRIPTION
There is a progress bar that is showing in multiple places. However, it has a reference to the fragment and there is a chance that it might leak it because it's not properly cleared out. I'm adding an endProgress call to the `onDestroy` method of the base fragment. This should correctly remove. the reference.

![Screenshot_1591626555](https://user-images.githubusercontent.com/1079756/84123323-fba56600-aa39-11ea-83f3-21ee37326c94.png)

To test:
- Check the login flow with Leak canary
- Check that the memory leak with the DialogInterface is no longer present.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
