### PR TITLE
Issue/12028 save for later

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -148,6 +148,9 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun isReaderImprovementsPhase2Enabled(): Boolean = AppPrefs.isReaderImprovementsPhase2Enabled()
 
+    fun shouldShowBookmarksSavedLocallyDialog(): Boolean = AppPrefs.shouldShowBookmarksSavedLocallyDialog()
+    fun setBookmarksSavedLocallyDialogShown() = AppPrefs.setBookmarksSavedLocallyDialogShown()
+
     companion object {
         private const val LIGHT_MODE_ID = 0
         private const val DARK_MODE_ID = 1

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -57,6 +57,6 @@ public class ReaderInterfaces {
      * used by adapters to notify when post bookmarked state has changed
      */
     public interface OnPostBookmarkedListener {
-        void onBookmarkedStateChanged(boolean isBookmarked, long blogId, long postId, boolean isCachingActionRequired);
+        void onBookmarkClicked(long blogId, long postId);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -450,7 +450,7 @@ public class ReaderPostListFragment extends Fragment
                     } else if (navTarget instanceof ShowNoSitesToReblog) {
                         ReaderActivityLauncher.showNoSiteToReblog(getActivity());
                     } else {
-                        throw new IllegalStateException("Action not supported in ReaderPostListFragment");
+                        throw new IllegalStateException("Action not supported in ReaderPostListFragment " + navTarget);
                     }
                     return Unit.INSTANCE;
                 }));
@@ -2727,7 +2727,7 @@ public class ReaderPostListFragment extends Fragment
 
     @Override
     public void reblog(ReaderPost post) {
-        mViewModel.onReblogButtonClicked(post);
+        mViewModel.onReblogButtonClicked(post, isBookmarksList());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.reader;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -83,6 +83,7 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.main.BottomNavController;
 import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.ui.main.WPMainActivity;
+import org.wordpress.android.ui.pages.SnackbarMessageHolder;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
 import org.wordpress.android.ui.reader.ReaderEvents.TagAdded;
@@ -97,6 +98,8 @@ import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionRecyclerAd
 import org.wordpress.android.ui.reader.adapters.ReaderSiteSearchAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSiteSearchAdapter.SiteSearchAdapterListener;
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEditorForReblog;
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog;
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab;
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowNoSitesToReblog;
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult;
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType;
@@ -449,6 +452,13 @@ public class ReaderPostListFragment extends Fragment
                         );
                     } else if (navTarget instanceof ShowNoSitesToReblog) {
                         ReaderActivityLauncher.showNoSiteToReblog(getActivity());
+                    } else if (navTarget instanceof ShowBookmarkedTab) {
+                        ActivityLauncher.viewSavedPostsListInReader(getActivity());
+                        if (requireActivity() instanceof WPMainActivity) {
+                            requireActivity().overridePendingTransition(0, 0);
+                        }
+                    } else if (navTarget instanceof ShowBookmarkedSavedOnlyLocallyDialog) {
+                        showBookmarksSavedLocallyDialog((ShowBookmarkedSavedOnlyLocallyDialog) navTarget);
                     } else {
                         throw new IllegalStateException("Action not supported in ReaderPostListFragment " + navTarget);
                     }
@@ -456,14 +466,17 @@ public class ReaderPostListFragment extends Fragment
                 }));
 
         mViewModel.getSnackbarEvents().observe(getViewLifecycleOwner(), event ->
-            event.applyIfNotHandled(holder -> {
-                WPSnackbar.make(
-                        requireActivity().findViewById(R.id.coordinator),
-                        holder.getMessageRes(),
-                        Snackbar.LENGTH_LONG
-                ).show();
-                return Unit.INSTANCE;
-            })
+                event.applyIfNotHandled(holder -> {
+                    showSnackbar(holder);
+                    return Unit.INSTANCE;
+                })
+        );
+
+        mViewModel.getPreloadPostEvents().observe(getViewLifecycleOwner(), event ->
+                event.applyIfNotHandled(holder -> {
+                    addWebViewCachingFragment(holder.getBlogId(), holder.getPostId());
+                    return Unit.INSTANCE;
+                })
         );
 
         mViewModel.start(mReaderViewModel);
