### PR TITLE
Skip prologue screen when adding a WP.com account from the Me screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -152,7 +152,11 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                     break;
                 case WPCOM_LOGIN_ONLY:
                     mUnifiedLoginTracker.setSource(Source.ADD_WORDPRESS_COM_ACCOUNT);
-                    loginFromPrologue();
+                    if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
+                        checkSmartLockPasswordAndStartLogin();
+                    } else {
+                        loginFromPrologue();
+                    }
                     break;
                 case SELFHOSTED_ONLY:
                     mUnifiedLoginTracker.setSource(Source.SELF_HOSTED);


### PR DESCRIPTION
Fixes #12253 

This PR changes the app behaviour so when you're logged with a self-hosted site and you go to the Me screen and click on "Log in with WordPress.com", you're no longer redirected to the Prologue. The reason is that the prologue offers 2 options - "Continue with WordPress.com" and "Continue with your site address". The second option doesn't make sense any more since the action the user is taking is explicitly "Log in with WordPress.com" account and they're already logged in with their site.
The user is now redirected directly to the "Get Started" screen where they can log in with their email or with Google. 

To test:
- Log in with your self-hosted site
- Go to Me/Log in with WordPress.com
- Notice that you're redirected to the "Get Started" screen and you skip the "Prologue" 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
