### PR TITLE
WP Stories: fix immersive style

### DIFF
--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -85,6 +85,9 @@
 
     <style name="WordPress.Stories.Immersive" parent="WordPress.NoActionBar">
         <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:immersive">true</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 
     <style name="WordPress.Editor.NoActionBar" parent="WordPress.NoActionBar">


### PR DESCRIPTION
This PR builds on top of #12264 

Fixes immersive mode for Stories. h/t @aforcier for spotting the problem

To test:
1. open the app, tap on the FAB
2. verify the screen fills in, and then PUBLISH button and so on take into account the space for the status bar

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
