### PR TITLE
Prepublishing Nudges : Persist post changes that occur in the bottom sheet 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -691,7 +691,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
             return null;
         }));
         mEditPostRepository.getPostChanged().observe(this, postEvent -> postEvent.applyIfNotHandled(post -> {
-            mViewModel.savePostToDb(this, mEditPostRepository, mSite);
+            mViewModel.savePostToDb(mEditPostRepository, mSite);
             return null;
         }));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts
 
+import android.content.Context
 import android.content.Intent
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -20,7 +21,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_SEARCH_AC
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_TAB_CHANGED
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.ListActionBuilder
-import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -80,6 +80,7 @@ class PostListMainViewModel @Inject constructor(
     private val postListEventListenerFactory: PostListEventListener.Factory,
     private val previewStateHelper: PreviewStateHelper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val savePostToDbUseCase: SavePostToDbUseCase,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val uploadStarter: UploadStarter
@@ -213,7 +214,8 @@ class PostListMainViewModel @Inject constructor(
         site: SiteModel,
         initPreviewState: PostListRemotePreviewState,
         currentBottomSheetPostId: LocalId,
-        editPostRepository: EditPostRepository
+        editPostRepository: EditPostRepository,
+        context: Context
     ) {
         this.site = site
         this.editPostRepository = editPostRepository
@@ -278,7 +280,7 @@ class PostListMainViewModel @Inject constructor(
 
         editPostRepository.run {
             postChanged.observe(this@PostListMainViewModel, Observer {
-                getEditablePost()?.let { post -> dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post)) }
+                savePostToDbUseCase.savePostToDb(context, editPostRepository, site)
             })
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -19,6 +20,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_SEARCH_AC
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_TAB_CHANGED
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.ListActionBuilder
+import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -273,6 +275,16 @@ class PostListMainViewModel @Inject constructor(
         lifecycleRegistry.markState(Lifecycle.State.STARTED)
 
         uploadStarter.queueUploadFromSite(site)
+
+        editPostRepository.run {
+            postChanged.observe(this@PostListMainViewModel, Observer {
+                getEditablePost()?.let { post -> updatePrepublishingBottomSheetPost(post) }
+            })
+        }
+    }
+
+    private fun updatePrepublishingBottomSheetPost(post: PostModel) {
+        dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post))
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -278,13 +278,9 @@ class PostListMainViewModel @Inject constructor(
 
         editPostRepository.run {
             postChanged.observe(this@PostListMainViewModel, Observer {
-                getEditablePost()?.let { post -> updatePrepublishingBottomSheetPost(post) }
+                getEditablePost()?.let { post -> dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post)) }
             })
         }
