### PR TITLE
Issue/12028 post card ui part 3.5

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
 import org.wordpress.android.ui.reader.repository.ReaderPostRepository
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.image.ImageType
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -86,7 +87,8 @@ class ReaderDiscoverViewModel @Inject constructor(
             val discoverSection: DiscoverLayoutUiState?,
             val videoOverlayVisbility: Boolean,
             val moreMenuVisbility: Boolean,
-            val photoFrameVisibility: Boolean
+            val photoFrameVisibility: Boolean,
+            val actionUiState: ActionUiState
         ) : ReaderCardUiState() {
             val dotSeparatorVisibility: Boolean = blogUrl != null
 
@@ -94,6 +96,14 @@ class ReaderDiscoverViewModel @Inject constructor(
                 val discoverText: Spanned,
                 val discoverAvatarUrl: String,
                 val imageType: ImageType
+            )
+
+            data class ActionUiState(
+                val isEnabled: Boolean,
+                val isSelected: Boolean,
+                val contentDescription: UiString,
+                val count: String? = null,
+                val onClicked: (Long, Boolean) -> Unit
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -48,10 +48,25 @@ class ReaderDiscoverViewModel @Inject constructor(
         _uiState.addSource(readerPostRepository.discoveryFeed) { posts ->
             _uiState.value = ContentUiState(
                     posts.map {
-                        postUiStateBuilder.mapPostToUiState(it, photonWidth, photonHeight)
+                        postUiStateBuilder.mapPostToUiState(
+                                post = it,
+                                photonWidth = photonWidth,
+                                photonHeight = photonHeight,
+                                isBookmarkList = false,
+                                onBookmarkClicked = this::onBookmarkClicked,
+                                onLikeClicked = this::onLikeClicked
+                        )
                     }
             )
         }
+    }
+
+    private fun onBookmarkClicked(postId: Long, blogId: Long, selected: Boolean) {
+        // TODO malinjir implement action
+    }
+
+    private fun onLikeClicked(postId: Long, blogId: Long, selected: Boolean) {
+        // TODO malinjir implement action
     }
 
     private fun loadPosts() {
@@ -88,7 +103,8 @@ class ReaderDiscoverViewModel @Inject constructor(
             val videoOverlayVisibility: Boolean,
             val moreMenuVisibility: Boolean,
             val photoFrameVisibility: Boolean,
-            val actionUiState: ActionUiState
+            val bookmarkAction: ActionUiState,
+            val likeAction: ActionUiState
         ) : ReaderCardUiState() {
             val dotSeparatorVisibility: Boolean = blogUrl != null
 
@@ -100,10 +116,10 @@ class ReaderDiscoverViewModel @Inject constructor(
 
             data class ActionUiState(
                 val isEnabled: Boolean,
-                val isSelected: Boolean,
-                val contentDescription: UiString,
-                val count: String? = null,
-                val onClicked: (Long, Boolean) -> Unit
+                val isSelected: Boolean? = false,
+                val contentDescription: UiString? = null,
+                val count: Int = 0,
+                val onClicked: ((Long, Long, Boolean) -> Unit)? = null
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -153,12 +153,17 @@ class ReaderPostUiStateBuilder @Inject constructor(
         } else {
             R.string.reader_add_bookmark
         }
-        return ActionUiState(
-                isEnabled = !post.isDiscoverPost,
-                isSelected = post.isBookmarked,
-                contentDescription = UiStringRes(contentDescription),
-                onClicked = onClicked
-        )
+        // TODO malinjir shouldn't the action be disabled just for posts which don't have blog and post id?
+        return if (!post.isDiscoverPost) {
+            ActionUiState(
+                    isEnabled = true,
+                    isSelected = post.isBookmarked,
+                    contentDescription = UiStringRes(contentDescription),
+                    onClicked = onClicked
+            )
+        } else {
+            ActionUiState(isEnabled = false)
+        }
     }
 
     private fun buildLikeSection(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -13,7 +13,9 @@ import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.EDITOR_P
 import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.OTHER
 import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.SITE_PICK
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState
+import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState.ActionUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState.DiscoverLayoutUiState
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.GravatarUtilsWrapper
 import org.wordpress.android.util.UrlUtilsWrapper
@@ -28,10 +30,14 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private val gravatarUtilsWrapper: GravatarUtilsWrapper,
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper
 ) {
-    fun mapPostToUiState(post: ReaderPost, photonWidth: Int, photonHeight: Int): ReaderPostUiState {
+    fun mapPostToUiState(
+        post: ReaderPost,
+        photonWidth: Int,
+        photonHeight: Int,
+        onBookmarkClicked: (Long, Boolean) -> Unit
+    ): ReaderPostUiState {
         // TODO malinjir onPostContainer click
         // TODO malinjir on item rendered callback -> handle load more event and trackRailcarRender
-        // TODO malinjir bookmark action
         // TODO malinjir reblog action
         // TODO malinjir comments action
         // TODO malinjir likes action
@@ -53,7 +59,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 // TODO malinjir Consider adding `postListType == ReaderPostListType.TAG_FOLLOWED` to showMoreMenu
                 moreMenuVisbility = accountStore.hasAccessToken(),
                 videoThumbnailUrl = buildVideoThumbnailUrl(post),
-                discoverSection = buildDiscoverSection(post)
+                discoverSection = buildDiscoverSection(post),
+                actionUiState = buildBookmarkPostSection(post, onBookmarkClicked)
         )
     }
 
@@ -131,5 +138,22 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private fun retrieveGalleryThumbnailUrls(): List<String> {
         // TODO malinjir Not yet implemented - Refactor ReaderThumbnailStrip.loadThumbnails()
         return emptyList()
+    }
+
+    private fun buildBookmarkPostSection(
+        post: ReaderPost,
+        onBookmarkClicked: (Long, Boolean) -> Unit
+    ): ActionUiState {
+        val contentDescription = if (post.isBookmarked) {
+            R.string.reader_remove_bookmark
+        } else {
+            R.string.reader_add_bookmark
+        }
+        return ActionUiState(
+                isEnabled = !post.isDiscoverPost,
+                isSelected = post.isBookmarked,
+                contentDescription = UiStringRes(contentDescription),
+                onClicked = onBookmarkClicked
+        )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -11,6 +11,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
@@ -40,7 +41,9 @@ class ReaderDiscoverViewModelTest {
     fun setUp() = test {
         viewModel = ReaderDiscoverViewModel(readerPostRepository, uiStateBuilder, TEST_DISPATCHER, TEST_DISPATCHER)
         whenever(readerPostRepository.discoveryFeed).thenReturn(fakeDiscoverFeed)
-        whenever(uiStateBuilder.mapPostToUiState(anyOrNull(), anyInt(), anyInt())).thenReturn(mock())
+        whenever(
+                uiStateBuilder.mapPostToUiState(anyOrNull(), anyInt(), anyInt(), anyBoolean(), anyOrNull(), anyOrNull())
+        ).thenReturn(mock())
     }
 
     @Test


### PR DESCRIPTION
Parent issue #12028

Merge instructions

1. Review this PR
2. Make sure #12236 is merged and remove the Not Ready for Merge tag
3. Update target branch to develop
4. Merge this PR

This PR copies the logic for Bookmark and Like actions on Reader post card items from - [likes](https://github.com/wordpress-mobile/WordPress-Android/blob/588b9582c3ad022b91fd1be63111ac306d76c4ef/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java#L901) and [bookmark](https://github.com/wordpress-mobile/WordPress-Android/blob/588b9582c3ad022b91fd1be63111ac306d76c4ef/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java#L933)

To test
This code isn't being used yet. We'll test the changes in upcoming PRs. Just try to review that the conditions are the same.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
