### PR TITLE
WP Stories: story composer ViewModel part4

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -90,7 +90,7 @@ import org.wordpress.android.ui.posts.editor.ImageEditorTracker;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.tracker.ReaderTracker;
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater.StatsWidgetUpdaters;
-import org.wordpress.android.ui.stories.StoryMediaSaveUploadBridge;
+import org.wordpress.android.ui.stories.media.StoryMediaSaveUploadBridge;
 import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.ui.uploads.UploadStarter;
 import org.wordpress.android.util.AppLog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -142,10 +142,9 @@ import org.wordpress.android.ui.posts.editor.StorePostViewModel;
 import org.wordpress.android.ui.posts.editor.StorePostViewModel.ActivityFinishState;
 import org.wordpress.android.ui.posts.editor.StorePostViewModel.UpdateFromEditor;
 import org.wordpress.android.ui.posts.editor.StorePostViewModel.UpdateFromEditor.PostFields;
+import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource;
 import org.wordpress.android.ui.posts.editor.media.EditorMedia;
-import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddExistingMediaSource;
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener;
-import org.wordpress.android.ui.posts.editor.media.EditorType;
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetListener;
 import org.wordpress.android.ui.posts.prepublishing.home.usecases.PublishPostImmediatelyUseCase;
 import org.wordpress.android.ui.posts.reactnative.ReactNativeRequestHandler;
@@ -553,7 +552,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
             return;
         }
 
