### PR TITLE
Updated layout params logic in AEV

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -27,6 +27,7 @@ class ActionableEmptyView : LinearLayout {
     lateinit var layout: View
     lateinit var subtitle: WPTextView
     lateinit var title: WPTextView
+
     /**
      * Image shown at the bottom after the subtitle.
      *
@@ -116,13 +117,13 @@ class ActionableEmptyView : LinearLayout {
      * @param topMargin top margin in pixels to offset with other views (e.g. toolbar or tabs)
      */
     fun updateLayoutForSearch(isSearching: Boolean, topMargin: Int) {
-        val params: RelativeLayout.LayoutParams
+        val params = layout.layoutParams as MarginLayoutParams
+
 
         if (isSearching) {
-            params = RelativeLayout.LayoutParams(
-                    LayoutParams.MATCH_PARENT,
-                    LayoutParams.WRAP_CONTENT
-            )
+            params.width = MarginLayoutParams.MATCH_PARENT
+            params.height = MarginLayoutParams.WRAP_CONTENT
+
             layout.setPadding(
                     0,
                     context.resources.getDimensionPixelSize(R.dimen.margin_extra_extra_large),
@@ -133,10 +134,8 @@ class ActionableEmptyView : LinearLayout {
             image.visibility = View.GONE
             button.visibility = View.GONE
         } else {
-            params = RelativeLayout.LayoutParams(
-                    LayoutParams.MATCH_PARENT,
-                    LayoutParams.MATCH_PARENT
-            )
+            params.width = MarginLayoutParams.MATCH_PARENT
+            params.height = MarginLayoutParams.MATCH_PARENT
             layout.setPadding(0, 0, 0, 0)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -7,7 +7,6 @@ import android.view.Gravity
 import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
-import android.widget.RelativeLayout
 import androidx.appcompat.widget.AppCompatButton
 import org.wordpress.android.R
 import org.wordpress.android.util.DisplayUtils
@@ -118,7 +117,6 @@ class ActionableEmptyView : LinearLayout {
      */
     fun updateLayoutForSearch(isSearching: Boolean, topMargin: Int) {
         val params = layout.layoutParams as MarginLayoutParams
-
 
         if (isSearching) {
             params.width = MarginLayoutParams.MATCH_PARENT


### PR DESCRIPTION
Currently, when calling `updateLayoutForSearch` of `ActionableEmptyView`, it assumes that its parent is a `RelativeLayout`, which might not be the case.

How to reproduce the problem on develop branch:
- Modify [page_empty_item.xml ](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/res/layout/page_empty_item.xml) and replace parent with `RelativeLayout` to `LinearLayout.
- Open Pages screen, assuming you have an empty view in one of the ViewPager fragments the app will crash with `ClassCastException: android.widget.RelativeLayout$LayoutParams cannot be cast to android.widget.LinearLayout$LayoutParams`

To test:
- Repeat the steps above and make sure the app does not crash.
- Make sure that AEV looks as expected.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
