### PR TITLE
Fix 11835: Input validation for post password dialog

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <option name="DEFAULT_COMPILER" value="Javac" />
-    <resourceExtensions />
     <wildcardResourcePatterns>
       <entry name="!?*.java" />
       <entry name="!?*.form" />
@@ -13,10 +11,9 @@
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
     </wildcardResourcePatterns>
-    <annotationProcessing>
-      <profile default="true" name="Default" enabled="false">
-        <processorPath useClasspath="true" />
-      </profile>
-    </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="WordPressAnnotations" target="1.7" />
+      <module name="WordPressProcessors" target="1.7" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
+    <option name="DEFAULT_COMPILER" value="Javac" />
+    <resourceExtensions />
     <wildcardResourcePatterns>
       <entry name="!?*.java" />
       <entry name="!?*.form" />
@@ -11,9 +13,10 @@
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
     </wildcardResourcePatterns>
-    <bytecodeTargetLevel>
-      <module name="WordPressAnnotations" target="1.7" />
-      <module name="WordPressProcessors" target="1.7" />
-    </bytecodeTargetLevel>
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="false">
+        <processorPath useClasspath="true" />
+      </profile>
+    </annotationProcessing>
   </component>
 </project>

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -746,13 +746,16 @@ public class EditPostSettingsFragment extends Fragment {
         EditPostRepository editPostRepository = getEditPostRepository();
         if (editPostRepository == null) return;
 
-        String newPassword = password.trim();
+        String trimmedPassword = password.trim();
+        Boolean isNewPasswordBlank = trimmedPassword.isEmpty();
         String previousPassword = editPostRepository.getPassword();
-        Boolean isNewPasswordBlank = newPassword.isEmpty();
         Boolean isPreviousPasswordBlank = previousPassword.isEmpty() || previousPassword.trim().isEmpty();
 
         // Nothing to save
         if (isNewPasswordBlank && isPreviousPasswordBlank) return;
+
+        // Save untrimmed password if not blank, else save empty string
+        String newPassword = isNewPasswordBlank ? trimmedPassword : password;
 
         editPostRepository.updateAsync(postModel -> {
             postModel.setPassword(newPassword);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -751,11 +751,8 @@ public class EditPostSettingsFragment extends Fragment {
         Boolean isNewPasswordBlank = newPassword.isEmpty();
         Boolean isPreviousPasswordBlank = previousPassword.isEmpty() || previousPassword.trim().isEmpty();
 
-        if (isNewPasswordBlank && isPreviousPasswordBlank) {
-            // TODO: 29/07/2020 Show toast and return. Nothing to save
-            ToastUtils.showToast(getContext(), R.string.post_not_found);
-            return;
-        }
+        // Nothing to save
+        if (isNewPasswordBlank && isPreviousPasswordBlank) return;
 
         editPostRepository.updateAsync(postModel -> {
             postModel.setPassword(newPassword);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -744,17 +744,28 @@ public class EditPostSettingsFragment extends Fragment {
 
     private void updatePassword(String password) {
         EditPostRepository editPostRepository = getEditPostRepository();
-        if (editPostRepository != null) {
-            editPostRepository.updateAsync(postModel -> {
-                postModel.setPassword(password);
-                return true;
-            }, (postModel, result) -> {
-                if (result == UpdatePostResult.Updated.INSTANCE) {
-                    mPasswordTextView.setText(password);
-                }
-                return null;
-            });
+        if (editPostRepository == null) return;
+
+        String newPassword = password.trim();
+        String previousPassword = editPostRepository.getPassword();
+        Boolean isNewPasswordBlank = newPassword.isEmpty();
+        Boolean isPreviousPasswordBlank = previousPassword.isEmpty() || previousPassword.trim().isEmpty();
+
+        if (isNewPasswordBlank && isPreviousPasswordBlank) {
+            // TODO: 29/07/2020 Show toast and return. Nothing to save
+            ToastUtils.showToast(getContext(), R.string.post_not_found);
+            return;
         }
+
+        editPostRepository.updateAsync(postModel -> {
+            postModel.setPassword(newPassword);
+            return true;
+        }, (postModel, result) -> {
+            if (result == UpdatePostResult.Updated.INSTANCE) {
+                mPasswordTextView.setText(newPassword);
+            }
+            return null;
+        });
     }
 
     private void updateCategories(List<Long> categoryList) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -749,7 +749,7 @@ public class EditPostSettingsFragment extends Fragment {
         String trimmedPassword = password.trim();
         Boolean isNewPasswordBlank = trimmedPassword.isEmpty();
         String previousPassword = editPostRepository.getPassword();
-        Boolean isPreviousPasswordBlank = previousPassword.isEmpty() || previousPassword.trim().isEmpty();
+        Boolean isPreviousPasswordBlank = previousPassword.trim().isEmpty();
 
         // Nothing to save
         if (isNewPasswordBlank && isPreviousPasswordBlank) return;


### PR DESCRIPTION
Fixes #11835 

## Issue

Users can set a 'blank' post password consisting entirely of spaces. There is no input validation of password submitted by users.

## Solution

Check provided password if it is blank, i.e. is empty or consists of spaces only.

1. Do nothing if the new password is blank, and the post does not already have a password.
2. Remove post password if the new password is blank, and the post has a password.
3. Set password, without trimming spaces, if it is not blank.

## To test

1. Create a new post.
2. Open Post Settings from overflow menu

### Test 1:
1. Set a post password consisting of only spaces.
2. Check that no password has been set.

### Test 2:
1. Set a post password consisting of only non-space characters.
2. Check that new password has been saved.

### Test 3:
1. With a non-space password set, set a new password consisting of only spaces
2. Check that password has been removed.

### Test 4:
1. Set a post password non-space characters, with leading/trailing spaces.
2. Check that new password is saved including leading/trailing spaces.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
