### PR TITLE
Issue/12028 post card ui part 3.6

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -58,7 +58,8 @@ class ReaderDiscoverViewModel @Inject constructor(
                                 onLikeClicked = this::onLikeClicked,
                                 onReblogClicked = this::onReblogClicked,
                                 onCommentsClicked = this::onCommentsClicked,
-                                onItemClicked = this::onItemClicked
+                                onItemClicked = this::onItemClicked,
+                                onItemRendered = this::onItemRendered
                         )
                     }
             )
@@ -82,6 +83,10 @@ class ReaderDiscoverViewModel @Inject constructor(
     }
 
     private fun onItemClicked(post: ReaderPost) {
+        // TODO malinjir implement action
+    }
+
+    private fun onItemRendered(post: ReaderPost) {
         // TODO malinjir implement action
     }
 
@@ -123,7 +128,8 @@ class ReaderDiscoverViewModel @Inject constructor(
             val likeAction: ActionUiState,
             val reblogAction: ActionUiState,
             val commentsAction: ActionUiState,
-            val onItemClicked: ((ReaderPost) -> Unit)
+            val onItemClicked: ((ReaderPost) -> Unit),
+            val onItemRendered: (ReaderPost) -> Unit
         ) : ReaderCardUiState() {
             val dotSeparatorVisibility: Boolean = blogUrl != null
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
+import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
@@ -56,7 +57,8 @@ class ReaderDiscoverViewModel @Inject constructor(
                                 onBookmarkClicked = this::onBookmarkClicked,
                                 onLikeClicked = this::onLikeClicked,
                                 onReblogClicked = this::onReblogClicked,
-                                onCommentsClicked = this::onCommentsClicked
+                                onCommentsClicked = this::onCommentsClicked,
+                                onItemClicked = this::onItemClicked
                         )
                     }
             )
@@ -76,6 +78,10 @@ class ReaderDiscoverViewModel @Inject constructor(
     }
 
     private fun onCommentsClicked(postId: Long, blogId: Long, selected: Boolean) {
+        // TODO malinjir implement action
+    }
+
+    private fun onItemClicked(post: ReaderPost) {
         // TODO malinjir implement action
     }
 
@@ -116,7 +122,8 @@ class ReaderDiscoverViewModel @Inject constructor(
             val bookmarkAction: ActionUiState,
             val likeAction: ActionUiState,
             val reblogAction: ActionUiState,
-            val commentsAction: ActionUiState
+            val commentsAction: ActionUiState,
+            val onItemClicked: ((ReaderPost) -> Unit)
         ) : ReaderCardUiState() {
             val dotSeparatorVisibility: Boolean = blogUrl != null
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -55,7 +55,8 @@ class ReaderDiscoverViewModel @Inject constructor(
                                 isBookmarkList = false,
                                 onBookmarkClicked = this::onBookmarkClicked,
                                 onLikeClicked = this::onLikeClicked,
-                                onReblogClicked = this::onReblogClicked
+                                onReblogClicked = this::onReblogClicked,
+                                onCommentsClicked = this::onCommentsClicked
                         )
                     }
             )
@@ -71,6 +72,10 @@ class ReaderDiscoverViewModel @Inject constructor(
     }
 
     private fun onReblogClicked(postId: Long, blogId: Long, selected: Boolean) {
+        // TODO malinjir implement action
+    }
+
+    private fun onCommentsClicked(postId: Long, blogId: Long, selected: Boolean) {
         // TODO malinjir implement action
     }
 
@@ -110,7 +115,8 @@ class ReaderDiscoverViewModel @Inject constructor(
             val photoFrameVisibility: Boolean,
             val bookmarkAction: ActionUiState,
             val likeAction: ActionUiState,
-            val reblogAction: ActionUiState
+            val reblogAction: ActionUiState,
+            val commentsAction: ActionUiState
         ) : ReaderCardUiState() {
             val dotSeparatorVisibility: Boolean = blogUrl != null
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -54,7 +54,8 @@ class ReaderDiscoverViewModel @Inject constructor(
                                 photonHeight = photonHeight,
                                 isBookmarkList = false,
                                 onBookmarkClicked = this::onBookmarkClicked,
-                                onLikeClicked = this::onLikeClicked
+                                onLikeClicked = this::onLikeClicked,
+                                onReblogClicked = this::onReblogClicked
                         )
                     }
             )
@@ -66,6 +67,10 @@ class ReaderDiscoverViewModel @Inject constructor(
     }
 
     private fun onLikeClicked(postId: Long, blogId: Long, selected: Boolean) {
+        // TODO malinjir implement action
+    }
+
+    private fun onReblogClicked(postId: Long, blogId: Long, selected: Boolean) {
         // TODO malinjir implement action
     }
 
