### PR TITLE
WP Stories: story composer ViewModel part5

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsSi
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureViewModel;
 import org.wordpress.android.ui.stories.StoryComposerViewModel;
+import org.wordpress.android.ui.stories.media.StoryEditorMediaViewModel;
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementViewModel;
 import org.wordpress.android.viewmodel.ViewModelFactory;
 import org.wordpress.android.viewmodel.ViewModelKey;
@@ -359,6 +360,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(StoryComposerViewModel.class)
     abstract ViewModel storyComposerViewModel(StoryComposerViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(StoryEditorMediaViewModel.class)
+    abstract ViewModel storyEditorMediaViewModel(StoryEditorMediaViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -60,7 +60,6 @@ import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.widgets.WPSnackbar
-import java.lang.ref.WeakReference
 import java.util.Objects
 import javax.inject.Inject
 
@@ -155,7 +154,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             )
         }
 
-        storyEditorMediaViewModel.start(requireNotNull(site), WeakReference(this))
+        storyEditorMediaViewModel.start(requireNotNull(site), this)
         setupStoryEditorMediaObserver()
         setupViewModelObservers()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -186,7 +186,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             }
         })
 
-        viewModel.shouldShowOptimizeImagesAdvertising.observe(this, Observer { event ->
+        viewModel.showOptimizeImagesAdvertisingDialog.observe(this, Observer { event ->
             event.applyIfNotHandled {
                 WPMediaUtils.advertiseImageOptimization(this@StoryComposerActivity) { this.invoke() }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -85,7 +85,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     @Inject lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: StoryComposerViewModel
-    private lateinit var storyEditorMedia: StoryEditorMediaViewModel
+    private lateinit var storyEditorMediaViewModel: StoryEditorMediaViewModel
 
     private var addingMediaToEditorProgressDialog: ProgressDialog? = null
 
@@ -141,6 +141,9 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(StoryComposerViewModel::class.java)
 
+        storyEditorMediaViewModel = ViewModelProviders.of(this, viewModelFactory)
+                .get(StoryEditorMediaViewModel::class.java)
+
         site?.let {
             viewModel.start(
                     it,
@@ -151,7 +154,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             )
         }
 
-        storyEditorMedia.start(requireNotNull(site), this)
+        storyEditorMediaViewModel.start(requireNotNull(site), this)
         setupStoryEditorMediaObserver()
         setupViewModelObservers()
     }
@@ -213,7 +216,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                         val uriList: List<Uri> = convertStringArrayIntoUrisList(
                                 it.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)
                         )
-                        storyEditorMedia.onPhotoPickerMediaChosen(uriList)
+                        storyEditorMediaViewModel.onPhotoPickerMediaChosen(uriList)
                     } else if (it.hasExtra(MediaBrowserActivity.RESULT_IDS)) {
                         handleMediaPickerIntentData(it)
                     }
@@ -223,7 +226,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     }
 
     override fun onDestroy() {
-        storyEditorMedia.cancelAddMediaToEditorActions()
+        storyEditorMediaViewModel.cancelAddMediaToEditorActions()
         super.onDestroy()
     }
 
@@ -279,11 +282,11 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             return
         }
 
