### PR TITLE
Prepublishing Nudges / Post Settings - Older drafts says Immediately instead of Publish On

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsUtils.kt
@@ -40,7 +40,7 @@ class PostSettingsUtils
             } else if (postUtilsWrapper.isPublishDateInTheFuture(postModel.dateCreated)) {
                 labelToUse = resourceProvider.getString(R.string.schedule_for, formattedDate)
             } else {
-                labelToUse = resourceProvider.getString(R.string.publish_on, formattedDate)
+                labelToUse = resourceProvider.getString(R.string.immediately)
             }
         } else if (postUtilsWrapper.shouldPublishImmediatelyOptionBeAvailable(status)) {
             labelToUse = resourceProvider.getString(R.string.immediately)


### PR DESCRIPTION
Fixes #12197

## Findings
This previous PR https://github.com/wordpress-mobile/WordPress-Android/pull/12198 contains the direction for this current implementation where we are showing `Immediately` instead of the older date on the `PostModel`.

## Solution
This solution simply shows `Immediately` instead of the `Publish On`.
## Testing

1. Go to the Post List. 
2. Click publish on a old draft. 
3. Ensure the bottom sheet's Publish Date says Immediately instead of the date. 

<kbd><img src="https://user-images.githubusercontent.com/1509205/87581728-0ab5ae80-c69f-11ea-9c0d-5d7206a5936a.gif" width="320"></kbd>

-----------
1. Go to the Post List. 
2. Open an old draft in the Editor. 
3. Ensure the bottom sheet's Publish Date says Immediately instead of the date. 

<kbd><img src="https://user-images.githubusercontent.com/1509205/87582489-1190f100-c6a0-11ea-9c9a-502a22cc5462.gif" width="320"></kbd>

----------
1. Go to the Post List. 
2. Open an old draft in the Editor. 
3. Click on the Post Settings. 
4. See Immediately under the Publish Date. 

<kbd><img src="https://user-images.githubusercontent.com/1509205/87583241-40f42d80-c6a1-11ea-84e2-612776758bba.gif" width="320"></kbd>

## Concerns 
I was wondering if the `PostSettingsUtilsTest` would have to be refactored for this change. The tests still passed and covered it but a second opinion would be appreciated. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 