### PR TITLE
Disable primary buttons on empty fields

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -219,6 +219,15 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         });
     }
 
+    private void updateContinueButtonEnabledStatus() {
+        View view = getView();
+        if (view != null) {
+            Button continueButton = (Button) view.findViewById(R.id.login_continue_button);
+            String currentEmail = mEmailInput.getEditText().getText().toString();
+            continueButton.setEnabled(!currentEmail.trim().isEmpty());
+        }
+    }
+
     private void setupTosButtons(Button continueTosButton, Button continueWithGoogleTosButton) {
         OnClickListener onClickListener = new OnClickListener() {
             public void onClick(View view) {
@@ -447,6 +456,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     public void onResume() {
         super.onResume();
         mAnalyticsListener.emailFormScreenResumed();
+        updateContinueButtonEnabledStatus();
     }
 
     @Override
@@ -537,6 +547,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         mEmailInput.setError(null);
         mIsSocialLogin = false;
         clearEmailError();
+        updateContinueButtonEnabledStatus();
     }
 
     private void showEmailError(int messageId) {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -109,6 +109,7 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
     @Override
     public void onResume() {
         super.onResume();
+        updatePrimaryButtonEnabledStatus();
 
         // connect to the Service. We'll receive updates via EventBus.
         mServiceEventConnection = new AutoForeground.ServiceEventConnection(getContext(),
@@ -125,6 +126,15 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
 
         // disconnect from the Service
         mServiceEventConnection.disconnect(getContext(), this);
+    }
+
+    private void updatePrimaryButtonEnabledStatus() {
+        View view = getView();
+        if (view != null) {
+            Button primaryButton = (Button) view.findViewById(R.id.primary_button);
+            String currentPassword = mPasswordInput.getEditText().getText().toString();
+            primaryButton.setEnabled(!currentPassword.trim().isEmpty());
+        }
     }
 
     @Override
@@ -266,6 +276,7 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
         mPasswordInput.setError(null);
 
         LoginWpcomService.clearLoginServiceState();
+        updatePrimaryButtonEnabledStatus();
     }
 
     private void showPasswordError() {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -129,11 +129,8 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
     }
 
     private void updatePrimaryButtonEnabledStatus() {
-        View view = getView();
-        if (view != null) {
-            String currentPassword = mPasswordInput.getEditText().getText().toString();
-            getPrimaryButton().setEnabled(!currentPassword.trim().isEmpty());
-        }
+        String currentPassword = mPasswordInput.getEditText().getText().toString();
+        getPrimaryButton().setEnabled(!currentPassword.trim().isEmpty());
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -131,9 +131,8 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
     private void updatePrimaryButtonEnabledStatus() {
         View view = getView();
         if (view != null) {
-            Button primaryButton = (Button) view.findViewById(R.id.primary_button);
             String currentPassword = mPasswordInput.getEditText().getText().toString();
-            primaryButton.setEnabled(!currentPassword.trim().isEmpty());
+            getPrimaryButton().setEnabled(!currentPassword.trim().isEmpty());
         }
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -261,6 +261,20 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
         outState.putBoolean(KEY_GET_SITE_OPTIONS_INITIATED, mGetSiteOptionsInitiated);
     }
 
+    @Override public void onResume() {
+        super.onResume();
+        updatePrimaryButtonEnabledStatus();
+    }
+
+    private void updatePrimaryButtonEnabledStatus() {
+        View view = getView();
+        if (view != null) {
+            String currentUsername = mUsernameInput.getEditText().getText().toString();
+            String currentPassword = mPasswordInput.getEditText().getText().toString();
+            getPrimaryButton().setEnabled(!currentPassword.trim().isEmpty() && !currentUsername.trim().isEmpty());
+        }
+    }
+
     protected void next() {
         mAnalyticsListener.trackSubmitClicked();
         if (!NetworkUtils.checkConnection(getActivity())) {
@@ -335,6 +349,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
         showError(null);
+        updatePrimaryButtonEnabledStatus();
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -267,12 +267,9 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
     }
 
     private void updatePrimaryButtonEnabledStatus() {
-        View view = getView();
-        if (view != null) {
-            String currentUsername = mUsernameInput.getEditText().getText().toString();
-            String currentPassword = mPasswordInput.getEditText().getText().toString();
-            getPrimaryButton().setEnabled(!currentPassword.trim().isEmpty() && !currentUsername.trim().isEmpty());
-        }
+        String currentUsername = mUsernameInput.getEditText().getText().toString();
+        String currentPassword = mPasswordInput.getEditText().getText().toString();
+        getPrimaryButton().setEnabled(!currentPassword.trim().isEmpty() && !currentUsername.trim().isEmpty());
     }
 
     protected void next() {


### PR DESCRIPTION
Fixes #12243 

This PR disables the primary buttons when the input fields are empty on following screens:
- Login with email - when the email input is empty
- Password with input - when the user decides to input password instead of using magic links
- Username and password input - when the user is logging in with a site address

One more screen that was already implementing this behaviour is the screen where the user inputs their site address to login. Is there any other screen you think we should fix?

To test:
- Start with a cleaned app
- Click on "Continue with Wordpress" and continue to the next screen
- Notice that the "Continue button is disabled
- Input anything into the "Email" input
- Notice that the "Continue button is now enabled
- Try writing and deleting the email, rotating the screen
- Use a valid email and continue to the next screen
- On the magic link screen decide to login with password instead
- Notice that the "Continue" button is now disabled
- Type a password
- Notice that it's now enabled


To test:
- Start with a cleaned app
- Click on "Enter your site address"
- Input a valid self-hosted site address and continue to the next screen
- Notice that the "Continue" button is now disabled
- Type in a username and a password
- Notice that the continue button is only enabled when both username and password are set

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
