### PR TITLE
Prepublishing Nudges : Changed Visibility to Visibility & Status

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="local_changes">Local changes</string>
     <string name="publish_now">Publish Now</string>
     <string name="update_now">Update Now</string>
+    <string name="status_and_visibility">Status &amp; Visibility</string>
 
     <string name="button_not_now">Not now</string>
 
@@ -1287,7 +1288,7 @@
 
     <!-- Post Settings -->
     <string name="post_settings">Post settings</string>
-    <string name="post_settings_status">Status</string>
+    <string name="post_settings_status" translatable="false">@string/status_and_visibility</string>
     <string name="post_settings_categories_and_tags">Categories &amp; Tags</string>
     <string name="post_settings_publish">Publish</string>
     <string name="post_settings_more_options">More Options</string>
@@ -2736,7 +2737,7 @@
 
     <!-- Prepublishing Nudges -->
     <string name="prepublishing_nudges_publish_action">Publish Date</string>
-    <string name="prepublishing_nudges_visibility_action">Visibility</string>
+    <string name="prepublishing_nudges_visibility_action" translatable="false">@string/status_and_visibility</string>
     <string name="prepublishing_nudges_tags_action">Tags</string>
     <string name="prepublishing_nudges_home_header_publishing_to">Publishing to</string>
     <string name="prepublishing_nudges_home_publish_button" translatable="false">@string/publish_now</string>
@@ -2745,7 +2746,7 @@
     <string name="prepublishing_nudges_back_button">Back</string>
     <string name="prepublishing_nudges_toolbar_title_tags">Add Tags</string>
     <string name="prepublishing_nudges_toolbar_title_publish">Publish</string>
-    <string name="prepublishing_nudges_toolbar_title_visibility">Visibility</string>
+    <string name="prepublishing_nudges_toolbar_title_visibility" translatable="false">@string/status_and_visibility</string>
     <string name="prepublishing_tags_description">Tags help tell readers what a post is about.</string>
     <string name="prepublishing_nudges_home_tags_not_set">Not set</string>
 


### PR DESCRIPTION
Fixes #12145 

## Solution
Change the strings from Visibility to Visibility & Status

## Testing
1. Create a new post. 
2. Go to Post Settings. 
3. See the Status and Visibility Label. 

Before | After 
--------|-------
 <kbd><img src="https://user-images.githubusercontent.com/1509205/84211054-084cad00-aa80-11ea-9701-6cc2b2369dd8.png" width="320"></kbd> |   <kbd><img src="https://user-images.githubusercontent.com/1509205/84211064-0b479d80-aa80-11ea-89b4-1e3d6edd121b.png" width="320"></kbd> 
---------------------
1. Create a new post. 
2. Go to the Editor. 
3. Click Publish
4. See the Status and Visibility Label. 

Before | After 
--------|-------
 <kbd><img src="https://user-images.githubusercontent.com/1509205/84210890-8b213800-aa7f-11ea-979b-3abe4d69b09d.png" width="320"></kbd>  |   <kbd><img src="https://user-images.githubusercontent.com/1509205/84210892-8c526500-aa7f-11ea-97fc-f2be9ccfab3b.png" width="320"></kbd>
---------------------
1. Create a new post. 
2. Go to the Editor. 
3. Click Publish
4. See the Status and Visibility Label. 
5. Click it to see the label in the toolbar.

Before | After 
--------|-------
 <kbd><img src="https://user-images.githubusercontent.com/1509205/84210957-c02d8a80-aa7f-11ea-85b8-caea19c8968a.png" width="320"></kbd>     |   <kbd><img src="https://user-images.githubusercontent.com/1509205/84210970-c91e5c00-aa7f-11ea-8183-b26ff393a778.png" width="320"></kbd>
   
## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
