### PR TITLE
WP Stories: default to opening the media picker first

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -677,6 +677,23 @@ public class ActivityLauncher {
         activity.startActivityForResult(intent, RequestCodes.CREATE_STORY);
     }
 
+    public static void addNewStoryWithMediaIdsForResult(
+            Activity activity,
+            SiteModel site,
+            PagePostCreationSourcesDetail source,
+            String[] mediaUris
+    ) {
+        if (site == null) {
+            return;
+        }
+
+        Intent intent = new Intent(activity, StoryComposerActivity.class);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS, mediaUris);
+        intent.putExtra(AnalyticsUtils.EXTRA_CREATION_SOURCE_DETAIL, source);
+        activity.startActivityForResult(intent, RequestCodes.CREATE_STORY);
+    }
+
     public static void editPostOrPageForResult(Activity activity, SiteModel site, PostModel post) {
         editPostOrPageForResult(new Intent(activity, EditPostActivity.class), activity, site, post.getId(), false);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -674,6 +674,7 @@ public class ActivityLauncher {
         Intent intent = new Intent(activity, StoryComposerActivity.class);
         intent.putExtra(WordPress.SITE, site);
         intent.putExtra(AnalyticsUtils.EXTRA_CREATION_SOURCE_DETAIL, source);
+        intent.putExtra(PhotoPickerActivity.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED, true);
         activity.startActivityForResult(intent, RequestCodes.CREATE_STORY);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -681,6 +681,23 @@ public class ActivityLauncher {
             Activity activity,
             SiteModel site,
             PagePostCreationSourcesDetail source,
+            long[] mediaIds
+    ) {
+        if (site == null) {
+            return;
+        }
+
+        Intent intent = new Intent(activity, StoryComposerActivity.class);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(MediaBrowserActivity.RESULT_IDS, mediaIds);
+        intent.putExtra(AnalyticsUtils.EXTRA_CREATION_SOURCE_DETAIL, source);
+        activity.startActivityForResult(intent, RequestCodes.CREATE_STORY);
+    }
+
+    public static void addNewStoryWithMediaUrisForResult(
+            Activity activity,
+            SiteModel site,
+            PagePostCreationSourcesDetail source,
             String[] mediaUris
     ) {
         if (site == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -696,6 +696,12 @@ class MySiteFragment : Fragment(),
                     val mediaId = data.getLongExtra(PhotoPickerActivity.EXTRA_MEDIA_ID, 0).toInt()
                     showSiteIconProgressBar(true)
                     updateSiteIconMediaId(mediaId)
+                } else if (data.getBooleanExtra(PhotoPickerActivity.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED, false)) {
+                    ActivityLauncher.addNewStoryForResult(
+                            activity,
+                            selectedSite,
+                            PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
+                    )
                 } else {
                     val mediaUriStringsArray = data.getStringArrayExtra(
                             PhotoPickerActivity.EXTRA_MEDIA_URIS

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -81,6 +81,7 @@ import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
+import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.news.NewsManager;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
@@ -846,7 +847,12 @@ public class WPMainActivity extends LocaleAwareActivity implements
         SiteModel site = getSelectedSite();
         if (site != null) {
             // TODO: evaluate to include the QuickStart logic like in the handleNewPostAction
-            ActivityLauncher.addNewStoryForResult(this, site, source);
+            ActivityLauncher.showPhotoPickerForResult(
+                    this,
+                    MediaBrowserType.WP_STORIES_MEDIA_PICKER,
+                    site,
+                    null // this is not required, only used for featured image in normal Posts
+            );
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -335,13 +335,17 @@ public class PhotoPickerActivity extends LocaleAwareActivity
 
             Intent data = new Intent()
                     .putExtra(EXTRA_MEDIA_ID, mediaIds.get(0))
-                    .putExtra(EXTRA_MEDIA_SOURCE, source.name());
+                    .putExtra(EXTRA_MEDIA_SOURCE, source.name())
+                    // set the browserType in the result, so caller can distinguish and handle things as needed
+                    .putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, mBrowserType);
             setResult(RESULT_OK, data);
             finish();
         } else {
             Intent data = new Intent()
                     .putExtra(MediaBrowserActivity.RESULT_IDS, ListUtils.toLongArray(mediaIds))
-                    .putExtra(EXTRA_MEDIA_SOURCE, source.name());
+                    .putExtra(EXTRA_MEDIA_SOURCE, source.name())
+                    // set the browserType in the result, so caller can distinguish and handle things as needed
+                    .putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, mBrowserType);
             setResult(RESULT_OK, data);
             finish();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -317,7 +317,9 @@ public class PhotoPickerActivity extends LocaleAwareActivity
         } else {
             Intent intent = new Intent()
                     .putExtra(EXTRA_MEDIA_URIS, convertUrisListToStringArray(mediaUris))
-                    .putExtra(EXTRA_MEDIA_SOURCE, source.name());
+                    .putExtra(EXTRA_MEDIA_SOURCE, source.name())
+                    // set the browserType in the result, so caller can distinguish and handle things as needed
+                    .putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, mBrowserType);
             setResult(RESULT_OK, intent);
             finish();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -129,6 +129,8 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                 val notificationType = intent.getSerializableExtra(ARG_NOTIFICATION_TYPE) as NotificationType
                 systemNotificationsTracker.trackTappedNotification(notificationType)
             }
+            // now see if we need to handle information coming from the MediaPicker to populate
+            handleMediaPickerIntentData(intent)
         } else {
             site = savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
             if (savedInstanceState.containsKey(STATE_KEY_POST_LOCAL_ID)) {
@@ -155,7 +157,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         data?.let {
             when (requestCode) {
                 RequestCodes.MULTI_SELECT_MEDIA_PICKER, RequestCodes.SINGLE_SELECT_MEDIA_PICKER -> {
-                    handleMediaPickerResult(it)
+                    handleMediaPickerIntentData(it)
                 }
                 RequestCodes.PHOTO_PICKER -> {
                     if (it.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)) {
@@ -164,7 +166,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                         )
                         editorMedia.onPhotoPickerMediaChosen(uriList)
                     } else if (it.hasExtra(MediaBrowserActivity.RESULT_IDS)) {
-                        handleMediaPickerResult(it)
+                        handleMediaPickerIntentData(it)
                     }
                 }
             }
@@ -218,7 +220,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         return true
     }
 
-    fun handleMediaPickerResult(data: Intent) {
+    fun handleMediaPickerIntentData(data: Intent) {
         // TODO move this to EditorMedia
         val ids = ListUtils.fromLongArray(
                 data.getLongArrayExtra(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -129,8 +129,6 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                 val notificationType = intent.getSerializableExtra(ARG_NOTIFICATION_TYPE) as NotificationType
                 systemNotificationsTracker.trackTappedNotification(notificationType)
             }
-            // now see if we need to handle information coming from the MediaPicker to populate
-            handleMediaPickerIntentData(intent)
         } else {
             site = savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
             if (savedInstanceState.containsKey(STATE_KEY_POST_LOCAL_ID)) {
@@ -143,6 +141,12 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         editorMedia.start(requireNotNull(site), this, STORY_EDITOR)
         postEditorAnalyticsSession?.start(null)
         startObserving()
+    }
+
+    override fun onLoadFromIntent(intent: Intent) {
+        super.onLoadFromIntent(intent)
+        // now see if we need to handle information coming from the MediaPicker to populate
+        handleMediaPickerIntentData(intent)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -140,7 +140,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                     savedInstanceState.getSerializable(STATE_KEY_EDITOR_SESSION_DATA) as PostEditorAnalyticsSession
         }
 
-        editorMedia.start(site!!, this, STORY_EDITOR)
+        editorMedia.start(requireNotNull(site), this, STORY_EDITOR)
         postEditorAnalyticsSession?.start(null)
         startObserving()
     }


### PR DESCRIPTION
This PR implements the changes to make the flow for Stories default to showing the Media Picker first, instead of the camera preview screen.


![newnavigation](https://user-images.githubusercontent.com/6597771/85642406-cd459e80-b667-11ea-8c36-f0dcdad911cb.gif)


To test:
1. open the WPAndroid app
2. tap on the FAB button
3. choose "Story"
4. the media picker is shown
5. test you can add images and videos from all available sources as shown in the animation above.
6. also test you can open the Stories' camera capture screren when tapping on the camera icon from the Media picker.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
