### PR TITLE
Fix follow button dark mode style

### DIFF
--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -57,6 +57,8 @@
         <!-- we can remove it after moving away from Bridge version of theme -->
         <item name="materialCardViewStyle">@style/Widget.MaterialComponents.CardView</item>
 
+        <item name="followButtonStyle">@style/Reader.Follow.Button</item>
+
         <item name="android:statusBarColor">?attr/colorSurface</item>
 
         <item name="windowActionModeOverlay">true</item>


### PR DESCRIPTION
This PR adds existing follow button style in the dark mode. Style was broken during follow button refactoring in the PR
https://github.com/wordpress-mobile/WordPress-Android/pull/12355. Old style was set in the light mode [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/res/values/styles.xml#L36) and already reviewed.

To test:

- Launch app and switch to Dark mode.
- Go to Reader -> Tap a post. 
- Notice that follow button look same as before. 

|Follow (Text + Icon)|
|---|
| <img width="320" alt="follow_with_text" src="https://user-images.githubusercontent.com/1405144/87628870-7fe0bc80-c74f-11ea-8e85-999a03d48f98.png">|

|Following (Text + Icon)|
|---|
| <img width="320" alt="following_with_text" src="https://user-images.githubusercontent.com/1405144/87628878-84a57080-c74f-11ea-919e-8657503786c4.png">|

|Follow (Only Icon)|
|---|
| <img width="320" alt="follow_only_icon" src="https://user-images.githubusercontent.com/1405144/87628909-9555e680-c74f-11ea-98c1-55bbff1034ad.png"> |

|Following (Only Icon)|
|---|
| <img width="320" alt="following_only_icon" src="https://user-images.githubusercontent.com/1405144/87628919-9ab33100-c74f-11ea-9201-e321c328b11d.png">|

Merge Instructions

I'm targeting `release/15.3` as the follow button will not be shown properly in the dark mode without this fix. 

cc @oguzkocer 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
