### PR TITLE
WP Stories: handle permissions granting

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1908,7 +1908,7 @@
     <string name="my_site_bottom_sheet_title">Add new</string>
     <string name="my_site_bottom_sheet_add_post">Blog post</string>
     <string name="my_site_bottom_sheet_add_page">Site page</string>
-    <string name="my_site_bottom_sheet_add_story">Story</string>
+    <string name="my_site_bottom_sheet_add_story">Story post</string>
 
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>


### PR DESCRIPTION

Builds on top of #12282 

This PR makes sure to course code to `onLoadFromIntent()` after permissions have been granted.
Also, if first we open the story composer with some media Uris, and then choose to use the camera later (and need to give the right permissions or microphone, video etc) then we remove the original media URIs given we are now only interested in the new use case.

Note all the changes are just encapsulated in the stories library.

To test:

#### CASE A (use picker first, then camera)

0. install the WPAndroid app from scratch
1. tap on FAB, Story
2. select media from the picker after giving permissions
3. observe it gets populated
4. now tap on + and now on the camera icon to open the stories camera mode
5. give permissions
6. take picture
7. observe it gets added

![permissionsA](https://user-images.githubusercontent.com/6597771/85778769-4c36e780-b6f9-11ea-9d33-14385cb1be8f.gif)

#### CASE B (camera first)
0. install the WPAndroid app from scratch
1. tap on FAB, Story
2. on the media picker, give permissions
3. tap on the camera icon to open the stories camera mode
4. give permissions
5. take picture
6. observe it gets added
![permissionsB](https://user-images.githubusercontent.com/6597771/85778751-46d99d00-b6f9-11ea-94d3-f1e7f42fd4f0.gif)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
