### PR TITLE
WP Stories  / Media Picker: Unification of ARG_BROWSER_TYPE

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -101,6 +101,7 @@ import static org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTIC
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTICLE_REBLOGGED;
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_ACCESS_ERROR;
 import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG_EDIT_IMAGE_DATA;
+import static org.wordpress.android.ui.media.MediaBrowserActivity.ARG_BROWSER_TYPE;
 import static org.wordpress.android.ui.pages.PagesActivityKt.EXTRA_PAGE_REMOTE_ID_KEY;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_ID_KEY;
 
@@ -186,7 +187,7 @@ public class ActivityLauncher {
                                                       @Nullable SiteModel site,
                                                       @Nullable Integer localPostId) {
         Intent intent = new Intent(context, PhotoPickerActivity.class);
-        intent.putExtra(PhotoPickerFragment.ARG_BROWSER_TYPE, browserType);
+        intent.putExtra(ARG_BROWSER_TYPE, browserType);
         if (site != null) {
             intent.putExtra(WordPress.SITE, site);
         }
@@ -492,7 +493,7 @@ public class ActivityLauncher {
     public static void viewCurrentBlogMedia(Context context, SiteModel site) {
         Intent intent = new Intent(context, MediaBrowserActivity.class);
         intent.putExtra(WordPress.SITE, site);
-        intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, MediaBrowserType.BROWSER);
+        intent.putExtra(ARG_BROWSER_TYPE, MediaBrowserType.BROWSER);
         context.startActivity(intent);
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_MEDIA_LIBRARY, site);
     }
