### PR TITLE
Use success step in epilogue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -310,7 +310,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             ReaderUpdateServiceStarter.startService(WordPress.getContext(),
                     EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
 
-            mUnifiedLoginTracker.track(Step.USERNAME_PASSWORD);
+            mUnifiedLoginTracker.track(Step.SUCCESS);
             if (mIsEmailSignup) {
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_EMAIL_EPILOGUE_VIEWED);
 


### PR DESCRIPTION
Fixes #12389 

This PR replaces the `USERNAME_PASSWORD` step in the signup epilogue screen with `SUCCESS`

To test:
- Go throught the signup flow
- Notice that the success step event is emitted instead of username_password 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
