### PR TITLE
Update Gutenberg to version 1.32.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 15.3
 -----
 * [*] Improve wording for confirmation dialogs when trashing posts
+* [***] Block Editor: Adds Copy, Cut, Paste, and Duplicate functionality to blocks
+* [***] Block Editor: The block editor now gives users the ability to individually edit unsupported blocks found in posts or pages. 
  
 15.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 * [*] Improve wording for confirmation dialogs when trashing posts
 * [***] Block Editor: Adds Copy, Cut, Paste, and Duplicate functionality to blocks
-* [***] Block Editor: Users can now individually edit unsupported blocks found in posts or pages. Not available on Jetpack connected self-hosted sites.
+* [***] Block Editor: Users can now individually edit unsupported blocks found in posts or pages. Not available on self-hosted sites.
  
 15.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 * [*] Improve wording for confirmation dialogs when trashing posts
 * [***] Block Editor: Adds Copy, Cut, Paste, and Duplicate functionality to blocks
-* [***] Block Editor: Users can now individually edit unsupported blocks found in posts or pages. Not available on self-hosted sites.
+* [***] Block Editor: Users can now individually edit unsupported blocks found in posts or pages. Not available on self-hosted sites or sites defaulted to classic editor.
  
 15.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 * [*] Improve wording for confirmation dialogs when trashing posts
 * [***] Block Editor: Adds Copy, Cut, Paste, and Duplicate functionality to blocks
-* [***] Block Editor: The block editor now gives users the ability to individually edit unsupported blocks found in posts or pages. 
+* [***] Block Editor: Users can now individually edit unsupported blocks found in posts or pages. Not available on Jetpack connected self-hosted sites.
  
 15.2
 -----

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -71,6 +71,7 @@ android {
         buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "true"
         buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "10"
         buildConfigField "boolean", "FEATURE_ANNOUNCEMENT_AVAILABLE", "false"
+        buildConfigField "boolean", "GUTENBERG_MENTIONS", "true"
     }
 
     // Gutenberg's dependency - react-native-video is using
@@ -94,6 +95,7 @@ android {
             buildConfigField "boolean", "TENOR_AVAILABLE", "false"
             buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
+            buildConfigField "boolean", "GUTENBERG_MENTIONS", "false"
         }
 
         zalpha { // alpha version - enable experimental features

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2017,6 +2017,14 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);
                         Bundle themeBundle = (editorTheme != null) ? editorTheme.getThemeSupport().toBundle() : null;
 
