### PR TITLE
Issue/clarify trash message

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 15.3
 -----
+* [*] Improve wording for confirmation dialogs when trashing posts
  
 15.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -101,10 +101,14 @@ class PostActionHandler(
             )
             BUTTON_STATS -> triggerPostListAction.invoke(ViewStats(site, post))
             BUTTON_TRASH -> {
-                if (post.isLocallyChanged) {
-                    postListDialogHelper.showTrashPostWithLocalChangesConfirmationDialog(post)
-                } else {
-                    trashPost(post)
+                when {
+                    post.isLocallyChanged -> {
+                        postListDialogHelper.showTrashPostWithLocalChangesConfirmationDialog(post)
+                    }
+                    PostUtils.hasAutoSave(post) -> {
+                        postListDialogHelper.showTrashPostWithUnsavedChangesConfirmationDialog(post)
+                    }
+                    else -> trashPost(post)
                 }
             }
             BUTTON_DELETE, BUTTON_DELETE_PERMANENTLY -> {
@@ -259,6 +263,11 @@ class PostActionHandler(
         // If post doesn't exist, nothing else to do
         val post = postStore.getPostByLocalPostId(localPostId) ?: return
         trashPost(post, true)
+    }
+
+    fun trashPostWithUnsavedChanges(localPostId: Int) {
+        val post = postStore.getPostByLocalPostId(localPostId) ?: return
+        trashPost(post)
     }
 
     private fun trashPost(post: PostModel, hasLocalChanges: Boolean = false) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -72,7 +72,7 @@ class PostActionHandler(
         invalidateList.invoke()
     })
 
-    fun handlePostButton(buttonType: PostListButtonType, post: PostModel) {
+    fun handlePostButton(buttonType: PostListButtonType, post: PostModel, hasAutoSave: Boolean) {
         when (buttonType) {
             BUTTON_EDIT -> editPostButtonAction(site, post)
             BUTTON_RETRY -> triggerPostListAction.invoke(RetryUpload(post))
@@ -105,7 +105,7 @@ class PostActionHandler(
                     post.isLocallyChanged -> {
                         postListDialogHelper.showTrashPostWithLocalChangesConfirmationDialog(post)
                     }
-                    PostUtils.hasAutoSave(post) -> {
+                    hasAutoSave -> {
                         postListDialogHelper.showTrashPostWithUnsavedChangesConfirmationDialog(post)
                     }
                     else -> trashPost(post)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListDialogHelper.kt
@@ -13,6 +13,8 @@ import org.wordpress.android.viewmodel.helpers.DialogHolder
 private const val CONFIRM_DELETE_POST_DIALOG_TAG = "CONFIRM_DELETE_POST_DIALOG_TAG"
 private const val CONFIRM_RESTORE_TRASHED_POST_DIALOG_TAG = "CONFIRM_RESTORE_TRASHED_POST_DIALOG_TAG"
 private const val CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG = "CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG"
+private const val CONFIRM_TRASH_POST_WITH_UNSAVED_CHANGES_DIALOG_TAG =
+        "CONFIRM_TRASH_POST_WITH_UNSAVED_CHANGES_DIALOG_TAG"
 private const val CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG = "CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG"
 private const val CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG = "CONFIRM_ON_AUTOSAVE_REVISION_DIALOG_TAG"
 private const val CONFIRM_SYNC_SCHEDULED_POST_DIALOG_TAG = "CONFIRM_SYNC_SCHEDULED_POST_DIALOG_TAG"
@@ -31,6 +33,7 @@ class PostListDialogHelper(
     private var localPostIdForDeleteDialog: Int? = null
     private var localPostIdForMoveTrashedPostToDraftDialog: Int? = null
     private var localPostIdForTrashPostWithLocalChangesDialog: Int? = null
+    private var localPostIdForTrashPostWithUnsavedChangesDialog: Int? = null
     private var localPostIdForConflictResolutionDialog: Int? = null
     private var localPostIdForAutosaveRevisionResolutionDialog: Int? = null
     private var localPostIdForScheduledPostSyncDialog: Int? = null
@@ -94,6 +97,21 @@ class PostListDialogHelper(
         showDialog.invoke(dialogHolder)
     }
 
+    fun showTrashPostWithUnsavedChangesConfirmationDialog(post: PostModel) {
+        if (!checkNetworkConnection.invoke()) {
+            return
+        }
+        val dialogHolder = DialogHolder(
+                tag = CONFIRM_TRASH_POST_WITH_UNSAVED_CHANGES_DIALOG_TAG,
+                title = UiStringRes(R.string.dialog_confirm_trash_losing_unsaved_changes_title),
+                message = UiStringRes(R.string.dialog_confirm_trash_losing_unsaved_changes_message),
+                positiveButton = UiStringRes(R.string.dialog_button_ok),
+                negativeButton = UiStringRes(R.string.dialog_button_cancel)
+        )
+        localPostIdForTrashPostWithUnsavedChangesDialog = post.id
+        showDialog.invoke(dialogHolder)
+    }
+
     fun showConflictedPostResolutionDialog(post: PostModel) {
         val dialogHolder = DialogHolder(
                 tag = CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG,
@@ -122,6 +140,7 @@ class PostListDialogHelper(
     fun onPositiveClickedForBasicDialog(
         instanceTag: String,
         trashPostWithLocalChanges: (Int) -> Unit,
+        trashPostWithUnsavedChanges: (Int) -> Unit,
         deletePost: (Int) -> Unit,
         publishPost: (Int) -> Unit,
         updateConflictedPostWithRemoteVersion: (Int) -> Unit,
@@ -145,6 +164,10 @@ class PostListDialogHelper(
             CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG -> localPostIdForTrashPostWithLocalChangesDialog?.let {
                 localPostIdForTrashPostWithLocalChangesDialog = null
                 trashPostWithLocalChanges(it)
+            }
+            CONFIRM_TRASH_POST_WITH_UNSAVED_CHANGES_DIALOG_TAG -> localPostIdForTrashPostWithUnsavedChangesDialog?.let {
+                localPostIdForTrashPostWithUnsavedChangesDialog = null
+                trashPostWithUnsavedChanges(it)
             }
             CONFIRM_RESTORE_TRASHED_POST_DIALOG_TAG -> localPostIdForMoveTrashedPostToDraftDialog?.let {
                 localPostIdForMoveTrashedPostToDraftDialog = null
@@ -171,6 +194,7 @@ class PostListDialogHelper(
             CONFIRM_DELETE_POST_DIALOG_TAG -> localPostIdForDeleteDialog = null
             CONFIRM_SYNC_SCHEDULED_POST_DIALOG_TAG -> localPostIdForScheduledPostSyncDialog = null
             CONFIRM_TRASH_POST_WITH_LOCAL_CHANGES_DIALOG_TAG -> localPostIdForTrashPostWithLocalChangesDialog = null
+            CONFIRM_TRASH_POST_WITH_UNSAVED_CHANGES_DIALOG_TAG -> localPostIdForTrashPostWithUnsavedChangesDialog = null
             CONFIRM_ON_CONFLICT_LOAD_REMOTE_POST_DIALOG_TAG -> localPostIdForConflictResolutionDialog?.let {
                 updateConflictedPostWithLocalVersion(it)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -418,6 +418,7 @@ class PostListMainViewModel @Inject constructor(
         postListDialogHelper.onPositiveClickedForBasicDialog(
                 instanceTag = instanceTag,
                 trashPostWithLocalChanges = postActionHandler::trashPostWithLocalChanges,
+                trashPostWithUnsavedChanges = postActionHandler::trashPostWithUnsavedChanges,
                 deletePost = postActionHandler::deletePost,
                 publishPost = postActionHandler::publishPost,
                 updateConflictedPostWithRemoteVersion = postConflictResolver::updateConflictedPostWithRemoteVersion,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -352,26 +352,28 @@ class PostListViewModel @Inject constructor(
         }?.index
     }
 
-    private fun transformPostModelToPostListItemUiState(post: PostModel) =
-            listItemUiStateHelper.createPostListItemUiState(
-                    authorFilterSelection,
-                    post = post,
-                    site = connector.site,
-                    unhandledConflicts = connector.doesPostHaveUnhandledConflict(post),
-                    hasAutoSave = connector.hasAutoSave(post),
-                    capabilitiesToPublish = uploadUtilsWrapper.userCanPublish(connector.site),
-                    statsSupported = isStatsSupported,
-                    featuredImageUrl =
-                    convertToPhotonUrlIfPossible(connector.getFeaturedImageUrl(post.featuredImageId)),
-                    formattedDate = PostUtils.getFormattedDate(post),
-                    performingCriticalAction = connector.postActionHandler.isPerformingCriticalAction(LocalId(post.id)),
-                    onAction = { postModel, buttonType, statEvent ->
-                        trackPostListAction(connector.site, buttonType, postModel, statEvent)
-                        connector.postActionHandler.handlePostButton(buttonType, postModel)
-                    },
-                    uploadStatusTracker = connector.uploadStatusTracker,
-                    isSearch = connector.postListType == SEARCH
-            )
+    private fun transformPostModelToPostListItemUiState(post: PostModel): PostListItemUiState {
+        val hasAutoSave = connector.hasAutoSave(post)
+        return listItemUiStateHelper.createPostListItemUiState(
+                authorFilterSelection,
+                post = post,
+                site = connector.site,
+                unhandledConflicts = connector.doesPostHaveUnhandledConflict(post),
+                hasAutoSave = hasAutoSave,
+                capabilitiesToPublish = uploadUtilsWrapper.userCanPublish(connector.site),
+                statsSupported = isStatsSupported,
+                featuredImageUrl =
+                convertToPhotonUrlIfPossible(connector.getFeaturedImageUrl(post.featuredImageId)),
+                formattedDate = PostUtils.getFormattedDate(post),
+                performingCriticalAction = connector.postActionHandler.isPerformingCriticalAction(LocalId(post.id)),
+                onAction = { postModel, buttonType, statEvent ->
+                    trackPostListAction(connector.site, buttonType, postModel, statEvent)
+                    connector.postActionHandler.handlePostButton(buttonType, postModel, hasAutoSave)
+                },
+                uploadStatusTracker = connector.uploadStatusTracker,
+                isSearch = connector.postListType == SEARCH
+        )
+    }
 
     private fun retryOnConnectionAvailableAfterRefreshError() {
         val connectionAvailableAfterRefreshError = networkUtilsWrapper.isNetworkAvailable() &&

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -371,6 +371,8 @@
     <!-- trash post with local changes dialog -->
     <string name="dialog_confirm_trash_losing_local_changes_title">Local changes</string>
     <string name="dialog_confirm_trash_losing_local_changes_message">Trashing this post will also discard local changes, are you sure you want to continue?</string>
+    <string name="dialog_confirm_trash_losing_unsaved_changes_title">Unsaved changes</string>
+    <string name="dialog_confirm_trash_losing_unsaved_changes_message">Trashing this post will also discard unsaved changes, are you sure you want to continue?</string>
 
     <!-- gutenberg informative dialog -->
     <string name="dialog_gutenberg_informative_title">Block Editor Enabled</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -370,7 +370,7 @@
 
     <!-- trash post with local changes dialog -->
     <string name="dialog_confirm_trash_losing_local_changes_title">Local changes</string>
-    <string name="dialog_confirm_trash_losing_local_changes_message">Trashing this post will discard local changes, are you sure you want to continue?</string>
+    <string name="dialog_confirm_trash_losing_local_changes_message">Trashing this post will also discard local changes, are you sure you want to continue?</string>
 
     <!-- gutenberg informative dialog -->
     <string name="dialog_gutenberg_informative_title">Block Editor Enabled</string>


### PR DESCRIPTION
Addresses, but does not fully fix #12165 ([relevant comment](https://github.com/wordpress-mobile/WordPress-Android/issues/12165#issuecomment-651799879)). First, this PR adds the word "also" to the confirmation dialog when deleting a post with local changes, "trashing" the post does not only just remove the local changes:

<img width="300" alt="Screen Shot 2020-07-06 at 4 08 25 PM" src="https://user-images.githubusercontent.com/4656348/86637583-cb52d800-bfa3-11ea-802d-d2e3adb12e11.png">

Second, this adds a similar dialog when deleting posts with unsaved changes to clarify the effect of trashing such a post (previously there was no confirmation dialog when deleting posts with unsaved changes):

<img width="300" alt="Screen Shot 2020-07-06 at 4 08 43 PM" src="https://user-images.githubusercontent.com/4656348/86637755-1a990880-bfa4-11ea-9fc3-c0130b944d8d.png">

### To Test

#### 1. Deleting Post With Local Changes
1. Open a published post on WPAndroid, make changes that are saved, and close the post without "updating" the published post.
2. Observe that the post list entry for the post states that it has "Local changes"
3. Tap More -> Trash for that post
4. Observe that a confirmation dialog appears that includes the word "also"
5. Tap Ok
6. Observe that the post is deleted

#### 2. Deleting Post With Unsaved Changes
1. Open a published post **on the web**, make changes to it, preview the post (to insure it autosaves), and close the post without "updating" the published post.
2. Open the post on WPAndroid
3. Observe that the post list entry for the post states "You've made unsaved changes to this post"
4. Tap More -> Trash for that post
5. Observe that a confirmation dialog appears stating that "Trashing this post will also discard unsaved changes, are you sure you want to continue?"
6. Tap "Cancel"
7. Observe that the post is **not** deleted
8. Tap More -> Trash for that post
9. Tap "Ok" this time when the confirmation dialog appears
10. Observe that the post is deleted

#### 3. Deleting "Normal" Post
1. Open a post that does not have either unsaved or local changes
2. Tap More -> Trash for that post
3. Observe that there is **not** a confirmation dialog and the post is immediately deleted.


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
