### PR TITLE
Double the time snackbar appears on screen.

### DIFF
--- a/WordPress/src/main/res/values/integers.xml
+++ b/WordPress/src/main/res/values/integers.xml
@@ -30,7 +30,7 @@
     <integer name="invite_message_char_limit">500</integer>
 
     <!-- Quick Start -->
-    <integer name="quick_start_snackbar_duration_ms">5000</integer>
+    <integer name="quick_start_snackbar_duration_ms">10000</integer>
 
     <!-- Support -->
     <integer name="max_length_support_name">50</integer>


### PR DESCRIPTION
Fixes #12261 

Doubles the time Quick Snackabr appears on the screen.

If you feel like testing it, start any QuickStart task and confirm that the related Snackbar stays on a screen for 10 seconds.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
