### PR TITLE
Show popup more menu part 3 - fix button clicks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.reader;
 import android.view.View;
 
 import org.wordpress.android.models.ReaderPost;
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType;
 
 public class ReaderInterfaces {
     private ReaderInterfaces() {
@@ -28,13 +29,6 @@ public class ReaderInterfaces {
     }
 
     /*
-     * called when user taps the dropdown arrow next to a post to show the popup menu
-     */
-    public interface OnPostPopupListener {
-        void onShowPostPopup(View view, ReaderPost post);
-    }
-
-    /*
      * used by adapters to notify when data has been loaded
      */
     public interface DataLoadedListener {
@@ -48,6 +42,15 @@ public class ReaderInterfaces {
         void onFollowTapped(View view, String blogName, long blogId);
 
         void onFollowingTapped();
+    }
+
+    /*
+     * Used by adapters to notify when button on post list item is clicked. This interface was created during
+     * refactoring for the new Discover tab. It isn't ideal but we wanted to re-use some of the legacy code but
+     * refactoring everything was out of scope of the project.
+     */
+    public interface OnPostListItemButtonListener {
+        void onButtonClicked(ReaderPost post, ReaderPostCardActionType actionType);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -98,6 +98,7 @@ import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionRecyclerAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSiteSearchAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSiteSearchAdapter.SiteSearchAdapterListener;
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType;
 import org.wordpress.android.ui.reader.reblog.NoSite;
 import org.wordpress.android.ui.reader.reblog.PostEditor;
 import org.wordpress.android.ui.reader.reblog.SitePicker;
@@ -148,8 +149,8 @@ import static org.wordpress.android.fluxc.generated.AccountActionBuilder.newUpda
 
 public class ReaderPostListFragment extends Fragment
         implements ReaderInterfaces.OnPostSelectedListener,
-        ReaderInterfaces.OnPostPopupListener,
         ReaderInterfaces.OnFollowListener,
+        ReaderInterfaces.OnPostListItemButtonListener,
         WPMainActivity.OnActivityBackPressedListener,
         WPMainActivity.OnScrollToTopListener,
         ReblogActionListener {
@@ -711,7 +712,7 @@ public class ReaderPostListFragment extends Fragment
 
     @Override
     @SuppressWarnings("unchecked")
-    public void onAttach(Context context) {
+    public void onAttach(@NonNull Context context) {
         super.onAttach(context);
 
         // detect the bottom nav controller when this fragment is hosted in the main activity - this is used to
@@ -831,7 +832,7 @@ public class ReaderPostListFragment extends Fragment
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         AppLog.d(T.READER, "reader post list > saving instance state");
 
         if (mCurrentTag != null) {
@@ -1395,11 +1396,6 @@ public class ReaderPostListFragment extends Fragment
         populateSearchSuggestionRecyclerAdapter(null); // always passing null as there's no need to filter
     }
 
-    private void resetSearchSuggestions() {
-        resetSearchSuggestionAdapter();
-        resetSearchSuggestionRecyclerAdapter();
-    }
-
     /*
      * create and assign the suggestion adapter for the search view
      */
@@ -1816,10 +1812,6 @@ public class ReaderPostListFragment extends Fragment
         }
     }
 
-    private boolean isEmptyViewShowing() {
-        return isAdded() && mActionableEmptyView.getVisibility() == View.VISIBLE;
-    }
-
     private void setCurrentTagFromEmptyViewButton(ActionableEmptyViewButtonType button) {
         ReaderTag tag;
 
@@ -2008,7 +2000,7 @@ public class ReaderPostListFragment extends Fragment
             mPostAdapter.setOnFollowListener(this);
             mPostAdapter.setReblogActionListener(this);
             mPostAdapter.setOnPostSelectedListener(this);
-            mPostAdapter.setOnPostPopupListener(this);
+            mPostAdapter.setOnPostListItemButtonListener(this);
             mPostAdapter.setOnDataLoadedListener(mDataLoadedListener);
             mPostAdapter.setOnDataRequestedListener(mDataRequestedListener);
             mPostAdapter.setOnPostBookmarkedListener(mOnPostBookmarkedListener);
@@ -2400,7 +2392,7 @@ public class ReaderPostListFragment extends Fragment
      */
     private final RecyclerView.OnScrollListener mOnScrollListener = new RecyclerView.OnScrollListener() {
         @Override
-        public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+        public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
             super.onScrolled(recyclerView, dx, dy);
             hideNewPostsBar();
         }
@@ -2580,88 +2572,45 @@ public class ReaderPostListFragment extends Fragment
         AnalyticsTracker.track(stat, properties);
     }
 
-    /*
-     * called when user taps "..." icon next to a post
-     */
     @Override
-    public void onShowPostPopup(View view, final ReaderPost post) {
-//        if (view == null || post == null || !isAdded()) {
-//            return;
-//        }
-//
-//        List<Integer> menuItems = new ArrayList<>();
-//
-//        if (ReaderPostTable.isPostFollowed(post)) {
-//            menuItems.add(ReaderMenuAdapter.ITEM_UNFOLLOW);
-//
-//            // When blogId and feedId are not equal, post is not a feed so show notifications option.
-//            if (post.blogId != post.feedId) {
-//                if (ReaderBlogTable.isNotificationsEnabled(post.blogId)) {
-//                    menuItems.add(ReaderMenuAdapter.ITEM_NOTIFICATIONS_OFF);
-//                } else {
-//                    menuItems.add(ReaderMenuAdapter.ITEM_NOTIFICATIONS_ON);
-//                }
-//            }
-//        } else {
-//            menuItems.add(ReaderMenuAdapter.ITEM_FOLLOW);
-//        }
-//
-//        menuItems.add(ReaderMenuAdapter.ITEM_SHARE);
-//        menuItems.add(ReaderMenuAdapter.ITEM_VISIT);
-//
-//        if (getPostListType() == ReaderPostListType.TAG_FOLLOWED) {
-//            menuItems.add(ReaderMenuAdapter.ITEM_BLOCK);
-//        }
-//
-//        Context context = view.getContext();
-//        final ListPopupWindow listPopup = new ListPopupWindow(context);
-//        listPopup.setWidth(context.getResources().getDimensionPixelSize(R.dimen.menu_item_width));
-//        listPopup.setAdapter(new ReaderMenuAdapter(context, menuItems));
-//        listPopup.setDropDownGravity(Gravity.END);
-//        listPopup.setAnchorView(view);
-//        listPopup.setModal(true);
-//        listPopup.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-//            @Override
-//            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-//                if (!isAdded()) {
-//                    return;
-//                }
-//
-//                listPopup.dismiss();
-//                switch ((int) id) {
-//                    case ReaderMenuAdapter.ITEM_FOLLOW:
-//                        onFollowTapped(getView(), post.getBlogName(), post.blogId);
-//                        toggleFollowStatusForPost(post);
-//                        break;
-//                    case ReaderMenuAdapter.ITEM_UNFOLLOW:
-//                        onFollowingTapped();
-//                        toggleFollowStatusForPost(post);
-//                        break;
-//                    case ReaderMenuAdapter.ITEM_BLOCK:
-//                        blockBlogForPost(post);
-//                        break;
-//                    case ReaderMenuAdapter.ITEM_NOTIFICATIONS_OFF:
-//                        AnalyticsUtils.trackWithSiteId(Stat.FOLLOWED_BLOG_NOTIFICATIONS_READER_MENU_OFF, post.blogId);
-//                        ReaderBlogTable.setNotificationsEnabledByBlogId(post.blogId, false);
-//                        updateSubscription(SubscriptionAction.DELETE, post.blogId);
-//                        break;
-//                    case ReaderMenuAdapter.ITEM_NOTIFICATIONS_ON:
-//                        AnalyticsUtils.trackWithSiteId(Stat.FOLLOWED_BLOG_NOTIFICATIONS_READER_MENU_ON, post.blogId);
-//                        ReaderBlogTable.setNotificationsEnabledByBlogId(post.blogId, true);
-//                        updateSubscription(SubscriptionAction.NEW, post.blogId);
-//                        break;
-//                    case ReaderMenuAdapter.ITEM_SHARE:
-//                        AnalyticsUtils.trackWithSiteId(Stat.SHARED_ITEM_READER, post.blogId);
-//                        sharePost(post);
-//                        break;
-//                    case ReaderMenuAdapter.ITEM_VISIT:
-//                        AnalyticsTracker.track(Stat.READER_ARTICLE_VISITED);
-//                        ReaderActivityLauncher.openPost(view.getContext(), post);
-//                        break;
-//                }
-//            }
-//        });
-//        listPopup.show();
+    public void onButtonClicked(ReaderPost post, ReaderPostCardActionType actionType) {
+        switch (actionType) {
+            case FOLLOW:
+                if (post.isFollowedByCurrentUser) {
+                    onFollowingTapped();
+                } else {
+                    onFollowTapped(getView(), post.getBlogName(), post.blogId);
+                }
+                toggleFollowStatusForPost(post);
+                break;
+            case SITE_NOTIFICATIONS:
+                if (ReaderBlogTable.isNotificationsEnabled(post.blogId)) {
+                    AnalyticsUtils.trackWithSiteId(Stat.FOLLOWED_BLOG_NOTIFICATIONS_READER_MENU_OFF, post.blogId);
+                    ReaderBlogTable.setNotificationsEnabledByBlogId(post.blogId, false);
+                    updateSubscription(SubscriptionAction.DELETE, post.blogId);
+                } else {
+                    AnalyticsUtils.trackWithSiteId(Stat.FOLLOWED_BLOG_NOTIFICATIONS_READER_MENU_ON, post.blogId);
+                    ReaderBlogTable.setNotificationsEnabledByBlogId(post.blogId, true);
+                    updateSubscription(SubscriptionAction.NEW, post.blogId);
+                }
+                break;
+            case SHARE:
+                AnalyticsUtils.trackWithSiteId(Stat.SHARED_ITEM_READER, post.blogId);
+                sharePost(post);
+                break;
+            case VISIT_SITE:
+                AnalyticsTracker.track(Stat.READER_ARTICLE_VISITED);
+                ReaderActivityLauncher.openPost(getContext(), post);
+                break;
+            case BLOCK_SITE:
+                blockBlogForPost(post);
+                break;
+            case BOOKMARK:
+            case LIKE:
+            case REBLOG:
+            case COMMENTS:
+                throw new IllegalStateException("These actoins should be handled in ReaderPostAdapter.");
+        }
     }
 
     @Override
@@ -2740,14 +2689,6 @@ public class ReaderPostListFragment extends Fragment
         if (isAdded() && getCurrentPosition() > 0) {
             mRecyclerView.smoothScrollToPosition(0);
         }
-    }
-
-    private boolean isCurrentTagManagedInFollowingTab() {
-        return ReaderUtils.isTagManagedInFollowingTab(
-                mCurrentTag,
-                mIsTopLevel,
-                mRecyclerView
-        );
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -337,7 +337,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     switch (type) {
                         case BOOKMARK:
                             toggleBookmark(post.blogId, post.postId);
-                            notifyItemChanged(position);
+                            renderPost(position, holder);
                             break;
                         case LIKE:
                             toggleLike(ctx, post, position, holder);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -33,6 +33,7 @@ import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.ReaderInterfaces;
 import org.wordpress.android.ui.reader.ReaderInterfaces.OnFollowListener;
+import org.wordpress.android.ui.reader.ReaderInterfaces.OnPostListItemButtonListener;
 import org.wordpress.android.ui.reader.ReaderInterfaces.ReblogActionListener;
 import org.wordpress.android.ui.reader.ReaderTypes;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
@@ -92,9 +93,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private final HashSet<String> mRenderedIds = new HashSet<>();
     private NewsItem mNewsItem;
 
+    private ReaderInterfaces.OnPostListItemButtonListener mOnPostListItemButtonListener;
     private ReaderInterfaces.OnFollowListener mFollowListener;
     private ReaderInterfaces.OnPostSelectedListener mPostSelectedListener;
-    private ReaderInterfaces.OnPostPopupListener mOnPostPopupListener;
     private ReaderInterfaces.DataLoadedListener mDataLoadedListener;
     private ReaderInterfaces.OnPostBookmarkedListener mOnPostBookmarkedListener;
     private ReaderActions.DataRequestedListener mDataRequestedListener;
@@ -347,8 +348,14 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         case COMMENTS:
                             ReaderActivityLauncher.showReaderComments(ctx, post.blogId, post.postId);
                             break;
-                        default:
-                            throw new IllegalArgumentException("onClick invoked with an unexpected type: " + type);
+                        case FOLLOW:
+                        case SITE_NOTIFICATIONS:
+                        case SHARE:
+                        case VISIT_SITE:
+                        case BLOCK_SITE:
+                            mOnPostListItemButtonListener.onButtonClicked(post, type);
+                            renderPost(position, holder);
+                            break;
                     }
                     return Unit.INSTANCE;
                 };
@@ -391,9 +398,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             return Unit.INSTANCE;
         };
         Function3<Long, Long, View, Unit> onMoreButtonClicked = (postId, blogId, view) -> {
-            if (mOnPostPopupListener != null) {
-                mOnPostPopupListener.onShowPostPopup(view, post);
-            }
+            // noop
             return Unit.INSTANCE;
         };
 
@@ -480,6 +485,10 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         return mCurrentTag != null && mCurrentTag.isDiscover();
     }
 
+    public void setOnPostListItemButtonListener(OnPostListItemButtonListener listener) {
+        mOnPostListItemButtonListener = listener;
+    }
+
     public void setOnFollowListener(OnFollowListener listener) {
         mFollowListener = listener;
     }
@@ -502,10 +511,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     public void setOnDataRequestedListener(ReaderActions.DataRequestedListener listener) {
         mDataRequestedListener = listener;
-    }
-
-    public void setOnPostPopupListener(ReaderInterfaces.OnPostPopupListener onPostPopupListener) {
-        mOnPostPopupListener = onPostPopupListener;
     }
 
     public void setOnBlogInfoLoadedListener(ReaderSiteHeaderView.OnBlogInfoLoadedListener listener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -56,9 +56,7 @@ class UiHelpers @Inject constructor() {
 
     fun setTextOrHide(view: TextView, text: CharSequence?) {
         updateVisibility(view, text != null)
-        text?.let {
-            view.text = text
-        }
+        view.text = text ?: ""
     }
 
     fun setImageOrHide(imageView: ImageView, @DrawableRes resId: Int?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -56,7 +56,9 @@ class UiHelpers @Inject constructor() {
 
     fun setTextOrHide(view: TextView, text: CharSequence?) {
         updateVisibility(view, text != null)
-        view.text = text ?: ""
+        text?.let {
+            view.text = text
+        }
     }
 
     fun setImageOrHide(imageView: ImageView, @DrawableRes resId: Int?) {


### PR DESCRIPTION
Parent issue #12028 

Merge instructions
1. Review this PR
2. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/12321
3. Update the target branch to develop
4. Remove "Not ready for merge" label
5. Merge this PR

This is a last PR in this mini-series. This PR fixes clicks on items in the popup/more/... menu on post card items. I've also removed some unused code and added missing @nonNull annotation to the ReaderPostListFragment.


To test:
Bookmark
1. Click on "Bookmark" icon on one of the items in the Following tab
2. Notice the icon gets filled and a snackbar message shown
3. Click on "ViewAll" action in the snack bar -> notice the post you bookmarked is in the "Saved" list
4. Switch back to the Following tab
5. Click on "Unbookmark" on the post
6. Notice the icon changes back from filled state to outlined state.

Reblog
1. Click on "reblog" icon on one of the items in the following tab
2. Notice site picker is shown

Comment
1. Click on "comment" icon on one of the items in the following tab
2. Notice post comments are shown

Like
1. Click on "Like" icon on one of the items in the following tab
2. The icon gets filled and the count number gets increased
3. Click on the icon again and notice the icon changes back from filled state to outline state and the count decreases

More - Following
1. Click on the More button on one of the items in the following tab
2. Notice the "Following" action is green
3. Click on "Following"
4. Click on the More button again
5. Notice the action is now blue and says "Follow"
6. Click on "Follow"
7. Click on the More button again
8. Notice the "Following" action is green again

More - Turn on site Notifications
1. Click on the More button on one of the items in the following tab
2. Notice "Turn on site notifications" is grey
3. Click on it
4. Click on the More button again
5. Notice the action now says "Turn off site notifications" and is green
6. Click on it
7. Click on the More button again
8. Notice the action now says "Turn on site notifications" and is grey again

More - Share
1. Click on the More button on one of the items in the following tab
2. Click on "Share"
3. Notice OS default share picker is shown

More - Visi Site
1. Click on the More button on one of the items in the following tab
2. Click on "Visit site"
3. Notice a browser with the post is shown

More - Block this site
1. Click on the More button on one of the items in the following tab
2. Click on "Block this site"
3. Notice the site is removed from the feed and a snackbar notification is shown 



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
