### PR TITLE
Remove java/kotlin code constraint creation in ReaderPostAdapter with xml

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -183,9 +183,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private class ReaderPostViewHolder extends RecyclerView.ViewHolder {
         final View mPostContainer;
 
-        private final ConstraintLayout mRootLayout;
-        private final ConstraintSet mRootLayoutConstraintSet = new ConstraintSet();
-
         private final TextView mTxtTitle;
         private final TextView mTxtText;
         private final TextView mTxtAuthorAndBlogName;
@@ -217,8 +214,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             super(itemView);
 
             mPostContainer = itemView.findViewById(R.id.post_container);
-            mRootLayout = itemView.findViewById(R.id.root_layout);
-            mRootLayoutConstraintSet.clone(mRootLayout);
 
             mTxtTitle = itemView.findViewById(R.id.text_title);
             mTxtText = itemView.findViewById(R.id.text_excerpt);
@@ -445,18 +440,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         if (post == null) {
             return;
         }
-
-        // Set title below thumbnail strip if card type is GALLERY
-        View txtTitlePreviousView = post.getCardType() == ReaderCardType.GALLERY
-                ? holder.mThumbnailStrip : holder.mImgFeatured;
-        holder.mRootLayoutConstraintSet.connect(
-                holder.mTxtTitle.getId(),
-                ConstraintSet.TOP,
-                txtTitlePreviousView.getId(),
-                ConstraintSet.BOTTOM,
-                mMarginExtraLarge
-        );
-        holder.mRootLayoutConstraintSet.applyTo(holder.mRootLayout);
 
         String urlString = "";
         if (post.hasBlogUrl()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -15,8 +15,6 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
 import androidx.constraintlayout.widget.Group;
 import androidx.recyclerview.widget.RecyclerView;
 

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -150,6 +150,7 @@
             app:layout_constraintDimensionRatio="16:9"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintStart_toStartOf="@id/guideline_beginning"
+            app:layout_constraintBottom_toTopOf="@id/text_title"
             app:layout_constraintTop_toBottomOf="@+id/layout_post_header" />
 
         <ImageView
@@ -209,19 +210,19 @@
             app:layout_constraintStart_toStartOf="@id/guideline_beginning"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintTop_toBottomOf="@id/layout_post_header"
+            app:layout_constraintBottom_toTopOf="@+id/text_title"
             tools:visibility="visible" />
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/text_title"
             style="@style/ReaderTextView.Post.Title"
             android:layout_width="0dp"
-            android:layout_marginTop="@dimen/margin_extra_large"
+            android:paddingTop="@dimen/margin_extra_large"
             android:includeFontPadding="false"
             android:textAlignment="viewStart"
             app:layout_constraintStart_toStartOf="@id/guideline_beginning"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintBottom_toTopOf="@+id/text_excerpt"
-            app:layout_constraintTop_toBottomOf="@+id/frame_photo"
             tools:text="text_title" />
 
         <org.wordpress.android.widgets.WPTextView


### PR DESCRIPTION
This PR replaces constraint created in java code with equal xml code.

To test:
1. Test that the post card type in reader still looks the same - make sure to test different types of cards (eg. with photo, with video, without photo and video ..)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
