### PR TITLE
Fixing support for reader page jump

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -21,6 +21,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.CookieManager
+import android.webkit.ValueCallback
 import android.webkit.WebView
 import android.widget.ProgressBar
 import android.widget.TextView
@@ -1501,6 +1502,19 @@ class ReaderPostDetailFragment : Fragment(),
             val openUrlType = if (shouldOpenExternal(url)) OpenUrlType.EXTERNAL else OpenUrlType.INTERNAL
             ReaderActivityLauncher.openUrl(activity, url, openUrlType)
         }
+        return true
+    }
+
+    override fun onPageJumpClick(pageJump: String?): Boolean {
+        val jsWasEnabled = readerWebView.settings.javaScriptEnabled
+
+        readerWebView.settings.javaScriptEnabled = true
+
+        readerWebView.evaluateJavascript("document.getElementById('$pageJump').offsetTop") {
+            val yOffset = (readerWebView.scale * it.toFloat()).toInt()
+            scrollView.smoothScrollTo(0, yOffset)
+        }
+        readerWebView.settings.javaScriptEnabled = jsWasEnabled
         return true
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1510,7 +1510,7 @@ class ReaderPostDetailFragment : Fragment(),
 
         readerWebView.settings.javaScriptEnabled = true
 
-        readerWebView.evaluateJavascript("document.getElementById('$pageJump').offsetTop") {result ->
+        readerWebView.evaluateJavascript("document.getElementById('$pageJump').offsetTop") { result ->
             // Note that 'result' can be the string 'null' in case the page jump identifier is not found on page
             val offsetTop = StringUtils.stringToInt(result, -1)
             if (offsetTop >= 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -111,6 +111,7 @@ import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.HtmlUtils
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.PermissionUtils
+import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.WPPermissionUtils.READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE
@@ -1505,15 +1506,22 @@ class ReaderPostDetailFragment : Fragment(),
     }
 
     override fun onPageJumpClick(pageJump: String?): Boolean {
-        val jsWasEnabled = readerWebView.settings.javaScriptEnabled
+        val wasJsEnabled = readerWebView.settings.javaScriptEnabled
 
         readerWebView.settings.javaScriptEnabled = true
 
-        readerWebView.evaluateJavascript("document.getElementById('$pageJump').offsetTop") {
-            val yOffset = (readerWebView.scale * it.toFloat()).toInt()
-            scrollView.smoothScrollTo(0, yOffset)
+        readerWebView.evaluateJavascript("document.getElementById('$pageJump').offsetTop") {result ->
+            // Note that 'result' can be the string 'null' in case the page jump identifier is not found on page
+            val offsetTop = StringUtils.stringToInt(result, -1)
+            if (offsetTop >= 0) {
+                val yOffset = (resources.displayMetrics.density * offsetTop).toInt()
+                scrollView.smoothScrollTo(0, yOffset)
+            } else {
+                ToastUtils.showToast(activity, R.string.reader_toast_err_page_jump_not_found)
+            }
         }
-        readerWebView.settings.javaScriptEnabled = jsWasEnabled
+
+        readerWebView.settings.javaScriptEnabled = wasJsEnabled
         return true
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -21,7 +21,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.CookieManager
-import android.webkit.ValueCallback
 import android.webkit.WebView
 import android.widget.ProgressBar
 import android.widget.TextView

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -37,6 +37,8 @@ public class ReaderWebView extends WPWebView {
         @SuppressWarnings("SameReturnValue")
         boolean onUrlClick(String url);
 
+        boolean onPageJumpClick(String pageJump);
+
         boolean onImageUrlClick(String imageUrl, View view, int x, int y);
 
         boolean onFileDownloadClick(String fileUrl);
@@ -195,15 +197,22 @@ public class ReaderWebView extends WPWebView {
     public boolean onTouchEvent(MotionEvent event) {
         if (event.getAction() == MotionEvent.ACTION_UP && mUrlClickListener != null) {
             HitTestResult hr = getHitTestResult();
-            if (hr != null && isValidClickedUrl(hr.getExtra())) {
-                if (UrlUtils.isImageUrl(hr.getExtra())) {
-                    return mUrlClickListener.onImageUrlClick(
-                            hr.getExtra(),
-                            this,
-                            (int) event.getX(),
-                            (int) event.getY());
+            if (hr != null) {
+                if (isValidClickedUrl(hr.getExtra())) {
+                    if (UrlUtils.isImageUrl(hr.getExtra())) {
+                        return mUrlClickListener.onImageUrlClick(
+                                hr.getExtra(),
+                                this,
+                                (int) event.getX(),
+                                (int) event.getY());
+                    } else {
+                        return mUrlClickListener.onUrlClick(hr.getExtra());
+                    }
                 } else {
-                    return mUrlClickListener.onUrlClick(hr.getExtra());
+                    String pageJump = UrlUtils.getPageJumpOrNull(hr.getExtra());
+                    if (null != pageJump) {
+                        return mUrlClickListener.onPageJumpClick(pageJump);
+                    }
                 }
             }
         }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1795,6 +1795,7 @@
     <string name="reader_toast_err_comment_not_found">Comment not found!</string>
     <string name="reader_toast_err_already_liked">You have already liked that comment</string>
     <string name="reader_toast_err_url_intent">Unable to open %s</string>
+    <string name="reader_toast_err_page_jump_not_found">Unable to find the linked page jump</string>
 
     <!-- snackbar messages -->
     <string name="reader_snackbar_err_cannot_like_post_logged_out">Can\'t like while logged out of WordPress.com</string>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -19,8 +19,6 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.wordpress.android.util.PhotonUtils.ATOMIC_MEDIA_PROXY_URL_PREFIX;
 import static org.wordpress.android.util.PhotonUtils.ATOMIC_MEDIA_PROXY_URL_SUFFIX;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -5,6 +5,8 @@ import android.text.TextUtils;
 import android.webkit.MimeTypeMap;
 import android.webkit.URLUtil;
 
+import androidx.annotation.Nullable;
+
 import org.wordpress.android.util.AppLog.T;
 
 import java.io.UnsupportedEncodingException;
@@ -17,6 +19,8 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.wordpress.android.util.PhotonUtils.ATOMIC_MEDIA_PROXY_URL_PREFIX;
 import static org.wordpress.android.util.PhotonUtils.ATOMIC_MEDIA_PROXY_URL_SUFFIX;
@@ -255,6 +259,20 @@ public class UrlUtils {
 
         return cleanedUrl.endsWith("jpg") || cleanedUrl.endsWith("jpeg")
                || cleanedUrl.endsWith("gif") || cleanedUrl.endsWith("png");
+    }
+
+    public static @Nullable String getPageJumpOrNull(String url) {
+        if (TextUtils.isEmpty(url)) {
+            return null;
+        }
+
+        if (url.contains("#")
+            && url.indexOf("#") < url.length() - 1
+            && url.split("#").length == 2) {
+            return url.substring(url.indexOf('#') + 1);
+        }
+
+        return null;
     }
 
     private static boolean isAtomicImageProxyUrl(String urlString) {


### PR DESCRIPTION
Fixes #7654 

Inspired by a @khaykov comment [here](https://github.com/wordpress-mobile/WordPress-Android/issues/7654#issuecomment-640883823) I tried to further explore that solution in this PR.

Result below

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/89052144-909b5000-d355-11ea-8798-f614de6e8a62.gif>
</p>

## To test

You can use this link to the post shown in the gif https://demo2020061600.wordpress.com/2020/07/31/up-bottom-2/
- check the page jump up to bottom works
- check the page jump bottom up works
- check the external link works
- smoke test the reader post detail

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
