### PR TITLE
Fetch WPCom sites on Jetpack connect instead of updating current site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionResultActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionResultActivity.java
@@ -132,7 +132,7 @@ public class JetpackConnectionResultActivity extends LocaleAwareActivity {
     private void finishAndGoBackToSource() {
         if (mSource == JetpackConnectionSource.STATS) {
             SiteModel site = (SiteModel) getIntent().getSerializableExtra(SITE);
-            mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(site));
+            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
             ActivityLauncher.viewBlogStatsAfterJetpackSetup(this, site);
         }
         finish();


### PR DESCRIPTION
Fixes #12112 

This was a very tricky bug. The issue is that when we call `newFetchSiteAction(site)` we end up in this clause in the FluxC code: 
```
if (site.isUsingWpComRestApi()) {
            mSiteRestClient.fetchSite(site);
        } else {
            mSiteXMLRPCClient.fetchSite(site);
        }
```
Since the site object is not using WPCom rest API yet when the Jetpack installation finishes, the code jumps into the `else` clause and retrieves the current site object from the XMLRPC instead of correctly loading it from the WPCom API (it should be there since Jetpack is already connected). 

This fix replaces the call to fetch the single updated site with a call to load all sites for the logged in user. This correctly downloads the WPCom sites including the self-hosted one that was just connected to Jetpack.

To test:
- Log in with a self-hosted site without Jetpack
- Go to Stats
- Go through the Jetpack installation/connection flow
- You end up being in Stats
- Go back to the My Site fragment
- Notice that the "Plugins" item in the menu is now visible

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