-        storyEditorMedia.addExistingMediaToEditorAsync(WP_MEDIA_LIBRARY, ids)
+        storyEditorMediaViewModel.addExistingMediaToEditorAsync(WP_MEDIA_LIBRARY, ids)
     }
 
     private fun setupStoryEditorMediaObserver() {
-        storyEditorMedia.uiState.observe(this,
+        storyEditorMediaViewModel.uiState.observe(this,
                 Observer { uiState: AddMediaToStoryPostUiState? ->
                     if (uiState != null) {
                         updateAddingMediaToStoryComposerProgressDialogState(uiState.progressDialogUiState)
@@ -295,7 +298,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                     }
                 }
         )
-        storyEditorMedia.snackBarMessage.observe(this,
+        storyEditorMediaViewModel.snackBarMessage.observe(this,
                 Observer<Event<SnackbarMessageHolder>> { event: Event<SnackbarMessageHolder?> ->
                     val messageHolder = event.getContentIfNotHandled()
                     if (messageHolder != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -60,6 +60,7 @@ import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.widgets.WPSnackbar
+import java.lang.ref.WeakReference
 import java.util.Objects
 import javax.inject.Inject
 
@@ -154,7 +155,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             )
         }
 
-        storyEditorMediaViewModel.start(requireNotNull(site), this)
+        storyEditorMediaViewModel.start(requireNotNull(site), WeakReference(this))
         setupStoryEditorMediaObserver()
         setupViewModelObservers()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -49,8 +49,8 @@ import org.wordpress.android.ui.posts.PublishPost
 import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource.WP_MEDIA_LIBRARY
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetListener
-import org.wordpress.android.ui.stories.media.StoryEditorMedia
-import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState
+import org.wordpress.android.ui.stories.media.StoryEditorMediaViewModel
+import org.wordpress.android.ui.stories.media.StoryEditorMediaViewModel.AddMediaToStoryPostUiState
 import org.wordpress.android.ui.utils.AuthenticationUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ListUtils
@@ -59,7 +59,6 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.viewmodel.Event
-import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 import org.wordpress.android.widgets.WPSnackbar
 import java.util.Objects
 import javax.inject.Inject
@@ -77,7 +76,6 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         PrepublishingBottomSheetListener {
     private var site: SiteModel? = null
 
-    @Inject lateinit var storyEditorMedia: StoryEditorMedia
     @Inject lateinit var progressDialogHelper: ProgressDialogHelper
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var postStore: PostStore
@@ -87,6 +85,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     @Inject lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: StoryComposerViewModel
+    private lateinit var storyEditorMedia: StoryEditorMediaViewModel
 
     private var addingMediaToEditorProgressDialog: ProgressDialog? = null
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -55,8 +55,8 @@ class StoryComposerViewModel @Inject constructor(
     private val _submitButtonClicked = MutableLiveData<Event<Unit>>()
     val submitButtonClicked: LiveData<Event<Unit>> = _submitButtonClicked
 
-    private val _shouldShowOptimizeImagesAdvertising = MutableLiveData<Event<() -> Unit>>()
-    val shouldShowOptimizeImagesAdvertising: LiveData<Event<() -> Unit>> = _shouldShowOptimizeImagesAdvertising
+    private val _showOptimizeImagesAdvertisingDialog = MutableLiveData<Event<() -> Unit>>()
+    val showOptimizeImagesAdvertisingDialog: LiveData<Event<() -> Unit>> = _showOptimizeImagesAdvertisingDialog
 
     init {
         lifecycleRegistry.currentState = Lifecycle.State.CREATED
@@ -157,7 +157,7 @@ class StoryComposerViewModel @Inject constructor(
     }
 
     override fun advertiseImageOptimization(listener: () -> Unit) {
-        _shouldShowOptimizeImagesAdvertising.postValue(Event(listener))
+        _showOptimizeImagesAdvertisingDialog.postValue(Event(listener))
     }
 
     fun onStorySaveButtonPressed() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.ui.posts.PostEditorAnalyticsSessionWrapper
 import org.wordpress.android.ui.posts.SavePostToDbUseCase
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
 import org.wordpress.android.ui.stories.usecase.SetUntitledStoryTitleIfTitleEmptyUseCase
-import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.viewmodel.Event
 import java.util.Objects

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMediaViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMediaViewModel.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stories.media
 import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -18,9 +19,9 @@ import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource
 import org.wordpress.android.ui.posts.editor.media.AddExistingMediaToPostUseCase
 import org.wordpress.android.ui.posts.editor.media.AddLocalMediaToPostUseCase
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
-import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingMediaToStoryIdle
-import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingMultipleMediaToStory
-import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState.AddingSingleMediaToStory
+import org.wordpress.android.ui.stories.media.StoryEditorMediaViewModel.AddMediaToStoryPostUiState.AddingMediaToStoryIdle
+import org.wordpress.android.ui.stories.media.StoryEditorMediaViewModel.AddMediaToStoryPostUiState.AddingMultipleMediaToStory
+import org.wordpress.android.ui.stories.media.StoryEditorMediaViewModel.AddMediaToStoryPostUiState.AddingSingleMediaToStory
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.viewmodel.Event
@@ -28,12 +29,12 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
-class StoryEditorMedia @Inject constructor(
+class StoryEditorMediaViewModel @Inject constructor(
     private val mediaUtilsWrapper: MediaUtilsWrapper,
     private val addLocalMediaToPostUseCase: AddLocalMediaToPostUseCase,
     private val addExistingMediaToPostUseCase: AddExistingMediaToPostUseCase,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
-) : CoroutineScope {
+) : ViewModel(), CoroutineScope {
     // region Fields
     private var job: Job = Job()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMediaViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMediaViewModel.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.stories.media.StoryEditorMediaViewModel.AddMedia
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.viewmodel.Event
+import java.lang.ref.WeakReference
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
@@ -42,7 +43,7 @@ class StoryEditorMediaViewModel @Inject constructor(
         get() = mainDispatcher + job
 
     private lateinit var site: SiteModel
-    private lateinit var editorMediaListener: EditorMediaListener
+    private lateinit var editorMediaListener: WeakReference<EditorMediaListener>
 
     private val _uiState: MutableLiveData<AddMediaToStoryPostUiState> = MutableLiveData()
     val uiState: LiveData<AddMediaToStoryPostUiState> = _uiState
@@ -50,7 +51,7 @@ class StoryEditorMediaViewModel @Inject constructor(
     private val _snackBarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     val snackBarMessage = _snackBarMessage as LiveData<Event<SnackbarMessageHolder>>
 
-    fun start(site: SiteModel, editorMediaListener: EditorMediaListener) {
+    fun start(site: SiteModel, editorMediaListener: WeakReference<EditorMediaListener>) {
         this.site = site
         this.editorMediaListener = editorMediaListener
         _uiState.value = AddingMediaToStoryIdle
@@ -59,7 +60,7 @@ class StoryEditorMediaViewModel @Inject constructor(
     // region Adding new media to a post
     fun advertiseImageOptimisationAndAddMedia(uriList: List<Uri>) {
         if (mediaUtilsWrapper.shouldAdvertiseImageOptimization()) {
-            editorMediaListener.advertiseImageOptimization {
+            editorMediaListener.get()?.advertiseImageOptimization {
                 addNewMediaItemsToEditorAsync(
                         uriList,
                         false
@@ -77,19 +78,25 @@ class StoryEditorMediaViewModel @Inject constructor(
             } else {
                 AddingSingleMediaToStory
             }
-            val allMediaSucceed = addLocalMediaToPostUseCase.addNewMediaToEditorAsync(
-                    uriList,
-                    site,
-                    freshlyTaken,
-                    editorMediaListener,
-                    false // don't start upload for StoryComposer, that'll be all started
-                                            // when finished composing
-            )
-            if (!allMediaSucceed) {
-                _snackBarMessage.value = Event(SnackbarMessageHolder(R.string.gallery_error))
-            }
-            _uiState.value = AddingMediaToStoryIdle
+            editorMediaListener.get()?.let {
+                val allMediaSucceed = addLocalMediaToPostUseCase.addNewMediaToEditorAsync(
+                        uriList,
+                        site,
+                        freshlyTaken,
+                        it,
+                        false // don't start upload for StoryComposer, that'll be all started
+                        // when finished composing
+                )
+                if (!allMediaSucceed) {
+                    throwSnackBarMessageError()
+                }
+                _uiState.value = AddingMediaToStoryIdle
+            } ?: throwSnackBarMessageError()
         }
+    }
+
+    private fun throwSnackBarMessageError () {
+        _snackBarMessage.value = Event(SnackbarMessageHolder(R.string.gallery_error))
     }
 
     fun onPhotoPickerMediaChosen(uriList: List<Uri>) {
@@ -104,12 +111,14 @@ class StoryEditorMediaViewModel @Inject constructor(
 
     fun addExistingMediaToEditorAsync(source: AddExistingMediaSource, mediaIdList: List<Long>) {
         launch {
-            addExistingMediaToPostUseCase.addMediaExistingInRemoteToEditorAsync(
-                    site,
-                    source,
-                    mediaIdList,
-                    editorMediaListener
-            )
+            editorMediaListener.get()?.let {
+                addExistingMediaToPostUseCase.addMediaExistingInRemoteToEditorAsync(
+                        site,
+                        source,
+                        mediaIdList,
+                        it
+                )
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMediaViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMediaViewModel.kt
@@ -3,10 +3,7 @@ package org.wordpress.android.ui.stories.media
 import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
@@ -25,22 +22,17 @@ import org.wordpress.android.ui.stories.media.StoryEditorMediaViewModel.AddMedia
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
-import kotlin.coroutines.CoroutineContext
 
 class StoryEditorMediaViewModel @Inject constructor(
     private val mediaUtilsWrapper: MediaUtilsWrapper,
     private val addLocalMediaToPostUseCase: AddLocalMediaToPostUseCase,
     private val addExistingMediaToPostUseCase: AddExistingMediaToPostUseCase,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
-) : ViewModel(), CoroutineScope {
+) : ScopedViewModel(mainDispatcher) {
     // region Fields
-    private var job: Job = Job()
-
-    override val coroutineContext: CoroutineContext
-        get() = mainDispatcher + job
-
     private lateinit var site: SiteModel
     private lateinit var editorMediaListener: EditorMediaListener
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaViewModelTest.kt
@@ -84,7 +84,8 @@ class StoryEditorMediaViewModelTest : BaseUnitTest() {
         val addLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase(
                 resultForAddNewMediaToEditorAsync = false
         )
-        val storyEditorMediaViewModel = createStoryEditorMediaViewModel(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
+        val storyEditorMediaViewModel =
+                createStoryEditorMediaViewModel(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
 
         val captor = argumentCaptor<Event<SnackbarMessageHolder>>()
         val observer: Observer<Event<SnackbarMessageHolder>> = mock()
@@ -104,7 +105,8 @@ class StoryEditorMediaViewModelTest : BaseUnitTest() {
         val addLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase(
                 resultForAddNewMediaToEditorAsync = true
         )
-        val storyEditorMediaViewModel = createStoryEditorMediaViewModel(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
+        val storyEditorMediaViewModel =
+                createStoryEditorMediaViewModel(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
 
         val captor = argumentCaptor<Event<SnackbarMessageHolder>>()
         val observer: Observer<Event<SnackbarMessageHolder>> = mock()

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaViewModelTest.kt
@@ -35,7 +35,7 @@ class StoryEditorMediaViewModelTest : BaseUnitTest() {
         val mediaUtilsWrapper = createMediaUtilsWrapper(shouldAdvertiseImageOptimization = true)
 
         // Act
-        createStoryEditorMedia(
+        createStoryEditorMediaViewModel(
                 editorMediaListener = editorMediaListener,
                 mediaUtilsWrapper = mediaUtilsWrapper
         ).advertiseImageOptimisationAndAddMedia(mock())
@@ -51,7 +51,7 @@ class StoryEditorMediaViewModelTest : BaseUnitTest() {
         val mediaUtilsWrapper = createMediaUtilsWrapper(shouldAdvertiseImageOptimization = false)
 
         // Act
-        createStoryEditorMedia(
+        createStoryEditorMediaViewModel(
                 editorMediaListener = editorMediaListener,
                 mediaUtilsWrapper = mediaUtilsWrapper
         )
@@ -63,13 +63,13 @@ class StoryEditorMediaViewModelTest : BaseUnitTest() {
     @Test
     fun `addNewMediaItemsToEditorAsync emits AddingSingleMedia for a single uri`() = test {
         // Arrange
-        val editorMedia = createStoryEditorMedia()
+        val storyEditorMediaViewModel = createStoryEditorMediaViewModel()
         val captor = argumentCaptor<AddMediaToStoryPostUiState>()
         val observer: Observer<AddMediaToStoryPostUiState> = mock()
-        editorMedia.uiState.observeForever(observer)
+        storyEditorMediaViewModel.uiState.observeForever(observer)
 
         // Act
-        editorMedia.addNewMediaItemsToEditorAsync(mock(), false)
+        storyEditorMediaViewModel.addNewMediaItemsToEditorAsync(mock(), false)
 
         // Assert
         verify(observer, times(3)).onChanged(captor.capture())
@@ -84,14 +84,14 @@ class StoryEditorMediaViewModelTest : BaseUnitTest() {
         val addLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase(
                 resultForAddNewMediaToEditorAsync = false
         )
-        val editorMedia = createStoryEditorMedia(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
+        val storyEditorMediaViewModel = createStoryEditorMediaViewModel(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
 
         val captor = argumentCaptor<Event<SnackbarMessageHolder>>()
         val observer: Observer<Event<SnackbarMessageHolder>> = mock()
-        editorMedia.snackBarMessage.observeForever(observer)
+        storyEditorMediaViewModel.snackBarMessage.observeForever(observer)
 
         // Act
-        editorMedia.addNewMediaItemsToEditorAsync(mock(), false)
+        storyEditorMediaViewModel.addNewMediaItemsToEditorAsync(mock(), false)
 
         // Assert
         verify(observer, times(1)).onChanged(captor.capture())
@@ -104,14 +104,14 @@ class StoryEditorMediaViewModelTest : BaseUnitTest() {
         val addLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase(
                 resultForAddNewMediaToEditorAsync = true
         )
-        val editorMedia = createStoryEditorMedia(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
+        val storyEditorMediaViewModel = createStoryEditorMediaViewModel(addLocalMediaToPostUseCase = addLocalMediaToPostUseCase)
 
         val captor = argumentCaptor<Event<SnackbarMessageHolder>>()
         val observer: Observer<Event<SnackbarMessageHolder>> = mock()
-        editorMedia.snackBarMessage.observeForever(observer)
+        storyEditorMediaViewModel.snackBarMessage.observeForever(observer)
 
         // Act
-        editorMedia.addNewMediaItemsToEditorAsync(mock(), false)
+        storyEditorMediaViewModel.addNewMediaItemsToEditorAsync(mock(), false)
         // Assert
         verify(observer, never()).onChanged(captor.capture())
     }
@@ -126,7 +126,7 @@ class StoryEditorMediaViewModelTest : BaseUnitTest() {
                 val mediaUtilsWrapper = createMediaUtilsWrapper()
 
                 // Act
-                createStoryEditorMedia(
+                createStoryEditorMediaViewModel(
                         mediaUtilsWrapper = mediaUtilsWrapper,
                         editorMediaListener = editorMediaListener
                 )
@@ -146,7 +146,7 @@ class StoryEditorMediaViewModelTest : BaseUnitTest() {
                 val mediaUtilsWrapper = createMediaUtilsWrapper()
 
                 // Act
-                createStoryEditorMedia(
+                createStoryEditorMediaViewModel(
                         mediaUtilsWrapper = mediaUtilsWrapper,
                         editorMediaListener = editorMediaListener
                 )
@@ -159,7 +159,7 @@ class StoryEditorMediaViewModelTest : BaseUnitTest() {
         private val VIDEO_URI = mock<Uri>()
         private val IMAGE_URI = mock<Uri>()
 
-        fun createStoryEditorMedia(
+        fun createStoryEditorMediaViewModel(
             mediaUtilsWrapper: MediaUtilsWrapper = createMediaUtilsWrapper(),
             addLocalMediaToPostUseCase: AddLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase(),
             addExistingMediaToPostUseCase: AddExistingMediaToPostUseCase = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaViewModelTest.kt
@@ -21,13 +21,13 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.editor.media.AddExistingMediaToPostUseCase
 import org.wordpress.android.ui.posts.editor.media.AddLocalMediaToPostUseCase
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
-import org.wordpress.android.ui.stories.media.StoryEditorMedia
-import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState
+import org.wordpress.android.ui.stories.media.StoryEditorMediaViewModel
+import org.wordpress.android.ui.stories.media.StoryEditorMediaViewModel.AddMediaToStoryPostUiState
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.viewmodel.Event
 
 @UseExperimental(InternalCoroutinesApi::class)
-class StoryEditorMediaTest : BaseUnitTest() {
+class StoryEditorMediaViewModelTest : BaseUnitTest() {
     @Test
     fun `advertiseImageOptimisationAndAddMedia shows dialog when shouldAdvertiseImageOptimization is true`() {
         // Arrange
@@ -165,8 +165,8 @@ class StoryEditorMediaTest : BaseUnitTest() {
             addExistingMediaToPostUseCase: AddExistingMediaToPostUseCase = mock(),
             siteModel: SiteModel = mock(),
             editorMediaListener: EditorMediaListener = mock()
-        ): StoryEditorMedia {
-            val editorMedia = StoryEditorMedia(
+        ): StoryEditorMediaViewModel {
+            val editorMedia = StoryEditorMediaViewModel(
                     mediaUtilsWrapper,
                     addLocalMediaToPostUseCase,
                     addExistingMediaToPostUseCase,


### PR DESCRIPTION
Builds on top of #12516 

This PR converts StoryEditorMedia into a StoryEditorMediaViewModel. 

#### Description
In reality there's not much needed to be done given the logic already was working and tested, but making this a ViewModel makes it comply with general architecture patterns we're implementing throughout WPAndroid, and prepares it for further functionality addition.

#### Notes
- the StoryViewModel now knows about StoryEditorMediaViewModel through the EditorMediaListener interface, wonder if this is a concern

To test:
- test the Stories functionality works (add local, external media, publish etc)

Just 1 reviewer needed for approval, but happy to learn from any comments! 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
