### PR TITLE
Issue/12064 add zendesk plan field

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/SupportModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/SupportModule.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.support.SupportHelper
 import org.wordpress.android.support.ZendeskHelper
+import org.wordpress.android.support.ZendeskPlanFieldHelper
 import javax.inject.Singleton
 
 @Module
@@ -15,10 +16,15 @@ class SupportModule {
     fun provideZendeskHelper(
         accountStore: AccountStore,
         siteStore: SiteStore,
-        supportHelper: SupportHelper
-    ): ZendeskHelper = ZendeskHelper(accountStore, siteStore, supportHelper)
+        supportHelper: SupportHelper,
+        zendeskPlanFieldHelper: ZendeskPlanFieldHelper
+    ): ZendeskHelper = ZendeskHelper(accountStore, siteStore, supportHelper, zendeskPlanFieldHelper)
 
     @Singleton
     @Provides
     fun provideSupportHelper(): SupportHelper = SupportHelper()
+
+    @Singleton
+    @Provides
+    fun provideZendeskPlanFieldHelper(): ZendeskPlanFieldHelper = ZendeskPlanFieldHelper()
 }

--- a/WordPress/src/main/java/org/wordpress/android/modules/SupportModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/SupportModule.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.support.SupportHelper
 import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.support.ZendeskPlanFieldHelper
+import org.wordpress.android.util.CrashLoggingUtilsWrapper
 import javax.inject.Singleton
 
 @Module
