### PR TITLE
Adds unit tests for GetDiscoverCardsUseCase

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTableWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTableWrapper.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.datasets
+
+import dagger.Reusable
+import javax.inject.Inject
+
+@Reusable
+class ReaderDiscoverCardsTableWrapper @Inject constructor() {
+    fun loadDiscoverCardsJsons() = ReaderDiscoverCardsTable.loadDiscoverCardsJsons()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/GetDiscoverCardsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/GetDiscoverCardsUseCase.kt
@@ -48,7 +48,7 @@ class GetDiscoverCardsUseCase @Inject constructor(
                                 if (post != null) {
                                     cards.add(ReaderPostCard(post))
                                 } else {
-                                    appLogWrapper.d(READER, "Post from /cards json not found in local db")
+                                    appLogWrapper.d(READER, "Post from /cards json not found in ReaderDatabase")
                                     continue@forLoop
                                 }
                             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/GetDiscoverCardsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/GetDiscoverCardsUseCase.kt
@@ -3,25 +3,30 @@ package org.wordpress.android.ui.reader.repository.usecases
 import dagger.Reusable
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import org.wordpress.android.datasets.ReaderDiscoverCardsTable
-import org.wordpress.android.datasets.ReaderPostTable
+import org.wordpress.android.datasets.ReaderDiscoverCardsTableWrapper
+import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
+import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.models.discover.ReaderDiscoverCard
 import org.wordpress.android.models.discover.ReaderDiscoverCard.InterestsYouMayLikeCard
 import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderPostCard
 import org.wordpress.android.models.discover.ReaderDiscoverCards
 import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.ui.reader.ReaderConstants
+import org.wordpress.android.util.AppLog.T.READER
 import javax.inject.Inject
 import javax.inject.Named
 
 @Reusable
 class GetDiscoverCardsUseCase @Inject constructor(
     private val parseDiscoverCardsJsonUseCase: ParseDiscoverCardsJsonUseCase,
+    private val readerDiscoverCardsTableWrapper: ReaderDiscoverCardsTableWrapper,
+    private val readerPostTableWrapper: ReaderPostTableWrapper,
+    private val appLogWrapper: AppLogWrapper,
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
 ) {
     suspend fun get(): ReaderDiscoverCards =
             withContext(ioDispatcher) {
-                val cardJsonList = ReaderDiscoverCardsTable.loadDiscoverCardsJsons()
+                val cardJsonList = readerDiscoverCardsTableWrapper.loadDiscoverCardsJsons()
                 val cards: ArrayList<ReaderDiscoverCard> = arrayListOf()
 
                 if (cardJsonList.isNotEmpty()) {
@@ -29,7 +34,7 @@ class GetDiscoverCardsUseCase @Inject constructor(
                             cardJsonList
                     )
 
-                    for (i in 0 until jsonObjects.length()) {
+                    forLoop@ for (i in 0 until jsonObjects.length()) {
                         val cardJson = jsonObjects.getJSONObject(i)
                         when (cardJson.getString(ReaderConstants.JSON_CARD_TYPE)) {
                             ReaderConstants.JSON_CARD_INTERESTS_YOU_MAY_LIKE -> {
@@ -39,8 +44,13 @@ class GetDiscoverCardsUseCase @Inject constructor(
                             ReaderConstants.JSON_CARD_POST -> {
                                 // TODO we might want to load the data in batch
                                 val (blogId, postId) = parseDiscoverCardsJsonUseCase.parseSimplifiedPostCard(cardJson)
-                                val post = ReaderPostTable.getBlogPost(blogId, postId, false)
-                                cards.add(ReaderPostCard(post))
+                                val post = readerPostTableWrapper.getBlogPost(blogId, postId, false)
+                                if (post != null) {
+                                    cards.add(ReaderPostCard(post))
+                                } else {
+                                    appLogWrapper.d(READER, "Post from /cards json not found in local db")
+                                    continue@forLoop
+                                }
                             }
                         }
                     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/usecases/GetDiscoverCardsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/usecases/GetDiscoverCardsUseCaseTest.kt
@@ -1,0 +1,102 @@
+package org.wordpress.android.ui.reader.repository.usecases
+
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.datasets.ReaderDiscoverCardsTableWrapper
+import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.models.discover.ReaderDiscoverCard.InterestsYouMayLikeCard
+import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderPostCard
+import org.wordpress.android.test
+import org.wordpress.android.ui.reader.ReaderConstants
+
+@InternalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class GetDiscoverCardsUseCaseTest {
+    private lateinit var useCase: GetDiscoverCardsUseCase
+    private val readerDiscoverCardsTableWrapper: ReaderDiscoverCardsTableWrapper = mock()
+    private val parseDiscoverCardsJsonUseCase: ParseDiscoverCardsJsonUseCase = mock()
+    private val mockedJsonArray: JSONArray = mock()
+    private val mockedJsonObject1: JSONObject = mock()
+    private val mockedJsonObject2: JSONObject = mock()
+    private val readerPostTableWrapper: ReaderPostTableWrapper = mock()
+    private val appLogWrapper: AppLogWrapper = mock()
+
+    @Before
+    fun setUp() {
+        useCase = GetDiscoverCardsUseCase(
+                parseDiscoverCardsJsonUseCase,
+                readerDiscoverCardsTableWrapper,
+                readerPostTableWrapper,
+                appLogWrapper,
+                TEST_DISPATCHER
+        )
+        whenever(parseDiscoverCardsJsonUseCase.convertListOfJsonArraysIntoSingleJsonArray(anyOrNull()))
+                .thenReturn(mockedJsonArray)
+        whenever(mockedJsonArray.length()).thenReturn(2)
+        whenever(mockedJsonArray.getJSONObject(0)).thenReturn(mockedJsonObject1)
+        whenever(mockedJsonArray.getJSONObject(1)).thenReturn(mockedJsonObject2)
+        whenever(readerDiscoverCardsTableWrapper.loadDiscoverCardsJsons()).thenReturn(listOf(""))
+        whenever(parseDiscoverCardsJsonUseCase.parseInterestCard(anyOrNull())).thenReturn(mock())
+        whenever(parseDiscoverCardsJsonUseCase.parseSimplifiedPostCard(anyOrNull())).thenReturn(Pair(101, 102))
+        whenever(readerPostTableWrapper.getBlogPost(anyLong(), anyLong(), anyBoolean())).thenReturn(mock())
+        whenever(mockedJsonObject1.getString(ReaderConstants.JSON_CARD_TYPE))
+                .thenReturn(ReaderConstants.JSON_CARD_POST)
+        whenever(mockedJsonObject2.getString(ReaderConstants.JSON_CARD_TYPE))
+                .thenReturn(ReaderConstants.JSON_CARD_INTERESTS_YOU_MAY_LIKE)
+    }
+
+    @Test
+    fun `interest you might like card is transformed into InterestsYouMayLikeCard object`() = test {
+        // Arrange
+        whenever(mockedJsonObject1.getString(ReaderConstants.JSON_CARD_TYPE))
+                .thenReturn(ReaderConstants.JSON_CARD_INTERESTS_YOU_MAY_LIKE)
+        // Act
+        val result = useCase.get()
+        // Assert
+        assertThat(result.cards[0]).isInstanceOf(InterestsYouMayLikeCard::class.java)
+    }
+
+    @Test
+    fun `post card is transformed into ReaderPostCard object`() = test {
+        // Arrange
+        whenever(mockedJsonObject1.getString(ReaderConstants.JSON_CARD_TYPE))
+                .thenReturn(ReaderConstants.JSON_CARD_POST)
+        // Act
+        val result = useCase.get()
+        // Assert
+        assertThat(result.cards[0]).isInstanceOf(ReaderPostCard::class.java)
+    }
+
+    @Test
+    fun `if post not found in local db the remaining items are still transformed`() = test {
+        // Arrange
+        whenever(readerPostTableWrapper.getBlogPost(anyLong(), anyLong(), anyBoolean())).thenReturn(null)
+        // Act
+        val result = useCase.get()
+        // Assert
+        assertThat(result.cards.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `all items from the json are transformed into cards`() = test {
+        // Arrange
+        whenever(readerPostTableWrapper.getBlogPost(anyLong(), anyLong(), anyBoolean())).thenReturn(mock())
+        // Act
+        val result = useCase.get()
+        // Assert
+        assertThat(result.cards.size).isEqualTo(2)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/usecases/GetDiscoverCardsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/usecases/GetDiscoverCardsUseCaseTest.kt
@@ -29,8 +29,8 @@ class GetDiscoverCardsUseCaseTest {
     private val readerDiscoverCardsTableWrapper: ReaderDiscoverCardsTableWrapper = mock()
     private val parseDiscoverCardsJsonUseCase: ParseDiscoverCardsJsonUseCase = mock()
     private val mockedJsonArray: JSONArray = mock()
-    private val mockedJsonObject1: JSONObject = mock()
-    private val mockedJsonObject2: JSONObject = mock()
+    private val mockedPostCardJson: JSONObject = mock()
+    private val mockedInterestsCardJson: JSONObject = mock()
     private val readerPostTableWrapper: ReaderPostTableWrapper = mock()
     private val appLogWrapper: AppLogWrapper = mock()
 
@@ -46,22 +46,22 @@ class GetDiscoverCardsUseCaseTest {
         whenever(parseDiscoverCardsJsonUseCase.convertListOfJsonArraysIntoSingleJsonArray(anyOrNull()))
                 .thenReturn(mockedJsonArray)
         whenever(mockedJsonArray.length()).thenReturn(2)
-        whenever(mockedJsonArray.getJSONObject(0)).thenReturn(mockedJsonObject1)
-        whenever(mockedJsonArray.getJSONObject(1)).thenReturn(mockedJsonObject2)
+        whenever(mockedJsonArray.getJSONObject(0)).thenReturn(mockedPostCardJson)
+        whenever(mockedJsonArray.getJSONObject(1)).thenReturn(mockedInterestsCardJson)
         whenever(readerDiscoverCardsTableWrapper.loadDiscoverCardsJsons()).thenReturn(listOf(""))
         whenever(parseDiscoverCardsJsonUseCase.parseInterestCard(anyOrNull())).thenReturn(mock())
         whenever(parseDiscoverCardsJsonUseCase.parseSimplifiedPostCard(anyOrNull())).thenReturn(Pair(101, 102))
         whenever(readerPostTableWrapper.getBlogPost(anyLong(), anyLong(), anyBoolean())).thenReturn(mock())
-        whenever(mockedJsonObject1.getString(ReaderConstants.JSON_CARD_TYPE))
+        whenever(mockedPostCardJson.getString(ReaderConstants.JSON_CARD_TYPE))
                 .thenReturn(ReaderConstants.JSON_CARD_POST)
-        whenever(mockedJsonObject2.getString(ReaderConstants.JSON_CARD_TYPE))
+        whenever(mockedInterestsCardJson.getString(ReaderConstants.JSON_CARD_TYPE))
                 .thenReturn(ReaderConstants.JSON_CARD_INTERESTS_YOU_MAY_LIKE)
     }
 
     @Test
-    fun `interest you might like card is transformed into InterestsYouMayLikeCard object`() = test {
+    fun `interest you might like card json is transformed into InterestsYouMayLikeCard object`() = test {
         // Arrange
-        whenever(mockedJsonObject1.getString(ReaderConstants.JSON_CARD_TYPE))
+        whenever(mockedPostCardJson.getString(ReaderConstants.JSON_CARD_TYPE))
                 .thenReturn(ReaderConstants.JSON_CARD_INTERESTS_YOU_MAY_LIKE)
         // Act
         val result = useCase.get()
@@ -70,9 +70,9 @@ class GetDiscoverCardsUseCaseTest {
     }
 
     @Test
-    fun `post card is transformed into ReaderPostCard object`() = test {
+    fun `post card json is transformed into ReaderPostCard object`() = test {
         // Arrange
-        whenever(mockedJsonObject1.getString(ReaderConstants.JSON_CARD_TYPE))
+        whenever(mockedPostCardJson.getString(ReaderConstants.JSON_CARD_TYPE))
                 .thenReturn(ReaderConstants.JSON_CARD_POST)
         // Act
         val result = useCase.get()
@@ -98,5 +98,16 @@ class GetDiscoverCardsUseCaseTest {
         val result = useCase.get()
         // Assert
         assertThat(result.cards.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `when cards json is empty an empty ReaderDiscoverCards is returned`() = test {
+        // Arrange
+        val emptyList = listOf<String>()
+        whenever(readerDiscoverCardsTableWrapper.loadDiscoverCardsJsons()).thenReturn(emptyList)
+        // Act
+        val result = useCase.get()
+        // Assert
+        assertThat(result.cards).isEmpty()
     }
 }


### PR DESCRIPTION
Parent issue #12319 

This PR adds unit tests for GetDiscoverCardsUseCase. I also fixed an issue when a post is not found in local db - we just log a message and continue.

To test:
No need to test anything.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
