### PR TITLE
Unified Login & Sign-Up: Add tracking to Signup Confirmation screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -132,7 +132,8 @@ class UnifiedLoginTracker
         LOGIN_MAGIC_LINK("login_magic_link"),
         LOGIN_PASSWORD("login_password"),
         LOGIN_SITE_ADDRESS("login_site_address"),
-        SIGNUP("signup")
+        SIGNUP("signup"),
+        GOOGLE_SIGNUP("google_signup")
     }
 
     enum class Step(val value: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -174,7 +174,8 @@ class UnifiedLoginTracker
         EDIT_USERNAME("edit_username"),
         HELP_FINDING_SITE_ADDRESS("help_finding_site_address"),
         SELECT_EMAIL_FIELD("select_email_field"),
-        PICK_EMAIL_FROM_HINT("pick_email_from_hint")
+        PICK_EMAIL_FROM_HINT("pick_email_from_hint"),
+        CREATE_ACCOUNT("create_account")
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -364,4 +364,9 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     public void trackSocialSignupConfirmationViewed() {
         mUnifiedLoginTracker.track(Flow.GOOGLE_SIGNUP, Step.START);
     }
+
+    @Override
+    public void trackCreateAccountClick() {
+        mUnifiedLoginTracker.trackClick(Click.CREATE_ACCOUNT);
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -354,4 +354,14 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     public void emailFormScreenResumed() {
         mUnifiedLoginTracker.setFlowAndStep(Flow.WORDPRESS_COM, Step.START);
     }
+
+    @Override
+    public void trackEmailSignupConfirmationViewed() {
+        mUnifiedLoginTracker.track(Flow.SIGNUP, Step.START);
+    }
+
+    @Override
+    public void trackSocialSignupConfirmationViewed() {
+        mUnifiedLoginTracker.track(Flow.GOOGLE_SIGNUP, Step.START);
+    }
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -81,4 +81,6 @@ public interface LoginAnalyticsListener {
     void trackEmailSignupConfirmationViewed();
 
     void trackSocialSignupConfirmationViewed();
+
+    void trackCreateAccountClick();
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -77,4 +77,8 @@ public interface LoginAnalyticsListener {
     void trackShowEmailHints();
 
     void emailFormScreenResumed();
+
+    void trackEmailSignupConfirmationViewed();
+
+    void trackSocialSignupConfirmationViewed();
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
@@ -230,6 +230,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.help) {
+            mAnalyticsListener.trackShowHelpClick();
             if (mLoginListener != null) {
                 mLoginListener.helpMagicLinkRequest(mEmail);
             }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
@@ -139,6 +139,7 @@ public class LoginMagicLinkSentFragment extends Fragment {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.help) {
+            mAnalyticsListener.trackShowHelpClick();
             if (mLoginListener != null) {
                 mLoginListener.helpMagicLinkSent(mEmail);
             }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
@@ -17,6 +17,7 @@ import kotlinx.android.synthetic.main.toolbar_login.*
 import org.wordpress.android.login.util.AvatarHelper.AvatarRequestListener
 import org.wordpress.android.login.util.AvatarHelper.loadAvatarFromEmail
 import org.wordpress.android.login.util.AvatarHelper.loadAvatarFromUrl
+import javax.inject.Inject
 
 class SignupConfirmationFragment : Fragment() {
     private var mLoginListener: LoginListener? = null
@@ -27,6 +28,8 @@ class SignupConfirmationFragment : Fragment() {
     private var mPhotoUrl: String? = null
     private var mService: String? = null
     private var mIsSocialSignup: Boolean = false
+
+    @Inject lateinit var mAnalyticsListener: LoginAnalyticsListener
 
     companion object {
         const val TAG = "signup_confirmation_fragment_tag"
@@ -131,7 +134,11 @@ class SignupConfirmationFragment : Fragment() {
         }
 
         if (savedInstanceState == null) {
-            // TODO Track screen
+            if (mIsSocialSignup) {
+                mAnalyticsListener.trackSocialSignupConfirmationViewed()
+            } else {
+                mAnalyticsListener.trackEmailSignupConfirmationViewed()
+            }
         }
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupConfirmationFragment.kt
@@ -122,6 +122,7 @@ class SignupConfirmationFragment : Fragment() {
             label.setText(R.string.signup_confirmation_message)
             signup_confirmation_button.setText(R.string.create_account)
             signup_confirmation_button.setOnClickListener {
+                mAnalyticsListener.trackCreateAccountClick()
                 mLoginListener?.showSignupSocial(mEmail, mDisplayName, mIdToken, mPhotoUrl, mService)
             }
         } else {
@@ -129,6 +130,7 @@ class SignupConfirmationFragment : Fragment() {
             label.setText(R.string.signup_confirmation_magic_link_message)
             signup_confirmation_button.setText(R.string.send_link_by_email)
             signup_confirmation_button.setOnClickListener {
+                mAnalyticsListener.trackRequestMagicLinkClick()
                 mLoginListener?.showSignupMagicLink(mEmail)
             }
         }
@@ -159,6 +161,7 @@ class SignupConfirmationFragment : Fragment() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.help) {
+            mAnalyticsListener.trackShowHelpClick()
             if (mLoginListener != null) {
                 mLoginListener?.helpSignupConfirmationScreen(mEmail)
             }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupMagicLinkFragment.java
@@ -157,6 +157,7 @@ public class SignupMagicLinkFragment extends Fragment {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.help) {
+            mAnalyticsListener.trackShowHelpClick();
             if (mLoginListener != null) {
                 mLoginListener.helpSignupMagicLinkScreen(mEmail);
             }


### PR DESCRIPTION
This PR adds screen tracking and click tracking to the Signup Confirmation screen (added in #12056). 

It also adds a missing click tracking to the Help button on the following screens: `LoginMagicLinkRequestFragment`, `LoginMagicLinkSentFragment` and `SignupMagicLinkFragment`.

## To test

**Email Signup**

0. Clear app data.
1. On the Prologue Screen, tap **Continue with WordPress.com**.
2. On the Email Screen, enter an email address that **_is not_** associated with a WordPress.com account.
3. Tap **Continue**.
4. Notice the Sign-Up Confirmation screen.
5. Notice the following event in Logcat: `unified_login_step` with `flow = signup` and `step = start`.
6. Tap the **?** icon on the toolbar.
7. Notice the following event in Logcat: `unified_login_interaction` with `flow = signup`, `step = start` and `click = show_help`.
8. Close the Help dialog.
9. Tap **Send link by email**.
10. Notice the following event in Logcat: `unified_login_interaction` with `flow = signup`, `step = start` and `click = request_magic_link`.

**Social Signup**

0. Clear app data.
1. On the Prologue Screen, tap **Continue with WordPress.com**.
2. On the Email Screen, tap **Continue with Google**.
3. Pick a Google account that **_is not_** associated with a WordPress.com account.
4. Notice the Sign-Up Confirmation screen.
5. Notice the following event in Logcat: `unified_login_step` with `flow = google_signup` and `step = start`.
6. Tap the **?** icon on the toolbar.
7. Notice the following event in Logcat: `unified_login_interaction` with `flow = google_signup`, `step = start` and `click = show_help`.
8. Close the Help dialog.
9. Tap **Create account**.
10. Notice the following event in Logcat: `unified_login_interaction` with `flow = google_signup`, `step = start` and `click = create_account`.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