@@ -476,6 +489,28 @@ public class ReaderPostListFragment extends Fragment
             mRecyclerView.showAppBarLayout();
             mSearchMenuItem.expandActionView();
             mRecyclerView.setToolbarScrollFlags(0);
+        }
+    }
+
+    private void showSnackbar(SnackbarMessageHolder holder) {
+        WPSnackbar snackbar = WPSnackbar.make(
+                requireActivity().findViewById(R.id.coordinator),
+                holder.getMessageRes(),
+                Snackbar.LENGTH_LONG
+        );
+        if (holder.getButtonTitleRes() != null) {
+            snackbar.setAction(getString(holder.getButtonTitleRes()), v -> holder.getButtonAction().invoke());
+        }
+        snackbar.show();
+    }
+
+    private void addWebViewCachingFragment(Long blogId, Long postId) {
+        String tag = blogId + "" + postId;
+
+        if (getParentFragmentManager().findFragmentByTag(tag) == null) {
+            getParentFragmentManager().beginTransaction()
+                                 .add(ReaderPostWebViewCachingFragment.newInstance(blogId, postId), tag)
+                                 .commit();
         }
     }
 
@@ -1895,34 +1930,7 @@ public class ReaderPostListFragment extends Fragment
     };
 
     private final ReaderInterfaces.OnPostBookmarkedListener mOnPostBookmarkedListener =
-            new ReaderInterfaces.OnPostBookmarkedListener() {
-                @Override public void onBookmarkedStateChanged(boolean isBookmarked, long blogId, long postId,
-                                                               boolean isCachingActionRequired) {
-                    if (!isAdded()) {
-                        return;
-                    }
-
-                    String tag = Long.toString(blogId) + Long.toString(postId);
-
-                    if (NetworkUtils.isNetworkAvailable(getActivity())
-                        && isCachingActionRequired && isBookmarked
-                        && getFragmentManager().findFragmentByTag(tag) == null) {
-                        getFragmentManager().beginTransaction()
-                                            .add(ReaderPostWebViewCachingFragment.newInstance(blogId, postId), tag)
-                                            .commit();
-                    }
-
-                    if (isBookmarked && !isBookmarksList()) {
-                        if (AppPrefs.shouldShowBookmarksSavedLocallyDialog()) {
-                            AppPrefs.setBookmarksSavedLocallyDialogShown();
-                            showBookmarksSavedLocallyDialog();
-                        } else {
-                            // show snackbar when not in saved posts list
-                            showBookmarkSnackbar();
-                        }
-                    }
-                }
-            };
+            (blogId, postId) -> mViewModel.onBookmarkButtonClicked(blogId, postId, isBookmarksList());
 
     private void announceListStateForAccessibility() {
         if (getView() != null) {
@@ -1931,15 +1939,11 @@ public class ReaderPostListFragment extends Fragment
         }
     }
 
