### PR TITLE
Show popup more menu part 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -12,14 +12,12 @@ import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.ImageSpan;
-import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
-import android.widget.AdapterView;
 import android.widget.AutoCompleteTextView;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
@@ -28,7 +26,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.widget.ListPopupWindow;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
@@ -96,7 +93,6 @@ import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions.BlockedBlogResult;
-import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionRecyclerAdapter;
@@ -2589,83 +2585,83 @@ public class ReaderPostListFragment extends Fragment
      */
     @Override
     public void onShowPostPopup(View view, final ReaderPost post) {
-        if (view == null || post == null || !isAdded()) {
-            return;
-        }
-
-        List<Integer> menuItems = new ArrayList<>();
-
-        if (ReaderPostTable.isPostFollowed(post)) {
-            menuItems.add(ReaderMenuAdapter.ITEM_UNFOLLOW);
-
-            // When blogId and feedId are not equal, post is not a feed so show notifications option.
-            if (post.blogId != post.feedId) {
-                if (ReaderBlogTable.isNotificationsEnabled(post.blogId)) {
-                    menuItems.add(ReaderMenuAdapter.ITEM_NOTIFICATIONS_OFF);
-                } else {
-                    menuItems.add(ReaderMenuAdapter.ITEM_NOTIFICATIONS_ON);
-                }
-            }
-        } else {
-            menuItems.add(ReaderMenuAdapter.ITEM_FOLLOW);
-        }
-
-        menuItems.add(ReaderMenuAdapter.ITEM_SHARE);
-        menuItems.add(ReaderMenuAdapter.ITEM_VISIT);
-
-        if (getPostListType() == ReaderPostListType.TAG_FOLLOWED) {
-            menuItems.add(ReaderMenuAdapter.ITEM_BLOCK);
-        }
-
-        Context context = view.getContext();
-        final ListPopupWindow listPopup = new ListPopupWindow(context);
-        listPopup.setWidth(context.getResources().getDimensionPixelSize(R.dimen.menu_item_width));
-        listPopup.setAdapter(new ReaderMenuAdapter(context, menuItems));
-        listPopup.setDropDownGravity(Gravity.END);
-        listPopup.setAnchorView(view);
-        listPopup.setModal(true);
-        listPopup.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                if (!isAdded()) {
-                    return;
-                }
-
-                listPopup.dismiss();
-                switch ((int) id) {
-                    case ReaderMenuAdapter.ITEM_FOLLOW:
-                        onFollowTapped(getView(), post.getBlogName(), post.blogId);
-                        toggleFollowStatusForPost(post);
-                        break;
-                    case ReaderMenuAdapter.ITEM_UNFOLLOW:
-                        onFollowingTapped();
-                        toggleFollowStatusForPost(post);
-                        break;
-                    case ReaderMenuAdapter.ITEM_BLOCK:
-                        blockBlogForPost(post);
-                        break;
-                    case ReaderMenuAdapter.ITEM_NOTIFICATIONS_OFF:
-                        AnalyticsUtils.trackWithSiteId(Stat.FOLLOWED_BLOG_NOTIFICATIONS_READER_MENU_OFF, post.blogId);
-                        ReaderBlogTable.setNotificationsEnabledByBlogId(post.blogId, false);
-                        updateSubscription(SubscriptionAction.DELETE, post.blogId);
-                        break;
-                    case ReaderMenuAdapter.ITEM_NOTIFICATIONS_ON:
-                        AnalyticsUtils.trackWithSiteId(Stat.FOLLOWED_BLOG_NOTIFICATIONS_READER_MENU_ON, post.blogId);
-                        ReaderBlogTable.setNotificationsEnabledByBlogId(post.blogId, true);
-                        updateSubscription(SubscriptionAction.NEW, post.blogId);
-                        break;
-                    case ReaderMenuAdapter.ITEM_SHARE:
-                        AnalyticsUtils.trackWithSiteId(Stat.SHARED_ITEM_READER, post.blogId);
-                        sharePost(post);
-                        break;
-                    case ReaderMenuAdapter.ITEM_VISIT:
-                        AnalyticsTracker.track(Stat.READER_ARTICLE_VISITED);
-                        ReaderActivityLauncher.openPost(view.getContext(), post);
-                        break;
-                }
-            }
-        });
-        listPopup.show();
+//        if (view == null || post == null || !isAdded()) {
+//            return;
+//        }
+//
+//        List<Integer> menuItems = new ArrayList<>();
+//
+//        if (ReaderPostTable.isPostFollowed(post)) {
+//            menuItems.add(ReaderMenuAdapter.ITEM_UNFOLLOW);
+//
+//            // When blogId and feedId are not equal, post is not a feed so show notifications option.
+//            if (post.blogId != post.feedId) {
+//                if (ReaderBlogTable.isNotificationsEnabled(post.blogId)) {
+//                    menuItems.add(ReaderMenuAdapter.ITEM_NOTIFICATIONS_OFF);
+//                } else {
+//                    menuItems.add(ReaderMenuAdapter.ITEM_NOTIFICATIONS_ON);
+//                }
+//            }
+//        } else {
+//            menuItems.add(ReaderMenuAdapter.ITEM_FOLLOW);
+//        }
+//
+//        menuItems.add(ReaderMenuAdapter.ITEM_SHARE);
+//        menuItems.add(ReaderMenuAdapter.ITEM_VISIT);
+//
+//        if (getPostListType() == ReaderPostListType.TAG_FOLLOWED) {
+//            menuItems.add(ReaderMenuAdapter.ITEM_BLOCK);
+//        }
+//
+//        Context context = view.getContext();
+//        final ListPopupWindow listPopup = new ListPopupWindow(context);
+//        listPopup.setWidth(context.getResources().getDimensionPixelSize(R.dimen.menu_item_width));
+//        listPopup.setAdapter(new ReaderMenuAdapter(context, menuItems));
+//        listPopup.setDropDownGravity(Gravity.END);
+//        listPopup.setAnchorView(view);
+//        listPopup.setModal(true);
+//        listPopup.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+//            @Override
+//            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+//                if (!isAdded()) {
+//                    return;
+//                }
+//
+//                listPopup.dismiss();
+//                switch ((int) id) {
+//                    case ReaderMenuAdapter.ITEM_FOLLOW:
+//                        onFollowTapped(getView(), post.getBlogName(), post.blogId);
+//                        toggleFollowStatusForPost(post);
+//                        break;
+//                    case ReaderMenuAdapter.ITEM_UNFOLLOW:
+//                        onFollowingTapped();
+//                        toggleFollowStatusForPost(post);
+//                        break;
+//                    case ReaderMenuAdapter.ITEM_BLOCK:
+//                        blockBlogForPost(post);
+//                        break;
+//                    case ReaderMenuAdapter.ITEM_NOTIFICATIONS_OFF:
+//                        AnalyticsUtils.trackWithSiteId(Stat.FOLLOWED_BLOG_NOTIFICATIONS_READER_MENU_OFF, post.blogId);
+//                        ReaderBlogTable.setNotificationsEnabledByBlogId(post.blogId, false);
+//                        updateSubscription(SubscriptionAction.DELETE, post.blogId);
+//                        break;
+//                    case ReaderMenuAdapter.ITEM_NOTIFICATIONS_ON:
+//                        AnalyticsUtils.trackWithSiteId(Stat.FOLLOWED_BLOG_NOTIFICATIONS_READER_MENU_ON, post.blogId);
+//                        ReaderBlogTable.setNotificationsEnabledByBlogId(post.blogId, true);
+//                        updateSubscription(SubscriptionAction.NEW, post.blogId);
+//                        break;
+//                    case ReaderMenuAdapter.ITEM_SHARE:
+//                        AnalyticsUtils.trackWithSiteId(Stat.SHARED_ITEM_READER, post.blogId);
+//                        sharePost(post);
+//                        break;
+//                    case ReaderMenuAdapter.ITEM_VISIT:
+//                        AnalyticsTracker.track(Stat.READER_ARTICLE_VISITED);
+//                        ReaderActivityLauncher.openPost(view.getContext(), post);
+//                        break;
+//                }
+//            }
+//        });
+//        listPopup.show();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
@@ -12,6 +12,8 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.content.res.AppCompatResources;
 
 import org.wordpress.android.R;
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction;
+import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.ColorUtils;
 import org.wordpress.android.util.ContextExtensionsKt;
 
