### PR TITLE
Address NPEs on NotificationsListFragmentPage

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -233,10 +233,6 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
 
     private fun hideEmptyView() {
         if (isAdded) {
-            if (actionable_empty_view == null) {
-                AppLog.d(T.NOTIFS,
-                        "NotificationsListFragmentPage.hideEmptyView view is null.")
-            }
             actionable_empty_view.visibility = View.GONE
             notifications_list.visibility = View.VISIBLE
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -125,8 +125,9 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
     }
 
     override fun onDestroyView() {
+        notesAdapter!!.cleanUp()
         swipeToRefreshHelper = null
-        notifications_list?.adapter = null
+        notifications_list.adapter = null
         notesAdapter = null
         super.onDestroyView()
     }
@@ -170,7 +171,7 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
             return
         }
         clearPendingNotificationsItemsOnUI()
-        val layoutManager = notifications_list?.layoutManager as LinearLayoutManager
+        val layoutManager = notifications_list.layoutManager as LinearLayoutManager
         if (layoutManager.findFirstCompletelyVisibleItemPosition() > 0) {
             layoutManager.smoothScrollToPosition(notifications_list, null, 0)
         }
@@ -204,7 +205,7 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
     private val mOnScrollListener: OnScrollListener = object : OnScrollListener() {
         override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
             super.onScrolled(recyclerView, dx, dy)
-            notifications_list?.removeOnScrollListener(this)
+            notifications_list.removeOnScrollListener(this)
             clearPendingNotificationsItemsOnUI()
         }
     }
@@ -232,8 +233,12 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
 
     private fun hideEmptyView() {
         if (isAdded) {
-            actionable_empty_view?.visibility = View.GONE
-            notifications_list?.visibility = View.VISIBLE
+            if (actionable_empty_view == null) {
+                AppLog.d(T.NOTIFS,
+                        "NotificationsListFragmentPage.hideEmptyView view is null.")
+            }
+            actionable_empty_view.visibility = View.GONE
+            notifications_list.visibility = View.VISIBLE
         }
     }
 
@@ -280,22 +285,22 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
         @StringRes buttonResId: Int = 0
     ) {
         if (isAdded) {
-            actionable_empty_view?.visibility = View.VISIBLE
-            notifications_list?.visibility = View.GONE
-            actionable_empty_view?.title?.setText(titleResId)
+            actionable_empty_view.visibility = View.VISIBLE
+            notifications_list.visibility = View.GONE
+            actionable_empty_view.title.setText(titleResId)
             if (descriptionResId != 0) {
-                actionable_empty_view?.subtitle?.setText(descriptionResId)
-                actionable_empty_view?.subtitle?.visibility = View.VISIBLE
+                actionable_empty_view.subtitle.setText(descriptionResId)
+                actionable_empty_view.subtitle.visibility = View.VISIBLE
             } else {
-                actionable_empty_view?.subtitle?.visibility = View.GONE
+                actionable_empty_view.subtitle.visibility = View.GONE
             }
             if (buttonResId != 0) {
-                actionable_empty_view?.button?.setText(buttonResId)
-                actionable_empty_view?.button?.visibility = View.VISIBLE
+                actionable_empty_view.button.setText(buttonResId)
+                actionable_empty_view.button.visibility = View.VISIBLE
             } else {
-                actionable_empty_view?.button?.visibility = View.GONE
+                actionable_empty_view.button.visibility = View.GONE
             }
-            actionable_empty_view?.button?.setOnClickListener { performActionForActiveFilter() }
+            actionable_empty_view.button.setOnClickListener { performActionForActiveFilter() }
         }
     }
 
@@ -336,7 +341,7 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
             }
             else -> showEmptyView(R.string.notifications_empty_list)
         }
-        actionable_empty_view?.image?.visibility = if (DisplayUtils.isLandscape(context)) View.GONE else View.VISIBLE
+        actionable_empty_view.image.visibility = if (DisplayUtils.isLandscape(context)) View.GONE else View.VISIBLE
     }
 
     private fun showNewNotificationsBar() {
@@ -344,22 +349,22 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
             return
         }
         AniUtils.startAnimation(layout_new_notificatons, R.anim.notifications_bottom_bar_in)