-    private void showBookmarksSavedLocallyDialog() {
-        mBookmarksSavedLocallyDialog = new MaterialAlertDialogBuilder(getActivity())
-                .setTitle(getString(R.string.reader_save_posts_locally_dialog_title))
-                .setMessage(getString(R.string.reader_save_posts_locally_dialog_message))
-                .setPositiveButton(R.string.dialog_button_ok, new OnClickListener() {
-                    @Override public void onClick(DialogInterface dialog, int which) {
-                        showBookmarkSnackbar();
-                    }
-                })
+    private void showBookmarksSavedLocallyDialog(ShowBookmarkedSavedOnlyLocallyDialog holder) {
+        mBookmarksSavedLocallyDialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(getString(holder.getTitle()))
+                .setMessage(getString(holder.getMessage()))
+                .setPositiveButton(holder.getButtonLabel(), (dialog, which) -> holder.getOkButtonAction().invoke())
                 .setCancelable(false)
                 .create();
         mBookmarksSavedLocallyDialog.show();
@@ -1948,26 +1952,6 @@ public class ReaderPostListFragment extends Fragment
     private boolean isBookmarksList() {
         return getPostListType() == ReaderPostListType.TAG_FOLLOWED
                && (mCurrentTag != null && mCurrentTag.isBookmarked());
-    }
-
-    private void showBookmarkSnackbar() {
-        if (!isAdded()) {
-            return;
-        }
-
-        WPSnackbar.make(getView(), R.string.reader_bookmark_snack_title, Snackbar.LENGTH_LONG)
-                  .setAction(R.string.reader_bookmark_snack_btn,
-                          new View.OnClickListener() {
-                              @Override public void onClick(View view) {
-                                  AnalyticsTracker
-                                          .track(AnalyticsTracker.Stat.READER_SAVED_LIST_VIEWED_FROM_POST_LIST_NOTICE);
-                                  ActivityLauncher.viewSavedPostsListInReader(getActivity());
-                                  if (getActivity() instanceof WPMainActivity) {
-                                      getActivity().overridePendingTransition(0, 0);
-                                  }
-                              }
-                          })
-                  .show();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -337,7 +337,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     switch (type) {
                         case BOOKMARK:
                             toggleBookmark(post.blogId, post.postId);
-                            notifyItemChanged(position);
+                            renderPost(position, holder);
                             break;
                         case LIKE:
                             toggleLike(ctx, post, position, holder);
@@ -718,31 +718,16 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
      * triggered when user taps the bookmark post button
      */
     private void toggleBookmark(final long blogId, final long postId) {
-        ReaderPost post = ReaderPostTable.getBlogPost(blogId, postId, false);
-
-        AnalyticsTracker.Stat eventToTrack;
-        if (post.isBookmarked) {
-            eventToTrack = isBookmarksList() ? AnalyticsTracker.Stat.READER_POST_UNSAVED_FROM_SAVED_POST_LIST
-                    : AnalyticsTracker.Stat.READER_POST_UNSAVED_FROM_OTHER_POST_LIST;
-            ReaderPostActions.removeFromBookmarked(post);
-        } else {
-            eventToTrack = isBookmarksList() ? AnalyticsTracker.Stat.READER_POST_SAVED_FROM_SAVED_POST_LIST
-                    : AnalyticsTracker.Stat.READER_POST_SAVED_FROM_OTHER_POST_LIST;
-            ReaderPostActions.addToBookmarked(post);
-        }
-
-        AnalyticsTracker.track(eventToTrack);
-
         // update post in array and on screen
-        post = ReaderPostTable.getBlogPost(blogId, postId, true);
+        ReaderPost post = ReaderPostTable.getBlogPost(blogId, postId, true);
         int position = mPosts.indexOfPost(post);
         if (post != null && position > -1) {
+            post.isBookmarked = !post.isBookmarked;
             mPosts.set(position, post);
+        }
 
-            if (mOnPostBookmarkedListener != null) {
-                mOnPostBookmarkedListener
-                        .onBookmarkedStateChanged(post.isBookmarked, blogId, postId, !isBookmarksList());
-            }
+        if (mOnPostBookmarkedListener != null) {
+            mOnPostBookmarkedListener.onBookmarkClicked(blogId, postId);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -4,12 +4,14 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.reader_discover_fragment_layout.*
 import org.wordpress.android.R
@@ -17,20 +19,27 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.main.SitePickerActivity
+import org.wordpress.android.ui.main.WPMainActivity
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.ReaderActivityLauncher
+import org.wordpress.android.ui.reader.ReaderPostWebViewCachingFragment
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEditorForReblog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.SharePost
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowNoSitesToReblog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
+import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 
 class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout) {
+    private var bookmarksSavedLocallyDialog: AlertDialog? = null
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var imageManager: ImageManager
@@ -56,7 +65,12 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReaderDiscoverViewModel::class.java)
         viewModel.uiState.observe(viewLifecycleOwner, Observer {
             when (it) {
-                is ContentUiState -> (recycler_view.adapter as ReaderDiscoverAdapter).update(it.cards)
+                is ContentUiState -> {
+                    (recycler_view.adapter as ReaderDiscoverAdapter).update(it.cards)
+                    if (it.bookmarkDialog != null) {
+                        showBookmarkSavedLocallyDialog(it.bookmarkDialog)
+                    }
+                }
             }
             uiHelpers.updateVisibility(recycler_view, it.contentVisiblity)
             uiHelpers.updateVisibility(progress_bar, it.progressVisibility)
@@ -73,15 +87,75 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
                             .showSitePickerForResult(this@ReaderDiscoverFragment, this.site, this.mode)
                     is OpenEditorForReblog -> ActivityLauncher
                             .openEditorForReblog(activity, this.site, this.post, this.source)
+                    is ShowBookmarkedTab -> {
+                        ActivityLauncher.viewSavedPostsListInReader(activity)
+                        if (requireActivity() is WPMainActivity) {
+                            requireActivity().overridePendingTransition(0, 0)
+                        }
+                    }
                 }
             }
         })
         viewModel.snackbarEvents.observe(viewLifecycleOwner, Observer {
             it?.applyIfNotHandled {
-                WPSnackbar.make(constraint_layout, getString(this.messageRes), Snackbar.LENGTH_LONG).show()
+                showSnackbar()
+            }
+        })
+        viewModel.preloadPostEvents.observe(viewLifecycleOwner, Observer {
+            it?.applyIfNotHandled {
+                addWebViewCachingFragment()
             }
         })
         viewModel.start()
+    }
+
+    private fun showBookmarkSavedLocallyDialog(bookmarkDialog: ShowBookmarkedSavedOnlyLocallyDialog) {
+        if (bookmarksSavedLocallyDialog == null) {
+            MaterialAlertDialogBuilder(requireActivity())
+                    .setTitle(getString(bookmarkDialog.title))
+                    .setMessage(getString(bookmarkDialog.message))
+                    .setPositiveButton(getString(bookmarkDialog.buttonLabel))
+                    { _, _ ->
+                        run {
+                            bookmarkDialog.okButtonAction.invoke()
+                            viewModel.bookmarkDialogOkClicked()
+                        }
+                    }
+                    .setOnDismissListener {
+                        bookmarksSavedLocallyDialog = null
+                    }
+                    .setCancelable(false)
+                    .create()
+                    .let {
+                        bookmarksSavedLocallyDialog = it
+                        it.show()
+                    }
+        }
+    }
+
+    private fun SnackbarMessageHolder.showSnackbar() {
+        val snackbar = WPSnackbar.make(constraint_layout, getString(this.messageRes), Snackbar.LENGTH_LONG)
+        if (this.buttonTitleRes != null) {
+            snackbar.setAction(getString(this.buttonTitleRes)) {
+                this.buttonAction.invoke()
+            }
+        }
+        snackbar.show()
+    }
+
+    private fun PreLoadPostContent.addWebViewCachingFragment() {
+        val tag = "$blogId$postId"
+
+        if (parentFragmentManager.findFragmentByTag(tag) == null) {
+            parentFragmentManager.beginTransaction()
+                    .add(ReaderPostWebViewCachingFragment.newInstance(blogId, postId), tag)
+                    .commit()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        bookmarksSavedLocallyDialog?.dismiss()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -67,9 +67,6 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
             when (it) {
                 is ContentUiState -> {
                     (recycler_view.adapter as ReaderDiscoverAdapter).update(it.cards)
-                    if (it.bookmarkDialog != null) {
-                        showBookmarkSavedLocallyDialog(it.bookmarkDialog)
-                    }
                 }
             }
             uiHelpers.updateVisibility(recycler_view, it.contentVisiblity)
@@ -93,6 +90,7 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
                             requireActivity().overridePendingTransition(0, 0)
                         }
                     }
+                    is ShowBookmarkedSavedOnlyLocallyDialog -> showBookmarkSavedLocallyDialog(this)
                 }
             }
         })
