### PR TITLE
Address NPE

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1580,6 +1580,10 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     private void updateAndSavePostAsync() {
+        if (mEditorFragment == null) {
+            AppLog.e(AppLog.T.POSTS, "Fragment not initialized");
+            return;
+        }
         mViewModel.updatePostObjectWithUIAsync(mEditPostRepository, this::updateFromEditor, null);
     }
 


### PR DESCRIPTION
Fixes #12230 

This PR prevents a NPE by adding a null check on mEditorFragment to `updateAndSavePostAsync`.

To test:
I was unable to replicate the NPE, so for testing I spent some time creating and editing posts, while backgrounding the app or quickly jumping out of the editor after tapping publish. 
For testing, I would ask that you do the same and verify that you don't experience any crashes. Thanks. 

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
