### PR TITLE
Adds stubbing for /mobile/feature-announcements

### DIFF
--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/mobile/feature-announcements.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/mobile/feature-announcements.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "urlPath": "/wpcom/v2/mobile/feature-announcements/",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a stub response for the new `/mobile/feature-announcements` endpoint which will fix the failing connected tests.

To test:
* Connected tests should pass in CI

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
