### PR TITLE
WP Stories: Set navigation bar to black

### DIFF
--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -84,6 +84,7 @@
     </style>
 
     <style name="WordPress.Stories.Immersive" parent="WordPress.NoActionBar">
+        <item name="android:navigationBarColor">@android:color/black</item>
     </style>
 
     <style name="WordPress.Editor.NoActionBar" parent="WordPress.NoActionBar">


### PR DESCRIPTION
Fixes https://github.com/Automattic/portkey-android/issues/365, setting the navigation bar to black in the stories creation experience (overriding the default white nav bar in the WordPress app).

This only affects API27+: the nav bar is fine on earlier API levels since we only [change the nav bar to white for those API levels](https://github.com/wordpress-mobile/WordPress-Android/blob/032bd1b56ed2774f79635cff5ae615ce327044cc/WordPress/src/main/res/values-v27/styles.xml).

![beforeafter](https://user-images.githubusercontent.com/9613966/85671218-9ff70000-b6fc-11ea-8c85-0c731eca9c56.png)

#### To test:
On various API levels, load the story creator and verify the navigation bar is always black.

Also check that things work fine on dark mode - from my testing the issue didn't appear on dark mode as the nav bar is set to black anyway.

#### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
