### PR TITLE
Check for remote field in features

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
@@ -9,19 +9,24 @@ import javax.inject.Singleton
 
 @Singleton
 class AppConfig
-@Inject constructor(private val remoteConfig: RemoteConfig, private val analyticsTracker: AnalyticsTrackerWrapper) {
+@Inject constructor(
+    private val remoteConfig: RemoteConfig,
+    private val analyticsTracker: AnalyticsTrackerWrapper
+) {
     /**
      * We need to keep the value of an already loaded feature flag to make sure the value is not changed while using the app.
      * We should only reload the flags when the application is created.
      */
     private val enabledFeatures = mutableMapOf<String, Boolean>()
     private val experimentValues = mutableMapOf<String, String>()
+    private val remoteConfigCheck = RemoteConfigCheck(this)
 
     /**
      * This method initialized the config and triggers refresh of remote configuration.
      */
     fun refresh() {
         remoteConfig.refresh()
+        remoteConfigCheck.checkRemoteFields()
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ExampleRemoteFeature.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ExampleRemoteFeature.kt
@@ -13,7 +13,8 @@ import javax.inject.Inject
 class ExampleRemoteFeature
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.TENOR_AVAILABLE
+        BuildConfig.TENOR_AVAILABLE,
+        EXAMPLE_REMOTE_FEATURE_FIELD
 ) {
     companion object {
         const val EXAMPLE_REMOTE_FEATURE_FIELD = "example_remote_feature_field"

--- a/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigCheckBuilder.kt
+++ b/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigCheckBuilder.kt
@@ -51,7 +51,8 @@ class RemoteConfigCheckBuilder(private val remoteFeatures: List<TypeName>) {
         val stringBuilder = StringBuilder()
         remoteFeatures.forEach { feature ->
             stringBuilder.appendln("if (${feature.first}.remoteField == null) {")
-            stringBuilder.appendln("    throw IllegalArgumentException(\"\"\"${feature.second} needs to define remoteField\"\"\")")
+            val error = "    throw IllegalArgumentException(\"\"\"${feature.second} needs to define remoteField\"\"\")"
+            stringBuilder.appendln(error)
             stringBuilder.appendln("}")
         }
         return CodeBlock.of(stringBuilder.toString().trimIndent())

--- a/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigCheckBuilder.kt
+++ b/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigCheckBuilder.kt
@@ -1,0 +1,71 @@
+package org.wordpress.android.processor
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
+import java.util.Locale
+
+class RemoteConfigCheckBuilder(private val remoteFeatures: List<TypeName>) {
+    @ExperimentalStdlibApi
+    fun getContent(): FileSpec {
+        val remoteFeaturesWithNames = remoteFeatures.map {
+            it.toString()
+                    .substringAfterLast(".")
+                    .decapitalize(Locale.ROOT) to it
+        }
+        val propertySpecs = remoteFeaturesWithNames.map { remoteFeature ->
+            val constructor = remoteFeature.second.toString().substringAfterLast(".")
+            PropertySpec.builder(remoteFeature.first, remoteFeature.second)
+                    .initializer(CodeBlock.of("$constructor(appConfig)".trimIndent()))
+                    .build()
+        }
+        val remoteConfigDefaults = TypeSpec.classBuilder("RemoteConfigCheck")
+                .addProperties(propertySpecs)
+                .primaryConstructor(
+                        listOf(
+                                PropertySpec.builder(
+                                        "appConfig",
+                                        ClassName.bestGuess("org.wordpress.android.util.config.AppConfig")
+                                ).build()
+                        )
+                )
+                .addFunction(
+                        FunSpec.builder("checkRemoteFields")
+                                .addCode(buildCheckFunction(remoteFeaturesWithNames))
+                                .build()
+                )
+                .build()
+        return FileSpec.builder("org.wordpress.android.util.config", "RemoteConfigCheck")
+                .addType(remoteConfigDefaults)
+                .addComment("Automatically generated file. DO NOT MODIFY")
+                .indent("    ")
+                .build()
+    }
+
+    private fun buildCheckFunction(remoteFeatures: List<Pair<String, TypeName>>): CodeBlock {
+        val stringBuilder = StringBuilder()
+        remoteFeatures.forEach { feature ->
+            stringBuilder.appendln("if (${feature.first}.remoteField == null) {")
+            stringBuilder.appendln("    throw IllegalArgumentException(\"\"\"${feature.second} needs to define remoteField\"\"\")")
+            stringBuilder.appendln("}")
+        }
+        return CodeBlock.of(stringBuilder.toString().trimIndent())
+    }
+
+    private fun TypeSpec.Builder.primaryConstructor(properties: List<PropertySpec>): TypeSpec.Builder {
+        val propertySpecs = properties.map { p -> p.toBuilder().initializer(p.name).build() }
+        val parameters = propertySpecs.map { ParameterSpec.builder(it.name, it.type).build() }
+        val constructor = FunSpec.constructorBuilder()
+                .addParameters(parameters)
+                .build()
+
+        return this
+                .primaryConstructor(constructor)
+                .addProperties(propertySpecs)
+    }
+}

--- a/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigDefaultsBuilder.kt
+++ b/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigDefaultsBuilder.kt
@@ -30,6 +30,7 @@ class RemoteConfigDefaultsBuilder(private val defaults: Map<String, String>) {
         return FileSpec.builder("org.wordpress.android.util.config", "RemoteConfigDefaults")
                 .addType(remoteConfigDefaults)
                 .addComment("Automatically generated file. DO NOT MODIFY")
+                .indent("    ")
                 .build()
     }
 }

--- a/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigProcessor.kt
+++ b/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigProcessor.kt
@@ -67,7 +67,7 @@ class RemoteConfigProcessor : AbstractProcessor() {
         } catch (e: Exception) {
             processingEnv.messager.printMessage(
                     Kind.ERROR,
-                    "Failed to generate remote config check: ${e.toString()}"
+                    "Failed to generate remote config check: $e"
             )
         }
     }

--- a/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigProcessor.kt
+++ b/libs/WordPressProcessors/src/main/java/org/wordpress/android/processor/RemoteConfigProcessor.kt
@@ -1,10 +1,11 @@
 package org.wordpress.android.processor
 
 import com.google.auto.service.AutoService
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.asTypeName
 import org.wordpress.android.annotation.Experiment
 import org.wordpress.android.annotation.Feature
 import java.io.File
-import java.lang.Exception
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
@@ -14,6 +15,7 @@ import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
 import javax.tools.Diagnostic.Kind
 
+@ExperimentalStdlibApi
 @AutoService(Processor::class) // For registering the service
 @SupportedSourceVersion(SourceVersion.RELEASE_8) // to support Java 8
 @SupportedAnnotationTypes(
@@ -26,12 +28,15 @@ class RemoteConfigProcessor : AbstractProcessor() {
             val annotation = element.getAnnotation(Experiment::class.java)
             annotation.remoteField to annotation.defaultVariant
         } ?: listOf()
+        val remoteFeatureNames = mutableListOf<TypeName>()
         val features = roundEnvironment?.getElementsAnnotatedWith(Feature::class.java)?.map { element ->
             val annotation = element.getAnnotation(Feature::class.java)
+            remoteFeatureNames.add(element.asType().asTypeName())
             annotation.remoteField to annotation.defaultValue.toString()
         } ?: listOf()
         return if (experiments.isNotEmpty() || features.isNotEmpty()) {
             generateRemoteConfigDefaults((experiments + features).toMap())
+            generateRemoteConfigCheck(remoteFeatureNames)
             true
         } else {
             false
@@ -47,7 +52,23 @@ class RemoteConfigProcessor : AbstractProcessor() {
             val kaptKotlinGeneratedDir = processingEnv.options[KAPT_KOTLIN_GENERATED_OPTION_NAME]
             fileContent.writeTo(File(kaptKotlinGeneratedDir))
         } catch (e: Exception) {
-            processingEnv.messager.printMessage(Kind.ERROR, "Failed to generate remote_config_defaults")
+            processingEnv.messager.printMessage(Kind.ERROR, "Failed to generate remote config defaults")
+        }
+    }
+
+    private fun generateRemoteConfigCheck(
+        remoteFeatureNames: List<TypeName>
+    ) {
+        try {
+            val fileContent = RemoteConfigCheckBuilder(remoteFeatureNames).getContent()
+
+            val kaptKotlinGeneratedDir = processingEnv.options[KAPT_KOTLIN_GENERATED_OPTION_NAME]
+            fileContent.writeTo(File(kaptKotlinGeneratedDir))
+        } catch (e: Exception) {
+            processingEnv.messager.printMessage(
+                    Kind.ERROR,
+                    "Failed to generate remote config check: ${e.toString()}"
+            )
         }
     }
 


### PR DESCRIPTION
It was previously possible to use the annotation for a remote feature but to miss to add the `remoteField` field parameter. This PR adds a generated class that checks whether all the features that are annotated with the `Feature` annotation have non-null remote field. 

To test:
- Create a feature annotated with `Feature` without the `remoteField`
- Run the app
- Notice that it crashes
- Add the `remoteField` 
- Notice that it doesn't crash any more

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
