### PR TITLE
Gutenberg/allow unsupported block editor on atomic sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2017,9 +2017,12 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);
                         Bundle themeBundle = (editorTheme != null) ? editorTheme.getThemeSupport().toBundle() : null;
 
-                        // The Unsupported Block Editor is disabled for self-hosted sites that are connected via Jetpack to a WP.com account.
-                        // This is because we don't have the self-hosted site's credentials which are required for us to be able to fetch the site's authentication cookie.
-                        // This cookie is needed to authenticate the network request that fetches the unsupported block editor web page.
+                        // The Unsupported Block Editor is disabled for self-hosted sites
+                        // that are connected via Jetpack to a WP.com account.
+                        // This is because we don't have the self-hosted site's credentials
+                        // which are required for us to be able to fetch the site's authentication cookie.
+                        // This cookie is needed to authenticate the network request
+                        // that fetches the unsupported block editor web page.
                         boolean isUnsupportedBlockEditorEnabled = mSite.isWPComAtomic() || !mSite.isJetpackConnected();
 
                         return GutenbergEditorFragment.newInstance(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2017,6 +2017,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);
                         Bundle themeBundle = (editorTheme != null) ? editorTheme.getThemeSupport().toBundle() : null;
 
+                        boolean isUnsupportedBlockEditorEnabled = mSite.isWPComAtomic() || !mSite.isJetpackConnected();
+
                         return GutenbergEditorFragment.newInstance(
                                 "",
                                 "",
@@ -2034,7 +2036,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                                 themeBundle,
                                 WordPress.getUserAgent(),
                                 mTenorFeatureConfig.isEnabled(),
-                                mSite.isJetpackConnected()
+                                isUnsupportedBlockEditorEnabled
                         );
                     } else {
                         // If gutenberg editor is not selected, default to Aztec.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2017,6 +2017,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);
                         Bundle themeBundle = (editorTheme != null) ? editorTheme.getThemeSupport().toBundle() : null;
 
+                        // The Unsupported Block Editor is disabled for self-hosted sites that are connected via Jetpack to a WP.com account.
+                        // This is because we don't have the self-hosted site's credentials which are required for us to be able to fetch the site's authentication cookie.
+                        // This cookie is needed to authenticate the network request that fetches the unsupported block editor web page.
                         boolean isUnsupportedBlockEditorEnabled = mSite.isWPComAtomic() || !mSite.isJetpackConnected();
 
                         return GutenbergEditorFragment.newInstance(

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergContainerFragment.java
@@ -35,7 +35,8 @@ public class GutenbergContainerFragment extends Fragment {
     private static final String ARG_PREFERRED_COLOR_SCHEME = "param_preferred_color_scheme";
     private static final String ARG_SITE_USING_WPCOM_REST_API = "param_site_using_wpcom_rest_api";
     private static final String ARG_EDITOR_THEME = "param_editor_theme";
-    private static final String ARG_SITE_JETPACK_IS_CONNECTED = "param_site_jetpack_is_connected";
+    private static final String ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED =
+            "param_site_is_unsupported_block_editor_enabled";
 
     private boolean mHtmlModeEnabled;
     private boolean mHasReceivedAnyContent;
@@ -48,7 +49,7 @@ public class GutenbergContainerFragment extends Fragment {
                                                          boolean isDarkMode,
                                                          boolean isSiteUsingWpComRestApi,
                                                          Bundle editorTheme,
-                                                         boolean siteJetpackIsConnected) {
+                                                         boolean isUnsupportedBlockEditorEnabled) {
         GutenbergContainerFragment fragment = new GutenbergContainerFragment();
         Bundle args = new Bundle();
         args.putString(ARG_POST_TYPE, postType);
@@ -58,7 +59,7 @@ public class GutenbergContainerFragment extends Fragment {
         args.putBoolean(ARG_PREFERRED_COLOR_SCHEME, isDarkMode);
         args.putBoolean(ARG_SITE_USING_WPCOM_REST_API, isSiteUsingWpComRestApi);
         args.putBundle(ARG_EDITOR_THEME, editorTheme);
-        args.putBoolean(ARG_SITE_JETPACK_IS_CONNECTED, siteJetpackIsConnected);
+        args.putBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED, isUnsupportedBlockEditorEnabled);
         fragment.setArguments(args);
         return fragment;
     }
@@ -109,7 +110,8 @@ public class GutenbergContainerFragment extends Fragment {
         boolean isDarkMode = getArguments().getBoolean(ARG_PREFERRED_COLOR_SCHEME);
         boolean isSiteUsingWpComRestApi = getArguments().getBoolean(ARG_SITE_USING_WPCOM_REST_API);
         Bundle editorTheme = getArguments().getBundle(ARG_EDITOR_THEME);
-        boolean siteJetpackIsConnected = getArguments().getBoolean(ARG_SITE_JETPACK_IS_CONNECTED);
+        boolean isUnsupportedBlockEditorEnabled =
+                getArguments().getBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED);
 
         Consumer<Exception> exceptionLogger = null;
         Consumer<String> breadcrumbLogger = null;
@@ -137,7 +139,7 @@ public class GutenbergContainerFragment extends Fragment {
                 breadcrumbLogger,
                 isSiteUsingWpComRestApi,
                 editorTheme,
-                siteJetpackIsConnected);
+                isUnsupportedBlockEditorEnabled);
 
         // clear the content initialization flag since a new ReactRootView has been created;
         mHasReceivedAnyContent = false;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/GutenbergEditorFragment.java
@@ -88,7 +88,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private static final String ARG_EDITOR_THEME = "param_editor_theme";
     private static final String ARG_SITE_USER_AGENT = "param_user_agent";
     private static final String ARG_TENOR_ENABLED = "param_tenor_enabled";
-    private static final String ARG_SITE_JETPACK_IS_CONNECTED = "param_site_jetpack_is_connected";
+    private static final String ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED =
+            "param_site_is_unsupported_block_editor_enabled";
 
     private static final int CAPTURE_PHOTO_PERMISSION_REQUEST_CODE = 101;
     private static final int CAPTURE_VIDEO_PERMISSION_REQUEST_CODE = 102;
@@ -137,7 +138,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                                                       @Nullable Bundle editorTheme,
                                                       String userAgent,
                                                       boolean tenorEnabled,
-                                                      boolean siteIsJetpackConnected) {
+                                                      boolean isUnsupportedBlockEditorEnabled) {
         GutenbergEditorFragment fragment = new GutenbergEditorFragment();
         Bundle args = new Bundle();
         args.putString(ARG_PARAM_TITLE, title);
@@ -156,7 +157,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         args.putBundle(ARG_EDITOR_THEME, editorTheme);
         args.putString(ARG_SITE_USER_AGENT, userAgent);
         args.putBoolean(ARG_TENOR_ENABLED, tenorEnabled);
-        args.putBoolean(ARG_SITE_JETPACK_IS_CONNECTED, siteIsJetpackConnected);
+        args.putBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED, isUnsupportedBlockEditorEnabled);
         fragment.setArguments(args);
         return fragment;
     }
