### PR TITLE
Updated SnackBar style

### DIFF
--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -43,12 +43,13 @@
             @style/Widget.MaterialComponents.PopupMenu.Overflow
         </item>
 
-         <item name="bottomSheetDialogTheme">
-             @style/WordPress.BottomSheetDialogTheme
-         </item>
+        <item name="bottomSheetDialogTheme">
+            @style/WordPress.BottomSheetDialogTheme
+        </item>
 
         <item name="toolbarStyle">@style/WordPress.ToolBar</item>
         <item name="appBarLayoutStyle">@style/WordPress.AppBarLayout</item>
+        <item name="snackbarStyle">@style/Widget.MaterialComponents.Snackbar</item>
 
         <!-- we can remove it after moving away from Bridge version of theme -->
         <item name="materialCardViewStyle">@style/Widget.MaterialComponents.CardView</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -27,6 +27,7 @@
         <item name="toolbarStyle">@style/WordPress.ToolBar</item>
         <item name="tabStyle">@style/WordPress.TabLayout</item>
         <item name="appBarLayoutStyle">@style/WordPress.AppBarLayout</item>
+        <item name="snackbarStyle">@style/Widget.MaterialComponents.Snackbar</item>
 
         <!-- we can remove it after moving away from Bridge version of theme -->
         <item name="materialCardViewStyle">@style/Widget.MaterialComponents.CardView</item>
@@ -1124,7 +1125,7 @@
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowAnimationStyle">@style/FullScreenDialogFragmentAnimation</item>
     </style>
-  
+
     <!-- Overload of Aztec theme -->
     <style name="FormatBarButton">
         <item name="android:minWidth">@dimen/format_bar_height</item>


### PR DESCRIPTION
Fixes #11663 

After updated to material theme our Snackars were left being, and looking a bit unsightly:

[![Image from Gyazo](https://i.gyazo.com/74553197793274aee4bac0073bc1152f.png)](https://gyazo.com/74553197793274aee4bac0073bc1152f)

This PR explicitly adds an updated style so they can look as expected:
[![Image from Gyazo](https://i.gyazo.com/971f1ec02b278319a7c224b49a5a0671.png)](https://gyazo.com/971f1ec02b278319a7c224b49a5a0671)

To test:
- Perform an action that results in a snack bar (publishing/trashing post, deleting the comment, etc.) 
- Make sure SnackBars have space around them and look like on the the screenshots.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
