### PR TITLE
Update Login headline from 36 to 37%

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginProloguePagerAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginProloguePagerAdapter.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.R
 class LoginProloguePagerAdapter(fm: FragmentManager) : FragmentPagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
     private val pages = listOf(
             Page(
-                    R.string.login_promo_title_36_percent,
+                    R.string.login_promo_title_37_percent,
                     R.string.login_promo_text_unlock_the_power,
                     R.drawable.img_illustration_promo
             )

--- a/WordPress/src/main/res/layout/login_intro_template_view.xml
+++ b/WordPress/src/main/res/layout/login_intro_template_view.xml
@@ -52,7 +52,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/logo_view"
-        tools:text="@string/login_promo_title_36_percent" />
+        tools:text="@string/login_promo_title_37_percent" />
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/promo_text"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2360,7 +2360,7 @@
     it may be used there and keeping it here is required for translation. -->
     <string name="log_in">Log In</string>
     <string name="login_promo_viewpager_content_description">Introduction</string>
-    <string name="login_promo_title_36_percent">36% of the web is built on WordPress.</string>
+    <string name="login_promo_title_37_percent">37% of the web is built on WordPress.</string>
     <string name="login_promo_text_unlock_the_power">Unlock the power of the most flexible website builder.</string>
     <string name="invalid_verification_code">Invalid verification code</string>
     <string name="send_link" tools:ignore="UnusedResources">Send link</string>


### PR DESCRIPTION
Fixes #12378 

This PR updates the headline in prologue from 36% to 37%

![Screenshot_1594297663](https://user-images.githubusercontent.com/1079756/87040113-82439380-c1f0-11ea-8163-9e214f4349a9.png)


To test:
- Clear app data
- Notice that the headline is updated

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
