### PR TITLE
Issue/12028 reader ui state builder tests

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -11,6 +11,7 @@ import org.wordpress.android.ui.reader.utils.ReaderIframeScanner;
 import org.wordpress.android.ui.reader.utils.ReaderImageScanner;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.DateTimeUtils;
+import org.wordpress.android.util.DateTimeUtilsWrapper;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.JSONUtils;
@@ -769,6 +770,13 @@ public class ReaderPost {
     public java.util.Date getDisplayDate() {
         if (mDateDisplay == null) {
             mDateDisplay = DateTimeUtils.dateFromIso8601(this.mDatePublished);
+        }
+        return mDateDisplay;
+    }
+
+    public java.util.Date getDisplayDate(DateTimeUtilsWrapper dateTimeUtilsWrapper) {
+        if (mDateDisplay == null) {
+            mDateDisplay = dateTimeUtilsWrapper.dateFromIso8601(this.mDatePublished);
         }
         return mDateDisplay;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -121,6 +121,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
             post.takeIf { post.cardType == VIDEO }
                     ?.let { post.featuredVideo }
 
+    // TODO malinjir show overlay when buildFullVideoUrl != null
     private fun buildVideoOverlayVisibility(post: ReaderPost) = post.cardType == VIDEO
 
     private fun buildThumbnailStripUrls(post: ReaderPost) =
@@ -140,9 +141,11 @@ class ReaderPostUiStateBuilder @Inject constructor(
             (post.hasFeaturedVideo() || post.hasFeaturedImage()) &&
                     post.cardType != GALLERY
 
+    // TODO malinjir show title only when buildPhotoTitle == null
     private fun buildTitle(post: ReaderPost) =
             post.takeIf { post.cardType != PHOTO && it.hasTitle() }?.title
 
+    // TODO malinjir show excerpt only when buildPhotoTitle == null
     private fun buildExcerpt(post: ReaderPost) =
             post.takeIf { post.cardType != PHOTO && post.hasExcerpt() }?.excerpt
 
@@ -209,29 +212,21 @@ class ReaderPostUiStateBuilder @Inject constructor(
         isBookmarkList: Boolean,
         onClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ): PrimaryAction {
-        val showLikes = when {
-            /* TODO malinjir why we don't show likes on bookmark list??? I think we wanted
-                 to keep the card as simple as possible. However, since we are showing all the actions now, some of them
-                 are just disabled, I think it's ok to enable the action. */
-            post.isDiscoverPost || isBookmarkList -> false
-            !accountStore.hasAccessToken() -> post.numLikes > 0
-            else -> post.canLikePost()
-        }
+        /* TODO malinjir why we don't show likes on bookmark list??? I think we wanted
+             to keep the card as simple as possible. However, since we are showing all the actions now, some of them
+             are just disabled, I think it's ok to enable the action. */
+        val likesEnabled = !isBookmarkList && post.canLikePost() && accountStore.hasAccessToken()
 
-        return if (showLikes) {
-            PrimaryAction(
-                    isEnabled = true,
-                    isSelected = post.isLikedByCurrentUser,
-                    contentDescription = UiStringText(
-                            readerUtilsWrapper.getLongLikeLabelText(post.numLikes, post.isLikedByCurrentUser)
-                    ),
-                    count = post.numLikes,
-                    onClicked = if (accountStore.hasAccessToken()) onClicked else null,
-                    type = LIKE
-            )
-        } else {
-            PrimaryAction(isEnabled = false, type = LIKE)
-        }
+        return PrimaryAction(
+                isEnabled = likesEnabled,
+                isSelected = post.isLikedByCurrentUser,
+                contentDescription = UiStringText(
+                        readerUtilsWrapper.getLongLikeLabelText(post.numLikes, post.isLikedByCurrentUser)
+                ),
+                count = post.numLikes,
+                onClicked = if (likesEnabled) onClicked else null,
+                type = LIKE
+        )
     }
 
     private fun buildReblogSection(
@@ -257,7 +252,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
                  to keep the card as simple as possible. However, since we are showing all the actions now, some of them
                  are just disabled, I think it's ok to enable the action. */
             post.isDiscoverPost || isBookmarkList -> false
-            !accountStore.hasAccessToken() -> post.numLikes > 0
+            !accountStore.hasAccessToken() -> post.numReplies > 0
             else -> post.isWP && (post.isCommentsOpen || post.numReplies > 0)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -154,7 +154,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
                     ?.let { gravatarUtilsWrapper.fixGravatarUrlWithResource(it, R.dimen.avatar_sz_medium) }
 
     private fun buildDateLine(post: ReaderPost) =
-            dateTimeUtilsWrapper.javaDateToTimeSpan(post.displayDate)
+            dateTimeUtilsWrapper.javaDateToTimeSpan(post.getDisplayDate(dateTimeUtilsWrapper))
 
     private fun buildDiscoverSectionUiState(
         discoverData: ReaderPostDiscoverData,

--- a/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
@@ -12,4 +12,6 @@ class DateTimeUtilsWrapper @Inject constructor(
             DateTimeUtils.iso8601FromTimestamp(localeManagerWrapper.getCurrentCalendar().timeInMillis / 1000)
 
     fun javaDateToTimeSpan(date: Date?): String = DateTimeUtils.javaDateToTimeSpan(date, appContext)
+
+    fun dateFromIso8601(date: String) = DateTimeUtils.dateFromIso8601(date)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -237,7 +237,7 @@ class ReaderPostUiStateBuilderTest {
             // Act
             val uiState = mapPostToUiState(post)
             // Assert
-            assertThat(uiState.fullVideoUrl).isNull()
+            assertThat(uiState.videoOverlayVisibility).isFalse()
         }
     }
     // endregion

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -3,28 +3,50 @@ package org.wordpress.android.ui.reader.discover
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.models.ReaderCardType
+import org.wordpress.android.models.ReaderCardType.DEFAULT
+import org.wordpress.android.models.ReaderCardType.GALLERY
+import org.wordpress.android.models.ReaderCardType.PHOTO
+import org.wordpress.android.models.ReaderCardType.VIDEO
 import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.models.ReaderPostDiscoverData
+import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType
+import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.EDITOR_PICK
+import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.OTHER
+import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.SITE_PICK
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.BLOG_PREVIEW
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
+import org.wordpress.android.ui.reader.models.ReaderImageList
+import org.wordpress.android.ui.reader.utils.ReaderImageScanner
 import org.wordpress.android.ui.reader.utils.ReaderImageScannerProvider
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.GravatarUtilsWrapper
 import org.wordpress.android.util.UrlUtilsWrapper
+import org.wordpress.android.util.image.ImageType
+import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
 class ReaderPostUiStateBuilderTest {
+    // region Set-up
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 
@@ -50,8 +72,17 @@ class ReaderPostUiStateBuilderTest {
                 readerPostMoreButtonUiStateBuilder
         )
         whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(anyOrNull())).thenReturn("")
+        whenever(gravatarUtilsWrapper.fixGravatarUrlWithResource(anyOrNull(), anyInt())).thenReturn("")
+        val imageScanner: ReaderImageScanner = mock()
+        whenever(readerImageScannerProvider.createReaderImageScanner(anyOrNull(), anyBoolean()))
+                .thenReturn(imageScanner)
+        whenever(imageScanner.getImageList(anyInt(), anyInt())).thenReturn(ReaderImageList(false))
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(readerUtilsWrapper.getLongLikeLabelText(anyInt(), anyBoolean())).thenReturn("")
     }
+    // endregion
 
+    // region BLOG HEADER
     @Test
     fun `clicks on blog header are disabled on blog preview`() {
         // Arrange
@@ -62,14 +93,679 @@ class ReaderPostUiStateBuilderTest {
         assertThat(uiState.postHeaderClickData).isNull()
     }
 
-    private fun mapPostToUiState(post: ReaderPost, postListType: ReaderPostListType = TAG_FOLLOWED): ReaderPostUiState {
+    @Test
+    fun `clicks on blog header are enabled when not blog preview`() {
+        // Arrange
+        val post = createPost()
+        ReaderPostListType.values().filter { it != BLOG_PREVIEW }.forEach {
+            // Act
+            val uiState = mapPostToUiState(post, it)
+            // Assert
+            assertThat(uiState.postHeaderClickData).isNotNull
+        }
+    }
+    // endregion
+
+    // region BLOG URL
+    @Test
+    fun `scheme is removed from blog url`() {
+        // Arrange
+        val post = createPost(blogUrl = "http://dummy.url")
+        whenever(urlUtilsWrapper.removeScheme("http://dummy.url")).thenReturn("dummy.url")
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.blogUrl).isEqualTo("dummy.url")
+    }
+    // endregion
+
+    // region DISCOVER SECTION
+    @Test
+    fun `discover section is empty when isDiscoverPost is false`() {
+        // Arrange
+        val post = createPost(isDiscoverPost = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.discoverSection).isNull()
+    }
+
+    @Test
+    fun `discover section is not empty when isDiscoverPost is true`() {
+        // Arrange
+        val post = createPost(isDiscoverPost = true)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.discoverSection).isNotNull
+    }
+
+    @Test
+    fun `discover section is empty when discoverType is OTHER`() {
+        // Arrange
+        val post = createPost(isDiscoverPost = true, discoverType = OTHER)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.discoverSection).isNull()
+    }
+
+    @Test
+    fun `discover section is not empty when discoverType is other than OTHER`() {
+        // Arrange
+        DiscoverType.values().filter { it != OTHER }.forEach {
+            val post = createPost(isDiscoverPost = true, discoverType = it)
+            // Act
+            val uiState = mapPostToUiState(post)
+            // Assert
+            assertThat(uiState.discoverSection).isNotNull
+        }
+    }
+
+    @Test
+    fun `discover uses ImageType AVATAR when EDITOR_PICK`() {
+        // Arrange
+        val post = createPost(isDiscoverPost = true, discoverType = EDITOR_PICK)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.discoverSection!!.imageType).isEqualTo(ImageType.AVATAR)
+    }
+
+    @Test
+    fun `discover uses ImageType BLAVATAR when SITE_PICK`() {
+        // Arrange
+        val post = createPost(isDiscoverPost = true, discoverType = SITE_PICK)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.discoverSection!!.imageType).isEqualTo(ImageType.BLAVATAR)
+    }
+
+    @Test
+    fun `discover uses fixed avatar URL`() {
+        // Arrange
+        val post = createPost(isDiscoverPost = true)
+        whenever(gravatarUtilsWrapper.fixGravatarUrlWithResource(anyOrNull(), anyInt())).thenReturn("12345")
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.discoverSection!!.discoverAvatarUrl).isEqualTo("12345")
+    }
+    // endregion
+
+    // region VIDEO
+    @Test
+    fun `videoUrl gets initialized for video cards`() {
+        // Arrange
+        val post = createPost(cardType = VIDEO, featuredVideoUrl = "12345")
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.fullVideoUrl).isEqualTo("12345")
+    }
+
+    @Test
+    fun `videoUrl does not get initialized for other than video cards`() {
+        // Arrange
+        val types = ReaderCardType.values()
+        types.filter { it != VIDEO }.forEach {
+            val post = createPost(cardType = it, featuredVideoUrl = "12345")
+            // Act
+            val uiState = mapPostToUiState(post)
+            // Assert
+            assertThat(uiState.fullVideoUrl).isNull()
+        }
+    }
+
+    @Test
+    fun `video overlay is displayed for video cards`() {
+        // Arrange
+        val post = createPost(cardType = VIDEO)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.videoOverlayVisibility).isTrue()
+    }
+
+    @Test
+    fun `video overlay is not displayed for other than video cards`() {
+        // Arrange
+        val types = ReaderCardType.values()
+        types.filter { it != VIDEO }.forEach {
+            val post = createPost(cardType = it)
+            // Act
+            val uiState = mapPostToUiState(post)
+            // Assert
+            assertThat(uiState.fullVideoUrl).isNull()
+        }
+    }
+    // endregion
+
+    // region THUMBNAIL STRIP
+    @Test
+    fun `thumbnail strip is not empty for GALLERY`() {
+        // Arrange
+        val post = createPost(cardType = GALLERY)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.thumbnailStripSection).isNotNull
+    }
+
+    @Test
+    fun `thumbnail strip is empty for other than GALLERY`() {
+        // Arrange
+        ReaderCardType.values().filter { it != GALLERY }.forEach {
+            val post = createPost(cardType = it)
+            // Act
+            val uiState = mapPostToUiState(post)
+            // Assert
+            assertThat(uiState.thumbnailStripSection).isNull()
+        }
+    }
+    // endregion
+
+    // region FEATURED IMAGE
+    @Test
+    fun `featured image is displayed for photo and default card types`() {
+        // Arrange
+        val dummyUrl = "12345"
+        ReaderCardType.values().filter { it == PHOTO || it == DEFAULT }.forEach {
+            val post = createPost(cardType = it, hasFeaturedImage = true, featuredImageUrlForDisplay = dummyUrl)
+            // Act
+            val uiState = mapPostToUiState(post)
+            // Assert
+            assertThat(uiState.featuredImageUrl).isEqualTo(dummyUrl)
+        }
+    }
+
+    @Test
+    fun `featured image is not displayed for other than photo and default card types`() {
+        // Arrange
+        ReaderCardType.values().filter { it != PHOTO && it != DEFAULT }.forEach {
+            val post = createPost(cardType = it, hasFeaturedImage = true)
+            // Act
+            val uiState = mapPostToUiState(post)
+            // Assert
+            assertThat(uiState.featuredImageUrl).isNull()
+        }
+    }
+
+    @Test
+    fun `featured image is not displayed when hasFeaturedImage returns false`() {
+        // Arrange
+        val post = createPost(cardType = PHOTO, hasFeaturedImage = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.featuredImageUrl).isNull()
+    }
+    // endregion
+
+    // region PHOTO TITLE
+    @Test
+    fun `photo title is displayed for photo card type`() {
+        // Arrange
+        val post = createPost(cardType = PHOTO)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.photoTitle).isNotNull()
+    }
+
+    @Test
+    fun `photo title is not displayed for other than photo card type`() {
+        // Arrange
+        ReaderCardType.values().filter { it != PHOTO }.forEach {
+            val post = createPost(cardType = it)
+            // Act
+            val uiState = mapPostToUiState(post)
+            // Assert
+            assertThat(uiState.photoTitle).isNull()
+        }
+    }
+
+    @Test
+    fun `photo title is not displayed when hasTitle returns false`() {
+        // Arrange
+        val post = createPost(cardType = PHOTO, hasTitle = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.photoTitle).isNull()
+    }
+    // endregion
+
+    // region PHOTO FRAME
+    @Test
+    fun `photo frame is visible for other than gallery type`() {
+        // Arrange
+        ReaderCardType.values().filter { it != GALLERY }.forEach {
+            val post = createPost(cardType = it, hasFeaturedVideo = true)
+            // Act
+            val uiState = mapPostToUiState(post)
+            // Assert
+            assertThat(uiState.photoFrameVisibility).isTrue()
+        }
+    }
+
+    @Test
+    fun `photo frame is not visible for gallery type`() {
+        // Arrange
+        val post = createPost(cardType = GALLERY, hasFeaturedVideo = true)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.photoFrameVisibility).isFalse()
+    }
+
+    @Test
+    fun `photo frame is visible when hasFeaturedVideo returns true`() {
+        // Arrange
+        val post = createPost(cardType = DEFAULT, hasFeaturedVideo = true)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.photoFrameVisibility).isTrue()
+    }
+
+    @Test
+    fun `photo frame is not visible when hasFeaturedVideo returns false`() {
+        // Arrange
+        val post = createPost(cardType = DEFAULT, hasFeaturedVideo = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.photoFrameVisibility).isFalse()
+    }
+
+    @Test
+    fun `photo frame is visible when hasFeaturedImage returns true`() {
+        // Arrange
+        val post = createPost(cardType = DEFAULT, hasFeaturedImage = true)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.photoFrameVisibility).isTrue()
+    }
+
+    @Test
+    fun `photo frame is not visible when hasFeaturedImage returns false`() {
+        // Arrange
+        val post = createPost(cardType = DEFAULT, hasFeaturedImage = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.photoFrameVisibility).isFalse()
+    }
+    // endregion
+
+    // region TITLE & EXCERPT
+    @Test
+    fun `title is displayed for other than PHOTO card type`() {
+        // Arrange
+        ReaderCardType.values().filter { it != PHOTO }.forEach {
+            val post = createPost(cardType = it)
+            // Act
+            val uiState = mapPostToUiState(post)
+            // Assert
+            assertThat(uiState.title).isNotNull()
+        }
+    }
+
+    @Test
+    fun `title is not displayed for PHOTO card type`() {
+        // Arrange
+        val post = createPost(cardType = PHOTO)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.title).isNull()
+    }
+
+    @Test
+    fun `title is not displayed when the post doesn't have a title`() {
+        // Arrange
+        val post = createPost(cardType = DEFAULT, hasTitle = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.title).isNull()
+    }
+
+    @Test
+    fun `excerpt is displayed for other than PHOTO card type`() {
+        // Arrange
+        ReaderCardType.values().filter { it != PHOTO }.forEach {
+            val post = createPost(cardType = it)
+            // Act
+            val uiState = mapPostToUiState(post)
+            // Assert
+            assertThat(uiState.excerpt).isNotNull()
+        }
+    }
+
+    @Test
+    fun `excerpt is not displayed for PHOTO card type`() {
+        // Arrange
+        val post = createPost(cardType = PHOTO)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.excerpt).isNull()
+    }
+
+    @Test
+    fun `excerpt is not displayed when the post doesn't have an excerpt`() {
+        // Arrange
+        val post = createPost(cardType = DEFAULT, hasExcerpt = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.excerpt).isNull()
+    }
+    // endregion
+
+    // region BLOG NAME
+    @Test
+    fun `blog name is displayed for regular post`() {
+        // Arrange
+        val post = createPost()
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.blogName).isNotNull()
+    }
+
+    @Test
+    fun `blogName is not displayed the post doesn't have a blog name`() {
+        // Arrange
+        val post = createPost(hasBlogName = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.blogName).isNull()
+    }
+    // endregion
+
+    // region DATELINE
+    @Test
+    fun `builds dateline from post's display date`() {
+        // Arrange
+        val post = createPost()
+        val dummyDate: Date = mock()
+        whenever(post.getDisplayDate(dateTimeUtilsWrapper)).thenReturn(dummyDate)
+        whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(dummyDate)).thenReturn("success")
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.dateLine).isEqualTo("success")
+    }
+    // endregion
+
+    // region BOOKMARK BUTTON
+    @Test
+    fun `bookmark button is disabled when postId is empty`() {
+        // Arrange
+        val post = createPost(postId = 0)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.bookmarkAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `bookmark button is disabled when blogId is empty`() {
+        // Arrange
+        val post = createPost(blogId = 0)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.bookmarkAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `bookmark button is enabled when blogid and postId is not empty`() {
+        // Arrange
+        val post = createPost(postId = 1L, blogId = 2L)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.bookmarkAction.isEnabled).isTrue()
+    }
+
+    @Test
+    fun `bookmark button is selected when the post is bookmarked`() {
+        // Arrange
+        val post = createPost(isBookmarked = true)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.bookmarkAction.isSelected).isTrue()
+    }
+
+    @Test
+    fun `bookmark button is not selected when the post is not bookmarked`() {
+        // Arrange
+        val post = createPost(isBookmarked = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.bookmarkAction.isSelected).isFalse()
+    }
+
+    @Test
+    fun `onButtonClicked listener is correctly assigned to bookmarkAction`() {
+        // Arrange
+        val post = createPost()
+        val onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit = mock()
+        val uiState = mapPostToUiState(post, onButtonClicked = onButtonClicked)
+        // Act
+        uiState.bookmarkAction.onClicked!!.invoke(1L, 1L, BOOKMARK)
+        // Assert
+        verify(onButtonClicked).invoke(1L, 1L, BOOKMARK)
+    }
+    // endregion
+
+    // region LIKE BUTTON
+    @Test
+    fun `like button is enabled on regular posts`() {
+        // Arrange
+        val post = createPost()
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.likeAction.isEnabled).isTrue()
+    }
+
+    @Test
+    fun `like button is disabled on bookmark list`() {
+        // Arrange
+        val post = createPost()
+        // Act
+        val uiState = mapPostToUiState(post, isBookmarkList = true)
+        // Assert
+        assertThat(uiState.likeAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `like button is disabled when the user is logged off`() {
+        // Arrange
+        val post = createPost()
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.likeAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `like button is disabled when likes are disabled on the post`() {
+        // Arrange
+        val post = createPost(isCanLikePost = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.likeAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `onButtonClicked listener is correctly assigned to likeAction`() {
+        // Arrange
+        val post = createPost()
+        val onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit = mock()
+        val uiState = mapPostToUiState(post, onButtonClicked = onButtonClicked)
+        // Act
+        uiState.likeAction.onClicked!!.invoke(1L, 1L, LIKE)
+        // Assert
+        verify(onButtonClicked).invoke(1L, 1L, LIKE)
+    }
+    // endregion
+
+    // region REBLOG BUTTON
+    @Test
+    fun `reblog button is enabled on regular posts`() {
+        // Arrange
+        val post = createPost()
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.reblogAction.isEnabled).isTrue()
+    }
+
+    @Test
+    fun `reblog button is disabled on private posts`() {
+        // Arrange
+        val post = createPost(isPrivate = true)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.reblogAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `reblog button is disabled when the user is logged off`() {
+        // Arrange
+        val post = createPost()
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.reblogAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `onButtonClicked listener is correctly assigned to reblogAction`() {
+        // Arrange
+        val post = createPost()
+        val onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit = mock()
+        val uiState = mapPostToUiState(post, onButtonClicked = onButtonClicked)
+        // Act
+        uiState.reblogAction.onClicked!!.invoke(1L, 1L, REBLOG)
+        // Assert
+        verify(onButtonClicked).invoke(1L, 1L, REBLOG)
+    }
+    // endregion
+
+    // region COMMENT BUTTON
+    @Test
+    fun `Comments button is enabled on regular posts`() {
+        // Arrange
+        val post = createPost()
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.commentsAction.isEnabled).isTrue()
+    }
+
+    @Test
+    fun `Comments button is disabled when comments are disabled on the post`() {
+        // Arrange
+        val post = createPost(isCommentsOpen = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.commentsAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `Comments button is disabled on non-wpcom posts`() {
+        // Arrange
+        val post = createPost(isWPCom = false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.commentsAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `Comments button is disabled when the user is logged off and the post does not have any comments`() {
+        // Arrange
+        val post = createPost(numOfReplies = 0)
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.commentsAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `Comments button is enabled when the user is logged off but the post has some comments`() {
+        // Arrange
+        val post = createPost(numOfReplies = 1)
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.commentsAction.isEnabled).isTrue()
+    }
+
+    @Test
+    fun `Comments button is disabled on discover posts`() {
+        // Arrange
+        val post = createPost(isDiscoverPost = true)
+        // Act
+        val uiState = mapPostToUiState(post)
+        // Assert
+        assertThat(uiState.commentsAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `Comments button is disabled on bookmark list`() {
+        // Arrange
+        val post = createPost()
+        // Act
+        val uiState = mapPostToUiState(post, isBookmarkList = true)
+        // Assert
+        assertThat(uiState.commentsAction.isEnabled).isFalse()
+    }
+
+    @Test
+    fun `Count on Comments button corresponds to number of comments on the post`() {
+        // Arrange
+        val post = createPost()
+        // Act
+        val uiState = mapPostToUiState(post, isBookmarkList = true)
+        // Assert
+        assertThat(uiState.commentsAction.isEnabled).isFalse()
+    }
+    // endregion
+
+    // region Private methods
+    private fun mapPostToUiState(
+        post: ReaderPost,
+        postListType: ReaderPostListType = TAG_FOLLOWED,
+        onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit = mock(),
+        isBookmarkList: Boolean = false
+    ): ReaderPostUiState {
         return builder.mapPostToUiState(
                 post = post,
                 photonWidth = 0,
                 photonHeight = 0,
                 postListType = postListType,
-                isBookmarkList = false,
-                onButtonClicked = mock(),
+                isBookmarkList = isBookmarkList,
+                onButtonClicked = onButtonClicked,
                 onItemClicked = mock(),
                 onItemRendered = mock(),
                 onDiscoverSectionClicked = mock(),
@@ -79,7 +775,56 @@ class ReaderPostUiStateBuilderTest {
         )
     }
 
-    private fun createPost(): ReaderPost {
-        return ReaderPost()
+    private fun createPost(
+        hasTitle: Boolean = true,
+        hasExcerpt: Boolean = true,
+        hasBlogName: Boolean = true,
+        blogUrl: String = "",
+        isDiscoverPost: Boolean = false,
+        discoverType: DiscoverType = SITE_PICK,
+        cardType: ReaderCardType = DEFAULT,
+        featuredVideoUrl: String? = null,
+        postId: Long = 1L,
+        blogId: Long = 2L,
+        isBookmarked: Boolean = false,
+        numOfReplies: Int = 0,
+        isWPCom: Boolean = true,
+        isCommentsOpen: Boolean = true,
+        isPrivate: Boolean = false,
+        isCanLikePost: Boolean = true,
+        hasFeaturedImage: Boolean = false,
+        featuredImageUrlForDisplay: String? = null,
+        hasFeaturedVideo: Boolean = false
+    ): ReaderPost {
+        val post = spy(ReaderPost().apply {
+            this.blogUrl = blogUrl
+            this.cardType = cardType
+            this.featuredVideo = featuredVideoUrl
+            this.blogId = blogId
+            this.postId = postId
+            this.isBookmarked = isBookmarked
+        })
+        // The ReaderPost contains business logic and accesses static classes. Using spy() allows us to use it in tests.
+        whenever(post.isDiscoverPost).thenReturn(isDiscoverPost)
+        if (isDiscoverPost) {
+            val mockedDiscoverData: ReaderPostDiscoverData = mock()
+            whenever(post.discoverData).thenReturn(mockedDiscoverData)
+            whenever(mockedDiscoverData.discoverType).thenReturn(discoverType)
+            whenever(mockedDiscoverData.attributionHtml).thenReturn(mock())
+            whenever(mockedDiscoverData.avatarUrl).thenReturn("dummyUrl")
+        }
+        post.numReplies = numOfReplies
+        post.isPrivate = isPrivate
+        whenever(post.hasTitle()).thenReturn(hasTitle)
+        whenever(post.hasBlogName()).thenReturn(hasBlogName)
+        whenever(post.hasExcerpt()).thenReturn(hasExcerpt)
+        whenever(post.canLikePost()).thenReturn(isCanLikePost)
+        whenever(post.isWP).thenReturn(isWPCom)
+        post.isCommentsOpen = isCommentsOpen
+        whenever(post.getFeaturedImageForDisplay(anyInt(), anyInt())).thenReturn(featuredImageUrlForDisplay)
+        whenever(post.hasFeaturedImage()).thenReturn(hasFeaturedImage)
+        whenever(post.hasFeaturedVideo()).thenReturn(hasFeaturedVideo)
+        return post
     }
+    // endregion
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -1,0 +1,85 @@
+package org.wordpress.android.ui.reader.discover
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
+import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.BLOG_PREVIEW
+import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
+import org.wordpress.android.ui.reader.utils.ReaderImageScannerProvider
+import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.util.DateTimeUtilsWrapper
+import org.wordpress.android.util.GravatarUtilsWrapper
+import org.wordpress.android.util.UrlUtilsWrapper
+
+@RunWith(MockitoJUnitRunner::class)
+class ReaderPostUiStateBuilderTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    private lateinit var builder: ReaderPostUiStateBuilder
+
+    @Mock lateinit var accountStore: AccountStore
+    @Mock lateinit var urlUtilsWrapper: UrlUtilsWrapper
+    @Mock lateinit var gravatarUtilsWrapper: GravatarUtilsWrapper
+    @Mock lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
+    @Mock lateinit var readerImageScannerProvider: ReaderImageScannerProvider
+    @Mock lateinit var readerUtilsWrapper: ReaderUtilsWrapper
+    @Mock lateinit var readerPostMoreButtonUiStateBuilder: ReaderPostMoreButtonUiStateBuilder
+
+    @Before
+    fun setUp() {
+        builder = ReaderPostUiStateBuilder(
+                accountStore,
+                urlUtilsWrapper,
+                gravatarUtilsWrapper,
+                dateTimeUtilsWrapper,
+                readerImageScannerProvider,
+                readerUtilsWrapper,
+                readerPostMoreButtonUiStateBuilder
+        )
+        whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(anyOrNull())).thenReturn("")
+    }
+
+    @Test
+    fun `clicks on blog header are disabled on blog preview`() {
+        // Arrange
+        val post = createPost()
+        // Act
+        val uiState = mapPostToUiState(post, BLOG_PREVIEW)
+        // Assert
+        assertThat(uiState.postHeaderClickData).isNull()
+    }
+
+    private fun mapPostToUiState(post: ReaderPost, postListType: ReaderPostListType = TAG_FOLLOWED): ReaderPostUiState {
+        return builder.mapPostToUiState(
+                post = post,
+                photonWidth = 0,
+                photonHeight = 0,
+                postListType = postListType,
+                isBookmarkList = false,
+                onButtonClicked = mock(),
+                onItemClicked = mock(),
+                onItemRendered = mock(),
+                onDiscoverSectionClicked = mock(),
+                onMoreButtonClicked = mock(),
+                onVideoOverlayClicked = mock(),
+                onPostHeaderViewClicked = mock()
+        )
+    }
+
+    private fun createPost(): ReaderPost {
+        return ReaderPost()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -744,11 +744,12 @@ class ReaderPostUiStateBuilderTest {
     @Test
     fun `Count on Comments button corresponds to number of comments on the post`() {
         // Arrange
-        val post = createPost()
+        val numReplies = 15
+        val post = createPost(numOfReplies = numReplies)
         // Act
-        val uiState = mapPostToUiState(post, isBookmarkList = true)
+        val uiState = mapPostToUiState(post)
         // Assert
-        assertThat(uiState.commentsAction.isEnabled).isFalse()
+        assertThat(uiState.commentsAction.count).isEqualTo(numReplies)
     }
     // endregion
 


### PR DESCRIPTION
Parent issue #12028

Merge instructions
1. Review this PR
2. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/12474 is merged
3. Change the target branch to develop
4. Remove Not ready for merge label
5. Merge this PR

This PR 
1. Adds bunch of unit tests for the ui state builder
2. Fixes a bug in the comments button logic - we were using "numLikes" instead of "numReplies" field
3. Updates like button logic 
    - removes `isDiscoverPost` check as it's part of the `canLikePost` check 
    - fixes a bug when the like button was enabled but onclick suppressed for logged off user (removes numLikes > 0 condition)
    - renames "showLike" to "enableLike" and simplifies the logic

To test:
1. Log in with a self hosted site
2. Find a post in the discover tab with a number next to the comments button
3. Check that the button is enabled
4. Make sure the button is disabled for all the other posts (posts without the number)
------------------
1. Log in with a .com site and make sure you can like posts in the following tab
2. Go to Discover tab and make sure the like button is disabled


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
