### PR TITLE
Prepublishing Nudges : Clear private post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/visibility/usecases/UpdatePostStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/visibility/usecases/UpdatePostStatusUseCase.kt
@@ -5,10 +5,14 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult
+import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import javax.inject.Inject
 
-class UpdatePostStatusUseCase @Inject constructor(private val dateTimeUtilsWrapper: DateTimeUtilsWrapper) {
+class UpdatePostStatusUseCase @Inject constructor(
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
+    private val postUtilsWrapper: PostUtilsWrapper
+) {
     fun updatePostStatus(
         postStatus: PostStatus,
         editPostRepository: EditPostRepository,
@@ -17,7 +21,9 @@ class UpdatePostStatusUseCase @Inject constructor(private val dateTimeUtilsWrapp
         editPostRepository.updateAsync({ postModel: PostModel ->
             // we set the date to immediately if it's scheduled.
             if (postStatus == PostStatus.PRIVATE) {
-                if (postModel.status == PostStatus.SCHEDULED.toString())
+                if (postModel.status == PostStatus.SCHEDULED.toString() || postUtilsWrapper.isPublishDateInTheFuture(
+                                postModel.dateCreated
+                        ))
                     postModel.setDateCreated(dateTimeUtilsWrapper.currentTimeInIso8601())
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/visibility/usecases/UpdatePostStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/visibility/usecases/UpdatePostStatusUseCase.kt
@@ -21,9 +21,7 @@ class UpdatePostStatusUseCase @Inject constructor(
         editPostRepository.updateAsync({ postModel: PostModel ->
             // we set the date to immediately if it's scheduled.
             if (postStatus == PostStatus.PRIVATE) {
-                if (postModel.status == PostStatus.SCHEDULED.toString() || postUtilsWrapper.isPublishDateInTheFuture(
-                                postModel.dateCreated
-                        ))
+                if (postUtilsWrapper.isPublishDateInTheFuture(postModel.dateCreated))
                     postModel.setDateCreated(dateTimeUtilsWrapper.currentTimeInIso8601())
             }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/visibility/usecases/UpdatePostStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/visibility/usecases/UpdatePostStatusUseCaseTest.kt
@@ -35,6 +35,7 @@ class UpdatePostStatusUseCaseTest : BaseUnitTest() {
         // arrange
         val currentDate = "2020-06-06T20:28:20+0200"
         whenever(dateTimeUtilsWrapper.currentTimeInIso8601()).thenReturn(currentDate)
+        whenever(postUtilsWrapper.isPublishDateInTheFuture(any())).thenReturn(true)
         editPostRepository.set { PostModel().apply { setStatus(PostStatus.SCHEDULED.toString()) } }
 
         // act
@@ -42,6 +43,42 @@ class UpdatePostStatusUseCaseTest : BaseUnitTest() {
 
         // assert
         assertThat(editPostRepository.dateCreated).isEqualTo(currentDate)
+    }
+
+    @Test
+    fun `if the new PostStatus is PRIVATE & the old PostStatus is not SCHEDULED then the date should be the same`() {
+        // arrange
+        val currentDate = "2020-06-06T20:28:20+0200"
+        editPostRepository.set {
+            PostModel().apply {
+                setDateCreated(currentDate)
+                setStatus(PostStatus.DRAFT.toString())
+            }
+        }
+        whenever(postUtilsWrapper.isPublishDateInTheFuture(any())).thenReturn(false)
+
+
+        // act
+        updatePostStatusUseCase.updatePostStatus(PRIVATE, editPostRepository) {}
+
+        // assert
+        assertThat(editPostRepository.dateCreated).isEqualTo(currentDate)
+    }
+
+    @Test
+    fun `if the new PostStatus is PRIVATE & the old PostStatus is DRAFT then the postModel should be updated`() {
+        // arrange
+        editPostRepository.set {
+            PostModel().apply {
+                setStatus(PostStatus.DRAFT.toString())
+            }
+        }
+
+        // act
+        updatePostStatusUseCase.updatePostStatus(PRIVATE, editPostRepository) {}
+
+        // assert
+        assertThat(editPostRepository.status).isEqualTo(PRIVATE)
     }
 
     @Test
@@ -76,39 +113,5 @@ class UpdatePostStatusUseCaseTest : BaseUnitTest() {
 
         // assert
         assertThat(editPostRepository.dateCreated).isEqualTo(dateCreated)
-    }
-
-    @Test
-    fun `if the new PostStatus is PRIVATE & the old PostStatus is not SCHEDULED then the date should be the same`() {
-        // arrange
-        val currentDate = "2020-06-06T20:28:20+0200"
-        editPostRepository.set {
-            PostModel().apply {
-                setDateCreated(currentDate)
-                setStatus(PostStatus.DRAFT.toString())
-            }
-        }
-
-        // act
-        updatePostStatusUseCase.updatePostStatus(PRIVATE, editPostRepository) {}
-
-        // assert
-        assertThat(editPostRepository.dateCreated).isEqualTo(currentDate)
-    }
-
-    @Test
-    fun `if the new PostStatus is PRIVATE & the old PostStatus is DRAFT then the postModel should be updated`() {
-        // arrange
-        editPostRepository.set {
-            PostModel().apply {
-                setStatus(PostStatus.DRAFT.toString())
-            }
-        }
-
-        // act
-        updatePostStatusUseCase.updatePostStatus(PRIVATE, editPostRepository) {}
-
-        // assert
-        assertThat(editPostRepository.status).isEqualTo(PRIVATE)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/visibility/usecases/UpdatePostStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/visibility/usecases/UpdatePostStatusUseCaseTest.kt
@@ -1,30 +1,32 @@
 package org.wordpress.android.ui.posts.prepublishing.visibility.usecases
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
-import org.wordpress.android.BaseUnitTest
-
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.model.post.PostStatus.PRIVATE
 import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.util.DateTimeUtilsWrapper
 
 class UpdatePostStatusUseCaseTest : BaseUnitTest() {
     private lateinit var editPostRepository: EditPostRepository
     private lateinit var updatePostStatusUseCase: UpdatePostStatusUseCase
     @Mock lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
+    @Mock lateinit var postUtilsWrapper: PostUtilsWrapper
 
     @InternalCoroutinesApi
     @Before
     fun setup() {
-        updatePostStatusUseCase = UpdatePostStatusUseCase(dateTimeUtilsWrapper)
+        updatePostStatusUseCase = UpdatePostStatusUseCase(dateTimeUtilsWrapper, postUtilsWrapper)
         editPostRepository = EditPostRepository(mock(), mock(), mock(), TEST_DISPATCHER, TEST_DISPATCHER)
     }
 
@@ -40,6 +42,40 @@ class UpdatePostStatusUseCaseTest : BaseUnitTest() {
 
         // assert
         assertThat(editPostRepository.dateCreated).isEqualTo(currentDate)
+    }
+
+    @Test
+    fun `if the new PostStatus is PRIVATE & the old PostStatus is PENDING & date is in future then the date created should be now`() {
+        // arrange
+        val currentDate = "2020-06-06T20:28:20+0200"
+        whenever(dateTimeUtilsWrapper.currentTimeInIso8601()).thenReturn(currentDate)
+        whenever(postUtilsWrapper.isPublishDateInTheFuture(any())).thenReturn(true)
+        editPostRepository.set { PostModel().apply { setStatus(PostStatus.PENDING.toString()) } }
+
+        // act
+        updatePostStatusUseCase.updatePostStatus(PRIVATE, editPostRepository) {}
+
+        // assert
+        assertThat(editPostRepository.dateCreated).isEqualTo(currentDate)
+    }
+
+    @Test
+    fun `if the new PostStatus is PRIVATE & the old PostStatus is PENDING & date is not in future then the date created should be the same`() {
+        // arrange
+        val dateCreated = "2020-06-06T20:28:20+0200"
+        whenever(postUtilsWrapper.isPublishDateInTheFuture(any())).thenReturn(false)
+        editPostRepository.set {
+            PostModel().apply {
+                setDateCreated(dateCreated)
+                setStatus(PostStatus.PENDING.toString())
+            }
+        }
+
+        // act
+        updatePostStatusUseCase.updatePostStatus(PRIVATE, editPostRepository) {}
+
+        // assert
+        assertThat(editPostRepository.dateCreated).isEqualTo(dateCreated)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/visibility/usecases/UpdateVisibilityUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/visibility/usecases/UpdateVisibilityUseCaseTest.kt
@@ -23,7 +23,7 @@ class UpdateVisibilityUseCaseTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Before
     fun setup() {
-        updateVisibilityUseCase = UpdateVisibilityUseCase(UpdatePostStatusUseCase(mock()))
+        updateVisibilityUseCase = UpdateVisibilityUseCase(UpdatePostStatusUseCase(mock(), mock()))
         editPostRepository = EditPostRepository(mock(), mock(), mock(), TEST_DISPATCHER, TEST_DISPATCHER)
         editPostRepository.set { PostModel() }
     }


### PR DESCRIPTION
Fixes #12148

## Solution
If the user switches to other `PostStatuses` eg. `Pending` and then switches to `Private` the `Publish Date` is not cleared if it's in the future. This is because the previous logic that clears the date was looking for the `Scheduled` `PostStatus` to clear but now it just checks to see if the date is in the future. 

## Testing
1. Create a new post. 
2. Click Publish. 
3. Select Publish Date. 
4. Select a future date. 
5. Select Pending Review and then select Private.
6. Go back and observe the future date is cleared.  

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 