### PR TITLE
Avoid NPE when webeditor is null

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 * [*] Improve wording for confirmation dialogs when trashing posts
 * [***] Block Editor: Adds Copy, Cut, Paste, and Duplicate functionality to blocks
-* [***] Block Editor: Users can now individually edit unsupported blocks found in posts or pages. Not available on Jetpack connected self-hosted sites.
+* [***] Block Editor: Users can now individually edit unsupported blocks found in posts or pages. Not available on selfhosted sites or sites defaulted to classic editor.
  
 15.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,8 +2,7 @@
 -----
 * [*] Improve wording for confirmation dialogs when trashing posts
 * [***] Block Editor: Adds Copy, Cut, Paste, and Duplicate functionality to blocks
-* [***] Block Editor: Users can now individually edit unsupported blocks found in posts or pages. Not available on selfhosted sites or sites defaulted to classic editor.
-* [***] Block Editor: Users can now individually edit unsupported blocks found in posts or pages. Not available on self-hosted sites.
+* [***] Block Editor: Users can now individually edit unsupported blocks found in posts or pages. Not available on self-hosted sites or sites defaulted to classic editor.
  
 15.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2026,7 +2026,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         // which are required for us to be able to fetch the site's authentication cookie.
                         boolean isUnsupportedBlockEditorEnabled =
                                 (mSite.isWPComAtomic() || !mSite.isJetpackConnected())
-                                && mSite.getWebEditor().equals("gutenberg");
+                                && "gutenberg".equals(mSite.getWebEditor());
 
                         return GutenbergEditorFragment.newInstance(
                                 "",

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2024,7 +2024,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         // to be set to classic and then the fallback will not work.
                         // We disable in Jetpack site because we don't have the self-hosted site's credentials
                         // which are required for us to be able to fetch the site's authentication cookie.
-                        boolean isUnsupportedBlockEditorEnabled = isWpCom && !"gutenberg".equals(mSite.getWebEditor());
+                        boolean isUnsupportedBlockEditorEnabled = isWpCom && "gutenberg".equals(mSite.getWebEditor());
 
                         return GutenbergEditorFragment.newInstance(
                                 "",

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2024,9 +2024,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         // to be set to classic and then the fallback will not work.
                         // We disable in Jetpack site because we don't have the self-hosted site's credentials
                         // which are required for us to be able to fetch the site's authentication cookie.
-                        boolean isUnsupportedBlockEditorEnabled =
-                                (mSite.isWPComAtomic() || !mSite.isJetpackConnected())
-                                && "gutenberg".equals(mSite.getWebEditor());
+                        boolean isUnsupportedBlockEditorEnabled = isWpCom && !"gutenberg".equals(mSite.getWebEditor());
 
                         return GutenbergEditorFragment.newInstance(
                                 "",


### PR DESCRIPTION
~When testing unsupported block editing for the gutengerg 1.32 release, I observed that on my pressable site the webEditor was null and this was crashing the app. This addresses that by reversing the `.equals()` check to avoid the NPE.~

UPDATE: This PR was originally fixing a NPE, but it grew to address a newly discovered bug on self-hosted sites, ~and then eventually to just disable the feature for the time being to allow for more testing~.

To test:
Load the gutenberg editor on a site where the webeditor value is null (a Pressable non-jetpack connected site is what I used), and confirm that the app does not crash.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
