### PR TITLE
Fix NPE change && to ||

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -1401,7 +1401,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     }
 
     private void trashComment() {
-        if (!isAdded() && mComment == null) {
+        if (!isAdded() || mComment == null) {
             return;
         }
 


### PR DESCRIPTION
Fixes #12022 

This PR addresses a fix to an NPE that should have used a || instead of an &&

NOTE: I have not been able to recreate the NPE on multiple devices and emulators. Please let me know if you experience any NPE's and the steps you took to recreate. Thanks in advance.
PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

FYI: @oguzkocer 