@@ -115,12 +113,7 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
                     .setTitle(getString(bookmarkDialog.title))
                     .setMessage(getString(bookmarkDialog.message))
                     .setPositiveButton(getString(bookmarkDialog.buttonLabel))
-                    { _, _ ->
-                        run {
-                            bookmarkDialog.okButtonAction.invoke()
-                            viewModel.bookmarkDialogOkClicked()
-                        }
-                    }
+                    { _, _ -> bookmarkDialog.okButtonAction.invoke() }
                     .setOnDismissListener {
                         bookmarksSavedLocallyDialog = null
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -112,8 +112,9 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
             MaterialAlertDialogBuilder(requireActivity())
                     .setTitle(getString(bookmarkDialog.title))
                     .setMessage(getString(bookmarkDialog.message))
-                    .setPositiveButton(getString(bookmarkDialog.buttonLabel))
-                    { _, _ -> bookmarkDialog.okButtonAction.invoke() }
+                    .setPositiveButton(getString(bookmarkDialog.buttonLabel)) {
+                        _, _ -> bookmarkDialog.okButtonAction.invoke()
+                    }
                     .setOnDismissListener {
                         bookmarksSavedLocallyDialog = null
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -66,13 +66,6 @@ class ReaderDiscoverViewModel @Inject constructor(
         loadPosts()
     }
 
-    fun bookmarkDialogOkClicked() {
-        val currentState = _uiState.value
-        if (currentState is ContentUiState && currentState.bookmarkDialog != null) {
-            _uiState.value = currentState.copy(bookmarkDialog = null)
-        }
-    }
-
     private fun init() {
         // Start with loading state
         _uiState.value = LoadingUiState
@@ -103,11 +96,7 @@ class ReaderDiscoverViewModel @Inject constructor(
             if (target is ShowSitePickerForResult) {
                 pendingReblogPost = target.post
             }
-            if (target is ShowBookmarkedSavedOnlyLocallyDialog) {
-                // We need to transform the navigation event into uiState in order to re-show dialog after config change
-                _uiState.value = (_uiState.value as ContentUiState).copy(bookmarkDialog = target)
-            } else
-                _navigationEvents.value = event
+            _navigationEvents.value = event
         }
 
         _snackbarEvents.addSource(readerPostCardActionsHandler.snackbarEvents) { event ->
@@ -176,11 +165,7 @@ class ReaderDiscoverViewModel @Inject constructor(
         val contentVisiblity: Boolean = false,
         val progressVisibility: Boolean = false
     ) {
-        data class ContentUiState(
-            val cards: List<ReaderCardUiState>,
-            val bookmarkDialog: ShowBookmarkedSavedOnlyLocallyDialog? = null
-        ) : DiscoverUiState(contentVisiblity = true)
-
+        data class ContentUiState(val cards: List<ReaderCardUiState>) : DiscoverUiState(contentVisiblity = true)
         object LoadingUiState : DiscoverUiState(progressVisibility = true)
         object ErrorUiState : DiscoverUiState()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
-import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.repository.ReaderPostRepository

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.reader.discover
 
+import androidx.annotation.StringRes
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
@@ -12,9 +14,17 @@ sealed class ReaderNavigationEvents {
     object ShowNoSitesToReblog : ReaderNavigationEvents()
     data class ShowSitePickerForResult(val site: SiteModel, val post: ReaderPost, val mode: SitePickerMode) :
             ReaderNavigationEvents()
+
     data class OpenEditorForReblog(
         val site: SiteModel,
         val post: ReaderPost,
         val source: PagePostCreationSourcesDetail
     ) : ReaderNavigationEvents()
+
+    object ShowBookmarkedTab : ReaderNavigationEvents()
+    class ShowBookmarkedSavedOnlyLocallyDialog(val okButtonAction: () -> Unit) : ReaderNavigationEvents() {
+        @StringRes val title: Int = R.string.reader_save_posts_locally_dialog_title
+        @StringRes val message: Int = R.string.reader_save_posts_locally_dialog_message
+        @StringRes val buttonLabel: Int = R.string.dialog_button_ok
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -191,8 +191,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
         } else {
             R.string.reader_add_bookmark
         }
-        // TODO malinjir shouldn't the action be disabled just for posts which don't have blog and post id?
-        return if (!post.isDiscoverPost) {
+        return if (post.postId != 0L && post.blogId != 0L) {
             PrimaryAction(
                     isEnabled = true,
                     isSelected = post.isBookmarked,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
@@ -42,7 +42,6 @@ class ReaderPostBookmarkUseCase @Inject constructor(
     private val _preloadPostEvents = MutableLiveData<Event<PreLoadPostContent>>()
     val preloadPostEvents = _preloadPostEvents
 
-
     suspend fun toggleBookmark(blogId: Long, postId: Long, isBookmarkList: Boolean) {
         return withContext(bgDispatcher) {
             val bookmarked = updatePostInDb(blogId, postId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
@@ -52,8 +52,12 @@ class ReaderPostBookmarkUseCase @Inject constructor(
             val showSnackbarAction = prepareSnackbarAction()
             if (bookmarked && !isBookmarkList) {
                 if (appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog()) {
-                    appPrefsWrapper.setBookmarksSavedLocallyDialogShown()
-                    _navigationEvents.postValue(Event(ShowBookmarkedSavedOnlyLocallyDialog(showSnackbarAction)))
+                    _navigationEvents.postValue(Event(ShowBookmarkedSavedOnlyLocallyDialog(
+                            okButtonAction = {
+                                appPrefsWrapper.setBookmarksSavedLocallyDialogShown()
+                                showSnackbarAction.invoke()
+                            })
+                    ))
                 } else {
                     showSnackbarAction.invoke()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
@@ -1,0 +1,120 @@
+package org.wordpress.android.ui.reader.usecases
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import org.wordpress.android.R.string
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_SAVED_FROM_OTHER_POST_LIST
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_SAVED_FROM_SAVED_POST_LIST
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_UNSAVED_FROM_SAVED_POST_LIST
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_SAVED_LIST_VIEWED_FROM_POST_LIST_NOTICE
+import org.wordpress.android.datasets.ReaderPostTable
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.reader.actions.ReaderPostActions
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.Event
+import javax.inject.Inject
+import javax.inject.Named
+
+/**
+ * This class handles bookmark/saveForLater button click events.
+ * It updates the post in the database, tracks events, initiates pre-load content and shows snackbar/dialog.
+ */
+class ReaderPostBookmarkUseCase @Inject constructor(
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val appPrefsWrapper: AppPrefsWrapper
+) {
+    private val _navigationEvents = MutableLiveData<Event<ReaderNavigationEvents>>()
+    val navigationEvents: LiveData<Event<ReaderNavigationEvents>> = _navigationEvents
+
+    private val _snackbarEvents = MutableLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
+    private val _preloadPostEvents = MutableLiveData<Event<PreLoadPostContent>>()
+    val preloadPostEvents = _preloadPostEvents
+
+
+    suspend fun toggleBookmark(blogId: Long, postId: Long, isBookmarkList: Boolean) {
+        return withContext(bgDispatcher) {
+            val bookmarked = updatePostInDb(blogId, postId)
+            trackEvent(bookmarked, isBookmarkList)
+            preloadContent(bookmarked, isBookmarkList, blogId, postId)
+
+            val showSnackbarAction = prepareSnackbarAction()
+            if (bookmarked && !isBookmarkList) {
+                if (appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog()) {
+                    appPrefsWrapper.setBookmarksSavedLocallyDialogShown()
+                    _navigationEvents.postValue(Event(ShowBookmarkedSavedOnlyLocallyDialog(showSnackbarAction)))
+                } else {
+                    showSnackbarAction.invoke()
+                }
+            }
+        }
+    }
+
+    private fun preloadContent(
+        bookmarked: Boolean,
+        isBookmarkList: Boolean,
+        blogId: Long,
+        postId: Long
+    ) {
+        val cachePostContent = bookmarked && networkUtilsWrapper.isNetworkAvailable() && !isBookmarkList
+        if (cachePostContent) {
+            _preloadPostEvents.postValue(Event(PreLoadPostContent(blogId, postId)))
+        }
+    }
+
+    private fun updatePostInDb(blogId: Long, postId: Long): Boolean {
+        // TODO malinjir replace direct db access with access to repository.
+        //  Also make sure PostUpdated event is emitted when we change the state of the post.
+        val post = ReaderPostTable.getBlogPost(blogId, postId, true)
+
+        val setToBookmarked = !post.isBookmarked
+
+        if (setToBookmarked) {
+            ReaderPostActions.addToBookmarked(post)
+        } else {
+            ReaderPostActions.removeFromBookmarked(post)
+        }
+        return setToBookmarked
+    }
+
+    private fun trackEvent(bookmarked: Boolean, isBookmarkList: Boolean) {
+        val trackingEvent = when {
+            bookmarked && isBookmarkList -> READER_POST_SAVED_FROM_SAVED_POST_LIST
+            bookmarked && !isBookmarkList -> READER_POST_SAVED_FROM_OTHER_POST_LIST
+            !bookmarked && isBookmarkList -> READER_POST_UNSAVED_FROM_SAVED_POST_LIST
+            !bookmarked && !isBookmarkList -> READER_POST_UNSAVED_FROM_SAVED_POST_LIST
+            else -> throw IllegalStateException("Developer error: This code should be unreachable.")
+        }
+        analyticsTrackerWrapper.track(trackingEvent)
+    }
+
+    private fun prepareSnackbarAction(): () -> Unit {
+        return {
+            _snackbarEvents.postValue(
+                    Event(
+                            SnackbarMessageHolder(
+                                    string.reader_bookmark_snack_title,
+                                    string.reader_bookmark_snack_btn,
+                                    buttonAction = {
+                                        analyticsTrackerWrapper
+                                                .track(READER_SAVED_LIST_VIEWED_FROM_POST_LIST_NOTICE)
+                                        _navigationEvents.postValue(Event(ShowBookmarkedTab))
+                                    })
+                    )
+            )
+        }
+    }
+}
+
+data class PreLoadPostContent(val blogId: Long, val postId: Long)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -4,17 +4,20 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
 import org.wordpress.android.R
+import org.wordpress.android.datasets.ReaderPostTable
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionsHandler
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.tracker.ReaderTrackerType
+import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.viewmodel.Event
@@ -40,6 +43,9 @@ class ReaderPostListViewModel @Inject constructor(
     private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
     val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
+    private val _preloadPostEvents = MediatorLiveData<Event<PreLoadPostContent>>()
+    val preloadPostEvents = _preloadPostEvents
+
     fun start(readerViewModel: ReaderViewModel?) {
         this.readerViewModel = readerViewModel
 
@@ -63,6 +69,10 @@ class ReaderPostListViewModel @Inject constructor(
         _snackbarEvents.addSource(readerPostCardActionsHandler.snackbarEvents) { event ->
             _snackbarEvents.value = event
         }
+
+        _preloadPostEvents.addSource(readerPostCardActionsHandler.preloadPostEvents) { event ->
+            _preloadPostEvents.value = event
+        }
     }
 
     /**
@@ -72,6 +82,11 @@ class ReaderPostListViewModel @Inject constructor(
      */
     fun onReblogButtonClicked(post: ReaderPost, bookmarksList: Boolean) {
         readerPostCardActionsHandler.onAction(post, REBLOG, bookmarksList)
+    }
+
+    fun onBookmarkButtonClicked(blogId: Long, postId: Long, isBookmarkList: Boolean) {
+        val post = ReaderPostTable.getBlogPost(blogId, postId, true)
+        readerPostCardActionsHandler.onAction(post, BOOKMARK, isBookmarkList)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -70,8 +70,8 @@ class ReaderPostListViewModel @Inject constructor(
      *
      * @param post post to reblog
      */
-    fun onReblogButtonClicked(post: ReaderPost) {
-        readerPostCardActionsHandler.onAction(post, REBLOG)
+    fun onReblogButtonClicked(post: ReaderPost, bookmarksList: Boolean) {
+        readerPostCardActionsHandler.onAction(post, REBLOG, bookmarksList)
     }
 
     /**


### PR DESCRIPTION
Parent issue #12028

This tasks extracts logic related to "save for later/bookmark" action on reader post list items. ReaderPostBookmarkUseCase contains all the related logic. It propagates events to the view layer using LiveData.

Merge Instructions
1. Review this PR
2. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/12358 is merged
3. Update target branch to develop
4. Remove "Not Ready for Merge" label
5. Merge this PR


To test:

Dialog
1. Clear app data
2. Open Reader - Following tab
3. Click on Bookmark action on one of the items
4. Notice a dialog is shown
5. Click on OK and go to Saved tab
6. Notice the post is saved there

Snackbar
1. Open Reader - Following tab
1. Click on Bookmark action on another item
2. Notice Snackbar is shown
3. Click on "View All" action in the snackbar
4. Notice the "Saved" tab is shown and the post is there

Offline
1. Open Reader - Following tab
1. Click on Bookmark action on yet another item
2. Notice snackbar is shown
3. Wait for cca 10s
4. Turn on airplane mode
5. Go to Saved tab
6. Open the post and notice the content (even images) are loaded correctly even though you are offline

Unbookmark
1. Click on unbookmark action on one of the saved items
2. Notice the post gets unbookmarked and is removed from the saved tab (it might still be there but in a collapsed mode with "Undo" action)


The new Discover tab can be potentially tested as well but it's a bit complicated. We'll test all the actions before it's released. I personally wouldn't worry about it now.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
