### PR TITLE
Renamed repos to data provider

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -58,7 +58,7 @@ class ReaderDiscoverViewModel @Inject constructor(
     private val photonWidth: Int = 500
     private val photonHeight: Int = 500
 
-    private lateinit var mReaderDiscoverDataProvider: ReaderDiscoverDataProvider
+    private lateinit var readerDiscoverDataProvider: ReaderDiscoverDataProvider
 
     fun start() {
         if (isStarted) return
@@ -72,11 +72,11 @@ class ReaderDiscoverViewModel @Inject constructor(
         _uiState.value = LoadingUiState
 
         // Get the correct repository
-        mReaderDiscoverDataProvider = readerDiscoverDataProviderFactory.create()
-        mReaderDiscoverDataProvider.start()
+        readerDiscoverDataProvider = readerDiscoverDataProviderFactory.create()
+        readerDiscoverDataProvider.start()
 
         // Listen to changes to the discover feed
-        _uiState.addSource(mReaderDiscoverDataProvider.discoverFeed) { posts ->
+        _uiState.addSource(readerDiscoverDataProvider.discoverFeed) { posts ->
             _uiState.value = ContentUiState(
                     // TODO malinjir we currently ignore all other types but ReaderPostCards
                     posts.cards.filterIsInstance<ReaderPostCard>().map {
@@ -98,7 +98,7 @@ class ReaderDiscoverViewModel @Inject constructor(
             )
         }
 
-        mReaderDiscoverDataProvider.communicationChannel.observeForever { data ->
+        readerDiscoverDataProvider.communicationChannel.observeForever { data ->
             data?.let {
                 // TODO listen for communications from the reeaderPostRepository, but not 4ever!
             }
@@ -169,7 +169,7 @@ class ReaderDiscoverViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        mReaderDiscoverDataProvider.stop()
+        readerDiscoverDataProvider.stop()
     }
 
     sealed class DiscoverUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProvider.kt
@@ -9,22 +9,16 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.BACKGROUND
-import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType.DEFAULT
 import org.wordpress.android.models.discover.ReaderDiscoverCards
 import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.ui.reader.ReaderConstants
 import org.wordpress.android.ui.reader.ReaderEvents.UpdatePostsEnded
-import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.Failure
-import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.Success
-import org.wordpress.android.ui.reader.repository.ReaderRepositoryEvent.PostLikeEnded.PostLikeFailure
-import org.wordpress.android.ui.reader.repository.ReaderRepositoryEvent.PostLikeEnded.PostLikeSuccess
-import org.wordpress.android.ui.reader.repository.ReaderRepositoryEvent.PostLikeEnded.PostLikeUnChanged
+import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.Started
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryEvent.ReaderPostTableActionEnded
 import org.wordpress.android.ui.reader.repository.usecases.FetchDiscoverCardsUseCase
 import org.wordpress.android.ui.reader.repository.usecases.GetDiscoverCardsUseCase
-import org.wordpress.android.ui.reader.repository.usecases.PostLikeActionUseCase
 import org.wordpress.android.ui.reader.repository.usecases.ShouldAutoUpdateTagUseCase
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FIRST_PAGE
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
@@ -36,16 +30,14 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
-// todo annmarie rename repository to Provider
-class ReaderDiscoverRepository constructor(
+class ReaderDiscoverDataProvider constructor(
     private val ioDispatcher: CoroutineDispatcher,
     private val eventBusWrapper: EventBusWrapper,
     private val readerTag: ReaderTag,
     private val getDiscoverCardsUseCase: GetDiscoverCardsUseCase,
     private val shouldAutoUpdateTagUseCase: ShouldAutoUpdateTagUseCase,
     private val fetchDiscoverCardsUseCase: FetchDiscoverCardsUseCase,
-    private val readerUpdatePostsEndedHandler: ReaderUpdatePostsEndedHandler,
-    private val postLikeActionUseCase: PostLikeActionUseCase
+    private val readerUpdatePostsEndedHandler: ReaderUpdatePostsEndedHandler
 ) : CoroutineScope {
     private var job: Job = Job()
 
@@ -84,22 +76,8 @@ class ReaderDiscoverRepository constructor(
     suspend fun refreshPosts() {
         withContext(ioDispatcher) {
             val response = fetchDiscoverCardsUseCase.fetch(REQUEST_FIRST_PAGE)
-            if (response != Success) _communicationChannel.postValue(Event(response))
-        }
-    }
-
-    suspend fun performLikeAction(post: ReaderPost, isAskingToLike: Boolean, wpComUserId: Long) {
-        withContext(ioDispatcher) {
-            when (val event = postLikeActionUseCase.perform(post, isAskingToLike, wpComUserId)) {
-                is PostLikeSuccess -> {
-                    reloadPosts()
-                }
-                is PostLikeFailure -> {
-                    _communicationChannel.postValue(Event(Failure(event)))
-                    reloadPosts()
-                }
-                is PostLikeUnChanged -> { }
-            }
+            // todo annmarie do we want to post all responses on the communication channel
+            if (response != Started) _communicationChannel.postValue(Event(response))
         }
     }
 
@@ -116,7 +94,8 @@ class ReaderDiscoverRepository constructor(
 
             if (refresh) {
                 val response = fetchDiscoverCardsUseCase.fetch(REQUEST_FIRST_PAGE)
-                if (response != Success) _communicationChannel.postValue(Event(response))
+                // todo annmarie do we want to post all responses on the communication channel
+                if (response != Started) _communicationChannel.postValue(Event(response))
             }
         }
     }
@@ -180,22 +159,20 @@ class ReaderDiscoverRepository constructor(
         private val getDiscoverCardsUseCase: GetDiscoverCardsUseCase,
         private val shouldAutoUpdateTagUseCase: ShouldAutoUpdateTagUseCase,
         private val fetchDiscoverCardsUseCase: FetchDiscoverCardsUseCase,
-        private val readerUpdatePostsEndedHandler: ReaderUpdatePostsEndedHandler,
-        private val postLikeActionUseCase: PostLikeActionUseCase
+        private val readerUpdatePostsEndedHandler: ReaderUpdatePostsEndedHandler
     ) {
-        fun create(readerTag: ReaderTag? = null): ReaderDiscoverRepository {
+        fun create(readerTag: ReaderTag? = null): ReaderDiscoverDataProvider {
             val tag = readerTag
                     ?: readerUtilsWrapper.getTagFromTagName(ReaderConstants.KEY_DISCOVER, DEFAULT)
 
-            return ReaderDiscoverRepository(
+            return ReaderDiscoverDataProvider(
                     ioDispatcher,
                     eventBusWrapper,
                     tag,
                     getDiscoverCardsUseCase,
                     shouldAutoUpdateTagUseCase,
                     fetchDiscoverCardsUseCase,
-                    readerUpdatePostsEndedHandler,
-                    postLikeActionUseCase
+                    readerUpdatePostsEndedHandler
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderRepositoryEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderRepositoryEvents.kt
@@ -18,6 +18,7 @@ sealed class ReaderRepositoryEvent {
 }
 
 sealed class ReaderRepositoryCommunication {
+    object Started : ReaderRepositoryCommunication()
     object Success : ReaderRepositoryCommunication()
     data class SuccessWithData<out T>(val data: T) : ReaderRepositoryCommunication()
     class Failure(val event: ReaderRepositoryEvent) : ReaderRepositoryCommunication()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/FetchDiscoverCardsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/FetchDiscoverCardsUseCase.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.reader.repository.usecases
 
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.Error.NetworkUnavailable
-import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.Success
+import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.Started
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverServiceStarter
 import org.wordpress.android.util.NetworkUtilsWrapper
@@ -20,6 +20,6 @@ class FetchDiscoverCardsUseCase @Inject constructor(
 
         ReaderDiscoverServiceStarter.startService(contextProvider.getContext(), discoverTask)
 
-        return Success
+        return Started
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/FetchPostsForTagUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/FetchPostsForTagUseCase.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.reader.repository.usecases
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.Error.NetworkUnavailable
-import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.Success
+import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.Started
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction.REQUEST_NEWER
@@ -26,6 +26,6 @@ class FetchPostsForTagUseCase @Inject constructor(
             updateAction
         )
 
-        return Success
+        return Started
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -24,7 +24,7 @@ import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.Discover
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
-import org.wordpress.android.ui.reader.repository.ReaderDiscoverRepository
+import org.wordpress.android.ui.reader.repository.ReaderDiscoverDataProvider
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ReactiveMutableLiveData
@@ -35,8 +35,8 @@ class ReaderDiscoverViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 
-    @Mock private lateinit var readerDiscoverRepositoryFactory: ReaderDiscoverRepository.Factory
-    @Mock private lateinit var readerDiscoverRepository: ReaderDiscoverRepository
+    @Mock private lateinit var mReaderDiscoverDataProviderFactory: ReaderDiscoverDataProvider.Factory
+    @Mock private lateinit var mReaderDiscoverDataProvider: ReaderDiscoverDataProvider
     @Mock private lateinit var uiStateBuilder: ReaderPostUiStateBuilder
     @Mock private lateinit var readerPostCardActionsHandler: ReaderPostCardActionsHandler
     @Mock private lateinit var reblogUseCase: ReblogUseCase
@@ -48,23 +48,23 @@ class ReaderDiscoverViewModelTest {
 
     @Before
     fun setUp() = test {
-        whenever(readerDiscoverRepositoryFactory.create()).thenReturn(readerDiscoverRepository)
+        whenever(mReaderDiscoverDataProviderFactory.create()).thenReturn(mReaderDiscoverDataProvider)
         viewModel = ReaderDiscoverViewModel(
-                readerDiscoverRepositoryFactory,
+                mReaderDiscoverDataProviderFactory,
                 uiStateBuilder,
                 readerPostCardActionsHandler,
                 reblogUseCase,
                 TEST_DISPATCHER,
                 TEST_DISPATCHER
         )
-        whenever(readerDiscoverRepository.discoverFeed).thenReturn(fakeDiscoverFeed)
+        whenever(mReaderDiscoverDataProvider.discoverFeed).thenReturn(fakeDiscoverFeed)
         whenever(
                 uiStateBuilder.mapPostToUiState(
                         anyOrNull(), anyInt(), anyInt(), anyOrNull(), anyBoolean(), anyOrNull(),
                         anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
                 )
         ).thenReturn(mock())
-        whenever(readerDiscoverRepository.communicationChannel).thenReturn(communicationChannel)
+        whenever(mReaderDiscoverDataProvider.communicationChannel).thenReturn(communicationChannel)
     }
 
     @Test


### PR DESCRIPTION
Fixes #12553 

- Renames `ReaderPostRepository` to `ReaderPostDataProvider`
- Renames `ReaderDiscoverRepository` to `ReaderDiscoverDataProvider.`
- Removes the like action functionality
- Adds `Started` to `ReaderRepositoryCommunication` and replaced Success in `FetchPostsForTagUseCase` and `FetchDiscoverCardsUseCase`

To test
Open the app with 
Set FF_READER_IMPROVEMENTS_PHASE_2 to true
Navigate to reader
Discover feed should load

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
