### PR TITLE
Issue 12334/story title layout refactor keyboard fix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -173,9 +173,15 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                     PrepublishingPublishSettingsFragment.newInstance(),
                     PrepublishingPublishSettingsFragment.TAG
             )
-            PrepublishingScreen.TAGS -> Pair(
-                    PrepublishingTagsFragment.newInstance(navigationTarget.site), PrepublishingTagsFragment.TAG
-            )
+            PrepublishingScreen.TAGS -> {
+                val isStoryPost = checkNotNull(arguments?.getBoolean(IS_STORY_POST)) {
+                    "arguments can't be null."
+                }
+                Pair(
+                    PrepublishingTagsFragment.newInstance(navigationTarget.site, isStoryPost),
+                        PrepublishingTagsFragment.TAG
+                )
+            }
         }
 
         fadeInFragment(fragment, tag)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
@@ -65,7 +65,7 @@ class PrepublishingHomeFragment : Fragment() {
             "arguments can't be null."
         }
         if (isStoryPost) {
-            requireActivity().getWindow().getDecorView().requestLayout()
+            requireActivity().window.decorView.requestLayout()
         }
         super.onResume()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
@@ -60,6 +60,16 @@ class PrepublishingHomeFragment : Fragment() {
         initViewModel()
     }
 
+    override fun onResume() {
+        val isStoryPost = checkNotNull(arguments?.getBoolean(IS_STORY_POST)) {
+            "arguments can't be null."
+        }
+        if (isStoryPost) {
+            requireActivity().getWindow().getDecorView().requestLayout()
+        }
+        super.onResume()
+    }
+
     private fun initViewModel() {
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(PrepublishingHomeViewModel::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
@@ -49,9 +49,11 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
 
     companion object {
         const val TAG = "prepublishing_tags_fragment_tag"
-        @JvmStatic fun newInstance(site: SiteModel): PrepublishingTagsFragment {
+        const val NEEDS_REQUEST_LAYOUT = "prepublishing_tags_fragment_needs_request_layout"
+        @JvmStatic fun newInstance(site: SiteModel, needsRequestLayout: Boolean): PrepublishingTagsFragment {
             val bundle = Bundle().apply {
                 putSerializable(WordPress.SITE, site)
+                putBoolean(NEEDS_REQUEST_LAYOUT, needsRequestLayout)
             }
             return PrepublishingTagsFragment().apply { arguments = bundle }
         }
@@ -74,6 +76,14 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
         if (wereTagsChanged()) {
             analyticsTrackerWrapper.trackPrepublishingNudges(Stat.EDITOR_POST_TAGS_CHANGED)
         }
+    }
+
+    override fun onResume() {
+        val needsRequestLayout = requireArguments().getBoolean(NEEDS_REQUEST_LAYOUT)
+        if (needsRequestLayout) {
+            requireActivity().getWindow().getDecorView().requestLayout()
+        }
+        super.onResume()
     }
 
     private fun initViewModel() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
@@ -112,7 +112,8 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
             toolbar_title.text = uiHelpers.getTextOfUiString(requireContext(), uiString)
         })
 
-        viewModel.start(getEditPostRepository())
+        val needsRequestLayout = requireArguments().getBoolean(NEEDS_REQUEST_LAYOUT)
+        viewModel.start(getEditPostRepository(), needsRequestLayout)
     }
 
     private fun getEditPostRepository(): EditPostRepository {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
@@ -113,7 +113,7 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
         })
 
         val needsRequestLayout = requireArguments().getBoolean(NEEDS_REQUEST_LAYOUT)
