### PR TITLE
Added a special focus point position for VIEW_SITE task

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -1213,16 +1213,24 @@ class MySiteFragment : Fragment(),
         val focusPointSize = resources.getDimensionPixelOffset(R.dimen.quick_start_focus_point_size)
         val horizontalOffset: Int
         val verticalOffset: Int
-        if (isTargetingBottomNavBar(activeTutorialPrompt!!.task)) {
-            horizontalOffset = quickStartTarget.width / 2 - focusPointSize + resources
-                    .getDimensionPixelOffset(R.dimen.quick_start_focus_point_bottom_nav_offset)
-            verticalOffset = 0
-        } else if (activeTutorialPrompt!!.task == UPLOAD_SITE_ICON) {
-            horizontalOffset = focusPointSize
-            verticalOffset = -focusPointSize / 2
-        } else {
-            horizontalOffset = resources.getDimensionPixelOffset(R.dimen.quick_start_focus_point_my_site_right_offset)
-            verticalOffset = (quickStartTarget.height - focusPointSize) / 2
+        when {
+            isTargetingBottomNavBar(activeTutorialPrompt!!.task) -> {
+                horizontalOffset = quickStartTarget.width / 2 - focusPointSize + resources
+                        .getDimensionPixelOffset(R.dimen.quick_start_focus_point_bottom_nav_offset)
+                verticalOffset = 0
+            }
+            activeTutorialPrompt!!.task == UPLOAD_SITE_ICON -> {
+                horizontalOffset = focusPointSize
+                verticalOffset = -focusPointSize / 2
+            }
+            activeTutorialPrompt!!.task == VIEW_SITE -> { // focus point might be hidden behind FAB
+                horizontalOffset = (focusPointSize / 0.5).toInt()
+                verticalOffset = (quickStartTarget.height - focusPointSize) / 2
+            }
+            else -> {
+                horizontalOffset = resources.getDimensionPixelOffset(R.dimen.quick_start_focus_point_my_site_right_offset)
+                verticalOffset = (quickStartTarget.height - focusPointSize) / 2
+            }
         }
         addQuickStartFocusPointAboveTheView(
                 parentView, quickStartTarget, horizontalOffset,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -1228,7 +1228,8 @@ class MySiteFragment : Fragment(),
                 verticalOffset = (quickStartTarget.height - focusPointSize) / 2
             }
             else -> {
-                horizontalOffset = resources.getDimensionPixelOffset(R.dimen.quick_start_focus_point_my_site_right_offset)
+                horizontalOffset =
+                        resources.getDimensionPixelOffset(R.dimen.quick_start_focus_point_my_site_right_offset)
                 verticalOffset = (quickStartTarget.height - focusPointSize) / 2
             }
         }

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -10,7 +10,9 @@
         android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="@dimen/toolbar_height">
+        android:layout_marginTop="@dimen/toolbar_height"
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/my_site_bottom_spacing">
 
         <!-- used to host quick start focus view - must be RelativeLayout or FrameLayout -->
         <RelativeLayout

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -267,6 +267,7 @@
     <dimen name="my_site_blavatar_container_corner_radius">4dp</dimen>
     <dimen name="my_site_blavatar_container_border_width">0.5dp</dimen>
     <dimen name="my_site_blavatar_corner_radius">2dp</dimen>
+    <dimen name="my_site_bottom_spacing">64dp</dimen>
 
     <!--me-->
     <dimen name="me_list_row_icon_size">24dp</dimen>


### PR DESCRIPTION
Fixes #12257

This PR moves a position of a focus point for the VIEW_SITE task so it would not be covered by FAB.
![Screenshot_1593054088](https://user-images.githubusercontent.com/728822/85648380-82229000-b655-11ea-883e-33fe8e7a7395.png)

To test:
- Create new site and start Quick Start.
- Navigate to `Customize Your Site` tasks, and select `View Your Site`.
- Find a focus point on new View Site row on MySite screen, and make sure it's not obstructed by FAB.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
