### PR TITLE
Issue/12028 post card ui part 3

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -26,6 +26,8 @@ public class ReaderConstants {
     // the Calypso web reader
     public static final int MIN_GALLERY_IMAGE_WIDTH = 144;
 
+    public static final int THUMBNAIL_STRIP_IMG_COUNT = 4;
+
     // referrer url for reader posts opened in a browser
     public static final String HTTP_REFERER_URL = "https://wordpress.com";
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -82,7 +82,7 @@ class ReaderDiscoverViewModel @Inject constructor(
             val featuredImageUrl: String?,
             val videoThumbnailUrl: String?,
             val avatarOrBlavatarUrl: String?,
-            val thumbnailStripSection: GalleryThumbnailStripData,
+            val thumbnailStripSection: GalleryThumbnailStripData?,
             val discoverSection: DiscoverLayoutUiState?,
             val videoOverlayVisbility: Boolean,
             val moreMenuVisbility: Boolean,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
+import org.wordpress.android.ui.reader.models.ReaderImageList
 import org.wordpress.android.ui.reader.repository.ReaderPostRepository
 import org.wordpress.android.util.image.ImageType
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -81,13 +82,18 @@ class ReaderDiscoverViewModel @Inject constructor(
             val featuredImageUrl: String?,
             val videoThumbnailUrl: String?,
             val avatarOrBlavatarUrl: String?,
-            val thumbnailStripUrls: List<String>?,
+            val thumbnailStripSection: GalleryThumbnailStripData,
             val discoverSection: DiscoverLayoutUiState?,
             val videoOverlayVisbility: Boolean,
             val moreMenuVisbility: Boolean,
             val photoFrameVisibility: Boolean
         ) : ReaderCardUiState() {
             val dotSeparatorVisibility: Boolean = blogUrl != null
+
+            data class GalleryThumbnailStripData(
+                val images: ReaderImageList,
+                val isPrivate: Boolean
+            )
 
             data class DiscoverLayoutUiState(
                 val discoverText: Spanned,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -12,8 +12,11 @@ import org.wordpress.android.models.ReaderPostDiscoverData
 import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.EDITOR_PICK
 import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.OTHER
 import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.SITE_PICK
+import org.wordpress.android.ui.reader.ReaderConstants
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState.DiscoverLayoutUiState
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState.GalleryThumbnailStripData
+import org.wordpress.android.ui.reader.utils.ReaderImageScannerProvider
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.GravatarUtilsWrapper
 import org.wordpress.android.util.UrlUtilsWrapper
@@ -26,7 +29,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private val accountStore: AccountStore,
     private val urlUtilsWrapper: UrlUtilsWrapper,
     private val gravatarUtilsWrapper: GravatarUtilsWrapper,
-    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
+    private val readerImageScannerProvider: ReaderImageScannerProvider
 ) {
     fun mapPostToUiState(post: ReaderPost, photonWidth: Int, photonHeight: Int): ReaderPostUiState {
         // TODO malinjir onPostContainer click
@@ -73,7 +77,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
 
     private fun buildThumbnailStripUrls(post: ReaderPost) =
             post.takeIf { it.cardType == GALLERY }
-                    ?.let { retrieveGalleryThumbnailUrls() }
+                    ?.let { retrieveGalleryThumbnailUrls(post) }
 
     private fun buildFeaturedImageUrl(post: ReaderPost, photonWidth: Int, photonHeight: Int): String? {
         return post
@@ -128,8 +132,10 @@ class ReaderPostUiStateBuilder @Inject constructor(
         return null
     }
 
-    private fun retrieveGalleryThumbnailUrls(): List<String> {
-        // TODO malinjir Not yet implemented - Refactor ReaderThumbnailStrip.loadThumbnails()
-        return emptyList()
+    private fun retrieveGalleryThumbnailUrls(post: ReaderPost): GalleryThumbnailStripData {
+        // scan post content for images suitable in a gallery
+        val images = readerImageScannerProvider.createReaderImageScanner(post.text, post.isPrivate)
+                .getImageList(ReaderConstants.THUMBNAIL_STRIP_IMG_COUNT, ReaderConstants.MIN_GALLERY_IMAGE_WIDTH)
+        return GalleryThumbnailStripData(images, post.isPrivate)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -32,6 +32,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
     private val readerImageScannerProvider: ReaderImageScannerProvider
 ) {
+    // TODO malinjir move this to a bg thread
     fun mapPostToUiState(post: ReaderPost, photonWidth: Int, photonHeight: Int): ReaderPostUiState {
         // TODO malinjir onPostContainer click
         // TODO malinjir on item rendered callback -> handle load more event and trackRailcarRender
@@ -51,7 +52,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 photoFrameVisibility = buildPhotoFrameVisbility(post),
                 photoTitle = buildPhotoTitle(post),
                 featuredImageUrl = buildFeaturedImageUrl(post, photonWidth, photonHeight),
-                thumbnailStripUrls = buildThumbnailStripUrls(post),
+                thumbnailStripSection = buildThumbnailStripUrls(post),
                 videoOverlayVisbility = buildVideoOverlayVisbility(post),
                 // TODO malinjir Consider adding `postListType == ReaderPostListType.TAG_FOLLOWED` to showMoreMenu
                 moreMenuVisbility = accountStore.hasAccessToken(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScannerProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScannerProvider.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.ui.reader.utils
+
+import dagger.Reusable
+import javax.inject.Inject
+
+@Reusable
+class ReaderImageScannerProvider @Inject constructor() {
+    fun createReaderImageScanner(postContent: String, isPrivate: Boolean) = ReaderImageScanner(postContent, isPrivate)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderThumbnailStrip.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderThumbnailStrip.java
@@ -13,7 +13,6 @@ import org.wordpress.android.R;
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher.PhotoViewerOption;
-import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.models.ReaderImageList;
 import org.wordpress.android.ui.reader.utils.ReaderImageScanner;
 import org.wordpress.android.util.AniUtils;
@@ -24,13 +23,14 @@ import org.wordpress.android.util.image.ImageType;
 
 import java.util.EnumSet;
 
+import static org.wordpress.android.ui.reader.ReaderConstants.MIN_GALLERY_IMAGE_WIDTH;
+import static org.wordpress.android.ui.reader.ReaderConstants.THUMBNAIL_STRIP_IMG_COUNT;
+
 /**
  * displays a row of image thumbnails from a reader post - only shows when two or more images
  * of a minimum size are found
  */
 public class ReaderThumbnailStrip extends LinearLayout {
-    public static final int IMAGE_COUNT = 4;
-
     private ViewGroup mView;
     private int mThumbnailHeight;
     private int mThumbnailWidth;
@@ -61,19 +61,20 @@ public class ReaderThumbnailStrip extends LinearLayout {
 
         int displayWidth = DisplayUtils.getDisplayPixelWidth(context);
         int margins = context.getResources().getDimensionPixelSize(R.dimen.reader_card_content_padding) * 2;
-        mThumbnailWidth = (displayWidth - margins) / IMAGE_COUNT;
+        mThumbnailWidth = (displayWidth - margins) / THUMBNAIL_STRIP_IMG_COUNT;
     }
 
     public void loadThumbnails(long blogId, long postId, boolean isPrivate) {
         // get rid of any views already added
         mView.removeAllViews();
 
+        // TODO malinjir Remove this loading image section and provide the images as parameters
         // get this post's content and scan it for images suitable in a gallery
         final String content = ReaderPostTable.getPostText(blogId, postId);
         final ReaderImageList imageList =
                 new ReaderImageScanner(content, isPrivate)
-                        .getImageList(IMAGE_COUNT, ReaderConstants.MIN_GALLERY_IMAGE_WIDTH);
-        if (imageList.size() < IMAGE_COUNT) {
+                        .getImageList(THUMBNAIL_STRIP_IMG_COUNT, MIN_GALLERY_IMAGE_WIDTH);
+        if (imageList.size() < THUMBNAIL_STRIP_IMG_COUNT) {
             mView.setVisibility(View.GONE);
             return;
         }
@@ -110,7 +111,7 @@ public class ReaderThumbnailStrip extends LinearLayout {
             });
 
             numAdded++;
-            if (numAdded >= IMAGE_COUNT) {
+            if (numAdded >= THUMBNAIL_STRIP_IMG_COUNT) {
                 break;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderThumbnailStrip.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderThumbnailStrip.java
@@ -65,15 +65,17 @@ public class ReaderThumbnailStrip extends LinearLayout {
     }
 
     public void loadThumbnails(long blogId, long postId, boolean isPrivate) {
-        // get rid of any views already added
-        mView.removeAllViews();
-
-        // TODO malinjir Remove this loading image section and provide the images as parameters
         // get this post's content and scan it for images suitable in a gallery
         final String content = ReaderPostTable.getPostText(blogId, postId);
         final ReaderImageList imageList =
                 new ReaderImageScanner(content, isPrivate)
                         .getImageList(THUMBNAIL_STRIP_IMG_COUNT, MIN_GALLERY_IMAGE_WIDTH);
+        loadThumbnails(imageList, isPrivate);
+    }
+
+    public void loadThumbnails(ReaderImageList imageList, boolean isPrivate) {
+        // get rid of any views already added
+        mView.removeAllViews();
         if (imageList.size() < THUMBNAIL_STRIP_IMG_COUNT) {
             mView.setVisibility(View.GONE);
             return;


### PR DESCRIPTION
Parent issue #12028

Merge instructions

1. Review this PR
2. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/12236 is merged
3. Update target branch to develop
4. Merge this PR

This PR moves the logic for finding images suitable for gallery thumbnail strip view to the ReaderPostUiStateBuilder. We still need to keep the previous implementation of the method as this PR targets develop and we haven't refactored the current usage yet.

To test:
Nothing to test - the changes aren't visible on the UI yet.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