+                        // The Unsupported Block Editor is disabled for self-hosted sites
+                        // that are connected via Jetpack to a WP.com account.
+                        // This is because we don't have the self-hosted site's credentials
+                        // which are required for us to be able to fetch the site's authentication cookie.
+                        // This cookie is needed to authenticate the network request
+                        // that fetches the unsupported block editor web page.
+                        boolean isUnsupportedBlockEditorEnabled = mSite.isWPComAtomic() || !mSite.isJetpackConnected();
+
                         return GutenbergEditorFragment.newInstance(
                                 "",
                                 "",
@@ -2034,7 +2042,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                                 themeBundle,
                                 WordPress.getUserAgent(),
                                 mTenorFeatureConfig.isEnabled(),
-                                mSite.isJetpackConnected()
+                                isUnsupportedBlockEditorEnabled
                         );
                     } else {
                         // If gutenberg editor is not selected, default to Aztec.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2024,9 +2024,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         // to be set to classic and then the fallback will not work.
                         // We disable in Jetpack site because we don't have the self-hosted site's credentials
                         // which are required for us to be able to fetch the site's authentication cookie.
-                        boolean isUnsupportedBlockEditorEnabled =
-                                (mSite.isWPComAtomic() || !mSite.isJetpackConnected())
-                                && mSite.getWebEditor().equals("gutenberg");
+                        boolean isUnsupportedBlockEditorEnabled = isWpCom && "gutenberg".equals(mSite.getWebEditor());
 
                         return GutenbergEditorFragment.newInstance(
                                 "",

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2018,13 +2018,15 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);
                         Bundle themeBundle = (editorTheme != null) ? editorTheme.getThemeSupport().toBundle() : null;
 
-                        // The Unsupported Block Editor is disabled for self-hosted sites
-                        // that are connected via Jetpack to a WP.com account.
-                        // This is because we don't have the self-hosted site's credentials
+                        // The Unsupported Block Editor is disabled for all self-hosted sites
+                        // even the one that are connected via Jetpack to a WP.com account.
+                        // The option is disabled on Self-hosted sites because they can have their web editor
+                        // to be set to classic and then the fallback will not work.
+                        // We disable in Jetpack site because we don't have the self-hosted site's credentials
                         // which are required for us to be able to fetch the site's authentication cookie.
-                        // This cookie is needed to authenticate the network request
-                        // that fetches the unsupported block editor web page.
-                        boolean isUnsupportedBlockEditorEnabled = mSite.isWPComAtomic() || !mSite.isJetpackConnected();
+                        boolean isUnsupportedBlockEditorEnabled =
+                                (mSite.isWPComAtomic() || !mSite.isJetpackConnected())
+                                && mSite.getWebEditor().equals("gutenberg");
 
                         return GutenbergEditorFragment.newInstance(
                                 "",

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -187,6 +187,7 @@ import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
+import org.wordpress.android.util.config.GutenbergMentionsFeatureConfig;
 import org.wordpress.android.util.config.TenorFeatureConfig;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
@@ -367,6 +368,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     @Inject AnalyticsTrackerWrapper mAnalyticsTrackerWrapper;
     @Inject PublishPostImmediatelyUseCase mPublishPostImmediatelyUseCase;
     @Inject TenorFeatureConfig mTenorFeatureConfig;
+    @Inject GutenbergMentionsFeatureConfig mGutenbergMentionsFeatureConfig;
 
     private StorePostViewModel mViewModel;
 
@@ -2010,7 +2012,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         String postType = mIsPage ? "page" : "post";
                         String languageString = LocaleManager.getLanguage(EditPostActivity.this);
                         String wpcomLocaleSlug = languageString.replace("_", "-").toLowerCase(Locale.ENGLISH);
-                        boolean supportsStockPhotos = mSite.isUsingWpComRestApi();
                         boolean isWpCom = getSite().isWPCom() || mSite.isPrivateWPComAtomic() || mSite.isWPComAtomic();
                         boolean isSiteUsingWpComRestApi = mSite.isUsingWpComRestApi();
 
@@ -2031,7 +2032,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
                                 postType,
                                 mIsNewPost,
                                 wpcomLocaleSlug,
-                                supportsStockPhotos,
                                 mSite.getUrl(),
                                 !isWpCom,
                                 isWpCom ? mAccountStore.getAccount().getUserId() : mSite.getSelfHostedSiteId(),
@@ -2042,7 +2042,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
                                 themeBundle,
                                 WordPress.getUserAgent(),
                                 mTenorFeatureConfig.isEnabled(),
-                                isUnsupportedBlockEditorEnabled
+                                isUnsupportedBlockEditorEnabled,
+                                mGutenbergMentionsFeatureConfig.isEnabled()
                         );
                     } else {
                         // If gutenberg editor is not selected, default to Aztec.

--- a/WordPress/src/main/java/org/wordpress/android/util/config/GutenbergMentionsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/GutenbergMentionsFeatureConfig.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import javax.inject.Inject
+
+class GutenbergMentionsFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.GUTENBERG_MENTIONS)

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -37,6 +37,7 @@ public class GutenbergContainerFragment extends Fragment {
     private static final String ARG_EDITOR_THEME = "param_editor_theme";
     private static final String ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED =
             "param_site_is_unsupported_block_editor_enabled";
+    private static final String ARG_ENABLE_MENTIONS_FLAG = "param_enable_mentions_flag";
 
     private boolean mHtmlModeEnabled;
     private boolean mHasReceivedAnyContent;
@@ -49,7 +50,8 @@ public class GutenbergContainerFragment extends Fragment {
                                                          boolean isDarkMode,
                                                          boolean isSiteUsingWpComRestApi,
                                                          Bundle editorTheme,
-                                                         boolean isUnsupportedBlockEditorEnabled) {
+                                                         boolean isUnsupportedBlockEditorEnabled,
+                                                         boolean enableMentionsFlag) {
         GutenbergContainerFragment fragment = new GutenbergContainerFragment();
         Bundle args = new Bundle();
         args.putString(ARG_POST_TYPE, postType);
@@ -60,6 +62,7 @@ public class GutenbergContainerFragment extends Fragment {
         args.putBoolean(ARG_SITE_USING_WPCOM_REST_API, isSiteUsingWpComRestApi);
         args.putBundle(ARG_EDITOR_THEME, editorTheme);
         args.putBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED, isUnsupportedBlockEditorEnabled);
+        args.putBoolean(ARG_ENABLE_MENTIONS_FLAG, enableMentionsFlag);
         fragment.setArguments(args);
         return fragment;
     }
@@ -112,6 +115,7 @@ public class GutenbergContainerFragment extends Fragment {
         Bundle editorTheme = getArguments().getBundle(ARG_EDITOR_THEME);
         boolean isUnsupportedBlockEditorEnabled =
                 getArguments().getBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED);
+        boolean enableMentionsFlag = getArguments().getBoolean(ARG_ENABLE_MENTIONS_FLAG);
 
         Consumer<Exception> exceptionLogger = null;
         Consumer<String> breadcrumbLogger = null;
@@ -139,7 +143,8 @@ public class GutenbergContainerFragment extends Fragment {
                 breadcrumbLogger,
                 isSiteUsingWpComRestApi,
                 editorTheme,
-                isUnsupportedBlockEditorEnabled);
+                isUnsupportedBlockEditorEnabled,
+                enableMentionsFlag);
 
         // clear the content initialization flag since a new ReactRootView has been created;
         mHasReceivedAnyContent = false;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -35,7 +35,8 @@ public class GutenbergContainerFragment extends Fragment {
     private static final String ARG_PREFERRED_COLOR_SCHEME = "param_preferred_color_scheme";
     private static final String ARG_SITE_USING_WPCOM_REST_API = "param_site_using_wpcom_rest_api";
     private static final String ARG_EDITOR_THEME = "param_editor_theme";
-    private static final String ARG_SITE_JETPACK_IS_CONNECTED = "param_site_jetpack_is_connected";
+    private static final String ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED =
+            "param_site_is_unsupported_block_editor_enabled";
 
     private boolean mHtmlModeEnabled;
     private boolean mHasReceivedAnyContent;
@@ -48,7 +49,7 @@ public class GutenbergContainerFragment extends Fragment {
                                                          boolean isDarkMode,
                                                          boolean isSiteUsingWpComRestApi,
                                                          Bundle editorTheme,
-                                                         boolean siteJetpackIsConnected) {
+                                                         boolean isUnsupportedBlockEditorEnabled) {
         GutenbergContainerFragment fragment = new GutenbergContainerFragment();
         Bundle args = new Bundle();
         args.putString(ARG_POST_TYPE, postType);
@@ -58,7 +59,7 @@ public class GutenbergContainerFragment extends Fragment {
         args.putBoolean(ARG_PREFERRED_COLOR_SCHEME, isDarkMode);
         args.putBoolean(ARG_SITE_USING_WPCOM_REST_API, isSiteUsingWpComRestApi);
         args.putBundle(ARG_EDITOR_THEME, editorTheme);
-        args.putBoolean(ARG_SITE_JETPACK_IS_CONNECTED, siteJetpackIsConnected);
+        args.putBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED, isUnsupportedBlockEditorEnabled);
         fragment.setArguments(args);
         return fragment;
     }
@@ -109,7 +110,8 @@ public class GutenbergContainerFragment extends Fragment {
         boolean isDarkMode = getArguments().getBoolean(ARG_PREFERRED_COLOR_SCHEME);
         boolean isSiteUsingWpComRestApi = getArguments().getBoolean(ARG_SITE_USING_WPCOM_REST_API);
         Bundle editorTheme = getArguments().getBundle(ARG_EDITOR_THEME);
-        boolean siteJetpackIsConnected = getArguments().getBoolean(ARG_SITE_JETPACK_IS_CONNECTED);
+        boolean isUnsupportedBlockEditorEnabled =
+                getArguments().getBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED);
 
         Consumer<Exception> exceptionLogger = null;
         Consumer<String> breadcrumbLogger = null;
@@ -137,7 +139,7 @@ public class GutenbergContainerFragment extends Fragment {
                 breadcrumbLogger,
                 isSiteUsingWpComRestApi,
                 editorTheme,
-                siteJetpackIsConnected);
+                isUnsupportedBlockEditorEnabled);
 
         // clear the content initialization flag since a new ReactRootView has been created;
         mHasReceivedAnyContent = false;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -77,7 +77,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private static final String ARG_POST_TYPE = "param_post_type";
     private static final String ARG_IS_NEW_POST = "param_is_new_post";
     private static final String ARG_LOCALE_SLUG = "param_locale_slug";
