### PR TITLE
Increase the cursor window size to 5MB

### DIFF
--- a/WordPress/src/debug/java/org/wordpress/android/WPWellSqlConfig.kt
+++ b/WordPress/src/debug/java/org/wordpress/android/WPWellSqlConfig.kt
@@ -37,4 +37,11 @@ class WPWellSqlConfig(context: Context) : WellSqlConfig(context) {
             super.onDowngrade(db, helper, oldVersion, newVersion)
         }
     }
+
+    /**
+     * Increase the cursor window size to 5MB for devices running API 28 and above. This should reduce the
+     * number of SQLiteBlobTooBigExceptions. Note that this is only called on API 28 and
+     * above since earlier versions don't allow adjusting the cursor window size.
+     */
+    override fun getCursorWindowSize() = (1024L * 1024L * 5L)
 }


### PR DESCRIPTION
Partially fixes https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/1513 and several other similar issues. Please check https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1586 and https://github.com/woocommerce/woocommerce-android/pull/2627 for details. Thanks @nbradbury & @AmandaRiu!

**To test:**
Smoke test the app.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
