### PR TITLE
Show popup more menu part 1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -68,7 +68,6 @@ import javax.inject.Inject;
 import kotlin.Unit;
 import kotlin.jvm.functions.Function2;
 import kotlin.jvm.functions.Function3;
-import kotlin.jvm.functions.Function4;
 
 public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private final ImageManager mImageManager;
@@ -331,8 +330,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             return;
         }
         Context ctx = holder.getViewContext();
-        Function4<Long, Long, Boolean, ReaderPostCardActionType, Unit> onButtonClicked =
-                (postId, blogId, selected, type) -> {
+        Function3<Long, Long, ReaderPostCardActionType, Unit> onButtonClicked =
+                (postId, blogId, type) -> {
                     //noinspection EnumSwitchStatementWhichMissesCases
                     switch (type) {
                         case BOOKMARK:

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -3,6 +3,9 @@ package org.wordpress.android.ui.reader.discover
 import android.text.Spanned
 import android.view.View
 import androidx.annotation.AttrRes
+import androidx.annotation.DrawableRes
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
 import org.wordpress.android.ui.reader.models.ReaderImageList
 import org.wordpress.android.ui.utils.UiDimen
 import org.wordpress.android.ui.utils.UiString
@@ -27,10 +30,11 @@ sealed class ReaderCardUiState {
         val videoOverlayVisibility: Boolean,
         val moreMenuVisibility: Boolean,
         val photoFrameVisibility: Boolean,
-        val bookmarkAction: ActionUiState,
-        val likeAction: ActionUiState,
-        val reblogAction: ActionUiState,
-        val commentsAction: ActionUiState,
+        val bookmarkAction: PrimaryAction,
+        val likeAction: PrimaryAction,
+        val reblogAction: PrimaryAction,
+        val commentsAction: PrimaryAction,
+        val moreMenuItems: List<SecondaryAction>,
         val postHeaderClickData: PostHeaderClickData?,
         val onItemClicked: (Long, Long) -> Unit,
         val onItemRendered: (Long, Long) -> Unit,
@@ -56,14 +60,42 @@ sealed class ReaderCardUiState {
             val imageType: ImageType,
             val onDiscoverClicked: ((Long, Long) -> Unit)
         )
-
-        data class ActionUiState(
-            val isEnabled: Boolean,
-            val isSelected: Boolean = false,
-            val contentDescription: UiString? = null,
-            val count: Int = 0,
-            val onClicked: ((Long, Long, Boolean) -> Unit)? = null
-        )
     }
 }
 
+sealed class ReaderPostCardAction {
+    abstract val type: ReaderPostCardActionType
+    open val onClicked: ((Long, Long, Boolean, ReaderPostCardActionType) -> Unit)? = null
+    open val isSelected: Boolean = false
+
+    data class PrimaryAction(
+        val isEnabled: Boolean,
+        val contentDescription: UiString? = null,
+        val count: Int = 0,
+        override val isSelected: Boolean = false,
+        override val type: ReaderPostCardActionType,
+        override val onClicked: ((Long, Long, Boolean, ReaderPostCardActionType) -> Unit)? = null
+    ) : ReaderPostCardAction()
+
+    data class SecondaryAction(
+        val label: UiString,
+        @AttrRes val labelColor: Int,
+        @DrawableRes val iconRes: Int,
+        @AttrRes val iconColor: Int = labelColor,
+        override val isSelected: Boolean = false,
+        override val type: ReaderPostCardActionType,
+        override val onClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+    ) : ReaderPostCardAction()
+}
+
+enum class ReaderPostCardActionType {
+    FOLLOW,
+    SITE_NOTIFICATIONS,
+    SHARE,
+    VISIT_SITE,
+    BLOCK_SITE,
+    LIKE,
+    BOOKMARK,
+    REBLOG,
+    COMMENTS
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -65,7 +65,7 @@ sealed class ReaderCardUiState {
 
 sealed class ReaderPostCardAction {
     abstract val type: ReaderPostCardActionType
-    open val onClicked: ((Long, Long, Boolean, ReaderPostCardActionType) -> Unit)? = null
+    open val onClicked: ((Long, Long, ReaderPostCardActionType) -> Unit)? = null
     open val isSelected: Boolean = false
 
     data class PrimaryAction(
@@ -74,7 +74,7 @@ sealed class ReaderPostCardAction {
         val count: Int = 0,
         override val isSelected: Boolean = false,
         override val type: ReaderPostCardActionType,
-        override val onClicked: ((Long, Long, Boolean, ReaderPostCardActionType) -> Unit)? = null
+        override val onClicked: ((Long, Long, ReaderPostCardActionType) -> Unit)? = null
     ) : ReaderPostCardAction()
 
     data class SecondaryAction(
@@ -84,7 +84,7 @@ sealed class ReaderPostCardAction {
         @AttrRes val iconColor: Int = labelColor,
         override val isSelected: Boolean = false,
         override val type: ReaderPostCardActionType,
-        override val onClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+        override val onClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ) : ReaderPostCardAction()
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -10,6 +10,15 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.COMMENTS
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SHARE
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SITE_NOTIFICATIONS
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.VISIT_SITE
 import org.wordpress.android.ui.reader.repository.ReaderPostRepository
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -54,10 +63,7 @@ class ReaderDiscoverViewModel @Inject constructor(
                                 photonWidth = photonWidth,
                                 photonHeight = photonHeight,
                                 isBookmarkList = false,
-                                onBookmarkClicked = this::onBookmarkClicked,
-                                onLikeClicked = this::onLikeClicked,
-                                onReblogClicked = this::onReblogClicked,
-                                onCommentsClicked = this::onCommentsClicked,
+                                onButtonClicked = this::onButtonClicked,
                                 onItemClicked = this::onItemClicked,
                                 onItemRendered = this::onItemRendered,
                                 onDiscoverSectionClicked = this::onDiscoverClicked,
@@ -71,20 +77,18 @@ class ReaderDiscoverViewModel @Inject constructor(
         }
     }
 
-    private fun onBookmarkClicked(postId: Long, blogId: Long, selected: Boolean) {
-        // TODO malinjir implement action
-    }
-
-    private fun onLikeClicked(postId: Long, blogId: Long, selected: Boolean) {
-        // TODO malinjir implement action
-    }
-
-    private fun onReblogClicked(postId: Long, blogId: Long, selected: Boolean) {
-        // TODO malinjir implement action
-    }
-
-    private fun onCommentsClicked(postId: Long, blogId: Long, selected: Boolean) {
-        // TODO malinjir implement action
+    private fun onButtonClicked(postId: Long, blogId: Long, selected: Boolean, type: ReaderPostCardActionType) {
+        when (type) {
+            FOLLOW -> TODO()
+            SITE_NOTIFICATIONS -> TODO()
+            SHARE -> TODO()
+            VISIT_SITE -> TODO()
+            BLOCK_SITE -> TODO()
+            LIKE -> TODO()
+            BOOKMARK -> TODO()
+            REBLOG -> TODO()
+            COMMENTS -> TODO()
+        }
     }
 
     private fun onVideoOverlayClicked(postId: Long, blogId: Long) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -77,7 +77,7 @@ class ReaderDiscoverViewModel @Inject constructor(
         }
     }
 
-    private fun onButtonClicked(postId: Long, blogId: Long, selected: Boolean, type: ReaderPostCardActionType) {
+    private fun onButtonClicked(postId: Long, blogId: Long, type: ReaderPostCardActionType) {
         when (type) {
             FOLLOW -> TODO()
             SITE_NOTIFICATIONS -> TODO()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -18,7 +18,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor() {
     fun buildMoreMenuItems(
         post: ReaderPost,
         postListType: ReaderPostListType,
-        onButtonClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+        onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ): List<SecondaryAction> {
         val menuItems = mutableListOf<SecondaryAction>()
         if (ReaderPostTable.isPostFollowed(post)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -1,0 +1,111 @@
+package org.wordpress.android.ui.reader.discover
+
+import dagger.Reusable
+import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.datasets.ReaderBlogTable
+import org.wordpress.android.datasets.ReaderPostTable
+import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
+import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.*
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import javax.inject.Inject
+
+@Reusable
+class ReaderPostMoreButtonUiStateBuilder @Inject constructor() {
+    fun buildMoreMenuItems(
+        post: ReaderPost,
+        postListType: ReaderPostListType,
+        onButtonClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+    ): List<SecondaryAction> {
+        val menuItems = mutableListOf<SecondaryAction>()
+        if (ReaderPostTable.isPostFollowed(post)) {
+            menuItems.add(
+                    SecondaryAction(
+                            type = FOLLOW,
+                            label = UiStringRes(string.reader_btn_unfollow),
+                            labelColor = R.attr.wpColorSuccess,
+                            iconRes = R.drawable.ic_reader_following_white_24dp,
+                            isSelected = true,
+                            onClicked = onButtonClicked
+                    )
+            )
+
+            // When blogId and feedId are not equal, post is not a feed so show notifications option.
+            if (post.blogId != post.feedId) {
+                if (ReaderBlogTable.isNotificationsEnabled(post.blogId)) {
+                    menuItems.add(
+                            SecondaryAction(
+                                    type = SITE_NOTIFICATIONS,
+                                    label = UiStringRes(string.reader_btn_notifications_off),
+                                    labelColor = R.attr.wpColorSuccess,
+                                    iconRes = R.drawable.ic_bell_white_24dp,
+                                    isSelected = true,
+                                    onClicked = onButtonClicked
+                            )
+                    )
+                } else {
+                    menuItems.add(
+                            SecondaryAction(
+                                    type = SITE_NOTIFICATIONS,
+                                    label = UiStringRes(string.reader_btn_notifications_on),
+                                    labelColor = R.attr.colorOnSurface,
+                                    iconRes = R.drawable.ic_bell_white_24dp,
+                                    iconColor = R.attr.wpColorOnSurfaceMedium,
+                                    isSelected = false,
+                                    onClicked = onButtonClicked
+                            )
+                    )
+                }
+            }
+        } else {
+            menuItems.add(
+                    SecondaryAction(
+                            type = FOLLOW,
+                            label = UiStringRes(string.reader_btn_follow),
+                            labelColor = R.attr.colorPrimary,
+                            iconRes = R.drawable.ic_reader_follow_white_24dp,
+                            isSelected = false,
+                            onClicked = onButtonClicked
+                    )
+            )
+        }
+
+        menuItems.add(
+                SecondaryAction(
+                        type = SHARE,
+                        label = UiStringRes(string.reader_btn_share),
+                        labelColor = R.attr.colorOnSurface,
+                        iconRes = R.drawable.ic_share_white_24dp,
+                        iconColor = R.attr.wpColorOnSurfaceMedium,
+                        onClicked = onButtonClicked
+                )
+        )
+        menuItems.add(
+                SecondaryAction(
+                        type = VISIT_SITE,
+                        label = UiStringRes(string.reader_label_visit),
+                        labelColor = R.attr.colorOnSurface,
+                        iconRes = R.drawable.ic_external_white_24dp,
+                        iconColor = R.attr.wpColorOnSurfaceMedium,
+                        onClicked = onButtonClicked
+                )
+        )
+
+        if (postListType == TAG_FOLLOWED) {
+            menuItems.add(
+                    SecondaryAction(
+                            type = BLOCK_SITE,
+                            label = UiStringRes(string.reader_menu_block_blog),
+                            labelColor = R.attr.colorOnSurface,
+                            iconRes = R.drawable.ic_block_white_24dp,
+                            iconColor = R.attr.wpColorOnSurfaceMedium,
+                            onClicked = onButtonClicked
+                    )
+            )
+        }
+        return menuItems
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -9,7 +9,11 @@ import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.*
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SHARE
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SITE_NOTIFICATIONS
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.VISIT_SITE
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import javax.inject.Inject
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -54,7 +54,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
         postListType: ReaderPostListType,
             // TODO malinjir try to refactor/remove this parameter
         isBookmarkList: Boolean,
-        onButtonClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit,
+        onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit,
         onItemClicked: (Long, Long) -> Unit,
         onItemRendered: (Long, Long) -> Unit,
         onDiscoverSectionClicked: (Long, Long) -> Unit,
@@ -184,7 +184,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
 
     private fun buildBookmarkSection(
         post: ReaderPost,
-        onClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+        onClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ): PrimaryAction {
         val contentDescription = if (post.isBookmarked) {
             R.string.reader_remove_bookmark
@@ -208,7 +208,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private fun buildLikeSection(
         post: ReaderPost,
         isBookmarkList: Boolean,
-        onClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+        onClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ): PrimaryAction {
         val showLikes = when {
             /* TODO malinjir why we don't show likes on bookmark list??? I think we wanted
@@ -237,7 +237,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
 
     private fun buildReblogSection(
         post: ReaderPost,
-        onReblogClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+        onReblogClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ): PrimaryAction {
         val canReblog = !post.isPrivate && accountStore.hasAccessToken()
         return if (canReblog) {
@@ -251,7 +251,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private fun buildCommentsSection(
         post: ReaderPost,
         isBookmarkList: Boolean,
-        onCommentsClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+        onCommentsClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ): PrimaryAction {
         val showComments = when {
             /* TODO malinjir why we don't show comments on bookmark list??? I think we wanted

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -16,10 +16,13 @@ import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.SITE_PIC
 import org.wordpress.android.ui.reader.ReaderConstants
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
-import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState.ActionUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState.DiscoverLayoutUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState.GalleryThumbnailStripData
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState.PostHeaderClickData
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
 import org.wordpress.android.ui.reader.utils.ReaderImageScannerProvider
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.utils.UiDimen.UIDimenRes
@@ -39,7 +42,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private val gravatarUtilsWrapper: GravatarUtilsWrapper,
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
     private val readerImageScannerProvider: ReaderImageScannerProvider,
-    private val readerUtilsWrapper: ReaderUtilsWrapper
+    private val readerUtilsWrapper: ReaderUtilsWrapper,
+    private val readerPostMoreButtonUiStateBuilder: ReaderPostMoreButtonUiStateBuilder
 ) {
     // TODO malinjir move this to a bg thread
     fun mapPostToUiState(
@@ -50,10 +54,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
         postListType: ReaderPostListType,
             // TODO malinjir try to refactor/remove this parameter
         isBookmarkList: Boolean,
-        onBookmarkClicked: (Long, Long, Boolean) -> Unit,
-        onLikeClicked: (Long, Long, Boolean) -> Unit,
-        onReblogClicked: (Long, Long, Boolean) -> Unit,
-        onCommentsClicked: (Long, Long, Boolean) -> Unit,
+        onButtonClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit,
         onItemClicked: (Long, Long) -> Unit,
         onItemRendered: (Long, Long) -> Unit,
         onDiscoverSectionClicked: (Long, Long) -> Unit,
@@ -79,15 +80,20 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 moreMenuVisibility = accountStore.hasAccessToken() && postListType == ReaderPostListType.TAG_FOLLOWED,
                 fullVideoUrl = buildFullVideoUrl(post),
                 discoverSection = buildDiscoverSection(post, onDiscoverSectionClicked),
-                bookmarkAction = buildBookmarkSection(post, onBookmarkClicked),
-                likeAction = buildLikeSection(post, isBookmarkList, onLikeClicked),
-                reblogAction = buildReblogSection(post, onReblogClicked),
-                commentsAction = buildCommentsSection(post, isBookmarkList, onCommentsClicked),
+                bookmarkAction = buildBookmarkSection(post, onButtonClicked),
+                likeAction = buildLikeSection(post, isBookmarkList, onButtonClicked),
+                reblogAction = buildReblogSection(post, onButtonClicked),
+                commentsAction = buildCommentsSection(post, isBookmarkList, onButtonClicked),
                 onItemClicked = onItemClicked,
                 onItemRendered = onItemRendered,
                 onMoreButtonClicked = onMoreButtonClicked,
                 onVideoOverlayClicked = onVideoOverlayClicked,
-                postHeaderClickData = buildOnPostHeaderViewClicked(onPostHeaderViewClicked, postListType)
+                postHeaderClickData = buildOnPostHeaderViewClicked(onPostHeaderViewClicked, postListType),
+                moreMenuItems = readerPostMoreButtonUiStateBuilder.buildMoreMenuItems(
+                        post,
+                        postListType,
+                        onButtonClicked
+                )
         )
     }
 
@@ -176,7 +182,10 @@ class ReaderPostUiStateBuilder @Inject constructor(
         return GalleryThumbnailStripData(images, post.isPrivate, post.text)
     }
 
-    private fun buildBookmarkSection(post: ReaderPost, onClicked: (Long, Long, Boolean) -> Unit): ActionUiState {
+    private fun buildBookmarkSection(
+        post: ReaderPost,
+        onClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+    ): PrimaryAction {
         val contentDescription = if (post.isBookmarked) {
             R.string.reader_remove_bookmark
         } else {
@@ -184,22 +193,23 @@ class ReaderPostUiStateBuilder @Inject constructor(
         }
         // TODO malinjir shouldn't the action be disabled just for posts which don't have blog and post id?
         return if (!post.isDiscoverPost) {
-            ActionUiState(
+            PrimaryAction(
                     isEnabled = true,
                     isSelected = post.isBookmarked,
                     contentDescription = UiStringRes(contentDescription),
-                    onClicked = onClicked
+                    onClicked = onClicked,
+                    type = BOOKMARK
             )
         } else {
-            ActionUiState(isEnabled = false)
+            PrimaryAction(isEnabled = false, type = BOOKMARK)
         }
     }
 
     private fun buildLikeSection(
         post: ReaderPost,
         isBookmarkList: Boolean,
-        onClicked: (Long, Long, Boolean) -> Unit
-    ): ActionUiState {
+        onClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+    ): PrimaryAction {
         val showLikes = when {
             /* TODO malinjir why we don't show likes on bookmark list??? I think we wanted
                  to keep the card as simple as possible. However, since we are showing all the actions now, some of them
@@ -210,38 +220,39 @@ class ReaderPostUiStateBuilder @Inject constructor(
         }
 
         return if (showLikes) {
-            ActionUiState(
+            PrimaryAction(
                     isEnabled = true,
                     isSelected = post.isLikedByCurrentUser,
                     contentDescription = UiStringText(
                             readerUtilsWrapper.getLongLikeLabelText(post.numLikes, post.isLikedByCurrentUser)
                     ),
                     count = post.numLikes,
-                    onClicked = if (accountStore.hasAccessToken()) onClicked else null
+                    onClicked = if (accountStore.hasAccessToken()) onClicked else null,
+                    type = LIKE
             )
         } else {
-            ActionUiState(isEnabled = false)
+            PrimaryAction(isEnabled = false, type = LIKE)
         }
     }
 
     private fun buildReblogSection(
         post: ReaderPost,
-        onReblogClicked: (Long, Long, Boolean) -> Unit
-    ): ActionUiState {
+        onReblogClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+    ): PrimaryAction {
         val canReblog = !post.isPrivate && accountStore.hasAccessToken()
         return if (canReblog) {
             // TODO Add content description
-            ActionUiState(isEnabled = true, onClicked = onReblogClicked)
+            PrimaryAction(isEnabled = true, onClicked = onReblogClicked, type = REBLOG)
         } else {
-            ActionUiState(isEnabled = false)
+            PrimaryAction(isEnabled = false, type = REBLOG)
         }
     }
 
     private fun buildCommentsSection(
         post: ReaderPost,
         isBookmarkList: Boolean,
-        onCommentsClicked: (Long, Long, Boolean) -> Unit
-    ): ActionUiState {
+        onCommentsClicked: (Long, Long, Boolean, ReaderPostCardActionType) -> Unit
+    ): PrimaryAction {
         val showComments = when {
             /* TODO malinjir why we don't show comments on bookmark list??? I think we wanted
                  to keep the card as simple as possible. However, since we are showing all the actions now, some of them
@@ -253,13 +264,17 @@ class ReaderPostUiStateBuilder @Inject constructor(
 
         // TODO Add content description
         return if (showComments) {
-            ActionUiState(
+            PrimaryAction(
                     isEnabled = true,
                     count = post.numReplies,
-                    onClicked = onCommentsClicked
+                    onClicked = onCommentsClicked,
+                    type = ReaderPostCardActionType.COMMENTS
             )
         } else {
-            ActionUiState(isEnabled = false)
+            PrimaryAction(
+                    isEnabled = false,
+                    type = ReaderPostCardActionType.COMMENTS
+            )
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.datasets.ReaderThumbnailTable
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
-import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState.ActionUiState
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils.VideoThumbnailUrlListener
 import org.wordpress.android.ui.reader.views.ReaderIconCountView
@@ -129,14 +129,14 @@ class ReaderPostViewHolder(
         }
     }
 
-    private fun updateActionButton(postId: Long, blogId: Long, state: ActionUiState, view: View) {
+    private fun updateActionButton(postId: Long, blogId: Long, state: PrimaryAction, view: View) {
         if (view is ReaderIconCountView) {
             view.setCount(state.count)
         }
         view.isEnabled = state.isEnabled
         view.isSelected = state.isSelected
         view.contentDescription = state.contentDescription?.let { uiHelpers.getTextOfUiString(view.context, it) }
-        view.setOnClickListener { state.onClicked?.invoke(postId, blogId, state.isSelected) }
+        view.setOnClickListener { state.onClicked?.invoke(postId, blogId, state.isSelected, state.type) }
     }
 
     private fun loadVideoThumbnail(state: ReaderPostUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -136,7 +136,7 @@ class ReaderPostViewHolder(
         view.isEnabled = state.isEnabled
         view.isSelected = state.isSelected
         view.contentDescription = state.contentDescription?.let { uiHelpers.getTextOfUiString(view.context, it) }
-        view.setOnClickListener { state.onClicked?.invoke(postId, blogId, state.isSelected, state.type) }
+        view.setOnClickListener { state.onClicked?.invoke(postId, blogId, state.type) }
     }
 
     private fun loadVideoThumbnail(state: ReaderPostUiState) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -44,8 +44,7 @@ class ReaderDiscoverViewModelTest {
         whenever(
                 uiStateBuilder.mapPostToUiState(
                         anyOrNull(), anyInt(), anyInt(), anyOrNull(), anyBoolean(), anyOrNull(),
-                        anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(),
-                        anyOrNull(), anyOrNull()
+                        anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
                 )
         ).thenReturn(mock())
     }


### PR DESCRIPTION
Parent issue #12028 

This PR 
1. Introduces `ReaderPostMoreButtonUiStateBuilder` - the logic is copied from [here](https://github.com/wordpress-mobile/WordPress-Android/blob/4c66010ebc5f966b117e304cf7c533c233329cee/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java#L2598) and the view attributes are copied from [here](https://github.com/wordpress-mobile/WordPress-Android/blob/0a6af83a5fd234207c944d5e539f0a0348d8d199/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java#L72).
2. Instead of passing a listener for each button on the card item, we now pass a single onButtonClicked listener with ReaderPostCardActionType which is used to determine which button was clicked.



To test:
I'm targeting a working branch since I'll keep improving/refactoring the same part of the code in the upcoming PRs. In order to increase efficiency I think it'd be best to test it in the last PR of this series so we don't keep testing the same behavior repeatedly. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
