### PR TITLE
WP Stories: fix count in saving progress notification

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1908,7 +1908,7 @@
     <string name="my_site_bottom_sheet_title">Add new</string>
     <string name="my_site_bottom_sheet_add_post">Blog post</string>
     <string name="my_site_bottom_sheet_add_page">Site page</string>
-    <string name="my_site_bottom_sheet_add_story">Story</string>
+    <string name="my_site_bottom_sheet_add_story">Story post</string>
 
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>


### PR DESCRIPTION
Fixes bad count in saving notification for stories.

Builds on top of #12291 

To test:
1. create a story with one frame (better if its video so you get to see the notification for longer)
2. tap PUBLISH to start the saving process
3. observe the notification reads "1 slide remaining" instead of "2 slides remaining"

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
