### PR TITLE
Temporarily disable Slack notifications for failing connected tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ workflows:
       - Connected Tests:
           requires:
             - gutenberg-bundle-build
-          post-to-slack: true
+          post-to-slack: false
           # Always run connected tests on develop and release branches
           filters:
             branches:


### PR DESCRIPTION
The smartlock issue from https://github.com/wordpress-mobile/WordPress-Android/pull/11808 is back 😭 