### PR TITLE
Extract Signup utils to fix crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -129,6 +129,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     @Inject protected Dispatcher mDispatcher;
     @Inject protected ImageManager mImageManager;
     @Inject protected AppPrefsWrapper mAppPrefsWrapper;
+    @Inject protected SignupUtils mSignupUtils;
 
     public static SignupEpilogueFragment newInstance(String displayName, String emailAddress,
                                                      String photoUrl, String username,
@@ -525,36 +526,6 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         return !TextUtils.equals(mAccount.getAccount().getUserName(), mUsername);
     }
 
-    /**
-     * Create a display name from the email address by taking everything before the "@" symbol,
-     * removing all non-letters and non-periods, replacing periods with spaces, and capitalizing
-     * the first letter of each word.
-     *
-     * @return {@link String} to be the display name
-     */
-    private String createDisplayNameFromEmail() {
-        String username = mEmailAddress.split("@")[0].replaceAll("[^A-Za-z/.]", "");
-        String[] array = username.split("\\.");
-        StringBuilder builder = new StringBuilder();
-
-        for (String s : array) {
-            String capitalized = s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
-            builder.append(capitalized.concat(" "));
-        }
-
-        return builder.toString().trim();
-    }
-
-    /**
-     * Create a username from the email address by taking everything before the "@" symbol and
-     * removing all non-alphanumeric characters.
-     *
-     * @return {@link String} to be the username
-     */
-    private String createUsernameFromEmail() {
-        return mEmailAddress.split("@")[0].replaceAll("[^A-Za-z0-9]", "").toLowerCase(Locale.ROOT);
-    }
-
     private boolean isPasswordInErrorMessage(String message) {
         String lowercaseMessage = message.toLowerCase(Locale.getDefault());
         String lowercasePassword = getString(R.string.password).toLowerCase(Locale.getDefault());
@@ -619,9 +590,9 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
 
     private void populateViews() {
         mEmailAddress = mAccountStore.getAccount().getEmail();
-        mDisplayName = createDisplayNameFromEmail();
+        mDisplayName = mSignupUtils.createDisplayNameFromEmail(mEmailAddress);
         mUsername = !TextUtils.isEmpty(mAccountStore.getAccount().getUserName())
-                ? mAccountStore.getAccount().getUserName() : createUsernameFromEmail();
+                ? mAccountStore.getAccount().getUserName() : mSignupUtils.createUsernameFromEmail(mEmailAddress);
         mHeaderDisplayName.setText(mDisplayName);
         mHeaderEmailAddress.setText(mEmailAddress);
         mEditTextDisplayName.setText(mDisplayName);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupUtils.kt
@@ -1,0 +1,44 @@
+package org.wordpress.android.ui.accounts.signup
+
+import java.util.Locale
+import javax.inject.Inject
+
+class SignupUtils
+@Inject constructor() {
+    /**
+     * Create a display name from the email address by taking everything before the "@" symbol,
+     * removing all non-letters and non-periods, replacing periods with spaces, and capitalizing
+     * the first letter of each word.
+     *
+     * @return [String] to be the display name
+     */
+    fun createDisplayNameFromEmail(emailAddress: String): String? {
+        val username = emailAddress.split("@").firstOrNull() ?: return null
+        val usernameArray = username.replace("[^A-Za-z/.]".toRegex(), "").split(".")
+        val builder = StringBuilder()
+        for (item in usernameArray) {
+            if (item.isNotEmpty()) {
+                builder.append(item.substring(0, 1).toUpperCase(Locale.ROOT))
+                if (item.length > 1) {
+                    builder.append(item.substring(1))
+                }
+            }
+        }
+        val displayName = builder.toString().trim { it <= ' ' }
+        return if (displayName.isNotEmpty()) displayName else null
+    }
+
+    /**
+     * Create a username from the email address by taking everything before the "@" symbol and
+     * removing all non-alphanumeric characters.
+     *
+     * @return [String] to be the username
+     */
+    fun createUsernameFromEmail(emailAddress: String): String? {
+        return emailAddress.split("@".toRegex())
+                .toTypedArray()
+                .get(0)
+                .replace("[^A-Za-z0-9]".toRegex(), "")
+                .toLowerCase(Locale.ROOT)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupUtils.kt
@@ -25,7 +25,7 @@ class SignupUtils
                 builder.append(" ")
             }
         }
-        val displayName = builder.toString().trim { it <= ' ' }
+        val displayName = builder.toString().trim()
         return if (displayName.isNotEmpty()) displayName else null
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupUtils.kt
@@ -22,6 +22,7 @@ class SignupUtils
                 if (item.length > 1) {
                     builder.append(item.substring(1))
                 }
+                builder.append(" ")
             }
         }
         val displayName = builder.toString().trim { it <= ' ' }
