### PR TITLE
Issue/12319 clear cards cache when necessary

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
@@ -21,6 +21,10 @@ object ReaderDiscoverCardsTable {
         db.execSQL("DROP TABLE IF EXISTS tbl_discover_cards")
     }
 
+    fun reset() {
+        reset(getWritableDb())
+    }
+
     fun reset(db: SQLiteDatabase) {
         AppLog.i(AppLog.T.READER, "resetting ReaderDiscoverCardsTable")
         dropTables(db)

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -228,6 +228,13 @@ public class ReaderTag implements Serializable, FilterCriteria {
         return true;
     }
 
+    /**
+     * Local only tag used to identify post cards for the "discover" tab in the Reader.
+     */
+    public static ReaderTag createDiscoverPostCardsTag() {
+        return new ReaderTag("", "", "", "", ReaderTagType.DISCOVER_POST_CARDS);
+    }
+
     @Override
     public boolean equals(Object object) {
         if (object instanceof ReaderTag) {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTagType.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTagType.java
@@ -7,7 +7,8 @@ public enum ReaderTagType {
     RECOMMENDED,
     CUSTOM_LIST,
     SEARCH,
-    INTERESTS;
+    INTERESTS,
+    DISCOVER_POST_CARDS;
 
     private static final int INT_DEFAULT = 0;
     private static final int INT_FOLLOWED = 1;
@@ -16,6 +17,7 @@ public enum ReaderTagType {
     private static final int INT_SEARCH = 4;
     private static final int INT_BOOKMARKED = 5;
     private static final int INT_INTERESTS = 6;
+    private static final int INT_DISCOVER_POST_CARDS = 7;
 
 
     public static ReaderTagType fromInt(int value) {
@@ -32,6 +34,8 @@ public enum ReaderTagType {
                 return BOOKMARKED;
             case INT_INTERESTS:
                 return INTERESTS;
+            case INT_DISCOVER_POST_CARDS:
+                return DISCOVER_POST_CARDS;
             default:
                 return DEFAULT;
         }
@@ -51,6 +55,8 @@ public enum ReaderTagType {
                 return INT_BOOKMARKED;
             case INTERESTS:
                 return INT_INTERESTS;
+            case DISCOVER_POST_CARDS:
+                return INT_DISCOVER_POST_CARDS;
             case DEFAULT:
             default:
                 return INT_DEFAULT;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
@@ -26,7 +26,7 @@ import org.wordpress.android.ui.reader.repository.usecases.FetchDiscoverCardsUse
 import org.wordpress.android.ui.reader.repository.usecases.GetDiscoverCardsUseCase
 import org.wordpress.android.ui.reader.repository.usecases.PostLikeActionUseCase
 import org.wordpress.android.ui.reader.repository.usecases.ShouldAutoUpdateTagUseCase
-import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FORCE
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FIRST_PAGE
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.viewmodel.Event
@@ -82,7 +82,7 @@ class ReaderDiscoverRepository constructor(
 
     suspend fun refreshPosts() {
         withContext(ioDispatcher) {
-            val response = fetchDiscoverCardsUseCase.fetch(REQUEST_FORCE)
+            val response = fetchDiscoverCardsUseCase.fetch(REQUEST_FIRST_PAGE)
             if (response != Success) _communicationChannel.postValue(Event(response))
         }
     }
@@ -112,7 +112,7 @@ class ReaderDiscoverRepository constructor(
                 _discoverFeed.postValue(result)
             }
             if (refresh) {
-                val response = fetchDiscoverCardsUseCase.fetch(REQUEST_FORCE)
+                val response = fetchDiscoverCardsUseCase.fetch(REQUEST_FIRST_PAGE)
                 if (response != Success) _communicationChannel.postValue(Event(response))
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -158,7 +158,7 @@ class ReaderDiscoverLogic constructor(
     private fun insertPostsIntoDb(posts: List<ReaderPost>) {
         val postList = ReaderPostList()
         postList.addAll(posts)
-        ReaderPostTable.addOrUpdatePosts(null, postList)
+        ReaderPostTable.addOrUpdatePosts(ReaderTag.createDiscoverPostCardsTag(), postList)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.datasets.ReaderDiscoverCardsTable
 import org.wordpress.android.datasets.ReaderPostTable
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderPostList
+import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.discover.ReaderDiscoverCard
 import org.wordpress.android.models.discover.ReaderDiscoverCard.InterestsYouMayLikeCard
 import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderPostCard
@@ -97,10 +98,7 @@ class ReaderDiscoverLogic constructor(
         }
 
         val listener = Listener { jsonObject -> // remember when this tag was updated if newer posts were requested
-            if (taskType == REQUEST_FIRST_PAGE) {
-                // TODO malinjir clear cache
-            }
-            handleRequestDiscoverDataResponse(jsonObject, resultListener)
+            handleRequestDiscoverDataResponse(taskType, jsonObject, resultListener)
         }
         val errorListener = ErrorListener { volleyError ->
             AppLog.e(READER, volleyError)
@@ -110,11 +108,18 @@ class ReaderDiscoverLogic constructor(
         WordPress.getRestClientUtilsV2()["read/tags/cards", params, null, listener, errorListener]
     }
 
-    private fun handleRequestDiscoverDataResponse(json: JSONObject?, resultListener: UpdateResultListener) {
+    private fun handleRequestDiscoverDataResponse(
+        taskType: DiscoverTasks,
+        json: JSONObject?,
+        resultListener: UpdateResultListener
+    ) {
         // TODO malinjir move to bg thread
         if (json == null) {
             resultListener.onUpdateResult(FAILED)
             return
+        }
+        if (taskType == REQUEST_FIRST_PAGE) {
+            clearCache()
         }
         val fullCardsJson = json.optJSONArray(JSON_CARDS)
 
@@ -199,5 +204,10 @@ class ReaderDiscoverLogic constructor(
 
     private fun insertCardsJsonIntoDb(simplifiedCardsJson: JSONArray) {
         ReaderDiscoverCardsTable.addCardsPage(simplifiedCardsJson.toString())
+    }
+
+    private fun clearCache() {
+        ReaderDiscoverCardsTable.reset()
+        ReaderPostTable.deletePostsWithTag(ReaderTag.createDiscoverPostCardsTag())
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -175,6 +175,9 @@ public class ReaderUpdateLogic {
                         )
                 );
 
+                // manually insert DISCOVER_POST_CARDS tag which is used to store posts for the discover tab
+                serverTopics.add(ReaderTag.createDiscoverPostCardsTag());
+
                 // parse topics from the response, detect whether they're different from local
                 ReaderTagList localTopics = new ReaderTagList();
                 localTopics.addAll(ReaderTagTable.getDefaultTags());


### PR DESCRIPTION
Parent issue #12319 

Merge instructions
1. Review this PR
2. Check if https://github.com/wordpress-mobile/WordPress-Android/pull/12572 has been merged. If it was, update the target branch to develop.
5. Merge this PR

This PR takes care of clearing cached posts fetched from the /cards endpoint after we force fetch the first page. I don't like this solution, but I couldn't come up with anything better. We use a similar approach for "Bookmark/SavedForLater" posts. 

The solution introduces a new local only ReaderTag. All the posts fetched from the /cards endpoint are stored under this tag so it's easy to filter them and purge the cache after we fetch a new data.

To test:
1. Clear app data
1. Turn on the RI Feature Flag
2. Go to "Discover" tab and notice there are posts displayed
3. Go to following tab just to make sure you fetch some other posts
4. Open Stetho and check the first ten posts (ordered by rowId) - these are the posts for the discover tab
5. Kill the app and start it again
6. Open Discover
7. Open Stetho and notice the first ten posts are not there and they are now on the last 10 ids (they were removed and re-insterted)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