-        mEditorMedia.start(mSite, this, EditorType.POST_EDITOR);
+        mEditorMedia.start(mSite, this);
         startObserving();
 
         if (mHasSetPostContent = mEditorFragment != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/EditorTracker.kt
@@ -6,7 +6,7 @@ import dagger.Reusable
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.editor.EditorFragmentAbstract.TrackableEvent
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddExistingMediaSource
+import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddExistingMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddExistingMediaToPostUseCase.kt
@@ -3,8 +3,12 @@ package org.wordpress.android.ui.posts.editor.media
 import dagger.Reusable
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.editor.EditorTracker
-import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddExistingMediaSource
 import javax.inject.Inject
+
+enum class AddExistingMediaSource {
+    WP_MEDIA_LIBRARY,
+    STOCK_PHOTO_LIBRARY
+}
 
 /**
  * Loads existing media items (they must have a valid url) from the local db and adds them to the editor.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMediaListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMediaListener.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.ui.posts.editor.media
+
+import org.wordpress.android.fluxc.model.PostImmutableModel
+import org.wordpress.android.ui.posts.EditPostActivity.OnPostUpdatedFromUIListener
+import org.wordpress.android.util.helpers.MediaFile
+
+interface EditorMediaListener {
+    fun appendMediaFiles(mediaFiles: Map<String, MediaFile>)
+    fun syncPostObjectWithUiAndSaveIt(listener: OnPostUpdatedFromUIListener? = null)
+    fun advertiseImageOptimization(listener: () -> Unit)
+    fun getImmutablePost(): PostImmutableModel
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMediaListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMediaListener.kt
@@ -10,4 +10,3 @@ interface EditorMediaListener {
     fun advertiseImageOptimization(listener: () -> Unit)
     fun getImmutablePost(): PostImmutableModel
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -46,12 +46,11 @@ import org.wordpress.android.ui.posts.PrepublishingBottomSheetFragment
 import org.wordpress.android.ui.posts.ProgressDialogHelper
 import org.wordpress.android.ui.posts.ProgressDialogUiState
 import org.wordpress.android.ui.posts.PublishPost
-import org.wordpress.android.ui.posts.editor.media.EditorMedia
-import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddExistingMediaSource.WP_MEDIA_LIBRARY
-import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddMediaToPostUiState
+import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource.WP_MEDIA_LIBRARY
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
-import org.wordpress.android.ui.posts.editor.media.EditorType.STORY_EDITOR
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetListener
+import org.wordpress.android.ui.stories.media.StoryEditorMedia
+import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState
 import org.wordpress.android.ui.utils.AuthenticationUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ListUtils
@@ -78,7 +77,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         PrepublishingBottomSheetListener {
     private var site: SiteModel? = null
 
-    @Inject lateinit var editorMedia: EditorMedia
+    @Inject lateinit var editorMedia: StoryEditorMedia
     @Inject lateinit var progressDialogHelper: ProgressDialogHelper
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var postStore: PostStore
@@ -153,7 +152,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             )
         }
 
-        editorMedia.start(requireNotNull(site), this, STORY_EDITOR)
+        editorMedia.start(requireNotNull(site), this)
         setupEditorMediaObserver()
         setupViewModelObservers()
     }
@@ -286,7 +285,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
 
     private fun setupEditorMediaObserver() {
         editorMedia.uiState.observe(this,
-                Observer { uiState: AddMediaToPostUiState? ->
+                Observer { uiState: AddMediaToStoryPostUiState? ->
                     if (uiState != null) {
                         updateAddingMediaToEditorProgressDialogState(uiState.progressDialogUiState)
                         if (uiState.editorOverlayVisibility) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -153,7 +153,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         }
 
         storyEditorMedia.start(requireNotNull(site), this)
-        setupEditorMediaObserver()
+        setupStoryEditorMediaObserver()
         setupViewModelObservers()
     }
 
@@ -283,11 +283,11 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         storyEditorMedia.addExistingMediaToEditorAsync(WP_MEDIA_LIBRARY, ids)
     }
 
-    private fun setupEditorMediaObserver() {
+    private fun setupStoryEditorMediaObserver() {
         storyEditorMedia.uiState.observe(this,
                 Observer { uiState: AddMediaToStoryPostUiState? ->
                     if (uiState != null) {
-                        updateAddingMediaToEditorProgressDialogState(uiState.progressDialogUiState)
+                        updateAddingMediaToStoryComposerProgressDialogState(uiState.progressDialogUiState)
                         if (uiState.editorOverlayVisibility) {
                             showLoading()
                         } else {
@@ -338,7 +338,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         WPMediaUtils.advertiseImageOptimization(this) { listener.invoke() }
     }
 
-    private fun updateAddingMediaToEditorProgressDialogState(uiState: ProgressDialogUiState) {
+    private fun updateAddingMediaToStoryComposerProgressDialogState(uiState: ProgressDialogUiState) {
         addingMediaToEditorProgressDialog = progressDialogHelper
                 .updateProgressDialogState(this, addingMediaToEditorProgressDialog, uiState, uiHelpers)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -59,7 +59,6 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.viewmodel.Event
-import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 import org.wordpress.android.widgets.WPSnackbar
 import java.util.Objects
 import javax.inject.Inject

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -77,7 +77,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         PrepublishingBottomSheetListener {
     private var site: SiteModel? = null
 
-    @Inject lateinit var editorMedia: StoryEditorMedia
+    @Inject lateinit var storyEditorMedia: StoryEditorMedia
     @Inject lateinit var progressDialogHelper: ProgressDialogHelper
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var postStore: PostStore
@@ -152,7 +152,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             )
         }
 
-        editorMedia.start(requireNotNull(site), this)
+        storyEditorMedia.start(requireNotNull(site), this)
         setupEditorMediaObserver()
         setupViewModelObservers()
     }
@@ -214,7 +214,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                         val uriList: List<Uri> = convertStringArrayIntoUrisList(
                                 it.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)
                         )
-                        editorMedia.onPhotoPickerMediaChosen(uriList)
+                        storyEditorMedia.onPhotoPickerMediaChosen(uriList)
                     } else if (it.hasExtra(MediaBrowserActivity.RESULT_IDS)) {
                         handleMediaPickerIntentData(it)
                     }
@@ -224,7 +224,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     }
 
     override fun onDestroy() {
-        editorMedia.cancelAddMediaToEditorActions()
+        storyEditorMedia.cancelAddMediaToEditorActions()
         super.onDestroy()
     }
 
@@ -280,11 +280,11 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             return
         }
 
-        editorMedia.addExistingMediaToEditorAsync(WP_MEDIA_LIBRARY, ids)
+        storyEditorMedia.addExistingMediaToEditorAsync(WP_MEDIA_LIBRARY, ids)
     }
 
     private fun setupEditorMediaObserver() {
-        editorMedia.uiState.observe(this,
+        storyEditorMedia.uiState.observe(this,
                 Observer { uiState: AddMediaToStoryPostUiState? ->
                     if (uiState != null) {
                         updateAddingMediaToEditorProgressDialogState(uiState.progressDialogUiState)
@@ -296,7 +296,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                     }
                 }
         )
-        editorMedia.snackBarMessage.observe(this,
+        storyEditorMedia.snackBarMessage.observe(this,
                 Observer<Event<SnackbarMessageHolder>> { event: Event<SnackbarMessageHolder?> ->
                     val messageHolder = event.getContentIfNotHandled()
                     if (messageHolder != null) {
@@ -310,7 +310,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                     }
                 }
         )
-        editorMedia.toastMessage.observe(this,
+        storyEditorMedia.toastMessage.observe(this,
                 Observer<Event<ToastMessageHolder>> { event: Event<ToastMessageHolder?> ->
                     val contentIfNotHandled = event.getContentIfNotHandled()
                     contentIfNotHandled?.show(this)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -310,12 +310,6 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                     }
                 }
         )
-        storyEditorMedia.toastMessage.observe(this,
-                Observer<Event<ToastMessageHolder>> { event: Event<ToastMessageHolder?> ->
-                    val contentIfNotHandled = event.getContentIfNotHandled()
-                    contentIfNotHandled?.show(this)
-                }
-        )
     }
 
     // EditorMediaListener

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource
 import org.wordpress.android.ui.posts.editor.media.AddExistingMediaToPostUseCase
 import org.wordpress.android.ui.posts.editor.media.AddLocalMediaToPostUseCase
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
-import org.wordpress.android.ui.posts.editor.media.UpdateMediaModelUseCase
 import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingMediaToStoryIdle
 import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingMultipleMediaToStory
 import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingSingleMediaToStory
@@ -32,7 +31,6 @@ import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 class StoryEditorMedia @Inject constructor(
-    private val updateMediaModelUseCase: UpdateMediaModelUseCase,
     private val mediaUtilsWrapper: MediaUtilsWrapper,
     private val addLocalMediaToPostUseCase: AddLocalMediaToPostUseCase,
     private val addExistingMediaToPostUseCase: AddExistingMediaToPostUseCase,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
@@ -24,8 +24,6 @@ import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPo
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.viewmodel.Event
-import org.wordpress.android.viewmodel.SingleLiveEvent
-import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
@@ -50,9 +48,6 @@ class StoryEditorMedia @Inject constructor(
 
     private val _snackBarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     val snackBarMessage = _snackBarMessage as LiveData<Event<SnackbarMessageHolder>>
-
-    private val _toastMessage = SingleLiveEvent<Event<ToastMessageHolder>>()
-    val toastMessage: LiveData<Event<ToastMessageHolder>> = _toastMessage
 
     fun start(site: SiteModel, editorMediaListener: EditorMediaListener) {
         this.site = site

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
@@ -7,50 +7,23 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import org.wordpress.android.R
-import org.wordpress.android.analytics.AnalyticsTracker
-import org.wordpress.android.analytics.AnalyticsTracker.Stat
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.EDITOR_UPLOAD_MEDIA_FAILED
-import org.wordpress.android.editor.EditorMediaUploadListener
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.MediaActionBuilder
-import org.wordpress.android.fluxc.model.MediaModel
-import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.MediaStore
-import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload
-import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload
-import org.wordpress.android.fluxc.store.MediaStore.MediaError
-import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
-import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.ProgressDialogUiState
 import org.wordpress.android.ui.posts.ProgressDialogUiState.HiddenProgressDialog
 import org.wordpress.android.ui.posts.ProgressDialogUiState.VisibleProgressDialog
 import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource
 import org.wordpress.android.ui.posts.editor.media.AddExistingMediaToPostUseCase
 import org.wordpress.android.ui.posts.editor.media.AddLocalMediaToPostUseCase
-import org.wordpress.android.ui.posts.editor.media.CleanUpMediaToPostAssociationUseCase
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
-import org.wordpress.android.ui.posts.editor.media.GetMediaModelUseCase
-import org.wordpress.android.ui.posts.editor.media.ReattachUploadingMediaUseCase
-import org.wordpress.android.ui.posts.editor.media.RemoveMediaUseCase
-import org.wordpress.android.ui.posts.editor.media.RetryFailedMediaUploadUseCase
 import org.wordpress.android.ui.posts.editor.media.UpdateMediaModelUseCase
 import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingMediaToStoryIdle
 import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingMultipleMediaToStory
 import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingSingleMediaToStory
-import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.MediaUtilsWrapper
-import org.wordpress.android.util.NetworkUtilsWrapper
-import org.wordpress.android.util.StringUtils
-import org.wordpress.android.util.ToastUtils.Duration
-import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
@@ -60,20 +33,10 @@ import kotlin.coroutines.CoroutineContext
 
 class StoryEditorMedia @Inject constructor(
     private val updateMediaModelUseCase: UpdateMediaModelUseCase,
-    private val getMediaModelUseCase: GetMediaModelUseCase,
-    private val dispatcher: Dispatcher,
     private val mediaUtilsWrapper: MediaUtilsWrapper,
-    private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val addLocalMediaToPostUseCase: AddLocalMediaToPostUseCase,
     private val addExistingMediaToPostUseCase: AddExistingMediaToPostUseCase,
-    private val retryFailedMediaUploadUseCase: RetryFailedMediaUploadUseCase,
-    private val cleanUpMediaToPostAssociationUseCase: CleanUpMediaToPostAssociationUseCase,
-    private val removeMediaUseCase: RemoveMediaUseCase,
-    private val reattachUploadingMediaUseCase: ReattachUploadingMediaUseCase,
-    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
-    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : CoroutineScope {
     // region Fields
     private var job: Job = Job()
@@ -83,8 +46,6 @@ class StoryEditorMedia @Inject constructor(
 
     private lateinit var site: SiteModel
     private lateinit var editorMediaListener: EditorMediaListener
-
-    private val deletedMediaItemIds = mutableListOf<String>()
 
     private val _uiState: MutableLiveData<AddMediaToStoryPostUiState> = MutableLiveData()
     val uiState: LiveData<AddMediaToStoryPostUiState> = _uiState
@@ -115,10 +76,6 @@ class StoryEditorMedia @Inject constructor(
         }
     }
 
-    fun addNewMediaToEditorAsync(mediaUri: Uri, freshlyTaken: Boolean) {
-        addNewMediaItemsToEditorAsync(listOf(mediaUri), freshlyTaken)
-    }
-
     fun addNewMediaItemsToEditorAsync(uriList: List<Uri>, freshlyTaken: Boolean) {
         launch {
             _uiState.value = if (uriList.size > 1) {
@@ -141,23 +98,6 @@ class StoryEditorMedia @Inject constructor(
         }
     }
 
-    /**
-     * This won't create a MediaModel. It assumes the model was already created.
-     */
-    fun addGifMediaToPostAsync(localMediaIds: IntArray) {
-        launch {
-            addLocalMediaToPostUseCase.addLocalMediaToEditorAsync(
-                    localMediaIds.toList(),
-                    editorMediaListener
-            )
-        }
-    }
-
-    fun addFreshlyTakenVideoToEditor() {
-        addNewMediaItemsToEditorAsync(listOf(mediaUtilsWrapper.getLastRecordedVideoUri()), true)
-                .also { AnalyticsTracker.track(Stat.EDITOR_ADDED_VIDEO_NEW) }
-    }
-
     fun onPhotoPickerMediaChosen(uriList: List<Uri>) {
         val onlyVideos = uriList.all { mediaUtilsWrapper.isVideo(it.toString()) }
         if (onlyVideos) {
@@ -167,18 +107,6 @@ class StoryEditorMedia @Inject constructor(
         }
     }
     // endregion
-
-    // region Add existing media to a post
-    fun addExistingMediaToEditorAsync(
-        mediaModels: List<MediaModel>,
-        source: AddExistingMediaSource
-    ) {
-        addExistingMediaToEditorAsync(source, mediaModels.map { it.mediaId })
-    }
-
-    fun addExistingMediaToEditorAsync(source: AddExistingMediaSource, mediaIds: LongArray) {
-        addExistingMediaToEditorAsync(source, mediaIds.toList())
-    }
 
     fun addExistingMediaToEditorAsync(source: AddExistingMediaSource, mediaIdList: List<Long>) {
         launch {
@@ -190,126 +118,9 @@ class StoryEditorMedia @Inject constructor(
             )
         }
     }
-    // endregion
-
-    // region Other
-    fun cancelMediaUploadAsync(localMediaId: Int, delete: Boolean) {
-        launch {
-            getMediaModelUseCase
-                    .loadMediaByLocalId(listOf(localMediaId))
-                    .firstOrNull()
-                    ?.let { mediaModel ->
-                        val payload = CancelMediaPayload(site, mediaModel, delete)
-                        dispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload))
-                    }
-        }
-    }
-
-    fun refreshBlogMedia() {
-        if (networkUtilsWrapper.isNetworkAvailable()) {
-            val payload = FetchMediaListPayload(site, MediaStore.DEFAULT_NUM_MEDIA_PER_FETCH, false)
-            dispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(payload))
-        } else {
-            _toastMessage.value = Event(
-                    ToastMessageHolder(
-                            R.string.error_media_refresh_no_connection,
-                            Duration.SHORT
-                    )
-            )
-        }
-    }
-
-    @Deprecated(message = "Blocking method shouldn't be used in new code.")
-    fun updateMediaUploadStateBlocking(uri: Uri, mediaUploadState: MediaUploadState): MediaModel? {
-        return runBlocking {
-            getMediaModelUseCase.createMediaModelFromUri(site.id, uri).mediaModels.firstOrNull()
-                    ?.let {
-                        updateMediaModelUseCase.updateMediaModel(
-                                it,
-                                editorMediaListener.getImmutablePost(),
-                                mediaUploadState
-                        )
-                        it
-                    }
-        }
-    }
-
-    fun retryFailedMediaAsync(failedMediaIds: List<Int>) {
-        launch {
-            retryFailedMediaUploadUseCase.retryFailedMediaAsync(editorMediaListener, failedMediaIds)
-        }
-    }
-
-    fun purgeMediaToPostAssociationsIfNotInPostAnymoreAsync() {
-        launch {
-            cleanUpMediaToPostAssociationUseCase
-                    .purgeMediaToPostAssociationsIfNotInPostAnymore(editorMediaListener.getImmutablePost())
-        }
-    }
-
-    fun reattachUploadingMediaForAztec(
-        editPostRepository: EditPostRepository,
-        isAztec: Boolean,
-        editorMediaUploadListener: EditorMediaUploadListener
-    ) {
-        if (isAztec) {
-            reattachUploadingMediaUseCase.reattachUploadingMediaForAztec(
-                    editPostRepository,
-                    editorMediaUploadListener
-            )
-        }
-    }
-
-    /*
-    * When the user deletes a media item that was being uploaded at that moment, we only cancel the
-    * upload but keep the media item in FluxC DB because the user might have deleted it accidentally,
-    * and they can always UNDO the delete action in Aztec.
-    * So, when the user exits then editor (and thus we lose the undo/redo history) we are safe to
-    * physically delete from the FluxC DB those items that have been deleted by the user using backspace.
-    * */
-    fun definitelyDeleteBackspaceDeletedMediaItemsAsync() {
-        launch {
-            removeMediaUseCase.removeMediaIfNotUploading(deletedMediaItemIds)
-        }
-    }
-
-    fun updateDeletedMediaItemIds(localMediaId: String) {
-        deletedMediaItemIds.add(localMediaId)
-        UploadService.setDeletedMediaItemIds(deletedMediaItemIds)
-    }
-
-    // endregion
 
     fun cancelAddMediaToEditorActions() {
         job.cancel()
-    }
-
-    fun onMediaDeleted(
-        showAztecEditor: Boolean,
-        showGutenbergEditor: Boolean,
-        localMediaId: String
-    ) {
-        updateDeletedMediaItemIds(localMediaId)
-        if (showAztecEditor && !showGutenbergEditor) {
-            // passing false here as we need to keep the media item in case the user wants to undo
-            cancelMediaUploadAsync(StringUtils.stringToInt(localMediaId), false)
-        } else {
-            launch {
-                removeMediaUseCase.removeMediaIfNotUploading(listOf(localMediaId))
-            }
-        }
-    }
-
-    fun onMediaUploadError(listener: EditorMediaUploadListener, media: MediaModel, error: MediaError) = launch {
-        val properties: Map<String, Any?> = withContext(bgDispatcher) {
-            analyticsUtilsWrapper
-                    .getMediaProperties(media.isVideo, null, media.filePath)
-                    .also {
-                        it["error_type"] = error.type.name
-                    }
-        }
-        analyticsTrackerWrapper.track(EDITOR_UPLOAD_MEDIA_FAILED, properties)
-        listener.onMediaUploadFailed(media.id.toString())
     }
 
     sealed class AddMediaToStoryPostUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.stories
