### PR TITLE
Modify background color

### DIFF
--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -318,7 +318,7 @@
     <color name="reader_following_empty_view_left_lower_plus">@color/pink_0</color>
     <color name="reader_following_empty_view_outline">@color/gray_10</color>
     <color name="reader_following_empty_view_middle_plus">@android:color/white</color>
-    <color name="reader_following_empty_view_background">@android:color/white</color>
+    <color name="reader_following_empty_view_background">@color/background_default</color>
 
     <!--Reader Post Card -->
     <color name="reader_post_list_background">@color/neutral_0</color>


### PR DESCRIPTION
Fixes a bug with the Following tab empty view background not matching the page background when in light mode..

To test:
1. Sign in to the app using an account that is not following any sites
2. Navigate to the Reader
3. Tap the Following tab
4. The empty view background show blend into the page background

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