@@ -104,7 +109,8 @@ class ReaderDiscoverViewModel @Inject constructor(
             val moreMenuVisibility: Boolean,
             val photoFrameVisibility: Boolean,
             val bookmarkAction: ActionUiState,
-            val likeAction: ActionUiState
+            val likeAction: ActionUiState,
+            val reblogAction: ActionUiState
         ) : ReaderCardUiState() {
             val dotSeparatorVisibility: Boolean = blogUrl != null
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -40,7 +40,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
             // TODO malinjir try to refactor/remove this parameter
         isBookmarkList: Boolean,
         onBookmarkClicked: (Long, Long, Boolean) -> Unit,
-        onLikeClicked: (Long, Long, Boolean) -> Unit
+        onLikeClicked: (Long, Long, Boolean) -> Unit,
+        onReblogClicked: (Long, Long, Boolean) -> Unit
     ): ReaderPostUiState {
         // TODO malinjir onPostContainer click
         // TODO malinjir on item rendered callback -> handle load more event and trackRailcarRender
@@ -67,7 +68,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 videoThumbnailUrl = buildVideoThumbnailUrl(post),
                 discoverSection = buildDiscoverSection(post),
                 bookmarkAction = buildBookmarkSection(post, onBookmarkClicked),
-                likeAction = buildLikeSection(post, isBookmarkList, onLikeClicked)
+                likeAction = buildLikeSection(post, isBookmarkList, onLikeClicked),
+                reblogAction = buildReblogSection(post, onReblogClicked)
         )
     }
 
@@ -194,6 +196,19 @@ class ReaderPostUiStateBuilder @Inject constructor(
                     ),
                     onClicked = if (accountStore.hasAccessToken()) onClicked else null
             )
+        } else {
+            ActionUiState(isEnabled = false)
+        }
+    }
+
+    private fun buildReblogSection(
+        post: ReaderPost,
+        onReblogClicked: (Long, Long, Boolean) -> Unit
+    ): ActionUiState {
+        val canReblog = !post.isPrivate && accountStore.hasAccessToken()
+        return if (canReblog) {
+            // TODO Add content description
+            ActionUiState(isEnabled = true, onClicked = onReblogClicked)
         } else {
             ActionUiState(isEnabled = false)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -41,7 +41,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
         isBookmarkList: Boolean,
         onBookmarkClicked: (Long, Long, Boolean) -> Unit,
         onLikeClicked: (Long, Long, Boolean) -> Unit,
-        onReblogClicked: (Long, Long, Boolean) -> Unit
+        onReblogClicked: (Long, Long, Boolean) -> Unit,
+        onCommentsClicked: (Long, Long, Boolean) -> Unit
     ): ReaderPostUiState {
         // TODO malinjir onPostContainer click
         // TODO malinjir on item rendered callback -> handle load more event and trackRailcarRender
@@ -69,7 +70,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 discoverSection = buildDiscoverSection(post),
                 bookmarkAction = buildBookmarkSection(post, onBookmarkClicked),
                 likeAction = buildLikeSection(post, isBookmarkList, onLikeClicked),
-                reblogAction = buildReblogSection(post, onReblogClicked)
+                reblogAction = buildReblogSection(post, onReblogClicked),
+                commentsAction = buildCommentsSection(post, isBookmarkList, onCommentsClicked)
         )
     }
 