-    private static final String ARG_SUPPORT_STOCK_PHOTOS = "param_support_stock_photos";
     private static final String ARG_SITE_URL = "param_site_url";
     private static final String ARG_IS_SITE_PRIVATE = "param_is_site_private";
     private static final String ARG_SITE_USER_ID = "param_user_id";
@@ -88,6 +87,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private static final String ARG_EDITOR_THEME = "param_editor_theme";
     private static final String ARG_SITE_USER_AGENT = "param_user_agent";
     private static final String ARG_TENOR_ENABLED = "param_tenor_enabled";
+    private static final String ARG_ENABLE_MENTIONS_FLAG = "param_enable_mentions_flag";
     private static final String ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED =
             "param_site_is_unsupported_block_editor_enabled";
 
@@ -127,7 +127,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                                                       String postType,
                                                       boolean isNewPost,
                                                       String localeSlug,
-                                                      boolean supportStockPhotos,
                                                       String siteUrl,
                                                       boolean isPrivate,
                                                       long userId,
@@ -138,7 +137,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                                                       @Nullable Bundle editorTheme,
                                                       String userAgent,
                                                       boolean tenorEnabled,
-                                                      boolean isUnsupportedBlockEditorEnabled) {
+                                                      boolean isUnsupportedBlockEditorEnabled,
+                                                      boolean enableMentionsFlag) {
         GutenbergEditorFragment fragment = new GutenbergEditorFragment();
         Bundle args = new Bundle();
         args.putString(ARG_PARAM_TITLE, title);
@@ -146,7 +146,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         args.putString(ARG_POST_TYPE, postType);
         args.putBoolean(ARG_IS_NEW_POST, isNewPost);
         args.putString(ARG_LOCALE_SLUG, localeSlug);
-        args.putBoolean(ARG_SUPPORT_STOCK_PHOTOS, supportStockPhotos);
         args.putString(ARG_SITE_URL, siteUrl);
         args.putBoolean(ARG_IS_SITE_PRIVATE, isPrivate);
         args.putLong(ARG_SITE_USER_ID, userId);
@@ -157,6 +156,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         args.putBundle(ARG_EDITOR_THEME, editorTheme);
         args.putString(ARG_SITE_USER_AGENT, userAgent);
         args.putBoolean(ARG_TENOR_ENABLED, tenorEnabled);
+        args.putBoolean(ARG_ENABLE_MENTIONS_FLAG, enableMentionsFlag);
         args.putBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED, isUnsupportedBlockEditorEnabled);
         fragment.setArguments(args);
         return fragment;
