### PR TITLE
[Gutenberg] Cover video upload completion processor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 15.1
 -----
+* [**] Block Editor: Add support allowing Cover Block video uploads to complete after the editor has closed
 * Fixes issue on Notifications tab when two screens were drawn on top of each other
 * [**] Fix video thumbnails, settings and preview in Media section for private sites
 * [**] Block Editor: Adds editor support for theme defined colors and theme defined gradients on cover and button blocks.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
@@ -11,6 +11,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CoverBlockProcessor extends BlockProcessor {
+    private boolean mHasVideoBackground = false;
+
     /**
      * Template pattern used to match and splice cover inner blocks
      */
@@ -55,6 +57,10 @@ public class CoverBlockProcessor extends BlockProcessor {
         if (id != null && id.getAsInt() == Integer.parseInt(mLocalId, 10)) {
             jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId, 10));
             jsonAttributes.addProperty("url", mRemoteUrl);
+
+            // check if background type is video
+            JsonElement backgroundType = jsonAttributes.get("backgroundType");
+            mHasVideoBackground = backgroundType != null && "video".equals(backgroundType.getAsString());
             return true;
         }
 
@@ -63,14 +69,23 @@ public class CoverBlockProcessor extends BlockProcessor {
 
     @Override boolean processBlockContentDocument(Document document) {
         // select cover block div
-        Element targetDiv = document.select(".wp-block-cover").first();
+        Element targetDiv = document.selectFirst(".wp-block-cover");
 
         // if a match is found, proceed with replacement
         if (targetDiv != null) {
-            // replace background-image url in style attribute
-            String style = PATTERN_BACKGROUND_IMAGE_URL.matcher(targetDiv.attr("style"))
-                    .replaceFirst(String.format("background-image:url(%1$s)", mRemoteUrl));
-            targetDiv.attr("style", style);
+            if (mHasVideoBackground) {
+                Element videoElement = targetDiv.selectFirst("video");
+                if (videoElement != null) {
+                    videoElement.attr("src", mRemoteUrl);
+                } else {
+                    return false;
+                }
+            } else {
+                // replace background-image url in style attribute
+                String style = PATTERN_BACKGROUND_IMAGE_URL.matcher(targetDiv.attr("style"))
+                                                           .replaceFirst(String.format("background-image:url(%1$s)", mRemoteUrl));
+                targetDiv.attr("style", style);
+            }
 
             // return injected block
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
@@ -82,8 +82,8 @@ public class CoverBlockProcessor extends BlockProcessor {
                 }
             } else {
                 // replace background-image url in style attribute
-                String style = PATTERN_BACKGROUND_IMAGE_URL.matcher(targetDiv.attr("style"))
-                                                           .replaceFirst(String.format("background-image:url(%1$s)", mRemoteUrl));
+                String style = PATTERN_BACKGROUND_IMAGE_URL.matcher(targetDiv.attr("style")).replaceFirst(
+                        String.format("background-image:url(%1$s)", mRemoteUrl));
                 targetDiv.attr("style", style);
             }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessorTest.kt
@@ -60,4 +60,12 @@ class CoverBlockProcessorTest {
         val processedBlock = processor.processBlock(TestContent.oldCoverBlockStyleOrderWithSpace)
         Assertions.assertThat(processedBlock).isEqualTo(TestContent.newCoverBlockStyleOrderWithoutSpace)
     }
+
+    @Test
+    fun `processBlock works with videos`() {
+        whenever(mediaFile.fileURL).thenReturn(TestContent.remoteVideoUrl)
+        processor = CoverBlockProcessor(TestContent.localMediaId, mediaFile, mediaUploadCompletionProcessor)
+        val processedBlock = processor.processBlock(TestContent.oldCoverBlockWithVideo)
+        Assertions.assertThat(processedBlock).isEqualTo(TestContent.newCoverBlockWithVideo)
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
@@ -499,6 +499,30 @@ object TestContent {
 <!-- /wp:cover -->
 """
 
+    const val oldCoverBlockWithVideo = """<!-- wp:cover {"url":"$localVideoUrl","id":$localMediaId,"backgroundType":"video"} -->
+<div class="wp-block-cover has-background-dim">
+  <video class="wp-block-cover__video-background" autoplay muted loop playsinline src="$localVideoUrl"></video>
+  <div class="wp-block-cover__inner-container">
+    <!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
+    <p class="has-text-align-center"></p>
+    <!-- /wp:paragraph -->
+  </div>
+</div>
+<!-- /wp:cover -->
+"""
+
+    const val newCoverBlockWithVideo = """<!-- wp:cover {"url":"$remoteVideoUrl","id":$remoteMediaId,"backgroundType":"video"} -->
+<div class="wp-block-cover has-background-dim">
+  <video class="wp-block-cover__video-background" autoplay muted loop playsinline src="$remoteVideoUrl"></video>
+  <div class="wp-block-cover__inner-container">
+    <!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
+    <p class="has-text-align-center"></p>
+    <!-- /wp:paragraph -->
+  </div>
+</div>
+<!-- /wp:cover -->
+"""
+
     const val oldPostImage = paragraphBlock + oldImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val newPostImage = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val oldPostVideo = paragraphBlock + newImageBlock + oldVideoBlock + newMediaTextBlock + newGalleryBlock


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1740

### Description

This PR adds logic to the cover block upload completion processor to handle the case for video background types.

#### To test:

##### Automated test:

The included unit test should pass.

##### Manual testing steps:

* Close/Re-open post with an ongoing **video** upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/cover.md#tc010)
* Close post with an ongoing **video** upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/cover.md#tc011)
* Test the upload outside of the editor with a combination of Video cover blocks within Image cover blocks and vice versa. Also replacing the image of the outer cover block. 

Image Testing (Validating there isn't a regression):

* Close/Re-open post with an ongoing **image** upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/cover.md#tc010)
* Close post with an ongoing **image** upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/cover.md#tc011)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