@@ -35,9 +36,7 @@ class SignupUtils
      * @return [String] to be the username
      */
     fun createUsernameFromEmail(emailAddress: String): String? {
-        return emailAddress.split("@".toRegex())
-                .toTypedArray()
-                .get(0)
+        return emailAddress.split("@".toRegex())[0]
                 .replace("[^A-Za-z0-9]".toRegex(), "")
                 .toLowerCase(Locale.ROOT)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/signup/SignupUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/signup/SignupUtilsTest.kt
@@ -85,8 +85,8 @@ class SignupUtilsTest {
         assertThat(displayName).isEqualTo(expectedDisplayName)
     }
 
-    private fun assertEmailMappedToUsername(email: String, expectedDisplayName: String? = null) {
-        val displayName = signupUtils.createUsernameFromEmail(email)
-        assertThat(displayName).isEqualTo(expectedDisplayName)
+    private fun assertEmailMappedToUsername(email: String, expectedUsername: String? = null) {
+        val username = signupUtils.createUsernameFromEmail(email)
+        assertThat(username).isEqualTo(expectedUsername)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/signup/SignupUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/signup/SignupUtilsTest.kt
@@ -41,8 +41,8 @@ class SignupUtilsTest {
     }
 
     @Test
-    fun `maps invalid email ending with dot and numbers`() {
-        assertEmailMappedToDisplayName("username.1+a.2.3@email.com", "Username A")
+    fun `maps invalid email ending with numbers in the middle`() {
+        assertEmailMappedToDisplayName("username.12.a@email.com", "Username A")
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/signup/SignupUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/signup/SignupUtilsTest.kt
@@ -22,7 +22,7 @@ class SignupUtilsTest {
 
     @Test
     fun `maps longer email to display name`() {
-        assertEmailMappedToDisplayName("firstname.lastname@email.com", "FirstnameLastname")
+        assertEmailMappedToDisplayName("firstname.lastname@email.com", "Firstname Lastname")
     }
 
     @Test
@@ -32,12 +32,17 @@ class SignupUtilsTest {
 
     @Test
     fun `maps single character longer email to display name`() {
-        assertEmailMappedToDisplayName("a.b.c@email.com", "ABC")
+        assertEmailMappedToDisplayName("a.b.c@email.com", "A B C")
     }
 
     @Test
     fun `maps invalid email only with domain to null`() {
         assertEmailMappedToDisplayName("@email.com", null)
+    }
+
+    @Test
+    fun `maps invalid email ending with dot and numbers`() {
+        assertEmailMappedToDisplayName("username.1+a.2.3@email.com", "Username A")
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/signup/SignupUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/signup/SignupUtilsTest.kt
@@ -1,0 +1,87 @@
+package org.wordpress.android.ui.accounts.signup
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class SignupUtilsTest {
+    private lateinit var signupUtils: SignupUtils
+
+    @Before
+    fun setUp() {
+        this.signupUtils = SignupUtils()
+    }
+
+    @Test
+    fun `maps simple email to display name`() {
+        assertEmailMappedToDisplayName("displayname@email.com", "Displayname")
+    }
+
+    @Test
+    fun `maps longer email to display name`() {
+        assertEmailMappedToDisplayName("firstname.lastname@email.com", "FirstnameLastname")
+    }
+
+    @Test
+    fun `maps single character short email to display name`() {
+        assertEmailMappedToDisplayName("a@email.com", "A")
+    }
+
+    @Test
+    fun `maps single character longer email to display name`() {
+        assertEmailMappedToDisplayName("a.b.c@email.com", "ABC")
+    }
+
+    @Test
+    fun `maps invalid email only with domain to null`() {
+        assertEmailMappedToDisplayName("@email.com", null)
+    }
+
+    @Test
+    fun `maps invalid email without domain to just display name`() {
+        assertEmailMappedToDisplayName("displayname", "Displayname")
+    }
+
+    @Test
+    fun `creates username from simple email`() {
+        assertEmailMappedToUsername("username@email.com", "username")
+    }
+
+    @Test
+    fun `creates username from longer email`() {
+        assertEmailMappedToUsername("firstname.lastname@email.com", "firstnamelastname")
+    }
+
+    @Test
+    fun `creates username from single character short email`() {
+        assertEmailMappedToUsername("a@email.com", "a")
+    }
+
+    @Test
+    fun `creates username from single character longer email`() {
+        assertEmailMappedToUsername("a.b.c@email.com", "abc")
+    }
+
+    @Test
+    fun `returns null username from invalid email only with domain`() {
+        assertEmailMappedToUsername("@email.com", "")
+    }
+
+    @Test
+    fun `creates username from invalid email without domain`() {
+        assertEmailMappedToUsername("username", "username")
+    }
+
+    private fun assertEmailMappedToDisplayName(email: String, expectedDisplayName: String? = null) {
+        val displayName = signupUtils.createDisplayNameFromEmail(email)
+        assertThat(displayName).isEqualTo(expectedDisplayName)
+    }
+
+    private fun assertEmailMappedToUsername(email: String, expectedDisplayName: String? = null) {
+        val displayName = signupUtils.createUsernameFromEmail(email)
+        assertThat(displayName).isEqualTo(expectedDisplayName)
+    }
+}


### PR DESCRIPTION
Fixes #12399 

This crash happens when you have an email like this `username.12.a@email.com`. The code that handles the username removes all the characters that are not a-z and we end up with an array of items like this `["username", "", "a"]`. As you see, the second item in the array is empty. This causes a crash because we're trying to call `substring(0, 1)` on this empty string. 

In this PR I've extracted the logic, added a check for empty string and wrote some tests. 

To test:
- Start with a fresh install of the app
- Click on "Sign up for WordPress.com"
- Select "Sign up with email"
- Use an email that contains letters having dots on both sides, for example for a Gmail account you can do something like this: `username+a.12.b@gmail.com` since the + gets stripped as well
- Go through the magic link signup
- Notice that the app no longer crashes, the suggested display name should be something like "Username A B"

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
