### PR TITLE
Replace temporary GravatarUtils from the Login library with the updated one from the Utils library

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginHeaderViewHolder.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginHeaderViewHolder.java
@@ -11,11 +11,11 @@ import androidx.recyclerview.widget.RecyclerView;
 import org.wordpress.android.R;
 import org.wordpress.android.fluxc.model.AccountModel;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.login.util.AvatarHelper.FakeGravatarUtils;
+import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.image.ImageManager;
 
-import static org.wordpress.android.login.util.AvatarHelper.FakeGravatarUtils.DefaultImage.STATUS_404;
+import static org.wordpress.android.util.GravatarUtils.DefaultImage.STATUS_404;
 import static org.wordpress.android.util.image.ImageType.AVATAR_WITHOUT_BACKGROUND;
 
 /**
@@ -75,10 +75,10 @@ class LoginHeaderViewHolder extends RecyclerView.ViewHolder {
     }
 
     private String constructGravatarUrl(Context context, AccountModel account) {
-        return FakeGravatarUtils.fixGravatarUrl(account.getAvatarUrl(), getAvatarSize(context), STATUS_404);
+        return GravatarUtils.fixGravatarUrl(account.getAvatarUrl(), getAvatarSize(context), STATUS_404);
     }
 
     private String constructGravatarUrl(Context context, SiteModel site) {
-        return FakeGravatarUtils.gravatarFromEmail(site.getEmail(), getAvatarSize(context), STATUS_404);
+        return GravatarUtils.gravatarFromEmail(site.getEmail(), getAvatarSize(context), STATUS_404);
     }
 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/AvatarHelper.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/AvatarHelper.kt
@@ -10,7 +10,8 @@ import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.Target
 import org.wordpress.android.login.R
-import org.wordpress.android.login.util.AvatarHelper.FakeGravatarUtils.DefaultImage.STATUS_404
+import org.wordpress.android.util.GravatarUtils
+import org.wordpress.android.util.GravatarUtils.DefaultImage.STATUS_404
 import org.wordpress.android.util.PhotonUtils
 import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.UrlUtils
@@ -23,7 +24,7 @@ object AvatarHelper {
         listener: AvatarRequestListener
     ) {
         val avatarSize = fragment.resources.getDimensionPixelSize(R.dimen.avatar_sz_login)
-        val avatarUrl = FakeGravatarUtils.gravatarFromEmail(email, avatarSize, STATUS_404)
+        val avatarUrl = GravatarUtils.gravatarFromEmail(email, avatarSize, STATUS_404)
         loadAvatarFromUrl(fragment, avatarUrl, avatarView, listener)
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/AvatarHelper.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/AvatarHelper.kt
@@ -12,9 +12,6 @@ import com.bumptech.glide.request.target.Target
 import org.wordpress.android.login.R
 import org.wordpress.android.util.GravatarUtils
 import org.wordpress.android.util.GravatarUtils.DefaultImage.STATUS_404
-import org.wordpress.android.util.PhotonUtils
-import org.wordpress.android.util.StringUtils
-import org.wordpress.android.util.UrlUtils
 
 object AvatarHelper {
     @JvmStatic fun loadAvatarFromEmail(
@@ -66,35 +63,5 @@ object AvatarHelper {
 
     interface AvatarRequestListener {
         fun onRequestFinished()
-    }
-
-    // This should be replaced by the GravatarUtils from the WordPress-Utils library, once it allows us to use a
-    // different DefaultImage (right now it's private)
-    object FakeGravatarUtils {
-        @JvmStatic fun gravatarFromEmail(email: String?, size: Int, defaultImage: DefaultImage) =
-                "http://gravatar.com/avatar/${StringUtils.getMd5Hash(email.orEmpty())}?d=$defaultImage&size=$size"
-
-        @JvmStatic fun fixGravatarUrl(imageUrl: String, size: Int, defaultImage: DefaultImage): String? =
-                if (imageUrl.isEmpty()) {
-                    ""
-                } else if (!imageUrl.contains("gravatar.com")) {
-                    // if this isn't a gravatar image, return as resized photon image url
-                    PhotonUtils.getPhotonImageUrl(imageUrl, size, size)
-                } else {
-                    // remove all other params, then add query string for size and default image
-                    UrlUtils.removeQuery(imageUrl) + "?d=$defaultImage&size=$size"
-                }
-
-        enum class DefaultImage(private val parameterName: String) {
-            MYSTERY_MAN("mm"),
-            STATUS_404("404"),
-            IDENTICON("identicon"),
-            MONSTER("monsterid"),
-            WAVATAR("wavatar"),
-            RETRO("retro"),
-            BLANK("blank");
-
-            override fun toString() = parameterName
-        }
     }
 }


### PR DESCRIPTION
Depends on #12494

During the UL&S project, we introduced a temporary copy of the `GravatarUtils` class from the Utils library to the Login library, in order to quickly overcome some limitations with some of its methods.

This class has now been updated on the Utils library and this PR replaces the temporary one with it.

To test:
- Navigate through both the login and signup flows and make sure the account's Gravatar loads correctly on all the screens where it is used (e.g. Magic Link screen, Password screen, etc). 
- Make sure it also loads correctly on both Login and Signup Epilogue screens.

Notes:
- Use a device with API 21 and 28 to test.
- Avoid using an account with no sites to test, as it might make the Post-Signup Interstitial to be shown instead of the Epilogue.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
