### PR TITLE
Remove animateLayoutChanges from discover fragment

### DIFF
--- a/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/constraint_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:animateLayoutChanges="true">
+    android:layout_height="match_parent">
 
     <ProgressBar
         android:id="@+id/progress_bar"


### PR DESCRIPTION
Parent issue #12028

Fixes the following exception which sometime occurs when you switch tabs in reader:
```
java.lang.IllegalStateException: Page(s) contain a ViewGroup with a LayoutTransition (or animateLayoutChanges="true"), which interferes with the scrolling animation. Make sure to call getLayoutTransition().setAnimateParentHierarchy(false) on all ViewGroups with a LayoutTr...
```
It was caused by "animateLayoutChanges" flag on the discover fragment container. This flag isn't necessary for this screen as the RecyclerView will take care of layout animation changes on the items. We could potentially animate from progress shown state to progress hidden state, but we don't do that anywhere else anyway.

To test:
Smoke test discover screen with RI FF flag on

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