@@ -260,18 +260,21 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             boolean isSiteUsingWpComRestApi = getArguments().getBoolean(ARG_SITE_USING_WPCOM_REST_API);
             Bundle editorTheme = getArguments().getBundle(ARG_EDITOR_THEME);
             boolean siteJetpackIsConnected = getArguments().getBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED);
+            boolean enableMentionsFlag = getArguments().getBoolean(ARG_ENABLE_MENTIONS_FLAG);
 
             FragmentManager fragmentManager = getChildFragmentManager();
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
             GutenbergContainerFragment gutenbergContainerFragment =
-                    GutenbergContainerFragment.newInstance(postType,
+                    GutenbergContainerFragment.newInstance(
+                            postType,
                             isNewPost,
                             localeSlug,
                             getTranslations(),
                             isDarkMode(),
                             isSiteUsingWpComRestApi,
                             editorTheme,
-                            siteJetpackIsConnected);
+                            siteJetpackIsConnected,
+                            enableMentionsFlag);
             gutenbergContainerFragment.setRetainInstance(true);
             fragmentTransaction.add(gutenbergContainerFragment, GutenbergContainerFragment.TAG);
             fragmentTransaction.commitNow();

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -88,7 +88,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private static final String ARG_EDITOR_THEME = "param_editor_theme";
     private static final String ARG_SITE_USER_AGENT = "param_user_agent";
     private static final String ARG_TENOR_ENABLED = "param_tenor_enabled";