-        layout_new_notificatons?.visibility = View.VISIBLE
+        layout_new_notificatons.visibility = View.VISIBLE
     }
 
     private fun showNewUnseenNotificationsUI() {
-        if (!isAdded || notifications_list?.layoutManager == null) {
+        if (!isAdded || notifications_list.layoutManager == null) {
             return
         }
-        notifications_list?.clearOnScrollListeners()
-        notifications_list?.postDelayed({
+        notifications_list.clearOnScrollListeners()
+        notifications_list.postDelayed({
             if (isAdded) {
-                notifications_list?.addOnScrollListener(mOnScrollListener)
+                notifications_list.addOnScrollListener(mOnScrollListener)
             }
         }, 1000L)
-        val first = notifications_list?.layoutManager!!.getChildAt(0)
+        val first = notifications_list.layoutManager!!.getChildAt(0)
         // Show new notifications bar if first item is not visible on the screen.
-        if (first != null && notifications_list?.layoutManager!!.getPosition(first) > 0) {
+        if (first != null && notifications_list.layoutManager!!.getPosition(first) > 0) {
             showNewNotificationsBar()
         }
     }
@@ -391,7 +396,7 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
                             )
                     val note = NotificationsTable.getNoteById(event.noteId)
                     if (note != null) {
-                        notesAdapter?.replaceNote(note)
+                        notesAdapter!!.replaceNote(note)
                     }
                 }
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -126,7 +126,7 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
 
     override fun onDestroyView() {
         swipeToRefreshHelper = null
-        notifications_list.adapter = null
+        notifications_list?.adapter = null
         notesAdapter = null
         super.onDestroyView()
     }
@@ -170,7 +170,7 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
             return
         }
         clearPendingNotificationsItemsOnUI()
-        val layoutManager = notifications_list.layoutManager as LinearLayoutManager
+        val layoutManager = notifications_list?.layoutManager as LinearLayoutManager
         if (layoutManager.findFirstCompletelyVisibleItemPosition() > 0) {
             layoutManager.smoothScrollToPosition(notifications_list, null, 0)
         }
@@ -204,7 +204,7 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
     private val mOnScrollListener: OnScrollListener = object : OnScrollListener() {
         override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
             super.onScrolled(recyclerView, dx, dy)
-            notifications_list.removeOnScrollListener(this)
+            notifications_list?.removeOnScrollListener(this)
             clearPendingNotificationsItemsOnUI()
         }
     }
@@ -344,11 +344,11 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
             return
         }
         AniUtils.startAnimation(layout_new_notificatons, R.anim.notifications_bottom_bar_in)
-        layout_new_notificatons.visibility = View.VISIBLE
+        layout_new_notificatons?.visibility = View.VISIBLE
     }
 
     private fun showNewUnseenNotificationsUI() {
-        if (!isAdded || notifications_list.layoutManager == null) {
+        if (!isAdded || notifications_list?.layoutManager == null) {
             return
         }
         notifications_list?.clearOnScrollListeners()

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -394,10 +394,6 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
                             .removeStickyEvent(
                                     NoteLikeOrModerationStatusChanged::class.java
                             )
-                    val note = NotificationsTable.getNoteById(event.noteId)
-                    if (note != null) {
-                        notesAdapter!!.replaceNote(note)
-                    }
                 }
         ) {
             EventBus.getDefault().removeStickyEvent(

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -232,8 +232,8 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
 
     private fun hideEmptyView() {
         if (isAdded) {
-            actionable_empty_view.visibility = View.GONE
-            notifications_list.visibility = View.VISIBLE
+            actionable_empty_view?.visibility = View.GONE
+            notifications_list?.visibility = View.VISIBLE
         }
     }
 
@@ -280,22 +280,22 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
         @StringRes buttonResId: Int = 0
     ) {
         if (isAdded) {
-            actionable_empty_view.visibility = View.VISIBLE
-            notifications_list.visibility = View.GONE
-            actionable_empty_view.title.setText(titleResId)
+            actionable_empty_view?.visibility = View.VISIBLE
+            notifications_list?.visibility = View.GONE
+            actionable_empty_view?.title?.setText(titleResId)
             if (descriptionResId != 0) {
-                actionable_empty_view.subtitle.setText(descriptionResId)
-                actionable_empty_view.subtitle.visibility = View.VISIBLE
+                actionable_empty_view?.subtitle?.setText(descriptionResId)
+                actionable_empty_view?.subtitle?.visibility = View.VISIBLE
             } else {
-                actionable_empty_view.subtitle.visibility = View.GONE
+                actionable_empty_view?.subtitle?.visibility = View.GONE
             }
             if (buttonResId != 0) {
-                actionable_empty_view.button.setText(buttonResId)
-                actionable_empty_view.button.visibility = View.VISIBLE
+                actionable_empty_view?.button?.setText(buttonResId)
+                actionable_empty_view?.button?.visibility = View.VISIBLE
             } else {
-                actionable_empty_view.button.visibility = View.GONE
+                actionable_empty_view?.button?.visibility = View.GONE
             }
-            actionable_empty_view.button.setOnClickListener { performActionForActiveFilter() }
+            actionable_empty_view?.button?.setOnClickListener { performActionForActiveFilter() }
         }
     }
 
@@ -336,7 +336,7 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
             }
             else -> showEmptyView(R.string.notifications_empty_list)
         }
