### PR TITLE
Remove unnecessary click event

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -156,7 +156,6 @@ class UnifiedLoginTracker
         LOGIN_WITH_SITE_ADDRESS("login_with_site_address"),
         LOGIN_WITH_GOOGLE("login_with_google"),
         FORGOTTEN_PASSWORD("forgotten_password"),
-        USE_PASSWORD_INSTEAD("use_password_instead"),
         TERMS_OF_SERVICE_CLICKED("terms_of_service_clicked"),
         SIGNUP_WITH_EMAIL("signup_with_email"),
         SIGNUP_WITH_GOOGLE("signup_with_google"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -163,7 +163,6 @@ class UnifiedLoginTracker
         SHOW_HELP("show_help"),
         SEND_CODE_WITH_TEXT("send_code_with_text"),
         SUBMIT_2FA_CODE("submit_2fa_code"),
-        CLICK_ON_LOGIN_SITE("click_on_login_site"),
         REQUEST_MAGIC_LINK("request_magic_link"),
         LOGIN_WITH_PASSWORD("login_with_password"),
         CREATE_NEW_SITE("create_new_site"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -304,11 +304,6 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
-    public void trackClickOnLoginSiteClicked() {
-        mUnifiedLoginTracker.trackClick(Click.CLICK_ON_LOGIN_SITE);
-    }
-
-    @Override
     public void trackSubmitClicked() {
         mUnifiedLoginTracker.trackClick(Click.SUBMIT);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -77,7 +77,6 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
     public void trackLoginMagicLinkExited() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_EXITED);
-        mUnifiedLoginTracker.trackClick(Click.USE_PASSWORD_INSTEAD);
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -58,8 +58,6 @@ public interface LoginAnalyticsListener {
 
     void trackSubmit2faCodeClicked();
 
-    void trackClickOnLoginSiteClicked();
-
     void trackSubmitClicked();
 
     void trackRequestMagicLinkClick();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -256,7 +256,6 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         siteLoginButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
-                mAnalyticsListener.trackClickOnLoginSiteClicked();
                 if (mLoginListener != null) {
                     LoginMode loginMode = mLoginListener.getLoginMode();
                     if (loginMode == LoginMode.JETPACK_STATS) {


### PR DESCRIPTION
This PR removes tracking of 2 events. One of these events (_CLICK_ON_LOGIN_SITE_) was not necessary because the flow is never triggered in the unified login flow (it was supposed to be sent when you click on "Log in with site address" from the wordpress_com screen). The second event (_USE_PASSWORD_INSTEAD_) was duplicated with _LOGIN_WITH_PASSWORD_

To test:
- Check that the removed events are not sent

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
