### PR TITLE
Added CCPA notice to privacy settings

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -854,6 +854,9 @@
     <string name="third_party_policy_learn_more_header">Third Party Policy</string>
     <string name="third_party_policy_learn_more_caption">We use other tracking tools, including some from third parties. Read about these and how to control them.</string>
     <string name="privacy_policy_read">Read privacy policy</string>
+    <string name="ccpa_privacy_notice_header">Privacy notice for California users</string>
+    <string name="ccpa_privacy_notice_caption">The California Consumer Privacy Act ("CCPA") requires us to provide California residents with some additional information about the categories of personal information we collect and share, where we get that personal information, and how and why we use it.</string>
+    <string name="ccpa_privacy_notice_read">Read CCPA privacy notice</string>
     <string name="preference_strip_image_location">Remove location from media</string>
     <string name="app_theme">Appearance</string>
     <string name="app_theme_light">Light</string>

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -42,6 +42,12 @@
             app:url="https://www.automattic.com/privacy" />
 
         <org.wordpress.android.ui.prefs.LearnMorePreference
+            android:title="@string/ccpa_privacy_notice_header"
+            app:button="@string/ccpa_privacy_notice_read"
+            app:caption="@string/ccpa_privacy_notice_caption"
+            app:url="https://automattic.com/privacy/#california-consumer-privacy-act-ccpa" />
+
+        <org.wordpress.android.ui.prefs.LearnMorePreference
             android:title="@string/third_party_policy_learn_more_header"
             app:button="@string/learn_more"
             app:caption="@string/third_party_policy_learn_more_caption"


### PR DESCRIPTION
This PR adds the [CCPA privacy notice](https://automattic.com/privacy/#california-consumer-privacy-act-ccpa) to the privacy settings screen:

<a href="https://user-images.githubusercontent.com/154014/84420383-92f7ee00-abdf-11ea-9421-7658a1e4e3c3.png"><img src="https://user-images.githubusercontent.com/154014/84420383-92f7ee00-abdf-11ea-9421-7658a1e4e3c3.png" width="500"></a>

@planarvoid or @malinajirka would either one of you mind giving this PR a quick 👀 ?

### To test:
1. Navigate to App Settings → Privacy Settings
2. Tap on `Read CCPA privacy notice`
3. Verify [this link](https://automattic.com/privacy/#california-consumer-privacy-act-ccpa) is displayed in the web browser

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
