### PR TITLE
Issue 12334/story title layout refactor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -173,9 +173,15 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                     PrepublishingPublishSettingsFragment.newInstance(),
                     PrepublishingPublishSettingsFragment.TAG
             )
-            PrepublishingScreen.TAGS -> Pair(
-                    PrepublishingTagsFragment.newInstance(navigationTarget.site), PrepublishingTagsFragment.TAG
-            )
+            PrepublishingScreen.TAGS -> {
+                val isStoryPost = checkNotNull(arguments?.getBoolean(IS_STORY_POST)) {
+                    "arguments can't be null."
+                }
+                Pair(
+                    PrepublishingTagsFragment.newInstance(navigationTarget.site, isStoryPost),
+                        PrepublishingTagsFragment.TAG
+                )
+            }
         }
 
         fadeInFragment(fragment, tag)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType
 import org.wordpress.android.ui.posts.PrepublishingScreen.HOME
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetListener
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsFragment
+import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.KeyboardResizeViewUtil
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
@@ -142,6 +143,12 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
         viewModel.triggerOnSubmitButtonClickedListener.observe(this, Observer { event ->
             event.getContentIfNotHandled()?.let { publishPost ->
                 prepublishingBottomSheetListener?.onSubmitButtonClicked(publishPost)
+            }
+        })
+
+        viewModel.dismissKeyboard.observe(this, Observer { event ->
+            event.applyIfNotHandled {
+                ActivityUtils.hideKeyboardForced(view)
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeAdapter.kt
@@ -11,16 +11,15 @@ import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.HomeUiState
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.StoryTitleUiState
 import org.wordpress.android.ui.posts.PrepublishingHomeViewHolder.PrepublishingHeaderListItemViewHolder
 import org.wordpress.android.ui.posts.PrepublishingHomeViewHolder.PrepublishingHomeListItemViewHolder
-import org.wordpress.android.ui.posts.PrepublishingHomeViewHolder.PrepublishingStoryTitleItemViewHolder
 import org.wordpress.android.ui.posts.PrepublishingHomeViewHolder.PrepublishingSubmitButtonViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
+import java.lang.IllegalStateException
 import javax.inject.Inject
 
 private const val headerViewType: Int = 1
 private const val homeItemViewType: Int = 2
 private const val submitButtonViewType: Int = 3
-private const val storyTitleViewType: Int = 4
 
 class PrepublishingHomeAdapter(context: Context) : RecyclerView.Adapter<PrepublishingHomeViewHolder>() {
     private var items: List<PrepublishingHomeItemUiState> = listOf()
@@ -33,7 +32,6 @@ class PrepublishingHomeAdapter(context: Context) : RecyclerView.Adapter<Prepubli
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PrepublishingHomeViewHolder {
         return when (viewType) {
-            storyTitleViewType -> PrepublishingStoryTitleItemViewHolder(parent, uiHelpers, imageManager)
             headerViewType -> PrepublishingHeaderListItemViewHolder(parent, uiHelpers, imageManager)
             homeItemViewType -> PrepublishingHomeListItemViewHolder(parent, uiHelpers)
             submitButtonViewType -> PrepublishingSubmitButtonViewHolder(parent, uiHelpers)
@@ -54,10 +52,11 @@ class PrepublishingHomeAdapter(context: Context) : RecyclerView.Adapter<Prepubli
 
     override fun getItemViewType(position: Int): Int {
         return when (items[position]) {
-            is StoryTitleUiState -> storyTitleViewType
             is HeaderUiState -> headerViewType
             is HomeUiState -> homeItemViewType
             is ButtonUiState -> submitButtonViewType
+            is StoryTitleUiState ->
+                throw IllegalStateException("StoryTitleUiState is not supported by the PrepublishingHomeAdapter")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
@@ -15,9 +15,14 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
 class PrepublishingHomeFragment : Fragment() {
+    @Inject lateinit var uiHelpers: UiHelpers
+    @Inject lateinit var imageManager: ImageManager
+
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: PrepublishingHomeViewModel
 
@@ -58,6 +63,11 @@ class PrepublishingHomeFragment : Fragment() {
     private fun initViewModel() {
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(PrepublishingHomeViewModel::class.java)
+
+        viewModel.storyTitleUiState.observe(viewLifecycleOwner, Observer { storyTitleUiState ->
+            uiHelpers.updateVisibility(story_title_header_view, true)
+            story_title_header_view.init(uiHelpers, imageManager, storyTitleUiState)
+        })
 
         viewModel.uiState.observe(viewLifecycleOwner, Observer { uiState ->
             (actions_recycler_view.adapter as PrepublishingHomeAdapter).update(uiState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
@@ -60,6 +60,16 @@ class PrepublishingHomeFragment : Fragment() {
         initViewModel()
     }
 
+    override fun onResume() {
+        val isStoryPost = checkNotNull(arguments?.getBoolean(IS_STORY_POST)) {
+            "arguments can't be null."
+        }
+        if (isStoryPost) {
+            requireActivity().window.decorView.requestLayout()
+        }
+        super.onResume()
+    }
+
     private fun initViewModel() {
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(PrepublishingHomeViewModel::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewHolder.kt
@@ -1,12 +1,9 @@
 package org.wordpress.android.ui.posts
 
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.EditText
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.LayoutRes
@@ -16,13 +13,9 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ButtonUiState
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.HeaderUiState
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.HomeUiState
-import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.StoryTitleUiState
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.util.image.ImageType
 import org.wordpress.android.util.image.ImageType.BLAVATAR
-
-private const val STORY_TITLE_EDIT_TEXT_REQUEST_FOCUS_DELAY = 1000L
 
 sealed class PrepublishingHomeViewHolder(
     internal val parent: ViewGroup,
@@ -51,48 +44,6 @@ sealed class PrepublishingHomeViewHolder(
 
             actionType.setTextColor(ContextCompat.getColor(itemView.context, uiState.actionTypeColor))
             actionResult.setTextColor(ContextCompat.getColor(itemView.context, uiState.actionResultColor))
-        }
-    }
-
-    class PrepublishingStoryTitleItemViewHolder(
-        parentView: ViewGroup,
-        val uiHelpers: UiHelpers,
-        val imageManager: ImageManager
-    ) : PrepublishingHomeViewHolder(parentView, R.layout.prepublishing_story_title_list_item) {
-        private val storyTitle: EditText = itemView.findViewById(R.id.story_title)
-        private val thumbnail: ImageView = itemView.findViewById(R.id.story_thumbnail)
-
-        private val thumbnailCornerRadius =
-                parentView.context.resources.getDimension(R.dimen.prepublishing_site_blavatar_corner_radius)
-                .toInt()
-
-        override fun onBind(uiState: PrepublishingHomeItemUiState) {
-            uiState as StoryTitleUiState
-
-            imageManager.loadImageWithCorners(
-                    thumbnail,
-                    ImageType.IMAGE,
-                    uiState.storyThumbnailUrl,
-                    thumbnailCornerRadius
-            )
-
-            uiState.storyTitle?.let { title ->
-                storyTitle.setText(uiHelpers.getTextOfUiString(parent.context, title))
-                storyTitle.setSelection(title.text.length)
-            }
-
-            storyTitle.postDelayed({
-                storyTitle.requestFocus()
-            }, STORY_TITLE_EDIT_TEXT_REQUEST_FOCUS_DELAY)
-
-            storyTitle.addTextChangedListener(object : TextWatcher {
-                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-
-                override fun afterTextChanged(view: Editable?) {
-                    uiState.onStoryTitleChanged.invoke(view.toString())
-                }
-            })
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
@@ -47,6 +47,9 @@ class PrepublishingHomeViewModel @Inject constructor(
     private val _uiState = MutableLiveData<List<PrepublishingHomeItemUiState>>()
     val uiState: LiveData<List<PrepublishingHomeItemUiState>> = _uiState
 
+    private val _storyTitleUiState = MutableLiveData<StoryTitleUiState>()
+    val storyTitleUiState: LiveData<StoryTitleUiState> = _storyTitleUiState
+
     private val _onActionClicked = MutableLiveData<Event<ActionType>>()
     val onActionClicked: LiveData<Event<ActionType>> = _onActionClicked
 
@@ -64,13 +67,12 @@ class PrepublishingHomeViewModel @Inject constructor(
     private fun setupHomeUiState(editPostRepository: EditPostRepository, site: SiteModel, isStoryPost: Boolean) {
         val prepublishingHomeUiStateList = mutableListOf<PrepublishingHomeItemUiState>().apply {
             if (isStoryPost) {
-                add(
-                        StoryTitleUiState(
-                                storyTitle = UiStringText(StringUtils.notNullStr(editPostRepository.title)),
-                                storyThumbnailUrl = storyRepositoryWrapper.getCurrentStoryThumbnailUrl()
-                        ) { storyTitle ->
-                            onStoryTitleChanged(storyTitle)
-                        })
+                _storyTitleUiState.postValue(StoryTitleUiState(
+                        storyTitle = UiStringText(StringUtils.notNullStr(editPostRepository.title)),
+                        storyThumbnailUrl = storyRepositoryWrapper.getCurrentStoryThumbnailUrl()
+                ) { storyTitle ->
+                    onStoryTitleChanged(storyTitle)
+                })
             } else {
                 add(HeaderUiState(UiStringText(site.name), StringUtils.notNullStr(site.iconUrl)))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
@@ -49,9 +49,11 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
 
     companion object {
         const val TAG = "prepublishing_tags_fragment_tag"
-        @JvmStatic fun newInstance(site: SiteModel): PrepublishingTagsFragment {
+        const val NEEDS_REQUEST_LAYOUT = "prepublishing_tags_fragment_needs_request_layout"
+        @JvmStatic fun newInstance(site: SiteModel, needsRequestLayout: Boolean): PrepublishingTagsFragment {
             val bundle = Bundle().apply {
                 putSerializable(WordPress.SITE, site)
+                putBoolean(NEEDS_REQUEST_LAYOUT, needsRequestLayout)
             }
             return PrepublishingTagsFragment().apply { arguments = bundle }
         }
@@ -74,6 +76,14 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
         if (wereTagsChanged()) {
             analyticsTrackerWrapper.trackPrepublishingNudges(Stat.EDITOR_POST_TAGS_CHANGED)
         }
+    }
+
+    override fun onResume() {
+        val needsRequestLayout = requireArguments().getBoolean(NEEDS_REQUEST_LAYOUT)
+        if (needsRequestLayout) {
+            requireActivity().getWindow().getDecorView().requestLayout()
+        }
+        super.onResume()
     }
 
     private fun initViewModel() {
@@ -102,7 +112,8 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
             toolbar_title.text = uiHelpers.getTextOfUiString(requireContext(), uiString)
         })
 
-        viewModel.start(getEditPostRepository())
+        val needsRequestLayout = requireArguments().getBoolean(NEEDS_REQUEST_LAYOUT)
+        viewModel.start(getEditPostRepository(), !needsRequestLayout)
     }
 
     private fun getEditPostRepository(): EditPostRepository {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsViewModel.kt
@@ -23,6 +23,7 @@ class PrepublishingTagsViewModel @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(bgDispatcher) {
     private var isStarted = false
+    private var closeKeyboard = true
     private lateinit var editPostRepository: EditPostRepository
     private var updateTagsJob: Job? = null
 
@@ -38,8 +39,9 @@ class PrepublishingTagsViewModel @Inject constructor(
     private val _toolbarTitleUiState = MutableLiveData<UiString>()
     val toolbarTitleUiState: LiveData<UiString> = _toolbarTitleUiState
 
-    fun start(editPostRepository: EditPostRepository) {
+    fun start(editPostRepository: EditPostRepository, closeKeyboard: Boolean = false) {
         this.editPostRepository = editPostRepository
+        this.closeKeyboard = closeKeyboard
 
         if (isStarted) return
         isStarted = true
@@ -62,7 +64,9 @@ class PrepublishingTagsViewModel @Inject constructor(
     fun onCloseButtonClicked() = _dismissBottomSheet.postValue(Event(Unit))
 
     fun onBackButtonClicked() {
-        _dismissKeyboard.postValue(Event(Unit))
+        if (closeKeyboard) {
+            _dismissKeyboard.postValue(Event(Unit))
+        }
         _navigateToHomeScreen.postValue(Event(Unit))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType
 import org.wordpress.android.ui.posts.PrepublishingScreen.HOME
+import org.wordpress.android.ui.posts.PrepublishingScreen.TAGS
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.viewmodel.Event
@@ -32,6 +33,9 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
 
     private val _dismissBottomSheet = MutableLiveData<Event<Unit>>()
     val dismissBottomSheet: LiveData<Event<Unit>> = _dismissBottomSheet
+
+    private val _dismissKeyboard = MutableLiveData<Event<Unit>>()
+    val dismissKeyboard: LiveData<Event<Unit>> = _dismissKeyboard
 
     private val _triggerOnSubmitButtonClickedListener = MutableLiveData<Event<PublishPost>>()
     val triggerOnSubmitButtonClickedListener: LiveData<Event<PublishPost>> = _triggerOnSubmitButtonClickedListener
@@ -64,6 +68,7 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
     }
 
     private fun navigateToScreen(prepublishingScreen: PrepublishingScreen) {
+        _dismissKeyboard.postValue(Event(Unit))
         updateNavigationTarget(PrepublishingNavigationTarget(site, prepublishingScreen))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType
 import org.wordpress.android.ui.posts.PrepublishingScreen.HOME
-import org.wordpress.android.ui.posts.PrepublishingScreen.TAGS
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.viewmodel.Event

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType
 import org.wordpress.android.ui.posts.PrepublishingScreen.HOME
+import org.wordpress.android.ui.posts.PrepublishingScreen.PUBLISH
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.viewmodel.Event
@@ -67,7 +68,15 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
     }
 
     private fun navigateToScreen(prepublishingScreen: PrepublishingScreen) {
-        _dismissKeyboard.postValue(Event(Unit))
+        // Note: given we know both the HOME and the TAGS screens have an EditText, we can ask to send the
+        // dismissKeyboard signal only when we're not either in one of these nor navigating towards one of these.
+        // At this point in code we only know where we want to navigate to, but it's ok since landing on any of these
+        // two we'll want the keyboard to stay up if it was already up ;) (i.e. don't dismiss it).
+        // For the case where this is not a story and hence there's no EditText in the HOME screen, we're ok too,
+        // because there wouldn't have been a keyboard up anyway.
+        if (prepublishingScreen == PUBLISH) {
+            _dismissKeyboard.postValue(Event(Unit))
+        }
         updateNavigationTarget(PrepublishingNavigationTarget(site, prepublishingScreen))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
@@ -47,7 +47,6 @@ class StoryTitleHeaderView @JvmOverloads constructor(
         story_title.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-
             override fun afterTextChanged(view: Editable?) {
                 uiState.onStoryTitleChanged.invoke(view.toString())
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
@@ -48,7 +48,9 @@ class StoryTitleHeaderView @JvmOverloads constructor(
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(view: Editable?) {
-                uiState.onStoryTitleChanged.invoke(view.toString())
+                view?.let {
+                    uiState.onStoryTitleChanged.invoke(it.toString())
+                }
             }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
@@ -1,0 +1,55 @@
+package org.wordpress.android.ui.stories
+
+import android.content.Context
+import android.text.Editable
+import android.text.TextWatcher
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import kotlinx.android.synthetic.main.prepublishing_story_title_list_item.view.*
+import org.wordpress.android.R
+import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.StoryTitleUiState
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.image.ImageType
+
+private const val STORY_TITLE_EDIT_TEXT_REQUEST_FOCUS_DELAY = 1000L
+
+class StoryTitleHeaderView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr) {
+    private val thumbnailCornerRadius =
+            context.resources.getDimension(R.dimen.prepublishing_site_blavatar_corner_radius)
+                    .toInt()
+
+    fun init(uiHelpers: UiHelpers, imageManager: ImageManager, uiState: StoryTitleUiState) {
+        LayoutInflater.from(context).inflate(R.layout.prepublishing_story_title_list_item, this, true)
+
+        imageManager.loadImageWithCorners(
+                story_thumbnail,
+                ImageType.IMAGE,
+                uiState.storyThumbnailUrl,
+                thumbnailCornerRadius
+        )
+
+        uiState.storyTitle?.let { title ->
+            story_title.setText(uiHelpers.getTextOfUiString(context, title))
+            story_title.setSelection(title.text.length)
+        }
+
+        story_title.postDelayed({
+            story_title.requestFocus()
+        }, STORY_TITLE_EDIT_TEXT_REQUEST_FOCUS_DELAY)
+
+        story_title.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+
+            override fun afterTextChanged(view: Editable?) {
+                uiState.onStoryTitleChanged.invoke(view.toString())
+            }
+        })
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
@@ -10,10 +10,9 @@ import kotlinx.android.synthetic.main.prepublishing_story_title_list_item.view.*
 import org.wordpress.android.R
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.StoryTitleUiState
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.focusAndShowKeyboard
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType
-
-private const val STORY_TITLE_EDIT_TEXT_REQUEST_FOCUS_DELAY = 1000L
 
 class StoryTitleHeaderView @JvmOverloads constructor(
     context: Context,
@@ -39,9 +38,11 @@ class StoryTitleHeaderView @JvmOverloads constructor(
             story_title.setSelection(title.text.length)
         }
 
-        story_title.postDelayed({
-            story_title.requestFocus()
-        }, STORY_TITLE_EDIT_TEXT_REQUEST_FOCUS_DELAY)
+        story_title.focusAndShowKeyboard()
+
+        story_title_content.setOnClickListener {
+            story_title.focusAndShowKeyboard()
+        }
 
         story_title.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}

--- a/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
@@ -1,10 +1,13 @@
 package org.wordpress.android.util
 
+import android.content.Context
 import android.graphics.Rect
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.view.TouchDelegate
 import android.view.View
+import android.view.ViewTreeObserver
+import android.view.inputmethod.InputMethodManager
 import androidx.annotation.DimenRes
 
 fun View.setVisible(visible: Boolean) {
@@ -33,5 +36,45 @@ fun View.expandTouchTargetArea(@DimenRes dimenRes: Int, heightOnly: Boolean = fa
         }
 
         parent.touchDelegate = TouchDelegate(touchTargetRect, this)
+    }
+}
+
+/**
+ * Ensures that the keyboard is only shown when the view has received focused.
+ *
+ * https://developer.squareup.com/blog/showing-the-android-keyboard-reliably/
+ */
+fun View.focusAndShowKeyboard() {
+    /**
+     * This is to be called when the window already has focus.
+     */
+    fun View.showTheKeyboardNow() {
+        if (isFocused) {
+            post {
+                // We still post the call, just in case we are being notified of the windows focus
+                // but InputMethodManager didn't get properly setup yet.
+                val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                imm.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+            }
+        }
+    }
+
+    requestFocus()
+    if (hasWindowFocus()) {
+        // No need to wait for the window to get focus.
+        showTheKeyboardNow()
+    } else {
+        // We need to wait until the window gets focus.
+        viewTreeObserver.addOnWindowFocusChangeListener(
+                object : ViewTreeObserver.OnWindowFocusChangeListener {
+                    override fun onWindowFocusChanged(hasFocus: Boolean) {
+                        // This notification will arrive just before the InputMethodManager gets set up.
+                        if (hasFocus) {
+                            this@focusAndShowKeyboard.showTheKeyboardNow()
+                            // It’s very important to remove this listener once we are done.
+                            viewTreeObserver.removeOnWindowFocusChangeListener(this)
+                        }
+                    }
+                })
     }
 }

--- a/WordPress/src/main/res/layout/post_prepublishing_home_fragment.xml
+++ b/WordPress/src/main/res/layout/post_prepublishing_home_fragment.xml
@@ -14,5 +14,15 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/story_title_header_view" />
+
+    <org.wordpress.android.ui.stories.StoryTitleHeaderView
+        android:id="@+id/story_title_header_view"
+        android:layout_width="0dp"
+        android:visibility="gone"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/actions_recycler_view"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/prepublishing_story_title_list_item.xml
+++ b/WordPress/src/main/res/layout/prepublishing_story_title_list_item.xml
@@ -56,7 +56,7 @@
             android:ellipsize="end"
             android:fontFamily="serif"
             android:hint="@string/prepublishing_nudges_story_title_hint"
-            android:inputType="textMultiLine"
+            android:inputType="textCapSentences|textMultiLine"
             android:maxLines="3"
             android:textAlignment="viewStart"
             android:textAppearance="?attr/textAppearanceHeadline5"

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
@@ -24,7 +24,6 @@ import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ButtonUiState
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ButtonUiState.PublishButtonUiState
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.HeaderUiState
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.HomeUiState
-import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.StoryTitleUiState
 import org.wordpress.android.ui.posts.prepublishing.home.usecases.GetButtonUiStateUseCase
 import org.wordpress.android.ui.stories.StoryRepositoryWrapper
 import org.wordpress.android.ui.stories.usecase.UpdateStoryPostTitleUseCase
@@ -308,7 +307,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
 
         viewModel.start(editPostRepository, site, expectedIsStoryPost)
 
-        assertThat(getStoryTitleUiStateList()).isNotEmpty
+        assertThat(getStoryTitleUiState()).isNotNull
     }
 
     @Test
@@ -317,7 +316,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
 
         viewModel.start(editPostRepository, site, expectedIsStoryPost)
 
-        assertThat(getStoryTitleUiStateList()).isEmpty()
+        assertThat(getStoryTitleUiState()).isNull()
     }
 
     @Test
@@ -370,9 +369,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
     }
 
     private fun getHeaderUiState() = viewModel.uiState.value?.filterIsInstance(HeaderUiState::class.java)?.first()
-    private fun getStoryTitleUiState() = getStoryTitleUiStateList()?.first()
-    private fun getStoryTitleUiStateList() =
-            viewModel.uiState.value?.filterIsInstance(StoryTitleUiState::class.java)
+    private fun getStoryTitleUiState() = viewModel.storyTitleUiState.value
 
     private fun getButtonUiState(): ButtonUiState? {
         return viewModel.uiState.value?.filterIsInstance(ButtonUiState::class.java)?.first()

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingTagsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingTagsViewModelTest.kt
@@ -76,4 +76,30 @@ class PrepublishingTagsViewModelTest : BaseUnitTest() {
 
         assertThat(captor.value).isEqualTo(expectedTags)
     }
+
+    @Test
+    fun `when viewModel is started with closeKeyboard=false then dismissKeyboard is not called when tapping back`() {
+        var event: Event<Unit>? = null
+        viewModel.dismissKeyboard.observeForever {
+            event = it
+        }
+
+        viewModel.start(mock(), closeKeyboard = false)
+        viewModel.onBackButtonClicked()
+
+        assertThat(event).isNull()
+    }
+
+    @Test
+    fun `when viewModel is started with closeKeyboard=true then dismissKeyboard is called when tapping back`() {
+        var event: Event<Unit>? = null
+        viewModel.dismissKeyboard.observeForever {
+            event = it
+        }
+
+        viewModel.start(mock(), closeKeyboard = true)
+        viewModel.onBackButtonClicked()
+
+        assertThat(event).isNotNull
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingViewModelTest.kt
@@ -128,12 +128,4 @@ class PrepublishingViewModelTest : BaseUnitTest() {
         assertThat(viewModel.dismissBottomSheet.value?.peekContent()).isNotNull()
         assertThat(viewModel.triggerOnSubmitButtonClickedListener.value?.peekContent()).isNotNull()
     }
-
-    @Test
-    fun `when onActionClicked is called with a PrepublishingScreen, dismiss keyboard`() {
-        viewModel.start(mock(), mock())
-        viewModel.onActionClicked(ActionType.TAGS)
-
-        assertThat(viewModel.dismissKeyboard.value).isNotNull
-    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingViewModelTest.kt
@@ -128,4 +128,12 @@ class PrepublishingViewModelTest : BaseUnitTest() {
         assertThat(viewModel.dismissBottomSheet.value?.peekContent()).isNotNull()
         assertThat(viewModel.triggerOnSubmitButtonClickedListener.value?.peekContent()).isNotNull()
     }
+
+    @Test
+    fun `when onActionClicked is called with a PrepublishingScreen, dismiss keyboard`() {
+        viewModel.start(mock(), mock())
+        viewModel.onActionClicked(ActionType.TAGS)
+
+        assertThat(viewModel.dismissKeyboard.value).isNotNull
+    }
 }


### PR DESCRIPTION
Fixes #12334 

## Solution
In this PR I am removing the `Story Title` component from the `RecyclerView` because it's causing focus issues.
A separate view has been creating to host this functionality and it's being added directly about the `RecyclerView` to mimic the effect of having a header view. 

Along with this functionality, you are also able to tap anywhere in the story title layout to trigger the focus of the `EditText` and open the keyboard.

## Testing

1. Create a story post. 
2. Click Next. 
3. See the bottom sheet open with the keyboard active and the story title focused.

<kbd><img src="https://user-images.githubusercontent.com/1509205/88044799-d36a5600-cb13-11ea-903f-48130ba2629e.gif" width="320"></kbd>

-------

1. Create a story post. 
2. Click Next. 
3. See the bottom sheet open with the keyboard active and the story title focused.
4. Close the keyboard. 
5. Click anywhere within the story title layout like below.

<kbd><img src="https://user-images.githubusercontent.com/1509205/88044650-c5b4d080-cb13-11ea-9262-8d9bd1359cdc.png" width="320"></kbd>

-----
1. Create a story post. 
2. Click Next. 
3. See the bottom sheet open with the keyboard active and the story title focused.
4. Click the Tags action. 
5. See that the keyboard is opened. 
6. Navigate back and see that the keyboard is opened for the story title. 

 <kbd><img src="https://user-images.githubusercontent.com/1509205/88432332-9b883a80-cdc1-11ea-97ab-c622fe8fb7e5.gif" width="320"></kbd>

-----
1. Create a story post. 
2. Click Next. 
3. See the bottom sheet open with the keyboard active and the story title focused.
4. Click the Publish Date action. 
5. See that the keyboard is closed before showing the Publish Date UI. 

<kbd><img src="https://user-images.githubusercontent.com/1509205/88432449-d7230480-cdc1-11ea-9623-73de329efbca.gif" width="320"></kbd>

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
