### PR TITLE
Fix: don't close MediaSettingsActivity for failed video thumbnail loads

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -773,7 +773,14 @@ public class MediaSettingsActivity extends LocaleAwareActivity
                                 AppLog.e(T.MEDIA, e);
                             }
                             showProgress(false);
-                            delayedFinishWithError();
+                            if (isVideo()) {
+                                // for videos it's ok if we fail to load the thumbnail - can happen.
+                                // let's show a toast but let the user edit the media settings!
+                                ToastUtils.showToast(MediaSettingsActivity.this,
+                                        R.string.error_media_thumbnail_not_loaded);
+                            } else {
+                                delayedFinishWithError();
+                            }
                         }
                     }
                 });

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1576,6 +1576,7 @@
     <string name="error_upload_page_media_param">There was an error uploading the media in this page: %s.</string>
     <string name="error_media_insufficient_fs_permissions">Read permission denied on device media</string>
     <string name="error_media_not_found">Media could not be found</string>
+    <string name="error_media_thumbnail_not_loaded">Media thumbnail could not be loaded</string>
     <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>
     <string name="error_media_parse_error">Unexpected response from server</string>
     <string name="error_media_upload">An error occurred while uploading media</string>


### PR DESCRIPTION
This is a follow up to https://github.com/wordpress-mobile/WordPress-Android/pull/12178

Fixes a bug that made the MediaSettingsActivity be finished even when only the thumbnail for the media could not be load.
This might make sense for images, but it should be a bit more flexible with videos (for example the first time a thumbnail is obtained it's made by extracting a frame of the video itself and it can take time).

Another strange case found is with the creation of a video on a public site, then switching the site to private, then trying to access the media section on that site. A rare 403 error can come up for an existing thumbnail URL for a previously uploaded video, that will prevent the thumbnail from being loaded. While this should be investigated and handled elsewhere (server-side), this PR itself still should provide a safeguard for this situation and in any case, should account for the situation described above (a thumbnail of a video not being loaded shouldn't be a blocker for the user to edit its media settings which are perfectly fine).

One way to test this is as follows
1. create and upload a new video to the media section of a site
2. turn the site private (My site -> settings -> privacy: private)
3. go to the Media section of the site
4. tap on the newly uploaded video
5. observe the media thumbnail can't be loaded, and a toast appears
6. observe you can still tap on the triangle play icon and have the preview load the video and play it. (the gif below shows this, it takes some time to load the video but if you wait you'll see it playing in the end)

![thumbnailloadfailok](https://user-images.githubusercontent.com/6597771/85173945-c2939f80-b24a-11ea-8a78-1678e71e88f7.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
