### PR TITLE
Fix/empty release notes short strings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: ../release-toolkit
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit
+  revision: 9f1b821b3b5837f883a67313dd52070f281d588e
+  branch: fix/empty-release-strings
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.9.10)
       activesupport (~> 4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 9f1b821b3b5837f883a67313dd52070f281d588e
-  branch: fix/empty-release-strings
+  revision: 841e167dffc0f45fc36a513f8ba68a37689141e8
+  tag: 0.9.11
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.10)
+    fastlane-plugin-wpmreleasetoolkit (0.9.11)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,7 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: b515c0b26b78bfffc3cbe5ceb3b51bb6eb979ab4
-  tag: 0.9.8
+PATH
+  remote: ../release-toolkit
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.8)
+    fastlane-plugin-wpmreleasetoolkit (0.9.10)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -165,7 +163,7 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.6)
+    oj (3.10.7)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.0)
@@ -176,7 +174,7 @@ GEM
       options (~> 2.3.0)
     public_suffix (2.0.5)
     rake (12.3.3)
-    rake-compiler (1.1.0)
+    rake-compiler (1.1.1)
       rake
     rchardet (1.8.0)
     representable (3.0.4)

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -28,11 +28,6 @@ msgid ""
 msgstr ""
 
 #. translators: A shorter version of the Release notes to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
-msgctxt "release_note_short_153"
-msgid ""
-"15.3:\n"
-msgstr ""
-
 msgctxt "release_note_short_152"
 msgid ""
 "15.2:\n"

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,4 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.9.8'
+#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.9.8'
+gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../wordpress-mobile/release-toolkit'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,4 +6,4 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'fix/empty-release-strings'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.11'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,4 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag:'0.9.8'
-gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../wordpress-mobile/release-toolkit'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'fix/empty-release-strings'


### PR DESCRIPTION
This PR tweaks the Fastlane lane that updates the PO file for Android metadata strings in order to omit the release_notes_short key update if the source file is empty. 
I've opted to make this change only for this string because I think it's the one and only string that we regularly and that can actually be empty: the `release_notes` string should be never empty and the other strings change rarely, so if we want to remove one of them, we probably should update the configuration in `update_appstore_strings` as well. 

To test:
1. Run `bundle exec fastlane update_appstore_strings version:15.3` and verify that `release_note_short_153` is not re-added to `PlayStoreStrings.po`.
2. Create a new test branch out of this one.
3. Add something in `WordPress/metadata/release_notes_short.txt` and commit it.
4. Run `bundle exec fastlane update_appstore_strings version:15.3` and verify that `release_note_short_153` is added to `PlayStoreStrings.po`. Note that the lane can fail here if you haven't pushed the test branch to GitHub. This is ok, but make sure that it fails on `git push`.
5. Delete the test branch.

**Note:** The changes in this PR are related to https://github.com/wordpress-mobile/release-toolkit/pull/147. When this is approved I'll release a new version of the `release-toolkit` and update this PR before merging it.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