@@ -26,5 +27,6 @@ class SupportModule {
 
     @Singleton
     @Provides
-    fun provideZendeskPlanFieldHelper(): ZendeskPlanFieldHelper = ZendeskPlanFieldHelper()
+    fun provideZendeskPlanFieldHelper(remoteLoggingUtils: CrashLoggingUtilsWrapper): ZendeskPlanFieldHelper =
+        ZendeskPlanFieldHelper(remoteLoggingUtils)
 }

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -494,6 +494,7 @@ private object TicketFieldIds {
     const val currentSite = 360000103103L
     const val appLanguage = 360008583691L
     const val sourcePlatform = 360009311651L
+    const val highestPlan = 25175963L
 }
 
 object ZendeskExtraTags {

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -415,7 +415,7 @@ private fun buildZendeskCustomFields(
     allSites?.let {
         val planIds = it.map { site -> site.planId }.distinct()
         val highestPlan = zendeskPlanFieldHelper.getHighestPlan(planIds)
-        highestPlan?.let {
+        if (highestPlan != UNKNOWN_PLAN) {
             customFields.add(CustomField(TicketFieldIds.highestPlan, highestPlan))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -429,10 +429,6 @@ private fun buildZendeskTags(allSites: List<SiteModel>?, origin: Origin, extraTa
         if (it.any { site -> site.isJetpackConnected }) {
             tags.add(ZendeskConstants.jetpackTag)
         }
-
-        // Find distinct plans and add them
-        val plans = it.mapNotNull { site -> site.planShortName }.distinct()
-        tags.addAll(plans)
     }
     tags.add(origin.toString())
     // Add Android tag to make it easier to filter tickets by platform

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -402,22 +402,25 @@ private fun buildZendeskCustomFields(
         "not_selected"
     }
 
-    val planIds = allSites?.map { site -> site.planId }?.distinct()
-    var highestPlan: String? = null
-    planIds?.let {
-        highestPlan = zendeskPlanFieldHelper.getHighestPlan(it)
-    }
-    return listOf(
-            CustomField(TicketFieldIds.appVersion, PackageUtils.getVersionName(context)),
-            CustomField(TicketFieldIds.blogList, getCombinedLogInformationOfSites(allSites)),
-            CustomField(TicketFieldIds.currentSite, currentSiteInformation),
-            CustomField(TicketFieldIds.deviceFreeSpace, DeviceUtils.getTotalAvailableMemorySize()),
-            CustomField(TicketFieldIds.logs, AppLog.toPlainText(context)),
-            CustomField(TicketFieldIds.networkInformation, getNetworkInformation(context)),
-            CustomField(TicketFieldIds.appLanguage, LanguageUtils.getPatchedCurrentDeviceLanguage(context)),
-            CustomField(TicketFieldIds.sourcePlatform, ZendeskConstants.sourcePlatform),
-            CustomField(TicketFieldIds.highestPlan, highestPlan ?: ZendeskPlanConstants.FREE)
+    val customFields = arrayListOf(
+        CustomField(TicketFieldIds.appVersion, PackageUtils.getVersionName(context)),
+        CustomField(TicketFieldIds.blogList, getCombinedLogInformationOfSites(allSites)),
+        CustomField(TicketFieldIds.currentSite, currentSiteInformation),
+        CustomField(TicketFieldIds.deviceFreeSpace, DeviceUtils.getTotalAvailableMemorySize()),
+        CustomField(TicketFieldIds.logs, AppLog.toPlainText(context)),
+        CustomField(TicketFieldIds.networkInformation, getNetworkInformation(context)),
+        CustomField(TicketFieldIds.appLanguage, LanguageUtils.getPatchedCurrentDeviceLanguage(context)),
+        CustomField(TicketFieldIds.sourcePlatform, ZendeskConstants.sourcePlatform)
     )
+    allSites?.let {
+        val planIds = it.map { site -> site.planId }.distinct()
+        val highestPlan = zendeskPlanFieldHelper.getHighestPlan(planIds)
+        highestPlan?.let {
+            customFields.add(CustomField(TicketFieldIds.highestPlan, highestPlan))
+        }
+    }
+
+    return customFields
 }
 
 /**

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskPlanFieldHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskPlanFieldHelper.kt
@@ -45,9 +45,39 @@ class ZendeskPlanFieldHelper {
         JetpackPlansConstants.JETPACK_PERSONAL,
         JetpackPlansConstants.JETPACK_PERSONAL_MONTHLY
     )
+    private val ecommercePlans: List<Long> = wpComEcommercePlans
+    private val businessOrProfessionalPlans: List<Long> = wpComBusinessPlans + jetpackBusinessPlans
+    private val premiumPlans: List<Long> = wpComPremiumPlans + jetpackPremiumPlans
+    private val personalPlans: List<Long> = wpComPersonalPlans + jetpackPersonalPlans
+    private val bloggerPlans: List<Long> = wpComBloggerPlans
 
+    /**
+     * This is a helper function that checks plan types from most expensive to least,
+     * so that we return the highest value plan type for the user and give them the appropriate
+     * service level (in case they have more than one plan).
+     * Internal Ref: p8wKgj-1eQ#comment-7475
+     */
     fun getHighestPlan(planIds: List<Long>): String {
-        return ZendeskPlanConstants.FREE
+        return when {
+            ecommercePlans.intersect(planIds).isNotEmpty() -> {
+                ZendeskPlanConstants.ECOMMERCE
+            }
+            businessOrProfessionalPlans.intersect(planIds).isNotEmpty() -> {
+                ZendeskPlanConstants.BUSINESS_PROFESSIONAL
+            }
+            premiumPlans.intersect(planIds).isNotEmpty() -> {
+                ZendeskPlanConstants.PREMIUM
+            }
+            personalPlans.intersect(planIds).isNotEmpty() -> {
+                ZendeskPlanConstants.PERSONAL
+            }
+            bloggerPlans.intersect(planIds).isNotEmpty() -> {
+                ZendeskPlanConstants.BLOGGER
+            }
+            else -> {
+                ZendeskPlanConstants.FREE
+            }
+        }
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskPlanFieldHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskPlanFieldHelper.kt
@@ -1,9 +1,79 @@
 package org.wordpress.android.support
 
 class ZendeskPlanFieldHelper {
+    // wpcom plans
+    private val wpComEcommercePlans = listOf(
+        WpComPlansConstants.WPCOM_ECOMMERCE_BUNDLE,
+        WpComPlansConstants.WPCOM_ECOMMERCE_BUNDLE_2Y
+    )
+
+    private val wpComBusinessPlans = listOf(
+        WpComPlansConstants.WPCOM_BUSINESS_BUNDLE,
+        WpComPlansConstants.WPCOM_BUSINESS_BUNDLE_MONTHLY,
+        WpComPlansConstants.WPCOM_BUSINESS_BUNDLE_2Y
+    )
+
+    private val wpComPremiumPlans = listOf(
+        WpComPlansConstants.WPCOM_PRO_BUNDLE,
+        WpComPlansConstants.WPCOM_VALUE_BUNDLE,
+        WpComPlansConstants.WPCOM_VALUE_BUNDLE_MONTHLY,
+        WpComPlansConstants.WPCOM_VALUE_BUNDLE_2Y
+    )
+
+    private val wpComPersonalPlans = listOf(
+        WpComPlansConstants.WPCOM_PERSONAL_BUNDLE,
+        WpComPlansConstants.WPCOM_PERSONAL_BUNDLE_2Y
+    )
+
+    private val wpComBloggerPlans = listOf(
+        WpComPlansConstants.WPCOM_BLOGGER_BUNDLE,
+        WpComPlansConstants.WPCOM_BLOGGER_BUNDLE_2Y
+    )
+
+    // jetpack plans
+    private val jetpackBusinessPlans = listOf(
+        JetpackPlansConstants.JETPACK_BUSINESS,
+        JetpackPlansConstants.JETPACK_BUSINESS_MONTHLY
+    )
+
+    private val jetpackPremiumPlans = listOf(
+        JetpackPlansConstants.JETPACK_PREMIUM,
+        JetpackPlansConstants.JETPACK_PREMIUM_MONTHLY
+    )
+
+    private val jetpackPersonalPlans = listOf(
+        JetpackPlansConstants.JETPACK_PERSONAL,
+        JetpackPlansConstants.JETPACK_PERSONAL_MONTHLY
+    )
+
     fun getHighestPlan(planIds: List<Long>): String {
         return ZendeskPlanConstants.FREE
     }
+}
+
+object WpComPlansConstants {
+    const val WPCOM_BLOGGER_BUNDLE = 1010L
+    const val WPCOM_PERSONAL_BUNDLE = 1009L
+    const val WPCOM_VALUE_BUNDLE = 1003L
+    const val WPCOM_PRO_BUNDLE = 1004L
+    const val WPCOM_BUSINESS_BUNDLE = 1008L
+    const val WPCOM_ECOMMERCE_BUNDLE = 1011L
+    const val WPCOM_VALUE_BUNDLE_MONTHLY = 1013L
+    const val WPCOM_BUSINESS_BUNDLE_MONTHLY = 1018L
+    const val WPCOM_PERSONAL_BUNDLE_2Y = 1029L
+    const val WPCOM_VALUE_BUNDLE_2Y = 1023L
+    const val WPCOM_BUSINESS_BUNDLE_2Y = 1028L
+    const val WPCOM_ECOMMERCE_BUNDLE_2Y = 1031L
+    const val WPCOM_BLOGGER_BUNDLE_2Y = 1030L
+}
+
+object JetpackPlansConstants {
+    const val JETPACK_PREMIUM = 2000L
+    const val JETPACK_BUSINESS = 2001L
+    const val JETPACK_PERSONAL = 2005L
+    const val JETPACK_PREMIUM_MONTHLY = 2003L
+    const val JETPACK_BUSINESS_MONTHLY = 2004L
+    const val JETPACK_PERSONAL_MONTHLY = 2006L
 }
 
 object ZendeskPlanConstants {

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskPlanFieldHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskPlanFieldHelper.kt
@@ -30,6 +30,10 @@ class ZendeskPlanFieldHelper {
         WpComPlansConstants.WPCOM_BLOGGER_BUNDLE_2Y
     )
 
+    private val wpFreePlans = listOf(
+        WpComPlansConstants.WPCOM_FREE
+    )
+
     // jetpack plans
     private val jetpackBusinessPlans = listOf(
         JetpackPlansConstants.JETPACK_BUSINESS,
@@ -45,19 +49,27 @@ class ZendeskPlanFieldHelper {
         JetpackPlansConstants.JETPACK_PERSONAL,
         JetpackPlansConstants.JETPACK_PERSONAL_MONTHLY
     )
-    private val ecommercePlans: List<Long> = wpComEcommercePlans
-    private val businessOrProfessionalPlans: List<Long> = wpComBusinessPlans + jetpackBusinessPlans
-    private val premiumPlans: List<Long> = wpComPremiumPlans + jetpackPremiumPlans
-    private val personalPlans: List<Long> = wpComPersonalPlans + jetpackPersonalPlans
-    private val bloggerPlans: List<Long> = wpComBloggerPlans
+
+    private val jetpackFreePlans = listOf(
+        JetpackPlansConstants.JETPACK_FREE
+    )
+
+    private val ecommercePlans = wpComEcommercePlans
+    private val businessOrProfessionalPlans = wpComBusinessPlans + jetpackBusinessPlans
+    private val premiumPlans = wpComPremiumPlans + jetpackPremiumPlans
+    private val personalPlans = wpComPersonalPlans + jetpackPersonalPlans
+    private val bloggerPlans = wpComBloggerPlans
+    private val freePlans = wpFreePlans + jetpackFreePlans
 
     /**
      * This is a helper function that checks plan types from most expensive to least,
      * so that we return the highest value plan type for the user and give them the appropriate
      * service level (in case they have more than one plan).
      * Internal Ref: p8wKgj-1eQ#comment-7475
+     *
+     * It doesn't support add_on_plan, tier and other plans that are included in the zendesk plan dropdown.
      */
-    fun getHighestPlan(planIds: List<Long>): String {
+    fun getHighestPlan(planIds: List<Long>): String? {
         return when {
             ecommercePlans.intersect(planIds).isNotEmpty() -> {
                 ZendeskPlanConstants.ECOMMERCE
@@ -74,14 +86,18 @@ class ZendeskPlanFieldHelper {
             bloggerPlans.intersect(planIds).isNotEmpty() -> {
                 ZendeskPlanConstants.BLOGGER
             }
-            else -> {
+            freePlans.intersect(planIds).isNotEmpty() -> {
                 ZendeskPlanConstants.FREE
+            }
+            else -> {
+                null
             }
         }
     }
 }
 
 object WpComPlansConstants {
+    const val WPCOM_FREE = 1L
     const val WPCOM_BLOGGER_BUNDLE = 1010L
     const val WPCOM_PERSONAL_BUNDLE = 1009L
     const val WPCOM_VALUE_BUNDLE = 1003L
@@ -98,6 +114,7 @@ object WpComPlansConstants {
 }
 
 object JetpackPlansConstants {
+    const val JETPACK_FREE = 2002L
     const val JETPACK_PREMIUM = 2000L
     const val JETPACK_BUSINESS = 2001L
     const val JETPACK_PERSONAL = 2005L

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskPlanFieldHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskPlanFieldHelper.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.support
+
+class ZendeskPlanFieldHelper {
+    fun getHighestPlan(planIds: List<Long>): String {
+        return ZendeskPlanConstants.FREE
+    }
+}
+
+object ZendeskPlanConstants {
+    const val ECOMMERCE = "ecommerce"
+    const val BUSINESS_PROFESSIONAL = "business_professional"
+    const val PREMIUM = "premium"
+    const val PERSONAL = "personal"
+    const val BLOGGER = "blogger"
+    const val FREE = "free"
+}

--- a/WordPress/src/test/java/org/wordpress/android/support/ZendeskPlanFieldHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/support/ZendeskPlanFieldHelperTest.kt
@@ -1,0 +1,121 @@
+package org.wordpress.android.support
+
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class ZendeskPlanFieldHelperTest {
+    private lateinit var zendeskPlanFieldHelper: ZendeskPlanFieldHelper
+
+    @Before
+    fun setUp() {
+        zendeskPlanFieldHelper = ZendeskPlanFieldHelper()
+    }
+
+    @Test
+    fun `getHighestPlan returns ecommerce if planIds includes an ecommerce plan`() {
+        // Given
+        val planIds = listOf(
+            WpComPlansConstants.WPCOM_PERSONAL_BUNDLE,
+            WpComPlansConstants.WPCOM_ECOMMERCE_BUNDLE_2Y,
+            JetpackPlansConstants.JETPACK_BUSINESS,
+            WpComPlansConstants.WPCOM_FREE
+        )
+
+        // Then
+        Assert.assertEquals(
+            ZendeskPlanConstants.ECOMMERCE,
+            zendeskPlanFieldHelper.getHighestPlan(planIds)
+        )
+    }
+
+    @Test
+    fun `getHighestPlan returns business_professional if planIds includes business but no ecommerce plans`() {
+        // Given
+        val planIds = listOf(
+            WpComPlansConstants.WPCOM_PERSONAL_BUNDLE,
+            JetpackPlansConstants.JETPACK_BUSINESS,
+            WpComPlansConstants.WPCOM_BUSINESS_BUNDLE,
+            WpComPlansConstants.WPCOM_FREE
+        )
+
+        // Then
+        Assert.assertEquals(
+            ZendeskPlanConstants.BUSINESS_PROFESSIONAL,
+            zendeskPlanFieldHelper.getHighestPlan(planIds)
+        )
+    }
+
+    @Test
+    fun `getHighestPlan returns premium if planIds includes premium but no ecommerce, business_professional plans`() {
+        // Given
+        val planIds = listOf(
+            WpComPlansConstants.WPCOM_VALUE_BUNDLE,
+            WpComPlansConstants.WPCOM_PERSONAL_BUNDLE,
+            WpComPlansConstants.WPCOM_FREE
+        )
+
+        // Then
+        Assert.assertEquals(
+            ZendeskPlanConstants.PREMIUM,
+            zendeskPlanFieldHelper.getHighestPlan(planIds)
+        )
+    }
+
+    @Test
+    fun `getHighestPlan returns personal if planIds includes a personal plan but no plan higher than it`() {
+        // Given
+        val planIds = listOf(
+            WpComPlansConstants.WPCOM_PERSONAL_BUNDLE,
+            JetpackPlansConstants.JETPACK_PERSONAL,
+            WpComPlansConstants.WPCOM_FREE,
+            WpComPlansConstants.WPCOM_BLOGGER_BUNDLE
+        )
+
+        // Then
+        Assert.assertEquals(
+            ZendeskPlanConstants.PERSONAL,
+            zendeskPlanFieldHelper.getHighestPlan(planIds)
+        )
+    }
+
+    @Test
+    fun `getHighestPlan returns blogger if planIds includes a blogger plan but no plan higher than it`() {
+        // Given
+        val planIds = listOf(
+            WpComPlansConstants.WPCOM_FREE,
+            WpComPlansConstants.WPCOM_BLOGGER_BUNDLE,
+            JetpackPlansConstants.JETPACK_FREE
+        )
+
+        // Then
+        Assert.assertEquals(
+            ZendeskPlanConstants.BLOGGER,
+            zendeskPlanFieldHelper.getHighestPlan(planIds)
+        )
+    }
+
+    @Test
+    fun `getHighestPlan returns free if planIds includes a free plan but no plan higher than it`() {
+        // Given
+        val planIds = listOf(
+            WpComPlansConstants.WPCOM_FREE,
+            JetpackPlansConstants.JETPACK_FREE
+        )
+
+        // Then
+        Assert.assertEquals(
+            ZendeskPlanConstants.FREE,
+            zendeskPlanFieldHelper.getHighestPlan(planIds)
+        )
+    }
+
+    @Test
+    fun `getHighestPlan returns null if no matching plan id found`() {
+        // Given
+        val planIds = listOf(100000L)
+
+        // Then
+        Assert.assertNull(zendeskPlanFieldHelper.getHighestPlan(planIds))
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/support/ZendeskPlanFieldHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/support/ZendeskPlanFieldHelperTest.kt
@@ -1,15 +1,21 @@
 package org.wordpress.android.support
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.wordpress.android.util.CrashLoggingUtilsWrapper
 
 class ZendeskPlanFieldHelperTest {
     private lateinit var zendeskPlanFieldHelper: ZendeskPlanFieldHelper
+    private val crashLoggingUtilsWrapper: CrashLoggingUtilsWrapper = mock()
 
     @Before
     fun setUp() {
-        zendeskPlanFieldHelper = ZendeskPlanFieldHelper()
+        zendeskPlanFieldHelper = ZendeskPlanFieldHelper(crashLoggingUtilsWrapper)
     }
 
     @Test
@@ -111,11 +117,31 @@ class ZendeskPlanFieldHelperTest {
     }
 
     @Test
-    fun `getHighestPlan returns null if no matching plan id found`() {
+    fun `getHighestPlan returns UNKNOWN_PLAN if no matching plan id found`() {
         // Given
         val planIds = listOf(100000L)
 
         // Then
-        Assert.assertNull(zendeskPlanFieldHelper.getHighestPlan(planIds))
+        Assert.assertEquals(
+            UNKNOWN_PLAN,
+            zendeskPlanFieldHelper.getHighestPlan(planIds)
+        )
+    }
+
+    @Test
+    fun `getHighestPlan logs error if unknown plan ids are found`() {
+        // Given
+        val planIds = listOf(
+            WpComPlansConstants.WPCOM_PERSONAL_BUNDLE,
+            123456789L,
+            9999999L,
+            JetpackPlansConstants.JETPACK_PREMIUM
+        )
+
+        // When
+        zendeskPlanFieldHelper.getHighestPlan(planIds)
+
+        // Then
+        verify(crashLoggingUtilsWrapper, times(1)).log(any<Throwable>())
     }
 }


### PR DESCRIPTION
Fixes #12064

This PR finds the highest plan for a user and sets it on the plan dropdown in the Zendesk. The logic to find highest plan is based on the one used by Calypso to a certain extent. `Internal ref: p8wKgj-1gx#comment-7723`

#### To test

1. Login using an email that is not your Zendesk agent email for your Zendesk identity and that has multiple sites with different plans associated with it.
2. Go to "My site" -> "Me" screen ->  “Help and Support” -> “My Tickets”.
3. Create a ticket.
4. Notice that Zendesk Ticket has the highest plan set on the plans dropdown.

---

5. Repeat Step 1-3 with an email that has no sites associated with it.
6. Notice that Zendesk Ticket plans dropdown is set to blank.

---

#### Note
- If a site has a plan that we don’t know about, it is logged to Sentry so that we can take an action. It can be tested by hard-coding unknown plan ids at this line https://github.com/wordpress-mobile/WordPress-Android/blob/733216fd12667fab7725aa9a0e8ba703d602bd08/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt#L416

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
