### PR TITLE
Save latest post changes when exiting editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -126,6 +126,7 @@ import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerIcon;
 import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult;
+import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult.Updated;
 import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostSettingsCallback;
 import org.wordpress.android.ui.posts.InsertMediaDialog.InsertMediaCallback;
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Editor;
@@ -166,6 +167,7 @@ import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AutolinkUtils;
+import org.wordpress.android.util.CrashLogging;
 import org.wordpress.android.util.DateTimeUtilsWrapper;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FluxCUtils;
@@ -369,6 +371,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     @Inject TenorFeatureConfig mTenorFeatureConfig;
     @Inject GutenbergMentionsFeatureConfig mGutenbergMentionsFeatureConfig;
     @Inject ModalLayoutPickerFeatureConfig mModalLayoutPickerFeatureConfig;
+    @Inject CrashLogging mCrashLogging;
 
     private StorePostViewModel mViewModel;
 
@@ -1560,10 +1563,49 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 (post, result) -> {
                     // Ignore the result as we want to invoke the listener even when the PostModel was up-to-date
                     if (listener != null) {
-                        listener.onPostUpdatedFromUI();
+                        listener.onPostUpdatedFromUI(result);
                     }
                     return null;
                 });
+    }
+
+    /**
+     * This method:
+     *   1. Shows and hides the editor's progress dialog;
+     *   2. Saves the post via {@link EditPostActivity#updateAndSavePostAsync(OnPostUpdatedFromUIListener)};
+     *   3. Invokes the listener method parameter
+     *   4. If there were changes in the post that needed to be saved, for debug builds the app will crash, and
+     *      for release builds we add to the logs and send a report off to Sentry because this
+     *      indicates that the editor's autosave mechanism failed to save all changes to the post. Ideally,
+     *      there should never be any changes that need to be saved when exiting the editor because all changes
+     *      should be caught by the autosave mechanism; and
+     */
+    private void updateAndSavePostAsyncOnEditorExit(@NonNull final OnPostUpdatedFromUIListener listener) {
+        if (mEditorFragment == null) {
+            return;
+        }
+
+        mEditorFragment.showSavingProgressDialogIfNeeded();
+        updateAndSavePostAsync((result) -> {
+            if (mEditorFragment != null) {
+                mEditorFragment.hideSavingProgressDialog();
+            }
+
+            listener.onPostUpdatedFromUI(result);
+
+            if (result == Updated.INSTANCE) {
+                String message = "Post had changes that needed to be saved when exiting the editor. "
+                                 + "This means that the editor's autosave mechanism failed to save all changes.";
+                if (BuildConfig.DEBUG) {
+                    throw new RuntimeException("Debug build crash: " + message + " This only crashes on debug builds.");
+                } else {
+                    AppLog.e(T.EDITOR, message);
+                    mCrashLogging.report(message, T.EDITOR);
+                }
+            } else {
+                AppLog.d(T.EDITOR, "Post had no changes that needed to be saved when exiting the editor.");
+            }
+        });
     }
 
     private UpdateFromEditor updateFromEditor(String oldContent) {
@@ -1714,7 +1756,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     public interface OnPostUpdatedFromUIListener {
-        void onPostUpdatedFromUI();
+        void onPostUpdatedFromUI(@Nullable UpdatePostResult updatePostResult);
     }
 
     @Override
@@ -1804,79 +1846,82 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     private void uploadPost(final boolean publishPost) {
-        AccountModel account = mAccountStore.getAccount();
-        // prompt user to verify e-mail before publishing
-        if (!account.getEmailVerified()) {
-            String message = TextUtils.isEmpty(account.getEmail())
-                    ? getString(R.string.editor_confirm_email_prompt_message)
-                    : String.format(getString(R.string.editor_confirm_email_prompt_message_with_email),
-                            account.getEmail());
+        updateAndSavePostAsyncOnEditorExit(((updatePostResult) -> {
+            AccountModel account = mAccountStore.getAccount();
+            // prompt user to verify e-mail before publishing
+            if (!account.getEmailVerified()) {
+                String message = TextUtils.isEmpty(account.getEmail())
+                        ? getString(R.string.editor_confirm_email_prompt_message)
+                        : String.format(getString(R.string.editor_confirm_email_prompt_message_with_email),
+                                account.getEmail());
 
-            AlertDialog.Builder builder = new MaterialAlertDialogBuilder(this);
-            builder.setTitle(R.string.editor_confirm_email_prompt_title)
-                   .setMessage(message)
-                   .setPositiveButton(android.R.string.ok,
-                           (dialog, id) -> {
-                               ToastUtils.showToast(EditPostActivity.this,
-                                       getString(R.string.toast_saving_post_as_draft));
-                               savePostAndOptionallyFinish(true, false);
-                           })
-                   .setNegativeButton(R.string.editor_confirm_email_prompt_negative,
-                           (dialog, id) -> mDispatcher
-                                   .dispatch(AccountActionBuilder.newSendVerificationEmailAction()));
-            builder.create().show();
-            return;
-        }
-        if (!mPostUtils.isPublishable(mEditPostRepository.getPost())) {
-            // TODO we don't want to show "publish" message when the user clicked on eg. save
-            mEditPostRepository.updateStatusFromPostSnapshotWhenEditorOpened();
-            EditPostActivity.this.runOnUiThread(() -> {
-                String message = getString(
-                        mIsPage ? R.string.error_publish_empty_page : R.string.error_publish_empty_post);
-                ToastUtils.showToast(EditPostActivity.this, message, Duration.SHORT);
-            });
-            return;
-        }
+                AlertDialog.Builder builder = new MaterialAlertDialogBuilder(this);
+                builder.setTitle(R.string.editor_confirm_email_prompt_title)
+                       .setMessage(message)
+                       .setPositiveButton(android.R.string.ok,
+                               (dialog, id) -> {
+                                   ToastUtils.showToast(EditPostActivity.this,
+                                           getString(R.string.toast_saving_post_as_draft));
+                                   savePostAndOptionallyFinish(true, false);
+                               })
+                       .setNegativeButton(R.string.editor_confirm_email_prompt_negative,
+                               (dialog, id) -> mDispatcher
+                                       .dispatch(AccountActionBuilder.newSendVerificationEmailAction()));
+                builder.create().show();
+                return;
+            }
+            if (!mPostUtils.isPublishable(mEditPostRepository.getPost())) {
+                // TODO we don't want to show "publish" message when the user clicked on eg. save
+                mEditPostRepository.updateStatusFromPostSnapshotWhenEditorOpened();
+                EditPostActivity.this.runOnUiThread(() -> {
+                    String message = getString(
+                            mIsPage ? R.string.error_publish_empty_page : R.string.error_publish_empty_post);
+                    ToastUtils.showToast(EditPostActivity.this, message, Duration.SHORT);
+                });
+                return;
+            }
 
-        // Loading the content from the GB HTML editor can take time on long posts.
-        // Let's show a progress dialog for now. Ref: https://github.com/wordpress-mobile/gutenberg-mobile/issues/713
-        mEditorFragment.showSavingProgressDialogIfNeeded();
+            // Loading the content from the GB HTML editor can take time on long posts.
+            // Let's show a progress dialog for now.
+            // Ref: https://github.com/wordpress-mobile/gutenberg-mobile/issues/713
+            mEditorFragment.showSavingProgressDialogIfNeeded();
 
-        boolean isFirstTimePublish = isFirstTimePublish(publishPost);
-        mEditPostRepository.updateAsync(postModel -> {
-            if (publishPost) {
-                // now set status to PUBLISHED - only do this AFTER we have run the isFirstTimePublish() check,
-                // otherwise we'd have an incorrect value
-                // also re-set the published date in case it was SCHEDULED and they want to publish NOW
-                if (postModel.getStatus().equals(PostStatus.SCHEDULED.toString())) {
-                    postModel.setDateCreated(mDateTimeUtils.currentTimeInIso8601());
-                }
+            boolean isFirstTimePublish = isFirstTimePublish(publishPost);
+            mEditPostRepository.updateAsync(postModel -> {
+                if (publishPost) {
+                    // now set status to PUBLISHED - only do this AFTER we have run the isFirstTimePublish() check,
+                    // otherwise we'd have an incorrect value
+                    // also re-set the published date in case it was SCHEDULED and they want to publish NOW
+                    if (postModel.getStatus().equals(PostStatus.SCHEDULED.toString())) {
+                        postModel.setDateCreated(mDateTimeUtils.currentTimeInIso8601());
+                    }
 
-                if (mUploadUtilsWrapper.userCanPublish(getSite())) {
-                    postModel.setStatus(PostStatus.PUBLISHED.toString());
+                    if (mUploadUtilsWrapper.userCanPublish(getSite())) {
+                        postModel.setStatus(PostStatus.PUBLISHED.toString());
+                    } else {
+                        postModel.setStatus(PostStatus.PENDING.toString());
+                    }
+
+                    mPostEditorAnalyticsSession.setOutcome(Outcome.PUBLISH);
                 } else {
-                    postModel.setStatus(PostStatus.PENDING.toString());
+                    mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
                 }
 
-                mPostEditorAnalyticsSession.setOutcome(Outcome.PUBLISH);
-            } else {
-                mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
-            }
+                AppLog.d(T.POSTS, "User explicitly confirmed changes. Post Title: " + postModel.getTitle());
+                // the user explicitly confirmed an intention to upload the post
+                postModel.setChangesConfirmedContentHashcode(postModel.contentHashcode());
 
-            AppLog.d(T.POSTS, "User explicitly confirmed changes. Post Title: " + postModel.getTitle());
-            // the user explicitly confirmed an intention to upload the post
-            postModel.setChangesConfirmedContentHashcode(postModel.contentHashcode());
-
-            // Hide the progress dialog now
-            mEditorFragment.hideSavingProgressDialog();
-            return true;
-        }, (postModel, result) -> {
-            if (result == UpdatePostResult.Updated.INSTANCE) {
-                ActivityFinishState activityFinishState = savePostOnline(isFirstTimePublish);
-                mViewModel.finish(activityFinishState);
-            }
-            return null;
-        });
+                // Hide the progress dialog now
+                mEditorFragment.hideSavingProgressDialog();
+                return true;
+            }, (postModel, result) -> {
+                if (result == Updated.INSTANCE) {
+                    ActivityFinishState activityFinishState = savePostOnline(isFirstTimePublish);
+                    mViewModel.finish(activityFinishState);
+                }
+                return null;
+            });
+        }));
     }
 
     private void savePostAndOptionallyFinish(final boolean doFinish, final boolean forceSave) {
@@ -1884,39 +1929,42 @@ public class EditPostActivity extends LocaleAwareActivity implements
             AppLog.e(AppLog.T.POSTS, "Fragment not initialized");
             return;
         }
-        // check if the opened post had some unsaved local changes
-        boolean isFirstTimePublish = isFirstTimePublish(false);
 
-        // if post was modified during this editing session, save it
-        boolean shouldSave = shouldSavePost() || forceSave;
+        updateAndSavePostAsyncOnEditorExit(((updatePostResult) -> {
+            // check if the opened post had some unsaved local changes
+            boolean isFirstTimePublish = isFirstTimePublish(false);
 
-        mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
-        ActivityFinishState activityFinishState = ActivityFinishState.CANCELLED;
-        if (shouldSave) {
-            /*
-             * Remote-auto-save isn't supported on self-hosted sites. We can save the post online (as draft)
-             * only when it doesn't exist in the remote yet. When it does exist in the remote, we can upload
-             * it only when the user explicitly confirms the changes - eg. clicks on save/publish/submit. The
-             * user didn't confirm the changes in this code path.
-             */
-            boolean isWpComOrIsLocalDraft = mSite.isUsingWpComRestApi() || mEditPostRepository.isLocalDraft();
-            if (isWpComOrIsLocalDraft) {
-                activityFinishState = savePostOnline(isFirstTimePublish);
-            } else if (forceSave) {
-                activityFinishState = savePostOnline(false);
-            } else {
-                activityFinishState = ActivityFinishState.SAVED_LOCALLY;
+            // if post was modified during this editing session, save it
+            boolean shouldSave = shouldSavePost() || forceSave;
+
+            mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
+            ActivityFinishState activityFinishState = ActivityFinishState.CANCELLED;
+            if (shouldSave) {
+                /*
+                 * Remote-auto-save isn't supported on self-hosted sites. We can save the post online (as draft)
+                 * only when it doesn't exist in the remote yet. When it does exist in the remote, we can upload
+                 * it only when the user explicitly confirms the changes - eg. clicks on save/publish/submit. The
+                 * user didn't confirm the changes in this code path.
+                 */
+                boolean isWpComOrIsLocalDraft = mSite.isUsingWpComRestApi() || mEditPostRepository.isLocalDraft();
+                if (isWpComOrIsLocalDraft) {
+                    activityFinishState = savePostOnline(isFirstTimePublish);
+                } else if (forceSave) {
+                    activityFinishState = savePostOnline(false);
+                } else {
+                    activityFinishState = ActivityFinishState.SAVED_LOCALLY;
+                }
             }
-        }
-        // discard post if new & empty
-        if (isDiscardable()) {
-            mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(mEditPostRepository.getEditablePost()));
-            mPostEditorAnalyticsSession.setOutcome(Outcome.CANCEL);
-            activityFinishState = ActivityFinishState.CANCELLED;
-        }
-        if (doFinish) {
-            mViewModel.finish(activityFinishState);
-        }
+            // discard post if new & empty
+            if (isDiscardable()) {
+                mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(mEditPostRepository.getEditablePost()));
+                mPostEditorAnalyticsSession.setOutcome(Outcome.CANCEL);
+                activityFinishState = ActivityFinishState.CANCELLED;
+            }
+            if (doFinish) {
+                mViewModel.finish(activityFinishState);
+            }
+        }));
     }
 
     private boolean shouldSavePost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SaveOnExitException.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SaveOnExitException.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.ui.posts
