### PR TITLE
Update FluxC to fix an AssertionError crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.16-beta-2'
+    fluxCVersion = 'a3c33899a'
 
     appCompatVersion = '1.0.2'
     constraintLayoutVersion = '1.1.3'


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1627
Merging these FluxC changes - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1630

This PR is here to update WPAndroid with the crash fix

To test:
- There are no reproduction steps, go to steps and make sure they don't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
