### PR TITLE
Prepublishing Nudges : Fixes a bug where the bottom sheet was not being dismissed on first try

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -53,12 +53,10 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
         isStarted = true
 
         this.site = site
-        this.currentScreen = currentScreenFromSavedState
+        this.currentScreen = currentScreenFromSavedState ?: HOME
 
         currentScreen?.let { screen ->
             navigateToScreen(screen)
-        } ?: run {
-            navigateToScreen(HOME)
         }
         fetchTags()
     }


### PR DESCRIPTION
Fixes #12406 

## Findings
A bug in the `PrepublishingViewModel` was causing the app to not dismiss the bottom sheet on first try because the bottom sheet was not made aware that it's currently on the `HOME` screen. So this was rectified in this PR. 

## Solution
To ensure that we are handling the initial `currentScreen` state appropriately. This is being done by setting the `currentScreen` with either a screen that was preserved during a configuration change or setting the initial screen to `HOME`. 

The previous logic was just navigating to the screen on launch. so the `currentScreen` was empty. 

## Testing

1. Create a new post.
2. Click Publish.
3. Click back.
4. Realize the bottom sheet is closed without needing to do this action twice.

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 

