### PR TITLE
Mock getUserTags

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderTagRepository.kt
@@ -26,12 +26,18 @@ class ReaderTagRepository @Inject constructor(
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
 ) {
     private val mutableRecommendedInterests = MutableLiveData<ReaderTagList>()
-    val recommendedInterests: LiveData<ReaderTagList> = mutableRecommendedInterests
+    private val recommendedInterests: LiveData<ReaderTagList> = mutableRecommendedInterests
 
     suspend fun getInterests(): ReaderTagList =
             withContext(ioDispatcher) {
                 delay(SECONDS.toMillis(5))
                 getMockInterests()
+            }
+
+    suspend fun getUserTags(isEmpty: Boolean = true): ReaderTagList =
+            withContext(ioDispatcher) {
+                delay(SECONDS.toMillis(5))
+                getMockUserTags(isEmpty)
             }
 
     // todo: full implementation needed
@@ -51,6 +57,14 @@ class ReaderTagRepository @Inject constructor(
         return withContext(ioDispatcher) {
             mutableRecommendedInterests.postValue(getMockInterests())
             recommendedInterests
+        }
+    }
+
+    private fun getMockUserTags(isEmpty: Boolean): ReaderTagList {
+        return if (isEmpty) {
+            ReaderTagList()
+        } else {
+            getMockInterests()
         }
     }
 


### PR DESCRIPTION
Supports #12255 

Adds a mock method for getting UserTags. The mock function can return an empty ReaderTagList or mocked data. The default is empty.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
