### PR TITLE
Use custom drawable to avoid a crash from Android

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
@@ -32,7 +32,8 @@
         android:hint="@string/password"
         android:importantForAutofill="noExcludeDescendants"
         android:inputType="textPassword"
-        app:passwordToggleEnabled="true" />
+        app:passwordToggleEnabled="true"
+        app:passwordToggleDrawable="@drawable/selector_password_visibility" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/login_reset_password"


### PR DESCRIPTION
Fixes #12466

I couldn't reproduce this error but we've seen this error before and it was fixed by replacing the standard "eye" icon in the password by our custom one. The related PRs are:
https://github.com/wordpress-mobile/WordPress-Android/pull/11172
https://github.com/wordpress-mobile/WordPress-Android/pull/10279
both fixing the same thing. 

<img width="492" alt="Screenshot 2020-07-17 at 11 23 17" src="https://user-images.githubusercontent.com/1079756/87770948-f4832c00-c81f-11ea-802a-6f239a472fca.png">
<img width="488" alt="Screenshot 2020-07-17 at 11 23 06" src="https://user-images.githubusercontent.com/1079756/87770953-f5b45900-c81f-11ea-9de3-9ad3c4ea4057.png">


To test:
- Open the cleaned app app 
- Click on "Enter your site address"
- Enter your site address
- On the next screen notice that the password eye icon looks ok

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