-        actionable_empty_view.image.visibility = if (DisplayUtils.isLandscape(context)) View.GONE else View.VISIBLE
+        actionable_empty_view?.image?.visibility = if (DisplayUtils.isLandscape(context)) View.GONE else View.VISIBLE
     }
 
     private fun showNewNotificationsBar() {
@@ -351,15 +351,15 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
         if (!isAdded || notifications_list.layoutManager == null) {
             return
         }
-        notifications_list.clearOnScrollListeners()
-        notifications_list.postDelayed({
+        notifications_list?.clearOnScrollListeners()
+        notifications_list?.postDelayed({
             if (isAdded) {
-                notifications_list.addOnScrollListener(mOnScrollListener)
+                notifications_list?.addOnScrollListener(mOnScrollListener)
             }
         }, 1000L)
-        val first = notifications_list.layoutManager!!.getChildAt(0)
+        val first = notifications_list?.layoutManager!!.getChildAt(0)
         // Show new notifications bar if first item is not visible on the screen.
-        if (first != null && notifications_list.layoutManager!!.getPosition(first) > 0) {
+        if (first != null && notifications_list?.layoutManager!!.getPosition(first) > 0) {
             showNewNotificationsBar()
         }
     }
@@ -391,7 +391,7 @@ class NotificationsListFragmentPage : Fragment(), OnScrollToTopListener, DataLoa
                             )
                     val note = NotificationsTable.getNoteById(event.noteId)
                     if (note != null) {
-                        notesAdapter!!.replaceNote(note)
+                        notesAdapter?.replaceNote(note)
                     }
                 }
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -2,8 +2,10 @@ package org.wordpress.android.ui.notifications.adapters;
 
 import android.content.Context;
 import android.os.AsyncTask;
+import android.os.AsyncTask.Status;
 import android.text.Spanned;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -77,6 +79,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     }
 
     private FILTERS mCurrentFilter = FILTERS.FILTER_ALL;
+    private ReloadNotesFromDBTask mReloadNotesFromDBTask;
 
     public interface DataLoadedListener {
         void onDataLoaded(int itemsCount);
@@ -339,8 +342,16 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         mOnNoteClickListener = mNoteClickListener;
     }
 
+    public void cleanUp() {
+        if (mReloadNotesFromDBTask != null && mReloadNotesFromDBTask.getStatus() != Status.FINISHED) {
+            mReloadNotesFromDBTask.cancel(true);
+            mReloadNotesFromDBTask = null;
+        }
+    }
+
     public void reloadNotesFromDBAsync() {
-        new ReloadNotesFromDBTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        mReloadNotesFromDBTask = new ReloadNotesFromDBTask();
+        mReloadNotesFromDBTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
     private class ReloadNotesFromDBTask extends AsyncTask<Void, Void, ArrayList<Note>> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -5,6 +5,7 @@ import android.os.AsyncTask;
 import android.os.AsyncTask.Status;
 import android.text.Spanned;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -341,7 +342,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         mOnNoteClickListener = mNoteClickListener;
     }
 
-    public void cleanUp() {
+    public void cancelReloadNotesTask() {
         if (mReloadNotesFromDBTask != null && mReloadNotesFromDBTask.getStatus() != Status.FINISHED) {
             mReloadNotesFromDBTask.cancel(true);
             mReloadNotesFromDBTask = null;
@@ -349,6 +350,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     }
 
     public void reloadNotesFromDBAsync() {
+        cancelReloadNotesTask();
         mReloadNotesFromDBTask = new ReloadNotesFromDBTask();
         mReloadNotesFromDBTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -5,7 +5,6 @@ import android.os.AsyncTask;
 import android.os.AsyncTask.Status;
 import android.text.Spanned;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;


### PR DESCRIPTION
Fixes #12227 

~~This PR adds safe calls **?.** to synthetic properties to prevent NPE on null views.~~
After a conversation with @malinajirka , I have removed the safe call operator and added a `.cancel()` on the asynctask to help eliminate memory leaks that could cause the views to be null. 

To test:
These NPE's are very intermittent and I haven't been able to reproduce any of these NPEs. For testing, please ensure that the Notifications list is functioning correctly. I did try adding a `Thread.currentThread().sleep(5000)` in the doInBackground of the asyncTask, but still could not get the NPE to throw.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
