### PR TITLE
Turn off predictive item animations for WrappingLinearLayoutManager

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/WrappingLinearLayoutManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/WrappingLinearLayoutManager.kt
@@ -56,4 +56,6 @@ class WrappingLinearLayoutManager(
     }
 
     override fun isAutoMeasureEnabled(): Boolean = enableAutoMeasure
+
+    override fun supportsPredictiveItemAnimations(): Boolean = false
 }


### PR DESCRIPTION
Fixes #12464, #11589. I've spent the last couple hours reading the source code for `RecyclerView` and as far as I can tell, these crashes are caused by an internal issue to `RecyclerView` rather than something we are doing. If we were to be at fault, it'd more than likely be a threading issue, but considering we calculate the diff and update the data in the main thread immediately after one another, I can't see this being the issue.

What seems to happen is; during layout `RecyclerView` tries to re-use a previous view holder, which they call `scrap`, and when the predictive animation is enabled they _seem_ to do this before the position is properly cleaned up, so the check fails for a view holder that's currently in a detached state. I'd need to put in more time to verify all my assumptions, but [this Stackoverflow answer](https://stackoverflow.com/a/33985508) seems to support it.

@jd-alexander one of your suggested solutions [in this comment](https://github.com/wordpress-mobile/WordPress-Android/issues/11589#issuecomment-609490215) also supports this, but I am curious why you opted not to open a PR for it at the time?

It's important to note that, this fix is not a certain one, but as far as I can tell, it's the best one we can try. If we merge this, I'll keep an eye on these crashes and follow up on it if necessary.

**To test:**
* I was unable to reproduce the issue, so we just need to verify that this change doesn't have any unforeseen side-effects, meaning it should work exactly how it did before.

**PR submission checklist:**

I am not sure whether we want to add a release note for this. The fix is not a certain one and we don't know exactly when it happens, so we probably can't give any meaningful information to the user about this.

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
