### PR TITLE
Clear site settings when fragments are destroyed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -251,6 +251,15 @@ public class MySiteFragment extends Fragment implements
         showQuickStartNoticeIfNecessary();
     }
 
+    @Override
+    public void onDestroy() {
+        if (mSiteSettings != null) {
+            mSiteSettings.clear();
+        }
+        mActionableEmptyView = null;
+        super.onDestroy();
+    }
+
     private void showQuickStartNoticeIfNecessary() {
         if (!QuickStartUtils.isQuickStartInProgress(mQuickStartStore) || !AppPrefs.isQuickStartNoticeRequired()) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -242,6 +242,9 @@ public class EditPostSettingsFragment extends Fragment {
 
     @Override
     public void onDestroy() {
+        if (mSiteSettings != null) {
+            mSiteSettings.clear();
+        }
         mDispatcher.unregister(this);
         super.onDestroy();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -378,6 +378,14 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     @Override
+    public void onDestroy() {
+        if (mSiteSettings != null) {
+            mSiteSettings.clear();
+        }
+        super.onDestroy();
+    }
+
+    @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (data != null) {
             switch (requestCode) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -165,7 +165,7 @@ public abstract class SiteSettingsInterface {
      */
     protected abstract void fetchRemoteData();
 
-    protected final Context mContext;
+    protected Context mContext;
     protected final SiteModel mSite;
     protected final SiteSettingsListener mListener;
     protected final SiteSettingsModel mSettings;
@@ -195,6 +195,11 @@ public abstract class SiteSettingsInterface {
     protected void finalize() throws Throwable {
         mDispatcher.unregister(this);
         super.finalize();
+    }
+
+    public void clear() {
+        mDispatcher.unregister(this);
+        mContext = null;
     }
 
     public void saveSettings() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
@@ -98,6 +98,14 @@ public class PublicizeButtonPrefsFragment extends PublicizeBaseFragment implemen
     }
 
     @Override
+    public void onDestroy() {
+        if (mSiteSettings != null) {
+            mSiteSettings.clear();
+        }
+        super.onDestroy();
+    }
+
+    @Override
     public void onSaveInstanceState(@NotNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);


### PR DESCRIPTION
If I understand it correctly, the site setting interface was leaking because it was registered to the dispatcher but it was never unregistered (the `finalize` is not guaranteed to happen). That's why the dispatcher still kept the reference to the site settings which was keeping a reference to the context. 

In this PR I'm adding a `clear` method to remove the reference when the parent fragment is destroyed (which should be a safe place to call it)

To test:
- Install leak canary
- Check that there is no leak with the site settings

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
