### PR TITLE
Display content information metrics

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+15.2
+-----
+* [**] Block editor: Display content metrics information (blocks, words, characters count).
+
 15.1
 -----
 * Fixes issue on Notifications tab when two screens were drawn on top of each other

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -16,7 +16,6 @@ import android.view.DragEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.MenuItem.OnMenuItemClickListener;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.MimeTypeMap;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -16,6 +16,7 @@ import android.view.DragEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.MenuItem.OnMenuItemClickListener;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.MimeTypeMap;
@@ -1065,6 +1066,20 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         shouldSwitchToGutenbergBeVisible(mEditorFragment, mSite)
                 );
             }
+        }
+
+        MenuItem contentInfo = menu.findItem(R.id.menu_content_info);
+        if (mEditorFragment instanceof GutenbergEditorFragment) {
+            contentInfo.setOnMenuItemClickListener((menuItem) -> {
+                try {
+                    mEditorFragment.showContentInfo();
+                } catch (EditorFragmentNotAddedException e) {
+                    ToastUtils.showToast(WordPress.getContext(), R.string.toast_content_info_failed);
+                }
+                return true;
+            });
+        } else {
+            contentInfo.setVisible(false); // only show the menu item when for Gutenberg
         }
 
         return super.onPrepareOptionsMenu(menu);

--- a/WordPress/src/main/res/menu/edit_post.xml
+++ b/WordPress/src/main/res/menu/edit_post.xml
@@ -44,6 +44,11 @@
         </item>
 
         <item
+            android:id="@+id/menu_content_info"
+            android:title="@string/menu_content_info" >
+        </item>
+
+        <item
             android:id="@+id/menu_post_settings"
             android:title="@string/post_settings" >
         </item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1421,6 +1421,7 @@
     <string name="menu_debug">Debug Menu</string>
     <string name="menu_switch_to_aztec_editor">Switch to classic editor</string>
     <string name="menu_switch_to_gutenberg_editor">Switch to block editor</string>
+    <string name="menu_content_info">Content info</string>
 
     <string name="post_title">Title</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1421,7 +1421,7 @@
     <string name="menu_debug">Debug Menu</string>
     <string name="menu_switch_to_aztec_editor">Switch to classic editor</string>
     <string name="menu_switch_to_gutenberg_editor">Switch to block editor</string>
-    <string name="menu_content_info">Content info</string>
+    <string name="menu_content_info">Content structure</string>
 
     <string name="post_title">Title</string>
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -994,6 +994,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
+    public void showContentInfo() throws EditorFragmentNotAddedException {
+        // not implemented for Aztec
+    }
+
+    @Override
     public LiveData<Editable> getTitleOrContentChanged() {
         return mTextWatcher.getAfterTextChanged();
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -30,6 +30,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract void setContent(CharSequence text);
     public abstract CharSequence getTitle() throws EditorFragmentNotAddedException;
     public abstract CharSequence getContent(CharSequence originalContent) throws EditorFragmentNotAddedException;
+    public abstract void showContentInfo() throws EditorFragmentNotAddedException;
     public abstract LiveData<Editable> getTitleOrContentChanged();
     public abstract void appendMediaFile(MediaFile mediaFile, String imageUrl, ImageLoader imageLoader);
     public abstract void appendMediaFiles(Map<String, MediaFile> mediaList);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -11,6 +11,7 @@ import org.wordpress.mobile.WPAndroidGlue.RequestExecutor;
 import org.wordpress.mobile.WPAndroidGlue.Media;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnAuthHeaderRequestedListener;
+import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnContentInfoReceivedListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorAutosaveListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorMountListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGetContentTimeout;
@@ -188,6 +189,10 @@ public class GutenbergContainerFragment extends Fragment {
 
     public CharSequence getTitle(OnGetContentTimeout onGetContentTimeout) {
         return mWPAndroidGlueCode.getTitle(onGetContentTimeout);
+    }
+
+    public void triggerGetContentInfo(OnContentInfoReceivedListener onContentInfoReceivedListener) {
+        mWPAndroidGlueCode.triggerGetContentInfo(onContentInfoReceivedListener);
     }
 
     public void showDevOptionsDialog() {

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -109,6 +109,11 @@
     <string name="editor_failed_to_insert_media_tap_to_retry">Failed to insert media.\nPlease tap to retry.</string>
     <string name="editor_failed_to_insert_media_tap_for_options">Failed to insert media.\nPlease tap for options.</string>
 
+    <string name="dialog_content_info_title">Content info</string>
+    <string name="dialog_content_info_body">%1$d blocks\n%2$d words\n%3$d characters</string>
+    <string name="toast_content_info_failed">Failed to get content info</string>
+    <string name="toast_content_info_editor_not_ready">Editor is still loading</string>
+
     <!-- Aztec -->
     <string name="editor_content_hint">Share your story here&#8230;</string>
 

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -109,9 +109,9 @@
     <string name="editor_failed_to_insert_media_tap_to_retry">Failed to insert media.\nPlease tap to retry.</string>
     <string name="editor_failed_to_insert_media_tap_for_options">Failed to insert media.\nPlease tap for options.</string>
 
-    <string name="dialog_content_info_title">Content info</string>
-    <string name="dialog_content_info_body">%1$d blocks\n%2$d words\n%3$d characters</string>
-    <string name="toast_content_info_failed">Failed to get content info</string>
+    <string name="dialog_content_info_title">Content structure</string>
+    <string name="dialog_content_info_body">Blocks: %1$d\nWords: %2$d\nCharacters: %3$d</string>
+    <string name="toast_content_info_failed">Failed to get content structure</string>
     <string name="toast_content_info_editor_not_ready">Editor is still loading</string>
 
     <!-- Aztec -->


### PR DESCRIPTION
Expands #12186 to include the WPAndroid UI to get and show the content information metrics.

Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2383

Follows this design, shared by @iamthomasbishop over Slack:

<img width="599" alt="Screen Shot 2020-06-12 at 11 51 51 AM" src="https://user-images.githubusercontent.com/1032913/84556682-c98f4f00-ad2c-11ea-930c-244986cb0a63.png">

Changes introduced:
1. Adds a "Content info" menu time in the 3-dot menu while editing a post/page. The menu item triggers a call to get the latest content, including the content information.
2. Upon receiving the latest content and info, a popup dialog displays the information

To test:
1. Run the app and open an existing post, preferably a long one
2. While the spinning progress bar is still on, tap on the "Content info" menu item inside the 3-dot menu
3. Notice the "Editor is still loading" toast being shown
4. Wait for the post to finish loading
5. Tap on the "Content info" menu item again
6. Notice the popup dialog with the block/word/character counts displayed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