@@ -23,20 +25,14 @@ import java.util.List;
  */
 public class ReaderMenuAdapter extends BaseAdapter {
     private final LayoutInflater mInflater;
-    private final List<Integer> mMenuItems = new ArrayList<>();
+    private final List<SecondaryAction> mMenuItems = new ArrayList<>();
+    private final UiHelpers mUiHelpers;
 
-    public static final int ITEM_FOLLOW = 0;
-    public static final int ITEM_UNFOLLOW = 1;
-    public static final int ITEM_BLOCK = 2;
-    public static final int ITEM_NOTIFICATIONS_OFF = 3;
-    public static final int ITEM_NOTIFICATIONS_ON = 4;
-    public static final int ITEM_SHARE = 5;
-    public static final int ITEM_VISIT = 6;
-
-    public ReaderMenuAdapter(Context context, @NonNull List<Integer> menuItems) {
+    public ReaderMenuAdapter(Context context, @NonNull UiHelpers uiHelpers, @NonNull List<SecondaryAction> menuItems) {
         super();
         mInflater = LayoutInflater.from(context);
         mMenuItems.addAll(menuItems);
+        mUiHelpers = uiHelpers;
     }
 
     @Override
@@ -51,7 +47,7 @@ public class ReaderMenuAdapter extends BaseAdapter {
 
     @Override
     public long getItemId(int position) {
-        return mMenuItems.get(position);
+        return mMenuItems.get(position).getType().ordinal();
     }
 
     @Override
@@ -65,67 +61,13 @@ public class ReaderMenuAdapter extends BaseAdapter {
             holder = (ReaderMenuHolder) convertView.getTag();
         }
 
-        int textRes;
-        int textColorRes;
-        int iconColorRes;
-        int iconRes;
-        switch (mMenuItems.get(position)) {
-            case ITEM_FOLLOW:
-                textRes = R.string.reader_btn_follow;
-                textColorRes =
-                        ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), R.attr.colorPrimary);
-                iconColorRes = textColorRes;
-                iconRes = R.drawable.ic_reader_follow_white_24dp;
-                break;
-            case ITEM_UNFOLLOW:
-                textRes = R.string.reader_btn_unfollow;
-                textColorRes =
-                        ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), R.attr.wpColorSuccess);
-                iconColorRes = textColorRes;
-                iconRes = R.drawable.ic_reader_following_white_24dp;
-                break;
-            case ITEM_BLOCK:
-                textRes = R.string.reader_menu_block_blog;
-                textColorRes =
-                        ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), R.attr.colorOnSurface);
-                iconColorRes = ContextExtensionsKt
-                        .getColorResIdFromAttribute(convertView.getContext(), R.attr.wpColorOnSurfaceMedium);
-                iconRes = R.drawable.ic_block_white_24dp;
-                break;
-            case ITEM_NOTIFICATIONS_OFF:
-                textRes = R.string.reader_btn_notifications_off;
-                textColorRes =
-                        ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), R.attr.wpColorSuccess);
-                iconColorRes = textColorRes;
-                iconRes = R.drawable.ic_bell_white_24dp;
-                break;
-            case ITEM_NOTIFICATIONS_ON:
-                textRes = R.string.reader_btn_notifications_on;
-                textColorRes = ContextExtensionsKt
-                        .getColorResIdFromAttribute(convertView.getContext(), R.attr.colorOnSurface);
-                iconColorRes = ContextExtensionsKt
-                        .getColorResIdFromAttribute(convertView.getContext(), R.attr.wpColorOnSurfaceMedium);
-                iconRes = R.drawable.ic_bell_white_24dp;
-                break;
-            case ITEM_SHARE:
-                textRes = R.string.reader_btn_share;
-                textColorRes =
-                        ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), R.attr.colorOnSurface);
-                iconColorRes = ContextExtensionsKt
-                        .getColorResIdFromAttribute(convertView.getContext(), R.attr.wpColorOnSurfaceMedium);
-                iconRes = R.drawable.ic_share_white_24dp;
-                break;
-            case ITEM_VISIT:
-                textRes = R.string.reader_label_visit;
-                textColorRes =
-                        ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), R.attr.colorOnSurface);
-                iconColorRes = ContextExtensionsKt
-                        .getColorResIdFromAttribute(convertView.getContext(), R.attr.wpColorOnSurfaceMedium);
-                iconRes = R.drawable.ic_external_white_24dp;
-                break;
-            default:
-                return convertView;
-        }
+        SecondaryAction item = mMenuItems.get(position);
+        String textRes = mUiHelpers.getTextOfUiString(convertView.getContext(), item.getLabel());
+        int textColorRes =
+                ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getLabelColor());
+        int iconColorRes =
+                ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getIconColor());
+        int iconRes = item.getIconRes();
 
         holder.mText.setText(textRes);
         holder.mText.setTextColor(AppCompatResources.getColorStateList(convertView.getContext(), textColorRes));

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.reader.discover
 
 import dagger.Reusable
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.datasets.ReaderBlogTable
 import org.wordpress.android.datasets.ReaderPostTable
 import org.wordpress.android.models.ReaderPost
