### PR TITLE
Add fun to support refresh requests

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader.repository
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
@@ -95,7 +94,6 @@ class ReaderDiscoverRepository constructor(
     }
 
     fun refreshPosts() {
-        Log.i(javaClass.simpleName, "***=> Made it to repo for a refresh")
         launch {
             val response = fetchPostsForTagUseCase.fetch(readerTag)
             if (response != Success) _communicationChannel.postValue(Event(response))
@@ -103,12 +101,10 @@ class ReaderDiscoverRepository constructor(
     }
 
     private fun onNewPosts(event: UpdatePostsEnded) {
-        Log.i(javaClass.simpleName, "***=> onNewPosts")
         reloadPosts()
     }
 
     private fun onChangedPosts(event: UpdatePostsEnded) {
-        Log.i(javaClass.simpleName, "***=> onChangedPosts")
         reloadPosts()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.repository
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
@@ -93,11 +94,21 @@ class ReaderDiscoverRepository constructor(
         return readerTag
     }
 
+    fun refreshPosts() {
+        Log.i(javaClass.simpleName, "***=> Made it to repo for a refresh")
+        launch {
+            val response = fetchPostsForTagUseCase.fetch(readerTag)
+            if (response != Success) _communicationChannel.postValue(Event(response))
+        }
+    }
+
     private fun onNewPosts(event: UpdatePostsEnded) {
+        Log.i(javaClass.simpleName, "***=> onNewPosts")
         reloadPosts()
     }
 
     private fun onChangedPosts(event: UpdatePostsEnded) {
+        Log.i(javaClass.simpleName, "***=> onChangedPosts")
         reloadPosts()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
@@ -76,6 +76,13 @@ class ReaderPostRepository(
         return readerTag
     }
 
+    fun refreshPosts() {
+        launch {
+            val response = fetchPostsForTagUseCase.fetch(readerTag)
+            if (response != Success) _communicationChannel.postValue(Event(response))
+        }
+    }
+
     // todo: annmarie - Possibly implement a "LikeManager" that will encapsulate all the "UseCase".
     fun performLikeAction(post: ReaderPost, isAskingToLike: Boolean, wpComUserId: Long) {
         launch {


### PR DESCRIPTION
Part of #12039 

This PR exposes a function for PTR support. `refreshPosts()` will kickoff the fetch from the server and results will be returned on the `posts` stream. 

To test:
The functionality isn't available in the fragment/viewmodel yet, so I rigged up a SwipeRefreshLayout and tested that the call made it to the repo and data was returned. 

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
