### PR TITLE
Expose Bookmark Reader Actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.reader.repository.ReaderRepositoryEvent.PostLike
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryEvent.PostLikeEnded.PostLikeUnChanged
 import org.wordpress.android.ui.reader.repository.usecases.FetchPostsForTagUseCase
 import org.wordpress.android.ui.reader.repository.usecases.GetPostsForTagUseCase
+import org.wordpress.android.ui.reader.repository.usecases.PostBookmarkActionUseCase
 import org.wordpress.android.ui.reader.repository.usecases.PostLikeActionUseCase
 import org.wordpress.android.ui.reader.repository.usecases.ShouldAutoUpdateTagUseCase
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction
@@ -38,7 +39,8 @@ class ReaderDiscoverRepository constructor(
     private val shouldAutoUpdateTagUseCase: ShouldAutoUpdateTagUseCase,
     private val fetchPostsForTagUseCase: FetchPostsForTagUseCase,
     private val readerUpdatePostsEndedHandler: ReaderUpdatePostsEndedHandler,
-    private val postLikeActionUseCase: PostLikeActionUseCase
+    private val postLikeActionUseCase: PostLikeActionUseCase,
+    private val postBookmarkActionUseCase: PostBookmarkActionUseCase
 ) : CoroutineScope {
     private var job: Job = Job()
 
@@ -91,6 +93,12 @@ class ReaderDiscoverRepository constructor(
                 }
                 is PostLikeUnChanged -> { }
             }
+        }
+    }
+
+    suspend fun performBookmarkAction(post: ReaderPost, isAskingToBookmark: Boolean) {
+        withContext(bgDispatcher) {
+            postBookmarkActionUseCase.perform(post, isAskingToBookmark)
         }
     }
 
@@ -158,7 +166,8 @@ class ReaderDiscoverRepository constructor(
         private val shouldAutoUpdateTagUseCase: ShouldAutoUpdateTagUseCase,
         private val fetchPostsForTagUseCase: FetchPostsForTagUseCase,
         private val readerUpdatePostsEndedHandler: ReaderUpdatePostsEndedHandler,
-        private val postLikeActionUseCase: PostLikeActionUseCase
+        private val postLikeActionUseCase: PostLikeActionUseCase,
+        private val postBookmarkActionUseCase: PostBookmarkActionUseCase
     ) {
         fun create(readerTag: ReaderTag? = null): ReaderDiscoverRepository {
             val tag = readerTag
@@ -171,7 +180,8 @@ class ReaderDiscoverRepository constructor(
                     shouldAutoUpdateTagUseCase,
                     fetchPostsForTagUseCase,
                     readerUpdatePostsEndedHandler,
-                    postLikeActionUseCase
+                    postLikeActionUseCase,
+                    postBookmarkActionUseCase
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.reader.repository.ReaderRepositoryEvent.PostLike
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryEvent.PostLikeEnded.PostLikeUnChanged
 import org.wordpress.android.ui.reader.repository.usecases.FetchPostsForTagUseCase
 import org.wordpress.android.ui.reader.repository.usecases.GetPostsForTagUseCase
+import org.wordpress.android.ui.reader.repository.usecases.PostBookmarkActionUseCase
 import org.wordpress.android.ui.reader.repository.usecases.PostLikeActionUseCase
 import org.wordpress.android.ui.reader.repository.usecases.ShouldAutoUpdateTagUseCase
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction
@@ -35,7 +36,8 @@ class ReaderPostRepository(
     private val shouldAutoUpdateTagUseCase: ShouldAutoUpdateTagUseCase,
     private val fetchPostsForTagUseCase: FetchPostsForTagUseCase,
     private val readerUpdatePostsEndedHandler: ReaderUpdatePostsEndedHandler,
-    private val postLikeActionUseCase: PostLikeActionUseCase
+    private val postLikeActionUseCase: PostLikeActionUseCase,
+    private val postBookmarkActionUseCase: PostBookmarkActionUseCase
 ) : CoroutineScope {
     private var job: Job = Job()
 
@@ -92,6 +94,12 @@ class ReaderPostRepository(
                     // Unused
                 }
             }
+        }
+    }
+
+    suspend fun performBookmarkAction(post: ReaderPost, isAskingToBookmark: Boolean) {
+        withContext(bgDispatcher) {
+            postBookmarkActionUseCase.perform(post, isAskingToBookmark)
         }
     }
 
@@ -161,7 +169,8 @@ class ReaderPostRepository(
         private val shouldAutoUpdateTagUseCase: ShouldAutoUpdateTagUseCase,
         private val fetchPostsForTagUseCase: FetchPostsForTagUseCase,
         private val readerUpdatePostsEndedHandler: ReaderUpdatePostsEndedHandler,
-        private val postLikeActionUseCase: PostLikeActionUseCase
+        private val postLikeActionUseCase: PostLikeActionUseCase,
+        private val postBookmarkActionUseCase: PostBookmarkActionUseCase
     ) {
         fun create(readerTag: ReaderTag): ReaderPostRepository {
             return ReaderPostRepository(
@@ -171,8 +180,8 @@ class ReaderPostRepository(
                     shouldAutoUpdateTagUseCase,
                     fetchPostsForTagUseCase,
                     readerUpdatePostsEndedHandler,
-                    postLikeActionUseCase
-
+                    postLikeActionUseCase,
+                    postBookmarkActionUseCase
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/PostBookmarkActionUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/PostBookmarkActionUseCase.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.reader.repository.usecases
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.modules.IO_THREAD
+import org.wordpress.android.ui.reader.actions.ReaderPostActionsWrapper
+import javax.inject.Inject
+import javax.inject.Named
+
+class PostBookmarkActionUseCase @Inject constructor(
+    @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
+    private val readerPostActionsWrapper: ReaderPostActionsWrapper
+) {
+    suspend fun perform(post: ReaderPost, isAskingToBookmark: Boolean) {
+        withContext(ioDispatcher) {
+            if (isAskingToBookmark)
+                readerPostActionsWrapper.addToBookmarked(post)
+            else
+                readerPostActionsWrapper.removeFromBookmarked(post)
+        }
+    }
+}


### PR DESCRIPTION
Part of #12039 

This PR continues with exposing `ReaderActions` methods via the repository. Included in this PR are the `addToBookmarked` and `removeFromBookmarked` reader action methods.  

To test:
This was tested locally by forcing requests via the repository. It will be further tested as we move forward with the RI project.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
