### PR TITLE
Guard for json nulls in upload completion processors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
@@ -54,13 +54,14 @@ public class CoverBlockProcessor extends BlockProcessor {
 
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("id");
-        if (id != null && id.getAsInt() == Integer.parseInt(mLocalId, 10)) {
+        if (id != null && !id.isJsonNull() && id.getAsInt() == Integer.parseInt(mLocalId, 10)) {
             jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId, 10));
             jsonAttributes.addProperty("url", mRemoteUrl);
 
             // check if background type is video
             JsonElement backgroundType = jsonAttributes.get("backgroundType");
-            mHasVideoBackground = backgroundType != null && "video".equals(backgroundType.getAsString());
+            mHasVideoBackground = backgroundType != null && !backgroundType.isJsonNull() && "video".equals(
+                    backgroundType.getAsString());
             return true;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/GalleryBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/GalleryBlockProcessor.java
@@ -68,15 +68,16 @@ public class GalleryBlockProcessor extends BlockProcessor {
 
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonArray ids = jsonAttributes.getAsJsonArray("ids");
-        if (ids == null) {
+        if (ids == null || ids.isJsonNull()) {
             return false;
         }
         JsonElement linkTo = jsonAttributes.get("linkTo");
-        if (linkTo != null) {
+        if (linkTo != null && !linkTo.isJsonNull()) {
             mLinkTo = linkTo.getAsString();
         }
         for (int i = 0; i < ids.size(); i++) {
-            if (ids.get(i).getAsString().equals(mLocalId)) {
+            JsonElement id = ids.get(i);
+            if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
                 ids.set(i, new JsonPrimitive(Integer.parseInt(mRemoteId, 10)));
                 return true;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/ImageBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/ImageBlockProcessor.java
@@ -33,7 +33,7 @@ public class ImageBlockProcessor extends BlockProcessor {
 
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("id");
-        if (id != null && id.getAsString().equals(mLocalId)) {
+        if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
             jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId));
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaTextBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaTextBlockProcessor.java
@@ -46,7 +46,7 @@ public class MediaTextBlockProcessor extends BlockProcessor {
 
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("mediaId");
-        if (id != null && id.getAsString().equals(mLocalId)) {
+        if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
             jsonAttributes.addProperty("mediaId", Integer.parseInt(mRemoteId));
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoBlockProcessor.java
@@ -30,7 +30,7 @@ public class VideoBlockProcessor extends BlockProcessor {
 
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("id");
-        if (id != null && id.getAsString().equals(mLocalId)) {
+        if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
             jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId));
             return true;
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaUploadCompletionProcessorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaUploadCompletionProcessorTest.kt
@@ -88,4 +88,10 @@ class MediaUploadCompletionProcessorTest {
         val processedContent = processor.processContent(TestContent.oldPostWithJsonNullId)
         Assertions.assertThat(processedContent).isEqualTo(TestContent.newPostWithJsonNullId)
     }
+
+    @Test
+    fun `processPost can handle blocks with json-null ids in gallery`() {
+        val processedContent = processor.processContent(TestContent.oldPostWithGalleryJsonNullId)
+        Assertions.assertThat(processedContent).isEqualTo(TestContent.newPostWithGalleryJsonNullId)
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaUploadCompletionProcessorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaUploadCompletionProcessorTest.kt
@@ -82,4 +82,10 @@ class MediaUploadCompletionProcessorTest {
         val processedContent = processor.processContent(TestContent.malformedCoverBlock)
         Assertions.assertThat(processedContent).isEqualTo(TestContent.malformedCoverBlock)
     }
+
+    @Test
+    fun `processPost can handle blocks with json-null ids`() {
+        val processedContent = processor.processContent(TestContent.oldPostWithJsonNullId)
+        Assertions.assertThat(processedContent).isEqualTo(TestContent.newPostWithJsonNullId)
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
@@ -523,6 +523,14 @@ object TestContent {
 <!-- /wp:cover -->
 """
 
+    const val imageBlockWithJsonNullId = """<!-- wp:image {"id":null,"align":"full"} -->
+<figure class="wp-block-image alignfull">
+  <img src="https://example.com" alt="" class="wp-image-77">
+  <figcaption><em>Gutenberg</em> on web</figcaption>
+</figure>
+<!-- /wp:image -->
+"""
+
     const val oldPostImage = paragraphBlock + oldImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val newPostImage = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val oldPostVideo = paragraphBlock + newImageBlock + oldVideoBlock + newMediaTextBlock + newGalleryBlock
@@ -533,4 +541,6 @@ object TestContent {
     const val newPostGallery = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val oldPostCover = paragraphBlock + newImageBlock + oldCoverBlock + newMediaTextBlock + oldGalleryBlock
     const val newPostCover = paragraphBlock + newImageBlock + newCoverBlock + newMediaTextBlock + newGalleryBlock
+    const val oldPostWithJsonNullId = paragraphBlock + oldImageBlock + imageBlockWithJsonNullId + newMediaTextBlock
+    const val newPostWithJsonNullId = paragraphBlock + newImageBlock + imageBlockWithJsonNullId + newMediaTextBlock
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
@@ -546,8 +546,6 @@ object TestContent {
 </figure>
 <!-- /wp:gallery -->
 """
-
-
     const val oldPostImage = paragraphBlock + oldImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val newPostImage = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val oldPostVideo = paragraphBlock + newImageBlock + oldVideoBlock + newMediaTextBlock + newGalleryBlock

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
@@ -530,6 +530,23 @@ object TestContent {
 </figure>
 <!-- /wp:image -->
 """
+    const val galleryBlockWithJsonNullId = """<!-- wp:gallery {"ids":[203,null,369]} -->
+<figure class="wp-block-gallery columns-3 is-cropped">
+  <ul class="blocks-gallery-grid">
+    <li class="blocks-gallery-item">
+      <figure><img src="https://example.com" alt="" data-id="203" data-full-url="https://example.com" data-link="https://example.com" class="wp-image-203"></figure>
+    </li>
+    <li class="blocks-gallery-item">
+      <figure><img src="https://example.com" alt="" data-id="77" data-full-url="https://example.com" data-link="https://example.com" class="wp-image-77"></figure>
+    </li>
+    <li class="blocks-gallery-item">
+      <figure><img src="https://example.com" alt="" data-id="369" data-full-url="https://example.com" data-link="https://example.com" class="wp-image-369"></figure>
+    </li>
+  </ul>
+</figure>
+<!-- /wp:gallery -->
+"""
+
 
     const val oldPostImage = paragraphBlock + oldImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val newPostImage = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
@@ -543,4 +560,6 @@ object TestContent {
     const val newPostCover = paragraphBlock + newImageBlock + newCoverBlock + newMediaTextBlock + newGalleryBlock
     const val oldPostWithJsonNullId = paragraphBlock + oldImageBlock + imageBlockWithJsonNullId + newMediaTextBlock
     const val newPostWithJsonNullId = paragraphBlock + newImageBlock + imageBlockWithJsonNullId + newMediaTextBlock
+    const val oldPostWithGalleryJsonNullId = paragraphBlock + oldImageBlock + galleryBlockWithJsonNullId
+    const val newPostWithGalleryJsonNullId = paragraphBlock + newImageBlock + galleryBlockWithJsonNullId
 }


### PR DESCRIPTION
Fixes #12397 

To test:
Run the unit tests - tests should pass (same tests should fail without the guards, with `UnsupportedOperationException: JsonNull`).

https://github.com/wordpress-mobile/WordPress-Android/pull/12412/commits/5a92e97531aa85bca3518b2da0820484141bbf67#diff-20fac76b4859b02136c6d27ec43b4306R86
and
https://github.com/wordpress-mobile/WordPress-Android/pull/12412/commits/281d52a1af24c28463bb59dd9cbcbe7ab6b8bce0#diff-20fac76b4859b02136c6d27ec43b4306R92

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
