### PR TITLE
Fix crash with vector on older devices

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ImageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ImageItemViewHolder.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.ImageView.ScaleType.CENTER
+import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ImageItem
 import org.wordpress.android.util.image.ImageManager
@@ -12,6 +14,9 @@ class ImageItemViewHolder(parent: ViewGroup, val imageManager: ImageManager) : B
 ) {
     private val image = itemView.findViewById<ImageView>(R.id.image)
     fun bind(item: ImageItem) {
-        imageManager.load(image, item.imageResource)
+        val vectorDrawable = VectorDrawableCompat.create(image.resources, item.imageResource, null)
+        if (vectorDrawable != null) {
+            imageManager.load(image, vectorDrawable, CENTER)
+        }
     }
 }

--- a/WordPress/src/main/res/layout/stats_block_image_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_image_item.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <ImageView
         android:id="@+id/image"
@@ -10,7 +11,7 @@
         android:layout_gravity="center_horizontal"
         android:layout_marginBottom="@dimen/margin_medium"
         android:contentDescription="@string/stats_manage_your_stats"
-        android:src="@drawable/insights_management_feature_image" />
+        app:srcCompat="@drawable/insights_management_feature_image" />
 
     <View
         android:id="@+id/image_gradient_overlay"


### PR DESCRIPTION
Fixes #12396

There is an issue with loading the new vector drawable in the insights management news card. It crashes on older devices. This is fixed by 2 steps. One is replacing the `android:src` in the XML layout file with `app:srcCompat` and the second one is using `VectorDrawableCompat` to load the vector drawable. The previously used compat method also crashes. 

To test:
- Open the app on a device with an older API (I tested it with 21) - use fresh install
- Log in
- Go to Stats
- See that there is the Insights Management card on the first place on the Insights screen and the app doesn't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
