### PR TITLE
Add reader css expiration logic

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -140,6 +140,9 @@ public class AppPrefs {
 
         // Keep the local_blog_id + local_post_id values that have HW Acc. turned off
         AZTEC_EDITOR_DISABLE_HW_ACC_KEYS,
+
+        // timestamp of the last update of the reader css styles
+        READER_CSS_UPDATED_TIMESTAMP
     }
 
     /**
@@ -227,9 +230,6 @@ public class AppPrefs {
 
         // feature flag for Reader Improvements Phase 2
         FF_READER_IMPROVEMENTS_PHASE_2,
-
-        // timestamp of the last update of the reader css styles
-        READER_CSS_UPDATED_TIMESTAMP
     }
 
     private static SharedPreferences prefs() {
@@ -1140,11 +1140,11 @@ public class AppPrefs {
     }
 
     public static long getReaderCssUpdatedTimestamp() {
-        return getLong(UndeletablePrefKey.READER_CSS_UPDATED_TIMESTAMP, 0);
+        return getLong(DeletablePrefKey.READER_CSS_UPDATED_TIMESTAMP, 0);
     }
 
     public static void setReaderCssUpdatedTimestamp(long timestamp) {
-        setLong(UndeletablePrefKey.READER_CSS_UPDATED_TIMESTAMP, timestamp);
+        setLong(DeletablePrefKey.READER_CSS_UPDATED_TIMESTAMP, timestamp);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -226,7 +226,10 @@ public class AppPrefs {
         LAST_FEATURE_ANNOUNCEMENT_APP_VERSION_CODE,
 
         // feature flag for Reader Improvements Phase 2
-        FF_READER_IMPROVEMENTS_PHASE_2
+        FF_READER_IMPROVEMENTS_PHASE_2,
+
+        // timestamp of the last update of the reader css styles
+        READER_CSS_UPDATED_TIMESTAMP
     }
 
     private static SharedPreferences prefs() {
@@ -1134,6 +1137,14 @@ public class AppPrefs {
 
     public static void setReaderTagsUpdatedTimestamp(long timestamp) {
         setLong(DeletablePrefKey.READER_TAGS_UPDATE_TIMESTAMP, timestamp);
+    }
+
+    public static long getReaderCssUpdatedTimestamp() {
+        return getLong(UndeletablePrefKey.READER_CSS_UPDATED_TIMESTAMP, 0);
+    }
+
+    public static void setReaderCssUpdatedTimestamp(long timestamp) {
+        setLong(UndeletablePrefKey.READER_CSS_UPDATED_TIMESTAMP, timestamp);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -67,6 +67,10 @@ class AppPrefsWrapper @Inject constructor() {
         get() = AppPrefs.getReaderTagsUpdatedTimestamp()
         set(timestamp) = AppPrefs.setReaderTagsUpdatedTimestamp(timestamp)
 
+    var readerCssUpdatedTimestamp: Long
+        get() = AppPrefs.getReaderCssUpdatedTimestamp()
+        set(timestamp) = AppPrefs.setReaderCssUpdatedTimestamp(timestamp)
+
     fun getAppWidgetSiteId(appWidgetId: Int) = AppPrefs.getStatsWidgetSelectedSiteId(appWidgetId)
     fun setAppWidgetSiteId(siteId: Long, appWidgetId: Int) = AppPrefs.setStatsWidgetSelectedSiteId(siteId, appWidgetId)
     fun removeAppWidgetSiteId(appWidgetId: Int) = AppPrefs.removeStatsWidgetSelectedSiteId(appWidgetId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCssProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCssProvider.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.ui.reader
+
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.reader.utils.DateProvider
+import org.wordpress.android.util.NetworkUtilsWrapper
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+const val EXPIRATION_IN_DAYS = 5L
+private const val BASE_CSS_URL = "https://wordpress.com/calypso/reader-mobile.css"
+
+class ReaderCssProvider @Inject constructor(
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val dateProvider: DateProvider
+) {
+    fun getCssUrl(): String {
+        val lastUpdated = appPrefsWrapper.readerCssUpdatedTimestamp
+        val currentDate = dateProvider.getCurrentDate().time
+
+        val urlSuffix = if (networkUtilsWrapper.isNetworkAvailable() && isExpired(lastUpdated, currentDate)) {
+            appPrefsWrapper.readerCssUpdatedTimestamp = currentDate
+            currentDate
+        } else {
+            lastUpdated
+        }
+        return "$BASE_CSS_URL?$urlSuffix"
+    }
+
+    private fun isExpired(lastUpdated: Long, currentDate: Long): Boolean {
+        return lastUpdated < currentDate - TimeUnit.DAYS.toMillis(EXPIRATION_IN_DAYS)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -183,6 +183,7 @@ class ReaderPostDetailFragment : Fragment(),
     @Inject internal lateinit var readerFileDownloadManager: ReaderFileDownloadManager
     @Inject internal lateinit var featuredImageUtils: FeaturedImageUtils
     @Inject internal lateinit var privateAtomicCookie: PrivateAtomicCookie
+    @Inject internal lateinit var readerCssProvider: ReaderCssProvider
 
     private val mSignInClickListener = View.OnClickListener {
         EventBus.getDefault()
@@ -1351,7 +1352,7 @@ class ReaderPostDetailFragment : Fragment(),
             scrollView.visibility = View.VISIBLE
 
             // render the post in the webView
-            renderer = ReaderPostRenderer(readerWebView, post, featuredImageUtils)
+            renderer = ReaderPostRenderer(readerWebView, post, featuredImageUtils, readerCssProvider)
 
             // if the post is from private atomic site postpone render until we have a special access cookie
             if (post!!.isPrivateAtomic && privateAtomicCookie.isCookieRefreshRequired()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -50,9 +50,11 @@ public class ReaderPostRenderer {
     private String mRenderedHtml;
     private ImageSizeMap mAttachmentSizes;
     private FeaturedImageUtils mFeaturedImageUtils;
+    private ReaderCssProvider mCssProvider;
 
     @SuppressLint("SetJavaScriptEnabled")
-    public ReaderPostRenderer(ReaderWebView webView, ReaderPost post, FeaturedImageUtils featuredImageUtils) {
+    public ReaderPostRenderer(ReaderWebView webView, ReaderPost post, FeaturedImageUtils featuredImageUtils,
+                              ReaderCssProvider cssProvider) {
         if (webView == null) {
             throw new IllegalArgumentException("ReaderPostRenderer requires a webView");
         }
@@ -64,6 +66,7 @@ public class ReaderPostRenderer {
         mWeakWebView = new WeakReference<>(webView);
         mResourceVars = new ReaderResourceVars(webView.getContext());
         mFeaturedImageUtils = featuredImageUtils;
+        mCssProvider = cssProvider;
 
         mMinFullSizeWidthDp = pxToDp(mResourceVars.mFullSizeImageWidthPx / 3);
         mMinMidSizeWidthDp = mMinFullSizeWidthDp / 2;
@@ -362,7 +365,7 @@ public class ReaderPostRenderer {
         // title isn't necessary, but it's invalid html5 without one
         sbHtml.append("<title>Reader Post</title>")
               .append("<link rel=\"stylesheet\" type=\"text/css\"\n"
-                      + "          href=\"https://wordpress.com/calypso/reader-mobile.css\">");
+                      + "          href=\"" + mCssProvider.getCssUrl() + "\">");
         // https://developers.google.com/chrome/mobile/docs/webview/pixelperfect
         sbHtml.append("<meta name='viewport' content='width=device-width, initial-scale=1'>")
               .append("<style type='text/css'>");

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
@@ -35,6 +35,7 @@ public class ReaderPostWebViewCachingFragment extends DaggerFragment {
     private long mPostId;
 
     @Inject FeaturedImageUtils mFeaturedImageUtils;
+    @Inject ReaderCssProvider mReaderCssProvider;
 
     public static ReaderPostWebViewCachingFragment newInstance(long blogId, long postId) {
         ReaderPostWebViewCachingFragment fragment = new ReaderPostWebViewCachingFragment();
@@ -73,7 +74,7 @@ public class ReaderPostWebViewCachingFragment extends DaggerFragment {
             });
 
             ReaderPostRenderer rendered =
-                    new ReaderPostRenderer((ReaderWebView) view, post, mFeaturedImageUtils);
+                    new ReaderPostRenderer((ReaderWebView) view, post, mFeaturedImageUtils, mReaderCssProvider);
             rendered.beginRender(); // rendering will cache post content using native WebView implementation.
         } else {
             // abort mission if no network is available

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderCssProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderCssProviderTest.kt
@@ -1,0 +1,90 @@
+package org.wordpress.android.ui.reader
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.reader.utils.DateProvider
+import org.wordpress.android.util.NetworkUtilsWrapper
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+@RunWith(MockitoJUnitRunner::class)
+class ReaderCssProviderTest {
+    private val networkUtilsWrapper: NetworkUtilsWrapper = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
+    private val dateProvider: DateProvider = mock()
+
+    private lateinit var cssProvider: ReaderCssProvider
+
+    @Before
+    fun setup() {
+        cssProvider = ReaderCssProvider(networkUtilsWrapper, appPrefsWrapper, dateProvider)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+    }
+
+    @Test
+    fun `url with current date suffix is returned when css expired`() {
+        // Arrange
+        val currentDate = TimeUnit.DAYS.toMillis(EXPIRATION_IN_DAYS + 1)
+        val lastUpdated = 0L
+
+        whenever(dateProvider.getCurrentDate()).thenReturn(Date(currentDate))
+        whenever(appPrefsWrapper.readerCssUpdatedTimestamp).thenReturn(lastUpdated)
+        // Act
+        val result = cssProvider.getCssUrl()
+        // Assert
+        assertThat(result.substringAfter("?")).isEqualTo(currentDate.toString())
+    }
+
+    @Test
+    fun `url with lastUpdated suffix is returned when css NOT expired`() {
+        // Arrange
+        val currentDate = getNotExpiredDate()
+        val lastUpdated = 0L
+
+        whenever(dateProvider.getCurrentDate()).thenReturn(Date(currentDate))
+        whenever(appPrefsWrapper.readerCssUpdatedTimestamp).thenReturn(lastUpdated)
+        // Act
+        val result = cssProvider.getCssUrl()
+        // Assert
+        assertThat(result.substringAfter("?")).isEqualTo(lastUpdated.toString())
+    }
+
+    @Test
+    fun `url with lastUpdated suffix is returned when device offline even when expired`() {
+        // Arrange
+        val currentDate = getExpiredDate()
+        val lastUpdated = 0L
+
+        whenever(dateProvider.getCurrentDate()).thenReturn(Date(currentDate))
+        whenever(appPrefsWrapper.readerCssUpdatedTimestamp).thenReturn(lastUpdated)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+        // Act
+        val result = cssProvider.getCssUrl()
+        // Assert
+        assertThat(result.substringAfter("?")).isEqualTo(lastUpdated.toString())
+    }
+
+    @Test
+    fun `currentDate is saved into shared preferences when css expired`() {
+        // Arrange
+        val currentDate = getExpiredDate()
+        val lastUpdated = 0L
+
+        whenever(dateProvider.getCurrentDate()).thenReturn(Date(currentDate))
+        whenever(appPrefsWrapper.readerCssUpdatedTimestamp).thenReturn(lastUpdated)
+        // Act
+        cssProvider.getCssUrl()
+        // Assert
+        verify(appPrefsWrapper).readerCssUpdatedTimestamp = currentDate
+    }
+
+    private fun getExpiredDate() = TimeUnit.DAYS.toMillis(EXPIRATION_IN_DAYS + 1)
+    private fun getNotExpiredDate() = TimeUnit.DAYS.toMillis(EXPIRATION_IN_DAYS - 1)
+}


### PR DESCRIPTION
Goal of this PR is to make sure Reader css styles get re-fetched every 5 days. 

The css file returned from the server has cache set to "infinity", so if the user fetched the file it'd never get re-fetched. We decided to introduce this naive implementation which simply changes the url every 5 days.

We are aware that if the user is online at the time of the expiration check but we fail to fetch the css file, the reader will look broken. But imo, it's a minor edge case issue.

To test:
1. Open Reader
2. Open a post
3. Use debugger or sniffer to check the css file url
4. Update the date on your device 4 days into the future
5. Repeat 1-3 and make sure the url is the same
6. Update the date on your device another 2 days into the future
7.  Repeat 1-3 and make sure the url is updated


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @leandroalonso 
