### PR TITLE
persist tag data on rotation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
@@ -30,6 +30,7 @@ public class PostSettingsTagsActivity extends LocaleAwareActivity implements Tag
             mTags = getIntent().getStringExtra(KEY_TAGS);
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
+            mTags = savedInstanceState.getString(KEY_TAGS);
         }
         if (mSite == null) {
             ToastUtils.showToast(this, R.string.blog_not_found, ToastUtils.Duration.SHORT);
@@ -64,6 +65,7 @@ public class PostSettingsTagsActivity extends LocaleAwareActivity implements Tag
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
+        outState.putString(KEY_TAGS, mTags);
     }
 
     @Override
@@ -100,6 +102,7 @@ public class PostSettingsTagsActivity extends LocaleAwareActivity implements Tag
             ((PostSettingsTagsFragment) fragment).closeKeyboard();
         }
     }
+
 
     @Override public void onTagsSelected(@NonNull String selectedTags) {
         mTags = selectedTags;


### PR DESCRIPTION
Fixes #12223 

### Description
This PR persist data that is in the tag field on orientation change.

### Solution

On Android the `onSaveInstanceState(Bundle outState)` is called just before the device changes it's orientation, so the value in the `mTag` variable was extracted and pass in the `outState` object which is then pass in the `onCreate` where `mTag` is then reinitialized  from the `savedInstanceState`

### Testing
Create a new Blog post.
Go to the options (three dots at top right corner) > Post Settings > Tags.
Enter some information in the tag field
Rotate the device.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

### Before

![Screen Recording 2020-07-17 at 3 02 15 PM](https://user-images.githubusercontent.com/16544777/87827887-661fa200-c841-11ea-9a9c-b7b998a40144.gif)

### After

![Screen Recording 2020-07-17 at 3 10 34 PM](https://user-images.githubusercontent.com/16544777/87827923-7a639f00-c841-11ea-826b-04ad913df52f.gif)