+
+/**
+ * This exception gets sent off to Sentry, and we are using distinct nested classes to make sure
+ * Sentry does not group these exceptions together.
+ */
+sealed class SaveOnExitException(message: String) : Exception(message) {
+    /**
+     * It is a known issue that this exception may occur if a user exits the editor _very_ quickly after updating
+     * the content of a post because the debouncer from the changes does not get a chance to fire. Therefore, we
+     * expect this exception to occur occasionally.
+     */
+    class AutosavePending : SaveOnExitException(
+            "Post had changes that needed to be saved when exiting the editor, but there was an autosave pending. " +
+                    "This can occur when the user makes changes just before exiting the editor and the autosave " +
+                    "debouncer does not have time to fire."
+    )
+
+    /**
+     * If this exception occurs then it indicates that the autosave mechanism failed because there were
+     * changes to the post content and the autosave mechanism was not preparing to save the post.
+     */
+    class NoAutosavePending : SaveOnExitException(
+            "Post had changes that needed to be saved when exiting the editor, and there was NOT an autosave " +
+                    "pending. This means that the editor's autosave mechanism failed."
+    )
+
+    companion object {
+        fun build(isAutosavePending: Boolean): SaveOnExitException = if (isAutosavePending) {
+            AutosavePending()
+        } else {
+            NoAutosavePending()
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -66,6 +66,8 @@ class StorePostViewModel
         }
     }
 
+    fun isAutosavePending(): Boolean = saveJob?.isActive ?: false
+
     fun savePostWithDelay() {
         saveJob?.cancel()
         saveJob = launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -335,7 +335,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         // TODO will implement when we support StoryPost editing
         // updateAndSavePostAsync(listener)
         // Ignore the result as we want to invoke the listener even when the PostModel was up-to-date
-        listener?.onPostUpdatedFromUI()
+        listener?.onPostUpdatedFromUI(null)
     }
 
     override fun advertiseImageOptimization(listener: () -> Unit) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
@@ -164,7 +164,7 @@ class StoryMediaSaveUploadBridge @Inject constructor(
     override fun syncPostObjectWithUiAndSaveIt(listener: OnPostUpdatedFromUIListener?) {
         // no op
         // WARNING: don't remove this, we need to call the listener no matter what, so save & upload actually happen
-        listener?.onPostUpdatedFromUI()
+        listener?.onPostUpdatedFromUI(null)
     }
 
     override fun advertiseImageOptimization(listener: () -> Unit) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/UploadMediaUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/UploadMediaUseCaseTest.kt
@@ -83,7 +83,7 @@ class UploadMediaUseCaseTest {
 
         private fun createEditorMediaListener() = mock<EditorMediaListener> {
             on { syncPostObjectWithUiAndSaveIt(any()) }.thenAnswer { invocation ->
-                (invocation.getArgument(0) as OnPostUpdatedFromUIListener).onPostUpdatedFromUI()
+                (invocation.getArgument(0) as OnPostUpdatedFromUIListener).onPostUpdatedFromUI(null)
             }
         }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -918,15 +918,13 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     public void removeMedia(String mediaId) {
     }
 
-    // Getting the content from the HTML editor can take time and the UI seems to be unresponsive.
+    // Getting the content from the editor can take time and the UI seems to be unresponsive.
     // Show a progress dialog for now. Ref: https://github.com/wordpress-mobile/gutenberg-mobile/issues/713
     @Override
     public boolean showSavingProgressDialogIfNeeded() {
         if (!isAdded()) {
             return false;
         }
-
-        if (!mHtmlModeEnabled) return false;
 
         if (mSavingContentProgressDialog != null && mSavingContentProgressDialog.isShowing()) {
             // Already on the screen? no need to show it again.


### PR DESCRIPTION
Ensures that we have always saved the latest content from the editor when we exit the editor.

In addition, as [discussed in this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/12144#issuecomment-645584192), in debug builds we are trying to make this issue extra visible by throwing an exception and crashing the editor, which causes the app to freeze for a few seconds and then recover outside the editor, adding a big red crash stacktrace to logcat. We obviously don't want to crash release builds, so instead we are sending an event to Sentry when there are changes to be saved because this means that the autosave mechanism failed. That event shows up looking like this: https://sentry.io/share/issue/f6224217e3e545cfb228982958317ef3/.

### Hiding the Whitespace Helps the Diff on This PR A Lot

When reviewing this, the diff is _much_ more manageable if you hide whitespace changes because there are a lot of indentation changes due to the callbacks wrapping a lot of code.

<img src="https://user-images.githubusercontent.com/4656348/90174574-38604700-dd74-11ea-81db-befedefe6de2.png" width="200" />

### To Test

Exit the editor before the 500ms debouncer has fired so there are "unsaved" changes.

1. Tap a character in the Gutenberg editor
2. Immediately press the back button to exit the editor
3. If a release build, an event similar to [this](https://sentry.io/share/issue/f6224217e3e545cfb228982958317ef3/) will be sent off to Sentry.  If a debug build, the editor will crash.
3. Confirm that the saved post includes the added character

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
