### PR TITLE
Add support for pageHandle on /cards endpoint

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -145,7 +145,9 @@ public class AppPrefs {
         AZTEC_EDITOR_DISABLE_HW_ACC_KEYS,
 
         // timestamp of the last update of the reader css styles
-        READER_CSS_UPDATED_TIMESTAMP
+        READER_CSS_UPDATED_TIMESTAMP,
+        // Identifier of the next page for the discover /cards endpoint
+        READER_CARDS_ENDPOINT_PAGE_HANDLE
     }
 
     /**
@@ -1160,6 +1162,14 @@ public class AppPrefs {
 
     public static void setReaderCssUpdatedTimestamp(long timestamp) {
         setLong(DeletablePrefKey.READER_CSS_UPDATED_TIMESTAMP, timestamp);
+    }
+
+    public static String getReaderCardsPageHandle() {
+        return getString(DeletablePrefKey.READER_CARDS_ENDPOINT_PAGE_HANDLE, null);
+    }
+
+    public static void setReaderCardsPageHandle(String pageHandle) {
+        setString(DeletablePrefKey.READER_CARDS_ENDPOINT_PAGE_HANDLE, pageHandle);
     }
 
      public static QuickStartTask getLastSkippedQuickStartTask() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -71,6 +71,10 @@ class AppPrefsWrapper @Inject constructor() {
         get() = AppPrefs.getReaderCssUpdatedTimestamp()
         set(timestamp) = AppPrefs.setReaderCssUpdatedTimestamp(timestamp)
 
+    var readerCardsPageHandle: String?
+        get() = AppPrefs.getReaderCardsPageHandle()
+        set(pageHandle) = AppPrefs.setReaderCardsPageHandle(pageHandle)
+
     fun getAppWidgetSiteId(appWidgetId: Int) = AppPrefs.getStatsWidgetSelectedSiteId(appWidgetId)
     fun setAppWidgetSiteId(siteId: Long, appWidgetId: Int) = AppPrefs.setStatsWidgetSelectedSiteId(siteId, appWidgetId)
     fun removeAppWidgetSiteId(appWidgetId: Int) = AppPrefs.removeStatsWidgetSelectedSiteId(appWidgetId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
@@ -26,7 +26,7 @@ import org.wordpress.android.ui.reader.repository.usecases.FetchDiscoverCardsUse
 import org.wordpress.android.ui.reader.repository.usecases.GetDiscoverCardsUseCase
 import org.wordpress.android.ui.reader.repository.usecases.PostLikeActionUseCase
 import org.wordpress.android.ui.reader.repository.usecases.ShouldAutoUpdateTagUseCase
-import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FORCE
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FIRST_PAGE
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.viewmodel.Event
@@ -82,7 +82,7 @@ class ReaderDiscoverRepository constructor(
 
     suspend fun refreshPosts() {
         withContext(ioDispatcher) {
-            val response = fetchDiscoverCardsUseCase.fetch(REQUEST_FORCE)
+            val response = fetchDiscoverCardsUseCase.fetch(REQUEST_FIRST_PAGE)
             if (response != Success) _communicationChannel.postValue(Event(response))
         }
     }
@@ -112,7 +112,7 @@ class ReaderDiscoverRepository constructor(
                 _discoverFeed.postValue(result)
             }
             if (refresh) {
-                val response = fetchDiscoverCardsUseCase.fetch(REQUEST_FORCE)
+                val response = fetchDiscoverCardsUseCase.fetch(REQUEST_FIRST_PAGE)
                 if (response != Success) _communicationChannel.postValue(Event(response))
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -61,20 +61,10 @@ class ReaderDiscoverLogic constructor(
     fun performTasks(task: DiscoverTasks, companion: JobParameters?) {
         listenerCompanion = companion
 
-        when (task) {
-            REQUEST_MORE -> {
-                requestDataForDiscover(REQUEST_MORE, UpdateResultListener {
-                    EventBus.getDefault().post(FetchDiscoverCardsEnded(it != FAILED))
-                    completionListener.onCompleted(listenerCompanion)
-                })
-            }
-            REQUEST_FIRST_PAGE -> {
-                requestDataForDiscover(REQUEST_FIRST_PAGE, UpdateResultListener {
-                    EventBus.getDefault().post(FetchDiscoverCardsEnded(it != FAILED))
-                    completionListener.onCompleted(listenerCompanion)
-                })
-            }
-        }
+        requestDataForDiscover(task, UpdateResultListener {
+            EventBus.getDefault().post(FetchDiscoverCardsEnded(it != FAILED))
+            completionListener.onCompleted(listenerCompanion)
+        })
     }
 
     private fun requestDataForDiscover(taskType: DiscoverTasks, resultListener: UpdateResultListener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.models.discover.ReaderDiscoverCard
 import org.wordpress.android.models.discover.ReaderDiscoverCard.InterestsYouMayLikeCard
 import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderPostCard
 import org.wordpress.android.modules.AppComponent
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.ReaderConstants.JSON_CARDS
 import org.wordpress.android.ui.reader.ReaderConstants.JSON_CARD_DATA
 import org.wordpress.android.ui.reader.ReaderConstants.JSON_CARD_INTERESTS_YOU_MAY_LIKE
@@ -24,14 +25,14 @@ import org.wordpress.android.ui.reader.ReaderConstants.POST_ID
 import org.wordpress.android.ui.reader.ReaderConstants.POST_PSEUDO_ID
 import org.wordpress.android.ui.reader.ReaderConstants.POST_SITE_ID
 import org.wordpress.android.ui.reader.ReaderEvents.FetchDiscoverCardsEnded
-import org.wordpress.android.ui.reader.actions.ReaderActions
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult.FAILED
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult.HAS_NEW
+import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult.UNCHANGED
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResultListener
 import org.wordpress.android.ui.reader.repository.usecases.ParseDiscoverCardsJsonUseCase
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener
-import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST
-import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FORCE
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FIRST_PAGE
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_MORE
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.READER
 import java.util.HashMap
@@ -49,9 +50,10 @@ class ReaderDiscoverLogic constructor(
     }
 
     @Inject lateinit var parseDiscoverCardsJsonUseCase: ParseDiscoverCardsJsonUseCase
+    @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
 
     enum class DiscoverTasks {
-        REQUEST, REQUEST_FORCE
+        REQUEST_MORE, REQUEST_FIRST_PAGE
     }
 
     private var listenerCompanion: JobParameters? = null
@@ -60,14 +62,14 @@ class ReaderDiscoverLogic constructor(
         listenerCompanion = companion
 
         when (task) {
-            REQUEST -> {
-                requestDataForDiscover(false, UpdateResultListener {
+            REQUEST_MORE -> {
+                requestDataForDiscover(REQUEST_MORE, UpdateResultListener {
                     EventBus.getDefault().post(FetchDiscoverCardsEnded(it != FAILED))
                     completionListener.onCompleted(listenerCompanion)
                 })
             }
-            REQUEST_FORCE -> {
-                requestDataForDiscover(true, UpdateResultListener {
+            REQUEST_FIRST_PAGE -> {
+                requestDataForDiscover(REQUEST_FIRST_PAGE, UpdateResultListener {
                     EventBus.getDefault().post(FetchDiscoverCardsEnded(it != FAILED))
                     completionListener.onCompleted(listenerCompanion)
                 })
@@ -75,18 +77,27 @@ class ReaderDiscoverLogic constructor(
         }
     }
 
-    private fun requestDataForDiscover(forceRefresh: Boolean, resultListener: ReaderActions.UpdateResultListener) {
+    private fun requestDataForDiscover(taskType: DiscoverTasks, resultListener: UpdateResultListener) {
         val params = HashMap<String, String>()
         // TODO malinjir pass interests the user is following
         params["tags"] = "android"
 
-        if (!forceRefresh) {
-            params["page_handle"] = ""
-            // TODO malinjir load page handle
+        when (taskType) {
+            REQUEST_FIRST_PAGE -> appPrefsWrapper.readerCardsPageHandle = null
+            REQUEST_MORE -> {
+                val pageHandle = appPrefsWrapper.readerCardsPageHandle
+                if (pageHandle?.isNotEmpty() == true) {
+                    params["page_handle"] = pageHandle
+                } else {
+                    // there are no more pages to load
+                    resultListener.onUpdateResult(UNCHANGED)
+                    return
+                }
+            }
         }
 
         val listener = Listener { jsonObject -> // remember when this tag was updated if newer posts were requested
-            if (forceRefresh) {
+            if (taskType == REQUEST_FIRST_PAGE) {
                 // TODO malinjir clear cache
             }
             handleRequestDiscoverDataResponse(jsonObject, resultListener)
@@ -116,7 +127,7 @@ class ReaderDiscoverLogic constructor(
         insertCardsJsonIntoDb(simplifiedCardsJson)
 
         val nextPageHandle = parseDiscoverCardsJsonUseCase.parseNextPageHandle(json)
-        // TODO malinjir save next page handle into shared preferences
+        appPrefsWrapper.readerCardsPageHandle = nextPageHandle
 
         resultListener.onUpdateResult(HAS_NEW)
     }


### PR DESCRIPTION
Parent issue #12319

This PR takes care of saving "page_handle" for the "/cards" endpoint.
We also
- load the page_handle and attach it to the request when loading more items.
- clear the page_handle when loading the first page (force refresh)
- return "unchanged" when the page_handle is null (no more items are available) and we are trying to load more items

To test:
This will be tested with the introduction of "load" more on the ui. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
