### PR TITLE
Issue/12319 reader discover endpoint

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -640,6 +640,16 @@
             android:label="Reader Update JobService" />
 
         <service
+            android:name=".ui.reader.services.discover.ReaderDiscoverService"
+            android:exported="false"
+            android:label="Reader Discover Service" />
+        <service
+            android:name=".ui.reader.services.discover.ReaderDiscoverJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false"
+            android:label="Reader Discover JobService" />
+
+        <service
             android:name=".ui.reader.services.post.ReaderPostService"
             android:exported="false"
             android:label="Reader Post Service" />

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -19,6 +19,7 @@ public class JobServiceId {
     public static final int JOB_READER_SEARCH_SERVICE_ID = 5000;
     public static final int JOB_PUBLICIZE_UPDATE_SERVICE_ID = 3000;
     public static final int JOB_READER_UPDATE_SERVICE_ID = 2000;
+    public static final int JOB_READER_DISCOVER_SERVICE_ID = 10000;
     public static final int JOB_GCM_REG_SERVICE_ID = 1000;
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverJobService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverJobService.kt
@@ -8,7 +8,6 @@ import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.Dis
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.READER
 import org.wordpress.android.util.LocaleManager
-import java.util.EnumSet
 
 class ReaderDiscoverJobService : JobService(), ServiceCompletionListener {
     private lateinit var readerDiscoverLogic: ReaderDiscoverLogic
@@ -17,16 +16,12 @@ class ReaderDiscoverJobService : JobService(), ServiceCompletionListener {
         super.attachBaseContext(LocaleManager.setLocale(newBase))
     }
 
-    override fun onStartJob(params: JobParameters?): Boolean {
+    override fun onStartJob(params: JobParameters): Boolean {
         AppLog.i(READER, "reader discover job service > started")
-        if (params?.extras?.containsKey(ReaderDiscoverServiceStarter.ARG_DISCOVER_TASKS) == true) {
-            val tmp = params.extras[ReaderDiscoverServiceStarter.ARG_DISCOVER_TASKS] as IntArray
-            val tasks = EnumSet.noneOf(DiscoverTasks::class.java)
-            for (i in tmp) {
-                tasks.add(DiscoverTasks.values()[i])
-            }
-            readerDiscoverLogic.performTasks(tasks, params)
-        }
+
+        val task = DiscoverTasks.values()[(params.extras[ReaderDiscoverServiceStarter.ARG_DISCOVER_TASK] as Int)]
+
+        readerDiscoverLogic.performTasks(task, params)
         return true
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverJobService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverJobService.kt
@@ -1,0 +1,54 @@
+package org.wordpress.android.ui.reader.services.discover
+
+import android.app.job.JobParameters
+import android.app.job.JobService
+import android.content.Context
+import org.wordpress.android.ui.reader.services.ServiceCompletionListener
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.READER
+import org.wordpress.android.util.LocaleManager
+import java.util.EnumSet
+
+class ReaderDiscoverJobService : JobService(), ServiceCompletionListener {
+    private lateinit var readerDiscoverLogic: ReaderDiscoverLogic
+
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase))
+    }
+
+    override fun onStartJob(params: JobParameters?): Boolean {
+        AppLog.i(READER, "reader discover job service > started")
+        if (params?.extras?.containsKey(ReaderDiscoverServiceStarter.ARG_DISCOVER_TASKS) == true) {
+            val tmp = params.extras[ReaderDiscoverServiceStarter.ARG_DISCOVER_TASKS] as IntArray
+            val tasks = EnumSet.noneOf(DiscoverTasks::class.java)
+            for (i in tmp) {
+                tasks.add(DiscoverTasks.values()[i])
+            }
+            readerDiscoverLogic.performTasks(tasks, params)
+        }
+        return true
+    }
+
+    override fun onStopJob(params: JobParameters): Boolean {
+        AppLog.i(READER, "reader discover job service > stopped")
+        jobFinished(params, false)
+        return false
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        readerDiscoverLogic = ReaderDiscoverLogic(this)
+        AppLog.i(READER, "reader discover job service > created")
+    }
+
+    override fun onDestroy() {
+        AppLog.i(READER, "reader discover job service > destroyed")
+        super.onDestroy()
+    }
+
+    override fun onCompleted(companion: Any) {
+        AppLog.i(READER, "reader discover job service > all tasks completed")
+        jobFinished(companion as JobParameters, false)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -1,0 +1,34 @@
+package org.wordpress.android.ui.reader.services.discover
+
+import org.wordpress.android.ui.reader.services.ServiceCompletionListener
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.READER
+import java.util.EnumSet
+
+/**
+ * This class contains logic related to fetching data for the discover tab in the Reader.
+ */
+class ReaderDiscoverLogic constructor(private val completionListener: ServiceCompletionListener) {
+    enum class DiscoverTasks {
+        REQUEST_REFRESH, REQUEST_OLDER
+    }
+
+    private var currentTasks: EnumSet<DiscoverTasks>? = null
+    private var mListenerCompanion: Any? = null
+
+    fun performTasks(tasks: EnumSet<DiscoverTasks>, companion: Any?) {
+        currentTasks = EnumSet.copyOf(tasks)
+        mListenerCompanion = companion
+    }
+
+    private fun taskCompleted(task: DiscoverTasks) {
+        currentTasks!!.remove(task)
+        if (currentTasks!!.isEmpty()) {
+            allTasksCompleted()
+        }
+    }
+    private fun allTasksCompleted() {
+        AppLog.i(READER, "reader service > all tasks completed")
+        completionListener.onCompleted(mListenerCompanion)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -1,34 +1,78 @@
 package org.wordpress.android.ui.reader.services.discover
 
+import android.app.job.JobParameters
+import com.wordpress.rest.RestRequest.ErrorListener
+import com.wordpress.rest.RestRequest.Listener
+import org.json.JSONObject
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.reader.actions.ReaderActions
+import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult.FAILED
+import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResultListener
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FORCE
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.READER
-import java.util.EnumSet
 
 /**
  * This class contains logic related to fetching data for the discover tab in the Reader.
  */
 class ReaderDiscoverLogic constructor(private val completionListener: ServiceCompletionListener) {
     enum class DiscoverTasks {
-        REQUEST_REFRESH, REQUEST_OLDER
+        REQUEST, REQUEST_FORCE
     }
 
-    private var currentTasks: EnumSet<DiscoverTasks>? = null
-    private var mListenerCompanion: Any? = null
+    private var listenerCompanion: JobParameters? = null
 
-    fun performTasks(tasks: EnumSet<DiscoverTasks>, companion: Any?) {
-        currentTasks = EnumSet.copyOf(tasks)
-        mListenerCompanion = companion
-    }
+    fun performTasks(task: DiscoverTasks, companion: JobParameters?) {
+        listenerCompanion = companion
 
-    private fun taskCompleted(task: DiscoverTasks) {
-        currentTasks!!.remove(task)
-        if (currentTasks!!.isEmpty()) {
-            allTasksCompleted()
+        when (task) {
+            REQUEST -> {
+                requestDataForDiscover(false, UpdateResultListener {
+                    // TODO malinjir emit REQUEST finish event
+                    completionListener.onCompleted(listenerCompanion)
+                })
+            }
+            REQUEST_FORCE -> {
+                requestDataForDiscover(true, UpdateResultListener {
+                    // TODO malinjir emit REQUEST_FORCE finish event
+                    completionListener.onCompleted(listenerCompanion)
+                })
+            }
         }
     }
-    private fun allTasksCompleted() {
-        AppLog.i(READER, "reader service > all tasks completed")
-        completionListener.onCompleted(mListenerCompanion)
+
+    private fun requestDataForDiscover(forceRefresh: Boolean, resultListener: ReaderActions.UpdateResultListener) {
+        val path = "read/tags/cards"
+
+        val sb = StringBuilder(path)
+
+        if (!forceRefresh) {
+            sb.append("?page_handle=")
+            // TODO malinjir load page handle
+        }
+        val listener = Listener { jsonObject -> // remember when this tag was updated if newer posts were requested
+            if (forceRefresh) {
+                // TODO malinjir clear cache
+            }
+            handleRequestDiscoverDataResponse(jsonObject, resultListener)
+        }
+        val errorListener = ErrorListener { volleyError ->
+            AppLog.e(READER, volleyError)
+            resultListener.onUpdateResult(FAILED)
+        }
+
+        WordPress.getRestClientUtilsV2()[sb.toString(), null, null, listener, errorListener]
+    }
+
+    private fun handleRequestDiscoverDataResponse(json: JSONObject?, resultListener: UpdateResultListener) {
+        if (json == null) {
+            resultListener.onUpdateResult(FAILED)
+            return
+        }
+        // TODO malinjir Parse data
+        // TODO malinjir Save data into db
+        // TODO malinjir Save next page handle
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverService.kt
@@ -6,11 +6,10 @@ import android.content.Intent
 import android.os.IBinder
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks
-import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverServiceStarter.ARG_DISCOVER_TASKS
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverServiceStarter.ARG_DISCOVER_TASK
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.READER
 import org.wordpress.android.util.LocaleManager
-import java.util.EnumSet
 
 /**
  * Service which updates data for discover tab in Reader, relies on EventBus to notify of changes.
@@ -37,9 +36,9 @@ class ReaderDiscoverService : Service(), ServiceCompletionListener {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        if (intent != null && intent.hasExtra(ARG_DISCOVER_TASKS)) {
-            val tasks = intent.getSerializableExtra(ARG_DISCOVER_TASKS) as EnumSet<DiscoverTasks>
-            readerDiscoverLogic.performTasks(tasks, null)
+        if (intent != null && intent.hasExtra(ARG_DISCOVER_TASK)) {
+            val task = intent.getSerializableExtra(ARG_DISCOVER_TASK) as DiscoverTasks
+            readerDiscoverLogic.performTasks(task, null)
         }
         return START_NOT_STICKY
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverService.kt
@@ -1,0 +1,51 @@
+package org.wordpress.android.ui.reader.services.discover
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import org.wordpress.android.ui.reader.services.ServiceCompletionListener
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverServiceStarter.ARG_DISCOVER_TASKS
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.READER
+import org.wordpress.android.util.LocaleManager
+import java.util.EnumSet
+
+/**
+ * Service which updates data for discover tab in Reader, relies on EventBus to notify of changes.
+ */
+class ReaderDiscoverService : Service(), ServiceCompletionListener {
+    private lateinit var readerDiscoverLogic: ReaderDiscoverLogic
+    override fun onBind(intent: Intent): IBinder? {
+        return null
+    }
+
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(LocaleManager.setLocale(newBase))
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        readerDiscoverLogic = ReaderDiscoverLogic(this)
+        AppLog.i(READER, "reader discover service > created")
+    }
+
+    override fun onDestroy() {
+        AppLog.i(READER, "reader discover service > destroyed")
+        super.onDestroy()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent != null && intent.hasExtra(ARG_DISCOVER_TASKS)) {
+            val tasks = intent.getSerializableExtra(ARG_DISCOVER_TASKS) as EnumSet<DiscoverTasks>
+            readerDiscoverLogic.performTasks(tasks, null)
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onCompleted(companion: Any) {
+        AppLog.i(READER, "reader discover service > all tasks completed")
+        stopSelf()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverServiceStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverServiceStarter.kt
@@ -1,0 +1,66 @@
+package org.wordpress.android.ui.reader.services.discover
+
+import android.app.job.JobInfo
+import android.app.job.JobInfo.Builder
+import android.app.job.JobScheduler
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.os.PersistableBundle
+import org.wordpress.android.JobServiceId
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.READER
+import java.util.EnumSet
+
+/*
+* This class provides a way to decide which kind of Service to start, depending on the platform we're running on.
+*
+*/
+object ReaderDiscoverServiceStarter {
+    const val ARG_DISCOVER_TASKS = "discover_tasks"
+
+    fun startService(context: Context, tasks: EnumSet<DiscoverTasks>) {
+        if (VERSION.SDK_INT < VERSION_CODES.O) {
+            if (tasks.size == 0) {
+                return
+            }
+            val intent = Intent(context, ReaderDiscoverService::class.java)
+            intent.putExtra(ARG_DISCOVER_TASKS, tasks)
+            context.startService(intent)
+        } else {
+            // schedule the JobService here for API >= 26. The JobScheduler is available since API 21, but
+            // it's preferable to use it only since enforcement in API 26 to not break any old behavior
+            val componentName = ComponentName(context, ReaderDiscoverService::class.java)
+            val extras = PersistableBundle()
+            extras.putIntArray(
+                    ARG_DISCOVER_TASKS,
+                    getIntArrayFromEnumSet(tasks)
+            )
+            val jobInfo = Builder(JobServiceId.JOB_READER_DISCOVER_SERVICE_ID, componentName)
+                    .setRequiresCharging(false)
+                    .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                    .setOverrideDeadline(0) // if possible, try to run right away
+                    .setExtras(extras)
+                    .build()
+            val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+            val resultCode = jobScheduler.schedule(jobInfo)
+            if (resultCode == JobScheduler.RESULT_SUCCESS) {
+                AppLog.i(READER, "reader discover service > job scheduled")
+            } else {
+                AppLog.e(READER, "reader discover service > job could not be scheduled")
+            }
+        }
+    }
+
+    private fun getIntArrayFromEnumSet(enumSet: EnumSet<DiscoverTasks>): IntArray {
+        val ordinals2 = IntArray(enumSet.size)
+        var index = 0
+        for (e in enumSet) {
+            ordinals2[index++] = e.ordinal
+        }
+        return ordinals2
+    }
+}


### PR DESCRIPTION
Parent issue #12319 

This PR introduces ReaderDiscoverService and related classes. Most of the code has been copied from `org.wordpress.android.ui.reader.services.update` package. I basically just converted it to Kotlin and removed the logic. This code could be refactored but it's above the scope of the project at the moment. So I decided to keep it consistent with the rest of the ReaderXYZServices.

Ideally mostly focus on checking that I didn't forgot something related to the ReaderUpdateService in these classes - eg logs etc.

To test:
No need to test anything yet. We are merging this PR into a working branch.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