@@ -209,6 +211,32 @@ class ReaderPostUiStateBuilder @Inject constructor(
         return if (canReblog) {
             // TODO Add content description
             ActionUiState(isEnabled = true, onClicked = onReblogClicked)
+        } else {
+            ActionUiState(isEnabled = false)
+        }
+    }
+
+    private fun buildCommentsSection(
+        post: ReaderPost,
+        isBookmarkList: Boolean,
+        onCommentsClicked: (Long, Long, Boolean) -> Unit
+    ): ActionUiState {
+        val showComments = when {
+            /* TODO malinjir why we don't show comments on bookmark list??? I think we wanted
+                 to keep the card as simple as possible. However, since we are showing all the actions now, some of them
+                 are just disabled, I think it's ok to enable the action. */
+            post.isDiscoverPost || isBookmarkList -> false
+            !accountStore.hasAccessToken() -> post.numLikes > 0
+            else -> post.isWP && (post.isCommentsOpen || post.numReplies > 0)
+        }
+
+        // TODO Add content description
+        return if (showComments) {
+            ActionUiState(
+                    isEnabled = true,
+                    count = post.numReplies,
+                    onClicked = onCommentsClicked
+            )
         } else {
             ActionUiState(isEnabled = false)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -43,7 +43,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
         onLikeClicked: (Long, Long, Boolean) -> Unit,
         onReblogClicked: (Long, Long, Boolean) -> Unit,
         onCommentsClicked: (Long, Long, Boolean) -> Unit,
-        onItemClicked: (ReaderPost) -> Unit
+        onItemClicked: (ReaderPost) -> Unit,
+        onItemRendered: (ReaderPost) -> Unit
     ): ReaderPostUiState {
         // TODO malinjir on item rendered callback -> handle load more event and trackRailcarRender
 
@@ -69,7 +70,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 likeAction = buildLikeSection(post, isBookmarkList, onLikeClicked),
                 reblogAction = buildReblogSection(post, onReblogClicked),
                 commentsAction = buildCommentsSection(post, isBookmarkList, onCommentsClicked),
-                onItemClicked = onItemClicked
+                onItemClicked = onItemClicked,
+                onItemRendered = onItemRendered
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -42,13 +42,10 @@ class ReaderPostUiStateBuilder @Inject constructor(
         onBookmarkClicked: (Long, Long, Boolean) -> Unit,
         onLikeClicked: (Long, Long, Boolean) -> Unit,
         onReblogClicked: (Long, Long, Boolean) -> Unit,
-        onCommentsClicked: (Long, Long, Boolean) -> Unit
+        onCommentsClicked: (Long, Long, Boolean) -> Unit,
+        onItemClicked: (ReaderPost) -> Unit
     ): ReaderPostUiState {
-        // TODO malinjir onPostContainer click
         // TODO malinjir on item rendered callback -> handle load more event and trackRailcarRender
-        // TODO malinjir reblog action
-        // TODO malinjir comments action
-        // TODO malinjir likes action
 
         return ReaderPostUiState(
                 postId = post.postId,
@@ -71,7 +68,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 bookmarkAction = buildBookmarkSection(post, onBookmarkClicked),
                 likeAction = buildLikeSection(post, isBookmarkList, onLikeClicked),
                 reblogAction = buildReblogSection(post, onReblogClicked),
-                commentsAction = buildCommentsSection(post, isBookmarkList, onCommentsClicked)
+                commentsAction = buildCommentsSection(post, isBookmarkList, onCommentsClicked),
+                onItemClicked = onItemClicked
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -42,7 +42,10 @@ class ReaderDiscoverViewModelTest {
         viewModel = ReaderDiscoverViewModel(readerPostRepository, uiStateBuilder, TEST_DISPATCHER, TEST_DISPATCHER)
         whenever(readerPostRepository.discoveryFeed).thenReturn(fakeDiscoverFeed)
         whenever(
-                uiStateBuilder.mapPostToUiState(anyOrNull(), anyInt(), anyInt(), anyBoolean(), anyOrNull(), anyOrNull())
+                uiStateBuilder.mapPostToUiState(
+                        anyOrNull(), anyInt(), anyInt(), anyBoolean(), anyOrNull(),
+                        anyOrNull(), anyOrNull(), anyOrNull()
+                )
         ).thenReturn(mock())
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -44,7 +44,7 @@ class ReaderDiscoverViewModelTest {
         whenever(
                 uiStateBuilder.mapPostToUiState(
                         anyOrNull(), anyInt(), anyInt(), anyBoolean(), anyOrNull(),
-                        anyOrNull(), anyOrNull(), anyOrNull()
+                        anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
                 )
         ).thenReturn(mock())
     }


### PR DESCRIPTION
Parent issue #12028

Merge instructions

1. Review this PR
2. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/12238 is merged and remove the Not Ready for Merge tag
3. Update target branch to develop
4. Merge this PR

This PR copies the logic for reblog, comments and onItemClick actions on Reader post card items from - [reblog](https://github.com/wordpress-mobile/WordPress-Android/blob/588b9582c3ad022b91fd1be63111ac306d76c4ef/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java#L1013) and [comments](https://github.com/wordpress-mobile/WordPress-Android/blob/588b9582c3ad022b91fd1be63111ac306d76c4ef/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java#L982) and ([onitemclick](https://github.com/wordpress-mobile/WordPress-Android/blob/588b9582c3ad022b91fd1be63111ac306d76c4ef/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java#L593) which is always set so there isn't any logic). We are also introducing `onItemRendered` callback which will be used for tracking purposes and for loading more items when the user reaches the bottom of the list.

To test
This code isn't being used yet. We'll test the changes in upcoming PRs. Just try to review that the conditions are the same.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
