### PR TITLE
Changing the doMediaIdsSelected function logic to allow returning correct activity result.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -328,23 +328,25 @@ public class PhotoPickerActivity extends LocaleAwareActivity
 
     private void doMediaIdsSelected(ArrayList<Long> mediaIds, @NonNull PhotoPickerMediaSource source) {
         if (mediaIds != null && mediaIds.size() > 0) {
-            if (mBrowserType == MediaBrowserType.FEATURED_IMAGE_PICKER) {
-                // if user chose a featured image, track image picked event
-                mFeaturedImageHelper.trackFeaturedImageEvent(
-                        FeaturedImageHelper.TrackableEvent.IMAGE_PICKED,
-                        mLocalPostId
-                );
-
+            if (mBrowserType == MediaBrowserType.WP_STORIES_MEDIA_PICKER) {
+                // TODO WPSTORIES add TRACKS (see how it's tracked below? maybe do along the same lines)
                 Intent data = new Intent()
-                        .putExtra(EXTRA_MEDIA_ID, mediaIds.get(0))
+                        .putExtra(MediaBrowserActivity.RESULT_IDS, ListUtils.toLongArray(mediaIds))
+                        .putExtra(ARG_BROWSER_TYPE, mBrowserType)
                         .putExtra(EXTRA_MEDIA_SOURCE, source.name());
                 setResult(RESULT_OK, data);
                 finish();
             } else {
-                // TODO WPSTORIES add TRACKS (see how it's tracked above? maybe do along the same lines)
+                // if user chose a featured image, track image picked event
+                if (mBrowserType == MediaBrowserType.FEATURED_IMAGE_PICKER) {
+                    mFeaturedImageHelper.trackFeaturedImageEvent(
+                            FeaturedImageHelper.TrackableEvent.IMAGE_PICKED,
+                            mLocalPostId
+                    );
+                }
+
                 Intent data = new Intent()
-                        .putExtra(MediaBrowserActivity.RESULT_IDS, ListUtils.toLongArray(mediaIds))
-                        .putExtra(ARG_BROWSER_TYPE, mBrowserType)
+                        .putExtra(EXTRA_MEDIA_ID, mediaIds.get(0))
                         .putExtra(EXTRA_MEDIA_SOURCE, source.name());
                 setResult(RESULT_OK, data);
                 finish();


### PR DESCRIPTION
Fixes #12555 

The linked issue is referred specifically to setting a site icon, but I believe this can have a broader impact when picker is used with `mBrowserType` not being a `WP_STORIES_MEDIA_PICKER` nor a `FEATURED_IMAGE_PICKER`. 

Since I'm not familiar with WP Stories code I'm assuming things here so this PR is more on the side of making us aware of the issue than pretending this is a full fix of all possible use cases 😊 

PS: issue seems present in current develop, current beta seems ok so we should be fine fixing it before next code freeze AFAIU

### To test

For the site icon part you can follow the linked #12556 issue steps but as said this is more a trigger so we can check also other picker cases.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
