### PR TITLE
WordPress Stories : Updated string from Story to Story post

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1908,7 +1908,7 @@
     <string name="my_site_bottom_sheet_title">Add new</string>
     <string name="my_site_bottom_sheet_add_post">Blog post</string>
     <string name="my_site_bottom_sheet_add_page">Site page</string>
-    <string name="my_site_bottom_sheet_add_story">Story</string>
+    <string name="my_site_bottom_sheet_add_story">Story post</string>
 
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>


### PR DESCRIPTION
Fixes https://github.com/Automattic/portkey-android/issues/367

## Testing
1. Go to My Site. 
2. Click the create FAB. 
3. See the `Story post` string change. 

Before | After 
--------|-------
 <kbd><img src="https://user-images.githubusercontent.com/1509205/85794337-10e9e800-b6fc-11ea-9ef9-ad0292a6e40a.png" width="320"></kbd>       |       <kbd><img src="https://user-images.githubusercontent.com/1509205/85794341-12b3ab80-b6fc-11ea-9f43-9e40f8bdfd3a.png" width="320"></kbd>

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
