### PR TITLE
Updating aztec version to v1.3.44

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     ext {
-        aztecVersion = 'v1.3.42'
+        aztecVersion = 'v1.3.44'
     }
 
     dependencies {


### PR DESCRIPTION
PR's to Aztec since last version:

- [#909](https://github.com/wordpress-mobile/AztecEditor-Android/pull/909) - Adds the fix to animate the "+" image icon after the user clicks it.
- [#919](https://github.com/wordpress-mobile/AztecEditor-Android/pull/919) - Updates the strikethrough button to default to `<s>` tag instead of `<del>` tag

Related PR's:
- GB-Mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2526
- Gutenberg: https://github.com/WordPress/gutenberg/pull/24314



To test: See above links for steps used to test before merging above PR's

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