@@ -29,7 +28,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor() {
             menuItems.add(
                     SecondaryAction(
                             type = FOLLOW,
-                            label = UiStringRes(string.reader_btn_unfollow),
+                            label = UiStringRes(R.string.reader_btn_unfollow),
                             labelColor = R.attr.wpColorSuccess,
                             iconRes = R.drawable.ic_reader_following_white_24dp,
                             isSelected = true,
@@ -43,7 +42,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor() {
                     menuItems.add(
                             SecondaryAction(
                                     type = SITE_NOTIFICATIONS,
-                                    label = UiStringRes(string.reader_btn_notifications_off),
+                                    label = UiStringRes(R.string.reader_btn_notifications_off),
                                     labelColor = R.attr.wpColorSuccess,
                                     iconRes = R.drawable.ic_bell_white_24dp,
                                     isSelected = true,
@@ -54,7 +53,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor() {
                     menuItems.add(
                             SecondaryAction(
                                     type = SITE_NOTIFICATIONS,
-                                    label = UiStringRes(string.reader_btn_notifications_on),
+                                    label = UiStringRes(R.string.reader_btn_notifications_on),
                                     labelColor = R.attr.colorOnSurface,
                                     iconRes = R.drawable.ic_bell_white_24dp,
                                     iconColor = R.attr.wpColorOnSurfaceMedium,
@@ -68,7 +67,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor() {
             menuItems.add(
                     SecondaryAction(
                             type = FOLLOW,
-                            label = UiStringRes(string.reader_btn_follow),
+                            label = UiStringRes(R.string.reader_btn_follow),
                             labelColor = R.attr.colorPrimary,
                             iconRes = R.drawable.ic_reader_follow_white_24dp,
                             isSelected = false,
@@ -80,7 +79,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor() {
         menuItems.add(
                 SecondaryAction(
                         type = SHARE,
-                        label = UiStringRes(string.reader_btn_share),
+                        label = UiStringRes(R.string.reader_btn_share),
                         labelColor = R.attr.colorOnSurface,
                         iconRes = R.drawable.ic_share_white_24dp,
                         iconColor = R.attr.wpColorOnSurfaceMedium,
@@ -90,7 +89,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor() {
         menuItems.add(
                 SecondaryAction(
                         type = VISIT_SITE,
-                        label = UiStringRes(string.reader_label_visit),
+                        label = UiStringRes(R.string.reader_label_visit),
                         labelColor = R.attr.colorOnSurface,
                         iconRes = R.drawable.ic_external_white_24dp,
                         iconColor = R.attr.wpColorOnSurfaceMedium,
@@ -102,7 +101,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor() {
             menuItems.add(
                     SecondaryAction(
                             type = BLOCK_SITE,
-                            label = UiStringRes(string.reader_menu_block_blog),
+                            label = UiStringRes(R.string.reader_menu_block_blog),
                             labelColor = R.attr.colorOnSurface,
                             iconRes = R.drawable.ic_block_white_24dp,
                             iconColor = R.attr.wpColorOnSurfaceMedium,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -1,15 +1,36 @@
 package org.wordpress.android.ui.reader.discover.viewholders
 
 import android.content.Context
+import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.ListPopupWindow
 import kotlinx.android.synthetic.main.reader_cardview_post.*
 import org.wordpress.android.R
+import org.wordpress.android.R.dimen
 import org.wordpress.android.WordPress
 import org.wordpress.android.datasets.ReaderThumbnailTable
+import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter
+import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_BLOCK
+import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_FOLLOW
+import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_NOTIFICATIONS_OFF
+import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_NOTIFICATIONS_ON
+import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_SHARE
+import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_UNFOLLOW
+import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_VISIT
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.COMMENTS
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SHARE
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SITE_NOTIFICATIONS
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.VISIT_SITE
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils.VideoThumbnailUrlListener
 import org.wordpress.android.ui.reader.views.ReaderIconCountView
@@ -44,7 +65,7 @@ class ReaderPostViewHolder(
         uiHelpers.updateVisibility(dot_separator, state.dotSeparatorVisibility)
         uiHelpers.setTextOrHide(text_dateline, state.dateLine)
         uiHelpers.updateVisibility(image_more, state.moreMenuVisibility)
-        image_more.setOnClickListener { state.onMoreButtonClicked.invoke(uiState.postId, uiState.blogId, image_more) }
+        image_more.setOnClickListener { onMoreClicked(uiState, uiState.moreMenuItems, it) }
         layout_post_header.setBackgroundResource(
                 layout_post_header.context.getDrawableResIdFromAttribute(uiState.postHeaderClickData?.background ?: 0)
         )
@@ -162,5 +183,41 @@ class ReaderPostViewHolder(
                 }
             })
         }
+    }
+
+    private fun onMoreClicked(uiState: ReaderPostUiState, actions: List<SecondaryAction>, v: View) {
+        // TODO malinjir the popup menu was reused from the legacy implementation. It needs to be refactored.
+        val listPopup = ListPopupWindow(v.context)
+        listPopup.width = v.context.resources.getDimensionPixelSize(dimen.menu_item_width)
+        listPopup.setAdapter(ReaderMenuAdapter(v.context, actions.map {
+            when(it.type){
+                FOLLOW -> if(it.isSelected) {
+                        ITEM_UNFOLLOW
+                    } else {
+                        ITEM_FOLLOW
+                    }
+
+                SITE_NOTIFICATIONS ->
+                    if(it.isSelected) {
+                        ITEM_NOTIFICATIONS_OFF
+                    } else {
+                        ITEM_NOTIFICATIONS_ON
+                    }
+
+                SHARE -> ITEM_SHARE
+                VISIT_SITE -> ITEM_VISIT
+                BLOCK_SITE -> ITEM_BLOCK
+                LIKE, BOOKMARK, REBLOG, COMMENTS -> throw IllegalStateException("Unexpected type")
+            }
+        }))
+        listPopup.setDropDownGravity(Gravity.END)
+        listPopup.anchorView = v
+        listPopup.isModal = true
+        listPopup.setOnItemClickListener { _, _, position, _ ->
+            listPopup.dismiss()
+            val item = actions[position]
+            item.onClicked.invoke(uiState.postId, uiState.blogId, item.type)
+        }
+        listPopup.show()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -11,26 +11,10 @@ import org.wordpress.android.R.dimen
 import org.wordpress.android.WordPress
 import org.wordpress.android.datasets.ReaderThumbnailTable
 import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter
-import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_BLOCK
-import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_FOLLOW
-import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_NOTIFICATIONS_OFF
-import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_NOTIFICATIONS_ON
-import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_SHARE
-import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_UNFOLLOW
-import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter.ITEM_VISIT
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.COMMENTS
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SHARE
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SITE_NOTIFICATIONS
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.VISIT_SITE
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils.VideoThumbnailUrlListener
 import org.wordpress.android.ui.reader.views.ReaderIconCountView
@@ -189,27 +173,7 @@ class ReaderPostViewHolder(
         // TODO malinjir the popup menu was reused from the legacy implementation. It needs to be refactored.
         val listPopup = ListPopupWindow(v.context)
         listPopup.width = v.context.resources.getDimensionPixelSize(dimen.menu_item_width)
-        listPopup.setAdapter(ReaderMenuAdapter(v.context, actions.map {
-            when(it.type){
-                FOLLOW -> if(it.isSelected) {
-                        ITEM_UNFOLLOW
-                    } else {
-                        ITEM_FOLLOW
-                    }
-
-                SITE_NOTIFICATIONS ->
-                    if(it.isSelected) {
-                        ITEM_NOTIFICATIONS_OFF
-                    } else {
-                        ITEM_NOTIFICATIONS_ON
-                    }
-
-                SHARE -> ITEM_SHARE
-                VISIT_SITE -> ITEM_VISIT
-                BLOCK_SITE -> ITEM_BLOCK
-                LIKE, BOOKMARK, REBLOG, COMMENTS -> throw IllegalStateException("Unexpected type")
-            }
-        }))
+        listPopup.setAdapter(ReaderMenuAdapter(v.context, uiHelpers, actions))
         listPopup.setDropDownGravity(Gravity.END)
         listPopup.anchorView = v
         listPopup.isModal = true

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.appcompat.widget.ListPopupWindow
 import kotlinx.android.synthetic.main.reader_cardview_post.*
 import org.wordpress.android.R
-import org.wordpress.android.R.dimen
 import org.wordpress.android.WordPress
 import org.wordpress.android.datasets.ReaderThumbnailTable
 import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter
@@ -172,7 +171,7 @@ class ReaderPostViewHolder(
     private fun onMoreClicked(uiState: ReaderPostUiState, actions: List<SecondaryAction>, v: View) {
         // TODO malinjir the popup menu was reused from the legacy implementation. It needs to be refactored.
         val listPopup = ListPopupWindow(v.context)
-        listPopup.width = v.context.resources.getDimensionPixelSize(dimen.menu_item_width)
+        listPopup.width = v.context.resources.getDimensionPixelSize(R.dimen.menu_item_width)
         listPopup.setAdapter(ReaderMenuAdapter(v.context, uiHelpers, actions))
         listPopup.setDropDownGravity(Gravity.END)
         listPopup.anchorView = v


### PR DESCRIPTION
Parent issue #12028 

Merge instructions
1. Review this PR
2. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/12320 is merged
3. Update the target branch to **issue/12028-show-popup-more-main** 
4. Remove "Not ready for merge" label
5. Merge this PR

This PR 
1. Comments out the logic related to ReaderPostCard popup menu in ReaderPostListFragment - it even breaks the behavior as the onItemClick doesn't work now. But I thought it'd be easier to review if I created two separate PRs.
2. Updates ReaderMenuAdapter so it renders the items based on the provided uiState.
3. Updates ReaderPostViewHolder so the popup menu is shown when the user clicks on the "more/..." icon.

After these changes, the popup menu should be correctly shown and the correct items displayed. However, selecting one of the items from the menu will result in a crash for now. 

To test:
I'm targeting a working branch since I'll keep improving/refactoring the same part of the code in the upcoming PRs. In order to increase efficiency I think it'd be best to test it in the last PR of this series so we don't keep testing the same behavior repeatedly. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
