### PR TITLE
Prepublishing Nudges : Dark mode issue 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeItemUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeItemUiState.kt
@@ -11,9 +11,9 @@ typealias PublishPost = Boolean
 sealed class PrepublishingHomeItemUiState {
     data class HomeUiState(
         val actionType: ActionType,
-        @ColorRes val actionTypeColor: Int = R.color.black,
+        @ColorRes val actionTypeColor: Int = R.color.prepublishing_action_type_enabled_color,
         var actionResult: UiString? = null,
-        @ColorRes val actionResultColor: Int = R.color.gray_30,
+        @ColorRes val actionResultColor: Int = R.color.prepublishing_action_result_enabled_color,
         val actionClickable: Boolean,
         val onActionClicked: ((actionType: ActionType) -> Unit)?
     ) : PrepublishingHomeItemUiState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
@@ -76,8 +76,8 @@ class PrepublishingHomeViewModel @Inject constructor(
                                 actionType = PUBLISH,
                                 actionResult = editPostRepository.getEditablePost()
                                         ?.let { UiStringText(postSettingsUtils.getPublishDateLabel(it)) },
-                                actionTypeColor = R.color.gray_10,
-                                actionResultColor = R.color.gray_10,
+                                actionTypeColor = R.color.prepublishing_action_type_disabled_color,
+                                actionResultColor = R.color.prepublishing_action_result_disabled_color,
                                 actionClickable = false,
                                 onActionClicked = null
                         )

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -60,4 +60,11 @@
     <color name="reader_image_featured_border">@color/gray_80</color>
     <color name="reader_image_avatar_or_blavatar_border">@color/gray_80</color>
 
+    <!-- Prepublishing Nudges -->
+    <color name="prepublishing_toolbar_icon_color">@color/gray_10</color>
+    <color name="prepublishing_action_type_enabled_color">@color/white</color>
+    <color name="prepublishing_action_result_enabled_color">@color/gray_30</color>
+    <color name="prepublishing_action_type_disabled_color">@color/gray_60</color>
+    <color name="prepublishing_action_result_disabled_color">@color/gray_60</color>
+
 </resources>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -64,7 +64,7 @@
     <color name="prepublishing_toolbar_icon_color">@color/gray_10</color>
     <color name="prepublishing_action_type_enabled_color">@color/white</color>
     <color name="prepublishing_action_result_enabled_color">@color/gray_30</color>
-    <color name="prepublishing_action_type_disabled_color">@color/gray_60</color>
-    <color name="prepublishing_action_result_disabled_color">@color/gray_60</color>
+    <color name="prepublishing_action_type_disabled_color">@color/gray_50</color>
+    <color name="prepublishing_action_result_disabled_color">@color/gray_50</color>
 
 </resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -44,6 +44,10 @@
 
     <!-- Prepublishing Nudges -->
     <color name="prepublishing_toolbar_icon_color">@color/gray_50</color>
+    <color name="prepublishing_action_type_enabled_color">@color/black</color>
+    <color name="prepublishing_action_result_enabled_color">@color/gray_30</color>
+    <color name="prepublishing_action_type_disabled_color">@color/gray_10</color>
+    <color name="prepublishing_action_result_disabled_color">@color/gray_10</color>
 
     <!-- SEMANTIC -->
     <color name="accent">@color/pink_50</color>


### PR DESCRIPTION
Fixes #12193 

## Testing
1. Create a new post. 
2. Click Publish. 
3. See the bottom sheet. 

Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/84560396-3264d000-ad09-11ea-9a2a-9d0b1de91f0e.png" width="320"></kbd>  |  <kbd><img src="https://user-images.githubusercontent.com/1509205/84560399-398bde00-ad09-11ea-9340-822ec3657317.png" width="320"></kbd>
     
------------
1. Create a new post. 
2. Click Publish. 
3. See the bottom sheet. 
4. Click Status & Visibility. 
5. Select Private. 
6. Navigate back and see disabled Publish Date. 

Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/84560415-71932100-ad09-11ea-90e4-7cac36c3b320.png" width="320"></kbd>   |     <kbd><img src="https://user-images.githubusercontent.com/1509205/84560417-76f06b80-ad09-11ea-963d-ae9b6930baac.png" width="320"></kbd>


## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
