### PR TITLE
Prevent second open editor action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -66,9 +66,12 @@ class PostListFragment : Fragment() {
         PostListAdapter(
                 context = nonNullActivity,
                 imageManager = imageManager,
-                uiHelpers = uiHelpers
+                uiHelpers = uiHelpers,
+                postListFragment = this
         )
     }
+
+    public var canStartEditPostActivity= true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -137,6 +140,12 @@ class PostListFragment : Fragment() {
         )
 
         initObservers()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        canStartEditPostActivity = true
     }
 
     private fun initObservers() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -61,7 +61,8 @@ sealed class PostListItemViewHolder(
     class Standard(
         parent: ViewGroup,
         imageManager: ImageManager,
-        private val uiHelpers: UiHelpers
+        private val uiHelpers: UiHelpers,
+        private val postListFragment: PostListFragment
     ) : PostListItemViewHolder(R.layout.post_list_item, parent, imageManager, uiHelpers) {
         private val excerptTextView: WPTextView = itemView.findViewById(R.id.excerpt)
         private val actionButtons: List<PostListButton> = listOf(
@@ -74,7 +75,12 @@ sealed class PostListItemViewHolder(
             setBasicValues(item.data)
 
             uiHelpers.setTextOrHide(excerptTextView, item.data.excerpt)
-            itemView.setOnClickListener { item.onSelected.invoke() }
+            itemView.setOnClickListener { view ->
+                if (postListFragment.canStartEditPostActivity) {
+                    postListFragment.canStartEditPostActivity = false
+                    item.onSelected.invoke()
+                }
+            }
 
             actionButtons.forEachIndexed { index, button ->
                 updateMenuItem(button, item.actions.getOrNull(index))
@@ -87,7 +93,12 @@ sealed class PostListItemViewHolder(
                 when (action) {
                     is SingleItem -> {
                         postListButton.updateButtonType(action.buttonType)
-                        postListButton.setOnClickListener { action.onButtonClicked.invoke(action.buttonType) }
+                        postListButton.setOnClickListener { view ->
+                            if (postListFragment.canStartEditPostActivity) {
+                                postListFragment.canStartEditPostActivity = false
+                                action.onButtonClicked.invoke(action.buttonType)
+                            }
+                        }
                     }
                     is MoreItem -> {
                         postListButton.updateButtonType(action.buttonType)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostListAdapter.kt
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.ui.posts.PostListFragment
 import org.wordpress.android.ui.posts.PostListItemViewHolder
 import org.wordpress.android.ui.posts.PostListViewLayoutType
 import org.wordpress.android.ui.posts.PostListViewLayoutType.COMPACT
@@ -31,6 +32,7 @@ private const val VIEW_TYPE_LOADING_COMPACT = 4
 
 class PostListAdapter(
     context: Context,
+    private val postListFragment: PostListFragment,
     private val imageManager: ImageManager,
     private val uiHelpers: UiHelpers
 ) : PagedListAdapter<PostListItemType, ViewHolder>(PostListDiffItemCallback) {
@@ -70,7 +72,7 @@ class PostListAdapter(
                 LoadingViewHolder(view)
             }
             VIEW_TYPE_POST -> {
-                PostListItemViewHolder.Standard(parent, imageManager, uiHelpers)
+                PostListItemViewHolder.Standard(parent, imageManager, uiHelpers, postListFragment)
             }
             VIEW_TYPE_POST_COMPACT -> {
                 PostListItemViewHolder.Compact(parent, imageManager, uiHelpers)


### PR DESCRIPTION
Fixes #10493 

To test:

1. Navigate to Post list
2. Click twice quickly on edit button for a post, or on the post itself
3. Notice you can no longer get to Editors to open up simultaneously. (check linked issue #10493 for more info).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
