### PR TITLE
Fix build in develop

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.ui.reader.views.ReaderIconCountView
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR_CIRCULAR
-import org.wordpress.android.util.image.ImageType.READER
+import org.wordpress.android.util.image.ImageType.PHOTO_ROUNDED_CORNERS
 
 class ReaderPostViewHolder(
     private val uiHelpers: UiHelpers,
@@ -63,7 +63,7 @@ class ReaderPostViewHolder(
         } else {
             imageManager.loadImageWithCorners(
                     image_featured,
-                    READER,
+                    PHOTO_ROUNDED_CORNERS,
                     state.featuredImageUrl,
                     uiHelpers.getPxOfUiDimen(WordPress.getContext(), state.featuredImageCornerRadius)
             )


### PR DESCRIPTION
Fixes issue in develop which was introduced when `READER` ImageType was renamed in https://github.com/wordpress-mobile/WordPress-Android/pull/12206, but it was also used in da32475322c721033acae9d73de8020b158b022a which got merged first.

To test:
- Successful CI build should be enough

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
