### PR TITLE
Use view.postDelayed instead of creating a handler

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -233,7 +233,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
             public void onClick(View v) {
                 // slide out the bar on click, then re-check connection after a brief delay
                 AniUtils.animateBottomBar(mConnectionBar, false);
-                new Handler().postDelayed(new Runnable() {
+                v.postDelayed(new Runnable() {
                     @Override
                     public void run() {
                         if (!isFinishing()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -182,6 +182,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     private FloatingActionButton mFloatingActionButton;
     private WPTooltipView mFabTooltip;
     private static final String MAIN_BOTTOM_SHEET_TAG = "MAIN_BOTTOM_SHEET_TAG";
+    private final Handler mHandler = new Handler();
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -228,20 +229,14 @@ public class WPMainActivity extends LocaleAwareActivity implements
         mBottomNav.init(getSupportFragmentManager(), this);
 
         mConnectionBar = findViewById(R.id.connection_bar);
-        mConnectionBar.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                // slide out the bar on click, then re-check connection after a brief delay
-                AniUtils.animateBottomBar(mConnectionBar, false);
-                v.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (!isFinishing()) {
-                            checkConnection();
-                        }
-                    }
-                }, 2000);
-            }
+        mConnectionBar.setOnClickListener(v -> {
+            // slide out the bar on click, then re-check connection after a brief delay
+            AniUtils.animateBottomBar(mConnectionBar, false);
+            mHandler.postDelayed(() -> {
+                if (!isFinishing()) {
+                    checkConnection();
+                }
+            }, 2000);
         });
 
         mIsMagicLinkLogin = getIntent().getBooleanExtra(ARG_IS_MAGIC_LINK_LOGIN, false);
@@ -693,6 +688,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     protected void onDestroy() {
         EventBus.getDefault().unregister(this);
         mDispatcher.unregister(this);
+        mHandler.removeCallbacksAndMessages(null);
         super.onDestroy();
     }
 


### PR DESCRIPTION
Calling `postDelayed` on `new Handler()` could potentially lead to a leak of the main activity (since the `Runnable` references it). Using the handler of the view instead should tie the handler lifecycle to the view and be stopped when the view is destroyed.

To test:
- Install leak canary
- Turn off internet while using the app
- Stress test the connection bar (click & rotate & go to background)
- Check that there are no leaks 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
