### PR TITLE
Leak in animation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1065,12 +1065,6 @@ public class ReaderPostListFragment extends Fragment
         return rootView;
     }
 
-    @Override
-    public void onDestroyView() {
-        mActionableEmptyView = null;
-        super.onDestroyView();
-    }
-
     private void showSettings() {
         ReaderActivityLauncher.showReaderSubs(getActivity());
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -601,6 +601,7 @@ public class ReaderPostListFragment extends Fragment
 
         mViewModel.onFragmentPause(mIsTopLevel, getPostListType() == ReaderPostListType.SEARCH_RESULTS,
                 isFollowingScreen());
+        mNewPostsBar.clearAnimation();
     }
 
     @Override
@@ -1062,6 +1063,12 @@ public class ReaderPostListFragment extends Fragment
         }
 
         return rootView;
+    }
+
+    @Override
+    public void onDestroyView() {
+        mActionableEmptyView = null;
+        super.onDestroyView();
     }
 
     private void showSettings() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -601,7 +601,6 @@ public class ReaderPostListFragment extends Fragment
 
         mViewModel.onFragmentPause(mIsTopLevel, getPostListType() == ReaderPostListType.SEARCH_RESULTS,
                 isFollowingScreen());
-        mNewPostsBar.clearAnimation();
     }
 
     @Override
@@ -752,6 +751,7 @@ public class ReaderPostListFragment extends Fragment
     @Override
     public void onStop() {
         super.onStop();
+        mNewPostsBar.clearAnimation();
         mDispatcher.unregister(this);
         EventBus.getDefault().unregister(this);
     }


### PR DESCRIPTION
The new posts bar animation could live longer than the fragment which could lead to leaks. This PR adds a `clearAnimation` method called in `onPause`. We don't need to finish the animation if the user doesn't see it.

To test:
- Install leak canary
- Go to reader post list
- Check that there are no leaks

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