-    }
-
-    private fun updatePrepublishingBottomSheetPost(post: PostModel) {
-        dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post))
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -280,7 +280,7 @@ class PostListMainViewModel @Inject constructor(
 
         editPostRepository.run {
             postChanged.observe(this@PostListMainViewModel, Observer {
-                savePostToDbUseCase.savePostToDb(context, editPostRepository, site)
+                savePostToDbUseCase.savePostToDb(editPostRepository, site)
             })
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -247,7 +247,7 @@ class PostsListActivity : LocaleAwareActivity(),
 
     private fun initViewModel(initPreviewState: PostListRemotePreviewState, currentBottomSheetPostId: LocalId) {
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(PostListMainViewModel::class.java)
-        viewModel.start(site, initPreviewState, currentBottomSheetPostId, editPostRepository)
+        viewModel.start(site, initPreviewState, currentBottomSheetPostId, editPostRepository, this)
 
         viewModel.viewState.observe(this, Observer { state ->
             state?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SavePostToDbUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SavePostToDbUseCase.kt
@@ -15,10 +15,10 @@ class SavePostToDbUseCase
     private val uploadUtils: UploadUtilsWrapper,
     private val dateTimeUtils: DateTimeUtilsWrapper,
     private val dispatcher: Dispatcher,
-    private val pendingDraftsNotificationsUtils: PendingDraftsNotificationsUtilsWrapper
+    private val pendingDraftsNotificationsUtils: PendingDraftsNotificationsUtilsWrapper,
+    private val context: Context
 ) {
     fun savePostToDb(
-        context: Context,
         postRepository: EditPostRepository,
         site: SiteModel
     ) {
@@ -43,14 +43,13 @@ class SavePostToDbUseCase
                 post.setIsLocallyChanged(true)
             }
             post.setDateLocallyChanged(dateTimeUtils.currentTimeInIso8601())
-            handlePendingDraftNotifications(context, postRepository)
+            handlePendingDraftNotifications(postRepository)
             postRepository.savePostSnapshot()
             dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post))
         }
     }
 
     private fun handlePendingDraftNotifications(
-        context: Context,
         editPostRepository: EditPostRepository
     ) {
         if (editPostRepository.status == PostStatus.DRAFT) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -53,7 +53,7 @@ class StorePostViewModel
         editPostRepository: EditPostRepository,
         site: SiteModel
     ): ActivityFinishState {
-        savePostToDbUseCase.savePostToDb(context, editPostRepository, site)
+        savePostToDbUseCase.savePostToDb(editPostRepository, site)
         return if (networkUtils.isNetworkAvailable()) {
             postUtils.trackSavePostAnalytics(
                     editPostRepository.getPost(),
@@ -79,11 +79,10 @@ class StorePostViewModel
     }
 
     fun savePostToDb(
-        context: Context,
         postRepository: EditPostRepository,
         site: SiteModel
     ) {
-        savePostToDbUseCase.savePostToDb(context, postRepository, site)
+        savePostToDbUseCase.savePostToDb(postRepository, site)
     }
 
     fun updatePostObjectWithUIAsync(

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -1,11 +1,13 @@
 package org.wordpress.android.ui.posts
 
+import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -24,14 +26,17 @@ import org.wordpress.android.ui.posts.PostListViewLayoutType.COMPACT
 import org.wordpress.android.ui.posts.PostListViewLayoutType.STANDARD
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.uploads.UploadStarter
+import org.wordpress.android.viewmodel.Event
 
 class PostListMainViewModelTest : BaseUnitTest() {
     lateinit var site: SiteModel
     private val currentBottomSheetPostId = LocalId(0)
     @Mock lateinit var uploadStarter: UploadStarter
     @Mock lateinit var dispatcher: Dispatcher
+    @Mock lateinit var editPostRepository: EditPostRepository
     private lateinit var viewModel: PostListMainViewModel
 
+    @InternalCoroutinesApi
     @UseExperimental(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
@@ -40,6 +45,8 @@ class PostListMainViewModelTest : BaseUnitTest() {
         }
 
         site = SiteModel()
+
+        whenever(editPostRepository.postChanged).thenReturn(MutableLiveData(Event(PostModel())))
 
         viewModel = PostListMainViewModel(
                 dispatcher = dispatcher,
@@ -61,7 +68,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when started, it uploads all local drafts`() {
-        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, mock())
+        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository)
 
         verify(uploadStarter, times(1)).queueUploadFromSite(eq(site))
     }
@@ -69,7 +76,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
     @Test
     fun `search is available for wpcom and jetpack sites`() {
         site.origin = SiteModel.ORIGIN_WPCOM_REST
-        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, mock())
+        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository)
 
         var isSearchAvailable = false
         viewModel.isSearchAvailable.observeForever {
@@ -82,7 +89,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
     @Test
     fun `search is not available for xmlrpc sites`() {
         site.origin = SiteModel.ORIGIN_XMLRPC
-        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, mock())
+        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository)
 
         var isSearchAvailable = true
         viewModel.isSearchAvailable.observeForever {
@@ -95,7 +102,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
     @Test
     fun `calling onSearch() updates search query`() {
         val testSearch = "keyword"
-        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, mock())
+        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository)
 
         var searchQuery: String? = null
         viewModel.searchQuery.observeForever {
@@ -109,7 +116,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
 
     @Test
     fun `expanding and collapsing search triggers isSearchExpanded`() {
-        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, mock())
+        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository)
 
         var isSearchExpanded = false
         viewModel.isSearchExpanded.observeForever {
@@ -127,7 +134,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
     fun `expanding search after configuration change preserves search query`() {
         val testSearch = "keyword"
 
-        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, mock())
+        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository)
 
         var searchQuery: String? = null
         viewModel.searchQuery.observeForever {
@@ -150,7 +157,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
 
     @Test
     fun `search is using compact view mode independently from normal post list`() {
-        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, mock())
+        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository)
         assertThat(viewModel.viewLayoutType.value).isEqualTo(STANDARD) // default value
 
         var viewLayoutType: PostListViewLayoutType? = null
@@ -170,7 +177,6 @@ class PostListMainViewModelTest : BaseUnitTest() {
     @Test
     fun `if currentBottomSheetPostId isn't 0 then set the post in editPostRepository from the postStore`() {
         // arrange
-        val editPostRepository: EditPostRepository = mock()
         val bottomSheetPostId = LocalId(2)
 
         // act
@@ -183,7 +189,6 @@ class PostListMainViewModelTest : BaseUnitTest() {
     @Test
     fun `if currentBottomSheetPostId is 0 then don't set the post in editPostRepository from the postStore`() {
         // arrange
-        val editPostRepository: EditPostRepository = mock()
         val bottomSheetPostId = LocalId(0)
 
         // act

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -213,6 +213,6 @@ class PostListMainViewModelTest : BaseUnitTest() {
         editPostRepository.updateAsync(action, null)
 
         // assert
-        verify(savePostToDbUseCase, times(1)).savePostToDb(any(), any(), any())
+        verify(savePostToDbUseCase, times(1)).savePostToDb(any(), any())
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/StorePostViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/StorePostViewModelTest.kt
@@ -92,9 +92,9 @@ class StorePostViewModelTest : BaseUnitTest() {
 
     @Test
     fun `saves post to DB`() {
-        viewModel.savePostToDb(context, postRepository, site)
+        viewModel.savePostToDb(postRepository, site)
 
-        verify(savePostToDbUseCase).savePostToDb(context, postRepository, site)
+        verify(savePostToDbUseCase).savePostToDb(postRepository, site)
     }
 
     @Test
@@ -206,7 +206,7 @@ class StorePostViewModelTest : BaseUnitTest() {
                 site
         )
 
-        verify(savePostToDbUseCase).savePostToDb(context, postRepository, site)
+        verify(savePostToDbUseCase).savePostToDb(postRepository, site)
         assertThat(result).isEqualTo(SAVED_LOCALLY)
         verifyZeroInteractions(postUtils)
         verifyZeroInteractions(uploadService)
@@ -224,7 +224,7 @@ class StorePostViewModelTest : BaseUnitTest() {
                 site
         )
 
-        verify(savePostToDbUseCase).savePostToDb(context, postRepository, site)
+        verify(savePostToDbUseCase).savePostToDb(postRepository, site)
         assertThat(result).isEqualTo(SAVED_ONLINE)
         verify(postUtils).trackSavePostAnalytics(postModel, site)
         verify(uploadService).uploadPost(context, postId, isFirstTimePublish)


### PR DESCRIPTION
Fixes #12195
This is a partial solution to get this conversation started. More details below. 

## Partial Solution
Persist the post so the content that the user changes get persisted. This ensures that configuration changes do not cause the user to lose the changes that they make. 

Previously, we agreed that the post didn't have to get updated because the user would lose their changes to the post if they decided not to publish that specific post. But based on this specific bug that occurred it's best if the `PostModel` that gets modified is persisted so it can always be a source of truth in case there's any state loss.

## Concerns

1. So this solution just persists the post to the database but it gets overwritten when you do a refresh is done from the server. ( Making an assumption here.)Therefore, the user won't have these changes if they come off this screen. 
2. Since the `Post List` wasn't created for this kind of post-editing, I went searching for other components that had a close enough flow. I found this use case `SavePostToDbUseCase` and it seems to save the post with the appropriate business logic to signify the changes made. Nonetheless, it's reliance on `context` doesn't sit well with me especially since I just wrote lint rules to avoid this 😅  but it seems like the better full proof solution. 
3. I notice that because the `PostModel` is being modified and the list is being invalidated, certain post actions are disappearing as a result. 

<kbd><img src="https://user-images.githubusercontent.com/1509205/84614376-8c8d9e80-ae8b-11ea-95dd-92fc853c74e0.gif" width="320"></kbd>

4. Also in the above screenshot, I am realizing that the `Private` post doesn't show `Immediately` when the post is not a local draft, so even though it's showing the current date it doesn't say `Immediately`. 

## Testing
1. Go to the Draft Tab on the Post List. 
2. Click Publish on a Post. 
3. Change any of the options and don't navigate from the screen when it's changed.
4. Rotate and ensure that when you navigate back you see the data/selection. 
5. If you close the bottom sheet the Post in the Post List should be updated to reflect the new state. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
