### PR TITLE
RI: Post Card UI - Use default material theme colors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -500,7 +500,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             holder.mTxtPhotoTitle.setText(post.getTitle());
             mImageManager.loadImageWithCorners(
                 holder.mImgFeatured,
-                ImageType.READER,
+                ImageType.PHOTO_ROUNDED_CORNERS,
                 post.getFeaturedImageForDisplay(mPhotonWidth, mPhotonHeight),
                 imgFeaturedCornerRadius
             );
@@ -528,7 +528,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     @Override public void showThumbnail(String thumbnailUrl) {
                         mImageManager.loadImageWithCorners(
                             holder.mImgFeatured,
-                            ImageType.READER,
+                            ImageType.PHOTO_ROUNDED_CORNERS,
                             thumbnailUrl,
                             imgFeaturedCornerRadius
                         );
@@ -547,7 +547,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             } else if (post.hasFeaturedImage()) {
                 mImageManager.loadImageWithCorners(
                     holder.mImgFeatured,
-                    ImageType.READER,
+                    ImageType.PHOTO_ROUNDED_CORNERS,
                     post.getFeaturedImageForDisplay(mPhotonWidth, mPhotonHeight),
                     imgFeaturedCornerRadius
                 );

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -12,7 +12,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.AVATAR_WITH_BACKGROUND -> R.drawable.bg_oval_placeholder_user_32dp
             ImageType.AVATAR_WITHOUT_BACKGROUND -> R.drawable.ic_user_circle_grey_24dp
             ImageType.BLAVATAR -> R.drawable.bg_rectangle_placeholder_globe_32dp
-            ImageType.BLAVATAR_CIRCULAR -> R.drawable.bg_oval_placeholder
+            ImageType.BLAVATAR_CIRCULAR -> R.drawable.bg_oval_placeholder_globe_32dp
             ImageType.IMAGE -> null // don't display any error drawable
             ImageType.PHOTO -> R.color.placeholder
             ImageType.READER -> R.drawable.bg_rectangle_placholder_reader_radius_4dp
@@ -33,7 +33,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.AVATAR_WITH_BACKGROUND -> R.drawable.bg_oval_placeholder_user_32dp
             ImageType.AVATAR_WITHOUT_BACKGROUND -> R.drawable.ic_user_circle_grey_24dp
             ImageType.BLAVATAR -> R.color.placeholder
-            ImageType.BLAVATAR_CIRCULAR -> R.drawable.bg_oval_placeholder
+            ImageType.BLAVATAR_CIRCULAR -> R.drawable.bg_oval_placeholder_globe_32dp
             ImageType.IMAGE -> null // don't display any placeholder
             ImageType.PHOTO -> R.color.placeholder
             ImageType.READER -> R.drawable.bg_rectangle_placholder_reader_radius_4dp

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImagePlaceholderManager.kt
@@ -15,7 +15,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.BLAVATAR_CIRCULAR -> R.drawable.bg_oval_placeholder_globe_32dp
             ImageType.IMAGE -> null // don't display any error drawable
             ImageType.PHOTO -> R.color.placeholder
-            ImageType.READER -> R.drawable.bg_rectangle_placholder_reader_radius_4dp
+            ImageType.PHOTO_ROUNDED_CORNERS -> R.drawable.bg_rectangle_placeholder_radius_4dp
             ImageType.PLAN -> R.drawable.bg_oval_placholder_plans_32dp
             ImageType.PLUGIN -> R.drawable.plugin_placeholder
             ImageType.THEME -> R.color.placeholder
@@ -36,7 +36,7 @@ class ImagePlaceholderManager @Inject constructor() {
             ImageType.BLAVATAR_CIRCULAR -> R.drawable.bg_oval_placeholder_globe_32dp
             ImageType.IMAGE -> null // don't display any placeholder
             ImageType.PHOTO -> R.color.placeholder
-            ImageType.READER -> R.drawable.bg_rectangle_placholder_reader_radius_4dp
+            ImageType.PHOTO_ROUNDED_CORNERS -> R.drawable.bg_rectangle_placeholder_radius_4dp
             ImageType.PLAN -> R.drawable.bg_oval_placholder_plans_32dp
             ImageType.PLUGIN -> R.drawable.plugin_placeholder
             ImageType.THEME -> R.drawable.bg_rectangle_placeholder_themes_100dp

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageType.kt
@@ -13,7 +13,7 @@ enum class ImageType {
     BLAVATAR_CIRCULAR,
     IMAGE,
     PHOTO,
-    READER,
+    PHOTO_ROUNDED_CORNERS,
     PLAN,
     PLUGIN,
     THEME,

--- a/WordPress/src/main/res/drawable/bg_oval_placeholder_globe_32dp.xml
+++ b/WordPress/src/main/res/drawable/bg_oval_placeholder_globe_32dp.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+
+        <shape
+            android:shape="oval">
+
+            <solid
+                android:color="@color/placeholder" >
+            </solid>
+
+        </shape>
+
+    </item>
+
+    <item
+        android:drawable="@drawable/ic_globe_white_24dp"
+        android:bottom="4dp"
+        android:left="4dp"
+        android:right="4dp"
+        android:top="4dp">
+    </item>
+
+</layer-list>

--- a/WordPress/src/main/res/drawable/bg_oval_stroke_placeholder_1dp.xml
+++ b/WordPress/src/main/res/drawable/bg_oval_stroke_placeholder_1dp.xml
@@ -2,6 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
     <stroke
-        android:width="@dimen/reader_image_avatar_or_blavatar_border_width"
-        android:color="@color/reader_image_avatar_or_blavatar_border"/>
+        android:width="1dp"
+        android:color="@color/placeholder"/>
 </shape>

--- a/WordPress/src/main/res/drawable/bg_reader_image_featured.xml
+++ b/WordPress/src/main/res/drawable/bg_reader_image_featured.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <stroke
-        android:width="@dimen/reader_image_featured_border_width"
-        android:color="@color/reader_image_featured_border" />
-    <corners android:radius="@dimen/reader_featured_image_corner_radius"/>
-</shape>

--- a/WordPress/src/main/res/drawable/bg_rectangle_placeholder_radius_4dp.xml
+++ b/WordPress/src/main/res/drawable/bg_rectangle_placeholder_radius_4dp.xml
@@ -9,7 +9,7 @@
     </solid>
 
     <corners
-        android:radius="@dimen/reader_featured_image_corner_radius">
+        android:radius="4dp">
     </corners>
 
 </shape>

--- a/WordPress/src/main/res/drawable/bg_rectangle_stroke_placeholder_radius_4dp.xml
+++ b/WordPress/src/main/res/drawable/bg_rectangle_stroke_placeholder_radius_4dp.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke
+        android:width="1dp"
+        android:color="@color/placeholder"/>
+    <corners android:radius="4dp"/>
+</shape>

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -146,7 +146,7 @@
             android:contentDescription="@null"
             android:cropToPadding="true"
             android:padding="@dimen/reader_image_featured_border_width"
-            android:background="@drawable/bg_reader_image_featured"
+            android:background="@drawable/bg_rectangle_stroke_placeholder_radius_4dp"
             app:layout_constraintDimensionRatio="16:9"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintStart_toStartOf="@id/guideline_beginning"

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -39,7 +39,7 @@
             android:id="@+id/image_avatar_or_blavatar"
             style="@style/ReaderImageView.Avatar"
             android:importantForAccessibility="no"
-            android:background="@drawable/bg_reader_avatar_or_blavatar_with_border"
+            android:background="@drawable/bg_oval_stroke_placeholder_1dp"
             android:padding="@dimen/reader_image_avatar_or_blavatar_border_width"
             android:layout_marginEnd="@dimen/margin_medium"
             app:layout_constraintStart_toStartOf="@+id/guideline_beginning"

--- a/WordPress/src/main/res/layout/reader_cardview_xpost.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_xpost.xml
@@ -17,7 +17,7 @@
             android:id="@+id/image_avatar"
             style="@style/ReaderImageView.Avatar.ExtraSmall"
             android:layout_marginStart="@dimen/reader_xpost_avatar_margin_start"
-            android:background="@drawable/bg_reader_avatar_or_blavatar_with_border"
+            android:background="@drawable/bg_oval_stroke_placeholder_1dp"
             android:importantForAccessibility="no"
             android:padding="@dimen/reader_image_avatar_or_blavatar_border_width"
             android:src="@drawable/bg_rectangle_placeholder_user_32dp"
@@ -28,7 +28,7 @@
         <ImageView
             android:id="@+id/image_blavatar"
             style="@style/ReaderImageView.Avatar.ExtraSmall"
-            android:background="@drawable/bg_reader_avatar_or_blavatar_with_border"
+            android:background="@drawable/bg_oval_stroke_placeholder_1dp"
             android:importantForAccessibility="no"
             android:padding="@dimen/reader_image_avatar_or_blavatar_border_width"
             android:src="@drawable/bg_rectangle_placeholder_globe_32dp"

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -54,6 +54,5 @@
 
     <!-- Reader Post Card -->
     <color name="reader_post_list_background">@color/gray_100</color>
-    <color name="reader_image_avatar_or_blavatar_border">@color/gray_80</color>
 
 </resources>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -54,9 +54,6 @@
 
     <!-- Reader Post Card -->
     <color name="reader_post_list_background">@color/gray_100</color>
-    <color name="reader_label_text">@color/gray_20</color>
-    <color name="reader_post_title">@color/gray_5</color>
-    <color name="reader_site_title">@color/gray_5</color>
     <color name="reader_image_featured_border">@color/gray_80</color>
     <color name="reader_image_avatar_or_blavatar_border">@color/gray_80</color>
 

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -54,7 +54,6 @@
 
     <!-- Reader Post Card -->
     <color name="reader_post_list_background">@color/gray_100</color>
-    <color name="reader_image_featured_border">@color/gray_80</color>
     <color name="reader_image_avatar_or_blavatar_border">@color/gray_80</color>
 
 </resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -314,6 +314,5 @@
 
     <!--Reader Post Card -->
     <color name="reader_post_list_background">@color/neutral_0</color>
-    <color name="reader_image_avatar_or_blavatar_border">@color/gray_0</color>
 
 </resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -314,9 +314,6 @@
 
     <!--Reader Post Card -->
     <color name="reader_post_list_background">@color/neutral_0</color>
-    <color name="reader_label_text">@color/gray_40</color>
-    <color name="reader_post_title">@color/gray_90</color>
-    <color name="reader_site_title">@color/gray_90</color>
     <color name="reader_image_featured_border">@color/gray_0</color>
     <color name="reader_image_avatar_or_blavatar_border">@color/gray_0</color>
 

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -314,7 +314,6 @@
 
     <!--Reader Post Card -->
     <color name="reader_post_list_background">@color/neutral_0</color>
-    <color name="reader_image_featured_border">@color/gray_0</color>
     <color name="reader_image_avatar_or_blavatar_border">@color/gray_0</color>
 
 </resources>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -26,7 +26,7 @@
 
     <style name="ReaderTextView.Label" parent="ReaderTextView">
         <item name="android:textAppearance">?attr/textAppearanceCaption</item>
-        <item name="textColor">@color/reader_label_text</item>
+        <item name="android:alpha">@dimen/material_emphasis_high_type</item>
     </style>
 
     <style name="ReaderTextView.Label.Large" parent="ReaderTextView.Label">
@@ -40,7 +40,7 @@
         <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:ellipsize">end</item>
         <item name="android:maxLines">1</item>
-        <item name="textColor">@color/reader_site_title</item>
+        <item name="android:alpha">@dimen/material_emphasis_high_type</item>
     </style>
 
     <style name="ReaderTextView.Post.Title" parent="ReaderTextView">
@@ -51,7 +51,7 @@
         <item name="android:textStyle">bold</item>
         <item name="android:maxLines">3</item>
         <item name="android:fontFamily">serif</item>
-        <item name="textColor">@color/reader_post_title</item>
+        <item name="android:alpha">@dimen/material_emphasis_high_type</item>
     </style>
 
     <style name="ReaderTextView.Post.Title.Detail" parent="ReaderTextView.Post.Title">
@@ -64,11 +64,10 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textAppearance">?attr/textAppearanceBody2</item>
-        <item name="android:alpha">@dimen/material_emphasis_high_type</item>
+        <item name="android:alpha">@dimen/material_emphasis_medium</item>
         <item name="android:lineSpacingMultiplier">1.1</item>
         <item name="android:maxLines">3</item>
         <item name="android:ellipsize">end</item>
-        <item name="android:textColor">@color/reader_label_text</item>
     </style>
 
     <style name="ReaderTextView.XPost.SubTitle" parent="ReaderTextView">
@@ -80,7 +79,6 @@
         <item name="android:ellipsize">end</item>
         <item name="android:maxLines">2</item>
         <item name="android:fontFamily">serif</item>
-        <item name="textColor">@color/reader_post_title</item>
     </style>
 
     <style name="ReaderTextView.RemovedPost.Title" parent="ReaderTextView">
@@ -88,7 +86,7 @@
         <item name="android:singleLine">true</item>
         <item name="android:fontFamily">serif</item>
         <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
-        <item name="android:textColor">@color/reader_post_title</item>
+        <item name="android:alpha">@dimen/material_emphasis_high_type</item>
         <item name="android:gravity">center_vertical</item>
     </style>
 

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -64,7 +64,7 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textAppearance">?attr/textAppearanceBody2</item>
-        <item name="android:alpha">@dimen/material_emphasis_medium</item>
+        <item name="android:alpha">@dimen/material_emphasis_high_type</item>
         <item name="android:lineSpacingMultiplier">1.1</item>
         <item name="android:maxLines">3</item>
         <item name="android:ellipsize">end</item>


### PR DESCRIPTION
This PR addresses feedback to 
- Replace reader specific colors with our default ones (using Emphasis to get variations in the shades)
- Make the body/excerpt text color the same as the post title color

### To test
- Launch app and go to Reader tab
- Notice that colors for texts, borders, backgrounds on the post cards look similar to the ones used earlier or are acceptable
Reference: Figma -> Apps Reader Improvement -> Postcard UI ->  postcard anatomy (android)

#### Note
Trying to figure out how to replace `reader_post_list_background` with a default one. This is under discussion, will update once we have any decision on it.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
