### PR TITLE
Reblog action - snackbar messages

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -458,7 +458,7 @@ public class ReaderPostListFragment extends Fragment
         mViewModel.getSnackbarEvents().observe(getViewLifecycleOwner(), event ->
             event.applyIfNotHandled(holder -> {
                 WPSnackbar.make(
-                        requireActivity().findViewById(R.id.coordinator),
+                        requireView(),
                         holder.getMessageRes(),
                         Snackbar.LENGTH_LONG
                 ).show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -455,7 +455,18 @@ public class ReaderPostListFragment extends Fragment
                     return Unit.INSTANCE;
                 }));
 
-                mViewModel.start(mReaderViewModel);
+        mViewModel.getSnackbarEvents().observe(getViewLifecycleOwner(), event ->
+            event.applyIfNotHandled(holder -> {
+                WPSnackbar.make(
+                        requireActivity().findViewById(R.id.coordinator),
+                        holder.getMessageRes(),
+                        Snackbar.LENGTH_LONG
+                ).show();
+                return Unit.INSTANCE;
+            })
+        );
+
+        mViewModel.start(mReaderViewModel);
 
         if (isFollowingScreen()) {
             mSubFilterViewModel.onUserComesToReader();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.reader_discover_fragment_layout.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -26,6 +27,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReade
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 
 class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout) {
@@ -72,6 +74,11 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
                     is OpenEditorForReblog -> ActivityLauncher
                             .openEditorForReblog(activity, this.site, this.post, this.source)
                 }
+            }
+        })
+        viewModel.snackbarEvents.observe(viewLifecycleOwner, Observer {
+            it?.applyIfNotHandled {
+                WPSnackbar.make(constraint_layout, getString(this.messageRes), Snackbar.LENGTH_LONG).show()
             }
         })
         viewModel.start()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
+import org.wordpress.android.R
 import org.wordpress.android.datasets.ReaderPostTable
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.modules.BG_THREAD
@@ -146,8 +147,7 @@ class ReaderDiscoverViewModel @Inject constructor(
         if (navigationTarget != null) {
             _navigationEvents.postValue(Event(navigationTarget))
         }  else {
-            // TODO malinjir show toast R.string.reader_reblog_error
-            TODO()
+            _snackbarEvents.postValue(Event(SnackbarMessageHolder(R.string.reader_reblog_error)))
         }
         pendingReblogPost = null
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -94,7 +94,7 @@ class ReaderDiscoverViewModel @Inject constructor(
             _navigationEvents.value = event
         }
 
-        _snackbarEvents.addSource(readerPostCardActionsHandler.snackbarEvents) {event ->
+        _snackbarEvents.addSource(readerPostCardActionsHandler.snackbarEvents) { event ->
             _snackbarEvents.value = event
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.datasets.ReaderPostTable
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
@@ -37,6 +38,9 @@ class ReaderDiscoverViewModel @Inject constructor(
 
     private val _navigationEvents = MediatorLiveData<Event<ReaderNavigationEvents>>()
     val navigationEvents: LiveData<Event<ReaderNavigationEvents>> = _navigationEvents
+
+    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
     /**
      * Post which is about to be reblogged after the user selects a target site.
@@ -87,6 +91,10 @@ class ReaderDiscoverViewModel @Inject constructor(
                 pendingReblogPost = target.post
             }
             _navigationEvents.value = event
+        }
+
+        _snackbarEvents.addSource(readerPostCardActionsHandler.snackbarEvents) {event ->
+            _snackbarEvents.value = event
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -3,9 +3,11 @@ package org.wordpress.android.ui.reader.discover
 import android.content.ActivityNotFoundException
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTICLE_VISITED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.SHARED_ITEM_READER
 import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.SharePost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
@@ -31,6 +33,9 @@ class ReaderPostCardActionsHandler @Inject constructor(
 ) {
     private val _navigationEvents = MutableLiveData<Event<ReaderNavigationEvents>>()
     val navigationEvents: LiveData<Event<ReaderNavigationEvents>> = _navigationEvents
+
+    private val _snackbarEvents = MutableLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
     fun onAction(post: ReaderPost, type: ReaderPostCardActionType) {
         when (type) {
@@ -59,7 +64,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
         try {
             _navigationEvents.postValue(Event(SharePost(post)))
         } catch (ex: ActivityNotFoundException) {
-            // TODO malinjir show toast - R.string.reader_toast_err_share_intent
+            _snackbarEvents.postValue(Event(SnackbarMessageHolder(R.string.reader_toast_err_share_intent)))
         }
     }
 
@@ -86,8 +91,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
         if (navigationTarget != null) {
             _navigationEvents.postValue(Event(navigationTarget))
         } else {
-            // TODO malinjir show toast R.string.reader_reblog_error
-            TODO()
+            _snackbarEvents.postValue(Event(SnackbarMessageHolder(R.string.reader_reblog_error)))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -60,7 +60,7 @@ class ReaderPostListViewModel @Inject constructor(
             _navigationEvents.value = event
         }
 
-        _snackbarEvents.addSource(readerPostCardActionsHandler.snackbarEvents) {event ->
+        _snackbarEvents.addSource(readerPostCardActionsHandler.snackbarEvents) { event ->
             _snackbarEvents.value = event
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -3,8 +3,10 @@ package org.wordpress.android.ui.reader.viewmodels
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.R
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
@@ -35,6 +37,9 @@ class ReaderPostListViewModel @Inject constructor(
     private val _navigationEvents = MediatorLiveData<Event<ReaderNavigationEvents>>()
     val navigationEvents: LiveData<Event<ReaderNavigationEvents>> = _navigationEvents
 
+    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
     fun start(readerViewModel: ReaderViewModel?) {
         this.readerViewModel = readerViewModel
 
@@ -53,6 +58,10 @@ class ReaderPostListViewModel @Inject constructor(
                 pendingReblogPost = target.post
             }
             _navigationEvents.value = event
+        }
+
+        _snackbarEvents.addSource(readerPostCardActionsHandler.snackbarEvents) {event ->
+            _snackbarEvents.value = event
         }
     }
 
@@ -76,8 +85,7 @@ class ReaderPostListViewModel @Inject constructor(
         if (navigationTarget != null) {
             _navigationEvents.postValue(Event(navigationTarget))
         }  else {
-            // TODO malinjir show toast R.string.reader_reblog_error
-            TODO()
+            _snackbarEvents.postValue(Event(SnackbarMessageHolder(R.string.reader_reblog_error)))
         }
         pendingReblogPost = null
     }

--- a/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/constraint_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:animateLayoutChanges="true">


### PR DESCRIPTION
Parent issue #12028 

Merge instructions:
1. Review this PR
2. Review https://github.com/wordpress-mobile/WordPress-Android/pull/12357
3. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/12357 is merged
4. Update target branch to `develop`
3. Remove "Not ready for merge" label
3. Merge this PR

This PR implements snackbar messages used for propagating errors to the user in ReaderDiscoverFragment and ReaderPostListFragment.

To test:
I'm not sure how to easily test this without modifying the code. I'd recommend manually change the code and test "reblog" action.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
