### PR TITLE
WP Stories: Make emoji picker background transparent

### DIFF
--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -85,6 +85,9 @@
 
     <style name="WordPress.Stories.Immersive" parent="WordPress.NoActionBar">
         <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:immersive">true</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 
     <style name="WordPress.Editor.NoActionBar" parent="WordPress.NoActionBar">


### PR DESCRIPTION
Restores the background of the emoji picker to transparent - it was white in WPAndroid, probably due to theme inheritance.

![emoji-transparent](https://user-images.githubusercontent.com/9613966/85821849-7e594f80-b7b4-11ea-9bb1-bc17269f9024.png)

Stacked onto https://github.com/wordpress-mobile/WordPress-Android/pull/12286, that one should be merged before this one.

#### To test:
Verify that the emoji picker has a transparent background for various API levels.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
