### PR TITLE
Issue/remove remaining usage of obsolete attributes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginFlowThemeHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginFlowThemeHelper.kt
@@ -7,7 +7,7 @@ object LoginFlowThemeHelper {
     /**
      * This function should be used by activities that use the LoginFlow theme.
      * These activities often use components that refer to custom theme attributes defined by the WordPress theme,
-     * but that are missing from the LoginFlow theme. Some examples: wpColorText, wpColorError, wpColorSuccess, etc.
+     * but that are missing from the LoginFlow theme. Some examples: wpColorError, wpColorSuccess, etc.
      * Instead of extending the LoginFlow theme only to include these attributes and having to maintain them in multiple
      * places, we use this function to "inject" them directly.
      */

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.java
@@ -97,7 +97,7 @@ public class ReaderPostDetailHeaderView extends LinearLayout {
             txtTitle.setOnClickListener(mClickListener);
             txtSubtitle.setOnClickListener(mClickListener);
         } else {
-            int color = ContextExtensionsKt.getColorFromAttribute(getContext(), R.attr.wpColorText);
+            int color = ContextExtensionsKt.getColorFromAttribute(getContext(), R.attr.colorOnSurface);
             txtTitle.setTextColor(color);
             txtSubtitle.setTextColor(color);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -279,7 +279,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
         )
         spannableTitle.setSpan(
-                ForegroundColorSpan(context.getColorFromAttribute(R.attr.wpColorTextSubtle)),
+                ForegroundColorSpan(context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)),
                 domainSpan.first,
                 domainSpan.second,
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE

--- a/WordPress/src/main/res/layout/activity_log_item_detail.xml
+++ b/WordPress/src/main/res/layout/activity_log_item_detail.xml
@@ -45,7 +45,6 @@
                 android:ellipsize="end"
                 android:lines="1"
                 android:textAppearance="?attr/textAppearanceSubtitle2"
-                android:textColor="?attr/wpColorText"
                 tools:text="John Smith" />
 
             <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/activity_log_list_progress_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_progress_item.xml
@@ -45,8 +45,7 @@
                 android:gravity="start"
                 android:singleLine="true"
                 android:textAlignment="viewStart"
-                android:textAppearance="@style/Base.TextAppearance.AppCompat.Subhead"
-                android:textColor="?attr/wpColorText"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
                 tools:text="Rewinding to June 1 2018 12:22PM" />
 
             <org.wordpress.android.widgets.WPTextView
@@ -56,7 +55,7 @@
                 android:ellipsize="end"
                 android:singleLine="true"
                 android:textAppearance="@style/Base.TextAppearance.AppCompat.Body1"
-                android:textColor="@color/neutral_40"
+                android:textColor="?attr/wpColorOnSurfaceMedium"
                 tools:text="Rewind in progress" />
 
         </LinearLayout>

--- a/WordPress/src/main/res/layout/invite_username_button.xml
+++ b/WordPress/src/main/res/layout/invite_username_button.xml
@@ -7,15 +7,14 @@
     android:paddingStart="6dp"
     android:paddingEnd="12dp">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/username"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:layout_gravity="center_vertical"
         android:gravity="center_vertical"
-        android:textColor="?attr/wpColorText"
-        android:textSize="@dimen/text_sz_medium"
+        android:textAppearance="?attr/textAppearanceBody2"
         android:layout_marginEnd="5dp"/>
 
     <ImageButton

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -46,7 +46,7 @@
                 android:layout_gravity="center_horizontal"
                 android:layout_marginTop="@dimen/margin_medium"
                 android:textAllCaps="true"
-                android:textColor="?attr/wpColorText"
+                android:textColor="?attr/colorOnSurface"
                 android:textSize="@dimen/text_sz_small"
                 android:textStyle="bold"
                 tools:text="PDF" />
@@ -59,7 +59,7 @@
                 android:ellipsize="end"
                 android:gravity="center_horizontal"
                 android:singleLine="true"
-                android:textColor="?attr/wpColorText"
+                android:textColor="?attr/colorOnSurface"
                 android:textSize="@dimen/text_sz_extra_small"
                 tools:text="filename" />
         </LinearLayout>

--- a/WordPress/src/main/res/layout/people_invite_fragment.xml
+++ b/WordPress/src/main/res/layout/people_invite_fragment.xml
@@ -173,8 +173,7 @@
                     android:layout_below="@+id/message"
                     android:gravity="end"
                     android:padding="5dp"
-                    android:textColor="@color/neutral_40"
-                    android:textSize="@dimen/text_sz_small" />
+                    android:textAppearance="?attr/textAppearanceCaption" />
             </RelativeLayout>
 
             <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/post_list_button.xml
+++ b/WordPress/src/main/res/layout/post_list_button.xml
@@ -24,7 +24,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:singleLine="true"
-        android:textAppearance="?attr/textAppearanceBody2"
+        android:textSize="@dimen/text_sz_medium"
         android:textColor="?attr/wpColorOnSurfaceMedium"
         tools:text="text" />
 

--- a/WordPress/src/main/res/layout/post_list_button.xml
+++ b/WordPress/src/main/res/layout/post_list_button.xml
@@ -24,8 +24,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:singleLine="true"
-        android:textColor="?attr/wpColorTextSubtle"
-        android:textSize="@dimen/text_sz_medium"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="?attr/wpColorOnSurfaceMedium"
         tools:text="text" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/reader_activity_comment_list.xml
+++ b/WordPress/src/main/res/layout/reader_activity_comment_list.xml
@@ -17,7 +17,7 @@
             style="@style/ReaderTextView.EmptyList"
             android:layout_above="@+id/layout_bottom"
             android:text="@string/reader_empty_comments"
-            android:textColor="@color/neutral_40"
+            android:textColor="?attr/wpColorOnSurfaceMedium"
             android:visibility="gone"
             app:fixWidowWords="true"
             tools:visibility="visible" />

--- a/WordPress/src/main/res/layout/suggest_users_activity.xml
+++ b/WordPress/src/main/res/layout/suggest_users_activity.xml
@@ -14,8 +14,7 @@
         android:padding="@dimen/margin_medium"
         android:gravity="center"
         android:background="?attr/colorGutenbergBackground"
-        android:textColor="?attr/wpColorText"
-        android:textSize="@dimen/text_sz_medium"
+        android:textAppearance="?attr/textAppearanceBody2"
         android:visibility="gone"
         android:elevation="@dimen/popup_over_toolbar_elevation"
         />

--- a/WordPress/src/main/res/layout/suggestion_list_row.xml
+++ b/WordPress/src/main/res/layout/suggestion_list_row.xml
@@ -25,8 +25,7 @@
         android:ellipsize="end"
         android:gravity="center_vertical"
         android:maxLines="1"
-        android:textColor="?attr/wpColorText"
-        android:textSize="@dimen/text_sz_medium"
+        android:textAppearance="?attr/textAppearanceBody2"
         tools:text="user_login"
         android:layout_marginStart="@dimen/margin_medium"/>
 

--- a/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
+++ b/WordPress/src/main/res/layout/support_email_and_name_dialog.xml
@@ -1,54 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_height="match_parent"
     android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="@dimen/margin_dialog" >
+    android:padding="@dimen/margin_dialog">
 
     <TextView
         android:id="@+id/support_identity_input_dialog_message"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_dialog"
-        android:layout_width="wrap_content"
-        android:textColor="@color/neutral_40"
+        android:textColor="?attr/wpColorOnSurfaceMedium"
         android:textSize="@dimen/text_sz_large"
-        tools:text="@string/support_identity_input_dialog_enter_email_and_name" >
-    </TextView>
+        tools:text="@string/support_identity_input_dialog_enter_email_and_name" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent" >
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/support_identity_input_dialog_email_edit_text"
-            android:hint="@string/support_identity_input_dialog_email_label"
-            android:inputType="textEmailAddress"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/margin_large"
-            android:layout_width="match_parent"
-            android:textColor="?attr/wpColorText"
-            android:textSize="@dimen/text_sz_medium" >
-        </com.google.android.material.textfield.TextInputEditText>
+            android:hint="@string/support_identity_input_dialog_email_label"
+            android:inputType="textEmailAddress"
+            android:textAppearance="?attr/textAppearanceBody2" />
 
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent" >
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/support_identity_input_dialog_name_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:hint="@string/support_identity_input_dialog_name_label"
             android:inputType="text"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"
             android:maxLength="@integer/max_length_support_name"
-            android:textColor="?attr/wpColorText"
-            android:textSize="@dimen/text_sz_medium" >
-        </com.google.android.material.textfield.TextInputEditText>
+            android:textAppearance="?attr/textAppearanceBody2" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/WordPress/src/main/res/layout/toolbar_spinner_dropdown_item.xml
+++ b/WordPress/src/main/res/layout/toolbar_spinner_dropdown_item.xml
@@ -5,8 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="@dimen/margin_large"
-    android:textColor="?attr/wpColorText"
-    android:textSize="@dimen/text_sz_large"
+    android:textAppearance="?attr/textAppearanceBody1"
     android:textAlignment="viewStart"
     android:gravity="start"
     tools:text="spinner dropdown item" />

--- a/WordPress/src/main/res/layout/wppref_text_dialog.xml
+++ b/WordPress/src/main/res/layout/wppref_text_dialog.xml
@@ -11,7 +11,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_large"
-        android:textColor="@color/neutral_40"
+        android:textColor="?attr/wpColorOnSurfaceMedium"
         android:textSize="@dimen/text_sz_large"
         android:labelFor="@+id/edit"
         tools:text="text_subtitle" />

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -17,8 +17,6 @@
         <item name="colorControlActivated">?attr/colorPrimary</item>
         <item name="colorAccent">?attr/colorPrimary</item>
 
-        <item name="wpColorText">@android:color/white</item>
-        <item name="wpColorTextSubtle">@color/neutral_50</item>
         <item name="wpColorError">@color/error_50</item>
         <item name="wpColorSuccess">@color/green_30</item>
         <item name="wpColorWarningDark">@color/warning_50</item>

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -4,8 +4,6 @@
     <attr name="longClickHint" format="string" />
 
     <!-- Semantic colors -->
-    <attr name="wpColorText" format="reference|color" />
-    <attr name="wpColorTextSubtle" format="reference|color" />
     <attr name="wpColorError" format="reference|color" />
     <attr name="wpColorSuccess" format="reference|color" />
     <attr name="wpColorAppBar" format="reference|color" />

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -108,9 +108,8 @@
     <style name="ReaderTextView.EmptyList" parent="ReaderTextView">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:textSize">@dimen/text_sz_large</item>
+        <item name="android:textAppearance">?attr/textAppearanceBody1</item>
         <item name="android:gravity">center</item>
-        <item name="android:textColor">?attr/wpColorText</item>
     </style>
 
     <style name="ReaderTextView.Interests.Title" parent="ReaderTextView">

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -272,7 +272,7 @@
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">fill_parent</item>
         <item name="android:gravity">center_horizontal|center_vertical</item>
-        <item name="android:textColor">@color/neutral_40</item>
+        <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>
     </style>
 
     <style name="WordPress.Button.Primary" parent="Widget.MaterialComponents.Button">
@@ -704,7 +704,7 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:gravity">center_vertical</item>
-        <item name="android:textColor">@color/neutral_40</item>
+        <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>
         <item name="android:textSize">@dimen/text_sz_medium</item>
     </style>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -35,8 +35,6 @@
 
         <item name="followButtonStyle">@style/Reader.Follow.Button</item>
 
-        <item name="wpColorText">@color/neutral_70</item>
-        <item name="wpColorTextSubtle">@color/neutral</item>
         <item name="wpColorError">@color/error</item>
         <item name="wpColorSuccess">@color/green_50</item>
         <item name="wpColorWarningDark">@color/warning_50</item>
@@ -178,9 +176,7 @@
         </item>
     </style>
 
-    <style name="TabTextStyle.WordPress" parent="android:Widget.Material.ActionBar.TabText">
-        <item name="android:textColor">?attr/wpColorText</item>
-    </style>
+    <style name="TabTextStyle.WordPress" parent="android:Widget.Material.ActionBar.TabText" />
 
     <style name="DropDownNav.WordPress" parent="android:Widget.Material.Light.Spinner">
         <item name="android:background">@drawable/spinner_background_ab_wordpress</item>
@@ -901,19 +897,19 @@
     <style name="DomainRegistrationFormTitle">
         <item name="android:textSize">@dimen/text_sz_medium</item>
         <item name="android:textStyle">bold</item>
-        <item name="android:textColor">?attr/wpColorText</item>
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textAlignment">viewStart</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:gravity">start</item>
     </style>
 
     <style name="DomainRegistrationFormSubTitle">
         <item name="android:textSize">@dimen/text_sz_small</item>
-        <item name="android:textColor">?attr/wpColorText</item>
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textAlignment">viewStart</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:gravity">start</item>
     </style>
 


### PR DESCRIPTION
Fixes #10759

After transitioning to the material theme we have left two legacy attributes that should not be used - `wpColorText` and `wpColorTextSubtle`. 

This PR replaces the with `colorOnSurface` and `wpColorOnSurfaceMedium`, or with `textAppearance` that already includes our default text color.

To test:
 You don't need to check all the places where the color was updated, rather you can go through code and confirm that:
- `wpColorText` was replaced with `colorOnSurface`
- `wpColorTextSubtle` or `@color/neutral_40` were replaced with `wpColorOnSurfaceMedium`
- When applicable `wpColorText` and text size were replaced with `textAppearance` attribute.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
