### PR TITLE
Prepublishing Nudges : Remove the close button from the bottom sheet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -176,10 +176,6 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
         viewModel.writeToBundle(outState)
     }
 
-    override fun onCloseClicked() {
-        viewModel.onCloseClicked()
-    }
-
     override fun onBackClicked() {
         viewModel.onBackClicked()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingScreenClosedListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingScreenClosedListener.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.posts
 
 interface PrepublishingScreenClosedListener {
-    fun onCloseClicked()
     fun onBackClicked()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
@@ -58,10 +58,6 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        close_button.setOnClickListener {
-            trackTagsChangedEvent()
-            viewModel.onCloseButtonClicked()
-        }
         back_button.setOnClickListener {
             trackTagsChangedEvent()
             viewModel.onBackButtonClicked()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
@@ -76,12 +76,6 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(PrepublishingTagsViewModel::class.java)
 
-        viewModel.dismissBottomSheet.observe(viewLifecycleOwner, Observer { event ->
-            event?.applyIfNotHandled {
-                closeListener?.onCloseClicked()
-            }
-        })
-
         viewModel.dismissKeyboard.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
                 ActivityUtils.hideKeyboardForced(tags_edit_text)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsViewModel.kt
@@ -29,9 +29,6 @@ class PrepublishingTagsViewModel @Inject constructor(
     private val _navigateToHomeScreen = MutableLiveData<Event<Unit>>()
     val navigateToHomeScreen: LiveData<Event<Unit>> = _navigateToHomeScreen
 
-    private val _dismissBottomSheet = MutableLiveData<Event<Unit>>()
-    val dismissBottomSheet: LiveData<Event<Unit>> = _dismissBottomSheet
-
     private val _dismissKeyboard = MutableLiveData<Event<Unit>>()
     val dismissKeyboard: LiveData<Event<Unit>> = _dismissKeyboard
 
@@ -58,8 +55,6 @@ class PrepublishingTagsViewModel @Inject constructor(
             updatePostTagsUseCase.updateTags(selectedTags, editPostRepository)
         }
     }
-
-    fun onCloseButtonClicked() = _dismissBottomSheet.postValue(Event(Unit))
 
     fun onBackButtonClicked() {
         _dismissKeyboard.postValue(Event(Unit))

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingPublishSettingsFragment.kt
@@ -41,19 +41,11 @@ class PrepublishingPublishSettingsFragment : PublishSettingsFragment() {
     }
 
     override fun setupContent(rootView: ViewGroup, viewModel: PublishSettingsViewModel) {
-        val closeButton = rootView.findViewById<View>(R.id.close_button)
         val backButton = rootView.findViewById<View>(R.id.back_button)
         val toolbarTitle = rootView.findViewById<TextView>(R.id.toolbar_title)
 
         (viewModel as PrepublishingPublishSettingsViewModel).let {
-            closeButton.setOnClickListener { viewModel.onCloseButtonClicked() }
             backButton.setOnClickListener { viewModel.onBackButtonClicked() }
-
-            viewModel.dismissBottomSheet.observe(this, Observer { event ->
-                event?.applyIfNotHandled {
-                    closeListener?.onCloseClicked()
-                }
-            })
 
             viewModel.navigateToHomeScreen.observe(this, Observer { event ->
                 event?.applyIfNotHandled {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingPublishSettingsViewModel.kt
@@ -31,9 +31,6 @@ class PrepublishingPublishSettingsViewModel @Inject constructor(
     private val _navigateToHomeScreen = MutableLiveData<Event<Unit>>()
     val navigateToHomeScreen: LiveData<Event<Unit>> = _navigateToHomeScreen
 
-    private val _dismissBottomSheet = MutableLiveData<Event<Unit>>()
-    val dismissBottomSheet: LiveData<Event<Unit>> = _dismissBottomSheet
-
     private val _updateToolbarTitle = MutableLiveData<UiString>()
     val updateToolbarTitle: LiveData<UiString> = _updateToolbarTitle
 
@@ -45,8 +42,6 @@ class PrepublishingPublishSettingsViewModel @Inject constructor(
     private fun setToolbarTitle() {
         _updateToolbarTitle.postValue(UiStringRes(R.string.prepublishing_nudges_toolbar_title_publish))
     }
-
-    fun onCloseButtonClicked() = _dismissBottomSheet.postValue(Event(Unit))
 
     fun onBackButtonClicked() {
         _navigateToHomeScreen.postValue(Event(Unit))

--- a/WordPress/src/main/res/layout/prepublishing_toolbar.xml
+++ b/WordPress/src/main/res/layout/prepublishing_toolbar.xml
@@ -48,13 +48,15 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/toolbar_title"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:gravity="center"
         android:textAppearance="?attr/textAppearanceHeadline6"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/bottom_sheet_handle"
         app:layout_constraintLeft_toRightOf="@id/back_button"
         app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/bottom_sheet_handle"
         app:layout_constraintTop_toBottomOf="@id/bottom_sheet_handle"
         tools:text="Publish" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/prepublishing_toolbar.xml
+++ b/WordPress/src/main/res/layout/prepublishing_toolbar.xml
@@ -24,25 +24,6 @@
             android:tint="@color/prepublishing_toolbar_icon_color" />
     </RelativeLayout>
 
-    <RelativeLayout
-        android:id="@+id/close_button"
-        android:layout_width="@dimen/min_touch_target_sz"
-        android:layout_height="@dimen/min_touch_target_sz"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toRightOf="@id/toolbar_title"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/bottom_sheet_handle">
-
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/prepublishing_nudges_back_button"
-            android:src="@drawable/ic_close_white_24dp"
-            android:tint="@color/prepublishing_toolbar_icon_color" />
-    </RelativeLayout>
-
     <View
         android:id="@+id/bottom_sheet_handle"
         android:layout_width="@dimen/bottom_sheet_handle_width"
@@ -73,7 +54,7 @@
         android:textAppearance="?attr/textAppearanceHeadline6"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toRightOf="@id/back_button"
-        app:layout_constraintRight_toLeftOf="@id/close_button"
+        app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/bottom_sheet_handle"
         tools:text="Publish" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingPublishSettingsViewModelTest.kt
@@ -56,16 +56,4 @@ class PrepublishingPublishSettingsViewModelTest : BaseUnitTest() {
 
         assertThat(event).isNotNull
     }
-
-    @Test
-    fun `when onCloseClicked is triggered dismissBottomSheet is called`() {
-        var event: Event<Unit>? = null
-        viewModel.dismissBottomSheet.observeForever {
-            event = it
-        }
-
-        viewModel.onCloseButtonClicked()
-
-        assertThat(event).isNotNull
-    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingTagsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingTagsViewModelTest.kt
@@ -54,18 +54,6 @@ class PrepublishingTagsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when onCloseClicked is triggered dismissBottomSheet is called`() {
-        var event: Event<Unit>? = null
-        viewModel.dismissBottomSheet.observeForever {
-            event = it
-        }
-
-        viewModel.onCloseButtonClicked()
-
-        assertThat(event).isNotNull
-    }
-
-    @Test
     fun `when onTagsSelected is called updatePostTagsUseCase's updateTags should be called`() = test {
         val expectedTags = "test, data"
         val captor = ArgumentCaptor.forClass(String::class.java)


### PR DESCRIPTION
Fixes #12487

## Solution
Remove the close button from the bottom sheet. 

## Testing

1. Create a new post. 
2. Click Publish. 
3. Click Publish Date. 
4. Ensure the close button is no longer visible. 

Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/88054307-bbe69980-cb22-11ea-83f3-32d7391c3934.png" width="320"></kbd>   |       <kbd><img src="https://user-images.githubusercontent.com/1509205/88054309-bdb05d00-cb22-11ea-8bd0-5d4ef49a03ad.png" width="320"></kbd>

--------------

1. Create a new post. 
2. Click Publish. 
3. Click Tags. 
4. Ensure the close button is no longer visible. 

Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/88054632-534bec80-cb23-11ea-8f0a-64d4a7882261.png" width="320"></kbd>  |       <kbd><img src="https://user-images.githubusercontent.com/1509205/88054668-5cd55480-cb23-11ea-9426-eedea8233f24.png" width="320"></kbd>

---------------
1. Create a new post. 
2. Click Publish. 
3. Click Tags. 
4. Ensure you can navigate back to home and then press back to close the bottom sheet. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
