### PR TITLE
Switch to dedicated file on develop to upload strings for translation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -69,6 +69,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
 
     localize_gutenberg(skip_module_update: true)
     localize_libs()
+    send_strings_for_translation()
     ensure_git_status_clean()
     get_prs_list(repository:GHHELPER_REPO, start_tag:"release/#{old_version}", report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{new_version}.txt")
   end
@@ -360,10 +361,17 @@ ENV["HAS_ALPHA_VERSION"]="true"
 # Dependencies handling lanes
 ########################################################################
   main_strings_path = "./WordPress/src/main/res/values/strings.xml"
+  update_strings_path = "./fastlane/resources/values/"
   libraries_strings_path = [
     {library: "Login Library", strings_path: "./libs/login/WordPressLoginFlow/src/main/res/values/strings.xml", exclusions: ["default_web_client_id"]},
     {library: "Image Editor", strings_path: "./libs/image-editor/ImageEditor/src/main/res/values/strings.xml", exclusions: []}
   ]
+
+  private_lane :send_strings_for_translation do | options |
+    sh("cd .. && mkdir -p #{update_strings_path} && cp #{main_strings_path} #{update_strings_path} && git add #{update_strings_path}strings.xml")
+    sh("git diff-index --quiet HEAD || git commit -m \"Send strings to translation.\"")
+    sh("git push origin HEAD")
+  end
 
   private_lane :commit_strings do | options |
     if (options[:auto_commit]) then

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1,0 +1,3059 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <string name="app_name" translatable="false">WordPress</string>
+
+    <!-- account setup -->
+    <string name="xmlrpc_missing_method_error">Couldn\'t connect. Required XML-RPC methods are missing on the server.</string>
+    <string name="xmlrpc_post_blocked_error">Couldn\'t connect. Your host is blocking POST requests, and the app needs
+        that in order to communicate with your site. Contact your host to solve this problem.</string>
+    <string name="xmlrpc_endpoint_forbidden_error">Couldn\'t connect. We received a 403 error when trying to access your
+        site XMLRPC endpoint. The app needs that in order to communicate with your site. Contact your host to solve
+        this problem.</string>
+    <string name="no_network_title">No network available</string>
+    <string name="no_network_message">There is no network available</string>
+    <string name="sign_out_wpcom_confirm_with_changes">You have changes to posts that haven’t been uploaded to your site. Logging out now will delete those changes from your device. Log out anyway?</string>
+    <string name="sign_out_wpcom_confirm_with_no_changes">Log out of WordPress?</string>
+
+    <!-- form labels -->
+    <string name="select_categories">Select categories</string>
+    <string name="tags_separate_with_commas">Separate tags with commas</string>
+    <string name="max_thumbnail_px_size">Maximum Image Size</string>
+    <string name="image_quality">Image Quality</string>
+    <string name="max_video_resolution">Maximum Video Size</string>
+    <string name="video_quality">Video Quality</string>
+    <string name="password">Password</string>
+
+    <!-- comment form labels -->
+    <string name="anonymous">Anonymous</string>
+
+    <!-- Screen titles -->
+    <string name="release_notes_screen_title">Release notes</string>
+    <string name="license_screen_title">License</string>
+    <string name="help_screen_title">Help and Support</string>
+    <string name="notif_settings_screen_title">Notification settings</string>
+    <string name="my_site_section_screen_title">My site</string>
+    <string name="me_section_screen_title">Me</string>
+    <string name="reader_screen_title">Reader</string>
+    <string name="notifications_screen_title">Notifications</string>
+    <string name="publicize_buttons_screen_title">Sharing buttons</string>
+    <string name="media_settings_screen_title">File details</string>
+    <string name="person_detail_screen_title">Person detail</string>
+    <string name="login_epilogue_screen_title">Logged in as</string>
+    <string name="login_prologue_screen_title">Login</string>
+    <string name="signup_epilogue_screen_title">New account</string>
+    <string name="share_intent_screen_title">Pick site</string>
+    <string name="edit_photo_screen_title">Edit Photo</string>
+    <string name="notif_detail_screen_title">Notification detail %s</string>
+
+    <!-- general strings -->
+    <string name="posts">Posts</string>
+    <string name="sites">Sites</string>
+    <string name="media">Media</string>
+    <string name="themes">Themes</string>
+    <string name="about_the_app">About the app</string>
+    <string name="username">Username</string>
+    <string name="cancel">Cancel</string>
+    <string name="save">Save</string>
+    <string name="add">Add</string>
+    <string name="remove">Remove</string>
+    <string name="removed">Removed</string>
+    <string name="search">Search</string>
+    <string name="show">Show</string>
+    <string name="hide">Hide</string>
+    <string name="select_all">Select all</string>
+    <string name="deselect_all">Deselect all</string>
+    <string name="sure_to_remove_account">Remove this site from the app?</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
+    <string name="error">Error</string>
+    <string name="connection_error">Connection error</string>
+    <string name="connection_to_server_lost">The connection to the server was lost</string>
+    <string name="category_refresh_error">Category refresh error</string>
+    <string name="incorrect_credentials">Incorrect username or password.</string>
+    <string name="cancel_edit">Cancel edit</string>
+    <string name="gallery_error">The media item couldn\'t be retrieved</string>
+    <string name="refresh">Refresh</string>
+    <string name="report_bug">Report bug</string>
+    <string name="blog_not_found">An error occurred when accessing this blog</string>
+    <string name="post_not_found">An error occurred when loading the post. Refresh your posts and try again.</string>
+    <string name="sign_in">Log in</string>
+    <string name="signing_out">Logging out…</string>
+    <string name="sign_in_wpcom">Log in to WordPress.com</string>
+    <string name="learn_more">Learn more</string>
+    <string name="uploading_post">Uploading \"%s\"</string>
+    <string name="language">Language</string>
+    <string name="interface_language">Interface Language</string>
+    <string name="signout">Log out</string>
+    <string name="undo">Undo</string>
+    <string name="never">Never</string>
+    <string name="unknown">Unknown</string>
+    <string name="off">Off</string>
+    <string name="could_not_load_page">Could not load page</string>
+    <string name="send">Send</string>
+    <string name="swipe_for_more">Swipe for more</string>
+    <string name="confirm">Confirm</string>
+    <string name="cant_open_url">Unable to open the link</string>
+    <string name="retry">Retry</string>
+    <string name="invalid_ip_or_range">Invalid IP or IP range</string>
+    <string name="copy_text">Copy</string>
+    <string name="error_please_choose_browser">Error opening the default web browser. Please choose another app:</string>
+    <string name="delete_yes">Delete</string>
+    <string name="add_count">Add %d</string>
+    <string name="preview_count">Preview %d</string>
+    <string name="dismiss">dismiss</string>
+    <string name="exit">exit</string>
+    <string name="ok">OK</string>
+    <string name="site_cannot_be_loaded">We cannot load the data for your site right now. Please try again later</string>
+    <string name="local_draft">Local draft</string>
+    <string name="local_changes">Local changes</string>
+    <string name="continue_label">Continue</string>
+    <string name="publish_now">Publish Now</string>
+    <string name="update_now">Update Now</string>
+    <string name="status_and_visibility">Status &amp; Visibility</string>
+
+    <string name="button_not_now">Not now</string>
+
+    <string name="latitude_longitude">%1$f, %2$f</string>
+    <string name="at_username">\@%s</string>
+
+    <string name="me">Me</string>
+    <string name="everyone">Everyone</string>
+
+    <!-- CAB -->
+    <string name="cab_selected">%d selected</string>
+
+    <!-- Media  -->
+    <string name="media_all">All</string>
+    <string name="media_images">Images</string>
+    <string name="media_documents">Documents</string>
+    <string name="media_videos">Videos</string>
+    <string name="media_audio">Audio</string>
+    <string name="media_gallery_column_count_single">1 column</string>
+    <string name="media_gallery_column_count_multi">%d columns</string>
+    <string name="media_gallery_type_thumbnail_grid">Thumbnail grid</string>
+    <string name="media_gallery_type_squares">Squares</string>
+    <string name="media_gallery_type_tiled">Tiled</string>
+    <string name="media_gallery_type_circles">Circles</string>
+    <string name="media_gallery_type_slideshow">Slideshow</string>
+    <string name="media_insert_title">Add multiple photos</string>
+    <string name="media_insert_individually">Add individually</string>
+    <string name="media_insert_as_gallery">Add as gallery</string>
+    <string name="media_downloading">Saving media to this device</string>
+    <string name="wp_media_title">WordPress media</string>
+    <string name="pick_photo">Select photo</string>
+    <string name="pick_video">Select video</string>
+    <string name="pick_media">Add image or video</string>
+    <string name="capture_or_pick_photo">Capture or select photo</string>
+    <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
+    <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
+    <string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
+    <string name="media_error_http_too_large_photo_upload">Image too large to upload. Try changing Optimize Images in your app\'s settings</string>
+    <string name="media_error_http_too_large_video_upload">Video too large to upload</string>
+    <string name="media_error_exceeds_php_filesize">File exceeds the maximum upload size for this site</string>
+    <string name="media_error_exceeds_memory_limit">File too large to be uploaded on this site</string>
+    <string name="media_error_internal_server_error">Upload error. Try changing Optimize Images in your app\'s settings</string>
+    <string name="media_error_timeout">Server took too long to respond</string>
+    <string name="share_media_permission_required">Permissions required in order to share images or videos</string>
+    <string name="media_fetching">Fetching media…</string>
+    <string name="media_upload_error">Media upload error occurred</string>
+    <string name="media_generic_error">Media error occurred</string>
+    <string name="media_space_used">%1$s used</string>
+    <string name="media_accessing_progress">Accessing content of a private site</string>
+    <string name="media_accessing_failed">Failed to access content of a private site. Some media might be unavailable</string>
+
+    <string name="media_upload_state_queued">Queued</string>
+    <string name="media_upload_state_uploading">Uploading</string>
+    <string name="media_upload_state_deleting">Deleting</string>
+    <string name="media_upload_state_deleted">Deleted</string>
+    <string name="media_upload_state_failed">Upload Failed</string>
+    <string name="media_upload_state_uploaded">Uploaded</string>
+
+    <string name="media_encoder_quality_80">Low</string>
+    <string name="media_encoder_quality_85">Medium</string>
+    <string name="media_encoder_quality_90">High</string>
+    <string name="media_encoder_quality_95">Very High</string>
+    <string name="media_encoder_quality_100">Maximum</string>
+
+    <!-- Edit Media -->
+    <string name="media_edit_title_text">Title</string>
+    <string name="media_edit_caption_text">Caption</string>
+    <string name="media_edit_alttext_text">Alt text</string>
+    <string name="media_edit_description_text">Description</string>
+    <string name="media_edit_link_text">Link to</string>
+    <string name="media_edit_link_hint">Open link in a new window/tab</string>
+    <string name="media_edit_failure">Failed to update</string>
+    <string name="media_edit_file_details_card_caption">File Details</string>
+    <string name="media_edit_customize_card_caption">Customize</string>
+    <string name="media_edit_url_caption">URL</string>
+    <string name="media_edit_filename_caption">File Name</string>
+    <string name="media_edit_filetype_caption">File Type</string>
+    <string name="media_edit_image_dimensions_caption">Image Dimensions</string>
+    <string name="media_edit_video_dimensions_caption">Video Dimensions</string>
+    <string name="media_edit_duration_caption">Duration</string>
+    <string name="media_edit_upload_date_caption">Upload Date</string>
+    <string name="media_edit_copy_url_toast">URL copied to clipboard</string>
+    <string name="fab_content_description_preview">Preview</string>
+
+    <!-- Media settings title -->
+    <string name="media_title_image_details">Image details</string>
+    <string name="media_title_video_details">Video details</string>
+    <string name="media_title_audio_details">Audio details</string>
+    <string name="media_title_document_details">Document details</string>
+
+    <!-- Delete Media -->
+    <string name="cannot_delete_multi_media_items">Some media can\'t be deleted at this time. Try again later.</string>
+    <string name="cannot_retry_deleted_media_item">Media has been removed. Delete it from this post?</string>
+    <string name="media_empty_list">You don\'t have any media</string>
+    <string name="media_empty_search_list">No media matching your search</string>
+    <string name="media_empty_image_list">You don\'t have any images</string>
+    <string name="media_empty_videos_list">You don\'t have any videos</string>
+    <string name="media_empty_documents_list">You don\'t have any documents</string>
+    <string name="media_empty_audio_list">You don\'t have any audio</string>
+    <string name="media_empty_upload_media">Upload media</string>
+    <string name="delete">Delete</string>
+    <string name="confirm_delete_media_image">Delete this image?</string>
+    <string name="confirm_remove_media_image">Remove this image from the post?</string>
+    <string name="confirm_delete_media_video">Delete this video?</string>
+    <string name="deleting_media_dlg">Deleting</string>
+    <string name="remove_image_from_post">Remove from post</string>
+
+    <!-- themes -->
+    <string name="themes_fetching">Fetching themes…</string>
+
+    <string name="theme_activate_button">Activate</string>
+    <string name="theme_fetch_failed">Failed to fetch themes</string>
+    <string name="theme_no_search_result_found">Sorry, no themes found.</string>
+
+    <!-- link view -->
+    <string name="link_enter_url">URL</string>
+    <string name="link_enter_url_text">Link text (optional)</string>
+    <string name="link_open_new_window">Open link in a new window/tab</string>
+
+    <!-- page view -->
+    <string name="title">Title</string>
+    <string name="pages_empty_list_button">Create a page</string>
+    <string name="page_settings">Page settings</string>
+    <string name="pages">Pages</string>
+    <string name="set_parent">Set Parent</string>
+    <string name="page_delete_error">There was a problem deleting the page</string>
+    <string name="page_status_change_error">There was a problem changing the page status</string>
+    <string name="page_parent_change_error">There was a problem changing the page parent</string>
+    <string name="page_delete_dialog_message">Are you sure you want to delete page %s?</string>
+    <string name="top_level">Top level</string>
+    <string name="page_moved_to_draft">Page has been moved to Drafts</string>
+    <string name="page_moved_to_trash">Page has been trashed</string>
+    <string name="page_moved_to_published">Page has been published</string>
+    <string name="page_moved_to_scheduled">Page has been scheduled</string>
+    <string name="page_permanently_deleted">Page has been permanently deleted</string>
+    <string name="page_parent_changed">Page parent has been changed</string>
+
+    <string name="page_cannot_set_homepage">To set Homepage enable \"Static Homepage\" in Site Settings</string>
+    <string name="page_cannot_set_posts_page">To set Posts page enable \"Static Homepage\" in Site Settings</string>
+    <string name="page_homepage_successfully_updated">Homepage successfully updated</string>
+    <string name="page_homepage_update_failed">Homepage update failed</string>
+    <string name="page_posts_page_successfully_updated">Posts Page successfully updated</string>
+    <string name="page_posts_page_update_failed">Posts Page update failed</string>
+
+    <!-- posts tab -->
+    <string name="posts_cannot_be_started">We cannot open the posts right now. Please try again later</string>
+    <string name="untitled">Untitled</string>
+    <string name="untitled_in_parentheses">(Untitled)</string>
+    <string name="post_uploading">Uploading post</string>
+    <string name="post_uploading_draft">Uploading draft</string>
+    <string name="post_queued">Queued post</string>
+    <string name="posts_empty_list">No posts yet. Why not create one?</string>
+    <string name="posts_empty_list_button">Create a post</string>
+    <string name="empty_list_default">This list is empty</string>
+    <string name="posts_published_empty">You haven\'t published any posts yet</string>
+    <string name="posts_scheduled_empty">You don\'t have any scheduled posts</string>
+    <string name="posts_draft_empty">You don\'t have any draft posts</string>
+    <string name="posts_trashed_empty">You don\'t have any trashed posts</string>
+    <string name="multiple_status_label_delimiter" translatable="false">\u0020·\u0020</string>
+    <string name="post_list_toggle_item_layout_cards_view">Switch to cards view</string>
+    <string name="post_list_toggle_item_layout_list_view">Switch to list view</string>
+    <string name="post_waiting_for_connection_publish">We\'ll publish the post when your device is back online.</string>
+    <string name="post_waiting_for_connection_pending">We\'ll submit your post for review when your device is back online.</string>
+    <string name="post_waiting_for_connection_scheduled">We\'ll schedule your post when your device is back online.</string>
+    <string name="post_waiting_for_connection_private">We\'ll publish your private post when your device is back online.</string>
+    <string name="post_waiting_for_connection_draft">We\'ll save your draft when your device is back online</string>
+    <string name="post_waiting_for_connection_publish_cancel"> We won\'t publish these changes.</string>
+    <string name="post_waiting_for_connection_pending_cancel">We won\'t submit these changes for review. </string>
+    <string name="post_waiting_for_connection_scheduled_cancel">We won\'t schedule these changes.</string>
+    <string name="post_waiting_for_connection_draft_cancel">We won\'t save the latest changes to your draft.</string>
+
+    <!-- buttons on post cards -->
+    <string name="button_edit">Edit</string>
+    <string name="button_publish">Publish</string>
+    <string name="button_sync">Sync</string>
+    <string name="button_view">View</string>
+    <string name="button_preview">Preview</string>
+    <string name="button_insert">Insert</string>
+    <string name="button_stats">Stats</string>
+    <string name="button_trash">Trash</string>
+    <string name="button_delete_permanently">Delete Permanently</string>
+    <string name="button_delete" translatable="false">@string/delete</string>
+    <string name="button_more" translatable="false">@string/more</string>
+    <string name="button_discard">Discard</string>
+    <string name="button_retry">Retry</string>
+    <string name="button_move_to_draft">Move to Draft</string>
+
+    <!-- post uploads -->
+    <string name="upload_failed_param">Upload failed for \"%s\"</string>
+
+    <string name="media_file_post_singular_mixed_not_uploaded_one_file">1 post with 1 file not uploaded</string>
+    <string name="media_file_posts_plural_mixed_not_uploaded_one_file">%1$d posts with 1 file not uploaded</string>
+    <string name="media_file_page_singular_mixed_not_uploaded_one_file">1 page with 1 file not uploaded</string>
+    <string name="media_file_pages_plural_mixed_not_uploaded_one_file">%1$d pages with 1 file not uploaded</string>
+    <string name="media_file_pages_and_posts_mixed_not_uploaded_one_file">%1$d posts / pages with 1 file not uploaded</string>
+
+    <string name="media_file_post_singular_mixed_not_uploaded_files_plural">1 post with %1$d files not uploaded</string>
+    <string name="media_file_posts_plural_mixed_not_uploaded_files_plural">%1$d posts with %2$d files not uploaded</string>
+    <string name="media_file_page_singular_mixed_not_uploaded_files_plural">1 page with %1$d files not uploaded</string>
+    <string name="media_file_pages_plural_mixed_not_uploaded_files_plural">%1$d pages with %2$d files not uploaded</string>
+    <string name="media_file_pages_and_posts_mixed_not_uploaded_files_plural">%1$d posts / pages with %2$d files not uploaded</string>
+
+    <string name="media_file_post_singular_only_not_uploaded">1 post not uploaded</string>
+    <string name="media_file_posts_plural_only_not_uploaded">%1$d posts not uploaded</string>
+    <string name="media_file_page_singular_only_not_uploaded">1 page not uploaded</string>
+    <string name="media_file_pages_plural_only_not_uploaded">%1$d pages not uploaded</string>
+    <string name="media_file_pages_and_posts_only_not_uploaded">%1$d posts / pages not uploaded</string>
+
+    <string name="media_files_not_uploaded">%d files not uploaded</string>
+    <string name="media_files_uploaded">%d files uploaded</string>
+    <string name="media_file_not_uploaded">1 file not uploaded</string>
+    <string name="media_file_uploaded">1 file uploaded</string>
+    <string name="media_files_uploaded_successfully">, %d successfully uploaded</string>
+    <string name="media_all_files_uploaded_successfully">%d files uploaded successfully</string>
+    <string name="retry_needs_aztec" translatable="false">Retry only available in the Beta editor</string>
+    <string name="media_files_uploaded_write_post">Write Post</string>
+
+    <!-- post view -->
+    <string name="draft_uploaded">Draft uploaded</string>
+    <string name="post_published">Post published</string>
+    <string name="post_submitted">Post submitted</string>
+    <string name="page_published">Page published</string>
+    <string name="post_scheduled">Post scheduled</string>
+    <string name="page_scheduled">Page scheduled</string>
+    <string name="post_updated">Post updated</string>
+    <string name="page_updated">Page updated</string>
+    <string name="file_not_found">Couldn\'t find the file for upload. Was it deleted or moved?</string>
+    <string name="delete_post">Delete post?</string>
+    <string name="delete_page">Delete page?</string>
+    <string name="posts_fetching">Fetching posts…</string>
+    <string name="pages_fetching">Fetching pages…</string>
+    <string name="dialog_confirm_delete_permanently_post">Are you sure you\'d like to permanently delete this post?</string>
+
+    <!-- scheduled post sync confirmation dialog -->
+    <string name="dialog_confirm_scheduled_post_sync_title">Ready to Sync?</string>
+    <string name="dialog_confirm_scheduled_post_sync_message">This post will be synced immediately.</string>
+    <string name="dialog_confirm_scheduled_post_sync_yes">Sync now</string>
+
+    <!-- post version sync conflict dialog -->
+    <string name="dialog_confirm_load_remote_post_title">Resolve sync conflict</string>
+    <string name="dialog_confirm_load_remote_post_body">This post has two versions that are in conflict. Select the version you would like to discard.\n\n</string>
+    <string name="dialog_confirm_load_remote_post_body_2">Local\nSaved on %s\n\nWeb\nSaved on %s\n</string>
+    <string name="dialog_confirm_load_remote_post_discard_local">Discard Local</string>
+    <string name="dialog_confirm_load_remote_post_discard_web">Discard Web</string>
+    <string name="toast_conflict_updating_post">Updating post</string>
+    <string name="snackbar_conflict_local_version_discarded">Local version discarded</string>
+    <string name="snackbar_conflict_web_version_discarded">Web version discarded</string>
+    <string name="snackbar_conflict_undo">Undo</string>
+
+    <!-- post autosave revision dialog -->
+    <string name="dialog_confirm_autosave_title">Which version would you like to edit?</string>
+    <string name="dialog_confirm_autosave_body_first_part">You recently made changes to this post but didn\'t save them. Choose a version to load:\n\n</string>
+    <string name="dialog_confirm_autosave_body_first_part_for_page">You recently made changes to this page but didn\'t save them. Choose a version to load:\n\n</string>
+    <string name="dialog_confirm_autosave_body_second_part">From this app\nSaved on %s\n\nFrom another device\nSaved on %s\n</string>
+    <string name="dialog_confirm_autosave_restore_button">The version from another device</string>
+    <string name="dialog_confirm_autosave_dont_restore_button">The version from this app</string>
+
+    <!-- trash post with local changes dialog -->
+    <string name="dialog_confirm_trash_losing_local_changes_title">Local changes</string>
+    <string name="dialog_confirm_trash_losing_local_changes_message">Trashing this post will discard local changes, are you sure you want to continue?</string>
+
+    <!-- gutenberg informative dialog -->
+    <string name="dialog_gutenberg_informative_title">Block Editor Enabled</string>
+    <string name="dialog_gutenberg_informative_description_post">You\’re now using the block editor for new posts, great! If you\’d like to change to the classic editor, go to \'My Site\' &gt; \'Site Settings\'.</string>
+    <string name="dialog_gutenberg_informative_description_page">You\’re now using the block editor for new pages, great! If you\’d like to change to the classic editor, go to \'My Site\' &gt; \'Site Settings\'.</string>
+    <string name="dialog_gutenberg_informative_description_v2">We made big improvements to the block editor and think it\'s worth a try! We enabled it for new posts and pages but if you\'d like to change to the classic editor, go to \'My Site\' &gt; \'Site Settings\'.</string>
+
+    <!-- reload drop down -->
+    <string name="loading">Loading…</string>
+
+    <!-- comment view -->
+    <string name="on">on</string>
+    <string name="comment_status_approved">Approved</string>
+    <string name="comment_status_unapproved">Pending</string>
+    <string name="comment_status_spam">Spam</string>
+    <string name="comment_status_trash">Trashed</string>
+    <string name="comment_status_all">All</string>
+    <string name="edit_comment">Edit comment</string>
+    <string name="comments_empty_list">No comments yet</string>
+    <string name="comments_empty_list_filtered_approved">No approved comments</string>
+    <string name="comments_empty_list_filtered_pending">No pending comments</string>
+    <string name="comments_empty_list_filtered_spam">No spam comments</string>
+    <string name="comments_empty_list_filtered_trashed">No trashed comments</string>
+    <string name="comment_reply_to_user">Reply to %s</string>
+    <string name="comment_trashed">Comment trashed</string>
+    <string name="comment_spammed">Comment marked as spam</string>
+    <string name="comment_deleted_permanently">Comment deleted</string>
+    <string name="comment">Comment</string>
+    <string name="comments_fetching">Fetching comments…</string>
+    <string name="comment_approved_talkback">Comment approved</string>
+    <string name="comment_unapproved_talkback">Comment unapproved</string>
+    <string name="comment_liked_talkback">Comment liked</string>
+    <string name="comment_unliked_talkback">Comment unliked</string>
+    <string name="comment_trash_talkback">Comment sent to trash</string>
+    <string name="comment_untrash_talkback">Comment restored</string>
+    <string name="comment_delete_talkback">Comment deleted</string>
+    <string name="comment_spam_talkback">Comment marked as spam</string>
+    <string name="comment_unspam_talkback">Comment marked as not spam</string>
+    <string name="comment_title">%s on %s</string>
+    <string name="comment_read_source_post">Read the source post</string>
+    <string name="comment_toast_err_share_intent">Unable to share</string>
+    <string name="comment_share_link_via">Share via</string>
+
+    <!-- comment menu and buttons on comment detail - keep these short! -->
+    <string name="mnu_comment_approve">Approve</string>
+    <string name="mnu_comment_unapprove">Unapprove</string>
+    <string name="mnu_comment_spam">Spam</string>
+    <string name="mnu_comment_unspam">Not spam</string>
+    <string name="mnu_comment_trash">Trash</string>
+    <string name="mnu_comment_untrash">Restore</string>
+    <string name="mnu_comment_delete_permanently">Delete</string>
+    <string name="mnu_comment_liked">Liked</string>
+
+    <!-- comment dialogs - must be worded to work for moderation of single/multiple comments -->
+    <string name="dlg_approving_comments">Approving</string>
+    <string name="dlg_unapproving_comments">Unapproving</string>
+    <string name="dlg_spamming_comments">Marking as spam</string>
+    <string name="dlg_trashing_comments">Sending to trash</string>
+    <string name="dlg_deleting_comments">Deleting comments</string>
+    <string name="dlg_confirm_trash_comments">Send to trash?</string>
+    <string name="dlg_confirm_action_trash">Trash</string>
+    <string name="dlg_cancel_action_dont_trash">Don\'t trash</string>
+
+    <!-- comment actions -->
+    <string name="reply">Reply</string>
+    <string name="trash">Trash</string>
+    <string name="like">Like</string>
+    <string name="approve">Approve</string>
+    <string name="copy_link_address">Copy link address</string>
+    <string name="comment_moderated_approved">Comment approved!</string>
+    <string name="comment_liked">Comment liked</string>
+    <string name="comment_q_action_done_generic">Action done!</string>
+    <string name="comment_q_action_processing">Processing…</string>
+    <string name="comment_q_action_liking">Liking…</string>
+    <string name="comment_q_action_approving">Approving…</string>
+    <string name="comment_q_action_replying">Replying…</string>
+    <string name="comment_q_action_copied_url">Link address copied</string>
+
+    <!-- pending draft local notifications -->
+    <string name="pending_draft_one_day_1">You drafted \'%1$s\' yesterday. Don\'t forget to publish it!</string>
+    <string name="pending_draft_one_day_2">Did you know that \'%1$s\' is still a draft? Publish away!</string>
+    <string name="pending_draft_one_week_1">Your draft \'%1$s\' awaits you - be sure to publish it!</string>
+    <string name="pending_draft_one_week_2">\'%1$s\' remains a draft. Remember to publish it!</string>
+    <string name="pending_draft_one_month">Don\'t leave it hanging! \'%1$s\' is waiting to be published.</string>
+    <string name="pending_draft_one_generic">Don\'t leave it hanging! \'%1$s\' is waiting to be published.</string>
+
+    <!-- edit comment view -->
+    <string name="saving_changes">Saving changes</string>
+    <string name="sure_to_cancel_edit_comment">Cancel editing this comment?</string>
+    <string name="dlg_sure_to_delete_comment">Permanently delete this comment?</string>
+    <string name="dlg_sure_to_delete_comments">Permanently delete these comments?</string>
+    <string name="content_required">Comment is required</string>
+    <string name="toast_comment_unedited">Comment hasn\'t changed</string>
+
+    <!-- context menu -->
+    <string name="remove_account">Remove site</string>
+
+    <!-- post actions -->
+    <string name="post_trashed">Post sent to trash</string>
+    <string name="post_trashing">Post is being trashed</string>
+    <string name="post_restored">Post restored</string>
+    <string name="post_restoring">Post is being restored</string>
+    <string name="post_moving_to_draft">Post is being moved to draft</string>
+
+    <string name="share_link">Share link</string>
+    <string name="view_in_browser">View in browser</string>
+    <string name="preview">Preview</string>
+    <string name="update_verb">Update</string>
+    <string name="uploading_title">Uploading…</string>
+
+    <string name="uploading_subtitle_mixed_page_singular_media_plural">1 page, and %1$d of %2$d files remaining</string>
+    <string name="uploading_subtitle_mixed_post_singular_media_plural">1 post, and %1$d of %2$d files remaining</string>
+    <string name="uploading_subtitle_mixed_pages_plural_media_plural">%1$d pages, and %2$d of %3$d files remaining</string>
+    <string name="uploading_subtitle_mixed_posts_plural_media_plural">%1$d posts, and %2$d of %3$d files remaining</string>
+    <string name="uploading_subtitle_mixed_pages_and_posts_plural_media_plural">%1$d pages / posts, and %2$d of %3$d files remaining</string>
+
+    <string name="uploading_subtitle_mixed_page_singular_media_one">1 page, and 1 file remaining</string>
+    <string name="uploading_subtitle_mixed_post_singular_media_one">1 post, and 1 file remaining</string>
+    <string name="uploading_subtitle_mixed_pages_plural_media_one">%1$d pages, and 1 file remaining</string>
+    <string name="uploading_subtitle_mixed_posts_plural_media_one">%1$d posts, and 1 file remaining</string>
+    <string name="uploading_subtitle_mixed_pages_and_posts_plural_media_one">%1$d pages / posts, and 1 file remaining</string>
+
+    <string name="uploading_subtitle_posts_only_plural">%1$d posts remaining</string>
+    <string name="uploading_subtitle_pages_only_plural">%1$d pages remaining</string>
+    <string name="uploading_subtitle_posts_only_one">1 post remaining</string>
+    <string name="uploading_subtitle_pages_only_one">1 page remaining</string>
+    <string name="uploading_subtitle_pages_posts">%1$d pages / posts remaining</string>
+    <string name="uploading_subtitle_media_only">%1$d of %2$d files remaining</string>
+    <string name="uploading_subtitle_media_only_one">1 file remaining</string>
+    <string name="uploading_media">Uploading media…</string>
+
+    <!-- new account view -->
+    <string name="no_site_error">The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.</string>
+
+    <!-- category management -->
+    <string name="categories">Categories</string>
+    <string name="add_new_category">Add new category</string>
+    <string name="category_name">Category name</string>
+    <string name="category_parent">Parent category (optional):</string>
+    <string name="adding_cat_failed">Adding category failed</string>
+    <string name="adding_cat_success">Category added successfully</string>
+    <string name="cat_name_required">The category name field is required</string>
+    <string name="top_level_category_name">Top level</string>
+
+
+    <!-- action from share intents -->
+    <string name="share_action_post">Add to new post</string>
+    <string name="share_action_media">Add to media library</string>
+    <string name="share_intent_pick_site">Pick site</string>
+    <string name="share_intent_adding_to">Adding to</string>
+    <string name="share_action">Share</string>
+    <string name="cant_share_no_visible_blog">You can\'t share to WordPress without a visible blog</string>
+
+    <!-- file errors -->
+    <string name="file_error_create">Couldn\'t create temp file for media upload. Make sure there is enough free space on your device.</string>
+
+    <!-- SD Card errors -->
+    <string name="sdcard_title">SD Card Required</string>
+    <string name="sdcard_message">A mounted SD card is required to upload media</string>
+
+    <!--     Begin     -->
+    <!-- Site Settings -->
+    <!--               -->
+
+    <!-- General -->
+    <string name="discussion">Discussion</string>
+    <string name="privacy">Privacy</string>
+    <string name="related_posts">Related Posts</string>
+    <string name="more">More</string>
+    <string name="none">None</string>
+    <string name="disabled">Disabled</string>
+    <string name="comments">Comments</string>
+    <string name="close_after">Close after</string>
+    <string name="oldest_first">Oldest first</string>
+    <string name="newest_first">Newest first</string>
+    <string name="days_quantity_one">1 day</string>
+    <string name="days_quantity_other">%d days</string>
+
+    <!-- PreferenceCategory Headers -->
+    <string name="site_settings_general_header">General</string>
+    <string name="site_settings_account_header">Account</string>
+    <string name="site_settings_writing_header">Writing</string>
+    <string name="site_settings_editor">Editor</string>
+    <string name="site_settings_discussion_header" translatable="false">@string/discussion</string>
+    <string name="site_settings_discussion_new_posts_header">Defaults for new posts</string>
+    <string name="site_settings_comments_header" translatable="false">@string/comments</string>
+    <string name="site_settings_advanced_header">Advanced</string>
+    <string name="site_settings_traffic_header">Traffic</string>
+    <string name="site_settings_performance">Performance</string>
+    <string name="site_settings_homepage">Homepage</string>
+
+    <!-- Preference Titles -->
+    <string name="site_settings_title_title">Site Title</string>
+    <string name="site_settings_tagline_title">Tagline</string>
+    <string name="site_settings_address_title">Address</string>
+    <string name="site_settings_privacy_title" translatable="false">@string/privacy</string>
+    <string name="site_settings_language_title" translatable="false">@string/language</string>
+    <string name="site_settings_username_title" translatable="false">@string/username</string>
+    <string name="site_settings_password_title" translatable="false">@string/password</string>
+    <string name="site_settings_password_dialog_title">Update password</string>
+    <string name="site_settings_default_category_title">Default Category</string>
+    <string name="site_settings_tags_empty_button">Create a tag</string>
+    <string name="site_settings_tags_empty_subtitle">Add your frequently used tags here so they can be quickly selected when tagging your posts</string>
+    <string name="site_settings_tags_empty_title">You don\'t have any tags</string>
+    <string name="site_settings_tags_empty_title_search">No tags matching your search</string>
+    <string name="site_settings_tags_title">Tags</string>
+    <string name="site_settings_default_format_title">Default Format</string>
+    <string name="site_settings_week_start_title">Week starts on</string>
+    <string name="site_settings_date_format_title">Date Format</string>
+    <string name="site_settings_time_format_title">Time Format</string>
+    <string name="site_settings_timezone_title">Timezone</string>
+    <string name="site_settings_timezone_subtitle">Choose a city in your timezone</string>
+    <string name="site_settings_posts_per_page_title">Posts per page</string>
+    <string name="site_settings_format_entry_custom">Custom</string>
+    <string name="site_settings_format_hint_custom">Custom format</string>
+    <string name="site_settings_format_help">Learn more about date &amp; time formatting</string>
+    <string name="site_settings_image_original_size">Original Size</string>
+    <string name="site_settings_optimize_images">Optimize Images</string>
+    <string name="site_settings_default_image_width_title" translatable="false">@string/max_thumbnail_px_size</string>
+    <string name="site_settings_default_image_quality_title" translatable="false">@string/image_quality</string>
+    <string name="site_settings_optimize_videos">Optimize Videos</string>
+    <string name="site_settings_default_video_width_title" translatable="false">@string/max_video_resolution</string>
+    <string name="site_settings_default_video_quality_title" translatable="false">@string/video_quality</string>
+    <string name="site_settings_related_posts_title" translatable="false">@string/related_posts</string>
+    <string name="site_settings_more_title" translatable="false">@string/more</string>
+    <string name="site_settings_allow_comments_title">Allow Comments</string>
+    <string name="site_settings_send_pingbacks_title">Send Pingbacks</string>
+    <string name="site_settings_receive_pingbacks_title">Receive Pingbacks</string>
+    <string name="site_settings_identity_required_title">Must include name and email</string>
+    <string name="site_settings_account_required_title">Users must be logged in</string>
+    <string name="site_settings_close_after_title" translatable="false">@string/close_after</string>
+    <string name="site_settings_sort_by_title">Sort by</string>
+    <string name="site_settings_threading_title">Threading</string>
+    <string name="site_settings_paging_title">Paging</string>
+    <string name="site_settings_whitelist_title">Automatically approve</string>
+    <string name="site_settings_multiple_links_title">Links in comments</string>
+    <string name="site_settings_moderation_hold_title">Hold for Moderation</string>
+    <string name="site_settings_blacklist_title">Blacklist</string>
+    <string name="site_settings_delete_site_title">Delete Site</string>
+    <string name="site_settings_timezones_error">Unable to load timezones</string>
+    <string name="site_settings_amp_title">Accelerated Mobile Pages (AMP)</string>
+    <string name="site_settings_amp_summary">Your WordPress.com site supports the use of Accelerated Mobile Pages, a Google-led initiative that dramatically speeds up loading times on mobile devices</string>
+    <string name="site_settings_gutenberg_default_for_new_posts">Use Block Editor</string>
+    <string name="site_settings_gutenberg_default_for_new_posts_summary">Edit new posts and pages with the block editor</string>
+    <string name="site_settings_password_updated">Password updated</string>
+    <string name="site_settings_update_password_message">To reconnect the app to your self-hosted site, enter the site\'s new password here.</string>
+    <string name="site_settings_homepage_settings">Homepage Settings</string>
+    <string name="site_settings_homepage_settings_description">Choose from a homepage that displays your latest posts (classic blog) or a fixed/static page.</string>
+
+    <string name="site_settings_failed_to_load_pages">Loading of pages failed</string>
+    <string name="site_settings_accept_homepage">Accept</string>
+    <string name="site_settings_failed_to_save_homepage_settings">Cannot save homepage settings</string>
+    <string name="site_settings_cannot_save_homepage_settings_before_pages_loaded">Cannot save homepage settings before pages are loaded</string>
+    <string name="site_settings_failed_update_homepage_settings">Homepage settings update failed, check your internet connection</string>
+    <string name="site_settings_page_for_posts_and_homepage_cannot_be_equal">Selected homepage and page for posts cannot be the same.</string>
+
+    <!-- Media -->
+    <string name="site_settings_quota_header">Media</string>
+    <string name="site_settings_quota_space_title">Space Used</string>
+    <string name="site_settings_quota_space_hint">If you need more space consider upgrading your WordPress plan.</string>
+    <string name="site_settings_quota_space_value">%1$s of %2$s</string>
+    <string name="site_settings_quota_space_unlimited">%1$s of unlimited</string>
+
+    <!-- these represent a formatted amount along with a measuring unit, i.e. 10 B, or 132 kB, or 10.2 MB, 1,037.76 kB etc. -->
+    <string name="file_size_in_bytes">%s B</string>
+    <string name="file_size_in_kilobytes">%s kB</string>
+    <string name="file_size_in_megabytes">%s MB</string>
+    <string name="file_size_in_gigabytes">%s GB</string>
+    <string name="file_size_in_terabytes">%s TB</string>
+
+    <!-- Speed up your site -->
+    <string name="site_settings_lazy_load_images_summary">Improve your site\'s speed by only loading images visible on the screen.</string>
+
+    <!-- Site accelerator -->
+    <string name="site_settings_site_accelerator">Site Accelerator</string>
+    <string name="site_settings_site_accelerator_on">On</string>
+    <string name="site_settings_site_accelerator_off">Off</string>
+    <string name="site_settings_lazy_load_images">Lazy load images</string>
+    <string name="site_settings_faster_images">Faster images</string>
+    <string name="site_settings_faster_static_files">Faster static files</string>
+    <string name="site_settings_site_accelerator_summary">Load pages faster by allowing Jetpack to optimize your images and static files (like CSS and JavaScript).</string>
+    <!-- Media performance -->
+    <string name="site_settings_media">Media</string>
+    <string name="site_settings_ad_free_video_hosting">Ad-free Video Hosting</string>
+    <!-- Jetpack search -->
+    <string name="site_settings_jetpack_search">Jetpack Search</string>
+    <string name="site_settings_improved_search">Improved Search</string>
+    <string name="site_settings_improved_search_summary">Replace WordPress build-in search with an improved search experience</string>
+
+    <string name="site_settings_more">More</string>
+    <string name="site_settings_performance_and_speed">Performance and Speed</string>
+
+    <!-- Homepage settings -->
+    <string name="site_settings_classic_blog">Classic Blog</string>
+    <string name="site_settings_static_homepage">Static Homepage</string>
+    <string name="site_settings_posts_page">Posts Page</string>
+    <string name="site_settings_select_page">Select Page</string>
+
+    <!-- tag list and detail -->
+    <string name="tag_name_hint">Tag</string>
+    <string name="tag_description_hint">Description</string>
+    <string name="add_new_tag">Add New Tag</string>
+    <string name="error_tag_exists">A tag with this name already exists</string>
+    <string name="dlg_confirm_delete_tag">Permanently delete \'%s\' tag?</string>
+    <string name="dlg_deleting_tag">Deleting</string>
+    <string name="dlg_saving_tag">Saving</string>
+
+    <!-- Jetpack settings -->
+    <string name="jetpack_site_settings_category_title">Jetpack Settings</string>
+    <string name="jetpack_security_setting_title">Security</string>
+    <string name="jetpack_monitor_uptime_title">Monitor your site\'s uptime</string>
+    <string name="jetpack_send_email_notifications_title">Send notifications by email</string>
+    <string name="jetpack_send_wp_notifications_title">Send push notifications</string>
+    <string name="jetpack_prevent_brute_force_category_title">Brute force attack protection</string>
+    <string name="jetpack_prevent_brute_force_title">Block malicious login attempts</string>
+    <string name="jetpack_brute_force_whitelist_title">Whitelisted IP addresses</string>
+    <string name="jetpack_wpcom_sign_in_category_title">WordPress.com login</string>
+    <string name="jetpack_allow_wpcom_sign_in_title">Allow WordPress.com login</string>
+    <string name="jetpack_match_wpcom_via_email_title">Match accounts using email</string>
+    <string name="jetpack_require_two_factor_title">Require two-step authentication</string>
+
+    <!-- Preference Summaries -->
+    <string name="site_settings_privacy_public_summary">Public</string>
+    <string name="site_settings_privacy_hidden_summary">Hidden</string>
+    <string name="site_settings_privacy_private_summary">Private</string>
+    <string name="site_settings_threading_summary">%d levels</string>
+    <string name="site_settings_whitelist_all_summary">Comments from all users</string>
+    <string name="site_settings_whitelist_known_summary">Comments from known users</string>
+    <string name="site_settings_whitelist_none_summary" translatable="false">@string/none</string>
+    <string name="site_settings_optimize_images_summary">Enable to resize and compress pictures</string>
+    <string name="site_settings_optimize_video_summary">Enable to resize and compress videos</string>
+
+    <string name="weekday_sunday">Sunday</string>
+    <string name="weekday_monday">Monday</string>
+    <string name="weekday_tuesday">Tuesday</string>
+    <string name="weekday_wednesday">Wednesday</string>
+    <string name="weekday_thursday">Thursday</string>
+    <string name="weekday_friday">Friday</string>
+    <string name="weekday_saturday">Saturday</string>
+
+    <string name="detail_approve_manual">Require manual approval for everyone\'s comments.</string>
+    <string name="detail_approve_auto_if_previously_approved">Automatically approve if the user has a previously approved comment</string>
+    <string name="detail_approve_auto">Automatically approve everyone\'s comments.</string>
+    <string-array name="site_settings_auto_approve_details" translatable="false">
+        <item>@string/detail_approve_manual</item>
+        <item>@string/detail_approve_auto_if_previously_approved</item>
+        <item>@string/detail_approve_auto</item>
+    </string-array>
+
+    <string name="site_settings_multiple_links_summary_zero">Require approval for more than 0 links</string>
+    <string name="site_settings_multiple_links_summary_one">Require approval for more than 1 link</string>
+    <string name="site_settings_multiple_links_summary_other">Require approval for more than %d links</string>
+    <string name="site_settings_paging_summary_one">1 comment per page</string>
+    <string name="site_settings_paging_summary_other">%d comments per page</string>
+
+    <string name="privacy_public">Your site is visible to everyone and may be indexed by search engines</string>
+    <string name="privacy_public_not_indexed">Your site is visible to everyone but asks search engines not to index it</string>
+    <string name="privacy_private">Your site is visible only to you and users you approve</string>
+    <string-array name="privacy_details" translatable="false">
+        <item>@string/privacy_public</item>
+        <item>@string/privacy_public_not_indexed</item>
+        <item>@string/privacy_private</item>
+    </string-array>
+
+    <!-- Preference Entries -->
+    <string name="approve_manual">No comments</string>
+    <string name="approve_auto_if_previously_approved">Known users\' comments</string>
+    <string name="approve_auto">All users</string>
+    <string-array name="site_settings_auto_approve_entries" translatable="false">
+        <item>@string/approve_manual</item>
+        <item>@string/approve_auto_if_previously_approved</item>
+        <item>@string/approve_auto</item>
+    </string-array>
+
+    <string-array name="site_settings_privacy_entries" translatable="false">
+        <item>@string/site_settings_privacy_public_summary</item>
+        <item>@string/site_settings_privacy_hidden_summary</item>
+        <item>@string/site_settings_privacy_private_summary</item>
+    </string-array>
+
+    <string-array name="site_settings_sort_entries" translatable="false">
+        <item>@string/oldest_first</item>
+        <item>@string/newest_first</item>
+    </string-array>
+
+    <!-- Hints (long press) -->
+    <string name="site_settings_title_hint">In a few words, explain what this site is about</string>
+    <string name="site_settings_tagline_hint">A short description or catchy phrase to describe your blog</string>
+    <string name="site_settings_address_hint">Changing your address is not currently supported</string>
+    <string name="site_settings_privacy_hint">Controls who can see your site</string>
+    <string name="site_settings_language_hint">Language this blog is primarily written in</string>
+    <string name="site_settings_username_hint">Current user account</string>
+    <string name="site_settings_password_hint">Change your password</string>
+    <string name="site_settings_category_hint">Sets new post category</string>
+    <string name="site_settings_tags_hint">Manage your site\'s tags</string>
+    <string name="site_settings_format_hint">Sets new post format</string>
+    <string name="site_settings_image_width_hint">Resizes images in posts to this width</string>
+    <string name="site_settings_image_quality_hint">Quality of pictures. Higher values mean better quality pictures.</string>
+    <string name="site_settings_video_width_hint">Resizes videos in posts to this size</string>
+    <string name="site_settings_video_quality_hint">Quality of videos. Higher values mean better quality videos.</string>
+    <string name="site_settings_related_posts_hint">Show or hide related posts in reader</string>
+    <string name="site_settings_more_hint">View all available Discussion settings</string>
+    <string name="site_settings_discussion_hint">View and change your sites discussion settings</string>
+    <string name="site_settings_jetpack_performance_settings_hint">View and change your Jetpack performance settings</string>
+    <string name="site_settings_allow_comments_hint">Allow readers to post comments</string>
+    <string name="site_settings_send_pingbacks_hint">Attempt to notify any blogs linked to from the article</string>
+    <string name="site_settings_receive_pingbacks_hint">Allow link notifications from other blogs</string>
+    <string name="site_settings_close_after_hint">Disallow comments after the specified time</string>
+    <string name="site_settings_sort_by_hint">Determines the order comments are displayed</string>
+    <string name="site_settings_threading_hint">Allow nested comments to a certain depth</string>
+    <string name="site_settings_paging_hint">Display comments in chunks of a specified size</string>
+    <string name="site_settings_identity_required_hint">Comment author must fill out name and e-mail</string>
+    <string name="site_settings_user_account_required_hint">Users must be registered and logged in to comment</string>
+    <string name="site_settings_whitelist_hint">Comment author must have a previously approved comment</string>
+    <string name="site_settings_multiple_links_hint">Ignores link limit from known users</string>
+    <string name="site_settings_moderation_hold_hint">Comments that match a filter are put in the moderation queue</string>
+    <string name="site_settings_blacklist_hint">Comments that match a filter are marked as spam</string>
+
+    <!-- Related Posts -->
+    <string name="site_settings_rp_switch_title">Show Related Posts</string>
+    <string name="site_settings_rp_switch_summary">Related Posts displays relevant content from your site below your posts.</string>
+    <string name="site_settings_rp_show_header_title">Show Header</string>
+    <string name="site_settings_rp_show_images_title">Show Images</string>
+    <string name="site_settings_rp_preview_header" translatable="false">@string/related_posts</string>
+    <string name="site_settings_rp_preview1_title">Big iPhone/iPad Update Now Available</string>
+    <string name="site_settings_rp_preview1_site">in \"Mobile\"</string>
+    <string name="site_settings_rp_preview2_title">The WordPress for Android App Gets a Big Facelift</string>
+    <string name="site_settings_rp_preview2_site">in \"Apps\"</string>
+    <string name="site_settings_rp_preview3_title">Upgrade Focus: VideoPress For Weddings</string>
+    <string name="site_settings_rp_preview3_site">in \"Upgrade\"</string>
+
+    <!-- Learn More -->
+    <string name="site_settings_learn_more_header" translatable="false">@string/learn_more</string>
+    <string name="site_settings_learn_more_caption">You can override these settings for individual posts.</string>
+
+    <!-- List Editors (Blacklist, Hold for Moderation) -->
+    <string name="site_settings_list_editor_summary_one">1 item</string>
+    <string name="site_settings_list_editor_summary_other">%d items</string>
+
+    <string name="site_settings_list_editor_action_mode_title">Selected %1$d</string>
+    <string name="site_settings_list_editor_no_items_text">No items</string>
+    <string name="site_settings_list_editor_input_hint">Enter a word or phrase</string>
+    <string name="site_settings_hold_for_moderation_description">When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be held in the moderation queue. You can enter partial words, so \"press\" will match \"WordPress.\"</string>
+    <string name="site_settings_blacklist_description">When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam. You can enter partial words, so \"press\" will match \"WordPress.\"</string>
+    <string name="site_settings_jetpack_whitelist_description">You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1–12.12.12.100</string>
+
+    <!-- Dialogs -->
+    <string name="site_settings_discussion_title" translatable="false">@string/discussion</string>
+    <string name="site_settings_close_after_dialog_title">Close commenting</string>
+    <string name="site_settings_paging_dialog_header">Comments per page</string>
+    <string name="site_settings_paging_dialog_description">Break comment threads into multiple pages.</string>
+    <string name="site_settings_threading_dialog_header">Thread up to</string>
+    <string name="site_settings_threading_dialog_description">Allow comments to be nested in threads.</string>
+    <string name="site_settings_close_after_dialog_header" translatable="false">@string/close_after</string>
+    <string name="site_settings_close_after_dialog_description">Automatically close comments on articles.</string>
+    <string name="site_settings_close_after_dialog_switch_text">Automatically close</string>
+
+    <!-- Errors -->
+    <string name="site_settings_unknown_language_code_error">Language code not recognized</string>
+    <string name="site_settings_disconnected_toast">No connection. Editing is disabled.</string>
+
+    <!--               -->
+    <!-- Site Settings -->
+    <!--      End      -->
+
+    <!-- preferences -->
+    <string name="open_source_licenses">Open source licenses</string>
+    <string name="whats_new_in_version_title">What\'s New</string>
+    <string name="preference_open_device_settings">Open device settings</string>
+    <string name="preference_collect_information">Collect information</string>
+    <string name="preference_crash_reports">Crash reports</string>
+    <string name="preference_crash_reports_summary">Allow automatic crash reports to help us improve the app\'s performance.</string>
+    <string name="preference_privacy_settings">Privacy settings</string>
+    <string name="cookie_policy_learn_more_header">Cookie Policy</string>
+    <string name="cookie_policy_learn_more_caption">Share information with our analytics tool about your use of services while logged in to your WordPress.com account.</string>
+    <string name="privacy_policy_learn_more_header">Privacy Policy</string>
+    <string name="privacy_policy_learn_more_caption">This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy.</string>
+    <string name="third_party_policy_learn_more_header">Third Party Policy</string>
+    <string name="third_party_policy_learn_more_caption">We use other tracking tools, including some from third parties. Read about these and how to control them.</string>
+    <string name="privacy_policy_read">Read privacy policy</string>
+    <string name="ccpa_privacy_notice_header">Privacy notice for California users</string>
+    <string name="ccpa_privacy_notice_caption">The California Consumer Privacy Act ("CCPA") requires us to provide California residents with some additional information about the categories of personal information we collect and share, where we get that personal information, and how and why we use it.</string>
+    <string name="ccpa_privacy_notice_read">Read CCPA privacy notice</string>
+    <string name="preference_strip_image_location">Remove location from media</string>
+    <string name="app_theme">Appearance</string>
+    <string name="app_theme_light">Light</string>
+    <string name="app_theme_dark">Dark</string>
+    <string name="app_theme_default">Set by Battery Saver</string>
+    <string name="app_theme_entry_value_light" translatable="false">light</string>
+    <string name="app_theme_entry_value_dark" translatable="false">dark</string>
+    <string name="app_theme_entry_value_default" translatable="false">default</string>
+    <string name="app_theme_entry_value_default_key" translatable="false">@string/app_theme_entry_value_light</string>
+    <string-array name="app_theme_entries" translatable="false" tools:ignore="InconsistentArrays">
+        <item>@string/app_theme_light</item>
+        <item>@string/app_theme_dark</item>
+    </string-array>
+    <string-array name="app_theme_entry_values" translatable="false" tools:ignore="InconsistentArrays">
+        <item>@string/app_theme_entry_value_light</item>
+        <item>@string/app_theme_entry_value_dark</item>
+    </string-array>
+
+    <!-- stats -->
+    <string name="stats">Stats</string>
+    <string name="stats_jetpack_connection_setup_info">To use Stats on your WordPress site, you\'ll need to install the Jetpack plugin.</string>
+    <string name="stats_jetpack_connection_setup">Install Jetpack</string>
+    <string name="stats_jetpack_connection_faq">Jetpack FAQ</string>
+    <string name="content_description_people_looking_charts">People looking at graphs and charts</string>
+    <string name="jetpack_connection_terms_and_conditions">By setting up Jetpack you agree to our %1$sterms and conditions%2$s</string>
+
+    <!-- Stats refresh -->
+    <string name="stats_no_data_yet">No data yet</string>
+    <string name="stats_no_data_for_period">No data for this period</string>
+    <string name="stats_empty_insights_title">No insights added yet</string>
+    <string name="stats_manage_insights">Manage Insights</string>
+    <string name="stats_followers_wordpress_com">WordPress.com</string>
+    <string name="stats_followers_email">Email</string>
+    <string name="stats_followers_count_message">Total %1$s Followers: %2$s</string>
+    <string name="stats_follower_label">Follower</string>
+    <string name="stats_follower_since_label">Since</string>
+    <string name="stats_comments_authors">Authors</string>
+    <string name="stats_comments_posts_and_pages">Posts and pages</string>
+    <string name="stats_comments_author_label">Author</string>
+    <string name="stats_comments_title_label">Title</string>
+    <string name="stats_comments_label">Comments</string>
+    <string name="stats_posts_and_pages_title_label">Title</string>
+    <string name="stats_posts_and_pages_views_label">Views</string>
+    <string name="stats_tags_and_categories_title_label">Title</string>
+    <string name="stats_tags_and_categories_views_label">Views</string>
+    <string name="stats_category_folded_name">%1$s | %2$s</string>
+    <string name="stats_publicize_service_label">Service</string>
+    <string name="stats_publicize_followers_label">Followers</string>
+    <string name="stats_from_to_dates_in_week_label">%1$s - %2$s</string>
+    <string name="stats_item_settings">Stats item settings</string>
+    <string name="stats_cannot_be_started">We cannot open the statistics at the moment. Please try again later</string>
+    <string name="stats_traffic_increase">+%1$s (%2$s%%)</string>
+    <string name="stats_traffic_change">%1$s (%2$s%%)</string>
+    <string name="stats_fewer_posts">Fewer posts</string>
+    <string name="stats_more_posts">More posts</string>
+    <string name="stats_site_not_loaded_yet" tools:ignore="UnusedResources">Site not loaded yet</string>
+    <string name="showing_stats_for">Showing stats for:</string>
+    <string name="stats_menu_move_up">Move up</string>
+    <string name="stats_menu_move_down">Move down</string>
+    <string name="stats_menu_remove">Remove from insights</string>
+    <string name="stats_site_neutral_utc">Site timezone (UTC)</string>
+    <string name="stats_site_positive_utc">Site timezone (UTC + %s)</string>
+    <string name="stats_site_negative_utc">Site timezone (UTC - %s)</string>
+    <string name="stats_data_not_recorded_for_period">File download stats were not recorded before June 28th 2019.</string>
+
+    <!-- Number suffixes -->
+    <string name="negative_prefix">-%s</string>
+    <string name="suffix_1_000">%sk</string>
+    <string name="suffix_1_000_000">%sM</string>
+    <string name="suffix_1_000_000_000">%sB</string>
+    <string name="suffix_1_000_000_000_000">%sT</string>
+    <string name="suffix_1_000_000_000_000_000">%sQa</string>
+    <string name="suffix_1_000_000_000_000_000_000">%sQi</string>
+
+    <!-- Stats accessibility strings -->
+    <string name="stats_loading_card">Loading selected card data</string>
+    <string name="stats_overview_content_description">%1$s %2$s for period: %3$s, change from previous period - %4$s</string>
+    <string name="stats_graph_updated">Graph updated.</string>
+    <string name="stats_expand_content_description">Expand</string>
+    <string name="stats_collapse_content_description">Collapse</string>
+    <string name="stats_item_expanded">Item expanded</string>
+    <string name="stats_item_collapsed">Item collapsed</string>
+    <string name="stats_list_item_description">%1$s: %2$s, %3$s: %4$s</string>
+    <string name="stats_bar_chart_accessibility_entry">%1$s, %2$d %3$s</string>
+    <string name="stats_bar_chart_accessibility_overlapping_entry">  &amp; %1$d %2$s</string>
+
+    <string name="stats_box_type_low">low</string>
+    <string name="stats_box_type_medium">medium</string>
+    <string name="stats_box_type_high">high</string>
+    <string name="stats_box_type_very_high">very high</string>
+
+    <string name="stats_posting_activity_action">navigate all stats for this period</string>
+    <string name="stats_posting_activity_content_description">The days with %1$s views for %2$s are : %2$s %3$s.Tap for more.</string>
+    <string name="stats_posting_activity_label_content_description">Posting Activity for %1$s</string>
+    <string name="stats_posting_activity_empty_description">There are no stats in this period.</string>
+    <string name="stats_posting_activity_end_description">You have heard all stats for this period.
+        Tapping again will restart from the beginning.</string>
+
+    <string name="stats_manage_your_stats">Manage Your Stats</string>
+    <string name="stats_management_news_card_message">Choose what stats to see, and focus on the data you care most about. Tap %1$s at the bottom of Insights to customise your stats.</string>
+    <string name="stats_management_try_it_now">Try it now</string>
+    <string name="stats_management_dismiss_insights_news_card">Dismiss</string>
+    <string name="stats_management_add_new_stats_card">Add new stats card</string>
+    <string name="stats_management_screen_title">Add New Card</string>
+    <string name="stats_management_new">New</string>
+
+    <!-- Stats refreshed widgets -->
+
+    <string name="stats_widget_add">Add widget</string>
+    <string name="stats_widget_views_title">Views This Week</string>
+    <string name="stats_widget_all_time_title">All-time</string>
+    <string name="stats_widget_site">Site</string>
+    <string name="stats_widget_site_caption">Select your site</string>
+    <string name="stats_widget_color">Color</string>
+    <string name="stats_widget_color_light">Light</string>
+    <string name="stats_widget_color_dark">Dark</string>
+    <string name="stats_widget_select_your_site">Select your site</string>
+    <string name="stats_widget_select_color">Color</string>
+    <string name="stats_widget_select_type">Type</string>
+    <string name="stats_widget_error_no_data">Couldn\'t load data</string>
+    <string name="stats_widget_error_no_network">No network available</string>
+    <string name="stats_widget_error_no_access_token">To view your stats, log in to the WordPress.com account.</string>
+
+    <!-- Jetpack install -->
+    <string name="jetpack">Jetpack</string>
+    <string name="install_jetpack">Install Jetpack</string>
+    <string name="install_jetpack_message">Your website credentials will not be stored and are used only for the purpose of installing Jetpack.</string>
+    <string name="installing_jetpack">Installing Jetpack</string>
+    <string name="installing_jetpack_message">Installing Jetpack on your site. This can take up to a few minutes to complete.</string>
+    <string name="jetpack_installed">Jetpack installed</string>
+    <string name="jetpack_installed_message">Now that Jetpack is installed, we just need to get you set up. This will only take a minute.</string>
+    <string name="jetpack_installation_problem">There was a problem</string>
+    <string name="jetpack_installation_problem_message">Jetpack could not be installed at this time.</string>
+    <string name="install_jetpack_continue">Set up</string>
+    <string name="install_jetpack_retry">Retry</string>
+    <string name="login_to_to_connect_jetpack">Log in to the WordPress.com account you used to connect Jetpack.</string>
+
+    <!-- activity log -->
+    <string name="activity">Activity</string>
+    <string name="activity_log">Activity Log</string>
+    <string name="activity_log_icon">Activity icon</string>
+    <string name="activity_log_event">Event</string>
+    <string name="rewind">Rewind</string>
+    <string name="activity_log_button">Activity Log action button</string>
+    <string name="activity_log_jetpack_icon">Jetpack icon</string>
+    <string name="activity_log_empty_title">No activity yet</string>
+    <string name="activity_log_empty_subtitle">When you make changes to your site you\'ll be able to see your activity history here</string>
+    <string name="activity_log_rewind_started_snackbar_message">Your site is being restored\nRewinding to %1$s %2$s</string>
+    <string name="activity_log_rewind_finished_snackbar_message">Your site has been successfully restored\nRewound to %1$s %2$s</string>
+    <string name="activity_log_rewind_finished_snackbar_message_no_dates">Your site has been successfully restored</string>
+    <string name="activity_log_currently_restoring_title">Currently restoring your site</string>
+    <string name="activity_log_currently_restoring_message">Rewinding to %1$s %2$s</string>
+    <string name="activity_log_currently_restoring_message_no_dates">Rewind in progress</string>
+    <string name="activity_log_rewind_site">Rewind Site</string>
+    <string name="activity_log_rewind_dialog_message">Are you sure you want to rewind your site back to %1$s at %2$s? This will remove all content and options created or changed since then.</string>
+    <string name="activity_log_limited_content_on_free_plan">Since you\'re on a free plan, you\'ll see limited events in your activity.</string>
+
+    <!-- stats: labels for timeframes -->
+    <string name="stats_timeframe_today">Today</string>
+    <string name="stats_timeframe_yesterday">Yesterday</string>
+    <string name="stats_timeframe_days">Days</string>
+    <string name="stats_timeframe_weeks">Weeks</string>
+    <string name="stats_timeframe_months">Months</string>
+    <string name="stats_timeframe_years">Years</string>
+
+    <string name="stats_views">Views</string>
+    <string name="stats_visitors">Visitors</string>
+    <string name="stats_likes">Likes</string>
+    <string name="stats_comments" translatable="false">@string/comments</string>
+
+    <!-- stats: labels for the views -->
+    <string name="stats_view_countries">Countries</string>
+    <string name="stats_view_top_posts_and_pages">Posts &amp; Pages</string>
+    <string name="stats_view_clicks">Clicks</string>
+    <string name="stats_view_tags_and_categories">Tags &amp; Categories</string>
+    <string name="stats_view_authors">Authors</string>
+    <string name="stats_view_referrers">Referrers</string>
+    <string name="stats_view_videos">Videos</string>
+    <string name="stats_view_comments" translatable="false">@string/comments</string>
+    <string name="stats_view_search_terms">Search Terms</string>
+    <string name="stats_view_publicize">Publicize</string>
+    <string name="stats_view_followers">Followers</string>
+    <string name="stats_view_follower_totals">Follower Totals</string>
+
+    <!-- stats: followers -->
+    <string name="stats_followers_seconds_ago">seconds ago</string>
+    <string name="stats_followers_a_minute_ago">a minute ago</string>
+    <string name="stats_followers_minutes">%1$d minutes</string>
+    <string name="stats_followers_an_hour_ago">an hour ago</string>
+    <string name="stats_followers_hours">%1$d hours</string>
+    <string name="stats_followers_a_day">A day</string>
+    <string name="stats_followers_days">%1$d days</string>
+    <string name="stats_followers_a_month">A month</string>
+    <string name="stats_followers_months">%1$d months</string>
+    <string name="stats_followers_a_year">A year</string>
+    <string name="stats_followers_years">%1$d years</string>
+
+    <!-- stats: search terms -->
+    <string name="stats_search_terms_unknown_search_terms">Unknown Search Terms</string>
+
+    <!-- Stats insights -->
+    <string name="stats_insights">Insights</string>
+    <string name="stats_insights_all_time">All-time posts, views, and visitors</string>
+    <string name="stats_insights_today">Today\'s Stats</string>
+    <string name="stats_insights_latest_post_summary">Latest Post Summary</string>
+    <string name="stats_insights_popular">Most Popular Time</string>
+    <string name="stats_insights_this_year_site_stats">This Year</string>
+    <string name="stats_insights_annual_site_stats">Annual Site Stats</string>
+    <string name="stats_insights_year">Year</string>
+    <string name="stats_insights_posts">Posts</string>
+    <string name="stats_insights_total_comments">Total comments</string>
+    <string name="stats_insights_average_comments">Avg comments/post</string>
+    <string name="stats_insights_total_likes">Total likes</string>
+    <string name="stats_insights_average_likes">Avg likes/post</string>
+    <string name="stats_insights_total_words">Total words</string>
+    <string name="stats_insights_average_words">Avg words/post</string>
+    <string name="stats_insights_best_day">Best Day</string>
+    <string name="stats_insights_best_hour">Best Hour</string>
+    <string name="stats_insights_best_ever">Best Views Ever</string>
+    <string name="stats_insights_today_stats">Today</string>
+
+    <!-- Stats refreshed insights -->
+    <string name="stats_insights_all_time_stats">All-time</string>
+    <string name="stats_insights_tags_and_categories">Tags and Categories</string>
+    <string name="stats_insights_latest_post_empty">You haven\'t published any posts yet. Once you start publishing, your latest post\'s summary will appear here:</string>
+    <string name="stats_insights_latest_post_with_no_engagement">It\'s been %1$s since %2$s was published. Get the ball rolling and increase your post views by sharing your post:</string>
+    <string name="stats_insights_latest_post_message">It’s been %1$s since %2$s was published. Here’s how the post performed so far:</string>
+    <string name="stats_insights_create_post">Create post</string>
+    <string name="stats_insights_share_post">Share post</string>
+    <string name="stats_insights_view_more">View more</string>
+    <string name="stats_insights_load_more" tools:ignore="UnusedResources">Load more</string>
+    <string name="stats_insights_facebook">Facebook</string>
+    <string name="stats_insights_twitter">Twitter</string>
+    <string name="stats_insights_tumblr">Tumblr</string>
+    <string name="stats_insights_google_plus">Google+</string>
+    <string name="stats_insights_linkedin">LinkedIn</string>
+    <string name="stats_insights_social">Social</string>
+    <string name="stats_insights_path">Path</string>
+    <string name="stats_most_popular_percent_views">%1$d%% of views</string>
+    <string name="stats_insights_posting_activity">Posting Activity</string>
+    <string name="stats_insights_management_title">Only see the most relevant stats. Add and organise your insights below.</string>
+
+    <string name="stats_insights_management_general">General</string>
+    <string name="stats_insights_management_posts_and_pages">Posts and Pages</string>
+    <string name="stats_insights_management_activity">Activity</string>
+
+    <!-- Stats refreshed widgets -->
+    <string name="stats_widget_log_in_message">Please log in to the WordPress app to add a widget.</string>
+    <string name="stats_widget_weekly_views_name">Views this week</string>
+    <string name="stats_widget_all_time_insights_name">All-time</string>
+    <string name="stats_widget_today_insights_name">Today</string>
+    <string name="stats_widget_minified_name">At a glance</string>
+
+    <!-- Stats post detail -->
+    <string name="stats_detail_months_and_years">Months and Years</string>
+    <string name="stats_months_and_years_period_label">Period</string>
+    <string name="stats_months_and_years_views_label">Views</string>
+    <string name="stats_detail_average_views_per_day">Avg. Views Per Day</string>
+    <string name="stats_detail_recent_weeks">Recent Weeks</string>
+
+    <string name="stats_posts_and_pages">Posts and Pages</string>
+    <string name="stats_referrers">Referrers</string>
+    <string name="stats_referrer_label">Referrer</string>
+    <string name="stats_referrer_views_label">Views</string>
+    <string name="stats_clicks">Clicks</string>
+    <string name="stats_clicks_link_label">Link</string>
+    <string name="stats_clicks_label">Clicks</string>
+    <string name="stats_countries">Countries</string>
+    <string name="stats_country_label">Country</string>
+    <string name="stats_country_views_label">Views</string>
+    <string name="stats_videos">Videos</string>
+    <string name="stats_videos_title_label">Title</string>
+    <string name="stats_videos_views_label">Views</string>
+    <string name="stats_search_terms">Search Terms</string>
+    <string name="stats_search_terms_label">Search Term</string>
+    <string name="stats_search_terms_views_label">Views</string>
+    <string name="stats_authors">Authors</string>
+    <string name="stats_author_label">Author</string>
+    <string name="stats_author_views_label">Views</string>
+    <string name="stats_post_label">Post</string>
+    <string name="stats_post_views_label">Views</string>
+    <string name="stats_file_downloads">File downloads</string>
+    <string name="stats_file_downloads_title_label">File</string>
+    <string name="stats_file_downloads_value_label">Downloads</string>
+
+    <string name="stats_select_previous_period_description">Select previous period</string>
+    <string name="stats_select_next_period_description">Select next period</string>
+
+    <string name="stats_loading_error">Data not loaded</string>
+    <string name="stats_loading_block_error">There was a problem loading your data, refresh your page to try again.</string>
+
+    <!-- invalid_url -->
+    <string name="invalid_site_url_message">Check that the site URL entered is valid</string>
+
+    <!-- QuickPress -->
+    <string name="quickpress_shortcut_activity_label">Select blog for QuickPress shortcut</string>
+    <string name="quickpress_add_error">Shortcut name can\'t be empty</string>
+    <string name="quickpress_add_alert_title">Set shortcut name</string>
+    <string name="quickpress_shortcut_with_account_param">QP %s</string>
+
+    <!-- HTTP Authentication -->
+    <string name="httpuser">HTTP username</string>
+    <string name="httppassword">HTTP password</string>
+    <string name="settings">Settings</string>
+    <string name="http_authorization_required">Authorization required</string>
+
+    <!-- post scheduling and password -->
+    <string name="submit_for_review">Submit</string>
+    <string name="schedule_verb">Schedule</string>
+
+    <!-- notifications -->
+    <string name="note_reply_successful">Reply published</string>
+    <string name="new_notifications">%d new notifications</string>
+    <string name="more_notifications">and %d more.</string>
+    <string name="notifications_empty_list">No notifications</string>
+    <string name="notifications_empty_all">No notifications…yet.</string>
+    <string name="notifications_empty_unread">You\'re all up to date!</string>
+    <string name="notifications_empty_comments">No comments yet</string>
+    <string name="notifications_empty_followers">No followers yet</string>
+    <string name="notifications_empty_likes">No likes yet</string>
+    <string name="notifications_empty_action_all">Get active! Comment on posts from blogs you follow.</string>
+    <string name="notifications_empty_action_unread">Reignite the conversation: write a new post</string>
+    <string name="notifications_empty_action_comments">Join a conversation: comment on posts from blogs you follow</string>
+    <string name="notifications_empty_action_followers_likes">Get noticed: comment on posts you\'ve read</string>
+    <string name="notifications_jetpack_connection_setup_info">To get helpful notifications on your device from your WordPress site, you\'ll need to install the Jetpack plugin. Would you like to set up Jetpack?</string>
+    <string name="notifications_empty_view_reader">Go to Reader</string>
+    <string name="content_description_person_reading_device_notification">Person reading device with notifications</string>
+    <string name="older_two_days">Older than 2 days</string>
+    <string name="older_last_week">Older than a week</string>
+    <string name="older_month">Older than a month</string>
+    <string name="error_notification_open">Could not open notification</string>
+    <string name="ignore">Ignore</string>
+    <string name="push_auth_expired">The request has expired. Log in to WordPress.com to try again.</string>
+    <string name="follows">Follows</string>
+    <string name="notifications_label_new_notifications">New notifications</string>
+    <string name="notifications_label_new_notifications_subtitle">Tap to show them</string>
+    <string name="notifications_tab_title_all">All</string>
+    <string name="notifications_tab_title_unread_notifications">Unread</string>
+    <string name="notifications_tab_title_comments">Comments</string>
+    <string name="notifications_tab_title_follows">Follows</string>
+    <string name="notifications_tab_title_likes">Likes</string>
+
+    <!-- Notification Settings -->
+    <string name="notification_settings">Notification Settings</string>
+    <string name="notification_settings_master_status_on">On</string>
+    <string name="notification_settings_master_status_off">Off</string>
+    <string name="notification_settings_master_hint_on">Disable notifications</string>
+    <string name="notification_settings_master_hint_off">Enable notifications</string>
+    <string name="notification_settings_master_off_title">To receive notifications on this device, turn Notification Settings on.</string>
+    <string name="notification_settings_master_off_message">Turning Notification Settings off will disable all notifications from this app, regardless of type. You can fine-tune which kind of notification you receive after turning Notification Settings on.</string>
+    <string name="notification_settings_category_followed_sites">Followed Sites</string>
+    <string name="notification_settings_category_your_sites">Your Sites</string>
+    <string name="notification_settings_item_your_sites_all_followed_sites">All My Followed Sites</string>
+    <string name="notification_settings_item_your_sites_all_your_sites">All My Sites</string>
+    <string name="notification_settings_category_other">Other</string>
+    <string name="notification_settings_item_other_comments_other_blogs">Comments on other sites</string>
+    <string name="notification_settings_item_other_pending_drafts">Notify me on pending drafts</string>
+    <string name="notification_settings_item_other_account_emails">Email from WordPress.com</string>
+    <string name="notification_settings_item_other_account_emails_summary">We\'ll always send important emails regarding your account, but you can get some helpful extras, too.</string>
+    <string name="notification_settings_category_sights_and_sounds">Sights and Sounds</string>
+    <string name="notification_settings_item_sights_and_sounds_choose_sound">Choose sound</string>
+    <string name="notification_settings_item_sights_and_sounds_choose_sound_default" translatable="false">content://settings/system/notification_sound</string>
+    <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibrate device</string>
+    <string name="notification_settings_item_sights_and_sounds_blink_light">Blink light</string>
+    <string name="notifications_tab">Notifications tab</string>
+    <string name="email">Email</string>
+    <string name="email_address">Email address</string>
+    <string name="app_notifications">App notifications</string>
+    <string name="comment_likes">Comment likes</string>
+    <string name="error_loading_notifications">Couldn\'t load notification settings</string>
+    <string name="notification_types">Notification Types</string>
+    <string name="notifications_disabled">App notifications have been disabled. Tap here to enable them in Settings.</string>
+    <string name="notifications_tab_summary">Settings for notifications that appear in the Notifications tab.</string>
+    <string name="notifications_email_summary">Settings for notifications that are sent to the email tied to your account.</string>
+    <string name="notifications_push_summary">Settings for notifications that appear on your device.</string>
+    <string name="search_sites">Search sites</string>
+    <string name="notifications_no_search_results">No sites matched \'%s\'</string>
+    <string name="notification_sound_has_invalid_path">The chosen sound has invalid path. Please choose another.</string>
+
+    <string name="notification_settings_followed_dialog_email_posts_switch">Email me new posts</string>
+    <string name="notification_settings_followed_dialog_notification_posts_description">Receive notifications for new posts from this site</string>
+    <string name="notification_settings_followed_dialog_notification_posts_switch">New posts</string>
+    <string name="notification_settings_followed_dialog_email_posts_daily">Daily</string>
+    <string name="notification_settings_followed_dialog_email_posts_instantly">Instantly</string>
+    <string name="notification_settings_followed_dialog_email_posts_weekly">Weekly</string>
+    <string name="notification_settings_followed_dialog_email_comments">Email me new comments</string>
+    <string name="notification_settings_followed_dialog_title">Notifications</string>
+
+    <string name="notifications_tab_dialog_master_status_on">Notifications for this site</string>
+    <string name="notifications_tab_dialog_master_status_off">Notifications for this site</string>
+    <string name="notifications_tab_dialog_master_hint_on">Disable notifications display on notifications tab for this site</string>
+    <string name="notifications_tab_dialog_master_hint_off">Enable notifications display on notifications tab for this site</string>
+    <string name="notifications_tab_dialog_master_off_title">To see notifications on notifications tab for this site, turn Notifications for this site on.</string>
+    <string name="notifications_tab_dialog_master_off_message">Turning Notifications for this site off will disable notifications display on notifications tab for this site. You can fine-tune which kind of notification you see after turning Notifications for this site on.</string>
+
+    <string name="master_switch_default_title_on">On</string>
+    <string name="master_switch_default_title_off">Off</string>
+
+    <string name="comments_on_my_site">Comments on my site</string>
+    <string name="likes_on_my_comments">Likes on my comments</string>
+    <string name="likes_on_my_posts">Likes on my posts</string>
+    <string name="site_follows">Site follows</string>
+    <string name="site_achievements">Site achievements</string>
+    <string name="username_mentions">Username mentions</string>
+    <string-array name="notifications_blog_settings" translatable="false">
+        <item>@string/comments_on_my_site</item>
+        <item>@string/likes_on_my_comments</item>
+        <item>@string/likes_on_my_posts</item>
+        <item>@string/site_follows</item>
+        <item>@string/site_achievements</item>
+        <item>@string/username_mentions</item>
+    </string-array>
+
+    <string name="replies_to_my_comments">Replies to my comments</string>
+    <string-array name="notifications_other_settings" translatable="false">
+        <item>@string/replies_to_my_comments</item>
+        <item>@string/likes_on_my_comments</item>
+    </string-array>
+
+    <string name="notif_suggestions">Suggestions</string>
+    <string name="notif_research">Research</string>
+    <string name="notif_community">Community</string>
+    <string-array name="notifications_wpcom_settings" translatable="false">
+        <item>@string/notif_suggestions</item>
+        <item>@string/notif_research</item>
+        <item>@string/notif_community</item>
+    </string-array>
+
+    <string name="notif_tips">Tips for getting the most out of WordPress.com.</string>
+    <string name="notif_surveys">Opportunities to participate in WordPress.com research &amp; surveys.</string>
+    <string name="notif_events">Information on WordPress.com courses and events (online &amp; in-person).</string>
+    <string-array name="notifications_wpcom_settings_summaries" translatable="false">
+        <item>@string/notif_tips</item>
+        <item>@string/notif_surveys</item>
+        <item>@string/notif_events</item>
+    </string-array>
+
+    <!-- reader -->
+    <string name="reader">Reader</string>
+    <string name="reader_filter_cta">Filter</string>
+    <string name="reader_filter_sites_title">Sites</string>
+    <string name="reader_filter_tags_title">Tags</string>
+    <string name="reader_filter_main_title">Following</string>
+    <string name="reader_filter_empty_sites_list">See the newest posts from sites you follow</string>
+    <string name="reader_filter_empty_tags_list">You can follow posts on a specific subject by adding a tag</string>
+    <string name="reader_filter_self_hosted_empty_sites_list">Log in to WordPress.com to see the latest posts from sites you follow</string>
+    <string name="reader_filter_self_hosted_empty_tagss_list">Log in to WordPress.com to see the latest posts from tags you follow</string>
+    <string name="reader_filter_empty_sites_action">Follow a site</string>
+    <string name="reader_filter_empty_tags_action">Add a tag</string>
+    <string name="reader_filter_self_hosted_empty_sites_tags_action">Log in to WordPress.com</string>
+    <string name="reader_dot_separator" translatable="false">\u0020\u2022\u0020</string>
+
+    <!-- editor -->
+    <string name="editor_post_saved_online">Post saved online</string>
+    <string name="editor_page_saved_online">Page saved online</string>
+    <string name="editor_post_saved_locally">Post saved on device</string>
+    <string name="editor_page_saved_locally">Page saved on device</string>
+    <string name="editor_draft_saved_online">Draft saved online</string>
+    <string name="editor_draft_saved_locally">Draft saved on device</string>
+    <string name="editor_post_saved_locally_failed_media">The post has failed media uploads and has been saved locally</string>
+    <string name="editor_page_saved_locally_failed_media">The page has failed media uploads and has been saved locally</string>
+    <string name="editor_uploading_post">Your post is uploading</string>
+    <string name="editor_uploading_page">Your page is uploading</string>
+    <string name="editor_uploading_draft">Your draft is uploading</string>
+    <string name="editor_post_converted_back_to_draft">Post converted back to draft</string>
+    <string name="editor_failed_to_insert_media_tap_to_retry">Failed to insert media.\nPlease tap to retry.</string>
+
+    <!-- Post Settings -->
+    <string name="post_settings">Post settings</string>
+    <string name="post_settings_status" translatable="false">@string/status_and_visibility</string>
+    <string name="post_settings_categories_and_tags">Categories &amp; Tags</string>
+    <string name="post_settings_publish">Publish</string>
+    <string name="post_settings_more_options">More Options</string>
+    <string name="post_settings_not_set">Not Set</string>
+    <string name="post_settings_excerpt">Excerpt</string>
+    <string name="post_settings_slug">Slug</string>
+    <string name="post_settings_tags">Tags</string>
+    <string name="post_settings_post_format">Post Format</string>
+    <string name="post_settings_featured_image">Featured Image</string>
+    <string name="post_settings_set_featured_image">Set Featured Image</string>
+    <string name="post_settings_featured_image_uploading_tap_for_options">Uploading media.\nPlease tap for options.</string>
+    <string name="post_settings_choose_featured_image">Choose featured image</string>
+    <string name="post_settings_remove_featured_image">Remove featured image</string>
+    <string name="post_settings_retry_featured_image">Retry uploading</string>
+    <string name="post_settings_slug_dialog_hint">The slug is the URL-friendly version of the post title.</string>
+    <string name="post_settings_excerpt_dialog_hint">Excerpts are optional hand-crafted summaries of your content.</string>
+    <string name="post_settings_password_dialog_hint">Only those with this password can view this post</string>
+    <string name="post_settings_time_and_date">Time and Date</string>
+    <string name="post_settings_notification">Notification</string>
+    <string name="post_settings_add_to_calendar">Add to calendar</string>
+
+    <string name="post_notification_off">Off</string>
+    <string name="post_notification_one_hour_before">1 hour before</string>
+    <string name="post_notification_ten_minutes_before">10 minutes before</string>
+    <string name="post_notification_when_published">When published</string>
+    <string name="post_notification_error">Notification can\'t be created when the publish date is in the past.</string>
+
+    <!-- post date selection -->
+    <string name="publish_date">Publish Date</string>
+    <string name="immediately">Immediately</string>
+    <string name="now">Now</string>
+    <string name="scheduled_for">Scheduled for: %s</string>
+    <string name="backdated_for">Backdated for: %s</string>
+    <string name="published_on">Published on: %s</string>
+    <string name="schedule_for">Schedule for: %s</string>
+    <string name="publish_on">Publish on: %s</string>
+
+    <!-- post schedule notifications -->
+    <string name="notification_scheduled_post">Scheduled post</string>
+    <string name="notification_scheduled_post_one_hour_reminder">Scheduled post: 1 hour reminder</string>
+    <string name="notification_scheduled_post_ten_minute_reminder">Scheduled post: 10 minute reminder</string>
+    <string name="notification_post_has_been_published">\"%s\" has been published</string>
+    <string name="notification_post_will_be_published_in_one_hour">\"%s\" will be published in 1 hour</string>
+    <string name="notification_post_will_be_published_in_ten_minutes">\"%s\" will be published in 10 minutes</string>
+    <string name="calendar_scheduled_post_title">WordPress Scheduled Post: \"%s\"</string>
+    <string name="calendar_scheduled_post_description">\"%s\" scheduled for publishing on \"%s\" in your WordPress app \n %s</string>
+
+    <!-- location -->
+    <string name="post_settings_location">Location</string>
+    <string name="post_settings_error_placepicker_missing_play_services">Can\'t open the Location Picker, Google Play Services is not available</string>
+    <string name="remove_location">Remove Location</string>
+    <string name="change_location">Change Location</string>
+
+    <!-- Post Status -->
+    <string name="post_status_publish_post">Publish</string>
+    <string name="post_status_pending_review">Pending review</string>
+    <string name="post_status_draft">Draft</string>
+    <string name="post_status_post_private">Private</string>
+    <string name="post_status_post_scheduled">Scheduled</string>
+    <string name="post_status_post_trashed">Trashed</string>
+    <string name="post_status_post_published">Published</string>
+
+    <string-array name="post_settings_statuses" translatable="false">
+        <item>@string/post_status_publish_post</item>
+        <item>@string/post_status_draft</item>
+        <item>@string/post_status_pending_review</item>
+        <item>@string/post_status_post_private</item>
+    </string-array>
+
+    <!-- Aztec -->
+    <string name="editor_content_hint">Share your story here…</string>
+
+    <string name="editor_dropped_html_images_not_allowed">Dropping images while in HTML mode is not allowed</string>
+    <string name="editor_dropped_text_error">Error occurred while dropping text</string>
+    <string name="editor_dropped_title_images_not_allowed">Dropping images in the Title is not allowed</string>
+    <string name="editor_dropped_unsupported_files">Warning: not all dropped items are supported!</string>
+
+    <string name="error_media_small">Media too small to show</string>
+
+    <string name="menu_save_as_draft">Save as Draft</string>
+    <string name="menu_publish_now" translatable="false">@string/publish_now</string>
+    <string name="menu_preview">Preview</string>
+    <string name="menu_history">History</string>
+    <string name="menu_html_mode">HTML Mode</string>
+    <string name="menu_html_mode_done_snackbar">Switched to HTML mode</string>
+    <string name="menu_visual_mode">Visual Mode</string>
+    <string name="menu_visual_mode_done_snackbar">Switched to Visual mode</string>
+    <string name="menu_undo_snackbar_action">UNDO</string>
+
+    <string name="menu_undo">Undo</string>
+    <string name="menu_redo">Redo</string>
+    <string name="menu_debug">Debug Menu</string>
+    <string name="menu_switch_to_aztec_editor">Switch to classic editor</string>
+    <string name="menu_switch_to_gutenberg_editor">Switch to block editor</string>
+    <string name="menu_content_info">Content structure</string>
+
+    <string name="post_title">Title</string>
+
+    <string name="upload_finished_toast">Can\'t stop the upload because it\'s already finished</string>
+
+    <string name="link_dialog_title">Insert link</string>
+    <string name="link_dialog_button_remove_link">Remove Link</string>
+    <string name="link_dialog_edit_hint">http(s)://</string>
+    <string name="link_dialog_button_ok">OK</string>
+    <string name="link_dialog_button_cancel">Cancel</string>
+
+    <!-- History -->
+    <string name="description_user">User avatar</string>
+    <string name="history_detail_button_next">Next</string>
+    <string name="history_detail_button_previous">Previous</string>
+    <string name="history_detail_title">Revision</string>
+    <string name="history_empty_subtitle_page">When you make changes to your page you\'ll be able to see the history here</string>
+    <string name="history_empty_subtitle_post">When you make changes to your post you\'ll be able to see the history here</string>
+    <string name="history_empty_title">No history yet</string>
+    <string name="history_footer_page">Page Created on %1$s at %2$s</string>
+    <string name="history_footer_post">Post Created on %1$s at %2$s</string>
+    <string name="history_load_dialog_button_positive">Load</string>
+    <string name="history_loaded_revision">Revision loaded</string>
+    <string name="history_loading_revision">Loading revision</string>
+    <string name="history_fetching_revisions">Fetching revisions…</string>
+    <string name="history_title" translatable="false">@string/menu_history</string>
+    <string name="history_preview_visual">Visual preview</string>
+    <string name="history_preview_html">HTML preview</string>
+    <string name="history_no_title">(no title)</string>
+
+    <!-- Post Formats -->
+    <string name="post_format_aside">Aside</string>
+    <string name="post_format_audio">Audio</string>
+    <string name="post_format_chat">Chat</string>
+    <string name="post_format_gallery">Gallery</string>
+    <string name="post_format_image">Image</string>
+    <string name="post_format_link">Link</string>
+    <string name="post_format_quote">Quote</string>
+    <string name="post_format_standard">Standard</string>
+    <string name="post_format_status">Status</string>
+    <string name="post_format_video">Video</string>
+    <string-array name="post_format_display_names" translatable="false">
+        <item>@string/post_format_standard</item>
+        <item>@string/post_format_aside</item>
+        <item>@string/post_format_audio</item>
+        <item>@string/post_format_chat</item>
+        <item>@string/post_format_gallery</item>
+        <item>@string/post_format_image</item>
+        <item>@string/post_format_link</item>
+        <item>@string/post_format_quote</item>
+        <item>@string/post_format_status</item>
+        <item>@string/post_format_video</item>
+    </string-array>
+
+    <!-- Menu Buttons -->
+    <string name="new_post">New post</string>
+    <string name="new_media">New media</string>
+
+    <!-- Image Alignment -->
+    <string name="image_alignment">Alignment</string>
+
+    <string name="alignment_none">None</string>
+    <string name="alignment_left">Left</string>
+    <string name="alignment_center">Center</string>
+    <string name="alignment_right">Right</string>
+
+    <string-array name="alignment_key_array" translatable="false">
+        <item>none</item>
+        <item>left</item>
+        <item>center</item>
+        <item>right</item>
+    </string-array>
+
+    <string-array name="alignment_array" translatable="false">
+        <item>@string/alignment_none</item>
+        <item>@string/alignment_left</item>
+        <item>@string/alignment_center</item>
+        <item>@string/alignment_right</item>
+    </string-array>
+
+
+    <!-- Image Size -->
+    <string name="image_size">Size</string>
+
+    <string name="image_size_thumbnail_label">Thumbnail</string>
+    <string name="image_size_medium_label">Medium</string>
+    <string name="image_size_large_label">Large</string>
+    <string name="image_size_full_label">Full Size</string>
+
+    <string name="image_size_thumbnail_css_class" translatable="false">size-thumbnail</string>
+    <string name="image_size_medium_css_class" translatable="false">size-medium</string>
+    <string name="image_size_large_css_class" translatable="false">size-large</string>
+    <string name="image_size_full_css_class" translatable="false">size-full</string>
+
+    <!-- About View -->
+    <string name="app_title">WordPress for Android</string>
+    <string name="publisher">Publisher:</string>
+    <string name="publisher_with_company_param">Publisher: %s</string>
+    <string name="copyright_with_year_and_company_params">© %1$d %2$s</string>
+    <string name="automattic_inc" translatable="false">Automattic, Inc</string>
+    <string name="automattic_url" translatable="false">automattic.com</string>
+    <string name="version">Version</string>
+    <string name="version_with_name_param">Version %s</string>
+    <string name="tos">Terms of Service</string>
+    <string name="privacy_policy">Privacy policy</string>
+
+    <!-- Remote Post&Page has conflicts with local post -->
+    <string name="local_post_is_conflicted">Version conflict</string>
+    <string name="local_post_autosave_revision_available">You\'ve made unsaved changes to this post</string>
+    <string name="local_page_is_conflicted" translatable="false">@string/local_post_is_conflicted</string>
+    <string name="local_page_autosave_revision_available">You\'ve made unsaved changes to this page</string>
+
+    <!-- Post Remote Preview -->
+    <string name="post_preview_saving_draft">Saving…</string>
+    <string name="post_preview_remote_auto_saving_post">Generating Preview…</string>
+    <string name="remote_preview_operation_error">Error while trying to save post before preview</string>
+    <string name="preview_unavailable_self_hosted_sites">Preview Unavailable</string>
+    <string name="error_preview_empty_post">Can\'t preview an empty post</string>
+    <string name="error_preview_empty_page">Can\'t preview an empty page</string>
+    <string name="error_preview_empty_draft">Can\'t preview an empty draft</string>
+
+    <!-- message on post preview explaining links are disabled -->
+    <string name="preview_screen_links_disabled">Links are disabled on the preview screen</string>
+
+    <string name="image_settings">Image settings</string>
+    <string name="wordpress_blog">WordPress blog</string>
+    <string name="wordpress_dot_com" translatable="false">wordpress.com</string>
+
+    <!-- Error Messages -->
+    <!-- The following messages can\'t be factorized due to i18n -->
+    <string name="error_refresh_posts">Posts couldn\'t be refreshed at this time</string>
+    <string name="error_refresh_pages" tools:ignore="UnusedResources">Pages couldn\'t be refreshed at this time</string>
+    <string name="error_refresh_comments">Comments couldn\'t be refreshed at this time</string>
+    <string name="error_refresh_comments_showing_older">Comments couldn\'t be refreshed at this time - showing older comments</string>
+    <string name="error_refresh_media">Media couldn\'t be refreshed at this time</string>
+    <string name="error_deleting_post">An error occurred while deleting the post</string>
+    <string name="error_restoring_post">An error occurred while restoring the post</string>
+
+    <string name="error_refresh_unauthorized_comments">You don\'t have permission to view or edit comments</string>
+    <string name="error_refresh_unauthorized_pages">You don\'t have permission to view or edit pages</string>
+    <string name="error_refresh_unauthorized_posts">You don\'t have permission to view or edit posts</string>
+    <string name="error_fetch_my_profile">Couldn\'t retrieve your profile</string>
+    <string name="error_fetch_account_settings">Couldn\'t retrieve your account settings</string>
+    <string name="error_disabled_apis">Could not fetch settings: Some APIs are unavailable for this OAuth app ID + account combination.</string>
+    <string name="error_post_my_profile_no_connection">No connection, couldn\'t save your profile</string>
+    <string name="error_post_account_settings">Couldn\'t save your account settings</string>
+    <string name="error_generic">An error occurred</string>
+    <string name="error_generic_network">A network error occurred. Please check your connection and try again.</string>
+    <string name="error_moderate_comment">An error occurred while moderating</string>
+    <string name="error_edit_comment">An error occurred while editing the comment</string>
+    <string name="error_publish_empty_post">Can\'t publish an empty post</string>
+    <string name="error_publish_empty_page">Can\'t publish an empty page</string>
+    <string name="error_save_empty_draft">Can\'t save an empty draft</string>
+    <string name="error_publish_no_network">Device is offline. Post saved locally.</string>
+    <string name="error_publish_page_no_network">Device is offline. Page saved locally.</string>
+    <string name="error_upload_post_param">There was an error uploading this post: %s.</string>
+    <string name="error_upload_page_param">There was an error uploading this page: %s.</string>
+    <string name="error_upload_post_media_param">There was an error uploading the media in this post: %s.</string>
+    <string name="error_upload_page_media_param">There was an error uploading the media in this page: %s.</string>
+    <string name="error_media_insufficient_fs_permissions">Read permission denied on device media</string>
+    <string name="error_media_not_found">Media could not be found</string>
+    <string name="error_media_thumbnail_not_loaded">Media thumbnail could not be loaded</string>
+    <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>
+    <string name="error_media_parse_error">Unexpected response from server</string>
+    <string name="error_media_upload">An error occurred while uploading media</string>
+    <string name="error_media_refresh_no_connection">Connection required to refresh library</string>
+    <string name="error_media_load">Unable to load media</string>
+    <string name="error_media_save">Unable to save media</string>
+    <string name="error_media_canceled">Uploading media were canceled</string>
+    <string name="error_post_does_not_exist">This post no longer exists</string>
+    <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
+    <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
+    <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>
+    <string name="error_fetch_remote_site_settings">Couldn\'t retrieve site info</string>
+    <string name="error_post_remote_site_settings">Couldn\'t save site info</string>
+    <string name="error_fetch_users_list">Couldn\'t retrieve site users</string>
+    <string name="error_fetch_followers_list">Couldn\'t retrieve site followers</string>
+    <string name="error_fetch_email_followers_list">Couldn\'t retrieve site email followers</string>
+    <string name="error_fetch_viewers_list">Couldn\'t retrieve site viewers</string>
+    <string name="error_update_role">Couldn\'t update user role</string>
+    <string name="error_remove_user">Couldn\'t remove user</string>
+    <string name="error_remove_follower">Couldn\'t remove follower</string>
+    <string name="error_remove_viewer">Couldn\'t remove viewer</string>
+    <string name="error_notif_q_action_like">Could not like comment. Please try again later.</string>
+    <string name="error_notif_q_action_approve">Could not approve comment. Please try again later.</string>
+    <string name="error_notif_q_action_reply">Could not reply to comment. Please try again later.</string>
+    <string name="error_generic_error">We couldn\'t complete this action.</string>
+    <string name="error_generic_error_retrying">We couldn\'t complete this action, but we\'ll try again later. </string>
+    <string name="error_browser_no_network">Unable to load this page right now.</string>
+    <string name="error_network_connection">Check your network connection and try again.</string>
+
+    <!-- Post Error -->
+    <string name="error_unknown_post">Could not find the post on the server</string>
+    <string name="error_unknown_page">Could not find the page on the server</string>
+    <string name="error_unknown_post_type">Unknown post format</string>
+
+    <string name="error_media_recover_post">We couldn\'t upload this media.</string>
+    <string name="error_media_recover_post_not_published">We couldn\'t upload this media, and didn\'t publish the post.</string>
+    <string name="error_media_recover_post_not_published_private">We couldn\'t upload this media, and didn\'t publish this private post.</string>
+    <string name="error_media_recover_post_not_scheduled">We couldn\'t upload this media, and didn\'t schedule this post.</string>
+    <string name="error_media_recover_post_not_submitted">We couldn\'t upload this media, and didn\'t submit this post for review. </string>
+    <string name="error_media_recover_post_not_published_retrying" translatable="false">@string/error_post_not_published_retrying</string>
+    <string name="error_media_recover_post_not_published_retrying_private" translatable="false">@string/error_post_not_published_retrying_private</string>
+    <string name="error_media_recover_post_not_scheduled_retrying" translatable="false">@string/error_post_not_scheduled_retrying</string>
+    <string name="error_media_recover_post_not_submitted_retrying" translatable="false">@string/error_post_not_submitted_retrying</string>
+
+    <string name="error_post_not_published">We couldn\'t complete this action, and didn\'t publish this post.</string>
+    <string name="error_post_not_published_private">We couldn\'t complete this action, and didn\'t publish this private post.</string>
+    <string name="error_post_not_scheduled">We couldn\'t complete this action, and didn\'t schedule this post.</string>
+    <string name="error_post_not_submitted">We couldn\'t complete this action, and didn\'t submit this post for review.</string>
+    <string name="error_post_not_published_retrying">We couldn\'t publish this post, but we\'ll try again later.</string>
+    <string name="error_post_not_published_retrying_private">We couldn\'t publish this private post, but we\'ll try again later.</string>
+    <string name="error_post_not_scheduled_retrying">We couldn\'t schedule this post, but we\'ll try again later.</string>
+    <string name="error_post_not_submitted_retrying">We couldn\'t submit this post for review, but we\'ll try again later. </string>
+
+    <!-- Image Descriptions for Accessibility -->
+    <string name="error_load_comment">Couldn\'t load the comment</string>
+    <string name="error_downloading_image">Error downloading image</string>
+    <string name="cd_related_post_preview_image">Related post preview image</string>
+
+    <!--
+      Jetpack strings
+    -->
+    <string name="jetpack_disconnect_pref_title">"Disconnect from WordPress.com"</string>
+    <string name="jetpack_disconnect_confirmation_message">Are you sure you want to disconnect Jetpack from the site?</string>
+    <string name="jetpack_disconnect_confirm">Disconnect</string>
+    <string name="jetpack_disconnect_success_toast">Site disconnected</string>
+    <string name="jetpack_disconnect_error_toast">Error disconnecting site</string>
+    <string name="jetpack_already_connected_toast">You are already connected to Jetpack</string>
+    <string name="jetpack_connection_failed_with_reason">Connection to Jetpack failed: %s</string>
+
+    <!--
+      reader strings
+    -->
+    <string name="reader_save_for_later_title">Saved posts</string>
+    <string name="reader_save_for_later_display_name">Saved</string>
+    <string name="reader_discover_display_name">Discover</string>
+    <string name="reader_my_likes_display_name">Likes</string>
+    <string name="reader_following_display_name">Following</string>
+
+    <!-- timespan shown for posts/comments published within the past 60 seconds -->
+    <string name="timespan_now">now</string>
+
+    <!-- title shown for untitled posts and blogs -->
+    <string name="reader_untitled_post">(Untitled)</string>
+
+    <!-- accessibility announcement when list loads -->
+    <string name="reader_acessibility_list_loaded">"The list has loaded with %1$d items."</string>
+
+    <!-- activity titles -->
+    <string name="reader_title_deeplink">WordPress Reader</string>
+    <string name="reader_title_applog">Application log</string>
+    <string name="reader_title_blog_preview">Reader Site</string>
+    <string name="reader_title_tag_preview">Reader Tag</string>
+    <string name="reader_title_post_detail">Reader Post</string>
+    <string name="reader_title_post_detail_wpcom">WordPress.com Post</string>
+    <string name="reader_title_related_post_detail">Related Post</string>
+    <string name="reader_title_subs">Manage Tags &amp; Sites</string>
+    <string name="reader_title_photo_viewer">%1$d of %2$d</string>
+    <string name="reader_title_comments" translatable="false">@string/comments</string>
+
+    <!-- view pager titles -->
+    <string name="reader_page_followed_tags">Followed tags</string>
+    <string name="reader_page_followed_blogs">Followed sites</string>
+    <string name="reader_page_recommended_blogs">Sites you may like</string>
+
+    <!-- menu text -->
+    <string name="reader_menu_tags">Edit tags and sites</string>
+    <string name="reader_menu_block_blog">Block this site</string>
+
+    <!-- button text -->
+    <string name="reader_btn_share">Share</string>
+    <string name="reader_btn_follow">Follow</string>
+    <string name="reader_btn_unfollow">Following</string>
+    <string name="reader_add_bookmark">Add to saved posts</string>
+    <string name="reader_remove_bookmark">Remove from saved posts</string>
+    <string name="reader_btn_bookmark">Save</string>
+    <string name="reader_btn_bookmarked">Saved</string>
+    <string name="reader_bookmark_snack_btn">View All</string>
+    <string name="reader_bookmark_snack_title">Post saved</string>
+    <string name="reader_btn_notifications_off">Turn off site notifications</string>
+    <string name="reader_btn_notifications_on">Turn on site notifications</string>
+    <string name="reader_btn_select_few_interests">Select a few to continue</string>
+    <string name="reader_btn_done">Done</string>
+
+
+    <!-- accessibility content desciptions -->
+    <string name="reader_btn_remove_filter_content_description">Remove the current filter</string>
+    <string name="reader_btn_select_filter_content_description">Select a Site or Tag to filter posts</string>
+    <string name="reader_btn_selected_filter_tick_content_description">Selected</string>
+    <string name="reader_bottom_sheet_content_description">Select a Tag or Site, Pop Up Window</string>
+    <string name="reader_choose_interests_content_description">Choose your interests</string>
+
+    <string name="reader_followed_blog_notifications">Enable notifications for %1$s%2$s%3$s?</string>
+    <string name="reader_followed_blog_notifications_action">Enable</string>
+    <string name="reader_followed_blog_notifications_this">this site</string>
+
+    <!-- EditText hints -->
+    <string name="reader_hint_comment_on_post">Reply to post…</string>
+    <string name="reader_hint_comment_on_comment">Reply to comment…</string>
+    <string name="reader_hint_add_tag_or_url">Enter a URL or tag to follow</string>
+    <string name="reader_hint_post_search">Search WordPress</string>
+    <string name="reader_hint_search_followed_sites">Search followed sites</string>
+
+    <!-- TextView labels -->
+    <string name="reader_label_new_posts">New posts</string>
+    <string name="reader_label_new_posts_subtitle">Tap to show them</string>
+    <string name="reader_label_added_tag">Added %s</string>
+    <string name="reader_label_removed_tag">Removed %s</string>
+    <string name="reader_label_reply">Reply</string>
+    <string name="reader_label_followed_blog">Site followed</string>
+    <string name="reader_label_comments_closed">Comments are closed</string>
+    <string name="reader_label_view_original">View original article</string>
+    <string name="reader_label_follow_count">%,d followers</string>
+    <string name="reader_label_gap_marker">Load more posts</string>
+    <string name="reader_label_post_search_explainer">What would you like to find?</string>
+    <string name="reader_label_local_related_posts">More in %s</string>
+    <string name="reader_label_global_related_posts">More on WordPress.com</string>
+    <string name="reader_label_visit">Visit site</string>
+    <string name="reader_label_discover_follow_tags">Discover and follow tags you love</string>
+    <string name="reader_label_choose_your_interests">Choose your interests</string>
+    <string name="reader_photo_by">Photo by %s</string>
+    <string name="reader_view_comments">View comments</string>
+
+    <string name="reader_excerpt_link">Visit %s for more</string>
+
+    <!-- reblog -->
+    <string name="reader_view_reblog">Reblog</string>
+    <string name="reader_no_site_to_reblog_title">No available WordPress.com sites</string>
+    <string name="reader_no_site_to_reblog_detail">Once you create a WordPress.com site, you can reblog content that you like to your own site.</string>
+    <string name="reader_no_site_to_reblog_action">Manage Sites</string>
+    <string name="reader_reblog_error">Reblog failed</string>
+    <string name="sitepicker_continue_flow">Continue</string>
+
+    <!-- like counts -->
+    <string name="reader_label_like">Like</string>
+    <string name="reader_likes_one">One person likes this</string>
+    <string name="reader_likes_multi">%,d people like this</string>
+    <string name="reader_likes_only_you">You like this</string>
+    <string name="reader_likes_you_and_one">You and one other like this</string>
+    <string name="reader_likes_you_and_multi">You and %,d others like this</string>
+    <string name="reader_label_liked_by">Liked By</string>
+
+    <string name="reader_short_like_count_none">Like</string>
+    <string name="reader_short_like_count_one">1 Like</string>
+    <string name="reader_short_like_count_multi">%s Likes</string>
+
+    <string name="reader_short_comment_count_one">1 Comment</string>
+    <string name="reader_short_comment_count_multi">%s Comments</string>
+
+    <!-- toast messages -->
+    <string name="reader_toast_err_comment_failed">Couldn\'t post your comment</string>
+    <string name="reader_toast_err_tag_exists">You already follow this tag</string>
+    <string name="reader_toast_err_tag_invalid">That isn\'t a valid tag</string>
+    <string name="reader_toast_err_add_tag">Unable to add this tag</string>
+    <string name="reader_toast_err_remove_tag">Unable to remove this tag</string>
+    <string name="reader_toast_err_share_intent">Unable to share</string>
+    <string name="reader_toast_err_view_image">Unable to view image</string>
+    <string name="reader_toast_err_get_blog_info">Unable to show this site</string>
+    <string name="reader_toast_err_already_follow_blog">You already follow this site</string>
+    <string name="reader_toast_err_follow_blog">Unable to follow this site</string>
+    <string name="reader_toast_err_follow_blog_not_found">This site could not be found</string>
+    <string name="reader_toast_err_follow_blog_not_authorized">You are not authorized to access this site</string>
+    <string name="reader_toast_err_unfollow_blog">Unable to unfollow this site</string>
+    <string name="reader_toast_blog_blocked">Posts from this site will no longer be shown</string>
+    <string name="reader_toast_err_block_blog">Unable to block this site</string>
+    <string name="reader_toast_err_generic">Unable to perform this action</string>
+    <string name="reader_toast_err_cannot_like_post">Failed to like this post</string>
+    <string name="reader_toast_err_comment_not_found">Comment not found!</string>
+    <string name="reader_toast_err_already_liked">You have already liked that comment</string>
+    <string name="reader_toast_err_url_intent">Unable to open %s</string>
+
+    <!-- snackbar messages -->
+    <string name="reader_snackbar_err_cannot_like_post_logged_out">Can\'t like while logged out of WordPress.com</string>
+
+    <!-- failure messages when retrieving a single reader post -->
+    <string name="reader_err_get_post_generic">Unable to retrieve this post</string>
+    <string name="reader_err_get_post_not_authorized">You\'re not authorized to view this post</string>
+    <string name="reader_err_get_post_not_authorized_fallback">You\'re not authorized to view this post. Use the top action button to try a browser instead.</string>
+    <string name="reader_err_get_post_not_authorized_signin">You\'re not authorized to view this post. Try signing in to WordPress.com first.</string>
+    <string name="reader_err_get_post_not_authorized_signin_fallback">You\'re not authorized to view this post. Try signing in to WordPress.com first or use the top action button to open a browser instead.</string>
+    <string name="reader_err_get_post_not_found">This post no longer exists</string>
+
+    <!-- empty list/grid text -->
+    <string name="reader_empty_posts_no_connection" translatable="false">@string/no_network_title</string>
+    <string name="reader_empty_posts_request_failed">Unable to retrieve posts</string>
+    <string name="reader_self_hosted_select_filter">Use the filter button to find posts on specific subjects</string>
+    <string name="reader_empty_posts_in_tag">No posts with this tag</string>
+    <string name="reader_empty_posts_in_tag_updating">Fetching posts…</string>
+    <string name="reader_empty_posts_in_custom_list">The sites in this list haven\'t posted anything recently</string>
+    <string name="reader_empty_followed_tags_subtitle">Add tags here to find posts about your favorite topics</string>
+    <string name="reader_empty_followed_tags_title">No followed tags</string>
+    <string name="reader_empty_recommended_blogs">No recommended sites</string>
+    <string name="reader_empty_followed_blogs_title">No followed sites</string>
+    <string name="reader_empty_followed_blogs_search_title">No sites matching your search</string>
+    <string name="reader_empty_followed_blogs_description">When you follow sites, you\'ll see their content here</string>
+    <string name="reader_empty_followed_blogs_no_recent_posts_title">No recent posts</string>
+    <string name="reader_empty_followed_blogs_no_recent_posts_description">The sites you follow haven\'t posted anything recently</string>
+    <string name="reader_empty_followed_blogs_button_discover">Discover sites</string>
+    <string name="reader_empty_followed_blogs_button_followed">Go to following</string>
+    <string name="reader_empty_posts_liked_title">Nothing liked yet</string>
+    <string name="reader_empty_posts_liked_description">Posts that you like will appear here</string>
+    <string name="reader_empty_saved_posts_title">No posts saved — yet!</string>
+    <string name="reader_empty_saved_posts_description">Tap %s to save a post to your list.</string>
+    <string name="reader_empty_saved_posts_content_description">Tap the Add to Save Posts button to save a post to your list.</string>
+    <string name="reader_empty_comments">No comments yet</string>
+    <string name="reader_empty_posts_in_blog">This site is empty</string>
+    <string name="reader_empty_search_title">No results found</string>
+    <string name="reader_empty_search_description">No results found for %s for your language</string>
+    <string name="reader_empty_search_request_failed">Unable to perform search</string>
+
+    <string name="dlg_confirm_clear_search_history">Clear search history?</string>
+    <string name="label_clear_search_history">Clear search history</string>
+
+    <!-- attribution line for Discover posts, ex: "Originally posted by [AuthorName] on [BlogName] -->
+    <string name="reader_discover_attribution_author_and_blog">Originally posted by %1$s on %2$s</string>
+    <string name="reader_discover_attribution_author">Originally posted by %s</string>
+    <string name="reader_discover_attribution_blog">Originally posted on %s</string>
+    <string name="reader_discover_visit_blog">Visit %s</string>
+
+    <!-- dialogs -->
+    <string name="reader_save_posts_locally_dialog_title">Save Posts for Later</string>
+    <string name="reader_save_posts_locally_dialog_message">Save this post, and come back to read it whenever you\'d like. It will only be available on this device — saved posts don\'t sync to your other devices.</string>
+
+    <!-- connection bar which appears on main activity when there's no connection -->
+    <string name="connectionbar_no_connection">No connection</string>
+
+    <!-- NUX strings -->
+    <string name="invalid_email_message">Your email address isn\'t valid</string>
+    <string name="email_invalid">Enter a valid email address</string>
+    <string name="username_or_password_incorrect">The username or password you entered is incorrect</string>
+    <string name="ssl_certificate_details">Details</string>
+    <string name="ssl_certificate_error">Invalid SSL certificate</string>
+    <string name="ssl_certificate_ask_trust">If you usually connect to this site without problems, this error could mean that someone is trying to impersonate the site, and you shouldn\'t continue. Would you like to trust the certificate anyway?</string>
+    <string name="verification_code">Verification code</string>
+    <string name="auth_required">Log in again to continue.</string>
+    <string name="logging_in">Logging in</string>
+    <string name="magic_link_unavailable_error_message">Currently unavailable. Please enter your password</string>
+    <string name="checking_email">Checking email</string>
+    <string name="already_logged_in_wpcom">You\'re already logged in a WordPress.com account, you can\'t add a WordPress.com site bound to another account.</string>
+    <string name="cannot_add_duplicate_site">This site already exists in the app, you can\'t add it.</string>
+    <string name="duplicate_site_detected">A duplicate site has been detected.</string>
+    <string name="error_user_username_instead_of_email">Please log in using your WordPress.com username instead of your email address.</string>
+
+    <!-- Help view -->
+    <string name="help">Help</string>
+    <string name="forgot_password">Lost your password?</string>
+    <string name="contact_us">Contact us</string>
+    <string name="browse_our_faq_button">Browse our FAQ</string>
+    <string name="my_tickets">My Tickets</string>
+    <string name="application_log_button">Application log</string>
+    <string name="support_contact_email">Contact email</string>
+    <string name="support_contact_email_not_set">Not set</string>
+    <string name="support_push_notification_title">WordPress</string>
+    <string name="support_push_notification_message">New message from \'Help &amp; Support\'</string>
+
+    <!--My Site-->
+    <string name="my_site_header_external">External</string>
+    <string name="my_site_header_configuration">Configuration</string>
+    <string name="my_site_header_look_and_feel">Look and Feel</string>
+    <string name="my_site_header_publish">Publish</string>
+    <string name="my_site_btn_site_pages">Site Pages</string>
+    <string name="my_site_btn_blog_posts">Blog Posts</string>
+    <string name="my_site_btn_sharing">Sharing</string>
+    <string name="my_site_btn_site_settings">Settings</string>
+    <string name="my_site_btn_comments" translatable="false">@string/comments</string>
+    <string name="my_site_btn_switch_site">Switch Site</string>
+    <string name="my_site_btn_view_admin">View Admin</string>
+    <string name="my_site_btn_view_site">View Site</string>
+    <string name="my_site_btn_plugins">Plugins</string>
+    <string name="my_site_create_new_site">Create a new site for your business, magazine, or personal blog; or connect an existing WordPress installation.</string>
+    <string name="my_site_create_new_site_title">You don\'t have any sites</string>
+    <string name="my_site_add_new_site">Add new site</string>
+    <string name="my_site_select_domains_page_title">Site Address</string>
+    <string name="my_site_custom_domain_name">All WordPress.com plans include a custom domain name. Register your free premium domain now.</string>
+    <string name="my_site_verify_your_email">Verify your email address - instructions sent to %s</string>
+    <string name="my_site_verify_your_email_without_email">Verify your email address - instructions sent to your email</string>
+    <string name="my_site_icon_dialog_title">Site Icon</string>
+    <string name="my_site_icon_dialog_add_message">Would you like to add a site icon?</string>
+    <string name="my_site_icon_dialog_change_message">How would you like to edit the icon?</string>
+    <string name="my_site_icon_dialog_add_requires_permission_message">You don\'t have permission to add a site icon.</string>
+    <string name="my_site_icon_dialog_change_requires_permission_message">You don\'t have permission to edit the site icon.</string>
+    <string name="my_site_icon_dialog_change_button">Change</string>
+    <string name="my_site_icon_dialog_remove_button">Remove</string>
+    <string name="my_site_icon_dialog_cancel_button">Cancel</string>
+    <string name="my_site_icon_content_description">Change site icon</string>
+
+    <string name="my_site_bottom_sheet_title">Add new</string>
+    <string name="my_site_bottom_sheet_add_post">Blog post</string>
+    <string name="my_site_bottom_sheet_add_page">Site page</string>
+
+    <!-- site picker -->
+    <string name="site_picker_title">Choose site</string>
+    <string name="site_picker_edit_visibility">Show/hide sites</string>
+    <string name="site_picker_add_site">Add new site</string>
+    <string name="site_picker_add_self_hosted">Add self-hosted site</string>
+    <string name="site_picker_create_wpcom">Create WordPress.com site</string>
+    <string name="site_picker_cant_hide_current_site">\"%s\" wasn\'t hidden because it\'s the current site</string>
+    <string name="site_picker_remove_site_empty">No sites matching your search</string>
+    <string name="site_picker_remove_site_error">Error removing site, try again later</string>
+    <string name="site_picker_failed_selecting_added_site">Couldn\'t select newly added self-hosted site.</string>
+    <string name="site_picker_ask_site_select">Couldn\'t select site. Please try again.</string>
+
+    <!-- Application logs view -->
+    <string name="logs_copied_to_clipboard">Application logs have been copied to the clipboard</string>
+
+    <!--Support strings-->
+    <string name="support_identity_input_dialog_enter_email_and_name">To continue please enter your email address and name</string>
+    <string name="support_identity_input_dialog_enter_email">Please enter your email address</string>
+    <string name="support_identity_input_dialog_email_label">Email</string>
+    <string name="support_identity_input_dialog_name_label">Name</string>
+
+    <!--Me-->
+    <string name="me_profile_photo">Profile Photo</string>
+    <string name="me_btn_app_settings">App Settings</string>
+    <string name="me_btn_support">Help &amp; Support</string>
+    <string name="me_btn_login_logout">Login/Logout</string>
+    <string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
+    <string name="me_disconnect_from_wordpress_com">Log out of WordPress.com</string>
+
+    <!--TabBar Accessibility Labels-->
+    <string name="tabbar_accessibility_label_my_site">My Site. View your site and manage it, including stats.</string>
+    <string name="tabbar_accessibility_label_reader">Reader. Follow content from other sites.</string>
+    <string name="tabbar_accessibility_label_notifications">Notifications. Manage your notifications.</string>
+
+    <!-- Special characters -->
+    <string name="bullet" translatable="false">\u2022</string>
+    <string name="previous_button" translatable="false">&lt;</string>
+    <string name="next_button" translatable="false">&gt;</string>
+
+    <!-- Publicize and sharing -->
+    <string name="sharing">Sharing</string>
+    <string name="sharing_disabled">Sharing module disabled</string>
+    <string name="sharing_disabled_description">You cannot access your sharing settings because your Sharing Jetpack module is disabled.</string>
+    <string name="connections_label">Connections</string>
+    <string name="connections_description">Connect your favorite social media services to automatically share new posts with friends.</string>
+    <string name="connected_accounts_label">Connected accounts</string>
+    <string name="connection_service_label">Publicize to %s</string>
+    <string name="connection_service_description">Connect to automatically share your blog posts to %s.</string>
+    <string name="share_btn_connect">Connect</string>
+    <string name="share_btn_disconnect">Disconnect</string>
+    <string name="share_btn_reconnect">Reconnect</string>
+    <string name="share_btn_connect_another_account">Connect another account</string>
+    <string name="dlg_confirm_publicize_disconnect">Disconnect from %s?</string>
+    <string name="connecting_social_network">Connecting %s</string>
+    <string name="connection_chooser_message">Select the account you wish to authorize. Note that your posts will be shared to the selected account automatically.</string>
+    <string name="icon_and_text_display">Icon &amp; Text</string>
+    <string name="icon_only_display">Icon Only</string>
+    <string name="text_only_display">Text Only</string>
+    <string name="official_buttons_display">Official Buttons</string>
+    <string-array name="sharing_button_style_display_array" translatable="false">
+        <item>@string/icon_and_text_display</item>
+        <item>@string/icon_only_display</item>
+        <item>@string/text_only_display</item>
+        <item>@string/official_buttons_display</item>
+    </string-array>
+    <string name="icon_text" translatable="false">icon-text</string>
+    <string name="icon" translatable="false">icon</string>
+    <string name="text" translatable="false">text</string>
+    <string name="official" translatable="false">official</string>
+    <string-array name="sharing_button_style_array" translatable="false">
+        <item>@string/icon_text</item>
+        <item>@string/icon</item>
+        <item>@string/text</item>
+        <item>@string/official</item>
+    </string-array>
+    <string name="site_settings_reblog_and_like_header">Reblog &amp; Like</string>
+    <string name="site_settings_like_header">Like</string>
+    <string name="site_settings_reblog">Show Reblog Button</string>
+    <string name="site_settings_like">Show Like Button</string>
+    <string name="manage">Manage</string>
+    <string name="sharing_buttons">Sharing buttons</string>
+    <string name="label">Label</string>
+    <string name="button_style">Button Style</string>
+    <string name="sharing_comment_likes">Comment Likes</string>
+    <string name="twitter_username">Twitter Username</string>
+    <string name="sharing_sharing_buttons_description">Select which buttons are shown under your posts</string>
+    <string name="sharing_more_description">A \"More\" button contains a dropdown which displays sharing buttons</string>
+    <string name="sharing_edit_more_buttons">Edit \"More\" Buttons</string>
+    <string name="buttons">Buttons</string>
+    <string name="sharing_comment_likes_description">Allow all comments to be Liked by you and your readers</string>
+    <string name="likes">Likes</string>
+    <string name="twitter">Twitter</string>
+    <string name="connected">Connected</string>
+    <string name="cannot_connect_account_error">The %s connection could not be made because no account was selected.</string>
+    <string name="connecting_account">Connecting account</string>
+    <string name="sharing_label_message">Change the text of the sharing buttons\' label. This text won\'t appear until you add at least one sharing button.</string>
+    <string name="sharing_twitter_message">This will be included in tweets when people share using the Twitter button</string>
+    <string name="dialog_title_sharing_facebook_account_must_have_pages">Not Connected</string>
+    <string name="sharing_facebook_account_must_have_pages">The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages.</string>
+
+    <!--Theme Browser-->
+    <string name="current_theme">Current Theme</string>
+    <string name="customize">Customize</string>
+    <string name="details">Details</string>
+    <string name="support">Support</string>
+    <string name="active">Active</string>
+
+    <string name="theme_activate">Activate</string>
+    <string name="theme_try_and_customize">Try &amp; Customize</string>
+    <string name="theme_view">View</string>
+    <string name="theme_details">Details</string>
+    <string name="theme_support">Support</string>
+    <string name="theme_done">DONE</string>
+    <string name="theme_manage_site">MANAGE SITE</string>
+    <string name="theme_prompt">Thanks for choosing %1$s</string>
+    <string name="theme_by_author_prompt_append"> by %1$s</string>
+    <string name="theme_activation_error">Something went wrong. Could not activate theme</string>
+    <string name="selected_theme">Selected Theme</string>
+    <string name="could_not_load_theme">Could not load theme</string>
+    <string name="themes_empty_list">No themes matching your search</string>
+
+    <!--People Management-->
+    <string name="people">People</string>
+    <string name="role">Role</string>
+    <string name="follower_subscribed_since">Since %1$s</string>
+    <string name="person_remove_confirmation_title">Remove %1$s</string>
+    <string name="user_remove_confirmation_message">If you remove %1$s, that user will no longer be able to access this site, but any content that was created by %1$s will remain on the site.\n\nWould you still like to remove this user?</string>
+    <string name="follower_remove_confirmation_message">If removed, this follower will stop receiving notifications about this site, unless they re-follow.\n\nWould you still like to remove this follower?</string>
+    <string name="viewer_remove_confirmation_message">If you remove this viewer, he or she will not be able to visit this site.\n\nWould you still like to remove this viewer?</string>
+    <string name="person_removed">Successfully removed %1$s</string>
+    <string name="invite_people">Invite People</string>
+    <string name="invite_names_title">Usernames or Emails</string>
+    <string name="invite">Invite</string>
+    <string name="button_invite" translatable="false">@string/invite</string>
+    <string name="invite_username_not_found">%s: User not found</string>
+    <string name="invite_already_a_member">%s: Already a member</string>
+    <string name="invite_already_following">%s: Already following</string>
+    <string name="invite_user_blocked_invites">%s: User blocked invites</string>
+    <string name="invite_invalid_email">%s: Invalid email</string>
+    <string name="invite_message_title">Custom Message</string>
+    <string name="invite_message_remaining_zero">0 characters remaining</string>
+    <string name="invite_message_remaining_one">1 character remaining</string>
+    <string name="invite_message_remaining_other">%d characters remaining</string>
+    <string name="invite_message_info">(Optional) You can enter a custom message of up to 500 characters that will be included in the invitation to the user(s).</string>
+    <string name="invite_message_usernames_limit">Invite up to 10 email addresses and/or WordPress.com usernames. Those needing a username will be sent instructions on how to create one.</string>
+    <string name="invite_error_no_usernames">Please add at least one username</string>
+    <string name="invite_error_invalid_usernames_one">Cannot send: A username or email is invalid</string>
+    <string name="invite_error_invalid_usernames_multiple">Cannot send: There are invalid usernames or emails</string>
+    <string name="invite_error_sending">An error occurred while trying to send the invite!</string>
+    <string name="invite_error_some_failed">Invite sent but error(s) occurred!</string>
+    <string name="invite_error_for_username">%1$s: %2$s</string>
+    <string name="invite_sent">Invite sent successfully</string>
+
+    <string name="people_dropdown_item_team">Team</string>
+    <string name="people_dropdown_item_followers">Followers</string>
+    <string name="people_dropdown_item_email_followers">Email Followers</string>
+    <string name="people_dropdown_item_viewers">Viewers</string>
+    <string name="people_empty_list_filtered_users">No users yet</string>
+    <string name="people_empty_list_filtered_followers">No followers yet</string>
+    <string name="people_empty_list_filtered_email_followers">No email followers yet</string>
+    <string name="people_empty_list_filtered_viewers">No viewers yet</string>
+    <string name="people_fetching">Fetching users…</string>
+    <string name="title_follower">Follower</string>
+    <string name="title_email_follower">Email Follower</string>
+
+    <string name="role_follower">Follower</string>
+    <string name="role_viewer">Viewer</string>
+
+    <!--Plugins-->
+    <string name="plugins">Plugins</string>
+    <string name="plugin_byline">by %s</string>
+    <string name="plugin_active">Active</string>
+    <string name="plugin_inactive">Inactive</string>
+    <string name="plugin_detail_label_state_active">Active</string>
+    <string name="plugin_detail_label_state_autoupdates">Autoupdates</string>
+    <string name="plugin_not_found">An error occurred when accessing this plugin</string>
+    <string name="plugin_version">Version %s</string>
+    <string name="plugin_installed_version">Version %s installed</string>
+    <string name="plugin_installed">Installed</string>
+    <string name="plugin_auto_managed">Auto-managed</string>
+    <string name="plugin_install">Install</string>
+    <string name="plugin_available_version">Version %s is available</string>
+    <string name="plugin_updated_successfully">Successfully updated %s</string>
+    <string name="plugin_installed_successfully">Successfully installed %s</string>
+    <string name="plugin_updated_failed">Error updating %s.</string>
+    <string name="plugin_updated_failed_detailed">Error updating %1$s: %2$s</string>
+    <string name="plugin_removed_successfully">Successfully removed %s</string>
+    <string name="plugin_remove_failed">Error removing %s</string>
+    <string name="plugin_installed_failed">Error installing %s</string>
+    <string name="plugin_configuration_failed">An error occurred while configuring the plugin: %s</string>
+    <string name="plugin_disable_progress_dialog_message">Disabling %s…</string>
+    <string name="plugin_remove_progress_dialog_message">Removing %s…</string>
+    <string name="plugin_remove_dialog_title">Remove Plugin</string>
+    <string name="plugin_remove_dialog_message">Are you sure you want to remove %1$s from %2$s?\n\nThis will deactivate the plugin and delete all associated files and data.</string>
+    <string name="plugin_install_custom_domain_required_dialog_title">Install plugin</string>
+    <string name="plugin_install_custom_domain_required_dialog_message">To install plugins, you need to have a custom domain associated with your site.</string>
+    <string name="plugin_install_custom_domain_required_dialog_register_btn">Register domain</string>
+    <string name="plugin_check_domain_credits_progress_dialog_message">Checking domain credits</string>
+    <string name="plugin_check_domain_credit_error">Failed to check available domain credits</string>
+    <string name="plugin_install_first_plugin_confirmation_dialog_title">Install plugin</string>
+    <string name="plugin_install_first_plugin_confirmation_dialog_message">Installing the first plugin on your site can take up to 1 minute. During this time you won’t be able to make changes to your site.</string>
+    <string name="plugin_install_first_plugin_confirmation_dialog_install_btn">Install</string>
+    <string name="plugin_fetch_error">Unable to load plugins</string>
+    <string name="plugin_search_error">Unable to search plugins</string>
+    <string name="plugin_manage">Manage</string>
+    <string name="plugin_see_all">See All</string>
+    <string name="plugins_empty_search_list">No matches</string>
+    <string name="plugin_install_first_plugin_progress_dialog_message">Installing plugin…</string>
+    <string name="plugin_install_first_plugin_almost_finished_dialog_message">We\'re doing the final setup — almost done…</string>
+
+    <!-- Domain Registration -->
+    <string name="register_domain">Register Domain</string>
+    <string name="domains_suggestions_choose_domain">Choose Domain</string>
+    <string name="domains_suggestions_empty_list">No suggestions found</string>
+    <string name="domains_suggestions_intro_title">Choose a premium domain name</string>
+    <string name="domains_suggestions_intro_description">This is where people will find you on the internet.</string>
+    <string name="domain_suggestions_search_hint">Type a keyword for more ideas</string>
+    <string name="domain_suggestions_fetch_error">Domain suggestions couldn\'t be loaded</string>
+    <string name="domain_registration_contact_form_input_error">Please enter a valid %s</string>
+    <string name="domain_registration_privacy_protection_title">Privacy Protection</string>
+    <string name="domain_registration_privacy_protection_description">Domain owners have to share contact information in a public database of all domains.
+        With Privacy Protection, we publish our own information instead of yours and privately forward any communication to you.</string>
+    <string name="domain_registration_privacy_protection_tos">By registering this domain you agree to our %1$sterms and conditions%2$s</string>
+    <string name="domain_privacy_option_on_title">Register privately with Privacy Protection</string>
+    <string name="domain_privacy_option_off_title">Register publicly</string>
+    <string name="domain_contact_information_title">Domain contact information</string>
+    <string name="domain_contact_information_description">For your convenience, we have pre-filled your WordPress.com
+        contact information. Please review to be sure it’s the correct information you want to use for this domain.</string>
+    <string name="domain_contact_information_organization_hint">Organization (optional)</string>
+    <string name="domain_contact_information_phone_number_hint">Phone</string>
+    <string name="domain_contact_information_country_code_hint">Country code</string>
+    <string name="domain_contact_information_country_hint">Country</string>
+    <string name="domain_contact_information_address_hint">Address</string>
+    <string name="domain_contact_information_address_hint_two">Address 2</string>
+    <string name="domain_contact_information_city_hint">City</string>
+    <string name="domain_contact_information_state_hint">State</string>
+    <string name="domain_contact_information_state_not_available_hint">State (Not Available)</string>
+    <string name="domain_contact_information_postal_code_hint">Postal code</string>
+    <string name="domain_contact_information_register_domain_button">Register Domain</string>
+    <string name="domain_registration_result_title">Congratulations</string>
+    <string name="domain_registration_result_description">your new domain &lt;b&gt;%s&lt;/b&gt; is being set up. Your site is
+        doing somersaults in excitement!</string>
+    <string name="domain_registration_result_continue_button">continue</string>
+    <string name="domain_registration_country_picker_dialog_title">Select Country</string>
+    <string name="domain_registration_state_picker_dialog_title">Select State</string>
+    <string name="domain_registration_registering_domain_name_progress_dialog_message">Registering domain name…</string>
+
+    <!-- Automated Transfer Eligibility Errors -->
+    <string name="plugin_install_site_ineligible_default_error">If you just registered a domain name, please wait until we finish setting it up and try again.\n\nIf not, looks like something went wrong and plugin feature might not be available for this site.</string>
+    <string name="plugin_install_site_ineligible_not_using_custom_domain">Plugin feature requires a custom domain.</string>
+    <string name="plugin_install_site_ineligible_no_business_plan">Plugin feature requires a business plan.</string>
+    <string name="plugin_install_site_ineligible_site_private">Plugin feature requires the site to be public.</string>
+    <string name="plugin_install_site_ineligible_email_unverified">Plugin feature requires a verified email address.</string>
+    <string name="plugin_install_site_ineligible_excessive_disk_space">Plugin cannot be installed due to disk space limitations.</string>
+    <string name="plugin_install_site_ineligible_no_vip_sites">Plugin cannot be installed on VIP sites.</string>
+    <string name="plugin_install_site_ineligible_non_admin_user">Plugin feature requires admin privileges.</string>
+    <string name="plugin_install_site_ineligible_not_domain_owner">Plugin feature requires primary domain subscription to be associated with this user.</string>
+    <string name="plugin_install_site_ineligible_site_graylisted">Plugin feature requires the site to be in good standing.</string>
+
+    <string name="plugin_caption_installed" translatable="false">@string/plugin_installed</string>
+    <string name="plugin_caption_featured">Featured</string>
+    <string name="plugin_caption_popular">Popular</string>
+    <string name="plugin_caption_new">New</string>
+    <string name="plugin_caption_search">Search Plugins</string>
+
+    <string name="wordpress_dot_org_plugin_page">WordPress.org Plugin page</string>
+    <string name="plugin_home_page">Plugin homepage</string>
+    <string name="plugin_settings">Settings</string>
+    <string name="plugin_description">Description</string>
+    <string name="plugin_installation">Installation</string>
+    <string name="plugin_whatsnew">What\'s New</string>
+    <string name="plugin_faq">Frequently Asked Questions</string>
+    <string name="plugin_read_reviews">Read Reviews</string>
+    <string name="plugin_num_ratings">%s ratings</string>
+    <string name="plugin_num_downloads">%s downloads</string>
+    <string name="plugin_empty_text">None provided</string>
+    <string name="plugin_needs_update">Needs update</string>
+
+    <string name="plugin_one_stars">1 stars</string>
+    <string name="plugin_two_stars">2 stars</string>
+    <string name="plugin_three_stars">3 stars</string>
+    <string name="plugin_four_stars">4 stars</string>
+    <string name="plugin_five_stars">5 stars</string>
+
+    <string name="plugin_info_version">Version</string>
+    <string name="plugin_info_lastupdated">Last Updated</string>
+    <string name="plugin_info_requires_version">Requires WordPress Version</string>
+    <string name="plugin_info_your_version">Your WordPress Version</string>
+
+    <string name="plugin_icon_content_description">Plugin icon</string>
+    <string name="plugin_external_link_icon_content_description">External link</string>
+    <string name="plugin_chevron_icon_content_description">Toggle text</string>
+
+    <string name="plugin_fetching_error_after_at">It takes longer than usual to refresh plugin details. Please check again later.</string>
+
+    <!--My profile-->
+    <string name="my_profile">My Profile</string>
+    <string name="first_name">First name</string>
+    <string name="last_name">Last name</string>
+    <string name="public_display_name">Public display name</string>
+    <string name="public_display_name_hint">Display name will default to your username if it is not set</string>
+    <string name="about_me">About me</string>
+    <string name="about_me_hint">A few words about you…</string>
+    <string name="start_over">Start Over</string>
+    <string name="site_settings_start_over_hint">Start your site over</string>
+    <string name="start_over_email_subject">Start over with site %s</string>
+    <string name="start_over_email_body">I want to start over with the site %s</string>
+    <string name="start_over_email_intent_error">Unable to send an email</string>
+    <string name="let_us_help">Let Us Help</string>
+    <string name="start_over_text">If you want a site but don\'t want any of the posts and pages you have now, our support team can delete your posts, pages, media and comments for you.\n\nThis will keep your site and URL active, but give you a fresh start on your content creation. Just contact us to have your current content cleared out.</string>
+    <string name="contact_support">Contact support</string>
+    <string name="confirm_delete_site">Confirm Delete Site</string>
+    <string name="confirm_delete_site_prompt">Please type in %1$s in the field below to confirm. Your site will then be gone forever.</string>
+    <string name="site_settings_export_content_title">Export content</string>
+    <string name="error_deleting_site">Error deleting site</string>
+    <string name="error_deleting_site_summary">There was an error in deleting your site. Please contact support for more assistance.</string>
+    <string name="primary_domain">Primary Domain</string>
+    <string name="export_site_hint">Export your site to an XML file</string>
+    <string name="delete_site_warning_title">Delete site?</string>
+    <string name="delete_site_warning">All your posts, images, and data will be deleted. And this site’s address (%s) will be lost.</string>
+    <string name="delete_site_warning_subtitle">Be careful! Once a site is deleted, it cannot be recovered. Please be sure before you proceed.</string>
+    <string name="delete_site_hint">Delete site</string>
+    <string name="delete_site_progress">Deleting site…</string>
+    <string name="purchases_request_error">Something went wrong. Could not request purchases.</string>
+    <string name="premium_upgrades_title">Premium Upgrades</string>
+    <string name="premium_upgrades_message">You have active premium upgrades on your site. Please cancel your upgrades prior to deleting your site.</string>
+    <string name="show_purchases">Show purchases</string>
+    <string name="checking_purchases">Checking purchases</string>
+
+    <!--Account Settings-->
+    <string name="account_settings">Account Settings</string>
+    <string name="pending_email_change_snackbar">Click the verification link in the email sent to %1$s to confirm your new address</string>
+    <string name="primary_site">Primary site</string>
+    <string name="web_address">Web address</string>
+    <string name="web_address_dialog_hint">Shown publicly when you comment.</string>
+    <string name="change_password">Change password</string>
+    <string name="change_password_confirmation">Password changed successfully</string>
+    <string name="change_password_dialog_hint">Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ &amp; ).</string>
+    <string name="change_password_dialog_message">Changing password…</string>
+    <string name="exporting_content_progress">Exporting content…</string>
+    <string name="export_email_sent">Export email sent!</string>
+    <string name="export_your_content">Export your content</string>
+    <string name="export_your_content_message">Your posts, pages, and settings will be emailed to you at %s.</string>
+
+    <!-- Plans -->
+    <string name="plan">Plan</string>
+    <string name="plans">Plans</string>
+    <string name="plans_loading_error_network_title">No connection</string>
+    <string name="plans_loading_error_no_plans_title">Cannot load Plans</string>
+    <string name="plans_loading_error_no_plans_subtitle">We cannot load Plans at the moment. Please try again later.</string>
+    <string name="plans_loading_error_no_cache_subtitle">An internet connection is required to view Plans.</string>
+    <string name="plans_loading_error_with_cache_subtitle">An internet connection is required to view Plans, so details may be out-of-date.</string>
+    <string name="plans_loading_error_with_cache_button">View Plans Anyway</string>
+
+    <!-- gravatar -->
+    <string name="error_cropping_image">Error cropping the image</string>
+    <string name="error_locating_image">Error locating the cropped image</string>
+    <string name="error_refreshing_gravatar">Error reloading your Gravatar</string>
+    <string name="error_updating_gravatar">Error updating your Gravatar</string>
+
+    <!-- Editor -->
+    <string name="discard">Discard</string>
+    <string name="edit">Edit</string>
+    <string name="tap_to_try_again">Tap to try again!</string>
+    <string name="add_media_progress">Adding media</string>
+    <string name="suggestion_invalid_user">"%s is not a valid user"</string>
+    <string name="suggestion_no_matching_users">"No matching users available."</string>
+
+    <string name="stop_upload_dialog_title">Stop uploading?</string>
+
+    <string name="image_settings_dismiss_dialog_title">Discard unsaved changes?</string>
+    <string name="image_settings_save_toast">Changes saved</string>
+
+    <string name="image_caption">Caption</string>
+    <string name="image_link_to">Link to</string>
+    <string name="image_width">Width</string>
+
+    <!-- Editor: Errors -->
+    <string name="editor_failed_uploads_switch_html">Some media uploads have failed. You can\'t switch to HTML mode
+        in this state. Remove all failed uploads and continue?</string>
+    <string name="editor_toast_uploading_please_wait">You are currently uploading media. Please wait until this completes.</string>
+    <string name="editor_remove_failed_uploads">Remove failed uploads</string>
+    <string name="error_all_media_upload_canceled">All media uploads have been cancelled due to an unknown error. Please retry uploading</string>
+
+    <string name="photo_picker_title">Choose photo</string>
+    <string name="photo_picker_video_title">Choose video</string>
+    <string name="photo_picker_photo_or_video_title">Choose media</string>
+    <string name="photo_picker_choose_photo">Choose photo from device</string>
+    <string name="photo_picker_choose_video">Choose video from device</string>
+    <string name="photo_picker_capture_photo">Take photo</string>
+    <string name="photo_picker_capture_video">Take video</string>
+    <string name="photo_picker_stock_media">Choose from Free Photo Library</string>
+    <string name="photo_picker_gif">Choose from Tenor</string>
+    <string name="photo_picker_soft_ask_label">%s needs permissions to access your photos</string>
+    <string name="photo_picker_soft_ask_allow">Allow</string>
+    <string name="photo_picker_soft_ask_permissions_denied">%1$s was denied access to your photos. To fix this, edit your permissions and turn on %2$s.</string>
+    <string name="photo_picker_use_photo">Use this photo</string>
+    <string name="photo_picker_use_video">Use this video</string>
+    <string name="photo_picker_use_media">Use this media</string>
+    <string name="photo_picker_use_gif">Use this GIF</string>
+    <string name="photo_picker_image_thumbnail_content_description">Image Thumbnail</string>
+    <string name="photo_picker_image_thumbnail_selected">Image selected</string>
+    <string name="photo_picker_image_selected">,Selected</string>
+    <string name="photo_picker_image_thumbnail_unselected">Image unselected</string>
+    <string name="stock_media_picker_search_hint">Search free photo library</string>
+    <string name="stock_media_picker_list_content_description">Photo library</string>
+    <string name="stock_media_picker_initial_empty_text">Search to find free photos to add to your Media Library</string>
+    <string name="stock_media_picker_initial_empty_subtext">Photos provided by %s</string>
+
+    <!-- GIFs -->
+    <string name="gif_picker_search_hint">Search Tenor</string>
+    <string name="gif_powered_by_tenor">Powered by Tenor</string>
+    <string name="gif_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
+    <string name="gif_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
+    <string name="gif_picker_empty_search_list" tools:ignore="UnusedResources">No media matching your search</string>
+    <string name="gif_list_search_returned_unknown_error" tools:ignore="UnusedResources">There was a problem handling the request</string>
+
+    <!-- E-mail verification reminder dialog -->
+    <string name="toast_saving_post_as_draft">Saving post as draft</string>
+    <string name="toast_verification_email_sent">Verification email sent, check your inbox</string>
+    <string name="toast_verification_email_send_error">Error sending verification email. Are you already verified?</string>
+    <string name="editor_confirm_email_prompt_title">Please confirm your email address</string>
+    <string name="editor_confirm_email_prompt_message">We sent you an email when you first signed up. Please open the message and click the blue button to enable publishing.</string>
+    <string name="editor_confirm_email_prompt_message_with_email">We sent an email to %s when you first signed up. Please open the message and click the blue button to enable publishing.</string>
+    <string name="editor_confirm_email_prompt_negative">Resend Email</string>
+
+    <!-- smart toasts -->
+    <string name="smart_toast_comments_long_press">Tap and hold to select multiple comments</string>
+
+    <!-- permissions -->
+    <string name="button_edit_permissions">Edit permissions</string>
+    <string name="permissions_denied_title">Permissions</string>
+    <string name="permissions_denied_message">It looks like you turned off permissions required for this feature.&lt;br/&gt;&lt;br/&gt;To change this, edit your permissions and make sure &lt;strong&gt;%s&lt;/strong&gt; is enabled.</string>
+    <string name="permission_storage">Storage</string>
+    <string name="permission_camera">Camera</string>
+
+    <!-- Image Optimization promo -->
+    <string name="turn_on">Turn on</string>
+    <string name="leave_off">Leave off</string>
+    <string name="image_optimization_promo_title">Turn on image optimization?</string>
+    <string name="image_optimization_promo_desc">Image optimization shrinks images for quicker uploading.\n\nYou can change this any time in site settings.</string>
+
+    <!-- Login -->
+    <!-- If any of these appear unused, be sure to check the same string in the login library -
+    it may be used there and keeping it here is required for translation. -->
+    <string name="log_in">Log In</string>
+    <string name="login_promo_viewpager_content_description">Introduction</string>
+    <string name="login_promo_text_onthego">Publish from the park. Blog from the bus. Comment from the café. WordPress goes where you go.</string>
+    <string name="login_promo_text_realtime">Watch readers from around the world read and interact with your site — in realtime.</string>
+    <string name="login_promo_text_anytime">Catch up with your favorite sites and join the conversation anywhere, any time.</string>
+    <string name="login_promo_text_notifications">Your notifications travel with you — see comments and likes as they happen.</string>
+    <string name="login_promo_text_jetpack">Manage your Jetpack-powered site on the go — you\'ve got WordPress in your pocket.</string>
+    <string name="invalid_verification_code">Invalid verification code</string>
+    <string name="send_link">Send link</string>
+    <string name="enter_your_password_instead">Enter your password instead</string>
+    <string name="alternatively">Alternatively:</string>
+    <string name="enter_email_wordpress_com">Log in to WordPress.com using an email address to manage all your WordPress sites.</string>
+    <string name="enter_email_for_site">Log in with WordPress.com to connect to %1$s</string>
+    <string name="next">Next</string>
+    <string name="open_mail">Open mail</string>
+    <string name="enter_site_address_instead">Log in by entering your site address.</string>
+    <string name="enter_username_instead">Log in with your username.</string>
+    <string name="enter_verification_code">Almost there! Please enter the verification code from your Authenticator app.</string>
+    <string name="enter_verification_code_sms">We sent a text message to the phone number ending in %s. Please enter the verification code in the SMS.</string>
+    <string name="login_text_otp">Text me a code instead.</string>
+    <string name="login_text_otp_another">Text me another code instead.</string>
+    <string name="requesting_otp">Requesting a verification code via SMS.</string>
+    <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address. Try the link below to log in using your site address.</string>
+    <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
+    <string name="login_magic_links_label">We\'ll email you a magic link that\'ll log you in instantly, no password needed. Hunt and peck no more!</string>
+    <string name="login_magic_links_sent_label">Your magic link is on its way! Check your email on this device and tap the link in the email you received from WordPress.com.</string>
+    <string name="login_magic_link_email_requesting">Requesting log-in email</string>
+    <string name="enter_wpcom_password">Enter your WordPress.com password.</string>
+    <string name="enter_wpcom_password_google">To proceed with this Google account, please provide the matching WordPress.com password. This will be asked only once.</string>
+    <string name="connect_more">Connect Another Site</string>
+    <string name="connect_site">Connect Site</string>
+    <string name="login_continue">Continue</string>
+    <string name="login_already_logged_in_wpcom">Already logged in to WordPress.com</string>
+    <string name="login_username_at">\@%s</string>
+    <string name="enter_site_address">Enter the address of the WordPress site you\'d like to connect.</string>
+    <string name="enter_site_address_share_intent">Enter the address of your WordPress site you\'d like to share the content to.</string>
+    <string name="login_site_address">Site address</string>
+    <string name="login_site_address_help">Need help finding your site address?</string>
+    <string name="login_site_address_help_title">What\'s my site address?</string>
+    <string name="login_site_address_help_content">Your site address appears in the bar at the top of the screen when you visit your site in Chrome.</string>
+    <string name="login_site_address_more_help">Need more help?</string>
+    <string name="login_checking_site_address">Checking site address</string>
+    <string name="login_error_while_adding_site">Error while adding site. Error code: %s</string>
+    <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
+    <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
+    <string name="login_invalid_site_url">Please enter a complete website address, like example.com.</string>
+    <string name="login_empty_username">Please enter a username</string>
+    <string name="login_empty_password">Please enter a password</string>
+    <string name="login_empty_2fa">Please enter a verification code</string>
+    <string name="login_email_button_signup">Don\'t have an account? %1$sSign up%2$s</string>
+    <string name="login_email_client_not_found">Can\'t detect your email client app</string>
+    <string name="login_logged_in_as">Logged in as</string>
+    <string name="login_epilogue_mysites_one">My site</string>
+    <string name="login_epilogue_mysites_other">My sites</string>
+    <string name="login_google_button_suffix">Log in with Google.</string>
+    <string name="login_error_button">Close</string>
+    <string name="login_error_email_not_found_v2">There\'s no WordPress.com account matching this Google account.</string>
+    <string name="login_error_generic">There was some trouble connecting with the Google account.</string>
+    <string name="login_error_sms_throttled">We\'ve made too many attempts to send an SMS verification code — take a break, and request a new one in a minute.</string>
+    <string name="login_error_generic_start">Google login could not be started.</string>
+    <string name="login_error_suffix">\nMaybe try a different account?</string>
+    <string name="enter_wpcom_or_jetpack_site">Please enter a WordPress.com or Jetpack-connected self-hosted WordPress site</string>
+    <string name="enter_wordpress_site">The website at this address is not a WordPress site. For us to connect to it, the site must have WordPress installed.</string>
+    <string name="login_need_help_finding_connected_email">Need help finding the email you connected with?</string>
+    <string name="send_verification_email">Send verification email</string>
+    <string name="enter_credentials_for_site">Log in with your %1$s site credentials</string>
+    <string name="enter_site_credentials_instead">Log in with site credentials</string>
+    <string name="login_site_credentials_magic_link_label">Almost there! We just need to verify your Jetpack connected email address &lt;b&gt;%1$s&lt;/b&gt;</string>
+    <string name="login_discovery_error_xmlrpc">We were unable to access the &lt;b&gt;XMLRPC file&lt;/b&gt; on your site. You will need to reach out to your host to resolve this.</string>
+    <string name="login_discovery_error_http_auth">We were unable to access your site because it requires &lt;b&gt;HTTP Authentication&lt;/b&gt;. You will need to reach out to your host to resolve this.</string>
+    <string name="login_discovery_error_ssl">We were unable to access your site because of a problem with the &lt;b&gt;SSL Certificate&lt;/b&gt;. You will need to reach out to your host to resolve this.</string>
+    <string name="login_discovery_error_generic">We were unable to access your site. You will need to reach out to your host to resolve this.</string>
+    <!-- Screen titles -->
+    <string name="email_address_login_title">Email address login</string>
+    <string name="site_address_login_title">Site address login</string>
+    <string name="magic_link_login_title">Magic link login</string>
+    <string name="magic_link_sent_login_title">Magic link sent</string>
+    <string name="selfhosted_site_login_title">Login credentials</string>
+    <string name="verification_2fa_screen_title">Code verification</string>
+
+    <!-- Signup -->
+    <string name="sign_up">Sign Up for WordPress.com</string>
+    <string name="signup_email_error_generic">There was some trouble checking the email address.</string>
+    <string name="signup_email_header">To create your new WordPress.com account, please enter your email address.</string>
+    <string name="signup_epilogue_error_avatar">There was some trouble uploading your avatar.</string>
+    <string name="signup_epilogue_error_avatar_view">Your avatar has been uploaded and will be available shortly.</string>
+    <string name="signup_epilogue_error_generic">There was some trouble updating your account. You can retry or revert your changes to continue.</string>
+    <string name="signup_epilogue_error_button_negative">Revert</string>
+    <string name="signup_epilogue_error_button_positive">Retry</string>
+    <string name="signup_epilogue_heading">New account</string>
+    <string name="signup_epilogue_hint_display">Display Name</string>
+    <string name="signup_epilogue_hint_password">Password (optional)</string>
+    <string name="signup_epilogue_hint_password_detail">You can always log in with a magic link like the one you just used, but you can also set up a password if you prefer.</string>
+    <string name="signup_epilogue_hint_username">Username</string>
+    <string name="signup_magic_link_error">There was some trouble sending the email. You can retry now or close and try again later.</string>
+    <string name="signup_magic_link_error_button_negative">Close</string>
+    <string name="signup_magic_link_error_button_positive">Retry</string>
+    <string name="signup_magic_link_message">We sent you a magic signup link! Check your email on this device, and tap the link in the email to finish signing up.</string>
+    <string name="signup_magic_link_progress">Sending email</string>
+    <string name="signup_terms_of_service_text">By signing up, you agree to our %1$sTerms of Service%2$s.</string>
+    <string name="signup_updating_account">Updating account…</string>
+    <string name="signup_user_exists">Email already exists on WordPress.com.\nProceeding with login.</string>
+    <string name="signup_with_email_button">Sign Up with Email</string>
+    <string name="signup_with_google_button">Sign Up with Google</string>
+    <string name="signup_with_google_progress">Signing up with Google…</string>
+    <string name="content_description_add_avatar">Add avatar</string>
+    <!-- Screen titles -->
+    <string name="signup_email_screen_title">Email signup</string>
+    <string name="signup_magic_link_title">Magic link sent</string>
+
+    <string name="username_changer_action">Save</string>
+    <string name="username_changer_dismiss_button_positive">Discard</string>
+    <string name="username_changer_dismiss_message">Discard changing username?</string>
+    <string name="username_changer_error_generic">An error occurred while retrieving username suggestions.</string>
+    <string name="username_changer_error_none">No usernames are suggested from %1$s%2$s%3$s. Please enter more letters or numbers to get suggestions.</string>
+    <string name="username_changer_header">Your current username is %1$s%2$s%3$s. With few exceptions, others will only ever see your display name, %4$s%5$s%6$s.</string>
+    <string name="username_changer_hint">Type to get more suggestions</string>
+    <string name="username_changer_title">Change username</string>
+
+    <string name="settings_username_changer_header">You are about to change your username, which is currently %1$s%2$s%3$s.You will not be able to change your username back.</string>
+    <string name="settings_username_changer_confirm_dialog_title">Careful!</string>
+    <string name="settings_username_changer_confirm_dialog_content">You are changing your username to %1$s%2$s%3$s. Changing your username will also affect your Gravatar profile and Intense Debate profile addresses. Confirm your new username to continue.</string>
+    <string name="settings_username_changer_confirm_dialog_positive_action">Change Username</string>
+    <string name="settings_username_changer_progress_dialog">Saving username…</string>
+    <string name="settings_username_changer_toast_content">Your new username is %1$s</string>
+    <string name="settings_username_changer_snackbar_cancel">This action can\'t be canceled. Username might have been already updated.</string>
+
+    <string name="google_error_timeout">Google took too long to respond. You may need to wait until you have a stronger internet connection.</string>
+
+    <!-- Post-Signup Interstitial -->
+    <string name="post_signup_interstitial_title">Welcome to WordPress</string>
+    <string name="post_signup_interstitial_subtitle">Whatever you want to create or share, we’ll help you do it right here.</string>
+    <string name="post_signup_interstitial_create_new_site" translatable="false">@string/site_picker_create_wpcom</string>
+    <string name="post_signup_interstitial_add_self_hosted_site" translatable="false">@string/site_picker_add_self_hosted</string>
+    <string name="post_signup_interstitial_not_right_now">Not right now</string>
+    <string name="content_description_person_building_website">Person building website</string>
+
+    <!-- Android O notification channels, these show in the Android app settings -->
+    <string name="notification_channel_general_title">General</string>
+    <string name="notification_channel_important_title">Important</string>
+    <string name="notification_channel_transient_title">Transient</string>
+    <string name="notification_channel_reminder_title">Reminder</string>
+
+    <string name="notification_channel_normal_id" translatable="false">wpandroid_notification_normal_channel_id</string>
+    <string name="notification_channel_important_id" translatable="false">wpandroid_notification_important_channel_id</string>
+    <string name="notification_channel_transient_id" translatable="false">wpandroid_notification_transient_channel_id</string>
+    <string name="notification_channel_reminder_id" translatable="false">wpandroid_notification_reminder_channel_id</string>
+
+    <!-- Required by the login library - overwrites the placeholder value with a real channel -->
+    <string content_override="true" name="login_notification_channel_id" translatable="false">@string/notification_channel_normal_id</string>
+
+    <!-- Site Creation notifications -->
+    <string name="notification_site_creation_title_success">Site created!</string>
+    <string name="notification_site_creation_created">Tap to continue.</string>
+
+    <!-- Login notifications -->
+    <string name="notification_login_title_success">Logged in!</string>
+    <string name="notification_logged_in">Tap to continue.</string>
+    <string name="notification_login_title_in_progress">Login in progress…</string>
+    <string name="notification_logging_in">Please wait while logging in.</string>
+    <string name="notification_login_title_stopped">Login stopped</string>
+    <string name="notification_error_wrong_password">Please double check your password to continue.</string>
+    <string name="notification_2fa_needed">Please provide an authentication code to continue.</string>
+    <string name="notification_login_failed">An error has occurred.</string>
+    <string name="notification_wpcom_username_needed">Please log in with your username and password.</string>
+    <string name="change_photo">Change photo</string>
+
+    <!-- Content description for accessibility  -->
+    <string name="featured_image_desc">featured image</string>
+    <string name="theme_image_desc">theme image</string>
+    <string name="blavatar_desc">site icon</string>
+    <string name="comment_checkmark_desc">check mark</string>
+    <string name="profile_picture">%s\'s profile picture</string>
+    <string name="invite_user_delete_desc">remove %s</string>
+    <string name="media_grid_item_image_desc">media preview, filename %s</string>
+    <string name="media_grid_item_retry_desc">retry</string>
+    <string name="media_grid_item_trash_desc">trash</string>
+    <string name="media_grid_item_play_video_desc">play video</string>
+    <string name="media_preview_audio_desc">audio</string>
+    <string name="media_preview_desc">preview</string>
+    <string name="media_preview_title">%1$d of %2$d</string>
+    <string name="media_settings_image_preview_desc">image preview</string>
+    <string name="media_settings_play">play</string>
+    <string name="people_invite_role_info_desc">role info</string>
+    <string name="photo_picker_device_desc">pick from device</string>
+    <string name="photo_picker_camera_desc">open camera</string>
+    <string name="photo_picker_wpmedia_desc">pick from WordPress media</string>
+    <string name="plugin_detail_banner_desc">plugin banner</string>
+    <string name="plugin_detail_logo_desc">plugin logo</string>
+    <string name="reader_cardview_post_play_video_desc">play featured video</string>
+    <string name="photo_picker_thumbnail_desc">Play video</string>
+    <string name="reader_list_item_suggestion_remove_desc">delete</string>
+    <string name="reader_photo_view_desc">photo</string>
+    <string name="show_more_desc">show more</string>
+    <string name="open_external_link_desc">Open external link</string>
+    <string name="notification_settings_switch_desc">Notifications</string>
+    <string name="notifications_tab_dialog_switch_desc">Notifications</string>
+    <string name="navigate_up_desc">navigate up</string>
+    <string name="fab_add_tag_desc">Create Tag</string>
+    <string name="fab_create_desc">Create a post</string>
+    <string name="reader_avatar_desc">profile picture</string>
+    <string name="reader_gallery_images_desc">image gallery</string>
+    <string name="quick_start_completed_tasks_header_chevron_expand_desc">expand</string>
+    <string name="quick_start_completed_tasks_header_chevron_collapse_desc">collapse</string>
+    <string name="suggestions_updated_content_description">Suggestions updated</string>
+    <string name="navigate_forward_desc">Go forward</string>
+    <string name="navigate_back_desc">Go back</string>
+    <string name="share_desc">Share</string>
+    <string name="preview_type_desc">Select preview type</string>
+    <string name="close_dialog_button_desc">Close Dialog</string>
+
+    <string name="content_description_more">More</string>
+    <string name="quick_start_button_negative" tools:ignore="UnusedResources">Not now</string>
+    <string name="quick_start_button_negative_short" tools:ignore="UnusedResources">Cancel</string>
+    <string name="quick_start_button_positive" tools:ignore="UnusedResources">Go</string>
+    <string name="quick_start_task_skip_menu_title">Skip task</string>
+    <string name="quick_start_complete_view_title">All tasks complete!</string>
+    <string name="quick_start_complete_view_subtitle">Congratulations on completing your list. A job well done.</string>
+    <string name="quick_start_remove_next_steps_menu_title">Remove this</string>
+    <string name="quick_start_dialog_remove_next_steps_title">Remove Next Steps</string>
+    <string name="quick_start_dialog_remove_next_steps_message">Removing Next Steps will hide all tours on this site. This action cannot be undone.</string>
+    <string name="quick_start_dialog_browse_themes_message">Explore dozens of layout options and find your perfect fit.</string>
+    <string name="quick_start_dialog_browse_themes_message_short" tools:ignore="UnusedResources">Tap %1$s Themes %2$s to discover new themes</string>
+    <string name="quick_start_dialog_browse_themes_title">Browse themes</string>
+    <string name="quick_start_dialog_check_stats_message">Keep up to date on your site\'s performance.</string>
+    <string name="quick_start_dialog_check_stats_title">Check your site stats</string>
+    <string name="quick_start_dialog_choose_theme_title">Choose a theme</string>
+    <string name="quick_start_dialog_choose_theme_message">Browse all our themes to find your perfect fit.</string>
+    <string name="quick_start_dialog_create_page_message">Add a page for key content — an \"About\" page is a great start.</string>
+    <string name="quick_start_dialog_create_page_title">Create a new page</string>
+    <string name="quick_start_dialog_customize_site_message">Tweak fonts, add images, and more.</string>
+    <string name="quick_start_dialog_customize_site_message_short_customize">Tap %1$s Customize %2$s to start personalizing your site</string>
+    <string name="quick_start_dialog_customize_site_message_short_themes" tools:ignore="UnusedResources">Tap %1$s Themes %2$s to continue</string>
+    <string name="quick_start_dialog_customize_site_title">Customize your site</string>
+    <string name="quick_start_dialog_enable_sharing_message">Automatically share new posts to your social media accounts.</string>
+    <string name="quick_start_dialog_enable_sharing_message_short_connections">Tap the %1$s Connections %2$s to add your social media accounts</string>
+    <string name="quick_start_dialog_enable_sharing_message_short_sharing" tools:ignore="UnusedResources">Tap %1$s Sharing %2$s to continue</string>
+    <string name="quick_start_dialog_enable_sharing_title">Enable post sharing</string>
+    <string name="quick_start_dialog_explore_plans_message">Learn about the marketing and SEO tools in our paid plans.</string>
+    <string name="quick_start_dialog_explore_plans_title">Explore plans</string>
+    <string name="quick_start_dialog_follow_sites_message">Find sites that inspire you, and follow them to get updates when they post.</string>
+    <string name="quick_start_dialog_follow_sites_message_short_reader" tools:ignore="UnusedResources">Tap %1$s Reader %2$s to continue</string>
+    <string name="quick_start_dialog_follow_sites_message_short_search">Tap %1$s Search %2$s to look for sites with similar interests</string>
+    <string name="quick_start_dialog_follow_sites_title">Follow other sites</string>
+    <string name="quick_start_dialog_migration_message">We\'ve added more tasks to help you grow your audience.</string>
+    <string name="quick_start_dialog_migration_title">We\'ve made some changes to your checklist</string>
+    <string name="quick_start_dialog_need_help_button_negative">No Thanks</string>
+    <string name="quick_start_dialog_need_help_button_neutral">Never</string>
+    <string name="quick_start_dialog_need_help_button_positive">Accept</string>
+    <string name="quick_start_dialog_need_help_message">We\'ll walk you through the basics of building and growing your site.</string>
+    <string name="quick_start_dialog_need_help_title">Want a little help getting started?</string>
+    <string name="quick_start_dialog_publish_post_message">Draft and publish your first post.</string>
+    <string name="quick_start_dialog_publish_post_message_short" tools:ignore="UnusedResources">Tap %1$s Create Post %2$s to create a new post</string>
+    <string name="quick_start_dialog_publish_post_title">Publish a post</string>
+    <string name="quick_start_dialog_share_site_title">Share your site</string>
+    <string name="quick_start_dialog_share_site_message">Connect to your social media accounts – your site will automatically share new posts.</string>
+    <string name="quick_start_dialog_upload_site_icon_message_short" tools:ignore="UnusedResources">Tap %1$s Your Site Icon %2$s to upload a new one</string>
+    <string name="quick_start_dialog_check_stats_message_short" tools:ignore="UnusedResources">Tap %1$s Stats %2$s to see how your site is performing.</string>
+    <string name="quick_start_dialog_create_new_page_message_short" tools:ignore="UnusedResources">Tap %1$s Site Pages %2$s to continue.</string>
+    <string name="quick_start_dialog_create_new_page_message_short_pages">Tap %1$s Add Page %2$s to create a new page.</string>
+    <string name="quick_start_dialog_create_new_post_message_short" tools:ignore="UnusedResources">Tap %1$s Blog Posts %2$s to continue.</string>
+    <string name="quick_start_dialog_create_new_post_message_short_posts">Tap %1$s Add Post %2$s to create a new post.</string>
+    <string name="quick_start_dialog_explore_plans_message_short" tools:ignore="UnusedResources">Tap %1$s Plan %2$s to see your current plan and other available plans</string>
+    <string name="quick_start_dialog_upload_icon_message">Your visitors will see your icon in their browser. Add a custom icon for a polished, pro look.</string>
+    <string name="quick_start_dialog_upload_icon_title">Upload a site icon</string>
+    <string name="quick_start_dialog_view_site_message">Enjoy your finished product!</string>
+    <string name="quick_start_dialog_view_site_message_short" tools:ignore="UnusedResources">Tap %1$s View Site %2$s to preview your site</string>
+    <string name="quick_start_dialog_view_site_title">View your site</string>
+    <string name="quick_start_complete_tasks_header">Complete (%d)</string>
+    <string name="quick_start_list_browse_themes_subtitle" translatable="false">@string/quick_start_dialog_browse_themes_message</string>
+    <string name="quick_start_list_browse_themes_title" translatable="false">@string/quick_start_dialog_browse_themes_title</string>
+    <string name="quick_start_list_check_stats_subtitle" translatable="false">@string/quick_start_dialog_check_stats_message</string>
+    <string name="quick_start_list_check_stats_title" translatable="false">@string/quick_start_dialog_check_stats_title</string>
+    <string name="quick_start_list_create_page_subtitle" translatable="false">@string/quick_start_dialog_create_page_message</string>
+    <string name="quick_start_list_create_page_title" translatable="false">@string/quick_start_dialog_create_page_title</string>
+    <string name="quick_start_list_create_site_subtitle">Get your site up and running.</string>
+    <string name="quick_start_list_create_site_title">Create your site</string>
+    <string name="quick_start_list_customize_site_subtitle" translatable="false">@string/quick_start_dialog_customize_site_message</string>
+    <string name="quick_start_list_customize_site_title" translatable="false">@string/quick_start_dialog_customize_site_title</string>
+    <string name="quick_start_list_enable_sharing_subtitle" translatable="false">@string/quick_start_dialog_enable_sharing_message</string>
+    <string name="quick_start_list_enable_sharing_title" translatable="false">@string/quick_start_dialog_enable_sharing_title</string>
+    <string name="quick_start_list_explore_plans_subtitle" translatable="false">@string/quick_start_dialog_explore_plans_message</string>
+    <string name="quick_start_list_explore_plans_title" translatable="false">@string/quick_start_dialog_explore_plans_title</string>
+    <string name="quick_start_list_follow_site_subtitle" translatable="false">@string/quick_start_dialog_follow_sites_message</string>
+    <string name="quick_start_list_follow_site_title" translatable="false">@string/quick_start_dialog_follow_sites_title</string>
+    <string name="quick_start_list_publish_post_subtitle" translatable="false">@string/quick_start_dialog_publish_post_message</string>
+    <string name="quick_start_list_publish_post_title" translatable="false">@string/quick_start_dialog_publish_post_title</string>
+    <string name="quick_start_list_upload_icon_subtitle" translatable="false">@string/quick_start_dialog_upload_icon_message</string>
+    <string name="quick_start_list_upload_icon_title" translatable="false">@string/quick_start_dialog_upload_icon_title</string>
+    <string name="quick_start_list_view_site_subtitle" translatable="false">@string/quick_start_dialog_view_site_message</string>
+    <string name="quick_start_list_view_site_title" translatable="false">@string/quick_start_dialog_view_site_title</string>
+    <string name="quick_start_sites">Next Steps</string>
+    <string name="quick_start_sites_type_customize">Customize Your Site</string>
+    <string name="quick_start_sites_type_grow">Grow Your Audience</string>
+    <string name="quick_start_sites_type_subtitle">%1$d of %2$d complete</string>
+    <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
+    <string name="quick_start_span_start" translatable="false">&lt;span&gt;</string>
+    <string name="quick_start_focus_point_description">tap here</string>
+
+    <!-- Pages -->
+    <string name="pages_published" tools:ignore="UnusedResources">Published</string>
+    <string name="pages_drafts" tools:ignore="UnusedResources">Drafts</string>
+    <string name="pages_scheduled" tools:ignore="UnusedResources">Scheduled</string>
+    <string name="pages_trashed" tools:ignore="UnusedResources">Trashed</string>
+    <string name="pages_pending">Pending review</string>
+    <string name="pages_private">Private</string>
+    <string name="pages_view">View</string>
+    <string name="pages_set_parent">Set parent</string>
+    <string name="pages_set_as_homepage">Set as Homepage</string>
+    <string name="pages_set_as_posts_page">Set as Posts Page</string>
+    <string name="pages_publish_now" translatable="false">@string/publish_now</string>
+    <string name="pages_move_to_draft">Move to Draft</string>
+    <string name="pages_move_to_trash">Move to Trash</string>
+    <string name="pages_delete_permanently">Delete Permanently</string>
+    <string name="pages_empty_search_result">No pages matching your search</string>
+    <string name="pages_search_suggestion">Search pages</string>
+    <string name="pages_empty_published">You haven\'t published any pages yet</string>
+    <string name="pages_empty_drafts">You don\'t have any draft pages</string>
+    <string name="pages_empty_scheduled">You don\'t have any scheduled pages</string>
+    <string name="pages_empty_trashed">You don\'t have any trashed pages</string>
+    <string name="pages_open_page_error">The selected page is not available</string>
+    <string name="pages_and_posts_cancel_auto_upload">Cancel upload</string>
+    <string name="pages_list_author">Page author</string>
+    <string name="pages_cannot_be_started">We cannot open pages at the moment. Please try again later</string>
+    <string name="pages_item_subtitle">%1$s · %2$s</string>
+    <string name="pages_item_subtitle_date_author">%1$s · %2$s · %3$s</string>
+
+    <string name="page_status_pending_review" translatable="false">@string/post_status_pending_review</string>
+    <string name="page_status_page_private" translatable="false">@string/post_status_post_private</string>
+
+    <string name="page_local_draft" translatable="false">@string/local_draft</string>
+    <string name="page_local_changes" translatable="false">@string/local_changes</string>
+    <string name="page_uploading">Uploading page</string>
+    <string name="page_uploading_draft" translatable="false">@string/post_uploading_draft</string>
+    <string name="page_queued">Queued page</string>
+
+    <string name="page_waiting_for_connection_publish">We\'ll publish the page when your device is back online.</string>
+    <string name="page_waiting_for_connection_pending">We\'ll submit your page for review when your device is back online.</string>
+    <string name="page_waiting_for_connection_scheduled">We\'ll schedule your page when your device is back online.</string>
+    <string name="page_waiting_for_connection_private">We\'ll publish your private page when your device is back online.</string>
+    <string name="page_waiting_for_connection_draft">We\'ll save your draft when your device is back online</string>
+
+    <string name="error_media_recover_page_not_published">We couldn\'t upload this media, and didn\'t publish the page.</string>
+    <string name="error_media_recover_page_not_published_private">We couldn\'t upload this media, and didn\'t publish this private page.</string>
+    <string name="error_media_recover_page_not_scheduled">We couldn\'t upload this media, and didn\'t schedule this page.</string>
+    <string name="error_media_recover_page_not_submitted">We couldn\'t upload this media, and didn\'t submit this page for review. </string>
+
+    <string name="error_page_not_published_retrying">We couldn\'t publish this page, but we\'ll try again later.</string>
+    <string name="error_page_not_published_retrying_private">We couldn\'t publish this private page, but we\'ll try again later.</string>
+    <string name="error_page_not_scheduled_retrying">We couldn\'t schedule this page, but we\'ll try again later.</string>
+    <string name="error_page_not_submitted_retrying">We couldn\'t submit this page for review, but we\'ll try again later. </string>
+
+    <string name="error_media_recover_page_not_published_retrying" translatable="false">@string/error_page_not_published_retrying</string>
+    <string name="error_media_recover_page_not_published_retrying_private" translatable="false">@string/error_page_not_published_retrying_private</string>
+    <string name="error_media_recover_page_not_scheduled_retrying" translatable="false">@string/error_page_not_scheduled_retrying</string>
+    <string name="error_media_recover_page_not_submitted_retrying" translatable="false">@string/error_page_not_submitted_retrying</string>
+
+
+    <string name="error_page_not_published">We couldn\'t complete this action, and didn\'t publish this page.</string>
+    <string name="error_page_not_published_private">We couldn\'t complete this action, and didn\'t publish this private page.</string>
+    <string name="error_page_not_scheduled">We couldn\'t complete this action, and didn\'t schedule this page.</string>
+    <string name="error_page_not_submitted">We couldn\'t complete this action, and didn\'t submit this page for review.</string>
+
+    <string name="error_media_recover_page" translatable="false">@string/error_media_recover_post</string>
+    <string name="error_unknown_page_type">Unknown page format</string>
+
+    <!-- Posts -->
+    <string name="post_list_author">Post author</string>
+    <string name="post_list_tab_published_posts">Published</string>
+    <string name="post_list_tab_drafts">Drafts</string>
+    <string name="post_list_tab_scheduled_posts">Scheduled</string>
+    <string name="post_list_tab_trashed_posts">Trashed</string>
+    <string name="post_list_search_prompt">Search posts</string>
+    <string name="post_list_search_nothing_found">No posts matching your search</string>
+    <string name="post_list_move_trashed_post_to_draft_dialog_title">Move post to Drafts?</string>
+    <string name="post_list_move_trashed_post_to_draft_dialog_message">Trashed posts can\'t be edited. Do you want change the status of this post to "draft" so you can work on it?</string>
+    <string name="post_list_move_trashed_post_to_draft_dialog_positive">Move to Draft</string>
+    <string name="post_list_move_trashed_post_to_draft_dialog_negative">Cancel</string>
+
+    <!-- Web Preview -->
+    <string name="web_preview_default">Default</string>
+    <string name="web_preview_desktop">Desktop</string>
+
+    <string name="create_post_page_fab_tooltip">Create a post or page</string>
+    <string name="create_post_page_fab_tooltip_contributors">Create a post</string>
+
+    <!-- News Card -->
+    <!-- When announcing a new feature, add new strings and make sure to update LocalNewsItem.kt -->
+    <!-- Never reuse same keys for new announcements! The new value might not be translated before the release
+    which would result in showing an out-of-date announcement. Moreover since the url has translatable set to false,
+    the out-of-date announcement might redirect the user to the new feature. -->
+    <!--suppress UnusedResources -->
+    <string name="news_card_announcement_title_sample_announcement">[New feature available]</string>
+    <!--suppress UnusedResources -->
+    <string name="news_card_announcement_content_sample_announcement">[No time to read right now? No problem: save posts for when you do.]</string>
+    <!--suppress UnusedResources -->
+    <string name="news_card_announcement_action_sample_announcement">[Read more]</string>
+    <!--suppress UnusedResources -->
+    <string name="news_card_announcement_action_url_sample_announcement" translatable="false">https://en.blog.wordpress.com/2018/06/21/bookmark-posts-with-save-for-later/</string>
+    <!-- END (News Card) -->
+
+    <!-- Site Creation -->
+    <string name="new_site_creation_screen_title_general">Create Site</string>
+    <string name="new_site_creation_screen_title_step_count">%1$d of %2$d</string>
+    <string name="new_site_creation_preview_title">Your site has been created!</string>
+    <string name="new_site_creation_preview_subtitle">You\'ll be able to customize look and feel of your site later</string>
+    <string name="site_creation_segments_title">Tell us what kind of site you\’d like to make</string>
+    <string name="site_creation_segments_subtitle">This helps us make recommendations. But you’re never locked in — all sites evolve!</string>
+    <string name="site_creation_fetch_suggestions_error_unknown">There was a problem</string>
+    <string name="site_creation_error_generic_title">There was a problem</string>
+    <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>
+    <string name="new_site_creation_empty_domain_list_message">No available addresses matching your search</string>
+    <string name="new_site_creation_unavailable_domain">This domain is unavailable</string>
+    <string name="new_site_creation_domain_header_title">Choose a domain name for your site</string>
+    <string name="new_site_creation_domain_header_subtitle">This is where people will find you on the internet.</string>
+    <string name="new_site_creation_search_domain_input_hint">Search Domains</string>
+    <string name="site_creation_domain_finish_button">Create site</string>
+    <string name="new_site_creation_create_site_button">Create Site</string>
+    <string name="notification_new_site_creation_title">Create Site</string>
+    <string name="notification_new_site_creation_failed">There was a problem</string>
+    <string name="notification_new_site_creation_creating_site_subtitle">We\'re creating your new site</string>
+
+    <string name="new_site_creation_creating_site_loading_title">Hooray!\nAlmost done</string>
+    <string name="new_site_creation_creating_site_loading_subtitle">Your site will be ready shortly</string>
+    <string name="new_site_creation_creating_site_loading_1">Grabbing site URL</string>
+    <string name="new_site_creation_creating_site_loading_2">Adding site features</string>
+    <string name="new_site_creation_creating_site_loading_3">Setting up theme</string>
+    <string name="new_site_creation_creating_site_loading_4">Creating dashboard</string>
+
+    <string name="cancel_new_site_wizard_content_description">Cancel Site Creation Wizard</string>
+    <string name="site_created_but_not_fetched_snackbar_message">It seems like you\'re on a slow connection. If you don\'t see your new site in the list, try refreshing.</string>
+    <string name="new_site_creation_clear_all_content_description">Clear</string>
+    <string name="new_site_creation_site_preview_content_description">Showing site preview</string>
+    <string name="new_site_creation_preview_back_pressed_warning">You may lose your progress. Are you sure you want to exit?</string>
+
+    <!-- App rating dialog -->
+    <string name="app_rating_title">Enjoying WordPress?</string>
+    <string name="app_rating_message">Nice to see you again! If you’re digging the app, we\’d love a rating on the Google Play Store.</string>
+    <string name="app_rating_rate_now">Rate now</string>
+    <string name="app_rating_rate_later">Later</string>
+    <string name="app_rating_rate_never">No thanks</string>
+
+    <string name="description_collapse">Collapse</string>
+    <string name="description_expand">Expand</string>
+
+    <string name="preview_image_description">Preview Image</string>
+    <string name="preview_image_thumbnail_description">Preview Image Thumbnail</string>
+    <string name="failed_to_load_image_tap_to_retry">Failed to load image.\nPlease tap to retry.</string>
+    <string name="done">done</string>
+    <string name="error_failed_to_load_into_file">Failed to load into file, please try again.</string>
+    <string name="error_failed_to_crop_and_save_image">Failed to crop and save image, please try again.</string>
+    <string name="crop">crop</string>
+    <string name="insert_label_with_count">Insert %d</string>
+
+    <!-- Feature Announcement -->
+    <string name="feature_announcement_dialog_label">What\'s New In WordPress</string>
+    <string name="feature_announcement_find_out_mode">Find out more</string>
+
+    <!-- Prepublishing Nudges -->
+    <string name="prepublishing_nudges_publish_action">Publish Date</string>
+    <string name="prepublishing_nudges_visibility_action" translatable="false">@string/status_and_visibility</string>
+    <string name="prepublishing_nudges_tags_action">Tags</string>
+    <string name="prepublishing_nudges_home_header_publishing_to">Publishing to</string>
+    <string name="prepublishing_nudges_home_publish_button" translatable="false">@string/publish_now</string>
+    <string name="prepublishing_nudges_home_schedule_button">Schedule Now</string>
+    <string name="prepublishing_nudges_home_submit_button">Submit Now</string>
+    <string name="prepublishing_nudges_home_save_button">Save Now</string>
+    <string name="prepublishing_nudges_home_update_button" translatable="false">@string/update_now</string>
+    <string name="prepublishing_nudges_back_button">Back</string>
+    <string name="prepublishing_nudges_toolbar_title_tags">Add Tags</string>
+    <string name="prepublishing_nudges_toolbar_title_publish">Publish</string>
+    <string name="prepublishing_nudges_toolbar_title_visibility" translatable="false">@string/status_and_visibility</string>
+    <string name="prepublishing_tags_description">Tags help tell readers what a post is about.</string>
+    <string name="prepublishing_nudges_home_tags_not_set">Not set</string>
+
+    <string name="prepublishing_nudges_visibility_password">Password Protected</string>
+
+    <!--Autogenerated:Gutenberg Native-->
+    <!-- translators: accessibility text. Inform about current value. %1$s: Control label %2$s: Current value. -->
+    <string name="gutenberg_native_1_s_current_value_is_2_s" tools:ignore="UnusedResources">%1$s. Current value is %2$s</string>
+    <!-- translators: sample content for "Contact" page template -->
+    <string name="gutenberg_native_10_street_road" tools:ignore="UnusedResources">10 Street Road</string>
+    <!-- translators: sample content for "Contact" page template -->
+    <string name="gutenberg_native_555_555_1234" tools:ignore="UnusedResources">(555)555–1234</string>
+    <!-- translators: sample content for "Portfolio" page template -->
+    <string name="gutenberg_native_a_description_of_the_project_and_the_works_presented" tools:ignore="UnusedResources">A description of the project and the works presented.</string>
+    <!-- translators: sample content for "Contact" page template -->
+    <string name="gutenberg_native_a_href_mailto_mail_example_com_mail_example_com_a" tools:ignore="UnusedResources">&lt;a href=\"mailto:mail@example.com\"&gt;mail@example.com&lt;/a&gt;</string>
+    <!-- translators: sample content for "Team" page template -->
+    <string name="gutenberg_native_a_short_bio_with_personal_history_key_achievements_or_an_interest" tools:ignore="UnusedResources">A short bio with personal history, key achievements, or an interesting fact.</string>
+    <!-- translators: sample content for "Services" page template -->
+    <string name="gutenberg_native_a_short_description_of_the_services_you_offer" tools:ignore="UnusedResources">A short description of the services you offer.</string>
+    <string name="gutenberg_native_add_a_description" tools:ignore="UnusedResources">Add a description</string>
+    <string name="gutenberg_native_add_a_shortcode" tools:ignore="UnusedResources">Add a shortcode…</string>
+    <string name="gutenberg_native_add_annotation" tools:ignore="UnusedResources">Add annotation</string>
+    <string name="gutenberg_native_add_block_after" tools:ignore="UnusedResources">Add Block After</string>
+    <string name="gutenberg_native_add_block_before" tools:ignore="UnusedResources">Add Block Before</string>
+    <string name="gutenberg_native_add_block_here" tools:ignore="UnusedResources">ADD BLOCK HERE</string>
+    <string name="gutenberg_native_add_image" tools:ignore="UnusedResources">ADD IMAGE</string>
+    <string name="gutenberg_native_add_image_or_video" tools:ignore="UnusedResources">ADD IMAGE OR VIDEO</string>
+    <string name="gutenberg_native_add_link_text" tools:ignore="UnusedResources">Add link text</string>
+    <string name="gutenberg_native_add_paragraph_block" tools:ignore="UnusedResources">Add paragraph block</string>
+    <string name="gutenberg_native_add_to_beginning" tools:ignore="UnusedResources">Add To Beginning</string>
+    <string name="gutenberg_native_add_to_end" tools:ignore="UnusedResources">Add To End</string>
+    <string name="gutenberg_native_add_url" tools:ignore="UnusedResources">Add URL</string>
+    <string name="gutenberg_native_add_video" tools:ignore="UnusedResources">ADD VIDEO</string>
+    <string name="gutenberg_native_alt_text" tools:ignore="UnusedResources">Alt Text</string>
+    <string name="gutenberg_native_an_unknown_error_occurred_please_try_again" tools:ignore="UnusedResources">An unknown error occurred. Please try again.</string>
+    <string name="gutenberg_native_annotations_sidebar" tools:ignore="UnusedResources">Annotations Sidebar</string>
+    <!-- translators: title for "Blog" page template -->
+    <string name="gutenberg_native_blog" tools:ignore="UnusedResources">Blog</string>
+    <string name="gutenberg_native_choose_from_device" tools:ignore="UnusedResources">Choose from device</string>
+    <!-- translators: sample content for "Contact" page template -->
+    <string name="gutenberg_native_city_10100" tools:ignore="UnusedResources">City, 10100</string>
+    <string name="gutenberg_native_columns_settings" tools:ignore="UnusedResources">Columns Settings</string>
+    <string name="gutenberg_native_content" tools:ignore="UnusedResources">Content…</string>
+    <!-- translators: %s: current cell value. -->
+    <string name="gutenberg_native_current_value_is_s" tools:ignore="UnusedResources">Current value is %s</string>
+    <string name="gutenberg_native_customize" tools:ignore="UnusedResources">CUSTOMIZE</string>
+    <string name="gutenberg_native_dismiss" tools:ignore="UnusedResources">Dismiss</string>
+    <!-- translators: sample content for "About" page template -->
+    <string name="gutenberg_native_don_t_cry_because_it_s_over_smile_because_it_happened" tools:ignore="UnusedResources">Don’t cry because it’s over, smile because it happened.</string>
+    <string name="gutenberg_native_double_tap_and_hold_to_edit" tools:ignore="UnusedResources">Double tap and hold to edit</string>
+    <string name="gutenberg_native_double_tap_to_add_a_block" tools:ignore="UnusedResources">Double tap to add a block</string>
+    <!-- translators: accessibility text (hint for focusing a slider) -->
+    <string name="gutenberg_native_double_tap_to_change_the_value_using_slider" tools:ignore="UnusedResources">Double tap to change the value using slider</string>
+    <!-- translators: accessibility text -->
+    <string name="gutenberg_native_double_tap_to_edit_this_value" tools:ignore="UnusedResources">Double tap to edit this value</string>
+    <!-- translators: accessibility text (hint for moving to color settings) -->
+    <string name="gutenberg_native_double_tap_to_go_to_color_settings" tools:ignore="UnusedResources">Double tap to go to color settings</string>
+    <string name="gutenberg_native_double_tap_to_move_the_block_down" tools:ignore="UnusedResources">Double tap to move the block down</string>
+    <string name="gutenberg_native_double_tap_to_move_the_block_to_the_left" tools:ignore="UnusedResources">Double tap to move the block to the left</string>
+    <string name="gutenberg_native_double_tap_to_move_the_block_to_the_right" tools:ignore="UnusedResources">Double tap to move the block to the right</string>
+    <string name="gutenberg_native_double_tap_to_move_the_block_up" tools:ignore="UnusedResources">Double tap to move the block up</string>
+    <string name="gutenberg_native_double_tap_to_open_action_sheet_with_available_options" tools:ignore="UnusedResources">Double tap to open Action Sheet with available options</string>
+    <string name="gutenberg_native_double_tap_to_open_bottom_sheet_with_available_options" tools:ignore="UnusedResources">Double tap to open Bottom Sheet with available options</string>
+    <string name="gutenberg_native_double_tap_to_redo_last_change" tools:ignore="UnusedResources">Double tap to redo last change</string>
+    <string name="gutenberg_native_double_tap_to_select" tools:ignore="UnusedResources">Double tap to select</string>
+    <string name="gutenberg_native_double_tap_to_select_a_video" tools:ignore="UnusedResources">Double tap to select a video</string>
+    <string name="gutenberg_native_double_tap_to_select_an_image" tools:ignore="UnusedResources">Double tap to select an image</string>
+    <string name="gutenberg_native_double_tap_to_select_layout" tools:ignore="UnusedResources">Double tap to select layout</string>
+    <!-- translators: accessibility text (hint for switches) -->
+    <string name="gutenberg_native_double_tap_to_toggle_setting" tools:ignore="UnusedResources">Double tap to toggle setting</string>
+    <string name="gutenberg_native_double_tap_to_undo_last_change" tools:ignore="UnusedResources">Double tap to undo last change</string>
+    <!-- translators: sample content for "About" page template -->
+    <string name="gutenberg_native_dr_seuss" tools:ignore="UnusedResources">Dr. Seuss</string>
+    <string name="gutenberg_native_edit_block_in_web_browser" tools:ignore="UnusedResources">Edit block in web browser</string>
+    <string name="gutenberg_native_edit_media" tools:ignore="UnusedResources">Edit media</string>
+    <string name="gutenberg_native_edit_video" tools:ignore="UnusedResources">Edit video</string>
+    <!-- translators: sample content for "Team" page template -->
+    <string name="gutenberg_native_email_me_a_href_mailto_mail_example_com_mail_example_com_a" tools:ignore="UnusedResources">Email me: &lt;a href=\"mailto:mail@example.com\"&gt;mail@example.com&lt;/a&gt;</string>
+    <string name="gutenberg_native_excerpt_length_words" tools:ignore="UnusedResources">Excerpt length (words)</string>
+    <string name="gutenberg_native_failed_to_insert_media_please_tap_for_options" tools:ignore="UnusedResources">Failed to insert media.\nPlease tap for options.</string>
+    <!-- translators: accessibility text. %s: gallery caption. -->
+    <string name="gutenberg_native_gallery_caption_s" tools:ignore="UnusedResources">Gallery caption. %s</string>
+    <!-- translators: sample content for "About" page template
+translators: sample content for "Contact" page template
+translators: sample content for "Portfolio" page template
+translators: sample content for "Services" page template
+translators: sample content for "Team" page template -->
+    <string name="gutenberg_native_get_in_touch" tools:ignore="UnusedResources">Get in Touch</string>
+    <string name="gutenberg_native_help_icon" tools:ignore="UnusedResources">Help icon</string>
+    <string name="gutenberg_native_here_is_the_panel_content" tools:ignore="UnusedResources">Here is the panel content!</string>
+    <string name="gutenberg_native_hide_keyboard" tools:ignore="UnusedResources">Hide keyboard</string>
+    <!-- translators: accessibility text. %s: image caption. -->
+    <string name="gutenberg_native_image_caption_s" tools:ignore="UnusedResources">Image caption. %s</string>
+    <string name="gutenberg_native_insert_mention" tools:ignore="UnusedResources">Insert mention</string>
+    <!-- translators: sample content for "Services" page template -->
+    <string name="gutenberg_native_inspiration" tools:ignore="UnusedResources">Inspiration</string>
+    <!-- translators: sample content for "About" page template -->
+    <string name="gutenberg_native_it_is_our_choices_harry_that_show_what_we_truly_are_far_more_than" tools:ignore="UnusedResources">It is our choices, Harry, that show what we truly are, far more than our abilities.</string>
+    <!-- translators: sample content for "About" page template -->
+    <string name="gutenberg_native_j_k_rowling" tools:ignore="UnusedResources">J.K. Rowling</string>
+    <!-- translators: sample content for "Team" page template -->
+    <string name="gutenberg_native_juan_p_rez" tools:ignore="UnusedResources">Juan Pérez</string>
+    <!-- translators: sample content for "About" page template
+translators: sample content for "Services" page template -->
+    <string name="gutenberg_native_let_s_build_something_together" tools:ignore="UnusedResources">Let’s build something together!</string>
+    <!-- translators: sample content for "Portfolio" page template -->
+    <string name="gutenberg_native_let_s_build_something_together_7019bfe3" tools:ignore="UnusedResources">Let\'s build something together!</string>
+    <!-- translators: sample content for "Contact" page template -->
+    <string name="gutenberg_native_let_s_talk_don_t_hesitate_to_reach_out_with_the_contact_informati" tools:ignore="UnusedResources">Let\'s talk 👋 Don\'t hesitate to reach out with the contact information below, or send a message using the form.</string>
+    <string name="gutenberg_native_link_inserted" tools:ignore="UnusedResources">Link inserted</string>
+    <string name="gutenberg_native_link_text" tools:ignore="UnusedResources">Link text</string>
+    <string name="gutenberg_native_link_to" tools:ignore="UnusedResources">Link To</string>
+    <!-- translators: accessibility text. %1: current block position (number). %2: next block position (number) -->
+    <string name="gutenberg_native_move_block_down_from_row_1_s_to_row_2_s" tools:ignore="UnusedResources">Move block down from row %1$s to row %2$s</string>
+    <!-- translators: accessibility text. %1: current block position (number). %2: next block position (number) -->
+    <string name="gutenberg_native_move_block_left_from_position_1_s_to_position_2_s" tools:ignore="UnusedResources">Move block left from position %1$s to position %2$s</string>
+    <!-- translators: accessibility text. %1: current block position (number). %2: next block position (number) -->
+    <string name="gutenberg_native_move_block_right_from_position_1_s_to_position_2_s" tools:ignore="UnusedResources">Move block right from position %1$s to position %2$s</string>
+    <!-- translators: accessibility text. %1: current block position (number). %2: next block position (number) -->
+    <string name="gutenberg_native_move_block_up_from_row_1_s_to_row_2_s" tools:ignore="UnusedResources">Move block up from row %1$s to row %2$s</string>
+    <string name="gutenberg_native_move_image_backward" tools:ignore="UnusedResources">Move Image Backward</string>
+    <string name="gutenberg_native_move_image_forward" tools:ignore="UnusedResources">Move Image Forward</string>
+    <!-- translators: %s: block title e.g: "Paragraph" -->
+    <string name="gutenberg_native_move_s_down" tools:ignore="UnusedResources">Move %s Down</string>
+    <!-- translators: %s: block title e.g: "Paragraph" -->
+    <string name="gutenberg_native_move_s_left" tools:ignore="UnusedResources">Move %s Left</string>
+    <!-- translators: %s: block title e.g: "Paragraph" -->
+    <string name="gutenberg_native_move_s_right" tools:ignore="UnusedResources">Move %s Right</string>
+    <!-- translators: %s: block title e.g: "Paragraph" -->
+    <string name="gutenberg_native_move_s_up" tools:ignore="UnusedResources">Move %s Up</string>
+    <string name="gutenberg_native_my_document_setting_panel" tools:ignore="UnusedResources">My Document Setting Panel</string>
+    <!-- translators: sample content for "Portfolio" page template -->
+    <string name="gutenberg_native_my_portfolio_showcases_various_projects_created_throughout_my_car" tools:ignore="UnusedResources">My portfolio showcases various projects created throughout my career. See my contact information below and get in touch.</string>
+    <string name="gutenberg_native_my_post_publish_panel" tools:ignore="UnusedResources">My post publish panel</string>
+    <string name="gutenberg_native_my_post_status_info" tools:ignore="UnusedResources">My post status info</string>
+    <string name="gutenberg_native_my_pre_publish_panel" tools:ignore="UnusedResources">My pre publish panel</string>
+    <string name="gutenberg_native_navigate_up" tools:ignore="UnusedResources">Navigate Up</string>
+    <string name="gutenberg_native_no_application_can_handle_this_request_please_install_a_web_brows" tools:ignore="UnusedResources">No application can handle this request. Please install a Web browser.</string>
+    <string name="gutenberg_native_number_of_columns" tools:ignore="UnusedResources">Number of columns</string>
+    <string name="gutenberg_native_only_show_excerpt" tools:ignore="UnusedResources">Only show excerpt</string>
+    <string name="gutenberg_native_open_block_actions_menu" tools:ignore="UnusedResources">Open Block Actions Menu</string>
+    <string name="gutenberg_native_open_settings" tools:ignore="UnusedResources">Open Settings</string>
+    <!-- translators: accessibility text. %s: Page break text. -->
+    <string name="gutenberg_native_page_break_block_s" tools:ignore="UnusedResources">Page break block. %s</string>
+    <string name="gutenberg_native_paste_url" tools:ignore="UnusedResources">Paste URL</string>
+    <!-- translators: title for "Portfolio" page template -->
+    <string name="gutenberg_native_portfolio" tools:ignore="UnusedResources">Portfolio</string>
+    <!-- translators: sample content for "Team" page template -->
+    <string name="gutenberg_native_position_or_job_title" tools:ignore="UnusedResources">Position or Job Title</string>
+    <!-- translators: accessibility text. empty post title. -->
+    <string name="gutenberg_native_post_title_empty" tools:ignore="UnusedResources">Post title. Empty</string>
+    <!-- translators: accessibility text. %s: text content of the post title. -->
+    <string name="gutenberg_native_post_title_s" tools:ignore="UnusedResources">Post title. %s</string>
+    <string name="gutenberg_native_problem_displaying_block" tools:ignore="UnusedResources">Problem displaying block</string>
+    <string name="gutenberg_native_problem_opening_the_video" tools:ignore="UnusedResources">Problem opening the video</string>
+    <!-- translators: sample content for "Portfolio" page template -->
+    <string name="gutenberg_native_project_name" tools:ignore="UnusedResources">Project Name</string>
+    <string name="gutenberg_native_remove_annotations" tools:ignore="UnusedResources">Remove annotations</string>
+    <string name="gutenberg_native_remove_image" tools:ignore="UnusedResources">Remove Image</string>
+    <!-- translators: %s: block title e.g: "Paragraph". -->
+    <string name="gutenberg_native_remove_s" tools:ignore="UnusedResources">Remove %s</string>
+    <string name="gutenberg_native_replace_current_block" tools:ignore="UnusedResources">Replace Current Block</string>
+    <string name="gutenberg_native_reset_block" tools:ignore="UnusedResources">Reset Block</string>
+    <!-- translators: accessibility text for the media block empty state. %s: media type -->
+    <string name="gutenberg_native_s_block_empty" tools:ignore="UnusedResources">%s block. Empty</string>
+    <!-- translators: accessibility text for blocks with invalid content. %d: localized block title -->
+    <string name="gutenberg_native_s_block_this_block_has_invalid_content" tools:ignore="UnusedResources">%s block. This block has invalid content</string>
+    <!-- translators: %s: Name of the block -->
+    <string name="gutenberg_native_s_isn_t_yet_supported_on_wordpress_for_android" tools:ignore="UnusedResources">\'%s\' isn\'t yet supported on WordPress for Android</string>
+    <!-- translators: %s: Name of the block -->
+    <string name="gutenberg_native_s_isn_t_yet_supported_on_wordpress_for_ios" tools:ignore="UnusedResources">\'%s\' isn\'t yet supported on WordPress for iOS</string>
+    <!-- translators: %s: block title e.g: "Paragraph". -->
+    <string name="gutenberg_native_s_settings" tools:ignore="UnusedResources">%s Settings</string>
+    <!-- translators: sample content for "Team" page template -->
+    <string name="gutenberg_native_sally_smith" tools:ignore="UnusedResources">Sally Smith</string>
+    <!-- translators: sample content for "Team" page template -->
+    <string name="gutenberg_native_samuel_the_dog" tools:ignore="UnusedResources">Samuel the Dog</string>
+    <string name="gutenberg_native_select_a_color" tools:ignore="UnusedResources">Select a color</string>
+    <!-- translators: title for "Services" page template -->
+    <string name="gutenberg_native_services" tools:ignore="UnusedResources">Services</string>
+    <string name="gutenberg_native_show_post_content" tools:ignore="UnusedResources">Show post content</string>
+    <!-- translators: Checkbox toggle label -->
+    <string name="gutenberg_native_show_section" tools:ignore="UnusedResources">Show section</string>
+    <string name="gutenberg_native_sidebar_title_plugin" tools:ignore="UnusedResources">Sidebar title plugin</string>
+    <string name="gutenberg_native_size" tools:ignore="UnusedResources">Size</string>
+    <string name="gutenberg_native_start_writing" tools:ignore="UnusedResources">Start writing…</string>
+    <!-- translators: sample content for "Services" page template -->
+    <string name="gutenberg_native_strategy" tools:ignore="UnusedResources">Strategy</string>
+    <string name="gutenberg_native_success_message" tools:ignore="UnusedResources">Success Message</string>
+    <string name="gutenberg_native_take_a_photo" tools:ignore="UnusedResources">Take a Photo</string>
+    <string name="gutenberg_native_take_a_photo_or_video" tools:ignore="UnusedResources">Take a Photo or Video</string>
+    <string name="gutenberg_native_take_a_video" tools:ignore="UnusedResources">Take a Video</string>
+    <string name="gutenberg_native_tap_here_to_show_help" tools:ignore="UnusedResources">Tap here to show help</string>
+    <string name="gutenberg_native_tap_to_hide_the_keyboard" tools:ignore="UnusedResources">Tap to hide the keyboard</string>
+    <!-- translators: title for "Team" page template -->
+    <string name="gutenberg_native_team" tools:ignore="UnusedResources">Team</string>
+    <string name="gutenberg_native_template_preview" tools:ignore="UnusedResources">Template Preview</string>
+    <!-- translators: sample content for "About" page template -->
+    <string name="gutenberg_native_the_way_to_get_started_is_to_quit_talking_and_begin_doing" tools:ignore="UnusedResources">The way to get started is to quit talking and begin doing.</string>
+    <!-- translators: sample content for "About" page template -->
+    <string name="gutenberg_native_this_is_sample_content_included_with_the_template_to_illustrate_i" tools:ignore="UnusedResources">This is sample content, included with the template to illustrate its features. Remove or replace it with your own words and media.</string>
+    <string name="gutenberg_native_title" tools:ignore="UnusedResources">Title:</string>
+    <string name="gutenberg_native_translate" tools:ignore="UnusedResources">Translate</string>
+    <string name="gutenberg_native_try_a_starter_layout" tools:ignore="UnusedResources">Try a starter layout</string>
+    <string name="gutenberg_native_ungroup" tools:ignore="UnusedResources">Ungroup</string>
+    <!-- translators: sample content for "Contact" page template -->
+    <string name="gutenberg_native_usa" tools:ignore="UnusedResources">USA</string>
+    <!-- translators: accessibility text. %s: video caption. -->
+    <string name="gutenberg_native_video_caption_s" tools:ignore="UnusedResources">Video caption. %s</string>
+    <!-- translators: sample content for "About" page template -->
+    <string name="gutenberg_native_visitors_will_want_to_know_who_is_on_the_other_side_of_the_page_u" tools:ignore="UnusedResources">Visitors will want to know who is on the other side of the page. Use this space to write about yourself, your site, your business, or anything you want. Use the testimonials below to quote others, talking about the same thing – in their own words.</string>
+    <!-- translators: sample content for "About" page template -->
+    <string name="gutenberg_native_walt_disney" tools:ignore="UnusedResources">Walt Disney</string>
+    <!-- translators: sample content for "Team" page template -->
+    <string name="gutenberg_native_want_to_work_with_us" tools:ignore="UnusedResources">Want to work with us?</string>
+    <string name="gutenberg_native_warning_message" tools:ignore="UnusedResources">Warning Message</string>
+    <!-- translators: sample content for "Team" page template -->
+    <string name="gutenberg_native_we_are_a_small_team_of_talented_professionals_with_a_wide_range_o" tools:ignore="UnusedResources">We are a small team of talented professionals with a wide range of skills and experience. We love what we do, and we do it with passion. We look forward to working with you.</string>
+    <string name="gutenberg_native_we_are_working_hard_to_add_more_blocks_with_each_release_in_the_m" tools:ignore="UnusedResources">We are working hard to add more blocks with each release. In the meantime, you can also edit this block using your device\'s web browser.</string>
+    <string name="gutenberg_native_we_are_working_hard_to_add_more_blocks_with_each_release_in_the_m_68559180" tools:ignore="UnusedResources">We are working hard to add more blocks with each release. In the meantime, you can also edit this post on the web.</string>
+    <!-- translators: sample content for "Services" page template -->
+    <string name="gutenberg_native_we_offer_a_range_of_services_to_help_you_achieve_the_results_you" tools:ignore="UnusedResources">We offer a range of services to help you achieve the results you\'re after. Not sure what you need, or what it costs? We can explain what services are right for you and tell you more about our fees. Get in touch below.</string>
+    <!-- translators: sample content for "Blog" page template -->
+    <string name="gutenberg_native_welcome_to_our_new_blog" tools:ignore="UnusedResources">Welcome to our new blog</string>
+    <!-- translators: sample content for "About" page template -->
+    <string name="gutenberg_native_what_people_say" tools:ignore="UnusedResources">What People Say</string>
+    <string name="gutenberg_native_wordpress_media_library" tools:ignore="UnusedResources">WordPress Media Library</string>
+    <!--/Autogenerated:Gutenberg Native-->
+</resources>


### PR DESCRIPTION
As a part of our branch renaming projects, we'll need to update the path that GlotPress uses to fetch new strings that need translation. 
Currently, the strings are picked from the main `strings.xml` file in the `master` branch. Upload from `master` assures that the changes applied during development don't affect the version in code freeze. 
But this breaks our standard flow as it requires to merge the release branch into `master` multiple times during the release cycle. 

This PR proposes a solution to this issue. Instead of using a different branch, we can use a different file. The main `strings.xml` file is copied to a different location which gets updated only during the code freeze. If we make GlotPress point to this _shadow_ `strings.xml` in `develop`, we can go back to the standard release cycle. 

I've been thinking to this solution for a while. I don't like it too much tbh, but I like it better than the current one. 
A benefit of this approach is that, in the future, we could elaborate the _shadow_ file instead of simply copying it in order to make up for missing feature in the GlotPress importer (for example: GlotPress doesn't support comments in XML files, but it supports them in others, so we could convert the file in a more conveniente format). 
 
To test:
The easiest way to test the changes is to tweak the `fastlane` to make the `send_strings_for_translation` lane public so that it can be called directly.

I'm opening this PR in order to get feedback on the solution itself other than the implementation.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
