### PR TITLE
Issue/12028 init rv

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -20,7 +20,9 @@ import org.wordpress.android.R.string
 import org.wordpress.android.WordPress
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.ui.WPWebViewActivity
+import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverFragment
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask.FOLLOWED_BLOGS
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask.TAGS
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter
@@ -159,7 +161,11 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
         override fun getItemCount(): Int = tags.size
 
         override fun createFragment(position: Int): Fragment {
-            return ReaderPostListFragment.newInstanceForTag(tags[position], ReaderPostListType.TAG_FOLLOWED, true)
+            return if (AppPrefs.isReaderImprovementsPhase2Enabled() && tags[position].isDiscover) {
+                ReaderDiscoverFragment()
+            } else {
+                ReaderPostListFragment.newInstanceForTag(tags[position], ReaderPostListType.TAG_FOLLOWED, true)
+            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
@@ -1,0 +1,63 @@
+package org.wordpress.android.ui.reader.discover
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView.Adapter
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState
+import org.wordpress.android.ui.reader.discover.ReaderViewHolder.ReaderPostViewHolder
+
+private const val postViewType: Int = 1
+
+class ReaderDiscoverAdapter : Adapter<ReaderViewHolder>() {
+    private val items = mutableListOf<ReaderCardUiState>()
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReaderViewHolder {
+        return when (viewType) {
+            postViewType -> ReaderPostViewHolder(parent)
+            else -> throw NotImplementedError("Unknown ViewType")
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: ReaderViewHolder, position: Int) {
+        holder.onBind(items[position])
+    }
+
+    fun update(newItems: List<ReaderCardUiState>) {
+        val diffResult = DiffUtil.calculateDiff(DiscoverDiffUtil(items, newItems))
+        items.clear()
+        items.addAll(newItems)
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (items[position]) {
+            is ReaderPostUiState -> postViewType
+        }
+    }
+
+    private class DiscoverDiffUtil(
+        val oldItems: List<ReaderCardUiState>,
+        val newItems: List<ReaderCardUiState>
+    ) : DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = oldItems[oldItemPosition]
+            val newItem = newItems[newItemPosition]
+            if (oldItem::class != newItem::class) {
+                return false
+            }
+            return when (oldItem) {
+                is ReaderPostUiState -> oldItem.id == (newItem as ReaderPostUiState).id
+            }
+        }
+
+        override fun getOldListSize(): Int = oldItems.size
+
+        override fun getNewListSize(): Int = newItems.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldItems[oldItemPosition] == newItems[newItemPosition]
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -37,7 +37,7 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
     private fun initViewModel() {
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReaderDiscoverViewModel::class.java)
         viewModel.uiState.observe(viewLifecycleOwner, Observer {
-            when(it) {
+            when (it) {
                 is ContentUiState -> (recycler_view.adapter as ReaderDiscoverAdapter).update(it.cards)
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -3,10 +3,15 @@ package org.wordpress.android.ui.reader.discover
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.reader_discover_fragment_layout.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import javax.inject.Inject
 
 class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout) {
@@ -20,10 +25,22 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setupViews()
         initViewModel()
+    }
+
+    private fun setupViews() {
+        recycler_view.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+        recycler_view.adapter = ReaderDiscoverAdapter()
     }
 
     private fun initViewModel() {
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReaderDiscoverViewModel::class.java)
+        viewModel.uiState.observe(viewLifecycleOwner, Observer {
+            when(it) {
+                is ContentUiState -> (recycler_view.adapter as ReaderDiscoverAdapter).update(it.cards)
+            }
+        })
+        viewModel.start()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderViewHolder.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.ui.reader.discover
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.recyclerview.widget.RecyclerView
+import org.wordpress.android.R
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState
+
+sealed class ReaderViewHolder(internal val parent: ViewGroup, @LayoutRes layout: Int) :
+        RecyclerView.ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
+    abstract fun onBind(uiState: ReaderCardUiState)
+
+    class ReaderPostViewHolder(
+        parentView: ViewGroup
+    ) : ReaderViewHolder(parentView, R.layout.reader_cardview_post) {
+        override fun onBind(uiState: ReaderCardUiState) {
+        }
+    }
+}

--- a/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
@@ -2,4 +2,10 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Partial fix for #12028

Merge Instructions
1. ~Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/12202 is merged~
2. ~Update target branch to develop (github will probably update it automatically)~
3. Merge this PR

This PR introduces RV and dummy ViewHolder to the new discover tab.

To test:
Prerequisites - Reader Improvements feature flag is enabled
1. Open Reader
2. Select some interests and press the button
3. Wait for a few seconds
4. Notice an empty post appears - the UI will be implemented in upcoming PRs

<img src="https://user-images.githubusercontent.com/2261188/84763716-ef3a8380-afcc-11ea-882c-697bfb1413d1.png" width="200px" />


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
