### PR TITLE
Zendesk unknown plan ids (0)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -414,9 +414,12 @@ private fun buildZendeskCustomFields(
     )
     allSites?.let {
         val planIds = it.map { site -> site.planId }.distinct()
-        val highestPlan = zendeskPlanFieldHelper.getHighestPlan(planIds)
-        if (highestPlan != UNKNOWN_PLAN) {
-            customFields.add(CustomField(TicketFieldIds.highestPlan, highestPlan))
+            .filter { planId -> planId != 0L }
+        if (planIds.isNotEmpty()) {
+            val highestPlan = zendeskPlanFieldHelper.getHighestPlan(planIds)
+            if (highestPlan != UNKNOWN_PLAN) {
+                customFields.add(CustomField(TicketFieldIds.highestPlan, highestPlan))
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #12340

I checked all linked issues - each one had an unknown plan id = 0 (`zendesk-unknown-plan-ids [0]`). There are few sites (e.g. self-hosted site) without any plan subscription for which `planId` is returned as 0. This PR filters 0 from `planIds` list used to find the highest plan for a user so that it doesn't unnecessarily get logged as an exception. 

To test:
- Create a new self-hosted site  (without jetpack, do not subscribe to any plan)
- Log in to WordPress app by entering this site address
- Go to Help -> My Tickets
- Create a ticket and notice that 0 doesn't get logged as an unknown id in Sentry.

Note:
Not sure which milestone to target. I think it'll be good if we can select milestone `15.2`.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