+package org.wordpress.android.ui.stories.media
 
 import android.content.Context
 import android.net.Uri
@@ -25,6 +25,9 @@ import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.ui.posts.SavePostToDbUseCase
 import org.wordpress.android.ui.posts.editor.media.AddLocalMediaToPostUseCase
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
+import org.wordpress.android.ui.stories.SaveStoryGutenbergBlockUseCase
+import org.wordpress.android.ui.stories.StoriesTrackerHelper
+import org.wordpress.android.ui.stories.StoryComposerActivity
 import org.wordpress.android.ui.uploads.UploadServiceFacade
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
@@ -27,7 +27,6 @@ import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload
 import org.wordpress.android.test
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddMediaToPostUiState
-import org.wordpress.android.ui.posts.editor.media.EditorType.POST_EDITOR
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -411,7 +410,7 @@ class EditorMediaTest : BaseUnitTest() {
                     TEST_DISPATCHER,
                     TEST_DISPATCHER
             )
-            editorMedia.start(siteModel, editorMediaListener, POST_EDITOR)
+            editorMedia.start(siteModel, editorMediaListener)
             return editorMedia
         }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaTest.kt
@@ -1,0 +1,202 @@
+package org.wordpress.android.ui.stories.usecase
+
+import android.net.Uri
+import androidx.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.test
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.posts.editor.media.AddExistingMediaToPostUseCase
+import org.wordpress.android.ui.posts.editor.media.AddLocalMediaToPostUseCase
+import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
+import org.wordpress.android.ui.stories.media.StoryEditorMedia
+import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState
+import org.wordpress.android.util.MediaUtilsWrapper
+import org.wordpress.android.viewmodel.Event
+
+@UseExperimental(InternalCoroutinesApi::class)
+class StoryEditorMediaTest : BaseUnitTest() {
+    @Test
+    fun `advertiseImageOptimisationAndAddMedia shows dialog when shouldAdvertiseImageOptimization is true`() {
+        // Arrange
+        val editorMediaListener = mock<EditorMediaListener>()
+        val mediaUtilsWrapper = createMediaUtilsWrapper(shouldAdvertiseImageOptimization = true)
+
+        // Act
+        createStoryEditorMedia(
+                editorMediaListener = editorMediaListener,
+                mediaUtilsWrapper = mediaUtilsWrapper
+        ).advertiseImageOptimisationAndAddMedia(mock())
+
+        // Assert
+        verify(editorMediaListener).advertiseImageOptimization(anyOrNull())
+    }
+
+    @Test
+    fun `advertiseImageOptimisationAndAddMedia does NOT show dialog when shouldAdvertiseImageOptimization is false`() {
+        // Arrange
+        val editorMediaListener = mock<EditorMediaListener>()
+        val mediaUtilsWrapper = createMediaUtilsWrapper(shouldAdvertiseImageOptimization = false)
+
+        // Act
+        createStoryEditorMedia(
+                editorMediaListener = editorMediaListener,
+                mediaUtilsWrapper = mediaUtilsWrapper
+        )
+                .advertiseImageOptimisationAndAddMedia(mock())
+        // Assert
+        verify(editorMediaListener, never()).advertiseImageOptimization(anyOrNull())
+    }
+
+    @Test
+    fun `addNewMediaItemsToEditorAsync emits AddingSingleMedia for a single uri`() = test {
+        // Arrange
+        val editorMedia = createStoryEditorMedia()
+        val captor = argumentCaptor<AddMediaToStoryPostUiState>()
+        val observer: Observer<AddMediaToStoryPostUiState> = mock()
+        editorMedia.uiState.observeForever(observer)
+
+        // Act
+        editorMedia.addNewMediaItemsToEditorAsync(mock(), false)
+
+        // Assert
+        verify(observer, times(3)).onChanged(captor.capture())
+        assertThat(captor.firstValue).isEqualTo(AddMediaToStoryPostUiState.AddingMediaToStoryIdle)
+        assertThat(captor.secondValue).isEqualTo(AddMediaToStoryPostUiState.AddingSingleMediaToStory)
+        assertThat(captor.thirdValue).isEqualTo(AddMediaToStoryPostUiState.AddingMediaToStoryIdle)
+    }
+
+    @Test
+    fun `addNewMediaItemsToEditorAsync shows snackbar when a media fails`() = test {
+        // Arrange
+        val addLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase(
+                resultForAddNewMediaToEditorAsync = false
+        )
+        val editorMedia = createStoryEditorMedia(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
+
+        val captor = argumentCaptor<Event<SnackbarMessageHolder>>()
+        val observer: Observer<Event<SnackbarMessageHolder>> = mock()
+        editorMedia.snackBarMessage.observeForever(observer)
+
+        // Act
+        editorMedia.addNewMediaItemsToEditorAsync(mock(), false)
+
+        // Assert
+        verify(observer, times(1)).onChanged(captor.capture())
+        assertThat(captor.firstValue.getContentIfNotHandled()?.messageRes).isEqualTo(R.string.gallery_error)
+    }
+
+    @Test
+    fun `addNewMediaItemsToEditorAsync does NOT show snackbar when all media succeed`() = test {
+        // Arrange
+        val addLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase(
+                resultForAddNewMediaToEditorAsync = true
+        )
+        val editorMedia = createStoryEditorMedia(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
+
+        val captor = argumentCaptor<Event<SnackbarMessageHolder>>()
+        val observer: Observer<Event<SnackbarMessageHolder>> = mock()
+        editorMedia.snackBarMessage.observeForever(observer)
+
+        // Act
+        editorMedia.addNewMediaItemsToEditorAsync(mock(), false)
+        // Assert
+        verify(observer, never()).onChanged(captor.capture())
+    }
+
+    @Test
+    fun `onPhotoPickerMediaChosen does NOT invoke shouldAdvertiseImageOptimization when only video files`() =
+            test {
+                // Arrange
+                val uris = listOf(VIDEO_URI, VIDEO_URI, VIDEO_URI, VIDEO_URI)
+                val editorMediaListener = mock<EditorMediaListener>()
+
+                val mediaUtilsWrapper = createMediaUtilsWrapper()
+
+                // Act
+                createStoryEditorMedia(
+                        mediaUtilsWrapper = mediaUtilsWrapper,
+                        editorMediaListener = editorMediaListener
+                )
+                        .onPhotoPickerMediaChosen(uris)
+                // Assert
+                verify(editorMediaListener, never()).advertiseImageOptimization(anyOrNull())
+                verify(mediaUtilsWrapper, never()).shouldAdvertiseImageOptimization()
+            }
+
+    @Test
+    fun `onPhotoPickerMediaChosen invokes shouldAdvertiseImageOptimization when at least 1 image file`() =
+            test {
+                // Arrange
+                val uris = listOf(VIDEO_URI, VIDEO_URI, IMAGE_URI, VIDEO_URI)
+                val editorMediaListener = mock<EditorMediaListener>()
+
+                val mediaUtilsWrapper = createMediaUtilsWrapper()
+
+                // Act
+                createStoryEditorMedia(
+                        mediaUtilsWrapper = mediaUtilsWrapper,
+                        editorMediaListener = editorMediaListener
+                )
+                        .onPhotoPickerMediaChosen(uris)
+                // Assert
+                verify(mediaUtilsWrapper).shouldAdvertiseImageOptimization()
+            }
+
+    private companion object Fixtures {
+        private val VIDEO_URI = mock<Uri>()
+        private val IMAGE_URI = mock<Uri>()
+
+        fun createStoryEditorMedia(
+            mediaUtilsWrapper: MediaUtilsWrapper = createMediaUtilsWrapper(),
+            addLocalMediaToPostUseCase: AddLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase(),
+            addExistingMediaToPostUseCase: AddExistingMediaToPostUseCase = mock(),
+            siteModel: SiteModel = mock(),
+            editorMediaListener: EditorMediaListener = mock()
+        ): StoryEditorMedia {
+            val editorMedia = StoryEditorMedia(
+                    mediaUtilsWrapper,
+                    addLocalMediaToPostUseCase,
+                    addExistingMediaToPostUseCase,
+                    TEST_DISPATCHER
+            )
+            editorMedia.start(siteModel, editorMediaListener)
+            return editorMedia
+        }
+
+        fun createMediaUtilsWrapper(
+            shouldAdvertiseImageOptimization: Boolean = false
+        ) =
+                mock<MediaUtilsWrapper> {
+                    on { shouldAdvertiseImageOptimization() }
+                            .thenReturn(shouldAdvertiseImageOptimization)
+                    on { isVideo(VIDEO_URI.toString()) }.thenReturn(true)
+                    on { isVideo(IMAGE_URI.toString()) }.thenReturn(false)
+                }
+
+        fun createAddLocalMediaToPostUseCase(resultForAddNewMediaToEditorAsync: Boolean = true) =
+                mock<AddLocalMediaToPostUseCase> {
+                    onBlocking {
+                        addNewMediaToEditorAsync(
+                                anyOrNull(),
+                                anyOrNull(),
+                                anyBoolean(),
+                                anyOrNull(),
+                                anyBoolean()
+                        )
+                    }.thenReturn(resultForAddNewMediaToEditorAsync)
+                }
+    }
+}


### PR DESCRIPTION
Builds on top of #12504 

Comes from #12493 (see [comments](https://github.com/wordpress-mobile/WordPress-Android/pull/12493#issuecomment-663472463))


### Things done in this PR
- created a new StoryEditorMedia class as a starting point for a proper VM
- moved out a an enum and a listener we needed on both EditorMedia and StoryEditorMedia: `EditorMediaListener` interface and `AddExistingMediaSource` enum

removed:
- `refreshBlogMedia`, didn't use it
- `retryFailedMediaAsync`: didn't use it but maybe in the future
+ `purgeMediaToPostAssociationsIfNotInPostAnymoreAsync`: I think we'll need this one as soon as we allow editing (very soon, before launch). Took it away for now to leave things in a clean state, will revisit soon
- `reattachUploadingMediaForAztec`, we don't have Aztec.
- `definitelyDeleteBackspaceDeletedMediaItemsAsync` we don't need this either
- `updateDeletedMediaItemIds`: removed
+ `onMediaDeleted`: we'll want to use this when editing posts as well. Deleting for now.
- `onMediaUploadError`: didn't use it, we don't show upload errors on the UI.
- `updateMediaUploadStateBlocking` (we don't upload with the UI on the front)
- `cancelMediaUploadAsync` (we don't upload with the UI on the front)
- `addGifMediaToPostAsync` (we don't use gifs for now)
- `addFreshlyTakenVideoToEditor` (we add video differently because the StoryComposer has its own camera capture mode)
- `addExistingMediaToEditorAsync` variants we didn't use (removed)

#### Some notes / questions
- `AddMediaToStoryPostUiState`. This class is a copy & paste of `AddMediaToPostUiState` in `EditorMedia`. Wonder how to make this better; I didn't feel it was OK to reuse the same class. Probably not a big deal, but copy/paste leaves me with a bitter taste 🤷‍♂️ 


To test:
- Make sure EditPostActivity media handling works well (add media from different sources, reattach, cancel, etc)
- Make sure StoryComposerActivity works well (add media from different sources, save, publish). 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
