### PR TITLE
Bugfix: Expected BEGIN_OBJECT but was BEGIN_ARRAY at path $[0]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = 'f0a8af974ecb39cd3e9df036a3cf4fca486bac4a'
+    fluxCVersion = '1.6.18-beta-2'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.16'
+    fluxCVersion = 'f0a8af974ecb39cd3e9df036a3cf4fca486bac4a'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1644
**Related PR:**
- https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1647
- https://github.com/WordPress/gutenberg/pull/24277

## To test:
1.) On a test site Install a theme with an invalid configuration such as:

```
add_theme_support( 'editor-gradient-presets', array(array()));
```

or 

```
add_theme_support( 'editor-color-palette', array(array()));
```

You can use [twentytwenty-copy-empty-array.zip](https://github.com/wordpress-mobile/WordPress-FluxC-Android/files/4997581/twentytwenty-copy-empty-array.zip) which is already setup.

2.) Open the app and navigate to the Gutenberg editor
Expect the editor to load
3.) Add a block that uses theme colors like Buttons 
Expect the default colors and gradients to be used in place of the invalid options.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
