### PR TITLE
Crash in full screen dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
@@ -64,7 +64,7 @@ public class FullScreenDialogFragment extends DialogFragment {
 
         boolean onDismissClicked(FullScreenDialogController controller);
 
-        void onViewCreated(FullScreenDialogController controller);
+        void setController(FullScreenDialogController controller);
     }
 
     public interface FullScreenDialogController {
@@ -181,7 +181,7 @@ public class FullScreenDialogFragment extends DialogFragment {
 
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        ((FullScreenDialogContent) getContent()).onViewCreated(mController);
+        ((FullScreenDialogContent) getContent()).setController(mController);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
@@ -153,6 +153,7 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
             if (suggestions != null) {
                 setUsernameSuggestions(suggestions);
             } else {
+                mUsernameSuggestionInput = getUsernameQueryFromDisplayName();
                 getUsernameSuggestions(mUsernameSuggestionInput);
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
@@ -211,6 +211,12 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
     }
 
     @Override
+    public void onDestroy() {
+        mGetSuggestionsHandler.removeCallbacksAndMessages(null);
+        super.onDestroy();
+    }
+
+    @Override
     public boolean onConfirmClicked(FullScreenDialogController controller) {
         ActivityUtils.hideKeyboard(getActivity());
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
@@ -14,6 +14,7 @@ import android.view.ViewGroup;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -135,13 +136,13 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
     }
 
     @Override
-    public void onViewCreated(final FullScreenDialogController controller) {
+    public void setController(final FullScreenDialogController controller) {
         mDialogController = controller;
     }
 
     @Override
-    public void onActivityCreated(@Nullable final Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
         if (savedInstanceState != null) {
             mIsShowingDismissDialog = savedInstanceState.getBoolean(KEY_IS_SHOWING_DISMISS_DIALOG);
@@ -244,7 +245,9 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
         outState.putBoolean(KEY_SHOULD_WATCH_TEXT, false);
         outState.putString(KEY_USERNAME_SELECTED, mUsernameSelected);
         outState.putInt(KEY_USERNAME_SELECTED_INDEX, mUsernameSelectedIndex);
-        outState.putStringArrayList(KEY_USERNAME_SUGGESTIONS, new ArrayList<>(mUsernamesAdapter.mItems));
+        if (mUsernamesAdapter != null) {
+            outState.putStringArrayList(KEY_USERNAME_SUGGESTIONS, new ArrayList<>(mUsernamesAdapter.mItems));
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
@@ -149,7 +149,12 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Dagger
             mShouldWatchText = savedInstanceState.getBoolean(KEY_SHOULD_WATCH_TEXT);
             mUsernameSelected = savedInstanceState.getString(KEY_USERNAME_SELECTED);
             mUsernameSelectedIndex = savedInstanceState.getInt(KEY_USERNAME_SELECTED_INDEX);
-            setUsernameSuggestions(savedInstanceState.getStringArrayList(KEY_USERNAME_SUGGESTIONS));
+            ArrayList<String> suggestions = savedInstanceState.getStringArrayList(KEY_USERNAME_SUGGESTIONS);
+            if (suggestions != null) {
+                setUsernameSuggestions(suggestions);
+            } else {
+                getUsernameSuggestions(mUsernameSuggestionInput);
+            }
 
             if (mIsShowingDismissDialog) {
                 showDismissDialog();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SettingsUsernameChangerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SettingsUsernameChangerFragment.kt
@@ -46,8 +46,8 @@ class SettingsUsernameChangerFragment : BaseUsernameChangerFullScreenDialogFragm
             ), HtmlCompat.FROM_HTML_MODE_LEGACY
     )
 
-    override fun onViewCreated(controller: FullScreenDialogController) {
-        super.onViewCreated(controller)
+    override fun setController(controller: FullScreenDialogController) {
+        super.setController(controller)
         dialogController = controller
 
         dialogController.setActionEnabled(false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanDetailsFragment.kt
@@ -93,7 +93,7 @@ class PlanDetailsFragment : Fragment(), FullScreenDialogContent {
         return true
     }
 
-    override fun onViewCreated(controller: FullScreenDialogController) {
+    override fun setController(controller: FullScreenDialogController) {
         dialogController = controller
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFullScreenDialogFragment.java
@@ -122,7 +122,7 @@ public class QuickStartFullScreenDialogFragment extends Fragment implements Full
     }
 
     @Override
-    public void onViewCreated(final FullScreenDialogController controller) {
+    public void setController(final FullScreenDialogController controller) {
         mDialogController = controller;
     }
 


### PR DESCRIPTION
Fixes #12036

I couldn't reproduce this issue but I'm pretty sure it happens because the `onActivityCreated` is not called in some cases when the activity is destroyed before the fragment is fully created. In this case the `onSaveInstanceState` is still called and the adapter is not initialised so the app crashes. I've fixed this by moving the initialization into the `onViewCreated` method. As part of this refactoring I've also renamed the `onViewCreated` method that was previously coming from an interface and which was used to set the controller. The new name is `setController`. I've made this because it was confusing to have two `onViewCreated` methods in the fragment. 

To test:
- Go to Account settings
- Open the dialog to change your username
- Stress test it (rotation, go to background and back)
- See that there is no crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
