### PR TITLE
Don't tag in hotfix lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -155,6 +155,20 @@ ENV["HAS_ALPHA_VERSION"]="true"
   lane :new_hotfix_release do | options |
     prev_ver = android_hotfix_prechecks(version_name: options[:version_name], skip_confirm: options[:skip_confirm])
     android_bump_version_hotfix(previous_version_name: prev_ver, version_name: options[:version_name], version_code: options[:version_code])
+  end
+
+  #####################################################################################
+  # finalize_hotfix_release
+  # -----------------------------------------------------------------------------------
+  # This lane finalizes the hotfix branch. 
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane finalize_hotfix_release
+  #
+  # Example:
+  # bundle exec fastlane finalize_hotfix_release
+  desc "Finalizes a hotfix release by tagging the build"
+  lane :finalize_hotfix_release do | options |
     android_tag_build(tag_alpha: false)
   end
 


### PR DESCRIPTION
This PR removes tagging from the hotfix lane. When we run the `hotfix` lane, we intend to merge some fixes to the created branch and then tag the build. Before this change, we were just tagging the hotfix to the same commit as the release we are fixing which is not the intended action.

@loremattei @jkmassel @mokagio I am pinging you all for review not because we need everyone to look at a single red line 😂 but rather for you all to be aware of the issue and maybe do it for other repos if necessary. I could also do it for all our repos after my afk, just let me know if you'd like me to.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
