### PR TITLE
WordPress Stories : Only show Status & Visibility section for non story posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
@@ -75,14 +75,17 @@ class PrepublishingHomeViewModel @Inject constructor(
                 add(HeaderUiState(UiStringText(site.name), StringUtils.notNullStr(site.iconUrl)))
             }
 
-            add(
-                    HomeUiState(
-                            actionType = VISIBILITY,
-                            actionResult = getPostVisibilityUseCase.getVisibility(editPostRepository).textRes,
-                            actionClickable = true,
-                            onActionClicked = ::onActionClicked
-                    )
-            )
+            if (!isStoryPost) {
+                add(
+                        HomeUiState(
+                                actionType = VISIBILITY,
+                                actionResult = getPostVisibilityUseCase.getVisibility(editPostRepository).textRes,
+                                actionClickable = true,
+                                onActionClicked = ::onActionClicked
+                        )
+                )
+            }
+
             if (editPostRepository.status != PostStatus.PRIVATE) {
                 add(
                         HomeUiState(

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
@@ -386,6 +386,32 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
         verify(storyRepositoryWrapper).setCurrentStoryTitle(eq(storyTitle))
     }
 
+    @Test
+    fun `verify that if isStoryPost is true then VISIBILITY UiState does not exist`() {
+        // arrange
+        val isStoryPost = true
+
+        // act
+        viewModel.start(editPostRepository, site, isStoryPost)
+        val visibilityAction = getHomeUiState(VISIBILITY)
+
+        // assert
+        assertThat(visibilityAction).isNull()
+    }
+
+    @Test
+    fun `verify that if isStoryPost is false then VISIBILITY UiState exist`() {
+        // arrange
+        val isStoryPost = false
+
+        // act
+        viewModel.start(editPostRepository, site, isStoryPost)
+        val visibilityAction = getHomeUiState(VISIBILITY)
+
+        // assert
+        assertThat(visibilityAction).isNotNull()
+    }
+
     private fun getHeaderUiState() = viewModel.uiState.value?.filterIsInstance(HeaderUiState::class.java)?.first()
     private fun getStoryTitleUiState() = getStoryTitleUiStateList()?.first()
     private fun getStoryTitleUiStateList() =


### PR DESCRIPTION
Fixes #12367

## Solution
The way how the `ViewModel` constructs UI state allowed me to simply check if a post is a story and if so then the Status section isn't shown. 

Utilizing this solution gets rids of the issue where the user is able to change the `PostStatus` and experience an unintended UI/UX. 

## Testing
1. Create a new blog post or page. 
2. Click Publish. 
3. Ensure that the `Status & Visibility` section is visible. 

-----------
1. Create a new story post. 
2. Click Publish. 
3. Ensure that the `Status & Visibility` section does not exist. 

Before | After 
--------|-------
  <kbd><img src="https://user-images.githubusercontent.com/1509205/86850135-61573300-c076-11ea-8057-e30924dfbe2a.png" width="320"></kbd>   |   <kbd><img src="https://user-images.githubusercontent.com/1509205/86850141-67e5aa80-c076-11ea-85ad-8581e48b2e98.png" width="320"></kbd>

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
