### PR TITLE
Issue/10726 site pages author picker phase v

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.PAGES_LIST_AUTHOR_FILTER_CHANGED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.PAGES_OPTIONS_PRESSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.PAGES_SEARCH_ACCESSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.PAGES_TAB_PRESSED
@@ -87,6 +88,7 @@ private const val SEARCH_DELAY = 200L
 private const val SCROLL_DELAY = 200L
 private const val SNACKBAR_DELAY = 500L
 private const val SEARCH_COLLAPSE_DELAY = 500L
+private const val TRACKS_SELECTED_AUTHOR_FILTER = "author_filter_selection"
 
 typealias LoadAutoSaveRevision = Boolean
 
@@ -857,12 +859,11 @@ class PagesViewModel
         if (authorFilterSelection != null && currentState.authorFilterSelection != authorFilterSelection) {
             _authorSelectionUpdated.value = authorFilterSelection
 
-            // todo annmarie - author filter - track the pages - future subtask
-//            AnalyticsUtils.trackWithSiteDetails(
-//                    POST_LIST_AUTHOR_FILTER_CHANGED,
-//                    site,
-//                    mutableMapOf(TRACKS_SELECTED_AUTHOR_FILTER to authorFilterSelection.toString() as Any)
-//            )
+            AnalyticsUtils.trackWithSiteDetails(
+                    PAGES_LIST_AUTHOR_FILTER_CHANGED,
+                    site,
+                    mutableMapOf(TRACKS_SELECTED_AUTHOR_FILTER to authorFilterSelection.toString() as Any)
+            )
         }
     }
 

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -618,6 +618,7 @@ public final class AnalyticsTracker {
         FEATURE_ANNOUNCEMENT_SHOWN_FROM_APP_SETTINGS,
         FEATURE_ANNOUNCEMENT_FIND_OUT_MORE_TAPPED,
         FEATURE_ANNOUNCEMENT_CLOSE_DIALOG_BUTTON_TAPPED,
+        PAGES_LIST_AUTHOR_FILTER_CHANGED,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1748,6 +1748,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "feature_announcement_button_tapped";
             case OPENED_PLANS_COMPARISON:
                 return "plans_compare";
+            case PAGES_LIST_AUTHOR_FILTER_CHANGED:
+                return "pages_list_author_filter_changed";
         }
         return null;
     }


### PR DESCRIPTION
Partly fixes #10726 

**Description**
This is the final PR in a series of 5 that implements the author filter within the pages list.
This PR adds a tracking event when the user changes the author filter.

**Merge Notes**
Before merging this PR into the feature branch, please make sure PR #12171 has already been merged. Phase IV branch has been committed to the phase V branch.

**To test**
1. Enable Collect information via Me -> App Settings -> Privacy Settings
2. Choose a site not owned by you, but one in which you are an author
3. Click on Pages
4. Click on the author filter and change the selection
5. Notice that the console contains the following log:
6. `🔵 Tracked: p`ages_list_author_filter_changed

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
