### PR TITLE
Unified Login & Sign-Up: Update login and sign-up UI tests

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -1,4 +1,5 @@
 package org.wordpress.android.e2e;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
 
@@ -31,23 +32,23 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void loginWithEmailPassword() {
-        new LoginFlow().chooseLogin()
-                 .enterEmailAddress()
-                 .enterPassword()
-                 .confirmLogin();
+        new LoginFlow().chooseContinueWithWpCom()
+                       .enterEmailAddress()
+                       .enterPassword()
+                       .confirmLogin();
     }
 
     @Test
     public void loginWithSiteAddress() {
-        new LoginFlow().chooseLogin()
-                 .chooseAndEnterSiteAddress(E2E_WP_COM_USER_SITE_ADDRESS)
-                 .enterUsernameAndPassword(E2E_WP_COM_USER_USERNAME, E2E_WP_COM_USER_PASSWORD)
-                 .confirmLogin();
+        new LoginFlow().chooseEnterYourSiteAddress()
+                       .enterSiteAddress(E2E_WP_COM_USER_SITE_ADDRESS)
+                       .enterUsernameAndPassword(E2E_WP_COM_USER_USERNAME, E2E_WP_COM_USER_PASSWORD)
+                       .confirmLogin();
     }
 
     @Test
     public void loginWithMagicLink() {
-        new LoginFlow().chooseLogin()
+        new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress()
                        .chooseMagicLink(mMagicLinkActivityTestRule)
                        .confirmLogin();
@@ -55,10 +56,10 @@ public class LoginTests extends BaseTest {
 
     @Test
     public void loginWithSelfHostedAccount() {
-        new LoginFlow().chooseLogin()
-                .chooseAndEnterSiteAddress(E2E_SELF_HOSTED_USER_SITE_ADDRESS)
-                .enterUsernameAndPassword(E2E_SELF_HOSTED_USER_USERNAME, E2E_SELF_HOSTED_USER_PASSWORD)
-                .confirmLogin();
+        new LoginFlow().chooseEnterYourSiteAddress()
+                       .enterSiteAddress(E2E_SELF_HOSTED_USER_SITE_ADDRESS)
+                       .enterUsernameAndPassword(E2E_SELF_HOSTED_USER_USERNAME, E2E_SELF_HOSTED_USER_PASSWORD)
+                       .confirmLogin();
     }
 
     @After

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.java
@@ -26,7 +26,7 @@ public class SignUpTests extends BaseTest {
 
     @Test
     public void signUpWithMagicLink() {
-        new SignupFlow().chooseSignupWithEmail()
+        new SignupFlow().chooseContinueWithWpCom()
                         .enterEmail(E2E_SIGNUP_EMAIL)
                         .openMagicLink(mMagicLinkActivityTestRule)
                         .checkEpilogue(

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -16,7 +16,6 @@ import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
-import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
@@ -27,27 +26,27 @@ import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 
 public class LoginFlow {
-    public LoginFlow chooseLogin() {
-        // Login Prologue – We want to log in, not sign up
+    public LoginFlow chooseContinueWithWpCom() {
+        // Login Prologue – We want to Continue with WordPress.com, not a site address
         // See LoginPrologueFragment
-        clickOn(R.id.login_button);
+        clickOn(R.id.first_button);
         return this;
     }
 
     public LoginFlow enterEmailAddress() {
-        // Email Address Screen – Fill it in and click "Next"
+        // Email Address Screen – Fill it in and click "Continue"
         // See LoginEmailFragment
         populateTextField(R.id.input, E2E_WP_COM_USER_EMAIL);
-        clickOn(R.id.primary_button);
+        clickOn(R.id.login_continue_button);
         return this;
     }
 
     public LoginFlow enterPassword() {
-        // Receive Magic Link or Enter Password Screen – Choose "Enter Password"
+        // Receive Magic Link or Enter Password Screen – Choose "Or type your password"
         // See LoginMagicLinkRequestFragment
         clickOn(R.id.login_enter_password);
 
-        // Password Screen – Fill it in and click "Next"
+        // Password Screen – Fill it in and click "Continue"
         // See LoginEmailPasswordFragment
         populateTextField(R.id.input, E2E_WP_COM_USER_PASSWORD);
         clickOn(R.id.primary_button);
@@ -70,11 +69,12 @@ public class LoginFlow {
     }
 
     public LoginFlow chooseMagicLink(ActivityTestRule<LoginMagicLinkInterceptActivity> magicLinkActivityTestRule) {
-        // Receive Magic Link or Enter Password Screen – Choose "Send Link"
+        // Receive Magic Link or Enter Password Screen – Choose "Send link by email"
         // See LoginMagicLinkRequestFragment
         clickOn(R.id.login_request_magic_link);
 
-        // Should See Open Mail button
+        // Should see "Check email" button
+        // See LoginMagicLinkSentFragment
         waitForElementToBeDisplayed(R.id.login_open_email_client);
 
         // Follow the magic link to continue login
@@ -97,8 +97,16 @@ public class LoginFlow {
         return this;
     }
 
-    public LoginFlow chooseAndEnterSiteAddress(String siteAddress) {
-        clickOn(onView(withText(R.string.enter_site_address_instead)));
+    public LoginFlow chooseEnterYourSiteAddress() {
+        // Login Prologue – We want to continue with a site address not a WordPress.com account
+        // See LoginPrologueFragment
+        clickOn(R.id.second_button);
+        return this;
+    }
+
+    public LoginFlow enterSiteAddress(String siteAddress) {
+        // Site Address Screen – Fill it in and click "Continue"
+        // See LoginSiteAddressFragment
         populateTextField(R.id.input, siteAddress);
         clickOn(R.id.primary_button);
         return this;

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
@@ -20,25 +20,29 @@ import static org.wordpress.android.support.WPSupportUtils.populateTextField;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 
 public class SignupFlow {
-    public SignupFlow chooseSignupWithEmail() {
-        clickOn(onView(withId(R.id.create_site_button)));
-        clickOn(onView(withId(R.id.signup_email)));
-
+    public SignupFlow chooseContinueWithWpCom() {
+        // Login Prologue – We want to Continue with WordPress.com, not a site address
+        // See LoginPrologueFragment
+        clickOn(R.id.first_button);
         return this;
     }
 
     public SignupFlow enterEmail(String email) {
         // Email file = id/input
         populateTextField(onView(withId(R.id.input)), email);
-        clickOn(onView(withId(R.id.primary_button)));
-
-        // Should See Open Mail button
-        waitForElementToBeDisplayed(R.id.signup_magic_link_button);
-
+        clickOn(onView(withId(R.id.login_continue_button)));
         return this;
     }
 
     public SignupFlow openMagicLink(ActivityTestRule<LoginMagicLinkInterceptActivity> magicLinkActivityTestRule) {
+        // Receive Magic Link – Choose "Send link by email"
+        // See SignupConfirmationFragment
+        clickOn(R.id.signup_confirmation_button);
+
+        // Should see "Check email" button
+        // See SignupMagicLinkFragment
+        waitForElementToBeDisplayed(R.id.signup_magic_link_button);
+
         // Follow the magic link to continue login
         // Intent is invoked directly rather than through a browser as WireMock is unavailable once in the background
         Intent intent = new Intent(
@@ -53,7 +57,7 @@ public class SignupFlow {
 
     public SignupFlow checkEpilogue(String displayName, String username) {
         // Check Epilogue data
-        ViewInteraction emailHeaderView = onView(withId(R.id.signup_epilogue_header_email));
+        ViewInteraction emailHeaderView = onView(withId(R.id.login_epilogue_header_subtitle));
         waitForElementToBeDisplayed(emailHeaderView);
 
         ViewInteraction displayNameField = onView(allOf(withId(R.id.input), withText(displayName)));

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -85,7 +85,7 @@ public class BaseTest {
     }
 
     protected void logoutIfNecessary() {
-        if (isElementDisplayed(R.id.login_button) || isElementDisplayed(R.id.login_open_email_client)) {
+        if (isElementDisplayed(R.id.first_button) || isElementDisplayed(R.id.login_open_email_client)) {
             return;
         }
 
@@ -93,9 +93,10 @@ public class BaseTest {
             logout();
         }
     }
+
     protected void wpLogin() {
         logoutIfNecessary();
-        new LoginFlow().chooseLogin()
+        new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress()
                        .enterPassword()
                        .confirmLogin();


### PR DESCRIPTION
This PR updates both login and sign-up UI tests to account for the changes made by the Unified Login & Sign-Up project.

Most changes are pretty straightforward as they basically update the necessary IDs to match new views and method names to stay consistent with the new flow.

To test:

- Run the optional UI/connected tests on CI and confirm they pass.
- Run the UI/connected tests locally with a new emulator (to ensure we don't run into [this SmartLock issue](https://github.com/wordpress-mobile/WordPress-Android/pull/12285)) and confirm they pass. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
