### PR TITLE
Updated colors used in crop activity.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -676,10 +676,12 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             UCrop.Options options = new UCrop.Options();
             options.setShowCropGrid(false);
             options.setStatusBarColor(ContextExtensionsKt.getColorFromAttribute(
-                    context,
-                    android.R.attr.statusBarColor));
+                    context, android.R.attr.statusBarColor
+            ));
             options.setToolbarColor(ContextExtensionsKt.getColorFromAttribute(context, R.attr.wpColorAppBar));
-            options.setToolbarWidgetColor(ContextExtensionsKt.getColorFromAttribute(context, R.attr.colorOnPrimarySurface));
+            options.setToolbarWidgetColor(ContextExtensionsKt.getColorFromAttribute(
+                    context, R.attr.colorOnPrimarySurface
+            ));
             options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.NONE);
             options.setHideBottomControls(true);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -27,7 +27,6 @@ import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
-import androidx.core.content.ContextCompat;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.yalantis.ucrop.UCrop;
@@ -64,6 +63,7 @@ import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.ContextExtensionsKt;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.StringUtils;
@@ -675,8 +675,11 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         if (context != null) {
             UCrop.Options options = new UCrop.Options();
             options.setShowCropGrid(false);
-            options.setStatusBarColor(ContextCompat.getColor(context, R.color.status_bar));
-            options.setToolbarColor(ContextCompat.getColor(context, R.color.primary));
+            options.setStatusBarColor(ContextExtensionsKt.getColorFromAttribute(
+                    context,
+                    android.R.attr.statusBarColor));
+            options.setToolbarColor(ContextExtensionsKt.getColorFromAttribute(context, R.attr.wpColorAppBar));
+            options.setToolbarWidgetColor(ContextExtensionsKt.getColorFromAttribute(context, R.attr.colorOnPrimarySurface));
             options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.NONE);
             options.setHideBottomControls(true);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -12,7 +12,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.View.OnClickListener
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -26,6 +25,7 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
+import org.wordpress.android.R.attr
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.ME_GRAVATAR_CROPPED
@@ -58,6 +58,7 @@ import org.wordpress.android.util.MediaUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import org.wordpress.android.util.WPMediaUtils
+import org.wordpress.android.util.getColorFromAttribute
 import org.wordpress.android.util.image.ImageManager.RequestListener
 import org.wordpress.android.util.image.ImageType.AVATAR_WITHOUT_BACKGROUND
 import java.io.File
@@ -379,8 +380,9 @@ class MeFragment : Fragment(), OnScrollToTopListener {
         val context = activity ?: return
         val options = Options()
         options.setShowCropGrid(false)
-        options.setStatusBarColor(ContextCompat.getColor(context, R.color.status_bar))
-        options.setToolbarColor(ContextCompat.getColor(context, R.color.primary))
+        options.setStatusBarColor(context.getColorFromAttribute(android.R.attr.statusBarColor))
+        options.setToolbarColor(context.getColorFromAttribute(R.attr.wpColorAppBar))
+        options.setToolbarWidgetColor(context.getColorFromAttribute(attr.colorOnPrimarySurface))
         options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.NONE)
         options.setHideBottomControls(true)
         UCrop.of(uri, Uri.fromFile(File(context.cacheDir, "cropped_for_gravatar.jpg")))

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -25,6 +25,7 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
+import org.wordpress.android.R.attr
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
@@ -133,6 +134,7 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.util.getColorFromAttribute
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR
 import org.wordpress.android.util.image.ImageType.USER
@@ -831,8 +833,9 @@ class MySiteFragment : Fragment(),
         val context = activity ?: return
         val options = Options()
         options.setShowCropGrid(false)
-        options.setStatusBarColor(ContextCompat.getColor(context, R.color.status_bar))
-        options.setToolbarColor(ContextCompat.getColor(context, R.color.primary))
+        options.setStatusBarColor(context.getColorFromAttribute(android.R.attr.statusBarColor))
+        options.setToolbarColor(context.getColorFromAttribute(R.attr.wpColorAppBar))
+        options.setToolbarWidgetColor(context.getColorFromAttribute(attr.colorOnPrimarySurface))
         options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.NONE)
         options.setHideBottomControls(true)
         UCrop.of(uri, Uri.fromFile(File(context.cacheDir, "cropped_for_site_icon.jpg")))

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -13,7 +13,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.PopupMenu
 import androidx.appcompat.widget.TooltipCompat
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options


### PR DESCRIPTION
Fixes #12277 

This PR fixes toolbar colors for cropping activity in 3rd party lib.

To test:
- Using Site Icon in My Site screen, Gravatar at Me screen or Sign Up Epilogue, navigate to image picker.
- Select an image and proceed to crop activity.
- Notice toolbar colors look as expected in both light and dark modes.

[![Image from Gyazo](https://i.gyazo.com/125ee3b7c9940bb2a9b455b94cd5eb9a.jpg)](https://gyazo.com/125ee3b7c9940bb2a9b455b94cd5eb9a)

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
