### PR TITLE
Remove reference to notes adapter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.java
@@ -196,6 +196,13 @@ public class NotificationsListFragmentPage extends Fragment implements
     }
 
     @Override
+    public void onDestroyView() {
+        mRecyclerView.setAdapter(null);
+        mNotesAdapter = null;
+        super.onDestroyView();
+    }
+
+    @Override
     public void onDataLoaded(int itemsCount) {
         if (!isAdded()) {
             CrashLoggingUtils.log("NotificationsListFragmentPage.onDataLoaded occurred when fragment is not attached.");


### PR DESCRIPTION
The NotesAdapter sometimes survives the view being destroyed and it keeps a reference to the parent recycler view. This PR makes the NotesAdapter static and clears out the RV adapter in the `onDestroyView ` method

To test:
- Install leak canary
- Go to the Notifications list
- Check that there are no leaks and it still works as expected

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
