### PR TITLE
Hide @-mentions feature on Gutenberg for Vanilla builds

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -71,6 +71,7 @@ android {
         buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "true"
         buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "10"
         buildConfigField "boolean", "FEATURE_ANNOUNCEMENT_AVAILABLE", "false"
+        buildConfigField "boolean", "GUTENBERG_MENTIONS", "true"
     }
 
     // Gutenberg's dependency - react-native-video is using
@@ -94,6 +95,7 @@ android {
             buildConfigField "boolean", "TENOR_AVAILABLE", "false"
             buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
+            buildConfigField "boolean", "GUTENBERG_MENTIONS", "false"
         }
 
         zalpha { // alpha version - enable experimental features

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -187,6 +187,7 @@ import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
+import org.wordpress.android.util.config.GutenbergMentionsFeatureConfig;
 import org.wordpress.android.util.config.TenorFeatureConfig;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
@@ -367,6 +368,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     @Inject AnalyticsTrackerWrapper mAnalyticsTrackerWrapper;
     @Inject PublishPostImmediatelyUseCase mPublishPostImmediatelyUseCase;
     @Inject TenorFeatureConfig mTenorFeatureConfig;
+    @Inject GutenbergMentionsFeatureConfig mGutenbergMentionsFeatureConfig;
 
     private StorePostViewModel mViewModel;
 
@@ -2010,7 +2012,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         String postType = mIsPage ? "page" : "post";
                         String languageString = LocaleManager.getLanguage(EditPostActivity.this);
                         String wpcomLocaleSlug = languageString.replace("_", "-").toLowerCase(Locale.ENGLISH);
-                        boolean supportsStockPhotos = mSite.isUsingWpComRestApi();
                         boolean isWpCom = getSite().isWPCom() || mSite.isPrivateWPComAtomic() || mSite.isWPComAtomic();
                         boolean isSiteUsingWpComRestApi = mSite.isUsingWpComRestApi();
 
@@ -2023,7 +2024,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
                                 postType,
                                 mIsNewPost,
                                 wpcomLocaleSlug,
-                                supportsStockPhotos,
                                 mSite.getUrl(),
                                 !isWpCom,
                                 isWpCom ? mAccountStore.getAccount().getUserId() : mSite.getSelfHostedSiteId(),
@@ -2034,7 +2034,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
                                 themeBundle,
                                 WordPress.getUserAgent(),
                                 mTenorFeatureConfig.isEnabled(),
-                                mSite.isJetpackConnected()
+                                mSite.isJetpackConnected(),
+                                mGutenbergMentionsFeatureConfig.isEnabled()
                         );
                     } else {
                         // If gutenberg editor is not selected, default to Aztec.

--- a/WordPress/src/main/java/org/wordpress/android/util/config/GutenbergMentionsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/GutenbergMentionsFeatureConfig.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import javax.inject.Inject
+
+class GutenbergMentionsFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.GUTENBERG_MENTIONS)

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -36,6 +36,7 @@ public class GutenbergContainerFragment extends Fragment {
     private static final String ARG_SITE_USING_WPCOM_REST_API = "param_site_using_wpcom_rest_api";
     private static final String ARG_EDITOR_THEME = "param_editor_theme";
     private static final String ARG_SITE_JETPACK_IS_CONNECTED = "param_site_jetpack_is_connected";
+    private static final String ARG_ENABLE_MENTIONS_FLAG = "param_enable_mentions_flag";
 
     private boolean mHtmlModeEnabled;
     private boolean mHasReceivedAnyContent;
@@ -48,7 +49,8 @@ public class GutenbergContainerFragment extends Fragment {
                                                          boolean isDarkMode,
                                                          boolean isSiteUsingWpComRestApi,
                                                          Bundle editorTheme,
-                                                         boolean siteJetpackIsConnected) {
+                                                         boolean siteJetpackIsConnected,
+                                                         boolean enableMentionsFlag) {
         GutenbergContainerFragment fragment = new GutenbergContainerFragment();
         Bundle args = new Bundle();
         args.putString(ARG_POST_TYPE, postType);
@@ -59,6 +61,7 @@ public class GutenbergContainerFragment extends Fragment {
         args.putBoolean(ARG_SITE_USING_WPCOM_REST_API, isSiteUsingWpComRestApi);
         args.putBundle(ARG_EDITOR_THEME, editorTheme);
         args.putBoolean(ARG_SITE_JETPACK_IS_CONNECTED, siteJetpackIsConnected);
+        args.putBoolean(ARG_ENABLE_MENTIONS_FLAG, enableMentionsFlag);
         fragment.setArguments(args);
         return fragment;
     }
@@ -110,6 +113,7 @@ public class GutenbergContainerFragment extends Fragment {
         boolean isSiteUsingWpComRestApi = getArguments().getBoolean(ARG_SITE_USING_WPCOM_REST_API);
         Bundle editorTheme = getArguments().getBundle(ARG_EDITOR_THEME);
         boolean siteJetpackIsConnected = getArguments().getBoolean(ARG_SITE_JETPACK_IS_CONNECTED);
+        boolean enableMentionsFlag = getArguments().getBoolean(ARG_ENABLE_MENTIONS_FLAG);
 
         Consumer<Exception> exceptionLogger = null;
         Consumer<String> breadcrumbLogger = null;
@@ -137,7 +141,8 @@ public class GutenbergContainerFragment extends Fragment {
                 breadcrumbLogger,
                 isSiteUsingWpComRestApi,
                 editorTheme,
-                siteJetpackIsConnected);
+                siteJetpackIsConnected,
+                enableMentionsFlag);
 
         // clear the content initialization flag since a new ReactRootView has been created;
         mHasReceivedAnyContent = false;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -77,7 +77,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private static final String ARG_POST_TYPE = "param_post_type";
     private static final String ARG_IS_NEW_POST = "param_is_new_post";
     private static final String ARG_LOCALE_SLUG = "param_locale_slug";
-    private static final String ARG_SUPPORT_STOCK_PHOTOS = "param_support_stock_photos";
     private static final String ARG_SITE_URL = "param_site_url";
     private static final String ARG_IS_SITE_PRIVATE = "param_is_site_private";
     private static final String ARG_SITE_USER_ID = "param_user_id";
@@ -89,6 +88,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private static final String ARG_SITE_USER_AGENT = "param_user_agent";
     private static final String ARG_TENOR_ENABLED = "param_tenor_enabled";
     private static final String ARG_SITE_JETPACK_IS_CONNECTED = "param_site_jetpack_is_connected";
+    private static final String ARG_ENABLE_MENTIONS_FLAG = "param_enable_mentions_flag";
 
     private static final int CAPTURE_PHOTO_PERMISSION_REQUEST_CODE = 101;
     private static final int CAPTURE_VIDEO_PERMISSION_REQUEST_CODE = 102;
@@ -126,7 +126,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                                                       String postType,
                                                       boolean isNewPost,
                                                       String localeSlug,
-                                                      boolean supportStockPhotos,
                                                       String siteUrl,
                                                       boolean isPrivate,
                                                       long userId,
@@ -137,7 +136,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                                                       @Nullable Bundle editorTheme,
                                                       String userAgent,
                                                       boolean tenorEnabled,
-                                                      boolean siteIsJetpackConnected) {
+                                                      boolean siteIsJetpackConnected,
+                                                      boolean enableMentionsFlag) {
         GutenbergEditorFragment fragment = new GutenbergEditorFragment();
         Bundle args = new Bundle();
         args.putString(ARG_PARAM_TITLE, title);
@@ -145,7 +145,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         args.putString(ARG_POST_TYPE, postType);
         args.putBoolean(ARG_IS_NEW_POST, isNewPost);
         args.putString(ARG_LOCALE_SLUG, localeSlug);
-        args.putBoolean(ARG_SUPPORT_STOCK_PHOTOS, supportStockPhotos);
         args.putString(ARG_SITE_URL, siteUrl);
         args.putBoolean(ARG_IS_SITE_PRIVATE, isPrivate);
         args.putLong(ARG_SITE_USER_ID, userId);
@@ -157,6 +156,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         args.putString(ARG_SITE_USER_AGENT, userAgent);
         args.putBoolean(ARG_TENOR_ENABLED, tenorEnabled);
         args.putBoolean(ARG_SITE_JETPACK_IS_CONNECTED, siteIsJetpackConnected);
+        args.putBoolean(ARG_ENABLE_MENTIONS_FLAG, enableMentionsFlag);
         fragment.setArguments(args);
         return fragment;
     }
@@ -259,18 +259,21 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             boolean isSiteUsingWpComRestApi = getArguments().getBoolean(ARG_SITE_USING_WPCOM_REST_API);
             Bundle editorTheme = getArguments().getBundle(ARG_EDITOR_THEME);
             boolean siteJetpackIsConnected = getArguments().getBoolean(ARG_SITE_JETPACK_IS_CONNECTED);
+            boolean enableMentionsFlag = getArguments().getBoolean(ARG_ENABLE_MENTIONS_FLAG);
 
             FragmentManager fragmentManager = getChildFragmentManager();
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
             GutenbergContainerFragment gutenbergContainerFragment =
-                    GutenbergContainerFragment.newInstance(postType,
+                    GutenbergContainerFragment.newInstance(
+                            postType,
                             isNewPost,
                             localeSlug,
                             getTranslations(),
                             isDarkMode(),
                             isSiteUsingWpComRestApi,
                             editorTheme,
-                            siteJetpackIsConnected);
+                            siteJetpackIsConnected,
+                            enableMentionsFlag);
             gutenbergContainerFragment.setRetainInstance(true);
             fragmentTransaction.add(gutenbergContainerFragment, GutenbergContainerFragment.TAG);
             fragmentTransaction.commitNow();


### PR DESCRIPTION
This PR updates the @-mentions feature in the gutenberg editor to only be present on dev and internal builds, but *not* on the build that is released to the public. I am accomplishing that by creating a feature flag that is true for any build _other than_ a `Vanilla` build.

Related PRs:
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/2468
* https://github.com/WordPress/gutenberg/pull/23804

### To Test

@-mentions includes both (1) an `@` button in the format bar for RichText blocks in gutenberg (you'll probably need to scroll the format bar to see it), and (2) a response anytime an "@" is typed following a space in such a block.

1. Verify that @-mentions exist in the following builds:
    * `WasabiDebug` build
    * `ZalphaRelease` build
2. Verify that @-mentions does *not* exist in a 
    * `VanillaRelease` build

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
