### PR TITLE
Issue/12319 new discover endpoint db table

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -215,6 +215,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
         ReaderThumbnailTable.createTables(db);
         ReaderBlogTable.createTables(db);
         ReaderSearchTable.createTables(db);
+        ReaderDiscoverCardsTable.INSTANCE.createTable(db);
     }
 
     private void dropAllTables(SQLiteDatabase db) {
@@ -226,6 +227,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
         ReaderThumbnailTable.dropTables(db);
         ReaderBlogTable.dropTables(db);
         ReaderSearchTable.dropTables(db);
+        ReaderDiscoverCardsTable.INSTANCE.dropTables(db);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -22,7 +22,7 @@ import java.util.Locale;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 138;
+    private static final int DB_VERSION = 139;
     private static final int DB_LAST_VERSION_WITHOUT_MIGRATION_SCRIPT = 136; // do not change this value
 
     /*
@@ -94,6 +94,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      * 136 - added tbl_posts.is_bookmarked
      * 137 - added support for migration scripts
      * 138 - added tbl_posts.is_private_atomic
+     * 139 - introduced new DiscoverCardsTable
      */
 
     /*
@@ -185,6 +186,9 @@ public class ReaderDatabase extends SQLiteOpenHelper {
                 currentVersion++;
             case 137:
                 db.execSQL("ALTER TABLE tbl_posts ADD is_private_atomic BOOLEAN;");
+                currentVersion++;
+            case 138:
+                ReaderDiscoverCardsTable.INSTANCE.createTable(db);
                 currentVersion++;
         }
         if (currentVersion != newVersion) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
@@ -1,0 +1,62 @@
+package org.wordpress.android.datasets
+
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
+import org.wordpress.android.WordPress
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.SqlUtils
+
+object ReaderDiscoverCardsTable {
+    private const val DISCOVER_CARDS_TABLE = "tbl_discover_cards"
+    private const val CARDS_JSON_COLUMN = "cards_json"
+    fun createTable(db: SQLiteDatabase) {
+        db.execSQL(
+                "CREATE TABLE IF NOT EXISTS $DISCOVER_CARDS_TABLE ("
+                        + "  _id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                        + " $CARDS_JSON_COLUMN TEXT"
+                        + ")"
+        )
+    }
+
+    fun dropTables(db: SQLiteDatabase) {
+        db.execSQL("DROP TABLE IF EXISTS tbl_discover_cards")
+    }
+
+    fun reset(db: SQLiteDatabase) {
+        AppLog.i(AppLog.T.READER, "resetting ReaderDiscoverCardsTable")
+        dropTables(db)
+        createTable(db)
+    }
+
+    private fun getReadableDb(): SQLiteDatabase {
+        return WordPress.wpDB.database
+    }
+
+    private fun getWritableDb(): SQLiteDatabase {
+        return WordPress.wpDB.database
+    }
+
+    fun addCardsPage(cardsJson: String) {
+        val values = ContentValues()
+        values.put(CARDS_JSON_COLUMN, cardsJson)
+
+        getWritableDb().insert(DISCOVER_CARDS_TABLE, null, values)
+    }
+
+    fun loadDiscoverCardsJsons(): List<String> {
+        val c = getReadableDb()
+                .rawQuery("SELECT * FROM $DISCOVER_CARDS_TABLE ORDER BY _id ASC", null)
+        return try {
+            val cardJsonList = arrayListOf<String>()
+            if (c.moveToFirst()) {
+                do {
+                    val cardJson = c.getString(c.getColumnIndex(CARDS_JSON_COLUMN))
+                    cardJsonList.add(cardJson)
+                } while (c.moveToNext())
+            }
+            return cardJsonList
+        } finally {
+            SqlUtils.closeCursor(c)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
@@ -46,17 +46,17 @@ object ReaderDiscoverCardsTable {
     fun loadDiscoverCardsJsons(): List<String> {
         val c = getReadableDb()
                 .rawQuery("SELECT * FROM $DISCOVER_CARDS_TABLE ORDER BY _id ASC", null)
-        return try {
-            val cardJsonList = arrayListOf<String>()
+        val cardJsonList = arrayListOf<String>()
+        try {
             if (c.moveToFirst()) {
                 do {
                     val cardJson = c.getString(c.getColumnIndex(CARDS_JSON_COLUMN))
                     cardJsonList.add(cardJson)
                 } while (c.moveToNext())
             }
-            return cardJsonList
         } finally {
             SqlUtils.closeCursor(c)
         }
+        return cardJsonList
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.datasets
 
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
-import org.wordpress.android.WordPress
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.SqlUtils
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
@@ -11,10 +11,10 @@ object ReaderDiscoverCardsTable {
     private const val CARDS_JSON_COLUMN = "cards_json"
     fun createTable(db: SQLiteDatabase) {
         db.execSQL(
-                "CREATE TABLE IF NOT EXISTS $DISCOVER_CARDS_TABLE ("
-                        + "  _id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                        + " $CARDS_JSON_COLUMN TEXT"
-                        + ")"
+                "CREATE TABLE IF NOT EXISTS $DISCOVER_CARDS_TABLE (" +
+                        "  _id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                        " $CARDS_JSON_COLUMN TEXT" +
+                        ")"
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
@@ -29,11 +29,11 @@ object ReaderDiscoverCardsTable {
     }
 
     private fun getReadableDb(): SQLiteDatabase {
-        return WordPress.wpDB.database
+        return ReaderDatabase.getReadableDb()
     }
 
     private fun getWritableDb(): SQLiteDatabase {
-        return WordPress.wpDB.database
+        return ReaderDatabase.getWritableDb()
     }
 
     fun addCardsPage(cardsJson: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -6,7 +6,10 @@ import com.wordpress.rest.RestRequest.Listener
 import org.json.JSONArray
 import org.json.JSONObject
 import org.wordpress.android.WordPress
+import org.wordpress.android.datasets.ReaderDiscoverCardsTable
+import org.wordpress.android.datasets.ReaderPostTable
 import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.models.ReaderPostList
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.models.ReaderTagType.DEFAULT
@@ -87,11 +90,11 @@ class ReaderDiscoverLogic constructor(private val completionListener: ServiceCom
 
         // Parse the json into cards model objects
         val cards = parseCards(fullCardsJson)
-        // TODO malinjir Save posts into db
+        insertPostsIntoDb(cards.filterIsInstance<ReaderPostCard>().map { it.post })
 
         // Simplify the json. The simplified version is used in the upper layers to load the data from the db.
         val simplifiedCardsJson = simplifyJson(fullCardsJson)
-        // TODO malinjir Save simplified json into db
+        insertCardsJsonIntoDb(simplifiedCardsJson)
 
         val nextPageHandle = parseNextPageHandle(json)
         // TODO malinjir save next page handle into shared preferences
@@ -115,6 +118,12 @@ class ReaderDiscoverLogic constructor(private val completionListener: ServiceCom
             }
         }
         return cards
+    }
+
+    private fun insertPostsIntoDb(posts: List<ReaderPost>) {
+        val postList = ReaderPostList()
+        postList.addAll(posts)
+        ReaderPostTable.addOrUpdatePosts(null, postList)
     }
 
     /**
@@ -155,6 +164,10 @@ class ReaderDiscoverLogic constructor(private val completionListener: ServiceCom
             interestTags.add(parseInterestTag(jsonInterests.optJSONObject(i)))
         }
         return interestTags
+    }
+
+    private fun insertCardsJsonIntoDb(simplifiedCardsJson: JSONArray) {
+        ReaderDiscoverCardsTable.addCardsPage(simplifiedCardsJson.toString())
     }
 
     private fun parseInterestTag(jsonInterest: JSONObject): ReaderTag {


### PR DESCRIPTION
Parent issue #10012 

This is a follow up for https://github.com/wordpress-mobile/WordPress-Android/pull/12507

Merge instructions:
1. Review this PR
2. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/12507 is merged
3. Update target branch to `issue/12319-new-discover-endpoint-main-issue `
4. Remove "Not Ready for Merge" tag
5. Merge this PR


This PR creates a new table which will be used for storing simplified responses from the /read/cards/ endpoint. The data will be displayed on the "discover" tab in Reader. 

The endpoint returns different types of cards. Currently, only two types are supported - `posts` and `interests_you_might_like`. However, more types will be added in the future. 

We considered creating a table for each type but it felt like an overkill. We decided to store just a simplified version of the server response into the database. Since we already have an existing table for post objects these are stored into tbl_posts. The simplified json response contains just postId, siteId and pseudoId. All the other fields of a post can be loaded from the tbl_posts table.


To test:
Make sure the app doesn't crash or log any migration errors when the reader improvements feature flag is turned off. Rest of this functionality will be tested when we start propagating the data to the UI.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
