### PR TITLE
[Gutenberg] Adjust the fetching of custom colors

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <option name="DEFAULT_COMPILER" value="Javac" />
-    <resourceExtensions />
     <wildcardResourcePatterns>
       <entry name="!?*.java" />
       <entry name="!?*.form" />
@@ -13,10 +11,9 @@
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
     </wildcardResourcePatterns>
-    <annotationProcessing>
-      <profile default="true" name="Default" enabled="false">
-        <processorPath useClasspath="true" />
-      </profile>
-    </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="WordPressAnnotations" target="1.7" />
+      <module name="WordPressProcessors" target="1.7" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
+    <option name="DEFAULT_COMPILER" value="Javac" />
+    <resourceExtensions />
     <wildcardResourcePatterns>
       <entry name="!?*.java" />
       <entry name="!?*.form" />
@@ -11,9 +13,10 @@
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
     </wildcardResourcePatterns>
-    <bytecodeTargetLevel>
-      <module name="WordPressAnnotations" target="1.7" />
-      <module name="WordPressProcessors" target="1.7" />
-    </bytecodeTargetLevel>
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="false">
+        <processorPath useClasspath="true" />
+      </profile>
+    </annotationProcessing>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '3d30383a186ea234061e64b704113a78fe0d34d4'
+    fluxCVersion = '1.6.15-beta-3'
 
     appCompatVersion = '1.0.2'
     constraintLayoutVersion = '1.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.15-beta-2'
+    fluxCVersion = '20782cf123eda3e81d4812cd4dbcc360a4b6551a'
 
     appCompatVersion = '1.0.2'
     constraintLayoutVersion = '1.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '20782cf123eda3e81d4812cd4dbcc360a4b6551a'
+    fluxCVersion = '3d30383a186ea234061e64b704113a78fe0d34d4'
 
     appCompatVersion = '1.0.2'
     constraintLayoutVersion = '1.1.3'


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2432
Flux-C PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1620

To Test:
1. Select a theme on your self-hosted site  _with_ custom gradients (such as [twentytwenty-copy.zip](https://github.com/wordpress-mobile/WordPress-iOS/files/4657974/twentytwenty-copy.zip))
1. In the Android app open the block editor 
1. **EXPECT:** to see the Custom Gradients
1. Change your site's theme to a theme _without_ custom gradients (such as Twenty-Twenty)
1. Open the block editor again
1. **EXPECT:** to see the Default Gradients

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
