### PR TITLE
WP Stories: default to first selected added item

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -302,7 +302,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         }
 
         addFramesToStoryFromMediaUriList(uriList)
-        setDefaultSelectionAndUpdateBackgroundSurfaceUI()
+        setDefaultSelectionAndUpdateBackgroundSurfaceUI(uriList)
     }
 
     override fun getImmutablePost(): PostImmutableModel {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1908,7 +1908,7 @@
     <string name="my_site_bottom_sheet_title">Add new</string>
     <string name="my_site_bottom_sheet_add_post">Blog post</string>
     <string name="my_site_bottom_sheet_add_page">Site page</string>
-    <string name="my_site_bottom_sheet_add_story">Story</string>
+    <string name="my_site_bottom_sheet_add_story">Story post</string>
 
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>


### PR DESCRIPTION
This PR builds on top of #12284 

When adding items from the media picker, this PR makes the default selection on the first selected item.

To test:
1. create a new story
2. pick some items, remmeber the order in which they were selected (1,2, 3 etc)
3. tap on the checkmark
4. observe the items get added in the same order, and the new selected item is number 1 of the selected list.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
