### PR TITLE
Improve site icon edit message for self hosted

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -465,12 +465,18 @@ class MySiteFragment : Fragment(),
                 }
                 completeQuickStarTask(UPLOAD_SITE_ICON)
             } else {
-                val message = if (hasIcon) {
-                    R.string.my_site_icon_dialog_change_requires_permission_message
-                } else {
-                    R.string.my_site_icon_dialog_add_requires_permission_message
+                val message = when {
+                    !site.isUsingWpComRestApi -> {
+                        R.string.my_site_icon_dialog_change_requires_jetpack_message
+                    }
+                    hasIcon -> {
+                        R.string.my_site_icon_dialog_change_requires_permission_message
+                    }
+                    else -> {
+                        R.string.my_site_icon_dialog_add_requires_permission_message
+                    }
                 }
-                showEditingSiteIconRequiresPermissionDialog(getString(message))
+                showEditingSiteIconNotAllowedDialog(getString(message))
             }
         }
     }
@@ -685,9 +691,9 @@ class MySiteFragment : Fragment(),
         dialog.show(requireActivity().supportFragmentManager, tag)
     }
 
-    private fun showEditingSiteIconRequiresPermissionDialog(message: String) {
+    private fun showEditingSiteIconNotAllowedDialog(message: String) {
         val dialog = BasicFragmentDialog()
-        val tag = TAG_EDIT_SITE_ICON_PERMISSIONS_DIALOG
+        val tag = TAG_EDIT_SITE_ICON_NOT_ALLOWED_DIALOG
         dialog.initialize(
                 tag, getString(R.string.my_site_icon_dialog_title),
                 message,
@@ -1183,7 +1189,7 @@ class MySiteFragment : Fragment(),
                     activity,
                     SITE_ICON_PICKER, selectedSite, null
             )
-            TAG_EDIT_SITE_ICON_PERMISSIONS_DIALOG -> {
+            TAG_EDIT_SITE_ICON_NOT_ALLOWED_DIALOG -> {
             }
             TAG_QUICK_START_DIALOG -> {
                 startQuickStart()
@@ -1270,7 +1276,7 @@ class MySiteFragment : Fragment(),
         when (instanceTag) {
             TAG_ADD_SITE_ICON_DIALOG -> showQuickStartNoticeIfNecessary()
             TAG_CHANGE_SITE_ICON_DIALOG,
-            TAG_EDIT_SITE_ICON_PERMISSIONS_DIALOG,
+            TAG_EDIT_SITE_ICON_NOT_ALLOWED_DIALOG,
             TAG_QUICK_START_DIALOG,
             TAG_QUICK_START_MIGRATION_DIALOG,
             TAG_REMOVE_NEXT_STEPS_DIALOG -> {
@@ -1518,7 +1524,7 @@ class MySiteFragment : Fragment(),
         const val TAG_ADD_SITE_ICON_DIALOG = "TAG_ADD_SITE_ICON_DIALOG"
         const val TAG_REMOVE_NEXT_STEPS_DIALOG = "TAG_REMOVE_NEXT_STEPS_DIALOG"
         const val TAG_CHANGE_SITE_ICON_DIALOG = "TAG_CHANGE_SITE_ICON_DIALOG"
-        const val TAG_EDIT_SITE_ICON_PERMISSIONS_DIALOG = "TAG_EDIT_SITE_ICON_PERMISSIONS_DIALOG"
+        const val TAG_EDIT_SITE_ICON_NOT_ALLOWED_DIALOG = "TAG_EDIT_SITE_ICON_NOT_ALLOWED_DIALOG"
         const val TAG_QUICK_START_DIALOG = "TAG_QUICK_START_DIALOG"
         const val TAG_QUICK_START_MIGRATION_DIALOG = "TAG_QUICK_START_MIGRATION_DIALOG"
         const val AUTO_QUICK_START_SNACKBAR_DELAY_MS = 1000

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1905,6 +1905,7 @@
     <string name="my_site_icon_dialog_change_message">How would you like to edit the icon?</string>
     <string name="my_site_icon_dialog_add_requires_permission_message">You don\'t have permission to add a site icon.</string>
     <string name="my_site_icon_dialog_change_requires_permission_message">You don\'t have permission to edit the site icon.</string>
+    <string name="my_site_icon_dialog_change_requires_jetpack_message">Editing site icons on self-hosted WordPress sites requires the Jetpack plugin.</string>
     <string name="my_site_icon_dialog_change_button">Change</string>
     <string name="my_site_icon_dialog_remove_button">Remove</string>
     <string name="my_site_icon_dialog_cancel_button">Cancel</string>


### PR DESCRIPTION
Partially covers #9179

Currently we need some improvements [at least on the API side](https://github.com/wordpress-mobile/WordPress-Android/issues/9179#issuecomment-664489409) to allow the site icon to be set for pure self-hosted sites.

Meanwhile seems reasonable to improve the user message when attempting to change site icon for self-hosted.

**NOTE:** while testing this PR I noticed that the set of a site icon from the WordPress Media Library is not working. Checked this issue is in develop from at least [this commit](dfac5d1710c5d85b875a3f0084778225b82ac779) (not saying that one introduced it, it's just how back I went). It's working fine in current beta 15.4-rc-1. I will address this in a separate PR.

## To test

### Pure self-hosted
- setup a pure self-hosted site (like using https://jurassic.ninja/) and add it the the app by address
- Check that you get the below message and you can close it without getting any icon update

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/88838946-902a7a00-d1da-11ea-9e59-9d29e2bf76d8.png>
</p>


### WP.COM/JP/ATOMIC with admin account
- Setup one of the above site type
- Login into the app with an admin account role (or a role above contributor)
- Try to Add/Edit the site icon and check you get the following

| ![Screenshot_1596041288](https://user-images.githubusercontent.com/47797566/88839572-8d7c5480-d1db-11ea-8fed-b4631854cfd3.png) | ![Screenshot_1596041770](https://user-images.githubusercontent.com/47797566/88839587-910fdb80-d1db-11ea-9a21-b9fa237c21b2.png) |
|---|---|

- Check you are able to Add/Edit the site icon as usual

### WP.COM/JP/ATOMIC with contributor account
- Same step as before but you should get the following message(s)

| ![Screenshot_1596048222](https://user-images.githubusercontent.com/47797566/88840334-97eb1e00-d1dc-11ea-91c7-5b803f470cf3.png) | ![Screenshot_1596048274](https://user-images.githubusercontent.com/47797566/88840348-9b7ea500-d1dc-11ea-91fe-b007b3f719f7.png) |
|---|---|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
