### PR TITLE
Fix isDirty check

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
@@ -36,6 +36,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
+// todo annmarie rename repository to Provider
 class ReaderDiscoverRepository constructor(
     private val ioDispatcher: CoroutineDispatcher,
     private val eventBusWrapper: EventBusWrapper,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverRepository.kt
@@ -114,7 +114,7 @@ class ReaderDiscoverRepository constructor(
             val refresh =
                     shouldAutoUpdateTagUseCase.get(readerTag)
 
-            if (forceReload || !existsInMemory ) {
+            if (forceReload || !existsInMemory) {
                 reloadPosts()
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
@@ -107,13 +107,15 @@ class ReaderPostRepository(
     // Internal functionality
     private suspend fun loadPosts() {
         withContext(ioDispatcher) {
+            val forceReload = isDirty.getAndSet(false)
             val existsInMemory = posts.value?.let {
                 !it.isEmpty()
             } ?: false
-            val refresh =
-                    shouldAutoUpdateTagUseCase.get(readerTag) || isDirty.getAndSet(false)
 
-            if (!existsInMemory) {
+            val refresh =
+                    shouldAutoUpdateTagUseCase.get(readerTag)
+
+            if (forceReload || !existsInMemory ) {
                 reloadPosts()
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
@@ -115,7 +115,7 @@ class ReaderPostRepository(
             val refresh =
                     shouldAutoUpdateTagUseCase.get(readerTag)
 
-            if (forceReload || !existsInMemory ) {
+            if (forceReload || !existsInMemory) {
                 reloadPosts()
             }
 


### PR DESCRIPTION
Addresses a bug in  #12039 

This PR moves the isDirty logic from the refresh check to the reload check. When the data is dirty, it should be reloaded from the database, not fetched from the server.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
