### PR TITLE
Issue/12028 reader post builder clean up

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -146,7 +146,8 @@ class ReaderDiscoverViewModel @Inject constructor(
 
             data class GalleryThumbnailStripData(
                 val images: ReaderImageList,
-                val isPrivate: Boolean
+                val isPrivate: Boolean,
+                val content: String // needs to be here as it's required by ReaderThumbnailStrip
             )
 
             data class DiscoverLayoutUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -128,7 +128,7 @@ class ReaderDiscoverViewModel @Inject constructor(
             val photoTitle: String?,
             val featuredImageUrl: String?,
             val featuredImageCornerRadius: UiDimen,
-            val videoThumbnailUrl: String?,
+            val fullVideoUrl: String?,
             val avatarOrBlavatarUrl: String?,
             val thumbnailStripSection: GalleryThumbnailStripData?,
             val discoverSection: DiscoverLayoutUiState?,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
 import org.wordpress.android.ui.reader.models.ReaderImageList
@@ -62,7 +63,8 @@ class ReaderDiscoverViewModel @Inject constructor(
                                 onReblogClicked = this::onReblogClicked,
                                 onCommentsClicked = this::onCommentsClicked,
                                 onItemClicked = this::onItemClicked,
-                                onItemRendered = this::onItemRendered
+                                onItemRendered = this::onItemRendered,
+                                postListType = TAG_FOLLOWED
                         )
                     }
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -64,6 +64,7 @@ class ReaderDiscoverViewModel @Inject constructor(
                                 onCommentsClicked = this::onCommentsClicked,
                                 onItemClicked = this::onItemClicked,
                                 onItemRendered = this::onItemRendered,
+                                onDiscoverSectionClicked = this::onDiscoverClicked,
                                 postListType = TAG_FOLLOWED
                         )
                     }
