### PR TITLE
Prepublishing Nudges : Update Publish Date Strings

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1343,7 +1343,7 @@
     <string name="post_settings_slug_dialog_hint">The slug is the URL-friendly version of the post title.</string>
     <string name="post_settings_excerpt_dialog_hint">Excerpts are optional hand-crafted summaries of your content.</string>
     <string name="post_settings_password_dialog_hint">Only those with this password can view this post</string>
-    <string name="post_settings_time_and_date">Time and Date</string>
+    <string name="post_settings_time_and_date">Date and Time</string>
     <string name="post_settings_notification">Notification</string>
     <string name="post_settings_add_to_calendar">Add to calendar</string>
 
@@ -2832,7 +2832,7 @@
     <string name="prepublishing_nudges_home_update_button" translatable="false">@string/update_now</string>
     <string name="prepublishing_nudges_back_button">Back</string>
     <string name="prepublishing_nudges_toolbar_title_tags">Add Tags</string>
-    <string name="prepublishing_nudges_toolbar_title_publish">Publish</string>
+    <string name="prepublishing_nudges_toolbar_title_publish">Publish Date</string>
     <string name="prepublishing_tags_description">Tags help tell readers what a post is about.</string>
     <string name="prepublishing_nudges_home_tags_not_set">Not set</string>
 


### PR DESCRIPTION
Fixes #12443 

## Solution
Updated the Publish UI strings for more consistency with the respective controls. 

## Testing

1. Create a new post. 
2. Click Publish. 
3. Click Publish Date. 
4. See the `Publish Date` toolbar title and the `Date and Time` option. 

Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/87459537-1e92df00-c5d1-11ea-8a4e-3dfc37f14b25.png" width="320"></kbd> |      <kbd><img src="https://user-images.githubusercontent.com/1509205/87705945-50887a80-c764-11ea-8743-5dc08f0dcfc3.png" width="320"></kbd>
-----------
1. Create a new post. 
2. Go to Post Settings. 
3. Click Publish Date. 
4. See the `Date and Time` option. 

Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/87706238-c7be0e80-c764-11ea-89bd-e299b097c0f7.png" width="320"></kbd> |       <kbd><img src="https://user-images.githubusercontent.com/1509205/87706256-d1477680-c764-11ea-9c15-731fee530d21.png" width="320"></kbd>

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 