### PR TITLE
Prepublishing Nudges : Fixed issue where rotating device would cause new tag to not persist

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsViewModel.kt
@@ -39,10 +39,11 @@ class PrepublishingTagsViewModel @Inject constructor(
     val toolbarTitleUiState: LiveData<UiString> = _toolbarTitleUiState
 
     fun start(editPostRepository: EditPostRepository) {
+        this.editPostRepository = editPostRepository
+
         if (isStarted) return
         isStarted = true
 
-        this.editPostRepository = editPostRepository
         setToolbarTitleUiState()
     }
 


### PR DESCRIPTION
Fixes #12224

## Solution

The `EditPostRepository` needs to be set before`isStarted` is called because when rotation takes place the `ViewModel` instance is retained thus it's already started. Nonetheless, the `EditPostRepository` reference needs to be set to the `ViewModel`

## Testing

1. Open any post for editing.
2. Add some tags.
3. Rotate the device.
4. Observe that previously entered tags remain visible.
5. Add a new tag to the list (after the device was rotated).
6. Tap the left arrow to go back or X to close the tag editor.
7. Observe that all the tags that have been added exist. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