@@ -93,6 +94,10 @@ class ReaderDiscoverViewModel @Inject constructor(
 
     private fun onItemRendered(postId: Long, blogId: Long) {
         AppLog.d(T.READER, "OnItemRendered")
+    }
+
+    private fun onDiscoverClicked(postId: Long, blogId: Long) {
+        AppLog.d(T.READER, "OnDiscoverClicked")
     }
 
     private fun loadPosts() {
@@ -147,7 +152,8 @@ class ReaderDiscoverViewModel @Inject constructor(
             data class DiscoverLayoutUiState(
                 val discoverText: Spanned,
                 val discoverAvatarUrl: String,
-                val imageType: ImageType
+                val imageType: ImageType,
+                val onDiscoverClicked: ((Long, Long) -> Unit)
             )
 
             data class ActionUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -65,6 +65,7 @@ class ReaderDiscoverViewModel @Inject constructor(
                                 onItemClicked = this::onItemClicked,
                                 onItemRendered = this::onItemRendered,
                                 onDiscoverSectionClicked = this::onDiscoverClicked,
+                                onMoreButtonClicked = this::onMoreButtonClicked,
                                 postListType = TAG_FOLLOWED
                         )
                     }
@@ -98,6 +99,10 @@ class ReaderDiscoverViewModel @Inject constructor(
 
     private fun onDiscoverClicked(postId: Long, blogId: Long) {
         AppLog.d(T.READER, "OnDiscoverClicked")
+    }
+
+    private fun onMoreButtonClicked(postId: Long, blogId: Long) {
+        AppLog.d(T.READER, "OnMoreButtonClicked")
     }
 
     private fun loadPosts() {
@@ -139,8 +144,9 @@ class ReaderDiscoverViewModel @Inject constructor(
             val likeAction: ActionUiState,
             val reblogAction: ActionUiState,
             val commentsAction: ActionUiState,
-            val onItemClicked: ((Long, Long) -> Unit),
-            val onItemRendered: (Long, Long) -> Unit
+            val onItemClicked: (Long, Long) -> Unit,
+            val onItemRendered: (Long, Long) -> Unit,
+            val onMoreButtonClicked: (Long, Long) -> Unit
         ) : ReaderCardUiState() {
             val dotSeparatorVisibility: Boolean = blogUrl != null
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -112,7 +112,6 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private fun buildPhotoTitle(post: ReaderPost) =
             post.takeIf { it.cardType == PHOTO && it.hasTitle() }?.title
 
-    // TODO malinjir `post.cardType != GALLERY` might not be needed
     private fun buildPhotoFrameVisibility(post: ReaderPost) =
             (post.hasFeaturedVideo() || post.hasFeaturedImage()) &&
                     post.cardType != GALLERY

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -74,7 +74,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 thumbnailStripSection = buildThumbnailStripUrls(post),
                 videoOverlayVisibility = buildVideoOverlayVisibility(post),
                 moreMenuVisibility = accountStore.hasAccessToken() && postListType == ReaderPostListType.TAG_FOLLOWED,
-                videoThumbnailUrl = buildVideoThumbnailUrl(post),
+                fullVideoUrl = buildFullVideoUrl(post),
                 discoverSection = buildDiscoverSection(post, onDiscoverSectionClicked),
                 bookmarkAction = buildBookmarkSection(post, onBookmarkClicked),
                 likeAction = buildLikeSection(post, isBookmarkList, onLikeClicked),
@@ -94,9 +94,9 @@ class ReaderPostUiStateBuilder @Inject constructor(
             post.takeIf { post.isDiscoverPost && post.discoverData.discoverType != OTHER }
                     ?.let { buildDiscoverSectionUiState(post.discoverData, onDiscoverSectionClicked) }
 
-    private fun buildVideoThumbnailUrl(post: ReaderPost) =
+    private fun buildFullVideoUrl(post: ReaderPost) =
             post.takeIf { post.cardType == VIDEO }
-                    ?.let { retrieveVideoThumbnailUrl() }
+                    ?.let { post.featuredVideo }
 
     private fun buildVideoOverlayVisibility(post: ReaderPost) = post.cardType == VIDEO
 
@@ -150,11 +150,6 @@ class ReaderPostUiStateBuilder @Inject constructor(
             else -> AVATAR
         }
         return DiscoverLayoutUiState(discoverText, discoverAvatarUrl, discoverAvatarImageType, onDiscoverSectionClicked)
-    }
-
-    private fun retrieveVideoThumbnailUrl(): String? {
-        // TODO malinjir Not yet implemented - Refactor ReaderVideoUtils.retrieveVideoThumbnailUrl
-        return null
     }
 
     private fun retrieveGalleryThumbnailUrls(post: ReaderPost): GalleryThumbnailStripData {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -161,7 +161,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
         // scan post content for images suitable in a gallery
         val images = readerImageScannerProvider.createReaderImageScanner(post.text, post.isPrivate)
                 .getImageList(ReaderConstants.THUMBNAIL_STRIP_IMG_COUNT, ReaderConstants.MIN_GALLERY_IMAGE_WIDTH)
-        return GalleryThumbnailStripData(images, post.isPrivate)
+        return GalleryThumbnailStripData(images, post.isPrivate, post.text)
     }
 
     private fun buildBookmarkSection(post: ReaderPost, onClicked: (Long, Long, Boolean) -> Unit): ActionUiState {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.EDITOR_P
 import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.OTHER
 import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.SITE_PICK
 import org.wordpress.android.ui.reader.ReaderConstants
+import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState.ActionUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState.DiscoverLayoutUiState
@@ -43,7 +44,9 @@ class ReaderPostUiStateBuilder @Inject constructor(
         post: ReaderPost,
         photonWidth: Int,
         photonHeight: Int,
-            // TODO malinjir try to refactor/remove this parameter
+        // TODO malinjir try to refactor/remove this parameter
+        postListType: ReaderPostListType,
+        // TODO malinjir try to refactor/remove this parameter
         isBookmarkList: Boolean,
         onBookmarkClicked: (Long, Long, Boolean) -> Unit,
         onLikeClicked: (Long, Long, Boolean) -> Unit,
@@ -66,11 +69,10 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 photoFrameVisibility = buildPhotoFrameVisibility(post),
                 photoTitle = buildPhotoTitle(post),
                 featuredImageUrl = buildFeaturedImageUrl(post, photonWidth, photonHeight),
-                featuredImageCornerRadius = UIDimenRes(dimen.reader_featured_image_corner_radius),
+                featuredImageCornerRadius = UIDimenRes(R.dimen.reader_featured_image_corner_radius),
                 thumbnailStripSection = buildThumbnailStripUrls(post),
                 videoOverlayVisibility = buildVideoOverlayVisibility(post),
-                // TODO malinjir Consider adding `postListType == ReaderPostListType.TAG_FOLLOWED` to showMoreMenu
-                moreMenuVisibility = accountStore.hasAccessToken(),
+                moreMenuVisibility = accountStore.hasAccessToken() && postListType == ReaderPostListType.TAG_FOLLOWED,
                 videoThumbnailUrl = buildVideoThumbnailUrl(post),
                 discoverSection = buildDiscoverSection(post),
                 bookmarkAction = buildBookmarkSection(post, onBookmarkClicked),

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -44,16 +44,17 @@ class ReaderPostUiStateBuilder @Inject constructor(
         post: ReaderPost,
         photonWidth: Int,
         photonHeight: Int,
-        // TODO malinjir try to refactor/remove this parameter
+            // TODO malinjir try to refactor/remove this parameter
         postListType: ReaderPostListType,
-        // TODO malinjir try to refactor/remove this parameter
+            // TODO malinjir try to refactor/remove this parameter
         isBookmarkList: Boolean,
         onBookmarkClicked: (Long, Long, Boolean) -> Unit,
         onLikeClicked: (Long, Long, Boolean) -> Unit,
         onReblogClicked: (Long, Long, Boolean) -> Unit,
         onCommentsClicked: (Long, Long, Boolean) -> Unit,
         onItemClicked: (Long, Long) -> Unit,
-        onItemRendered: (Long, Long) -> Unit
+        onItemRendered: (Long, Long) -> Unit,
+        onDiscoverSectionClicked: (Long, Long) -> Unit
     ): ReaderPostUiState {
         // TODO malinjir on item rendered callback -> handle load more event and trackRailcarRender
 
@@ -74,7 +75,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 videoOverlayVisibility = buildVideoOverlayVisibility(post),
                 moreMenuVisibility = accountStore.hasAccessToken() && postListType == ReaderPostListType.TAG_FOLLOWED,
                 videoThumbnailUrl = buildVideoThumbnailUrl(post),
-                discoverSection = buildDiscoverSection(post),
+                discoverSection = buildDiscoverSection(post, onDiscoverSectionClicked),
                 bookmarkAction = buildBookmarkSection(post, onBookmarkClicked),
                 likeAction = buildLikeSection(post, isBookmarkList, onLikeClicked),
                 reblogAction = buildReblogSection(post, onReblogClicked),
@@ -89,9 +90,9 @@ class ReaderPostUiStateBuilder @Inject constructor(
             ?.blogUrl
             ?.let { urlUtilsWrapper.removeScheme(it) }
 
-    private fun buildDiscoverSection(post: ReaderPost) =
+    private fun buildDiscoverSection(post: ReaderPost, onDiscoverSectionClicked: (Long, Long) -> Unit) =
             post.takeIf { post.isDiscoverPost && post.discoverData.discoverType != OTHER }
-                    ?.let { buildDiscoverSectionUiState(post.discoverData) }
+                    ?.let { buildDiscoverSectionUiState(post.discoverData, onDiscoverSectionClicked) }
 
     private fun buildVideoThumbnailUrl(post: ReaderPost) =
             post.takeIf { post.cardType == VIDEO }
@@ -132,7 +133,10 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private fun buildDateLine(post: ReaderPost) =
             dateTimeUtilsWrapper.javaDateToTimeSpan(post.displayDate)
 
-    private fun buildDiscoverSectionUiState(discoverData: ReaderPostDiscoverData): DiscoverLayoutUiState {
+    private fun buildDiscoverSectionUiState(
+        discoverData: ReaderPostDiscoverData,
+        onDiscoverSectionClicked: (Long, Long) -> Unit
+    ): DiscoverLayoutUiState {
         // TODO malinjir don't store Spanned in VM/UiState => refactor getAttributionHtml method.
         val discoverText = discoverData.attributionHtml
         val discoverAvatarUrl = gravatarUtilsWrapper.fixGravatarUrlWithResource(
@@ -145,8 +149,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
             OTHER -> throw IllegalStateException("This could should be unreachable.")
             else -> AVATAR
         }
-        // TODO malinjir discoverLayout onClick listener.
-        return DiscoverLayoutUiState(discoverText, discoverAvatarUrl, discoverAvatarImageType)
+        return DiscoverLayoutUiState(discoverText, discoverAvatarUrl, discoverAvatarImageType, onDiscoverSectionClicked)
     }
 
     private fun retrieveVideoThumbnailUrl(): String? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -54,7 +54,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
         onCommentsClicked: (Long, Long, Boolean) -> Unit,
         onItemClicked: (Long, Long) -> Unit,
         onItemRendered: (Long, Long) -> Unit,
-        onDiscoverSectionClicked: (Long, Long) -> Unit
+        onDiscoverSectionClicked: (Long, Long) -> Unit,
+        onMoreButtonClicked: (Long, Long) -> Unit
     ): ReaderPostUiState {
         // TODO malinjir on item rendered callback -> handle load more event and trackRailcarRender
 
@@ -81,7 +82,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 reblogAction = buildReblogSection(post, onReblogClicked),
                 commentsAction = buildCommentsSection(post, isBookmarkList, onCommentsClicked),
                 onItemClicked = onItemClicked,
-                onItemRendered = onItemRendered
+                onItemRendered = onItemRendered,
+                onMoreButtonClicked = onMoreButtonClicked
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.reader.discover
 
 import dagger.Reusable
 import org.wordpress.android.R
-import org.wordpress.android.R.dimen
-import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.ReaderCardType.DEFAULT
 import org.wordpress.android.models.ReaderCardType.GALLERY
@@ -20,7 +18,7 @@ import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCa
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState.DiscoverLayoutUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.ReaderCardUiState.ReaderPostUiState.GalleryThumbnailStripData
 import org.wordpress.android.ui.reader.utils.ReaderImageScannerProvider
-import org.wordpress.android.ui.reader.utils.ReaderUtils
+import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.utils.UiDimen.UIDimenRes
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -37,7 +35,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private val urlUtilsWrapper: UrlUtilsWrapper,
     private val gravatarUtilsWrapper: GravatarUtilsWrapper,
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
-    private val readerImageScannerProvider: ReaderImageScannerProvider
+    private val readerImageScannerProvider: ReaderImageScannerProvider,
+    private val readerUtilsWrapper: ReaderUtilsWrapper
 ) {
     // TODO malinjir move this to a bg thread
     fun mapPostToUiState(
@@ -198,13 +197,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
             ActionUiState(
                     isEnabled = true,
                     isSelected = post.isLikedByCurrentUser,
-                    // TODO malinjir remove static access and reference to context
                     contentDescription = UiStringText(
-                            ReaderUtils.getLongLikeLabelText(
-                                    WordPress.getContext(),
-                                    post.numLikes,
-                                    post.isLikedByCurrentUser
-                            )
+                            readerUtilsWrapper.getLongLikeLabelText(post.numLikes, post.isLikedByCurrentUser)
                     ),
                     onClicked = if (accountStore.hasAccessToken()) onClicked else null
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -94,7 +94,9 @@ class ReaderPostViewHolder(
                     state.discoverSection.discoverAvatarUrl
             )
         }
-        // TODO malinjir handle on discover click
+        layout_discover.setOnClickListener {
+            state.discoverSection?.onDiscoverClicked?.invoke(state.postId, state.blogId)
+        }
     }
 
     private fun updateActionButton(postId: Long, blogId: Long, state: ActionUiState, view: View) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -35,7 +35,10 @@ class ReaderPostViewHolder(
         uiHelpers.updateVisibility(image_video_overlay, state.videoOverlayVisibility)
         uiHelpers.setTextOrHide(text_photo_title, state.photoTitle)
         uiHelpers.updateVisibility(frame_photo, state.photoFrameVisibility)
-        // TODO malinjir thumbnail gallery strip
+        uiHelpers.updateVisibility(thumbnail_strip, state.thumbnailStripSection != null)
+        state.thumbnailStripSection?.let {
+            thumbnail_strip.loadThumbnails(it.images, it.isPrivate, it.content)
+        }
         // TODO malinjir video thumbnail
 
         // Content section

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -33,6 +33,7 @@ class ReaderPostViewHolder(
         uiHelpers.updateVisibility(dot_separator, state.dotSeparatorVisibility)
         uiHelpers.setTextOrHide(text_dateline, state.dateLine)
         uiHelpers.updateVisibility(image_more, state.moreMenuVisibility)
+        image_more.setOnClickListener { state.onMoreButtonClicked.invoke(uiState.postId, uiState.blogId) }
 
         // Featured image section
         updateFeaturedImage(state)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -21,7 +21,6 @@ class ReaderPostViewHolder(
 ) : ReaderViewHolder(parentView, R.layout.reader_cardview_post) {
     override fun onBind(uiState: ReaderCardUiState) {
         val state = uiState as ReaderPostUiState
-        // TODO malinjir handle mRootLayoutConstraintSet - see ReaderPostAdapter line 450
 
         // Header section
         updateAvatarOrBlavatar(state)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -119,23 +119,25 @@ class ReaderPostViewHolder(
     private fun loadVideoThumbnail(state: ReaderPostUiState) {
         /* TODO ideally, we'd be passing just a thumbnail url in the UiState. However, the code for retrieving
             thumbnail from full video URL needs to be fully refactored. */
-        ReaderVideoUtils.retrieveVideoThumbnailUrl(state.fullVideoUrl, object : VideoThumbnailUrlListener {
-            override fun showThumbnail(thumbnailUrl: String) {
-                imageManager.loadImageWithCorners(
-                        image_featured,
-                        READER,
-                        thumbnailUrl,
-                        uiHelpers.getPxOfUiDimen(WordPress.getContext(), state.featuredImageCornerRadius)
-                )
-            }
+        state.fullVideoUrl?.let { videoUrl ->
+            ReaderVideoUtils.retrieveVideoThumbnailUrl(videoUrl, object : VideoThumbnailUrlListener {
+                override fun showThumbnail(thumbnailUrl: String) {
+                    imageManager.loadImageWithCorners(
+                            image_featured,
+                            READER,
+                            thumbnailUrl,
+                            uiHelpers.getPxOfUiDimen(WordPress.getContext(), state.featuredImageCornerRadius)
+                    )
+                }
 
-            override fun showPlaceholder() {
-                imageManager.load(image_featured, VIDEO)
-            }
+                override fun showPlaceholder() {
+                    imageManager.load(image_featured, VIDEO)
+                }
 
-            override fun cacheThumbnailUrl(thumbnailUrl: String) {
-                ReaderThumbnailTable.addThumbnail(state.postId, state.fullVideoUrl, thumbnailUrl)
-            }
-        })
+                override fun cacheThumbnailUrl(thumbnailUrl: String) {
+                    ReaderThumbnailTable.addThumbnail(state.postId, videoUrl, thumbnailUrl)
+                }
+            })
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
@@ -27,4 +27,7 @@ class ReaderUtilsWrapper @Inject constructor(
 
     fun getDefaultTagFromDbOrCreateInMemory() =
             ReaderUtils.getDefaultTagFromDbOrCreateInMemory(appContext, tagUpdateClientUtilsProvider)
+
+    fun getLongLikeLabelText(numLikes: Int, isLikedByCurrentUser: Boolean): String =
+            ReaderUtils.getLongLikeLabelText(appContext, numLikes, isLikedByCurrentUser)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -44,7 +44,7 @@ class ReaderDiscoverViewModelTest {
         whenever(
                 uiStateBuilder.mapPostToUiState(
                         anyOrNull(), anyInt(), anyInt(), anyOrNull(), anyBoolean(), anyOrNull(),
-                        anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
+                        anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
                 )
         ).thenReturn(mock())
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -43,8 +43,8 @@ class ReaderDiscoverViewModelTest {
         whenever(readerPostRepository.discoveryFeed).thenReturn(fakeDiscoverFeed)
         whenever(
                 uiStateBuilder.mapPostToUiState(
-                        anyOrNull(), anyInt(), anyInt(), anyBoolean(), anyOrNull(),
-                        anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
+                        anyOrNull(), anyInt(), anyInt(), anyOrNull(), anyBoolean(), anyOrNull(),
+                        anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
                 )
         ).thenReturn(mock())
     }


### PR DESCRIPTION
Parent issue #12028 

This PR cleans-up some todos. I recommend reviewing the code by commits as the changes are mostly unrelated. 

This PR can be merged into both 15.2 or 15.3.

1.  https://github.com/wordpress-mobile/WordPress-Android/commit/e662571e92848664a7d1aa59d8f30aecc76762a5 - Replaces static access to utils with injectable wrapper to make the class testable
2. https://github.com/wordpress-mobile/WordPress-Android/commit/abd1cd14f158a717838729a276c880f15cc6051a - Fixes condition for the "more" menu on reader post cards ([see this code](https://github.com/wordpress-mobile/WordPress-Android/blob/588b9582c3ad022b91fd1be63111ac306d76c4ef/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java#L571)).
3. https://github.com/wordpress-mobile/WordPress-Android/commit/faf62d1a748b4f67ea2c2826d97f2584860300d4 - Adds onclick listener for discover section on the post card.
4. https://github.com/wordpress-mobile/WordPress-Android/commit/d76f48d238a09bc36db055ca4a955ca680ce4894 = Starts loading gallery thumbnail strip in the ReaderPostViewHolder
5. https://github.com/wordpress-mobile/WordPress-Android/commit/43c118f094877a94ff8ec0dff0730f98828ab690 and https://github.com/wordpress-mobile/WordPress-Android/commit/6c54543e0db7ea914bfed2984867b72cdce28eb3 - Starts loading video thumbnails in the ReaderPostViewHolder
6. https://github.com/wordpress-mobile/WordPress-Android/pull/12283/commits/5779849c0a3f583c402db30ff7aca0995812ff86 - Add onMoreButton click listener

To test:
1. This still can't be easily tested. However, I plan to start using ReaderPostViewHolder everywhere in the upcoming PR.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
