### PR TITLE
Issue/10726 site pages author picker phase iv

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
@@ -26,7 +26,8 @@ sealed class PageItem(open val type: Type) {
         open var actionsEnabled: Boolean,
         open val tapActionEnabled: Boolean,
         open val progressBarUiState: ProgressBarUiState,
-        open val showOverlay: Boolean
+        open val showOverlay: Boolean,
+        open val author: String?
     ) : PageItem(PAGE)
 
     data class PublishedPage(
@@ -42,7 +43,8 @@ sealed class PageItem(open val type: Type) {
         override val actions: Set<Action>,
         override var actionsEnabled: Boolean = true,
         override val progressBarUiState: ProgressBarUiState,
-        override val showOverlay: Boolean
+        override val showOverlay: Boolean,
+        override val author: String? = null
     ) : Page(
             remoteId = remoteId,
             localId = localId,
@@ -56,7 +58,8 @@ sealed class PageItem(open val type: Type) {
             actionsEnabled = actionsEnabled,
             tapActionEnabled = true,
             progressBarUiState = progressBarUiState,
-            showOverlay = showOverlay
+            showOverlay = showOverlay,
+            author = author
     )
 
     data class DraftPage(
@@ -71,7 +74,8 @@ sealed class PageItem(open val type: Type) {
         override val actions: Set<Action>,
         override var actionsEnabled: Boolean = true,
         override val progressBarUiState: ProgressBarUiState,
-        override val showOverlay: Boolean
+        override val showOverlay: Boolean,
+        override val author: String? = null
     ) : Page(
             remoteId = remoteId,
             localId = localId,
@@ -85,7 +89,8 @@ sealed class PageItem(open val type: Type) {
             actionsEnabled = actionsEnabled,
             tapActionEnabled = true,
             progressBarUiState = progressBarUiState,
-            showOverlay = showOverlay
+            showOverlay = showOverlay,
+            author = author
     )
 
     data class ScheduledPage(
@@ -100,7 +105,8 @@ sealed class PageItem(open val type: Type) {
         override val actions: Set<Action>,
         override var actionsEnabled: Boolean = true,
         override val progressBarUiState: ProgressBarUiState,
-        override val showOverlay: Boolean
+        override val showOverlay: Boolean,
+        override val author: String? = null
     ) : Page(
             remoteId = remoteId,
             localId = localId,
@@ -114,7 +120,8 @@ sealed class PageItem(open val type: Type) {
             actionsEnabled = actionsEnabled,
             tapActionEnabled = true,
             progressBarUiState = progressBarUiState,
-            showOverlay = showOverlay
+            showOverlay = showOverlay,
+            author = author
     )
 
     data class TrashedPage(
@@ -129,7 +136,8 @@ sealed class PageItem(open val type: Type) {
         override val actions: Set<Action>,
         override var actionsEnabled: Boolean = true,
         override val progressBarUiState: ProgressBarUiState,
-        override val showOverlay: Boolean
+        override val showOverlay: Boolean,
+        override val author: String? = null
     ) : Page(
             remoteId = remoteId,
             localId = localId,
@@ -143,7 +151,9 @@ sealed class PageItem(open val type: Type) {
             actionsEnabled = actionsEnabled,
             tapActionEnabled = false,
             progressBarUiState = progressBarUiState,
-            showOverlay = showOverlay
+            showOverlay = showOverlay,
+            author = author
+
     )
 
     data class ParentPage(

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -80,20 +80,7 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
                 else
                     page.title
 
-                val date = if (page.date == Date(0)) Date() else page.date
-                val stringDate = DateTimeUtils.javaDateToTimeSpan(date, parent.context)
-                        .capitalizeWithLocaleWithoutLint(parent.context.currentLocale)
-                val subtitle = page.subtitle
-                pageSubtitle.text = if (subtitle == null) {
-                    stringDate
-                } else {
-                    String.format(
-                            Locale.getDefault(),
-                            parent.context.getString(R.string.pages_item_subtitle),
-                            stringDate,
-                            parent.context.getString(subtitle)
-                    )
-                }
+                showSubtitle(page.date, page.author, page.subtitle)
 
                 labels.text = page.labels.map { uiHelper.getTextOfUiString(parent.context, it) }.sorted()
                         .joinToString(separator = " · ")
@@ -174,6 +161,42 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
                     featuredImage.visibility = View.GONE
                     imageManager?.cancelRequestAndClearImageView(featuredImage)
                 }
+            }
+        }
+
+        @ExperimentalStdlibApi
+        private fun showSubtitle(inputDate: Date, author: String?, subtitle: Int?) {
+            val date = if (inputDate == Date(0)) Date() else inputDate
+            val stringDate = DateTimeUtils.javaDateToTimeSpan(date, parent.context)
+                    .capitalizeWithLocaleWithoutLint(parent.context.currentLocale)
+
+            /** The subtitle can use 2 or 3 placeholders
+            * Date - Only (author & subtitle are null)
+            * Date - Author (author != null && subtitle == null)
+            * Date - subtitle (author == null && subtitle != null)
+            * Date - Author - subtitle (all have values)
+            */
+            pageSubtitle.text = if (author == null && subtitle == null) {
+                stringDate
+            } else if (author != null && subtitle == null) {
+                String.format(
+                        Locale.getDefault(),
+                        parent.context.getString(R.string.pages_item_subtitle),
+                        stringDate,
+                        author)
+            } else if (author == null && subtitle != null) {
+                String.format(
+                        Locale.getDefault(),
+                        parent.context.getString(R.string.pages_item_subtitle),
+                        stringDate,
+                        parent.context.getString(subtitle))
+            } else {
+                String.format(
+                        Locale.getDefault(),
+                        parent.context.getString(R.string.pages_item_subtitle_date_author),
+                        stringDate,
+                        author,
+                        parent.context.getString(subtitle!!))
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -462,6 +462,7 @@ class PagesFragment : Fragment() {
     private fun hideSearchList(myActionMenuItem: MenuItem) {
         pagesPager.visibility = View.VISIBLE
         tabLayout.visibility = View.VISIBLE
+        tabContainer.visibility = View.VISIBLE
         searchFrame.visibility = View.GONE
         if (myActionMenuItem.isActionViewExpanded) {
             myActionMenuItem.collapseActionView()
@@ -471,6 +472,7 @@ class PagesFragment : Fragment() {
     private fun showSearchList(myActionMenuItem: MenuItem) {
         pagesPager.visibility = View.GONE
         tabLayout.visibility = View.GONE
+        tabContainer.visibility = View.GONE
         searchFrame.visibility = View.VISIBLE
         if (!myActionMenuItem.isActionViewExpanded) {
             myActionMenuItem.expandActionView()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -257,12 +257,8 @@ class PageListViewModel @Inject constructor(
         return null
     }
 
-    private fun shouldFilterByAuthor(): Boolean {
-        return pagesViewModel.authorUIState.value?.authorFilterSelection == AuthorFilterSelection.ME
-    }
-
     private fun preparePublishedPages(pages: List<PageModel>, actionsEnabled: Boolean): List<PageItem> {
-        val filteredPages = if (shouldFilterByAuthor())
+        val filteredPages = if (pagesViewModel.shouldFilterByAuthor())
             pages.filter { it.post.authorId == accountStore.account.userId }
         else pages
 
@@ -303,7 +299,7 @@ class PageListViewModel @Inject constructor(
         pages: List<PageModel>,
         actionsEnabled: Boolean
     ): List<PageItem> {
-        val filteredPages = if (shouldFilterByAuthor())
+        val filteredPages = if (pagesViewModel.shouldFilterByAuthor())
             pages.filter { it.post.authorId == accountStore.account.userId }
         else pages
 
@@ -335,7 +331,7 @@ class PageListViewModel @Inject constructor(
     }
 
     private fun prepareDraftPages(pages: List<PageModel>, actionsEnabled: Boolean): List<PageItem> {
-        val filteredPages = if (shouldFilterByAuthor())
+        val filteredPages = if (pagesViewModel.shouldFilterByAuthor())
             pages.filter { it.post.authorId == accountStore.account.userId }
         else pages
 
@@ -362,7 +358,7 @@ class PageListViewModel @Inject constructor(
         pages: List<PageModel>,
         actionsEnabled: Boolean
     ): List<PageItem> {
-        val filteredPages = if (shouldFilterByAuthor())
+        val filteredPages = if (pagesViewModel.shouldFilterByAuthor())
             pages.filter { it.post.authorId == accountStore.account.userId }
         else pages
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.pages.PageItem.PublishedPage
 import org.wordpress.android.ui.pages.PageItem.ScheduledPage
 import org.wordpress.android.ui.pages.PageItem.TrashedPage
 import org.wordpress.android.ui.posts.AuthorFilterSelection
+import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.LocaleManagerWrapper
@@ -290,7 +291,9 @@ class PageListViewModel @Inject constructor(
                             actions = itemUiStateData.actions,
                             actionsEnabled = actionsEnabled,
                             progressBarUiState = itemUiStateData.progressBarUiState,
-                            showOverlay = itemUiStateData.showOverlay
+                            showOverlay = itemUiStateData.showOverlay,
+                            author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME)
+                                null else it.post.authorDisplayName
                     )
                 }
     }
@@ -320,7 +323,9 @@ class PageListViewModel @Inject constructor(
                                         actions = itemUiStateData.actions,
                                         actionsEnabled = actionsEnabled,
                                         progressBarUiState = itemUiStateData.progressBarUiState,
-                                        showOverlay = itemUiStateData.showOverlay
+                                        showOverlay = itemUiStateData.showOverlay,
+                                        author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME)
+                                            null else it.post.authorDisplayName
                                 )
                             }
                 }
@@ -349,7 +354,9 @@ class PageListViewModel @Inject constructor(
                     actions = itemUiStateData.actions,
                     actionsEnabled = actionsEnabled,
                     progressBarUiState = itemUiStateData.progressBarUiState,
-                    showOverlay = itemUiStateData.showOverlay
+                    showOverlay = itemUiStateData.showOverlay,
+                    author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME)
+                        null else it.post.authorDisplayName
             )
         }
     }
@@ -376,7 +383,9 @@ class PageListViewModel @Inject constructor(
                     actions = itemUiStateData.actions,
                     actionsEnabled = actionsEnabled,
                     progressBarUiState = itemUiStateData.progressBarUiState,
-                    showOverlay = itemUiStateData.showOverlay
+                    showOverlay = itemUiStateData.showOverlay,
+                    author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME)
+                        null else it.post.authorDisplayName
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -386,13 +386,9 @@ class PagesViewModel
         searchQuery: String
     ): SortedMap<PageListType, List<PageModel>> = withContext(defaultDispatcher) {
         val list = pageStore.search(site, searchQuery)
-        val filteredList = if (shouldFilterByAuthor())
-            list.filter {
-                    it.post.authorId == accountStore.account.userId }
-                    .groupBy { PageListType.fromPageStatus(it.status) }
-        else list.groupBy { PageListType.fromPageStatus(it.status) }
+                .groupBy { PageListType.fromPageStatus(it.status) }
 
-        return@withContext filteredList.toSortedMap(
+        return@withContext list.toSortedMap(
                 Comparator { previous, next ->
                     when {
                         previous == next -> 0

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -206,8 +206,8 @@ class PagesViewModel
     private val _authorSelectionUpdated = MutableLiveData<AuthorFilterSelection>()
     val authorSelectionUpdated = _authorSelectionUpdated
 
-    private val _authorUiState = MutableLiveData<PagesAuthorFilterUIState>()
-    val authorUIState: LiveData<PagesAuthorFilterUIState> = _authorUiState
+    private val _authorUIState = MutableLiveData<PagesAuthorFilterUIState>()
+    val authorUIState: LiveData<PagesAuthorFilterUIState> = _authorUIState
 
     data class BrowsePreview(
         val post: PostModel,
@@ -242,7 +242,7 @@ class PagesViewModel
         }
 
         _authorSelectionUpdated.value = authorFilterSelection
-        _authorUiState.value = PagesAuthorFilterUIState(
+        _authorUIState.value = PagesAuthorFilterUIState(
                 isAuthorFilterVisible = isFilteringByAuthorSupported,
                 authorFilterSelection = authorFilterSelection,
                 authorFilterItems = getAuthorFilterItems(authorFilterSelection, accountStore.account?.avatarUrl)
@@ -842,10 +842,10 @@ class PagesViewModel
             "updateViewStateTriggerPagerChange should not be called before the initial state is set"
         }
 
-        _authorUiState.value = PagesAuthorFilterUIState(
-                isAuthorFilterVisible ?: currentState.isAuthorFilterVisible,
-                authorFilterSelection ?: currentState.authorFilterSelection,
-                authorFilterItems ?: currentState.authorFilterItems
+        _authorUIState.value = _authorUIState.value?.copy(
+                isAuthorFilterVisible = isAuthorFilterVisible ?: currentState.isAuthorFilterVisible,
+                authorFilterSelection = authorFilterSelection ?: currentState.authorFilterSelection,
+                authorFilterItems = authorFilterItems ?: currentState.authorFilterItems
         )
 
         if (authorFilterSelection != null && currentState.authorFilterSelection != authorFilterSelection) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -387,7 +387,9 @@ class PagesViewModel
     ): SortedMap<PageListType, List<PageModel>> = withContext(defaultDispatcher) {
         val list = pageStore.search(site, searchQuery)
         val filteredList = if (shouldFilterByAuthor())
-            list.filter { it.post.authorId == accountStore.account.userId }.groupBy { PageListType.fromPageStatus(it.status) }
+            list.filter {
+                    it.post.authorId == accountStore.account.userId }
+                    .groupBy { PageListType.fromPageStatus(it.status) }
         else list.groupBy { PageListType.fromPageStatus(it.status) }
 
         return@withContext filteredList.toSortedMap(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -385,8 +385,12 @@ class PagesViewModel
         site: SiteModel,
         searchQuery: String
     ): SortedMap<PageListType, List<PageModel>> = withContext(defaultDispatcher) {
-        val list = pageStore.search(site, searchQuery).groupBy { PageListType.fromPageStatus(it.status) }
-        return@withContext list.toSortedMap(
+        val list = pageStore.search(site, searchQuery)
+        val filteredList = if (shouldFilterByAuthor())
+            list.filter { it.post.authorId == accountStore.account.userId }.groupBy { PageListType.fromPageStatus(it.status) }
+        else list.groupBy { PageListType.fromPageStatus(it.status) }
+
+        return@withContext filteredList.toSortedMap(
                 Comparator { previous, next ->
                     when {
                         previous == next -> 0
@@ -936,6 +940,11 @@ class PagesViewModel
         launch {
             liveData.value = value
         }
+    }
+
+    // todo: annmarie - a candidate for removal & align with PageListViewModel
+    private fun shouldFilterByAuthor(): Boolean {
+        return authorUIState.value?.authorFilterSelection == AuthorFilterSelection.ME
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -944,8 +944,7 @@ class PagesViewModel
         }
     }
 
-    // todo: annmarie - a candidate for removal & align with PageListViewModel
-    private fun shouldFilterByAuthor(): Boolean {
+    fun shouldFilterByAuthor(): Boolean {
         return authorUIState.value?.authorFilterSelection == AuthorFilterSelection.ME
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.PageItem.PublishedPage
 import org.wordpress.android.ui.pages.PageItem.ScheduledPage
 import org.wordpress.android.ui.pages.PageItem.TrashedPage
+import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.DRAFTS
@@ -119,7 +120,9 @@ class SearchListViewModel
                         ),
                         actionsEnabled = areActionsEnabled,
                         progressBarUiState = progressBarUiState,
-                        showOverlay = showOverlay
+                        showOverlay = showOverlay,
+                        author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME) null
+                                    else post.authorDisplayName
                 )
             PageStatus.DRAFT, PageStatus.PENDING -> DraftPage(
                     remoteId = remoteId,
@@ -136,7 +139,9 @@ class SearchListViewModel
                     ),
                     actionsEnabled = areActionsEnabled,
                     progressBarUiState = progressBarUiState,
-                    showOverlay = showOverlay
+                    showOverlay = showOverlay,
+                    author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME) null
+                                else post.authorDisplayName
             )
             PageStatus.TRASHED -> TrashedPage(
                     remoteId = remoteId,
@@ -153,7 +158,9 @@ class SearchListViewModel
                     ),
                     actionsEnabled = areActionsEnabled,
                     progressBarUiState = progressBarUiState,
-                    showOverlay = showOverlay
+                    showOverlay = showOverlay,
+                    author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME) null
+                                else post.authorDisplayName
             )
             PageStatus.SCHEDULED -> ScheduledPage(
                     remoteId = remoteId,
@@ -170,7 +177,9 @@ class SearchListViewModel
                     ),
                     actionsEnabled = areActionsEnabled,
                     progressBarUiState = progressBarUiState,
-                    showOverlay = showOverlay
+                    showOverlay = showOverlay,
+                    author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME) null
+                                else post.authorDisplayName
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/SearchListViewModel.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.PageItem.PublishedPage
 import org.wordpress.android.ui.pages.PageItem.ScheduledPage
 import org.wordpress.android.ui.pages.PageItem.TrashedPage
-import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.DRAFTS
@@ -121,8 +120,7 @@ class SearchListViewModel
                         actionsEnabled = areActionsEnabled,
                         progressBarUiState = progressBarUiState,
                         showOverlay = showOverlay,
-                        author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME) null
-                                    else post.authorDisplayName
+                        author = post.authorDisplayName
                 )
             PageStatus.DRAFT, PageStatus.PENDING -> DraftPage(
                     remoteId = remoteId,
@@ -140,8 +138,7 @@ class SearchListViewModel
                     actionsEnabled = areActionsEnabled,
                     progressBarUiState = progressBarUiState,
                     showOverlay = showOverlay,
-                    author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME) null
-                                else post.authorDisplayName
+                    author = post.authorDisplayName
             )
             PageStatus.TRASHED -> TrashedPage(
                     remoteId = remoteId,
@@ -159,8 +156,7 @@ class SearchListViewModel
                     actionsEnabled = areActionsEnabled,
                     progressBarUiState = progressBarUiState,
                     showOverlay = showOverlay,
-                    author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME) null
-                                else post.authorDisplayName
+                    author = post.authorDisplayName
             )
             PageStatus.SCHEDULED -> ScheduledPage(
                     remoteId = remoteId,
@@ -178,8 +174,7 @@ class SearchListViewModel
                     actionsEnabled = areActionsEnabled,
                     progressBarUiState = progressBarUiState,
                     showOverlay = showOverlay,
-                    author = if (pagesViewModel.authorUIState.value?.authorFilterSelection == ME) null
-                                else post.authorDisplayName
+                    author = post.authorDisplayName
             )
         }
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2670,6 +2670,7 @@
     <string name="pages_list_author">Page author</string>
     <string name="pages_cannot_be_started">We cannot open pages at the moment. Please try again later</string>
     <string name="pages_item_subtitle">%1$s · %2$s</string>
+    <string name="pages_item_subtitle_date_author">%1$s · %2$s · %3$s</string>
 
     <string name="page_status_pending_review" translatable="false">@string/post_status_pending_review</string>
     <string name="page_status_page_private" translatable="false">@string/post_status_post_private</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -391,7 +391,8 @@ class PageListViewModelTest : BaseUnitTest() {
 
         viewModel.pages.observeForever { pagesResult.add(it) }
 
-        val pageModels = (0..1).map { buildPageModel(it, authorId = it.toLong(), authorDisplayName = authorDisplayName) }
+        val pageModels = (0..1).map { buildPageModel(it, authorId = it.toLong(),
+                authorDisplayName = authorDisplayName) }
         pages.value = pageModels
 
         authorFilterState.value = PagesAuthorFilterUIState(
@@ -434,7 +435,6 @@ class PageListViewModelTest : BaseUnitTest() {
         assertNull(pageItem.author)
     }
 
-
     private fun buildPageModel(
         id: Int,
         date: Date = Date(0),
@@ -447,7 +447,7 @@ class PageListViewModelTest : BaseUnitTest() {
         val title = pageTitle ?: if (id < 10) "Title 0$id" else "Title $id"
         return PageModel(PostModel().apply { this.setId(id)
                 this.setAuthorId(authorId ?: 0)
-                this.setAuthorDisplayName(authorDisplayName)},
+                this.setAuthorDisplayName(authorDisplayName) },
                 site, id, title, status, date, false, id.toLong(),
                 parent, id.toLong())
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -90,7 +90,6 @@ class PageListViewModelTest : BaseUnitTest() {
         whenever(pagesViewModel.authorUIState).thenReturn(authorFilterState)
         val accountModel = AccountModel()
         accountModel.userId = 4
-        whenever(accountStore.account).thenReturn(accountModel)
     }
 
     @Test
@@ -372,7 +371,7 @@ class PageListViewModelTest : BaseUnitTest() {
         authorFilterSelection.value = ME
 
         pageItems = pagesResult[1].first
-        assertThat(pageItems).hasSize(3)
+        assertThat(pageItems).hasSize(13)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -12,16 +12,22 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.ui.pages.PageItem
 import org.wordpress.android.ui.pages.PageItem.Divider
 import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.PageItem.PublishedPage
+import org.wordpress.android.ui.pages.PagesAuthorFilterUIState
+import org.wordpress.android.ui.posts.AuthorFilterSelection
+import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
+import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.PUBLISHED
@@ -41,6 +47,7 @@ class PageListViewModelTest : BaseUnitTest() {
     @Mock lateinit var pageListItemActionsUseCase: CreatePageListItemActionsUseCase
     @Mock lateinit var createUploadStateUseCase: PostModelUploadUiStateUseCase
     @Mock lateinit var createLabelsUseCase: CreatePageListItemLabelsUseCase
+    @Mock lateinit var accountStore: AccountStore
 
     private lateinit var viewModel: PageListViewModel
     private val site = SiteModel()
@@ -55,6 +62,7 @@ class PageListViewModelTest : BaseUnitTest() {
                 mediaStore,
                 dispatcher,
                 localeManagerWrapper,
+                accountStore,
                 Dispatchers.Unconfined
         )
 
@@ -74,6 +82,14 @@ class PageListViewModelTest : BaseUnitTest() {
         whenever(createLabelsUseCase.createLabels(any(), any())).thenReturn(Pair(emptyList(), 0))
         site.id = 10
         pageListState.value = PageListState.DONE
+
+        val authorFilterSelection = MutableLiveData<AuthorFilterSelection>()
+        whenever(pagesViewModel.authorSelectionUpdated).thenReturn(authorFilterSelection)
+        val authorFilterState = MutableLiveData<PagesAuthorFilterUIState>()
+        whenever(pagesViewModel.authorUIState).thenReturn(authorFilterState)
+        val accountModel = AccountModel()
+        accountModel.userId = 4
+        whenever(accountStore.account).thenReturn(accountModel)
     }
 
     @Test
@@ -294,15 +310,82 @@ class PageListViewModelTest : BaseUnitTest() {
         assertThat((result[0].first[0] as PublishedPage).actions).isEqualTo(actions)
     }
 
+    @Test
+    fun `filter pages by everyone`() {
+        val pages = MutableLiveData<List<PageModel>>()
+        whenever(pagesViewModel.pages).thenReturn(pages)
+        val authorFilterSelection = MutableLiveData<AuthorFilterSelection>()
+        whenever(pagesViewModel.authorSelectionUpdated).thenReturn(authorFilterSelection)
+        val authorFilterState = MutableLiveData<PagesAuthorFilterUIState>()
+        whenever(pagesViewModel.authorUIState).thenReturn(authorFilterState)
+
+        viewModel.start(PUBLISHED, pagesViewModel)
+
+        val pagesResult = mutableListOf<Triple<List<PageItem>, Boolean, Boolean>>()
+
+        viewModel.pages.observeForever { pagesResult.add(it) }
+
+        val pageModels = (0..10).map { buildPageModel(it, authorId = it.toLong()) }
+        pages.value = pageModels
+
+        assertThat(pagesResult).hasSize(1)
+        var pageItems = pagesResult[0].first
+        assertThat(pageItems).hasSize(13)
+
+        authorFilterState.value = PagesAuthorFilterUIState(
+                authorFilterSelection = EVERYONE,
+                authorFilterItems = listOf(),
+                isAuthorFilterVisible = true)
+        authorFilterSelection.value = EVERYONE
+
+        pageItems = pagesResult[1].first
+        assertThat(pageItems).hasSize(13)
+    }
+
+    @Test
+    fun `filter pages by me`() {
+        val pages = MutableLiveData<List<PageModel>>()
+        whenever(pagesViewModel.pages).thenReturn(pages)
+        val authorFilterSelection = MutableLiveData<AuthorFilterSelection>()
+        whenever(pagesViewModel.authorSelectionUpdated).thenReturn(authorFilterSelection)
+        val authorFilterState = MutableLiveData<PagesAuthorFilterUIState>()
+        whenever(pagesViewModel.authorUIState).thenReturn(authorFilterState)
+
+        viewModel.start(PUBLISHED, pagesViewModel)
+
+        val pagesResult = mutableListOf<Triple<List<PageItem>, Boolean, Boolean>>()
+
+        viewModel.pages.observeForever { pagesResult.add(it) }
+
+        val pageModels = (0..10).map { buildPageModel(it, authorId = it.toLong()) }
+        pages.value = pageModels
+
+        assertThat(pagesResult).hasSize(1)
+        var pageItems = pagesResult[0].first
+        assertThat(pageItems).hasSize(13)
+
+        authorFilterState.value = PagesAuthorFilterUIState(
+                authorFilterSelection = ME,
+                authorFilterItems = listOf(),
+                isAuthorFilterVisible = true)
+        authorFilterSelection.value = ME
+
+        pageItems = pagesResult[1].first
+        assertThat(pageItems).hasSize(3)
+    }
+
     private fun buildPageModel(
         id: Int,
         date: Date = Date(0),
         parent: PageModel? = null,
         pageTitle: String? = null,
-        status: PageStatus = PageStatus.PUBLISHED
+        status: PageStatus = PageStatus.PUBLISHED,
+        authorId: Long? = null
     ): PageModel {
         val title = pageTitle ?: if (id < 10) "Title 0$id" else "Title $id"
-        return PageModel(PostModel().apply { this.setId(id) }, site, id, title, status, date, false, id.toLong(),
+        return PageModel(PostModel().apply { this.setId(id)
+                this.setAuthorId(authorId ?: 0) },
+                site, id, title, status, date, false, id.toLong(),
                 parent, id.toLong())
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.ui.pages.PageItem.Divider
 import org.wordpress.android.ui.pages.PageItem.DraftPage
 import org.wordpress.android.ui.pages.PageItem.Empty
 import org.wordpress.android.ui.pages.PageItem.PublishedPage
-import org.wordpress.android.ui.pages.PagesAuthorFilterUIState
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
@@ -110,8 +109,6 @@ class SearchListViewModelTest {
     fun `builds list with dividers from grouped result`() {
         val expectedTitle = "title"
         whenever(resourceProvider.getString(any())).thenReturn(expectedTitle)
-        val authorFilterState = MutableLiveData<PagesAuthorFilterUIState>()
-        whenever(pagesViewModel.authorUIState).thenReturn(authorFilterState)
 
         val publishedPageId = 1
         val publishedPageRemoteId = 11L

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/SearchListViewModelTest.kt
@@ -26,9 +26,10 @@ import org.wordpress.android.ui.pages.PageItem.Divider
 import org.wordpress.android.ui.pages.PageItem.DraftPage
 import org.wordpress.android.ui.pages.PageItem.Empty
 import org.wordpress.android.ui.pages.PageItem.PublishedPage
+import org.wordpress.android.ui.pages.PagesAuthorFilterUIState
 import org.wordpress.android.viewmodel.ResourceProvider
-import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType
+import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
 import java.util.Date
 import java.util.SortedMap
@@ -109,6 +110,8 @@ class SearchListViewModelTest {
     fun `builds list with dividers from grouped result`() {
         val expectedTitle = "title"
         whenever(resourceProvider.getString(any())).thenReturn(expectedTitle)
+        val authorFilterState = MutableLiveData<PagesAuthorFilterUIState>()
+        whenever(pagesViewModel.authorUIState).thenReturn(authorFilterState)
 
         val publishedPageId = 1
         val publishedPageRemoteId = 11L


### PR DESCRIPTION
Fixes part of #10726 

**Description**
This is the fourth PR in a series of five that introduce author filtering on the pages view. 

This PR handles showing the author display name on the pages list, including while viewing search results, when the author filter is set to everyone. When the filter is set to ME, the author name will not show.

Me - no author name | Everyone - author name
--------|------- 
<kbd><img src="https://user-images.githubusercontent.com/506707/84429929-f6d9e100-abf6-11ea-88ff-ad309586372e.png" width=320></kbd> | <kbd><img src="https://user-images.githubusercontent.com/506707/84429934-f9d4d180-abf6-11ea-9a4e-0e7fde5cafd9.png" width=320></kbd>

**Details**
- Added `author` property to Published, Drafts, Scheduled, and Trashed data models in `PageItem`
- Added a new function in `PageItemViewHolder` to manage the formatting of the subtitle line to include the author
- Added a new placeholder string for formatting a subtitle with three parameters
- Updated `PageListViewModel` to pass author name when filter is not ME
- Added two tests for showing-not showing author name

**Notes**

- Repeating my original call for opinions on the following behavior: The Posts feature also shows an author filter and saves state in App prefs. I implemented Pages to use the same appPrefs property, so the filter selection is maintained across pages to posts. 
- There is a “todo” placeholder in `PagesViewModel` . Setting up tracking will occur in the next PR.
    
**To test:**
Prep

- Be an author on a wp.com site that you are not the owner on
- Have pages in the above site in each of the four statuses: Published, Scheduled, Drafts, and Trashed (1) that you authored (2) that others authored

(A)

- Launch WPAndroid
- Select the site you prepped for the test
- Navigate to Pages
- Select Me from the author filter
- Ensure the author name is not shown
- Select Everyone from the author filter
- Ensure the author name is shown

(B)

- Launch WPAndroid
- Select the site you prepped for the test
- Navigate to Pages
- Select Me from the author filter
- Search for a page that you authored
- Ensure the author name is not shown
- Select Everyone from the author filter
- Search for any page
- Ensure the author name is shown


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
