### PR TITLE
Disable primary button on 2FA screen when verification code field is empty

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -283,6 +283,8 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         if (TextUtils.isEmpty(m2FaInput.getEditText().getText())) {
             m2FaInput.setText(getAuthCodeFromClipboard());
         }
+
+        updateContinueButtonEnabledStatus();
     }
 
     protected void next() {
@@ -327,7 +329,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         ClipboardManager clipboard = (ClipboardManager) getActivity().getSystemService(CLIPBOARD_SERVICE);
 
         if (clipboard.getPrimaryClip() != null && clipboard.getPrimaryClip().getItemAt(0) != null
-                && clipboard.getPrimaryClip().getItemAt(0).getText() != null) {
+            && clipboard.getPrimaryClip().getItemAt(0).getText() != null) {
             String code = clipboard.getPrimaryClip().getItemAt(0).getText().toString();
 
             final Matcher twoStepAuthCodeMatcher = TWO_STEP_AUTH_CODE.matcher("");
@@ -374,11 +376,17 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
         show2FaError(null);
+        updateContinueButtonEnabledStatus();
     }
 
     private void show2FaError(String message) {
         mAnalyticsListener.trackFailure(message);
         m2FaInput.setError(message);
+    }
+
+    private void updateContinueButtonEnabledStatus() {
+        String currentVerificationCode = m2FaInput.getEditText().getText().toString();
+        getPrimaryButton().setEnabled(!currentVerificationCode.trim().isEmpty());
     }
 
     @Override
@@ -496,7 +504,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
                 mAnalyticsListener.trackSocialConnectFailure();
                 doFinishLogin();
             }
-        // Two-factor authentication code was sent via SMS to account phone number; replace SMS nonce with response.
+            // Two-factor authentication code was sent via SMS to account phone number; replace SMS nonce with response.
         } else if (!TextUtils.isEmpty(event.phoneNumber) && !TextUtils.isEmpty(event.nonce)) {
             endProgress();
             mPhoneNumber = event.phoneNumber;


### PR DESCRIPTION
Fixes #12537 

This PR updates the 2FA screen to disable its primary button if the verification code field is empty. We had alreaady worked on something similar in #12415, but we missed this screen at the time.

## To test

0. Clear app data.
1. On the Prologue screen, if the Smart Lock dialog appears, dismiss it.
1. Tap **Continue with WordPress.com**.
1. On the Get Started screen, enter an email address that is associated with a 2FA WordPress.com account.
1. Tap **Continue**.
1. Notice the Login Magic Link screen.
1. Tap **Or type your password**.
1. Notice the Email/Password screen.
1. Enter the WordPress.com account password.
1. Tap **Continue**.
1. Notice the 2FA screen.
1. Notice how the **Continue** button is already disabled.
1. Type a verification code.
1. Notice how the **Continue** button is now enabled.

Note:
 - LoginFlow PR: wordpress-mobile/WordPress-Login-Flow-Android/pull/42

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
