### PR TITLE
Unified Login & Sign-Up: Fix tracking source for default login flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -791,8 +791,14 @@ public class ActivityLauncher {
     }
 
     public static void showSignInForResult(Activity activity) {
+        showSignInForResult(activity, false);
+    }
+
+    public static void showSignInForResult(Activity activity, boolean isWpComOnly) {
         Intent intent = new Intent(activity, LoginActivity.class);
-        WPCOM_LOGIN_ONLY.putInto(intent);
+        if (isWpComOnly) {
+            WPCOM_LOGIN_ONLY.putInto(intent);
+        }
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -149,7 +149,7 @@ public class MeFragment extends Fragment implements MainToolbarFragment, WPMainA
             if (mAccountStore.hasAccessToken()) {
                 signOutWordPressComWithConfirmation();
             } else {
-                ActivityLauncher.showSignInForResult(getActivity());
+                ActivityLauncher.showSignInForResult(getActivity(), true);
             }
         });
 


### PR DESCRIPTION
Fixes #12268

This PR adds the new method `ActivityLauncher.showSignInForResult(Activity activity, boolean isWpComOnly)` in addition to the existing `ActivityLauncher.showSignInForResult(Activity activity)` so we can correctly identify login flows that are started from the Me screen.

## To test

**Default**

0. Clear app data.
1. Open the app.
2. Notice the following event in Logcat: `unified_login_step` with `source = default`.

**Add WordPress.com Account**

0. Clear app data.
1. Login with a self-hosted site.
2. Go to the _**Me**_ screen.
3. Tap **Log in to WordPress.com**. 
4. Notice the following event in Logcat: `unified_login_step` with `source = add_wordpress_com_account`.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
