### PR TITLE
[Gutenberg] Fix gutenberg web-view auth issues with Atomic sites 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1989,7 +1989,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         String languageString = LocaleManager.getLanguage(EditPostActivity.this);
                         String wpcomLocaleSlug = languageString.replace("_", "-").toLowerCase(Locale.ENGLISH);
                         boolean supportsStockPhotos = mSite.isUsingWpComRestApi();
-                        boolean isWpCom = getSite().isWPCom();
+                        boolean isWpCom = getSite().isWPCom() || mSite.isPrivateWPComAtomic() || mSite.isWPComAtomic();
                         boolean isSiteUsingWpComRestApi = mSite.isUsingWpComRestApi();
 
                         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);


### PR DESCRIPTION
Fixes # https://github.com/wordpress-mobile/gutenberg-mobile/pull/2063#issuecomment-638471473

To test:
- Setup an atomic site and test as public and private.
- Create a post with a block not yet supported on mobile.
- Test on a real device.
- Will need Metro server running (on gutenberg-mobile develop branch is enough)
- Log out from your wp account in the app to clean cookies.
- Uninstall the app from your device.
- Install building the app from this PR.
- Login and go directly to the Atomic site.
- Open the created post with unsupported block.
- Open the unsupported block on the web view.
- Check that gutenberg opens on the web view without asking for credentials 🙏 

@Guarani could you please test this as you already did with WPiOS which experience can be used in this review?

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
