### PR TITLE
Issue 12330/bottom sheet publish flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -44,7 +44,6 @@ import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Outcome.CANCEL
-import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.ui.posts.PrepublishingBottomSheetFragment
 import org.wordpress.android.ui.posts.ProgressDialogHelper
 import org.wordpress.android.ui.posts.ProgressDialogUiState
@@ -90,7 +89,6 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     @Inject lateinit var savePostToDbUseCase: SavePostToDbUseCase
     @Inject lateinit var dispatcher: Dispatcher
     @Inject lateinit var systemNotificationsTracker: SystemNotificationsTracker
-    @Inject lateinit var postUtilsWrapper: PostUtilsWrapper
     private var postEditorAnalyticsSession: PostEditorAnalyticsSession? = null
 
     private var addingMediaToEditorProgressDialog: ProgressDialog? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -416,16 +416,6 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     }
 
     override fun onSubmitButtonClicked(publishPost: PublishPost) {
-        prepareAndProcessStoryPostForPublishing()
-    }
-
-    private fun prepareAndProcessStoryPostForPublishing() {
-        editPostRepository.update { postModel ->
-            postUtilsWrapper.preparePostForPublish(
-                    postModel,
-                    requireNotNull(site)
-            )
-        }
         processStorySaving()
     }
 }


### PR DESCRIPTION
Fixes #12330 

##  Solution
The initial `PostStatus` is set to `DRAFT`. Once the user has pressed the submit button we then prepare the post for publishing using shared logic from the publish flow of other parts of the app. 

## Testing
1. Create a new post. 
2. Click Publish. 
3. Release that the button says `Publish Now` instead of `Update Now`

Before | After 
--------|-------
 <kbd><img src="https://user-images.githubusercontent.com/1509205/86177081-a49c2980-baeb-11ea-9f6d-aafd5b292492.png" width="320"></kbd>  | <kbd><img src="https://user-images.githubusercontent.com/1509205/86177072-9d751b80-baeb-11ea-84ab-d3291168219b.png" width="320"></kbd> 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 