### PR TITLE
Issue/12028 init loading

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -12,10 +12,12 @@ import kotlinx.android.synthetic.main.reader_discover_fragment_layout.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
+import org.wordpress.android.ui.utils.UiHelpers
 import javax.inject.Inject
 
 class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var uiHelpers: UiHelpers
     private lateinit var viewModel: ReaderDiscoverViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -40,6 +42,9 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
             when (it) {
                 is ContentUiState -> (recycler_view.adapter as ReaderDiscoverAdapter).update(it.cards)
             }
+            uiHelpers.updateVisibility(recycler_view, it.contentVisiblity)
+            uiHelpers.updateVisibility(progress_bar, it.progressVisibility)
+            uiHelpers.updateVisibility(progress_text, it.progressVisibility)
         })
         viewModel.start()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -54,9 +54,12 @@ class ReaderDiscoverViewModel @Inject constructor(
 
     private fun mapPostToUiState(post: ReaderPost) = ReaderPostUiState(post.postId, UiStringText(post.title))
 
-    sealed class DiscoverUiState {
-        data class ContentUiState(val cards: List<ReaderCardUiState>) : DiscoverUiState()
-        object LoadingUiState : DiscoverUiState()
+    sealed class DiscoverUiState(
+        val contentVisiblity: Boolean = false,
+        val progressVisibility: Boolean = false
+    ) {
+        data class ContentUiState(val cards: List<ReaderCardUiState>) : DiscoverUiState(contentVisiblity = true)
+        object LoadingUiState : DiscoverUiState(progressVisibility = true)
         object ErrorUiState : DiscoverUiState()
     }
 

--- a/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
@@ -1,11 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:animateLayoutChanges="true">
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/progress_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:text="@string/loading"
+        android:textColor="?wpColorOnSurfaceMedium"
+        android:textSize="@dimen/text_sz_double_extra_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/progress_bar"
+        app:layout_constraintVertical_bias="0" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Partial fix for #12028

Merge instructions
1. Merge https://github.com/wordpress-mobile/WordPress-Android/pull/12209
2. Update target branch to `develop`
3. Remove the "Not ready for merge" label
4. Merge this PR

This PR shows a loading screen when the data for discover tab are being loaded. The UI of the loading isn't final and will be improved in upcoming PRs.

To test:
1. Open Reader
2. Choose some interests and press the button
3. Notice the fullscreen loading screen inside discover tab
4. Wait for a few seconds and notice the content is shown (the content is just an empty skeleton of a post card)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
