### PR TITLE
Issue/12028 discover ui state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -4,12 +4,15 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
-import org.wordpress.android.models.ReaderPostList
+import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState
 import org.wordpress.android.ui.reader.repository.ReaderPostRepository
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -38,7 +41,7 @@ class ReaderDiscoverViewModel @Inject constructor(
 
         // Listen to changes to the discover feed
         _uiState.addSource(readerPostRepository.discoveryFeed) { posts ->
-            _uiState.value = ContentUiState(posts)
+            _uiState.value = ContentUiState(posts.map { mapPostToUiState(it) })
         }
     }
 
@@ -49,9 +52,18 @@ class ReaderDiscoverViewModel @Inject constructor(
         }
     }
 
+    private fun mapPostToUiState(post: ReaderPost) = ReaderPostUiState(post.postId, UiStringText(post.title))
+
     sealed class DiscoverUiState {
-        data class ContentUiState(val posts: ReaderPostList) : DiscoverUiState()
+        data class ContentUiState(val cards: List<ReaderCardUiState>) : DiscoverUiState()
         object LoadingUiState : DiscoverUiState()
         object ErrorUiState : DiscoverUiState()
+    }
+
+    sealed class ReaderCardUiState {
+        data class ReaderPostUiState(
+            val id: Long,
+            val title: UiString
+        ) : ReaderCardUiState()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -1,6 +1,19 @@
 package org.wordpress.android.ui.reader.discover
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
+import org.wordpress.android.ui.reader.repository.ReaderPostRepository
 import javax.inject.Inject
 
-class ReaderDiscoverViewModel @Inject constructor() : ViewModel()
+class ReaderDiscoverViewModel @Inject constructor(private val readerPostRepository: ReaderPostRepository) : ViewModel() {
+    private val _uiState = MutableLiveData<DiscoverUiState>(LoadingUiState)
+    private val uiState: LiveData<DiscoverUiState> = _uiState
+
+    sealed class DiscoverUiState() {
+        data class ContentUiState() : DiscoverUiState()
+        object LoadingUiState : DiscoverUiState()
+        data class ErrorUiState() : DiscoverUiState()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -1,19 +1,57 @@
 package org.wordpress.android.ui.reader.discover
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.MediatorLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.wordpress.android.models.ReaderPostList
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
 import org.wordpress.android.ui.reader.repository.ReaderPostRepository
+import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
+import javax.inject.Named
 
-class ReaderDiscoverViewModel @Inject constructor(private val readerPostRepository: ReaderPostRepository) : ViewModel() {
-    private val _uiState = MutableLiveData<DiscoverUiState>(LoadingUiState)
-    private val uiState: LiveData<DiscoverUiState> = _uiState
+class ReaderDiscoverViewModel @Inject constructor(
+    private val readerPostRepository: ReaderPostRepository,
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+) : ScopedViewModel(mainDispatcher) {
+    private var isStarted = false
 
-    sealed class DiscoverUiState() {
-        data class ContentUiState() : DiscoverUiState()
+    private val _uiState = MediatorLiveData<DiscoverUiState>()
+    val uiState: LiveData<DiscoverUiState> = _uiState
+
+    fun start() {
+        if (isStarted) return
+        isStarted = true
+
+        init()
+        loadPosts()
+    }
+
+    private fun init() {
+        // Start with loading state
+        _uiState.value = LoadingUiState
+
+        // Listen to changes to the discover feed
+        _uiState.addSource(readerPostRepository.discoveryFeed) { posts ->
+            _uiState.value = ContentUiState(posts)
+        }
+    }
+
+    private fun loadPosts() {
+        // TODO we'll remove this method when the repositories start managing the requests automatically
+        launch(bgDispatcher) {
+            readerPostRepository.getDiscoveryFeed()
+        }
+    }
+
+    sealed class DiscoverUiState {
+        data class ContentUiState(val posts: ReaderPostList) : DiscoverUiState()
         object LoadingUiState : DiscoverUiState()
-        data class ErrorUiState() : DiscoverUiState()
+        object ErrorUiState : DiscoverUiState()
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -1,9 +1,7 @@
 package org.wordpress.android.ui.reader.discover
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.airbnb.lottie.animation.content.Content
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -21,7 +19,6 @@ import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.Discover
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
 import org.wordpress.android.ui.reader.repository.ReaderPostRepository
-import org.wordpress.android.viewmodel.pages.PostPageListLabelColorUseCase
 
 @InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -1,25 +1,75 @@
 package org.wordpress.android.ui.reader.discover
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.airbnb.lottie.animation.content.Content
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.models.ReaderPostList
+import org.wordpress.android.test
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
+import org.wordpress.android.ui.reader.repository.ReaderPostRepository
+import org.wordpress.android.viewmodel.pages.PostPageListLabelColorUseCase
 
+@InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class ReaderDiscoverViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 
+    @Mock private lateinit var readerPostRepository: ReaderPostRepository
+
+    private val fakeDiscoverFeed = MutableLiveData<ReaderPostList>()
+
     private lateinit var viewModel: ReaderDiscoverViewModel
 
     @Before
-    fun setUp() {
-        viewModel = ReaderDiscoverViewModel()
+    fun setUp() = test {
+        viewModel = ReaderDiscoverViewModel(readerPostRepository, TEST_DISPATCHER, TEST_DISPATCHER)
+        whenever(readerPostRepository.discoveryFeed).thenReturn(fakeDiscoverFeed)
     }
 
     @Test
-    fun foo() {
+    fun `initial uiState is loading`() {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        // Act
+        viewModel.start()
+
+        // Assert
+        assertThat(uiStates.size).isEqualTo(1)
+        assertThat(uiStates[0]).isEqualTo(LoadingUiState)
+    }
+
+    @Test
+    fun `uiState updated when discover feed finishes loading`() = test {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+
+        // Act
+        fakeDiscoverFeed.value = mock() // mock finished loading
+
+        // Assert
+        assertThat(uiStates.size).isEqualTo(2)
+        assertThat(uiStates[1]).isInstanceOf(ContentUiState::class.java)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.reader.discover
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
-import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -13,6 +12,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderPostList
 import org.wordpress.android.test
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState
@@ -63,10 +63,19 @@ class ReaderDiscoverViewModelTest {
         viewModel.start()
 
         // Act
-        fakeDiscoverFeed.value = mock() // mock finished loading
+        fakeDiscoverFeed.value = createDummyReaderPostList() // mock finished loading
 
         // Assert
         assertThat(uiStates.size).isEqualTo(2)
         assertThat(uiStates[1]).isInstanceOf(ContentUiState::class.java)
+    }
+
+    private fun createDummyReaderPostList(): ReaderPostList = ReaderPostList().apply {
+        this.add(createDummyReaderPost())
+    }
+
+    private fun createDummyReaderPost(): ReaderPost = ReaderPost().apply {
+        postId = 1
+        title = "DummyPost"
     }
 }


### PR DESCRIPTION
Partially fixes #12028 

Adds Loading and Content UIState to discover VM. Also starts loading data from the post repository and maps them to the UIState.

To test:
No user-facing changes. Code review + working CI should be enough.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
