### PR TITLE
Fix/code freeze localization

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name" translatable="false">WordPress</string>
@@ -2628,7 +2628,7 @@
     <string name="quick_start_dialog_view_site_message">Enjoy your finished product!</string>
     <string name="quick_start_dialog_view_site_message_short" tools:ignore="UnusedResources">Tap %1$s View Site %2$s to preview your site</string>
     <string name="quick_start_dialog_view_site_title">View your site</string>
-    <string name="quick_start_dialog_update_site_title_message_short">Tap <![CDATA[<b>%1$s</b>]]> to set a new title</string>
+    <string name="quick_start_dialog_update_site_title_message_short">Tap &lt;b&gt;%1$s&lt;/b&gt; to set a new title</string>
     <string name="quick_start_complete_tasks_header">Complete (%d)</string>
     <string name="quick_start_list_browse_themes_subtitle" translatable="false">@string/quick_start_dialog_browse_themes_message</string>
     <string name="quick_start_list_browse_themes_title" translatable="false">@string/quick_start_dialog_browse_themes_title</string>

--- a/tools/merge_strings_xml.py
+++ b/tools/merge_strings_xml.py
@@ -98,7 +98,10 @@ def merge_strings(main_xml, extra_sections):
         add_section(main_root, insertion_point_index, section_name, new_elements)
     # make sure xml file ends with a newline
     main_root.tail = '\n'
-    xml_output_tree.write(main_xml, encoding='utf-8', xml_declaration=True)
+    xml_string = ('<?xml version="1.0" encoding="UTF-8"?>' + '\n' + 
+        ET.tostring(main_root, encoding='utf8').split('\n',1)[1])
+    with open(main_xml, 'wb') as xml_file:
+        xml_file.write(xml_string)
 
 def main():
     merge_strings(


### PR DESCRIPTION
This PR updates the `merge_strings_xml.py` script to use double quotes in the XML declaration. 

We have had an issue where this script changed the quotes in the XML declaration from double to single and the next script in the flow changed them back to double quotes. This caused unnecessary commits where the only changes were the quotes and sometimes it caused failures. 

The root cause of the issue is that most XML libraries don't allow the user to select single or double quotes for the XML declaration: they just have a default. Since we use different languages in our flow, the XML libraries are different and they have different standards. 

Since most of our tooling in written in Ruby which defaults to double quotes and all the other `strings.xml` files use double quotes, I chose to fix the issue moving everything to double quotes. 

Unluckily, I couldn't find a clean way to fix it for the reasons above, so I ended up using what seems to be a very common solution which is manually add the header. 
Recent versions of Python allow a slightly better way for this as a `xml_declaration` parameter has been added to `ElementTree.tostring` to get the output without the library generated header, but since we don't use Python a lot and we don't require a specific minimum Python version in our setup, I opted for the slightly more hacky solution of manually replacing the first line of the library output which works with every Python version.

If you have any better solution or suggestion, I'm happy to update this PR with it :-). 
@Tug please let me know if you see any issue/possible side effect with this. 

To test:
- Run `./tools/merge_strings_xml.py` and verify that the header has double quotes. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
