### PR TITLE
WP Stories: introduce feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -73,6 +73,7 @@ android {
         buildConfigField "boolean", "FEATURE_ANNOUNCEMENT_AVAILABLE", "false"
         buildConfigField "boolean", "GUTENBERG_MENTIONS", "true"
         buildConfigField "boolean", "UNIFIED_LOGIN_AVAILABLE", "true"
+        buildConfigField "boolean", "WP_STORIES_AVAILABLE", "true"
     }
 
     // Gutenberg's dependency - react-native-video is using
@@ -97,6 +98,7 @@ android {
             buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
             buildConfigField "boolean", "GUTENBERG_MENTIONS", "false"
+            buildConfigField "boolean", "WP_STORIES_AVAILABLE", "false"
         }
 
         zalpha { // alpha version - enable experimental features

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -57,9 +57,9 @@ public class RequestCodes {
     // ImageEditor
     public static final int IMAGE_EDITOR_EDIT_IMAGE = 6000;
 
-    // Story creator
-    public static final int CREATE_STORY = 7000;
-
     // Other
     public static final int SELECTED_USER_MENTION = 7000;
+
+    // Story creator
+    public static final int CREATE_STORY = 8000;
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/WPStoriesFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/WPStoriesFeatureConfig.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import javax.inject.Inject
+
+class WPStoriesFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.WP_STORIES_AVAILABLE)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -195,6 +195,21 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     private fun getCreateContentMessageId(hasFullAccessToContent: Boolean): Int {
+        return if (wpStoriesFeatureConfig.isEnabled())
+            return getCreateContentMessageId_StoriesFlagOn(hasFullAccessToContent)
+        else
+            return getCreateContentMessageId_StoriesFlagOff(hasFullAccessToContent)
+    }
+
+    // create_post_page_fab_tooltip_stories_feature_flag_on
+    private fun getCreateContentMessageId_StoriesFlagOn(hasFullAccessToContent: Boolean): Int {
+        return if (hasFullAccessToContent)
+            R.string.create_post_page_fab_tooltip_stories_feature_flag_on
+        else
+            R.string.create_post_page_fab_tooltip_contributors_stories_feature_flag_on
+    }
+
+    private fun getCreateContentMessageId_StoriesFlagOff(hasFullAccessToContent: Boolean): Int {
         return if (hasFullAccessToContent)
             R.string.create_post_page_fab_tooltip
         else

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -135,6 +135,9 @@ class WPMainActivityViewModel @Inject constructor(
             // if user has at least 2 options (eventually filtering the content not accessible like pages in this case)
             // See p5T066-1cA-p2/#comment-4463
             if (hasFullAccessToContent) {
+                // reload main actions given the first time this is initialized, the SiteModel may not contain the
+                // latest info
+                loadMainActions(hasFullAccessToContent)
                 _isBottomSheetShowing.value = Event(true)
             } else {
                 _createAction.postValue(CREATE_NEW_POST)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2764,8 +2764,13 @@
     <string name="web_preview_default">Default</string>
     <string name="web_preview_desktop">Desktop</string>
 
-    <string name="create_post_page_fab_tooltip">Create a post, page or story</string>
-    <string name="create_post_page_fab_tooltip_contributors">Create a post or story</string>
+    <string name="create_post_page_fab_tooltip">Create a post or page</string>
+    <string name="create_post_page_fab_tooltip_contributors">Create a post</string>
+
+    <!--  these are needed while WPStories sits behind a feature flag  -->
+    <!--  TODO we'll need to replace them when the feature flag is gone -->
+    <string name="create_post_page_fab_tooltip_stories_feature_flag_on">Create a post, page or story</string>
+    <string name="create_post_page_fab_tooltip_contributors_stories_feature_flag_on">Create a post or story</string>
 
     <!-- News Card -->
     <!-- When announcing a new feature, add new strings and make sure to update LocalNewsItem.kt -->

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -217,18 +217,37 @@ class WPMainActivityViewModelTest {
     }
 
     @Test
-    fun `onResume set expected content message when user has full access to content`() {
+    fun `onResume set expected content message when user has full access to content if stories not enabled`() {
+        setupWPStoriesFeatureConfigEnabled(false)
         startViewModelWithDefaultParameters()
         viewModel.onResume(true)
         assertThat(viewModel.fabUiState.value!!.CreateContentMessageId).isEqualTo(R.string.create_post_page_fab_tooltip)
     }
 
     @Test
-    fun `onResume set expected content message when user has not full access to content`() {
+    fun `onResume set expected content message when user has not full access to content if stories not enabled`() {
+        setupWPStoriesFeatureConfigEnabled(false)
         startViewModelWithDefaultParameters()
         viewModel.onResume(false)
         assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
                 .isEqualTo(R.string.create_post_page_fab_tooltip_contributors)
+    }
+
+    @Test
+    fun `onResume set expected content message when user has full access to content if stories enabled`() {
+        setupWPStoriesFeatureConfigEnabled(true)
+        startViewModelWithDefaultParameters()
+        viewModel.onResume(true)
+        assertThat(viewModel.fabUiState.value!!.CreateContentMessageId).isEqualTo(R.string.create_post_page_fab_tooltip_stories_feature_flag_on)
+    }
+
+    @Test
+    fun `onResume set expected content message when user has not full access to content if stories enabled`() {
+        setupWPStoriesFeatureConfigEnabled(true)
+        startViewModelWithDefaultParameters()
+        viewModel.onResume(false)
+        assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
+                .isEqualTo(R.string.create_post_page_fab_tooltip_contributors_stories_feature_flag_on)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -238,7 +238,8 @@ class WPMainActivityViewModelTest {
         setupWPStoriesFeatureConfigEnabled(true)
         startViewModelWithDefaultParameters()
         viewModel.onResume(true)
-        assertThat(viewModel.fabUiState.value!!.CreateContentMessageId).isEqualTo(R.string.create_post_page_fab_tooltip_stories_feature_flag_on)
+        assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
+                .isEqualTo(R.string.create_post_page_fab_tooltip_stories_feature_flag_on)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.WPStoriesFeatureConfig
 
 @RunWith(MockitoJUnitRunner::class)
 class WPMainActivityViewModelTest {
@@ -41,6 +42,7 @@ class WPMainActivityViewModelTest {
     @Mock lateinit var onFeatureAnnouncementRequestedObserver: Observer<Unit>
     @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Mock lateinit var wpStoriesFeatureConfig: WPStoriesFeatureConfig
 
     private val featureAnnouncement = FeatureAnnouncement(
             "14.7",
@@ -70,6 +72,7 @@ class WPMainActivityViewModelTest {
                 buildConfigWrapper,
                 appPrefsWrapper,
                 analyticsTrackerWrapper,
+                wpStoriesFeatureConfig,
                 NoDelayCoroutineDispatcher()
         )
         viewModel.onFeatureAnnouncementRequested.observeForever(
@@ -158,7 +161,8 @@ class WPMainActivityViewModelTest {
     }
 
     @Test
-    fun `bottom sheet action is new story when new story is tapped`() {
+    fun `bottom sheet action is new story when new story is tapped if stories enabled`() {
+        setupWPStoriesFeatureConfigEnabled(buildConfigValue = true)
         viewModel.start(isFabVisible = true, hasFullAccessToContent = true)
         val action = viewModel.mainActions.value?.first { it.actionType == CREATE_NEW_STORY } as CreateAction
         assertThat(action).isNotNull
@@ -167,7 +171,26 @@ class WPMainActivityViewModelTest {
     }
 
     @Test
-    fun `bottom sheet is visualized when user has full access to content and has all 3 options`() {
+    fun `bottom sheet is visualized when user has full access to content if stories disabled`() {
+        setupWPStoriesFeatureConfigEnabled(buildConfigValue = false)
+        startViewModelWithDefaultParameters()
+        viewModel.onFabClicked(hasFullAccessToContent = true)
+        assertThat(viewModel.createAction.value).isNull()
+        assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isEqualTo(true)
+    }
+
+    @Test
+    fun `new post action is triggered from FAB when user has not full access to content if stories disabled`() {
+        setupWPStoriesFeatureConfigEnabled(buildConfigValue = false)
+        startViewModelWithDefaultParameters()
+        viewModel.onFabClicked(hasFullAccessToContent = false)
+        assertThat(viewModel.isBottomSheetShowing.value).isNull()
+        assertThat(viewModel.createAction.value).isEqualTo(CREATE_NEW_POST)
+    }
+
+    @Test
+    fun `bottom sheet is visualized when user has full access to content and has all 3 options if stories enabled`() {
+        setupWPStoriesFeatureConfigEnabled(buildConfigValue = true)
         startViewModelWithDefaultParameters()
         viewModel.onFabClicked(hasFullAccessToContent = true)
         assertThat(viewModel.createAction.value).isNull()
@@ -176,7 +199,8 @@ class WPMainActivityViewModelTest {
     }
 
     @Test
-    fun `bottom sheet is visualized when user has partial access to content and has only 2 options`() {
+    fun `bottom sheet is visualized when user has partial access and has only 2 options if stories enabled`() {
+        setupWPStoriesFeatureConfigEnabled(buildConfigValue = true)
         startViewModelWithDefaultParameters()
         viewModel.onFabClicked(hasFullAccessToContent = false)
         assertThat(viewModel.createAction.value).isNull()
@@ -309,5 +333,9 @@ class WPMainActivityViewModelTest {
 
     private fun startViewModelWithDefaultParameters() {
         viewModel.start(isFabVisible = true, hasFullAccessToContent = true)
+    }
+
+    private fun setupWPStoriesFeatureConfigEnabled(buildConfigValue: Boolean) {
+        whenever(wpStoriesFeatureConfig.isEnabled()).thenReturn(buildConfigValue)
     }
 }


### PR DESCRIPTION
This PR introduces a feature flag so WP Stories is only present on dev and internal builds (wasabi, jalapeno, alpha) and hidden from release (vanilla) builds. The flag is `true` for any build that is not the vanilla flavor.

To test:
1. Verify that the create Story option appears in the main screen FAB in the following builds:
    * `JalapenoDebug` build
    * `WasabiDebug` build
    * `ZalphaRelease` build
Also test that if you have full access to the site (you're an Admin) you'll be presented 3 options (Create Post, Page, Story).
If not (i.e. you're an Editor), you'll be presented with "Post, Story" options only.
The FAB tooltip is updated as well, so on a clean install it should show "Create a post, page or story" for admins, and "Create a post or story" for Editors.

2. Verify that Story option does *not* exist in a 
    * `VanillaRelease` build
   In this one, the FAB functionality should be as follows:
       *  if you have full access, the FAB should present 2 options (create Post, Page)
       * if you're only an editor (not admin), the FAB should directly create a new post and present the default selected editor (Aztec/Gutenberg)

The FAB tooltip in this case should remain as usual, so on a clean install it should show "Create a post or page" for admins, and "Create a post" for Editors (contributors).


Unit tests have been updated to reflect this as well (will have to be updated once more when the feature flag is removed).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
