### PR TITLE
WP Stories: update discard dialog text

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1908,7 +1908,7 @@
     <string name="my_site_bottom_sheet_title">Add new</string>
     <string name="my_site_bottom_sheet_add_post">Blog post</string>
     <string name="my_site_bottom_sheet_add_page">Site page</string>
-    <string name="my_site_bottom_sheet_add_story">Story</string>
+    <string name="my_site_bottom_sheet_add_story">Story post</string>
 
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>


### PR DESCRIPTION
Changes the Stories discard dialog text


<img width="394" alt="Screen Shot 2020-06-26 at 12 26 54" src="https://user-images.githubusercontent.com/6597771/85874260-bc507680-b7a8-11ea-92a2-186e0fa92e45.png">


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
