### PR TITLE
Fix npe in Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1825,20 +1825,21 @@ public class ReaderPostListFragment extends Fragment
     }
 
     private void setCurrentTagFromEmptyViewButton(ActionableEmptyViewButtonType button) {
-        ReaderTag tag;
+            ReaderTag tag = null;
 
-        switch (button) {
-            case DISCOVER:
-                tag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
-                break;
-            case FOLLOWED:
-                tag = ReaderUtils.getTagFromEndpoint(ReaderTag.FOLLOWING_PATH);
-                break;
-            default:
+            switch (button) {
+                case DISCOVER:
+                    tag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
+                    break;
+                case FOLLOWED:
+                    tag = ReaderUtils.getTagFromEndpoint(ReaderTag.FOLLOWING_PATH);
+                    break;
+            }
+            if (tag == null) {
                 tag = ReaderUtils.getDefaultTag();
-        }
+            }
 
-        mViewModel.onEmptyStateButtonTapped(tag);
+            mViewModel.onEmptyStateButtonTapped(tag);
     }
 
     /*


### PR DESCRIPTION
Fixes #12210 

I decided to create this fix even though it's not ideal, since it's technically hiding the bug. However, I couldn't figure out the reason why the data are not in the database and the number of affected users started to increase.

To test:
I don't know how to reproduce the issue, so just smoketest Reader.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
