### PR TITLE
Add support for parsing data from the new discover endpoint

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -83,13 +83,13 @@ public class ReaderPost {
 
         ReaderPost post = new ReaderPost();
 
-        post.postId = json.optLong("ID");
-        post.blogId = json.optLong("site_ID");
+        post.postId = json.optLong(ReaderConstants.POST_ID);
+        post.blogId = json.optLong(ReaderConstants.POST_SITE_ID);
         post.feedId = json.optLong("feed_ID");
         post.feedItemId = json.optLong("feed_item_ID");
 
-        if (json.has("pseudo_ID")) {
-            post.mPseudoId = JSONUtils.getString(json, "pseudo_ID"); // read/ endpoint
+        if (json.has(ReaderConstants.POST_PSEUDO_ID)) {
+            post.mPseudoId = JSONUtils.getString(json, ReaderConstants.POST_PSEUDO_ID); // read/ endpoint
         } else {
             post.mPseudoId = JSONUtils.getString(json, "global_ID"); // sites/ endpoint
         }

--- a/WordPress/src/main/java/org/wordpress/android/models/discover/ReaderDiscoverCards.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/discover/ReaderDiscoverCards.kt
@@ -6,6 +6,6 @@ import org.wordpress.android.models.ReaderTagList
 data class ReaderDiscoverCards(val cards: List<ReaderDiscoverCard>)
 
 sealed class ReaderDiscoverCard {
-    class InterestsYouMayLikeCard(val interests: ReaderTagList) : ReaderDiscoverCard()
+    data class InterestsYouMayLikeCard(val interests: ReaderTagList) : ReaderDiscoverCard()
     data class ReaderPostCard(val post: ReaderPost) : ReaderDiscoverCard()
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/discover/ReaderDiscoverCards.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/discover/ReaderDiscoverCards.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.models.discover
+
+import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.models.ReaderTagList
+
+data class ReaderDiscoverCards(val cards: List<ReaderDiscoverCard>)
+
+sealed class ReaderDiscoverCard {
+    class InterestsYouMayLikeCard(val interests: ReaderTagList) : ReaderDiscoverCard()
+    data class ReaderPostCard(val post: ReaderPost) : ReaderDiscoverCard()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -71,12 +71,22 @@ public class ReaderConstants {
     static final String KEY_ALREADY_TRACKED_LOCAL_RELATED_POSTS = "already_tracked_local_related_posts";
 
     // JSON key names
-    // tag endpoints
     public static final String JSON_TAG_TAGS_ARRAY = "tags";
     public static final String JSON_TAG_TITLE = "title";
     public static final String JSON_TAG_DISPLAY_NAME = "tag_display_name";
     public static final String JSON_TAG_SLUG = "slug";
     public static final String JSON_TAG_URL = "URL";
+    public static final String JSON_CARDS = "cards";
+    public static final String JSON_CARD_TYPE = "type";
+    public static final String JSON_CARD_INTERESTS_YOU_MAY_LIKE = "interests_you_may_like";
+    public static final String JSON_CARD_POST = "post";
+    public static final String JSON_CARD_DATA = "data";
+    public static final String JSON_NEXT_PAGE_HANDLE = "next_page_handle";
+
+    // JSON Post key names
+    public static final String POST_ID = "ID";
+    public static final String POST_SITE_ID = "site_ID";
+    public static final String POST_PSEUDO_ID = "pseudo_ID";
 
     public static final String KEY_FOLLOWING = "following";
     public static final String KEY_DISCOVER = "discover";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -3,16 +3,27 @@ package org.wordpress.android.ui.reader.services.discover
 import android.app.job.JobParameters
 import com.wordpress.rest.RestRequest.ErrorListener
 import com.wordpress.rest.RestRequest.Listener
+import org.json.JSONArray
 import org.json.JSONObject
 import org.wordpress.android.WordPress
+import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTagList
+import org.wordpress.android.models.ReaderTagType.DEFAULT
+import org.wordpress.android.models.discover.ReaderDiscoverCard
+import org.wordpress.android.models.discover.ReaderDiscoverCard.InterestsYouMayLikeCard
+import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderPostCard
+import org.wordpress.android.ui.reader.ReaderConstants
 import org.wordpress.android.ui.reader.actions.ReaderActions
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult.FAILED
+import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult.HAS_NEW
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResultListener
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FORCE
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.READER
+import org.wordpress.android.util.JSONUtils
 
 /**
  * This class contains logic related to fetching data for the discover tab in the Reader.
@@ -67,12 +78,91 @@ class ReaderDiscoverLogic constructor(private val completionListener: ServiceCom
     }
 
     private fun handleRequestDiscoverDataResponse(json: JSONObject?, resultListener: UpdateResultListener) {
+        // TODO malinjir move to bg thread
         if (json == null) {
             resultListener.onUpdateResult(FAILED)
             return
         }
-        // TODO malinjir Parse data
-        // TODO malinjir Save data into db
-        // TODO malinjir Save next page handle
+        val fullCardsJson = json.optJSONArray(ReaderConstants.JSON_CARDS)
+
+        // Parse the json into cards model objects
+        val cards = parseCards(fullCardsJson)
+        // TODO malinjir Save posts into db
+
+        // Simplify the json. The simplified version is used in the upper layers to load the data from the db.
+        val simplifiedCardsJson = simplifyJson(fullCardsJson)
+        // TODO malinjir Save simplified json into db
+
+        val nextPageHandle = parseNextPageHandle(json)
+        // TODO malinjir save next page handle into shared preferences
+
+        resultListener.onUpdateResult(HAS_NEW)
     }
+
+    private fun parseCards(cardsJsonArray: JSONArray): ArrayList<ReaderDiscoverCard> {
+        val cards: ArrayList<ReaderDiscoverCard> = arrayListOf()
+        for (i in 0 until cardsJsonArray.length()) {
+            val cardJson = cardsJsonArray.getJSONObject(i)
+            when (cardJson.getString(ReaderConstants.JSON_CARD_TYPE)) {
+                ReaderConstants.JSON_CARD_INTERESTS_YOU_MAY_LIKE -> {
+                    val interests = parseInterestTagsList(cardJson)
+                    cards.add(InterestsYouMayLikeCard(interests))
+                }
+                ReaderConstants.JSON_CARD_POST -> {
+                    val post = ReaderPost.fromJson(cardJson.getJSONObject(ReaderConstants.JSON_CARD_DATA))
+                    cards.add(ReaderPostCard(post))
+                }
+            }
+        }
+        return cards
+    }
+
+    /**
+     * This methods replace the gigantic post object with its simplified version. The post data are already stored in
+     * the database so we don't need to store them within the json.
+     */
+    private fun simplifyJson(cardsJsonArray: JSONArray): JSONArray {
+        for (i in 0 until cardsJsonArray.length()) {
+            val cardJson = cardsJsonArray.getJSONObject(i)
+            if (cardJson.getString(ReaderConstants.JSON_CARD_TYPE) == ReaderConstants.JSON_CARD_POST) {
+                cardsJsonArray.put(i, convertToSimplifiedPostJson(cardJson))
+            }
+        }
+        return cardsJsonArray
+    }
+
+    /**
+     * Removes all unnecessary fields from the gigantic post object - keeps only postId, siteId and pseudoId.
+     */
+    private fun convertToSimplifiedPostJson(cardJson: JSONObject): JSONObject {
+        val originalPostData = cardJson.getJSONObject(ReaderConstants.JSON_CARD_DATA)
+        val simplifiedPostData = JSONObject()
+        // copy only fields which uniquely identify this post
+        simplifiedPostData.put(ReaderConstants.POST_ID, originalPostData.get(ReaderConstants.POST_ID))
+        simplifiedPostData.put(ReaderConstants.POST_SITE_ID, originalPostData.get(ReaderConstants.POST_SITE_ID))
+        simplifiedPostData.put(ReaderConstants.POST_PSEUDO_ID, originalPostData.get(ReaderConstants.POST_PSEUDO_ID))
+        cardJson.put(ReaderConstants.JSON_CARD_DATA, simplifiedPostData)
+        return cardJson
+    }
+
+    private fun parseInterestTagsList(jsonObject: JSONObject?): ReaderTagList {
+        val interestTags = ReaderTagList()
+        if (jsonObject == null) {
+            return interestTags
+        }
+        val jsonInterests = jsonObject.optJSONArray(ReaderConstants.JSON_CARD_DATA) ?: return interestTags
+        for (i in 0 until jsonInterests.length()) {
+            interestTags.add(parseInterestTag(jsonInterests.optJSONObject(i)))
+        }
+        return interestTags
+    }
+
+    private fun parseInterestTag(jsonInterest: JSONObject): ReaderTag {
+        val tagTitle = JSONUtils.getStringDecoded(jsonInterest, ReaderConstants.JSON_TAG_TITLE)
+        val tagSlug = JSONUtils.getStringDecoded(jsonInterest, ReaderConstants.JSON_TAG_SLUG)
+        return ReaderTag(tagSlug, tagTitle, tagTitle, "", DEFAULT)
+    }
+
+    private fun parseNextPageHandle(jsonObject: JSONObject): String =
+            jsonObject.getString(ReaderConstants.JSON_NEXT_PAGE_HANDLE)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -134,15 +134,16 @@ class ReaderDiscoverLogic constructor(private val completionListener: ServiceCom
      * as it's already stored in the db.
      */
     private fun createSimplifiedJson(cardsJsonArray: JSONArray): JSONArray {
+        var index = 0
         val simplifiedJson = JSONArray()
         for (i in 0 until cardsJsonArray.length()) {
             val cardJson = cardsJsonArray.getJSONObject(i)
             when (cardJson.getString(JSON_CARD_TYPE)) {
                 JSON_CARD_INTERESTS_YOU_MAY_LIKE -> {
-                    simplifiedJson.put(i, cardJson)
+                    simplifiedJson.put(index++, cardJson)
                 }
                 JSON_CARD_POST -> {
-                    simplifiedJson.put(i, createSimplifiedPostJson(cardJson))
+                    simplifiedJson.put(index++, createSimplifiedPostJson(cardJson))
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -13,7 +13,17 @@ import org.wordpress.android.models.ReaderTagType.DEFAULT
 import org.wordpress.android.models.discover.ReaderDiscoverCard
 import org.wordpress.android.models.discover.ReaderDiscoverCard.InterestsYouMayLikeCard
 import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderPostCard
-import org.wordpress.android.ui.reader.ReaderConstants
+import org.wordpress.android.ui.reader.ReaderConstants.JSON_CARDS
+import org.wordpress.android.ui.reader.ReaderConstants.JSON_CARD_DATA
+import org.wordpress.android.ui.reader.ReaderConstants.JSON_CARD_INTERESTS_YOU_MAY_LIKE
+import org.wordpress.android.ui.reader.ReaderConstants.JSON_CARD_POST
+import org.wordpress.android.ui.reader.ReaderConstants.JSON_CARD_TYPE
+import org.wordpress.android.ui.reader.ReaderConstants.JSON_NEXT_PAGE_HANDLE
+import org.wordpress.android.ui.reader.ReaderConstants.JSON_TAG_SLUG
+import org.wordpress.android.ui.reader.ReaderConstants.JSON_TAG_TITLE
+import org.wordpress.android.ui.reader.ReaderConstants.POST_ID
+import org.wordpress.android.ui.reader.ReaderConstants.POST_PSEUDO_ID
+import org.wordpress.android.ui.reader.ReaderConstants.POST_SITE_ID
 import org.wordpress.android.ui.reader.actions.ReaderActions
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult.FAILED
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult.HAS_NEW
@@ -83,14 +93,14 @@ class ReaderDiscoverLogic constructor(private val completionListener: ServiceCom
             resultListener.onUpdateResult(FAILED)
             return
         }
-        val fullCardsJson = json.optJSONArray(ReaderConstants.JSON_CARDS)
+        val fullCardsJson = json.optJSONArray(JSON_CARDS)
 
         // Parse the json into cards model objects
         val cards = parseCards(fullCardsJson)
         // TODO malinjir Save posts into db
 
         // Simplify the json. The simplified version is used in the upper layers to load the data from the db.
-        val simplifiedCardsJson = simplifyJson(fullCardsJson)
+        val simplifiedCardsJson = createSimplifiedJson(fullCardsJson)
         // TODO malinjir Save simplified json into db
 
         val nextPageHandle = parseNextPageHandle(json)
@@ -103,13 +113,13 @@ class ReaderDiscoverLogic constructor(private val completionListener: ServiceCom
         val cards: ArrayList<ReaderDiscoverCard> = arrayListOf()
         for (i in 0 until cardsJsonArray.length()) {
             val cardJson = cardsJsonArray.getJSONObject(i)
-            when (cardJson.getString(ReaderConstants.JSON_CARD_TYPE)) {
-                ReaderConstants.JSON_CARD_INTERESTS_YOU_MAY_LIKE -> {
+            when (cardJson.getString(JSON_CARD_TYPE)) {
+                JSON_CARD_INTERESTS_YOU_MAY_LIKE -> {
                     val interests = parseInterestTagsList(cardJson)
                     cards.add(InterestsYouMayLikeCard(interests))
                 }
-                ReaderConstants.JSON_CARD_POST -> {
-                    val post = ReaderPost.fromJson(cardJson.getJSONObject(ReaderConstants.JSON_CARD_DATA))
+                JSON_CARD_POST -> {
+                    val post = ReaderPost.fromJson(cardJson.getJSONObject(JSON_CARD_DATA))
                     cards.add(ReaderPostCard(post))
                 }
             }
@@ -118,31 +128,43 @@ class ReaderDiscoverLogic constructor(private val completionListener: ServiceCom
     }
 
     /**
-     * This methods replace the gigantic post object with its simplified version. The post data are already stored in
-     * the database so we don't need to store them within the json.
+     * This method creates a simplified version of the provided json.
+     *
+     * It for example copies only ids from post object as we don't need to store the gigantic post in the json
+     * as it's already stored in the db.
      */
-    private fun simplifyJson(cardsJsonArray: JSONArray): JSONArray {
+    private fun createSimplifiedJson(cardsJsonArray: JSONArray): JSONArray {
+        val simplifiedJson = JSONArray()
         for (i in 0 until cardsJsonArray.length()) {
             val cardJson = cardsJsonArray.getJSONObject(i)
-            if (cardJson.getString(ReaderConstants.JSON_CARD_TYPE) == ReaderConstants.JSON_CARD_POST) {
-                cardsJsonArray.put(i, convertToSimplifiedPostJson(cardJson))
+            when (cardJson.getString(JSON_CARD_TYPE)) {
+                JSON_CARD_INTERESTS_YOU_MAY_LIKE -> {
+                    simplifiedJson.put(i, cardJson)
+                }
+                JSON_CARD_POST -> {
+                    simplifiedJson.put(i, createSimplifiedPostJson(cardJson))
+                }
             }
         }
-        return cardsJsonArray
+        return simplifiedJson
     }
 
     /**
-     * Removes all unnecessary fields from the gigantic post object - keeps only postId, siteId and pseudoId.
+     * Create a simplified copy of the json - keeps only postId, siteId and pseudoId.
      */
-    private fun convertToSimplifiedPostJson(cardJson: JSONObject): JSONObject {
-        val originalPostData = cardJson.getJSONObject(ReaderConstants.JSON_CARD_DATA)
+    private fun createSimplifiedPostJson(originalCardJson: JSONObject): JSONObject {
+        val originalPostData = originalCardJson.getJSONObject(JSON_CARD_DATA)
+
         val simplifiedPostData = JSONObject()
         // copy only fields which uniquely identify this post
-        simplifiedPostData.put(ReaderConstants.POST_ID, originalPostData.get(ReaderConstants.POST_ID))
-        simplifiedPostData.put(ReaderConstants.POST_SITE_ID, originalPostData.get(ReaderConstants.POST_SITE_ID))
-        simplifiedPostData.put(ReaderConstants.POST_PSEUDO_ID, originalPostData.get(ReaderConstants.POST_PSEUDO_ID))
-        cardJson.put(ReaderConstants.JSON_CARD_DATA, simplifiedPostData)
-        return cardJson
+        simplifiedPostData.put(POST_ID, originalPostData.get(POST_ID))
+        simplifiedPostData.put(POST_SITE_ID, originalPostData.get(POST_SITE_ID))
+        simplifiedPostData.put(POST_PSEUDO_ID, originalPostData.get(POST_PSEUDO_ID))
+
+        val simplifiedCardJson = JSONObject()
+        simplifiedCardJson.put(JSON_CARD_TYPE, originalCardJson.getString(JSON_CARD_TYPE))
+        simplifiedCardJson.put(JSON_CARD_DATA, simplifiedPostData)
+        return simplifiedCardJson
     }
 
     private fun parseInterestTagsList(jsonObject: JSONObject?): ReaderTagList {
@@ -150,7 +172,7 @@ class ReaderDiscoverLogic constructor(private val completionListener: ServiceCom
         if (jsonObject == null) {
             return interestTags
         }
-        val jsonInterests = jsonObject.optJSONArray(ReaderConstants.JSON_CARD_DATA) ?: return interestTags
+        val jsonInterests = jsonObject.optJSONArray(JSON_CARD_DATA) ?: return interestTags
         for (i in 0 until jsonInterests.length()) {
             interestTags.add(parseInterestTag(jsonInterests.optJSONObject(i)))
         }
@@ -158,11 +180,11 @@ class ReaderDiscoverLogic constructor(private val completionListener: ServiceCom
     }
 
     private fun parseInterestTag(jsonInterest: JSONObject): ReaderTag {
-        val tagTitle = JSONUtils.getStringDecoded(jsonInterest, ReaderConstants.JSON_TAG_TITLE)
-        val tagSlug = JSONUtils.getStringDecoded(jsonInterest, ReaderConstants.JSON_TAG_SLUG)
+        val tagTitle = JSONUtils.getStringDecoded(jsonInterest, JSON_TAG_TITLE)
+        val tagSlug = JSONUtils.getStringDecoded(jsonInterest, JSON_TAG_SLUG)
         return ReaderTag(tagSlug, tagTitle, tagTitle, "", DEFAULT)
     }
 
     private fun parseNextPageHandle(jsonObject: JSONObject): String =
-            jsonObject.getString(ReaderConstants.JSON_NEXT_PAGE_HANDLE)
+            jsonObject.getString(JSON_NEXT_PAGE_HANDLE)
 }


### PR DESCRIPTION
Parent issue #12319 

This PR adds parsing logic for the new discover endpoint


To test:
I've tested the app by faking responses in Charles and manually starting the service from the discover fragment. However, since this code isn't being used yet I don't think it's necessary for the reviewer to actually test the app. We'll have opportunity to test it before it's used in production.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
