### PR TITLE
Update visibility of viewpager and jetpack view on notifications tab

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 15.1
 -----
- 
+ * Fixes issue on Notifications tab when two screens were drawn on top of each other
 15.0
 -----
 * [*] Fix wrong icon is used when a Password is visible

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -79,6 +79,7 @@ public class NotificationsListFragment extends Fragment {
 
     private TabLayout mTabLayout;
     private ViewGroup mConnectJetpackView;
+    private WPViewPager mViewPager;
     private boolean mShouldRefreshNotifications;
     private int mLastTabPosition;
 
@@ -157,10 +158,10 @@ public class NotificationsListFragment extends Fragment {
             }
         });
 
-        WPViewPager viewPager = view.findViewById(R.id.view_pager);
-        viewPager.setAdapter(new NotificationsFragmentAdapter(getChildFragmentManager()));
-        viewPager.setPageMargin(getResources().getDimensionPixelSize(R.dimen.margin_extra_large));
-        mTabLayout.setupWithViewPager(viewPager);
+        mViewPager = view.findViewById(R.id.view_pager);
+        mViewPager.setAdapter(new NotificationsFragmentAdapter(getChildFragmentManager()));
+        mViewPager.setPageMargin(getResources().getDimensionPixelSize(R.dimen.margin_extra_large));
+        mTabLayout.setupWithViewPager(mViewPager);
 
         TextView jetpackTermsAndConditions = view.findViewById(R.id.jetpack_terms_and_conditions);
         jetpackTermsAndConditions.setText(Html.fromHtml(String.format(
@@ -194,8 +195,17 @@ public class NotificationsListFragment extends Fragment {
 
         if (!mAccountStore.hasAccessToken()) {
             showConnectJetpackView();
-            mTabLayout.setVisibility(View.GONE);
+            if (getView() != null) {
+                mConnectJetpackView.setVisibility(View.VISIBLE);
+                mTabLayout.setVisibility(View.GONE);
+                mViewPager.setVisibility(View.GONE);
+            }
         } else {
+            if (getView() != null) {
+                mConnectJetpackView.setVisibility(View.GONE);
+                mTabLayout.setVisibility(View.VISIBLE);
+                mViewPager.setVisibility(View.VISIBLE);
+            }
             if (mShouldRefreshNotifications) {
                 fetchNotesFromRemote();
             }
@@ -283,9 +293,7 @@ public class NotificationsListFragment extends Fragment {
     }
 
     private void showConnectJetpackView() {
-        if (isAdded() && mConnectJetpackView != null) {
-            mConnectJetpackView.setVisibility(View.VISIBLE);
-            mTabLayout.setVisibility(View.GONE);
+        if (isAdded() && getView() != null) {
             clearToolbarScrollFlags();
 
             Button setupButton = mConnectJetpackView.findViewById(R.id.jetpack_setup);


### PR DESCRIPTION
Fixes #12136 

Under certain circumstances JetPackView and NotificationsViewPager were drawn on top of each other. This PR updates their visibility in onResume.

To test:

2. Log in with a .com account
3. Add a self-hosted site using the self-hosted login
4. Click on Notifications
5. Click on My Site
6. Open App Settings
7. Log out of .com account
8. Open Notifications and notice the content is not broken
----------------------------------
9. Log in with a self-hosted site
10. Open Notifications
11. Connect Jetpack
12. Notice the content is not broken

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
