### PR TITLE
Capitalize the first letter of the story title.

### DIFF
--- a/WordPress/src/main/res/layout/prepublishing_story_title_list_item.xml
+++ b/WordPress/src/main/res/layout/prepublishing_story_title_list_item.xml
@@ -56,7 +56,7 @@
             android:ellipsize="end"
             android:fontFamily="serif"
             android:hint="@string/prepublishing_nudges_story_title_hint"
-            android:inputType="textMultiLine"
+            android:inputType="textCapSentences|textMultiLine"
             android:maxLines="3"
             android:textAlignment="viewStart"
             android:textAppearance="?attr/textAppearanceHeadline5"


### PR DESCRIPTION
Fixes #12408 
Builds on top of https://github.com/wordpress-mobile/WordPress-Android/pull/12520
## Solution
Set the flag on the `EditText` to perform the capitalization of the first letter. 

## Testing
1. Create a new story post. 
2. Click Next.
3. Type a title and notice that the first letter is capitalized.

Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/88441556-0a23c300-cdd7-11ea-9964-2e0baa352fd3.png" width="320"></kbd>    |      <kbd><img src="https://user-images.githubusercontent.com/1509205/88441569-11e36780-cdd7-11ea-953f-f910e27a6976.png" width="320"></kbd>

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
