### PR TITLE
Change source for wordpress_com login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -97,6 +97,7 @@ import static org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_ACCESS
 import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG_HIGH_RES_IMAGE_URL;
 import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG_LOW_RES_IMAGE_URL;
 import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG_OUTPUT_FILE_EXTENSION;
+import static org.wordpress.android.login.LoginMode.WPCOM_LOGIN_ONLY;
 import static org.wordpress.android.ui.pages.PagesActivityKt.EXTRA_PAGE_REMOTE_ID_KEY;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_ID_KEY;
 
@@ -791,6 +792,7 @@ public class ActivityLauncher {
 
     public static void showSignInForResult(Activity activity) {
         Intent intent = new Intent(activity, LoginActivity.class);
+        WPCOM_LOGIN_ONLY.putInto(intent);
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -144,24 +144,12 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
             switch (getLoginMode()) {
                 case FULL:
-                    mIsSignupFromLoginEnabled = true;
-                    mUnifiedLoginTracker.setSource(Source.ADD_WORDPRESS_COM_ACCOUNT);
-                    showFragment(new LoginPrologueFragment(), LoginPrologueFragment.TAG);
-                    if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
-                        mIsSmartLockTriggeredFromPrologue = true;
-                        mIsSiteLoginAvailableFromPrologue = true;
-                        initSmartLockIfNotFinished(true);
-                    }
+                    mUnifiedLoginTracker.setSource(Source.DEFAULT);
+                    loginFromPrologue();
                     break;
                 case WPCOM_LOGIN_ONLY:
-                    mIsSignupFromLoginEnabled = true;
-                    mUnifiedLoginTracker.setSource(Source.DEFAULT);
-                    showFragment(new LoginPrologueFragment(), LoginPrologueFragment.TAG);
-                    if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
-                        mIsSmartLockTriggeredFromPrologue = true;
-                        mIsSiteLoginAvailableFromPrologue = true;
-                        initSmartLockIfNotFinished(true);
-                    }
+                    mUnifiedLoginTracker.setSource(Source.ADD_WORDPRESS_COM_ACCOUNT);
+                    loginFromPrologue();
                     break;
                 case SELFHOSTED_ONLY:
                     mUnifiedLoginTracker.setSource(Source.SELF_HOSTED);
@@ -201,6 +189,16 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                 mUnifiedLoginTracker.setSource(source);
             }
             mUnifiedLoginTracker.setFlow(savedInstanceState.getString(KEY_UNIFIED_TRACKER_FLOW));
+        }
+    }
+
+    private void loginFromPrologue() {
+        mIsSignupFromLoginEnabled = true;
+        showFragment(new LoginPrologueFragment(), LoginPrologueFragment.TAG);
+        if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
+            mIsSmartLockTriggeredFromPrologue = true;
+            mIsSiteLoginAvailableFromPrologue = true;
+            initSmartLockIfNotFinished(true);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -144,6 +144,15 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
             switch (getLoginMode()) {
                 case FULL:
+                    mIsSignupFromLoginEnabled = true;
+                    mUnifiedLoginTracker.setSource(Source.ADD_WORDPRESS_COM_ACCOUNT);
+                    showFragment(new LoginPrologueFragment(), LoginPrologueFragment.TAG);
+                    if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
+                        mIsSmartLockTriggeredFromPrologue = true;
+                        mIsSiteLoginAvailableFromPrologue = true;
+                        initSmartLockIfNotFinished(true);
+                    }
+                    break;
                 case WPCOM_LOGIN_ONLY:
                     mIsSignupFromLoginEnabled = true;
                     mUnifiedLoginTracker.setSource(Source.DEFAULT);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -63,6 +63,7 @@ class UnifiedLoginTracker
         DEEPLINK("deeplink"),
         REAUTHENTICATION("reauthentication"),
         SELF_HOSTED("self_hosted"),
+        ADD_WORDPRESS_COM_ACCOUNT("add_wordpress_com_account"),
         DEFAULT("default")
     }
 


### PR DESCRIPTION
This PR adds a different source for the login from the Me fragment. As far as I could see the `WPCOM_LOGIN_ONLY` wasn't previously used but it should've been used for this case anyway. The only difference in functionality (if I see correctly) is slightly different flow when trying to log in with site address. Does that look correct @renanferrari ?

To test:
- Log in with a self-hosted site
- Go to Me fragment
- Click on Log in to WordPress.com
- Check that the flow starts with the new source

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