@@ -258,7 +259,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             String localeSlug = getArguments().getString(ARG_LOCALE_SLUG);
             boolean isSiteUsingWpComRestApi = getArguments().getBoolean(ARG_SITE_USING_WPCOM_REST_API);
             Bundle editorTheme = getArguments().getBundle(ARG_EDITOR_THEME);
-            boolean siteJetpackIsConnected = getArguments().getBoolean(ARG_SITE_JETPACK_IS_CONNECTED);
+            boolean siteJetpackIsConnected = getArguments().getBoolean(ARG_SITE_IS_UNSUPPORTED_BLOCK_EDITOR_ENABLED);
 
             FragmentManager fragmentManager = getChildFragmentManager();
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();


### PR DESCRIPTION
**Description:** The Unsupported Block Editor feature was disabled on sites connected via Jetpack because of an issue requesting cookies from those sites without having login credentials other than WP.com credentials.
This inadvertently blocked Atomic sites as well, which are also connected via Jetpack. Atomic sites, being WP.com sites, don't have the cookie issue so this PR enables this feature on those sites.

**GB-Mobile PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/2476
**GB PR:** https://github.com/WordPress/gutenberg/pull/23830

**Addresses:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2470

**To test:** perform [the Unsupported Block test cases 1 to 4](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/unsupported-block-editing.md).


PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

