### PR TITLE
Unified login tracking fix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -68,7 +68,7 @@ class UnifiedLoginTracker
 
     enum class Flow(val value: String) {
         GET_STARTED("get_started"),
-        LOGIN_SOCIAL("social_login"),
+        GOOGLE_LOGIN("google_login"),
         LOGIN_MAGIC_LINK("login_magic_link"),
         LOGIN_PASSWORD("login_password"),
         LOGIN_SITE_ADDRESS("login_site_address"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -205,7 +205,7 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
 
     @Override
     public void trackSocialButtonStart() {
-        mUnifiedLoginTracker.track(Flow.LOGIN_SOCIAL, Step.START);
+        mUnifiedLoginTracker.track(Flow.GOOGLE_LOGIN, Step.START);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -281,7 +281,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             ReaderUpdateServiceStarter.startService(WordPress.getContext(),
                     EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
 
-            mUnifiedLoginTracker.track(Step.SUCCESS);
+            mUnifiedLoginTracker.track(Step.USERNAME_PASSWORD);
             if (mIsEmailSignup) {
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_EMAIL_EPILOGUE_VIEWED);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -55,6 +55,8 @@ import org.wordpress.android.ui.FullScreenDialogFragment;
 import org.wordpress.android.ui.FullScreenDialogFragment.OnConfirmListener;
 import org.wordpress.android.ui.FullScreenDialogFragment.OnDismissListener;
 import org.wordpress.android.ui.RequestCodes;
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker;
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource;
@@ -129,6 +131,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     @Inject protected Dispatcher mDispatcher;
     @Inject protected ImageManager mImageManager;
     @Inject protected AppPrefsWrapper mAppPrefsWrapper;
+    @Inject protected UnifiedLoginTracker mUnifiedLoginTracker;
 
     public static SignupEpilogueFragment newInstance(String displayName, String emailAddress,
                                                      String photoUrl, String username,
@@ -278,6 +281,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             ReaderUpdateServiceStarter.startService(WordPress.getContext(),
                     EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
 
+            mUnifiedLoginTracker.track(Step.SUCCESS);
             if (mIsEmailSignup) {
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_EMAIL_EPILOGUE_VIEWED);
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/accounts/PostSignupInterstitialViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/accounts/PostSignupInterstitialViewModel.kt
@@ -5,6 +5,8 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.WELCOME_NO_SITES_IN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.WELCOME_NO_SITES_INTERSTITIAL_CREATE_NEW_SITE_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.WELCOME_NO_SITES_INTERSTITIAL_DISMISSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.WELCOME_NO_SITES_INTERSTITIAL_SHOWN
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step.SUCCESS
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -16,12 +18,14 @@ import javax.inject.Inject
 class PostSignupInterstitialViewModel
 @Inject constructor(
     private val appPrefs: AppPrefsWrapper,
+    private val unifiedLoginTracker: UnifiedLoginTracker,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ViewModel() {
     val navigationAction: SingleLiveEvent<NavigationAction> = SingleLiveEvent()
 
     fun onInterstitialShown() {
         analyticsTracker.track(WELCOME_NO_SITES_INTERSTITIAL_SHOWN)
+        unifiedLoginTracker.track(SUCCESS)
         appPrefs.shouldShowPostSignupInterstitial = false
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/accounts/PostSignupInterstitialViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/accounts/PostSignupInterstitialViewModelTest.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.WELCOME_NO_SITES_IN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.WELCOME_NO_SITES_INTERSTITIAL_CREATE_NEW_SITE_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.WELCOME_NO_SITES_INTERSTITIAL_DISMISSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.WELCOME_NO_SITES_INTERSTITIAL_SHOWN
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.accounts.PostSignupInterstitialViewModel.NavigationAction
@@ -25,6 +26,7 @@ class PostSignupInterstitialViewModelTest {
     @Rule @JvmField val rule = InstantTaskExecutorRule()
 
     private val appPrefs: AppPrefsWrapper = mock()
+    private val unifiedLoginTracker: UnifiedLoginTracker = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private val observer: Observer<NavigationAction> = mock()
 
@@ -32,7 +34,7 @@ class PostSignupInterstitialViewModelTest {
 
     @Before
     fun setUp() {
-        viewModel = PostSignupInterstitialViewModel(appPrefs, analyticsTracker)
+        viewModel = PostSignupInterstitialViewModel(appPrefs, unifiedLoginTracker, analyticsTracker)
         viewModel.navigationAction.observeForever(observer)
     }
 


### PR DESCRIPTION
This PR renames the `login_social` to `google_login` based on discussion with the iOS team 

It also adds tracking of `success` to the post signup interstitial screen. 

To test:
- Test Google signup
- Check that the `google_login` flow is used 
- Check that the post signup screen now triggers an event with the `username_password` step
- Check that the interstitial screen now triggers an event with the `success` step

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