-    private static final String ARG_SITE_JETPACK_IS_CONNECTED = "param_site_jetpack_is_connected";
+    private static final String ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED =
+            "param_site_is_unsupported_block_editor_enabled";
 
     private static final int CAPTURE_PHOTO_PERMISSION_REQUEST_CODE = 101;
     private static final int CAPTURE_VIDEO_PERMISSION_REQUEST_CODE = 102;
@@ -137,7 +138,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                                                       @Nullable Bundle editorTheme,
                                                       String userAgent,
                                                       boolean tenorEnabled,
-                                                      boolean siteIsJetpackConnected) {
+                                                      boolean isUnsupportedBlockEditorEnabled) {
         GutenbergEditorFragment fragment = new GutenbergEditorFragment();
         Bundle args = new Bundle();
         args.putString(ARG_PARAM_TITLE, title);
@@ -156,7 +157,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         args.putBundle(ARG_EDITOR_THEME, editorTheme);
         args.putString(ARG_SITE_USER_AGENT, userAgent);
         args.putBoolean(ARG_TENOR_ENABLED, tenorEnabled);
-        args.putBoolean(ARG_SITE_JETPACK_IS_CONNECTED, siteIsJetpackConnected);
+        args.putBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED, isUnsupportedBlockEditorEnabled);
         fragment.setArguments(args);
         return fragment;
     }
@@ -258,7 +259,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             String localeSlug = getArguments().getString(ARG_LOCALE_SLUG);
             boolean isSiteUsingWpComRestApi = getArguments().getBoolean(ARG_SITE_USING_WPCOM_REST_API);
             Bundle editorTheme = getArguments().getBundle(ARG_EDITOR_THEME);
-            boolean siteJetpackIsConnected = getArguments().getBoolean(ARG_SITE_JETPACK_IS_CONNECTED);
+            boolean siteJetpackIsConnected = getArguments().getBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED);
 
             FragmentManager fragmentManager = getChildFragmentManager();
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();


### PR DESCRIPTION
Update Gutenberg to version 1.32.0

To test:
 - Smoke test the block editor writing flow.
 - Test Copy, Cut, Paste, and Duplicate functionality to blocks
 - Test mentions insertion ( this will be under a feature flag and it's only for internal testing)
 - Improved editor loading experience with Ghost Effect.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