@@ -1010,7 +1011,7 @@ public class ActivityLauncher {
                                                 @NonNull MediaBrowserType browserType) {
         Intent intent = new Intent(activity, MediaBrowserActivity.class);
         intent.putExtra(WordPress.SITE, site);
-        intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, browserType);
+        intent.putExtra(ARG_BROWSER_TYPE, browserType);
         int requestCode;
         if (browserType.canMultiselect()) {
             requestCode = RequestCodes.MULTI_SELECT_MEDIA_PICKER;

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -54,7 +54,6 @@ import org.wordpress.android.ui.pages.PageParentActivity;
 import org.wordpress.android.ui.pages.PagesActivity;
 import org.wordpress.android.ui.people.PeopleManagementActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
-import org.wordpress.android.ui.photopicker.PhotoPickerFragment;
 import org.wordpress.android.ui.plans.PlansActivity;
 import org.wordpress.android.ui.plugins.PluginBrowserActivity;
 import org.wordpress.android.ui.plugins.PluginDetailActivity;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -57,7 +57,6 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource;
-import org.wordpress.android.ui.photopicker.PhotoPickerFragment;
 import org.wordpress.android.ui.prefs.AppPrefsWrapper;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -84,6 +84,8 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
+import static org.wordpress.android.ui.media.MediaBrowserActivity.ARG_BROWSER_TYPE;
+
 public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogueListener>
         implements OnConfirmListener, OnDismissListener {
     private EditText mEditTextDisplayName;
@@ -173,7 +175,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             @Override
             public void onClick(View view) {
                 Intent intent = new Intent(getActivity(), PhotoPickerActivity.class);
-                intent.putExtra(PhotoPickerFragment.ARG_BROWSER_TYPE, MediaBrowserType.GRAVATAR_IMAGE_PICKER);
+                intent.putExtra(ARG_BROWSER_TYPE, MediaBrowserType.GRAVATAR_IMAGE_PICKER);
                 startActivityForResult(intent, RequestCodes.PHOTO_PICKER);
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -809,7 +809,7 @@ class MySiteFragment : Fragment(),
     private fun isWPStoriesMediaBrowserTypeResult(data: Intent): Boolean {
         if (data.hasExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)) {
             val browserType = data.getSerializableExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)
-            return browserType == MediaBrowserType.WP_STORIES_MEDIA_PICKER
+            return (browserType as MediaBrowserType).isWPStoriesPicker()
         }
         return false
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -43,6 +43,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import static org.wordpress.android.ui.RequestCodes.IMAGE_EDITOR_EDIT_IMAGE;
+import static org.wordpress.android.ui.media.MediaBrowserActivity.ARG_BROWSER_TYPE;
 import static org.wordpress.android.ui.posts.FeaturedImageHelperKt.EMPTY_LOCAL_POST_ID;
 
 public class PhotoPickerActivity extends LocaleAwareActivity
@@ -109,11 +110,11 @@ public class PhotoPickerActivity extends LocaleAwareActivity
         }
 
         if (savedInstanceState == null) {
-            mBrowserType = (MediaBrowserType) getIntent().getSerializableExtra(PhotoPickerFragment.ARG_BROWSER_TYPE);
+            mBrowserType = (MediaBrowserType) getIntent().getSerializableExtra(ARG_BROWSER_TYPE);
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
             mLocalPostId = getIntent().getIntExtra(LOCAL_POST_ID, EMPTY_LOCAL_POST_ID);
         } else {
-            mBrowserType = (MediaBrowserType) savedInstanceState.getSerializable(PhotoPickerFragment.ARG_BROWSER_TYPE);
+            mBrowserType = (MediaBrowserType) savedInstanceState.getSerializable(ARG_BROWSER_TYPE);
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
             mLocalPostId = savedInstanceState.getInt(LOCAL_POST_ID, EMPTY_LOCAL_POST_ID);
         }
@@ -152,7 +153,7 @@ public class PhotoPickerActivity extends LocaleAwareActivity
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putSerializable(PhotoPickerFragment.ARG_BROWSER_TYPE, mBrowserType);
+        outState.putSerializable(ARG_BROWSER_TYPE, mBrowserType);
         outState.putInt(LOCAL_POST_ID, mLocalPostId);
         if (mSite != null) {
             outState.putSerializable(WordPress.SITE, mSite);
@@ -319,7 +320,7 @@ public class PhotoPickerActivity extends LocaleAwareActivity
                     .putExtra(EXTRA_MEDIA_URIS, convertUrisListToStringArray(mediaUris))
                     .putExtra(EXTRA_MEDIA_SOURCE, source.name())
                     // set the browserType in the result, so caller can distinguish and handle things as needed
-                    .putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, mBrowserType);
+                    .putExtra(ARG_BROWSER_TYPE, mBrowserType);
             setResult(RESULT_OK, intent);
             finish();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -344,6 +344,7 @@ public class PhotoPickerActivity extends LocaleAwareActivity
                 // TODO WPSTORIES add TRACKS (see how it's tracked above? maybe do along the same lines)
                 Intent data = new Intent()
                         .putExtra(MediaBrowserActivity.RESULT_IDS, ListUtils.toLongArray(mediaIds))
+                        .putExtra(ARG_BROWSER_TYPE, mBrowserType)
                         .putExtra(EXTRA_MEDIA_SOURCE, source.name());
                 setResult(RESULT_OK, data);
                 finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -56,12 +56,13 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import static org.wordpress.android.ui.media.MediaBrowserActivity.ARG_BROWSER_TYPE;
+
 public class PhotoPickerFragment extends Fragment {
     private static final String KEY_LAST_TAPPED_ICON = "last_tapped_icon";
     private static final String KEY_SELECTED_POSITIONS = "selected_positions";
 
     static final int NUM_COLUMNS = 3;
-    public static final String ARG_BROWSER_TYPE = "browser_type";
 
     public enum PhotoPickerIcon {
         ANDROID_CHOOSE_PHOTO(true),


### PR DESCRIPTION
Fixes a  bug in Stories picker, but may as well have happened / be happening something similar elsewhere either now or anytime soon.

Removed the `PhotoPickerFragment.ARG_BROWSER_TYPE` in favor of `MediaBrowserActivity.ARG_BROWSER_TYPE` given these `key` vars used to store extras in intents had the _same_ name but had a **different** definition, and led to unexpected results (sometimes an extra would be saved with one ARG, and trying to retrieve it with the incorrect ARG).

This was defined in PhotoPickerFragment:
```
ARG_BROWSER_TYPE = "browser_type";
```

This was defined in MediaBrowserActivity:
```
ARG_BROWSER_TYPE = "media_browser_type";
```

Also both were declared `public static` so it was super easy to pick the wrong one when importing assisted by the IDE. 🤕 

In particular, this bug made the Free photos library (StockPhotoPicker) not work correctly with the Stories functionality if the first image picked to start creating a Story was a Stock photo.
This is why this PR is targeting our stories alpha feature branch instead of `develop` (there's no problem right now in `develop`, although this was probably a ticking bomb)

To test:
1. open WPAndroid
2. tap on the FAB button
3. select Story
4. the media picker appears. Tap on the left bottom option
5. now choose Free photo library
6. enter a search query, tap a photo, tap "use this photo"
7. observe the image is correctly added as the first picture in the Story

cc @planarvoid @develric just in case given the Media Picker Consolidation project is nearing 👍 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
