### PR TITLE
WP Stories: fixes for alpha1 cut

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -289,11 +289,11 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         editPostRepository.set {
             val post: PostModel = postStore.instantiatePostModel(site, false, null, null)
             post.setStatus(PostStatus.DRAFT.toString())
-            post.setPostFormat(POST_FORMAT_WP_STORY_KEY)
             post
         }
         editPostRepository.savePostSnapshot()
         // this is an artifact to be able to call savePostToDb()
+        editPostRepository.getEditablePost()?.setPostFormat(POST_FORMAT_WP_STORY_KEY)
         site?.let {
             savePostToDbUseCase.savePostToDb(WordPress.getContext(), editPostRepository, it)
         }


### PR DESCRIPTION
Builds on #12346 

Has fixes for alpha1 cut.

### Fixes

- 69e90ba056 fixes a bug that would make stories have blank screens (no media url) on the viewer. Bug introduced here:
https://github.com/wordpress-mobile/WordPress-Android/commit/f7f5c6a4ce8ead542f2ded3d3474216ae53b30d9

This line was removed
```
// also, Story posts are always PUBLISHED	
        editPostRepository.getEditablePost()?.setStatus(PUBLISHED.toString())
```

Without this change, the Post would not get saved to FluxC - note the comment up there saying `// this is an artifact to be able to call savePostToDb()`? - ok so  the post will get saved later when enqueued for upload though, but because of this change, we lost the setting for `PostFormat == wpstory`.
Hence, when we were done uploading media and would check the post format to handle it correctly, we would fail, and as such we would not update the Post with the uploaded media URLs, resulting in blank screens on the viewer.

### Other fixes
see https://github.com/Automattic/portkey-android/pull/415

To test:
1. upload a story to the ninja site
2. observe your items are visible there as slides.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
