### PR TITLE
Update/translation review build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -521,9 +521,9 @@ ENV["HAS_ALPHA_VERSION"]="true"
       cmd_params=" -PversionName=\"#{options[:custom_version]}\""
     end
 
-    sh("../tools/update-translations.sh")
-    sh("../tools/update-translations.sh waiting")
-    sh("../tools/update-translations.sh fuzzy")
+    sh("../tools/update-translations.sh review")
+    sh("../tools/update-translations.sh review waiting")
+    sh("../tools/update-translations.sh review fuzzy")
 
     android_merge_translators_strings(strings_folder:"./WordPress/src/main/res/")
     sh("export SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD=1 && cd .. && ./gradlew --stacktrace assembleJalapenoDebug #{cmd_params}")

--- a/tools/review-language-codes.csv
+++ b/tools/review-language-codes.csv
@@ -1,0 +1,17 @@
+en-us,en-rUS,English(US)
+de,de,German
+es,es,Spanish
+fr,fr,French
+id,id,Indonesian
+it,it,Italian
+ja,ja,Japanese
+ko,ko,Korean
+nl,nl,Dutch
+ru,ru,Russian
+sv,sv,Swedish
+zh-cn,zh-rCN,Chinese(Simplified)
+zh-tw,zh-rTW,Chinese(Traditional)
+tr,tr,Turkish
+he,he,Hebrew
+pt-br,pt-rBR,Portuguese(Brazil)
+ar,ar,Arabic

--- a/tools/update-translations.sh
+++ b/tools/update-translations.sh
@@ -21,6 +21,7 @@ base_url="http://translate.wordpress.org/projects/apps/android/dev"
 
 if [ -n "$BUILD_TYPE" ]; then 
     base_url="https://translate.wordpress.com/projects/wporg/apps/android";
+    LANG_FILE="${SCRIPT_DIR}/../tools/review-language-codes.csv"
 fi
 
 if [ "$BUILD_FILTER" == "review" ]; then 

--- a/tools/update-translations.sh
+++ b/tools/update-translations.sh
@@ -44,7 +44,12 @@ for line in $(grep -v en-rUS $LANG_FILE) ; do
     test -d $RESDIR/values-$local/ || mkdir $RESDIR/values-$local/
     test -f $RESDIR/values-$local/$strings_file && cp $RESDIR/values-$local/$strings_file $RESDIR/values-$local/$strings_file.bak
     
-    curl -sSfL --globoff "$base_url/$code/default/export-translations?filters[status]=$filter&format=android" | sed $'s/\.\.\./\…/' | sed $'s/\t/    /g' | sed -E '/Translation-Revision-Date/!s/([[:digit:]])-([[:digit:]])/\1–\2/g' > $RESDIR/values-$local/$strings_file || (echo Error downloading $code && rm -rf $RESDIR/values-$local/)
+    curl -sSfL --globoff "$base_url/$code/default/export-translations?filters[status]=$filter&format=android" \
+        | sed $'s/\.\.\./\…/' \
+        | sed $'s/\t/    /g' \
+        | sed -E '/Translation-Revision-Date/!s/([[:digit:]])-([[:digit:]])/\1–\2/g' \
+        > $RESDIR/values-$local/$strings_file || (echo Error downloading $code && rm -rf $RESDIR/values-$local/)
+        
     test -f $RESDIR/values-$local/$strings_file.bak && rm $RESDIR/values-$local/$strings_file.bak
 done
 

--- a/tools/update-translations.sh
+++ b/tools/update-translations.sh
@@ -2,6 +2,7 @@
 
 SCRIPT_DIR=$(dirname "$0")
 BUILD_TYPE=$1
+BUILD_FILTER=$2
 LANG_FILE="${SCRIPT_DIR}/../tools/exported-language-codes.csv"
 RESDIR="${SCRIPT_DIR}/../WordPress/src/main/res/"
 
@@ -16,8 +17,14 @@ echo $HEADER > $LANGUAGE_DEF_FILE
 # Filter definition
 filter="current"
 strings_file="strings.xml"
+base_url="http://translate.wordpress.org/projects/apps/android/dev"
+
 if [ -n "$BUILD_TYPE" ]; then 
-    filter=$BUILD_TYPE; 
+    base_url="https://translate.wordpress.com/projects/wporg/apps/android";
+fi
+
+if [ "$BUILD_FILTER" == "review" ]; then 
+    filter=$BUILD_FILTER; 
     strings_file="strings-$filter.xml"
 fi
 
@@ -36,7 +43,7 @@ for line in $(grep -v en-rUS $LANG_FILE) ; do
     test -d $RESDIR/values-$local/ || mkdir $RESDIR/values-$local/
     test -f $RESDIR/values-$local/$strings_file && cp $RESDIR/values-$local/$strings_file $RESDIR/values-$local/$strings_file.bak
     
-    curl -sSfL --globoff "http://translate.wordpress.org/projects/apps/android/dev/$code/default/export-translations?filters[status]=$filter&format=android" | sed $'s/\.\.\./\…/' | sed $'s/\t/    /g' | sed -E '/Translation-Revision-Date/!s/([[:digit:]])-([[:digit:]])/\1–\2/g' > $RESDIR/values-$local/$strings_file || (echo Error downloading $code && rm -rf $RESDIR/values-$local/)
+    curl -sSfL --globoff "$base_url/$code/default/export-translations?filters[status]=$filter&format=android" | sed $'s/\.\.\./\…/' | sed $'s/\t/    /g' | sed -E '/Translation-Revision-Date/!s/([[:digit:]])-([[:digit:]])/\1–\2/g' > $RESDIR/values-$local/$strings_file || (echo Error downloading $code && rm -rf $RESDIR/values-$local/)
     test -f $RESDIR/values-$local/$strings_file.bak && rm $RESDIR/values-$local/$strings_file.bak
 done
 


### PR DESCRIPTION
This PR updates the build for translators to use the .com GlotPress instance. Currently, the .com instance is sync'ed only for some languages, so the script will download only those.

To test:

1. Run `bundle exec fastlane build_for_translation_review` and verify that the build succeeds and that the translations for the languages in `tools/review-language-codes.csv` have been downloaded.
2. Discard local changes.
3. Run `./tools/update-translations.sh` from the project root folder and verify that it succeeds and that all the translations have been downloaded.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
