### PR TITLE
Issue 12492/story composer viewmodel part 1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -90,7 +90,7 @@ import org.wordpress.android.ui.posts.editor.ImageEditorTracker;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.tracker.ReaderTracker;
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters;
-import org.wordpress.android.ui.stories.StoryMediaSaveUploadBridge;
+import org.wordpress.android.ui.stories.media.StoryMediaSaveUploadBridge;
 import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.ui.uploads.UploadStarter;
 import org.wordpress.android.util.AppLog;

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -41,6 +41,7 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDa
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsSiteSelectionViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureViewModel;
+import org.wordpress.android.ui.stories.StoryComposerViewModel;
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementViewModel;
 import org.wordpress.android.viewmodel.ViewModelFactory;
 import org.wordpress.android.viewmodel.ViewModelKey;
@@ -353,6 +354,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(MeViewModel.class)
     abstract ViewModel meViewModel(MeViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(StoryComposerViewModel.class)
+    abstract ViewModel storyComposerViewModel(StoryComposerViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -142,10 +142,9 @@ import org.wordpress.android.ui.posts.editor.StorePostViewModel;
 import org.wordpress.android.ui.posts.editor.StorePostViewModel.ActivityFinishState;
 import org.wordpress.android.ui.posts.editor.StorePostViewModel.UpdateFromEditor;
 import org.wordpress.android.ui.posts.editor.StorePostViewModel.UpdateFromEditor.PostFields;
+import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource;
 import org.wordpress.android.ui.posts.editor.media.EditorMedia;
-import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddExistingMediaSource;
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener;
-import org.wordpress.android.ui.posts.editor.media.EditorType;
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetListener;
 import org.wordpress.android.ui.posts.prepublishing.home.usecases.PublishPostImmediatelyUseCase;
 import org.wordpress.android.ui.posts.reactnative.ReactNativeRequestHandler;
@@ -553,7 +552,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
             return;
         }
 
-        mEditorMedia.start(mSite, this, EditorType.POST_EDITOR);
+        mEditorMedia.start(mSite, this);
         startObserving();
 
         if (mHasSetPostContent = mEditorFragment != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSessionWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSessionWrapper.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.fluxc.model.PostImmutableModel
+import org.wordpress.android.fluxc.model.SiteModel
+import javax.inject.Inject
+
+class PostEditorAnalyticsSessionWrapper @Inject constructor() {
+    fun getNewPostEditorAnalyticsSession(
+        editor: PostEditorAnalyticsSession.Editor,
+        post: PostImmutableModel?,
+        site: SiteModel?,
+        isNewPost: Boolean
+    ): PostEditorAnalyticsSession = PostEditorAnalyticsSession.getNewPostEditorAnalyticsSession(
+            editor,
+            post, site, isNewPost
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorTracker.kt
@@ -6,7 +6,7 @@ import dagger.Reusable
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.editor.EditorFragmentAbstract.TrackableEvent
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddExistingMediaSource
+import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddExistingMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddExistingMediaToPostUseCase.kt
@@ -3,8 +3,12 @@ package org.wordpress.android.ui.posts.editor.media
 import dagger.Reusable
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.editor.EditorTracker
-import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddExistingMediaSource
 import javax.inject.Inject
+
+enum class AddExistingMediaSource {
+    WP_MEDIA_LIBRARY,
+    STOCK_PHOTO_LIBRARY
+}
 
 /**
  * Loads existing media items (they must have a valid url) from the local db and adds them to the editor.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMediaListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMediaListener.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.ui.posts.editor.media
+
+import org.wordpress.android.fluxc.model.PostImmutableModel
+import org.wordpress.android.ui.posts.EditPostActivity.OnPostUpdatedFromUIListener
+import org.wordpress.android.util.helpers.MediaFile
+
+interface EditorMediaListener {
+    fun appendMediaFiles(mediaFiles: Map<String, MediaFile>)
+    fun syncPostObjectWithUiAndSaveIt(listener: OnPostUpdatedFromUIListener? = null)
+    fun advertiseImageOptimization(listener: () -> Unit)
+    fun getImmutablePost(): PostImmutableModel
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveInitialPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveInitialPostUseCase.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult
 import org.wordpress.android.ui.posts.SavePostToDbUseCase
 import javax.inject.Inject
 
@@ -20,9 +21,15 @@ class SaveInitialPostUseCase @Inject constructor(
         }
         editPostRepository.savePostSnapshot()
         // this is an artifact to be able to call savePostToDb()
-        editPostRepository.getEditablePost()?.setPostFormat(StoryComposerActivity.POST_FORMAT_WP_STORY_KEY)
-        site?.let {
-            savePostToDbUseCase.savePostToDb(editPostRepository, it)
-        }
+        editPostRepository.updateAsync({ postModel ->
+            postModel.setPostFormat(StoryComposerActivity.POST_FORMAT_WP_STORY_KEY)
+            true
+        }, { _, result ->
+            if (result == UpdatePostResult.Updated) {
+                site?.let {
+                    savePostToDbUseCase.savePostToDb(editPostRepository, it)
+                }
+            }
+        })
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveInitialPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveInitialPostUseCase.kt
@@ -12,7 +12,7 @@ class SaveInitialPostUseCase @Inject constructor(
     val postStore: PostStore,
     val savePostToDbUseCase: SavePostToDbUseCase
 ) {
-     fun saveInitialPost(editPostRepository: EditPostRepository, site: SiteModel?) {
+    fun saveInitialPost(editPostRepository: EditPostRepository, site: SiteModel?) {
         editPostRepository.set {
             val post: PostModel = postStore.instantiatePostModel(site, false, null, null)
             post.setStatus(PostStatus.DRAFT.toString())

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveInitialPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveInitialPostUseCase.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.ui.stories
+
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.SavePostToDbUseCase
+import javax.inject.Inject
+
+class SaveInitialPostUseCase @Inject constructor(
+    val postStore: PostStore,
+    val savePostToDbUseCase: SavePostToDbUseCase
+) {
+     fun saveInitialPost(editPostRepository: EditPostRepository, site: SiteModel?) {
+        editPostRepository.set {
+            val post: PostModel = postStore.instantiatePostModel(site, false, null, null)
+            post.setStatus(PostStatus.DRAFT.toString())
+            post
+        }
+        editPostRepository.savePostSnapshot()
+        // this is an artifact to be able to call savePostToDb()
+        editPostRepository.getEditablePost()?.setPostFormat(StoryComposerActivity.POST_FORMAT_WP_STORY_KEY)
+        site?.let {
+            savePostToDbUseCase.savePostToDb(editPostRepository, it)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -170,16 +170,18 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     }
 
     private fun setupViewModelObservers() {
-        viewModel.trackEditorCreatedPost.observe(this, Observer { event->event.applyIfNotHandled {
-            site?.let {
-                analyticsUtilsWrapper.trackEditorCreatedPost(
-                        intent.action,
-                        intent,
-                        it,
-                        editPostRepository.getPost()
-                )
+        viewModel.trackEditorCreatedPost.observe(this, Observer { event ->
+            event.applyIfNotHandled {
+                site?.let {
+                    analyticsUtilsWrapper.trackEditorCreatedPost(
+                            intent.action,
+                            intent,
+                            it,
+                            editPostRepository.getPost()
+                    )
+                }
             }
-        } })
+        })
     }
 
     override fun onLoadFromIntent(intent: Intent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -63,6 +63,7 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ListUtils
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
@@ -93,6 +94,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     @Inject lateinit var updateStoryPostTitleUseCase: UpdateStoryPostTitleUseCase
     @Inject lateinit var storyRepositoryWrapper: StoryRepositoryWrapper
     @Inject lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Inject lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: StoryComposerViewModel
 
@@ -155,7 +157,6 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                     it,
                     editPostRepository,
                     LocalId(localPostId),
-                    intent,
                     postEditorAnalyticsSession,
                     notificationType
             )
@@ -165,6 +166,20 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
 
         startObserving()
         updateStoryPostWithChanges()
+        setupViewModelObservers()
+    }
+
+    private fun setupViewModelObservers() {
+        viewModel.trackEditorCreatedPost.observe(this, Observer { event->event.applyIfNotHandled {
+            site?.let {
+                analyticsUtilsWrapper.trackEditorCreatedPost(
+                        intent.action,
+                        intent,
+                        it,
+                        editPostRepository.getPost()
+                )
+            }
+        } })
     }
 
     override fun onLoadFromIntent(intent: Intent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -42,7 +42,6 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.media.MediaBrowserActivity
 import org.wordpress.android.ui.media.MediaBrowserType
-import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity
 import org.wordpress.android.ui.posts.EditPostActivity.OnPostUpdatedFromUIListener
@@ -110,8 +109,8 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         // arbitrary post format for Stories. Will be used in Posts lists for filtering.
         // See https://wordpress.org/support/article/post-formats/
         const val POST_FORMAT_WP_STORY_KEY = "wpstory"
-        private const val STATE_KEY_POST_LOCAL_ID = "state_key_post_model_local_id"
-        private const val STATE_KEY_EDITOR_SESSION_DATA = "stateKeyEditorSessionData"
+        const val STATE_KEY_POST_LOCAL_ID = "state_key_post_model_local_id"
+        const val STATE_KEY_EDITOR_SESSION_DATA = "stateKeyEditorSessionData"
         const val KEY_POST_LOCAL_ID = "key_post_model_local_id"
         const val BASE_FRAME_MEDIA_ERROR_NOTIFICATION_ID: Int = 72300
     }
@@ -170,9 +169,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putSerializable(WordPress.SITE, site)
-        outState.putInt(STATE_KEY_POST_LOCAL_ID, editPostRepository.id)
-        outState.putSerializable(STATE_KEY_EDITOR_SESSION_DATA, postEditorAnalyticsSession)
+        viewModel.writeToBundle(outState)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.ui.stories
+
+import androidx.lifecycle.ViewModel
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.SavePostToDbUseCase
+import org.wordpress.android.ui.stories.StoryComposerActivity.Companion
+import javax.inject.Inject
+
+class StoryComposerViewModel @Inject constructor(
+    val postStore: PostStore,
+    val savePostToDbUseCase: SavePostToDbUseCase
+) :
+        ViewModel() {
+    private lateinit var editPostRepository: EditPostRepository
+    private lateinit var site: SiteModel
+    fun start(editPostRepository: EditPostRepository) {
+        this.editPostRepository = editPostRepository
+    }
+
+
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.ui.stories
 
 import android.content.Intent
+import android.os.Bundle
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -68,5 +70,11 @@ class StoryComposerViewModel @Inject constructor(
                 PostEditorAnalyticsSession.Editor.WP_STORIES_CREATOR,
                 post, site, true
         )
+    }
+
+    fun writeToBundle(outState: Bundle) {
+        outState.putSerializable(WordPress.SITE, site)
+        outState.putInt(StoryComposerActivity.STATE_KEY_POST_LOCAL_ID, editPostRepository.id)
+        outState.putSerializable(StoryComposerActivity.STATE_KEY_EDITOR_SESSION_DATA, postEditorAnalyticsSession)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -4,6 +4,8 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.lifecycle.ViewModel
 import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -11,13 +13,15 @@ import org.wordpress.android.push.NotificationType
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession
+import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Outcome.CANCEL
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import javax.inject.Inject
 
 class StoryComposerViewModel @Inject constructor(
     private val systemNotificationsTracker: SystemNotificationsTracker,
     private val saveInitialPostUseCase: SaveInitialPostUseCase,
-    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper
+    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper,
+    private val dispatcher: Dispatcher
 ) :
         ViewModel() {
     private lateinit var editPostRepository: EditPostRepository
@@ -25,6 +29,7 @@ class StoryComposerViewModel @Inject constructor(
     private lateinit var postEditorAnalyticsSession: PostEditorAnalyticsSession
 
     fun start(
+        site: SiteModel,
         editPostRepository: EditPostRepository,
         postId: LocalId,
         intent: Intent,
@@ -32,6 +37,7 @@ class StoryComposerViewModel @Inject constructor(
         notificationType: NotificationType?
     ) {
         this.editPostRepository = editPostRepository
+        this.site = site
 
         if (postId.value == 0) {
             // Create a new post
@@ -76,5 +82,16 @@ class StoryComposerViewModel @Inject constructor(
         outState.putSerializable(WordPress.SITE, site)
         outState.putInt(StoryComposerActivity.STATE_KEY_POST_LOCAL_ID, editPostRepository.id)
         outState.putSerializable(StoryComposerActivity.STATE_KEY_EDITOR_SESSION_DATA, postEditorAnalyticsSession)
+    }
+
+    fun onStoryDiscarded() {
+        // delete empty post from database
+        dispatcher.dispatch(PostActionBuilder.newRemovePostAction(editPostRepository.getEditablePost()))
+        postEditorAnalyticsSession.setOutcome(CANCEL)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        postEditorAnalyticsSession.end()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
@@ -1,0 +1,141 @@
+package org.wordpress.android.ui.stories.media
+
+import android.net.Uri
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.posts.ProgressDialogUiState
+import org.wordpress.android.ui.posts.ProgressDialogUiState.HiddenProgressDialog
+import org.wordpress.android.ui.posts.ProgressDialogUiState.VisibleProgressDialog
+import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource
+import org.wordpress.android.ui.posts.editor.media.AddExistingMediaToPostUseCase
+import org.wordpress.android.ui.posts.editor.media.AddLocalMediaToPostUseCase
+import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
+import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingMediaToStoryIdle
+import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingMultipleMediaToStory
+import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingSingleMediaToStory
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.MediaUtilsWrapper
+import org.wordpress.android.viewmodel.Event
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.coroutines.CoroutineContext
+
+class StoryEditorMedia @Inject constructor(
+    private val mediaUtilsWrapper: MediaUtilsWrapper,
+    private val addLocalMediaToPostUseCase: AddLocalMediaToPostUseCase,
+    private val addExistingMediaToPostUseCase: AddExistingMediaToPostUseCase,
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
+) : CoroutineScope {
+    // region Fields
+    private var job: Job = Job()
+
+    override val coroutineContext: CoroutineContext
+        get() = mainDispatcher + job
+
+    private lateinit var site: SiteModel
+    private lateinit var editorMediaListener: EditorMediaListener
+
+    private val _uiState: MutableLiveData<AddMediaToStoryPostUiState> = MutableLiveData()
+    val uiState: LiveData<AddMediaToStoryPostUiState> = _uiState
+
+    private val _snackBarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
+    val snackBarMessage = _snackBarMessage as LiveData<Event<SnackbarMessageHolder>>
+
+    fun start(site: SiteModel, editorMediaListener: EditorMediaListener) {
+        this.site = site
+        this.editorMediaListener = editorMediaListener
+        _uiState.value = AddingMediaToStoryIdle
+    }
+
+    // region Adding new media to a post
+    fun advertiseImageOptimisationAndAddMedia(uriList: List<Uri>) {
+        if (mediaUtilsWrapper.shouldAdvertiseImageOptimization()) {
+            editorMediaListener.advertiseImageOptimization {
+                addNewMediaItemsToEditorAsync(
+                        uriList,
+                        false
+                )
+            }
+        } else {
+            addNewMediaItemsToEditorAsync(uriList, false)
+        }
+    }
+
+    fun addNewMediaItemsToEditorAsync(uriList: List<Uri>, freshlyTaken: Boolean) {
+        launch {
+            _uiState.value = if (uriList.size > 1) {
+                AddingMultipleMediaToStory
+            } else {
+                AddingSingleMediaToStory
+            }
+            val allMediaSucceed = addLocalMediaToPostUseCase.addNewMediaToEditorAsync(
+                    uriList,
+                    site,
+                    freshlyTaken,
+                    editorMediaListener,
+                    false // don't start upload for StoryComposer, that'll be all started
+                                            // when finished composing
+            )
+            if (!allMediaSucceed) {
+                _snackBarMessage.value = Event(SnackbarMessageHolder(R.string.gallery_error))
+            }
+            _uiState.value = AddingMediaToStoryIdle
+        }
+    }
+
+    fun onPhotoPickerMediaChosen(uriList: List<Uri>) {
+        val onlyVideos = uriList.all { mediaUtilsWrapper.isVideo(it.toString()) }
+        if (onlyVideos) {
+            addNewMediaItemsToEditorAsync(uriList, false)
+        } else {
+            advertiseImageOptimisationAndAddMedia(uriList)
+        }
+    }
+    // endregion
+
+    fun addExistingMediaToEditorAsync(source: AddExistingMediaSource, mediaIdList: List<Long>) {
+        launch {
+            addExistingMediaToPostUseCase.addMediaExistingInRemoteToEditorAsync(
+                    site,
+                    source,
+                    mediaIdList,
+                    editorMediaListener
+            )
+        }
+    }
+
+    fun cancelAddMediaToEditorActions() {
+        job.cancel()
+    }
+
+    sealed class AddMediaToStoryPostUiState(
+        val editorOverlayVisibility: Boolean,
+        val progressDialogUiState: ProgressDialogUiState
+    ) {
+        /**
+         * Adding multiple media items at once can take several seconds on slower devices, so we show a blocking
+         * progress dialog in this situation - otherwise the user could accidentally back out of the process
+         * before all items were added
+         */
+        object AddingMultipleMediaToStory : AddMediaToStoryPostUiState(
+                editorOverlayVisibility = true,
+                progressDialogUiState = VisibleProgressDialog(
+                        messageString = UiStringRes(R.string.add_media_progress),
+                        cancelable = false,
+                        indeterminate = true
+                )
+        )
+
+        object AddingSingleMediaToStory : AddMediaToStoryPostUiState(true, HiddenProgressDialog)
+
+        object AddingMediaToStoryIdle : AddMediaToStoryPostUiState(false, HiddenProgressDialog)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.stories
+package org.wordpress.android.ui.stories.media
 
 import android.content.Context
 import android.net.Uri
@@ -25,6 +25,9 @@ import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.ui.posts.SavePostToDbUseCase
 import org.wordpress.android.ui.posts.editor.media.AddLocalMediaToPostUseCase
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
+import org.wordpress.android.ui.stories.SaveStoryGutenbergBlockUseCase
+import org.wordpress.android.ui.stories.StoriesTrackerHelper
+import org.wordpress.android.ui.stories.StoryComposerActivity
 import org.wordpress.android.ui.uploads.UploadServiceFacade
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/SetUntitledStoryTitleIfTitleEmptyUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/SetUntitledStoryTitleIfTitleEmptyUseCase.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.ui.stories.usecase
+
+import android.content.Context
+import org.wordpress.android.R
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.stories.StoryRepositoryWrapper
+import javax.inject.Inject
+
+class SetUntitledStoryTitleIfTitleEmptyUseCase @Inject constructor(
+    private val storyRepositoryWrapper: StoryRepositoryWrapper,
+    private val updateStoryPostTitleUseCase: UpdateStoryPostTitleUseCase,
+    private val context: Context
+) {
+    fun setUntitledStoryTitleIfTitleEmpty(editPostRepository: EditPostRepository) {
+        if (editPostRepository.title.isEmpty()) {
+            val untitledStoryTitle = context.resources.getString(R.string.untitled)
+            storyRepositoryWrapper.setCurrentStoryTitle(untitledStoryTitle)
+            updateStoryPostTitleUseCase.updateStoryTitle(untitledStoryTitle, editPostRepository)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
@@ -1,8 +1,11 @@
 package org.wordpress.android.util.analytics
 
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import dagger.Reusable
+import org.wordpress.android.fluxc.model.PostImmutableModel
+import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 
 /**
@@ -16,4 +19,7 @@ import javax.inject.Inject
 class AnalyticsUtilsWrapper @Inject constructor(private val appContext: Context) {
     fun getMediaProperties(isVideo: Boolean, mediaURI: Uri?, path: String?): MutableMap<String, Any?> =
             AnalyticsUtils.getMediaProperties(appContext, isVideo, mediaURI, path)
+
+    fun trackEditorCreatedPost(action: String?, intent: Intent, site: SiteModel, post: PostImmutableModel?) =
+            AnalyticsUtils.trackEditorCreatedPost(action, intent, site, post)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
@@ -27,7 +27,6 @@ import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload
 import org.wordpress.android.test
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddMediaToPostUiState
-import org.wordpress.android.ui.posts.editor.media.EditorType.POST_EDITOR
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -411,7 +410,7 @@ class EditorMediaTest : BaseUnitTest() {
                     TEST_DISPATCHER,
                     TEST_DISPATCHER
             )
-            editorMedia.start(siteModel, editorMediaListener, POST_EDITOR)
+            editorMedia.start(siteModel, editorMediaListener)
             return editorMedia
         }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveInitialPostUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveInitialPostUseCaseTest.kt
@@ -1,0 +1,46 @@
+package org.wordpress.android.ui.stories
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.SavePostToDbUseCase
+
+class SaveInitialPostUseCaseTest : BaseUnitTest() {
+    private lateinit var editPostRepository: EditPostRepository
+    private lateinit var saveInitialPostUseCase: SaveInitialPostUseCase
+    @Mock lateinit var site: SiteModel
+    @Mock lateinit var savePostToDbUseCase: SavePostToDbUseCase
+    @Mock lateinit var postStore: PostStore
+
+    @InternalCoroutinesApi
+    @Before
+    fun setup() {
+        saveInitialPostUseCase = SaveInitialPostUseCase(postStore, savePostToDbUseCase)
+        editPostRepository = EditPostRepository(mock(), mock(), mock(), TEST_DISPATCHER, TEST_DISPATCHER)
+    }
+
+    @Test
+    fun `if saveInitialPost is called then the PostModel should have a PostStatus of DRAFT`() {
+        // arrange
+        val expectedPostStatus = PostStatus.DRAFT
+        whenever(postStore.instantiatePostModel(any(), any(), any(), any())).thenReturn(PostModel())
+
+        // act
+        saveInitialPostUseCase.saveInitialPost(editPostRepository, site)
+
+        // assert
+        assertThat(editPostRepository.status).isEqualTo(expectedPostStatus)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/StoryComposerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/StoryComposerViewModelTest.kt
@@ -1,0 +1,242 @@
+package org.wordpress.android.ui.stories
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.push.NotificationType
+import org.wordpress.android.ui.notifications.SystemNotificationsTracker
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.PostEditorAnalyticsSession
+import org.wordpress.android.ui.posts.PostEditorAnalyticsSessionWrapper
+import org.wordpress.android.ui.posts.SavePostToDbUseCase
+import org.wordpress.android.ui.stories.usecase.SetUntitledStoryTitleIfTitleEmptyUseCase
+
+class StoryComposerViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: StoryComposerViewModel
+    private lateinit var editPostRepository: EditPostRepository
+    @Mock lateinit var systemNotificationsTracker: SystemNotificationsTracker
+    @Mock lateinit var saveInitialPostUseCase: SaveInitialPostUseCase
+    @Mock lateinit var savePostToDbUseCase: SavePostToDbUseCase
+    @Mock lateinit var setUntitledStoryTitleIfTitleEmptyUseCase: SetUntitledStoryTitleIfTitleEmptyUseCase
+    @Mock lateinit var postEditorAnalyticsSessionWrapper: PostEditorAnalyticsSessionWrapper
+    @Mock lateinit var dispatcher: Dispatcher
+    @Mock lateinit var postStore: PostStore
+    @Mock lateinit var site: SiteModel
+
+    @InternalCoroutinesApi
+    @Before
+    fun setUp() {
+        viewModel = StoryComposerViewModel(
+                systemNotificationsTracker,
+                saveInitialPostUseCase,
+                savePostToDbUseCase,
+                setUntitledStoryTitleIfTitleEmptyUseCase,
+                postEditorAnalyticsSessionWrapper,
+                dispatcher
+        )
+        editPostRepository = EditPostRepository(
+                mock(),
+                postStore,
+                mock(),
+                TEST_DISPATCHER,
+                TEST_DISPATCHER
+        )
+    }
+
+    @Test
+    fun `if postId is 0 then create a new post with saveInitialPostUseCase`() {
+        // arrange
+        val expectedPostId = LocalId(0)
+
+        // act
+        viewModel.start(site, editPostRepository, expectedPostId, mock(), mock())
+
+        verify(saveInitialPostUseCase, times(1)).saveInitialPost(eq(editPostRepository), eq(site))
+    }
+
+    @Test
+    fun `if postId is 0 then trackEditorCreatedPost is not null`() {
+        // arrange
+        val expectedPostId = LocalId(0)
+
+        // act
+        viewModel.start(site, editPostRepository, expectedPostId, mock(), mock())
+
+        assertThat(viewModel.trackEditorCreatedPost.value).isNotNull
+    }
+
+    @Test
+    fun `if postId is not 0 then trackEditorCreatedPost is null`() {
+        // arrange
+        val expectedPostId = LocalId(2)
+
+        // act
+        viewModel.start(site, editPostRepository, expectedPostId, mock(), mock())
+
+        assertThat(viewModel.trackEditorCreatedPost.value).isNull()
+    }
+
+    @Test
+    fun `if postId is a value other than 0 then load the post using the EditPostRepository's PostStore`() {
+        // arrange
+        val expectedPostId = LocalId(2)
+
+        // act
+        viewModel.start(site, editPostRepository, expectedPostId, mock(), mock())
+
+        verify(postStore, times(1)).getPostByLocalPostId(eq(expectedPostId.value))
+    }
+
+    @Test
+    fun `if postEditorAnalyticsSession does not exist then create one with PostEditorAnalyticsSessionWrapper`() {
+        // arrange
+        val postEditorAnalyticsSession: PostEditorAnalyticsSession? = null
+        whenever(
+                postEditorAnalyticsSessionWrapper.getNewPostEditorAnalyticsSession(
+                        any(),
+                        anyOrNull(),
+                        anyOrNull(),
+                        any()
+                )
+        ).thenReturn(mock())
+
+        // act
+        viewModel.start(site, editPostRepository, LocalId(0), postEditorAnalyticsSession, mock())
+
+        // assert
+        verify(postEditorAnalyticsSessionWrapper, times(1)).getNewPostEditorAnalyticsSession(
+                any(),
+                anyOrNull(),
+                anyOrNull(),
+                any()
+        )
+    }
+
+    @Test
+    fun `if postEditorAnalyticsSession exists then don't create one with PostEditorAnalyticsSessionWrapper`() {
+        // arrange
+        val postEditorAnalyticsSession: PostEditorAnalyticsSession? = mock()
+
+        // act
+        viewModel.start(site, editPostRepository, LocalId(0), postEditorAnalyticsSession, mock())
+
+        // assert
+        verify(postEditorAnalyticsSessionWrapper, times(0)).getNewPostEditorAnalyticsSession(
+                any(),
+                anyOrNull(),
+                anyOrNull(),
+                any()
+        )
+    }
+
+    @Test
+    fun `if notificationType is not null then systemNotificationsTracker should track it`() {
+        // arrange
+        val notificationType: NotificationType? = mock()
+
+        // act
+        viewModel.start(site, editPostRepository, LocalId(0), mock(), notificationType)
+
+        verify(systemNotificationsTracker, times(1)).trackTappedNotification(eq(notificationType!!))
+    }
+
+    @Test
+    fun `if notificationType is null then systemNotificationsTracker should not track it`() {
+        // arrange
+        val notificationType: NotificationType? = null
+
+        // act
+        viewModel.start(site, editPostRepository, LocalId(0), mock(), notificationType)
+
+        verify(systemNotificationsTracker, times(0)).trackTappedNotification(any())
+    }
+
+    @Test
+    fun `If EditPostRepository is updated then the savePostToDbUseCase should be called`() {
+        // arrange
+        editPostRepository.set { mock() }
+        val action = { _: PostModel -> true }
+
+        // act
+        viewModel.start(site, editPostRepository, LocalId(0), mock(), mock())
+        editPostRepository.updateAsync(action, null)
+
+        // assert
+        verify(savePostToDbUseCase, times(1)).savePostToDb(any(), any())
+    }
+
+    @Test
+    fun `If EditPostRepository is not updated then the savePostToDbUseCase should not be called`() {
+        // act
+        viewModel.start(site, editPostRepository, LocalId(0), mock(), mock())
+
+        // assert
+        verify(savePostToDbUseCase, times(0)).savePostToDb(any(), any())
+    }
+
+    @Test
+    fun `If onStoryDiscarded is called then the post is removed with the dispatcher`() {
+        // act
+        viewModel.start(site, editPostRepository, LocalId(0), mock(), mock())
+        viewModel.onStoryDiscarded()
+
+        // assert
+        verify(dispatcher, times(1)).dispatch(any<Action<PostModel>>())
+    }
+
+    @Test
+    fun `verify that triggering onStorySaveButtonPressed will trigger the associated openPrepublishingBottomSheet`() {
+        // act
+        viewModel.onStorySaveButtonPressed()
+
+        // assert
+        assertThat(viewModel.openPrepublishingBottomSheet.value).isNotNull
+    }
+
+    @Test
+    fun `if onSubmitClicked then setUntitledStoryTitleIfTitleEmptyUseCase should be triggered`() {
+        // act
+        viewModel.start(site, editPostRepository, LocalId(0), mock(), mock())
+        viewModel.onSubmitButtonClicked()
+
+        // assert
+        verify(setUntitledStoryTitleIfTitleEmptyUseCase, times(1))
+                .setUntitledStoryTitleIfTitleEmpty(any())
+    }
+
+    @Test
+    fun `if onSubmitClicked then submitButtonClicked LiveData event should be triggered`() {
+        // act
+        viewModel.start(site, editPostRepository, LocalId(0), mock(), mock())
+        viewModel.onSubmitButtonClicked()
+
+        // assert
+        assertThat(viewModel.submitButtonClicked.value).isNotNull
+    }
+
+    @Test
+    fun `if appendMediaFiles is called then the _mediaFilesUris LiveData event is called`() {
+        // act
+        viewModel.appendMediaFiles(mock())
+
+        // assert
+        assertThat(viewModel.mediaFilesUris).isNotNull
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/SetUntitledStoryTitleIfTitleEmptyUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/SetUntitledStoryTitleIfTitleEmptyUseCaseTest.kt
@@ -1,0 +1,87 @@
+package org.wordpress.android.ui.stories.usecase
+
+import android.content.Context
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.stories.StoryRepositoryWrapper
+
+class SetUntitledStoryTitleIfTitleEmptyUseCaseTest : BaseUnitTest() {
+    private lateinit var setUntitledStoryTitleIfTitleEmptyUseCase: SetUntitledStoryTitleIfTitleEmptyUseCase
+    @Mock lateinit var storyRepositoryWrapper: StoryRepositoryWrapper
+    @Mock lateinit var editPostRepository: EditPostRepository
+    @Mock lateinit var updateStoryPostTitleUseCase: UpdateStoryPostTitleUseCase
+    @Mock lateinit var context: Context
+
+    @Before
+    fun setup() {
+        setUntitledStoryTitleIfTitleEmptyUseCase = SetUntitledStoryTitleIfTitleEmptyUseCase(
+                storyRepositoryWrapper,
+                updateStoryPostTitleUseCase,
+                context
+        )
+    }
+
+    @Test
+    fun `if Post title is empty then set Untitled as the story title with the storyRepositoryWrapper`() {
+        // arrange
+        val expectedPostTitle = "Untitled"
+        whenever(editPostRepository.title).thenReturn("")
+        whenever(context.resources).thenReturn(mock())
+        whenever(context.resources.getString(R.string.untitled)).thenReturn(expectedPostTitle)
+
+        // act
+        setUntitledStoryTitleIfTitleEmptyUseCase.setUntitledStoryTitleIfTitleEmpty(editPostRepository)
+
+        // assert
+        verify(storyRepositoryWrapper).setCurrentStoryTitle(eq(expectedPostTitle))
+    }
+
+    @Test
+    fun `if Post title is empty then set Untitled as the story title with the updateStoryPostTitleUseCase`() {
+        // arrange
+        val expectedPostTitle = "Untitled"
+        whenever(editPostRepository.title).thenReturn("")
+        whenever(context.resources).thenReturn(mock())
+        whenever(context.resources.getString(R.string.untitled)).thenReturn(expectedPostTitle)
+
+        // act
+        setUntitledStoryTitleIfTitleEmptyUseCase.setUntitledStoryTitleIfTitleEmpty(editPostRepository)
+
+        // assert
+        verify(updateStoryPostTitleUseCase).updateStoryTitle(eq(expectedPostTitle), any())
+    }
+
+    @Test
+    fun `if Post title is not empty then storyRepositoryWrapper is not called`() {
+        // arrange
+        whenever(editPostRepository.title).thenReturn("Story Title")
+
+        // act
+        setUntitledStoryTitleIfTitleEmptyUseCase.setUntitledStoryTitleIfTitleEmpty(editPostRepository)
+
+        // assert
+        verify(storyRepositoryWrapper, times(0)).setCurrentStoryTitle(any())
+    }
+
+    @Test
+    fun `if Post title is not empty then updateStoryPostTitleUseCase is not called`() {
+        // arrange
+        whenever(editPostRepository.title).thenReturn("Story Title")
+
+        // act
+        setUntitledStoryTitleIfTitleEmptyUseCase.setUntitledStoryTitleIfTitleEmpty(editPostRepository)
+
+        // assert
+        verify(updateStoryPostTitleUseCase, times(0)).updateStoryTitle(any(), any())
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaTest.kt
@@ -1,0 +1,202 @@
+package org.wordpress.android.ui.stories.usecase
+
+import android.net.Uri
+import androidx.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.test
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.posts.editor.media.AddExistingMediaToPostUseCase
+import org.wordpress.android.ui.posts.editor.media.AddLocalMediaToPostUseCase
+import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
+import org.wordpress.android.ui.stories.media.StoryEditorMedia
+import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState
+import org.wordpress.android.util.MediaUtilsWrapper
+import org.wordpress.android.viewmodel.Event
+
+@UseExperimental(InternalCoroutinesApi::class)
+class StoryEditorMediaTest : BaseUnitTest() {
+    @Test
+    fun `advertiseImageOptimisationAndAddMedia shows dialog when shouldAdvertiseImageOptimization is true`() {
+        // Arrange
+        val editorMediaListener = mock<EditorMediaListener>()
+        val mediaUtilsWrapper = createMediaUtilsWrapper(shouldAdvertiseImageOptimization = true)
+
+        // Act
+        createStoryEditorMedia(
+                editorMediaListener = editorMediaListener,
+                mediaUtilsWrapper = mediaUtilsWrapper
+        ).advertiseImageOptimisationAndAddMedia(mock())
+
+        // Assert
+        verify(editorMediaListener).advertiseImageOptimization(anyOrNull())
+    }
+
+    @Test
+    fun `advertiseImageOptimisationAndAddMedia does NOT show dialog when shouldAdvertiseImageOptimization is false`() {
+        // Arrange
+        val editorMediaListener = mock<EditorMediaListener>()
+        val mediaUtilsWrapper = createMediaUtilsWrapper(shouldAdvertiseImageOptimization = false)
+
+        // Act
+        createStoryEditorMedia(
+                editorMediaListener = editorMediaListener,
+                mediaUtilsWrapper = mediaUtilsWrapper
+        )
+                .advertiseImageOptimisationAndAddMedia(mock())
+        // Assert
+        verify(editorMediaListener, never()).advertiseImageOptimization(anyOrNull())
+    }
+
+    @Test
+    fun `addNewMediaItemsToEditorAsync emits AddingSingleMedia for a single uri`() = test {
+        // Arrange
+        val editorMedia = createStoryEditorMedia()
+        val captor = argumentCaptor<AddMediaToStoryPostUiState>()
+        val observer: Observer<AddMediaToStoryPostUiState> = mock()
+        editorMedia.uiState.observeForever(observer)
+
+        // Act
+        editorMedia.addNewMediaItemsToEditorAsync(mock(), false)
+
+        // Assert
+        verify(observer, times(3)).onChanged(captor.capture())
+        assertThat(captor.firstValue).isEqualTo(AddMediaToStoryPostUiState.AddingMediaToStoryIdle)
+        assertThat(captor.secondValue).isEqualTo(AddMediaToStoryPostUiState.AddingSingleMediaToStory)
+        assertThat(captor.thirdValue).isEqualTo(AddMediaToStoryPostUiState.AddingMediaToStoryIdle)
+    }
+
+    @Test
+    fun `addNewMediaItemsToEditorAsync shows snackbar when a media fails`() = test {
+        // Arrange
+        val addLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase(
+                resultForAddNewMediaToEditorAsync = false
+        )
+        val editorMedia = createStoryEditorMedia(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
+
+        val captor = argumentCaptor<Event<SnackbarMessageHolder>>()
+        val observer: Observer<Event<SnackbarMessageHolder>> = mock()
+        editorMedia.snackBarMessage.observeForever(observer)
+
+        // Act
+        editorMedia.addNewMediaItemsToEditorAsync(mock(), false)
+
+        // Assert
+        verify(observer, times(1)).onChanged(captor.capture())
+        assertThat(captor.firstValue.getContentIfNotHandled()?.messageRes).isEqualTo(R.string.gallery_error)
+    }
+
+    @Test
+    fun `addNewMediaItemsToEditorAsync does NOT show snackbar when all media succeed`() = test {
+        // Arrange
+        val addLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase(
+                resultForAddNewMediaToEditorAsync = true
+        )
+        val editorMedia = createStoryEditorMedia(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
+
+        val captor = argumentCaptor<Event<SnackbarMessageHolder>>()
+        val observer: Observer<Event<SnackbarMessageHolder>> = mock()
+        editorMedia.snackBarMessage.observeForever(observer)
+
+        // Act
+        editorMedia.addNewMediaItemsToEditorAsync(mock(), false)
+        // Assert
+        verify(observer, never()).onChanged(captor.capture())
+    }
+
+    @Test
+    fun `onPhotoPickerMediaChosen does NOT invoke shouldAdvertiseImageOptimization when only video files`() =
+            test {
+                // Arrange
+                val uris = listOf(VIDEO_URI, VIDEO_URI, VIDEO_URI, VIDEO_URI)
+                val editorMediaListener = mock<EditorMediaListener>()
+
+                val mediaUtilsWrapper = createMediaUtilsWrapper()
+
+                // Act
+                createStoryEditorMedia(
+                        mediaUtilsWrapper = mediaUtilsWrapper,
+                        editorMediaListener = editorMediaListener
+                )
+                        .onPhotoPickerMediaChosen(uris)
+                // Assert
+                verify(editorMediaListener, never()).advertiseImageOptimization(anyOrNull())
+                verify(mediaUtilsWrapper, never()).shouldAdvertiseImageOptimization()
+            }
+
+    @Test
+    fun `onPhotoPickerMediaChosen invokes shouldAdvertiseImageOptimization when at least 1 image file`() =
+            test {
+                // Arrange
+                val uris = listOf(VIDEO_URI, VIDEO_URI, IMAGE_URI, VIDEO_URI)
+                val editorMediaListener = mock<EditorMediaListener>()
+
+                val mediaUtilsWrapper = createMediaUtilsWrapper()
+
+                // Act
+                createStoryEditorMedia(
+                        mediaUtilsWrapper = mediaUtilsWrapper,
+                        editorMediaListener = editorMediaListener
+                )
+                        .onPhotoPickerMediaChosen(uris)
+                // Assert
+                verify(mediaUtilsWrapper).shouldAdvertiseImageOptimization()
+            }
+
+    private companion object Fixtures {
+        private val VIDEO_URI = mock<Uri>()
+        private val IMAGE_URI = mock<Uri>()
+
+        fun createStoryEditorMedia(
+            mediaUtilsWrapper: MediaUtilsWrapper = createMediaUtilsWrapper(),
+            addLocalMediaToPostUseCase: AddLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase(),
+            addExistingMediaToPostUseCase: AddExistingMediaToPostUseCase = mock(),
+            siteModel: SiteModel = mock(),
+            editorMediaListener: EditorMediaListener = mock()
+        ): StoryEditorMedia {
+            val editorMedia = StoryEditorMedia(
+                    mediaUtilsWrapper,
+                    addLocalMediaToPostUseCase,
+                    addExistingMediaToPostUseCase,
+                    TEST_DISPATCHER
+            )
+            editorMedia.start(siteModel, editorMediaListener)
+            return editorMedia
+        }
+
+        fun createMediaUtilsWrapper(
+            shouldAdvertiseImageOptimization: Boolean = false
+        ) =
+                mock<MediaUtilsWrapper> {
+                    on { shouldAdvertiseImageOptimization() }
+                            .thenReturn(shouldAdvertiseImageOptimization)
+                    on { isVideo(VIDEO_URI.toString()) }.thenReturn(true)
+                    on { isVideo(IMAGE_URI.toString()) }.thenReturn(false)
+                }
+
+        fun createAddLocalMediaToPostUseCase(resultForAddNewMediaToEditorAsync: Boolean = true) =
+                mock<AddLocalMediaToPostUseCase> {
+                    onBlocking {
+                        addNewMediaToEditorAsync(
+                                anyOrNull(),
+                                anyOrNull(),
+                                anyBoolean(),
+                                anyOrNull(),
+                                anyBoolean()
+                        )
+                    }.thenReturn(resultForAddNewMediaToEditorAsync)
+                }
+    }
+}


### PR DESCRIPTION
Fixes #12492

## Solution

This is the first set of changes to the `StoryComposerActivity` that primarily involves moving the business logic that was within the `StoryComposerActivity`'s `onCreate()` to the `StoryComposerViewModel` 's `start()` method. 

- a `StoryComposerViewModel` has been created to host the business logic. 
- `saveIntialPost` has been converted to a use case and moved to the `StoryComposerViewModel`
- `SaveInitialPostUseCase` now has unit tests to verify it's behavior. These tests are located in `SaveInitialPostUseCaseTest `.
- the logic related to the `savedInstanceState` being null or not was moved into the `ViewModel`. All other operations where data was being fetched from the intent or bundle were left in the `StoryComposerActivity` and then the necessary values were passed to the `start()` method of the `ViewModel`. 
- The `AnalyticsUtils` usage was added to the `AnalyticsUtilsWrapper` so that the component could be injected into the `ViewModel` during test.
- Saving state to the bundle is now handled in the `ViewModel` since, it's business logic that determines what should be saved 40d7d20

## Testing

1. Create a new story post. 
2. Add slides to it. 
3. Publish the story. 

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