-        viewModel.start(getEditPostRepository(), needsRequestLayout)
+        viewModel.start(getEditPostRepository(), !needsRequestLayout)
     }
 
     private fun getEditPostRepository(): EditPostRepository {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsViewModel.kt
@@ -23,6 +23,7 @@ class PrepublishingTagsViewModel @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(bgDispatcher) {
     private var isStarted = false
+    private var dontCloseKeyboard = false
     private lateinit var editPostRepository: EditPostRepository
     private var updateTagsJob: Job? = null
 
@@ -38,8 +39,9 @@ class PrepublishingTagsViewModel @Inject constructor(
     private val _toolbarTitleUiState = MutableLiveData<UiString>()
     val toolbarTitleUiState: LiveData<UiString> = _toolbarTitleUiState
 
-    fun start(editPostRepository: EditPostRepository) {
+    fun start(editPostRepository: EditPostRepository, dontCloseKeyboard: Boolean = false) {
         this.editPostRepository = editPostRepository
+        this.dontCloseKeyboard = dontCloseKeyboard
 
         if (isStarted) return
         isStarted = true
@@ -62,7 +64,9 @@ class PrepublishingTagsViewModel @Inject constructor(
     fun onCloseButtonClicked() = _dismissBottomSheet.postValue(Event(Unit))
 
     fun onBackButtonClicked() {
-        _dismissKeyboard.postValue(Event(Unit))
+        if (!dontCloseKeyboard) {
+            _dismissKeyboard.postValue(Event(Unit))
+        }
         _navigateToHomeScreen.postValue(Event(Unit))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsViewModel.kt
@@ -23,7 +23,7 @@ class PrepublishingTagsViewModel @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(bgDispatcher) {
     private var isStarted = false
-    private var dontCloseKeyboard = false
+    private var closeKeyboard = true
     private lateinit var editPostRepository: EditPostRepository
     private var updateTagsJob: Job? = null
 
@@ -39,9 +39,9 @@ class PrepublishingTagsViewModel @Inject constructor(
     private val _toolbarTitleUiState = MutableLiveData<UiString>()
     val toolbarTitleUiState: LiveData<UiString> = _toolbarTitleUiState
 
-    fun start(editPostRepository: EditPostRepository, dontCloseKeyboard: Boolean = false) {
+    fun start(editPostRepository: EditPostRepository, closeKeyboard: Boolean = false) {
         this.editPostRepository = editPostRepository
-        this.dontCloseKeyboard = dontCloseKeyboard
+        this.closeKeyboard = closeKeyboard
 
         if (isStarted) return
         isStarted = true
@@ -64,7 +64,7 @@ class PrepublishingTagsViewModel @Inject constructor(
     fun onCloseButtonClicked() = _dismissBottomSheet.postValue(Event(Unit))
 
     fun onBackButtonClicked() {
-        if (!dontCloseKeyboard) {
+        if (closeKeyboard) {
             _dismissKeyboard.postValue(Event(Unit))
         }
         _navigateToHomeScreen.postValue(Event(Unit))

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType
 import org.wordpress.android.ui.posts.PrepublishingScreen.HOME
 import org.wordpress.android.ui.posts.PrepublishingScreen.PUBLISH
-import org.wordpress.android.ui.posts.PrepublishingScreen.TAGS
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.viewmodel.Event

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType
 import org.wordpress.android.ui.posts.PrepublishingScreen.HOME
+import org.wordpress.android.ui.posts.PrepublishingScreen.TAGS
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.viewmodel.Event
@@ -67,7 +68,9 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
     }
 
     private fun navigateToScreen(prepublishingScreen: PrepublishingScreen) {
-        _dismissKeyboard.postValue(Event(Unit))
+        if (prepublishingScreen != TAGS && prepublishingScreen != HOME) {
+            _dismissKeyboard.postValue(Event(Unit))
+        }
         updateNavigationTarget(PrepublishingNavigationTarget(site, prepublishingScreen))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType
 import org.wordpress.android.ui.posts.PrepublishingScreen.HOME
+import org.wordpress.android.ui.posts.PrepublishingScreen.PUBLISH
 import org.wordpress.android.ui.posts.PrepublishingScreen.TAGS
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -68,7 +69,13 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
     }
 
     private fun navigateToScreen(prepublishingScreen: PrepublishingScreen) {
-        if (prepublishingScreen != TAGS && prepublishingScreen != HOME) {
+        // Note: given we know both the HOME and the TAGS screens have an EditText, we can ask to send the
+        // dismissKeyboard signal only when we're not either in one of these nor navigating towards one of these.
+        // At this point in code we only know where we want to navigate to, but it's ok since landing on any of these
+        // two we'll want the keyboard to stay up if it was already up ;) (i.e. don't dismiss it).
+        // For the case where this is not a story and hence there's no EditText in the HOME screen, we're ok too,
+        // because there wouldn't have been a keyboard up anyway.
+        if (prepublishingScreen == PUBLISH) {
             _dismissKeyboard.postValue(Event(Unit))
         }
         updateNavigationTarget(PrepublishingNavigationTarget(site, prepublishingScreen))

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingTagsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingTagsViewModelTest.kt
@@ -91,7 +91,7 @@ class PrepublishingTagsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when viewModel is started with closeKeyboard=true then dismissKeyboard is effectively called when tapping back`() {
+    fun `when viewModel is started with closeKeyboard=true then dismissKeyboard is called when tapping back`() {
         var event: Event<Unit>? = null
         viewModel.dismissKeyboard.observeForever {
             event = it

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingTagsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingTagsViewModelTest.kt
@@ -76,4 +76,30 @@ class PrepublishingTagsViewModelTest : BaseUnitTest() {
 
         assertThat(captor.value).isEqualTo(expectedTags)
     }
+
+    @Test
+    fun `when viewModel is started with closeKeyboard=false then dismissKeyboard is not called when tapping back`() {
+        var event: Event<Unit>? = null
+        viewModel.dismissKeyboard.observeForever {
+            event = it
+        }
+
+        viewModel.start(mock(), closeKeyboard = false)
+        viewModel.onBackButtonClicked()
+
+        assertThat(event).isNull()
+    }
+
+    @Test
+    fun `when viewModel is started with closeKeyboard=true then dismissKeyboard is effectively called when tapping back`() {
+        var event: Event<Unit>? = null
+        viewModel.dismissKeyboard.observeForever {
+            event = it
+        }
+
+        viewModel.start(mock(), closeKeyboard = true)
+        viewModel.onBackButtonClicked()
+
+        assertThat(event).isNotNull
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingViewModelTest.kt
@@ -128,12 +128,4 @@ class PrepublishingViewModelTest : BaseUnitTest() {
         assertThat(viewModel.dismissBottomSheet.value?.peekContent()).isNotNull()
         assertThat(viewModel.triggerOnSubmitButtonClickedListener.value?.peekContent()).isNotNull()
     }
-
-    @Test
-    fun `when onActionClicked is called with a PrepublishingScreen, dismiss keyboard`() {
-        viewModel.start(mock(), mock())
-        viewModel.onActionClicked(ActionType.TAGS)
-
-        assertThat(viewModel.dismissKeyboard.value).isNotNull
-    }
 }


### PR DESCRIPTION
Builds on top of https://github.com/wordpress-mobile/WordPress-Android/pull/12520

This PR tries to alleviate the flicker effect observed in #12520 when switching to/from the Tags fragment / Home fragment when in a Story Post.

I'be been able to observe that the fragments need to be re-laid out in order to make space for them while the keyboard is shown or hidden, which is what triggers the `KeyboardResizeViewUtil`'s `ViewTreeObserver.OnGlobalLayoutListener()`

What this PR does is then:
- if we're showing the prepublishing bottom sheet for a Story, we avoid hiding / showing the keyboard while navigating from Home and Tags fragment (as both these fragments in the bottom sheet have EditText components to be used). This way, the lower section of the screen seems to remain the same (it is actually being repainted though, but it gives less of a flicker effect given the size and positioning of the keyboard window is the same)
- as a result of now not hiding / showing the keyboard, the `KeyboardResizeViewUtil`'s `ViewTreeObserver.OnGlobalLayoutListener()` is not triggered when navigating between these fragments and as such, we need to request a layout on the window ourselves, which we are doing in `onResume()` in the respective fragments.

This works well although it arguably adds some complexity (while the PR is short still), so open to thoughts. For users this should be better than seeing the keyboard disappearing/reappearing at once while the flickering for the fadeout/fadein of the home/tags fragments take place, all at the same time.

To test:
1. create a story
2. tap on PUBLISH
3. observe the story title field gets focused, keyboard is shown
4. tap on Tags
5. observe the keyboard remains occupying the same space on the screen (some parameters for the keyboard change as the IME type is requested, for example title caps, etc), also observe the tags fragment gets drawn correctly and you can scroll thorugh the tags list, drag the bottom sheet down, etc
6. tap back arrow on the bottom sheet
7. observe the keyboard remains occupying the same space
8. switch back and forth several times to make sure the fragments get redrawn correctly every time.

See video here https://cloudup.com/c-AZvLXg13Y


**Note**: if we agree on this approach, I'll add some unit tests for the new flags that have been added to ViewModels. Leaving this as a draft PR for now.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
