### PR TITLE
Adds missing mocks for stats and theme endpoints for screenshot generation

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -18,9 +18,6 @@ import org.wordpress.android.ui.WPLaunchActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.util.image.ImageType;
 
-import tools.fastlane.screengrab.Screengrab;
-import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
-
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 import static org.wordpress.android.support.WPSupportUtils.dialogExistsWithTitle;
 import static org.wordpress.android.support.WPSupportUtils.getCurrentActivity;
@@ -34,6 +31,9 @@ import static org.wordpress.android.support.WPSupportUtils.waitForAtLeastOneElem
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 import static org.wordpress.android.support.WPSupportUtils.waitForImagesOfTypeWithPlaceholder;
+
+import tools.fastlane.screengrab.Screengrab;
+import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -63,8 +63,8 @@ public class WPScreenshotTest extends BaseTest {
 
         editBlogPost();
         manageMedia();
-        navigateStats();
         navigateNotifications();
+        navigateStats();
 
         // Turn Demo Mode off on the emulator when we're done
         mDemoModeEnabler.disable();

--- a/fastlane/playstoreres/assets/intro-text.css
+++ b/fastlane/playstoreres/assets/intro-text.css
@@ -1,5 +1,5 @@
 *{
-	font-family: 'NotoSans';
+	font-family: 'Noto Sans';
 	color: white;
 	text-align: left;
 	line-height: 1.1875;

--- a/fastlane/playstoreres/assets/style.css
+++ b/fastlane/playstoreres/assets/style.css
@@ -1,5 +1,5 @@
 *{
-	font-family: 'NotoSans';
+	font-family: 'Noto Sans';
 	color: white;
 	text-align: center;
 }

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_clicks-year.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_clicks-year.json
@@ -26,8 +26,8 @@
                     "clicks": [
                         {
                             "icon": null,
-                            "url": "https://yourgroovysite.wordpress.com/about/",
-                            "name": "yourgroovysite.wordpress.com/about/",
+                            "url": "https://apps.wordpress.com/",
+                            "name": "apps.wordpress.com",
                             "views": 5,
                             "children": null
                         },

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_referrers.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_referrers.json
@@ -9,7 +9,19 @@
             "date": "{{now format='yyyy-MM-dd'}}",
             "days": {
                 "{{now format='yyyy-MM-dd'}}": {
-                    "groups": [],
+                    "groups": [
+                        {
+                            "group": "WordPress.com Reader",
+                            "name": "WordPress.com Reader",
+                            "url": "https://wordpress.com/read/",
+                            "icon": "https://secure.gravatar.com/blavatar/236c008da9dc0edb4b3464ecebb3fc1d?s=48",
+                            "total": 231,
+                            "follow_data": null,
+                            "results": {
+                                "views": 231
+                            }
+                        }
+                    ],
                     "other_views": 0,
                     "total_views": 0
                 }

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_top-authors.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_top-authors.json
@@ -9,7 +9,15 @@
             "date": "{{now format='yyyy-MM-dd'}}",
             "days": {
                 "{{now format='yyyy-MM-dd'}}": {
-                    "authors": []
+                    "authors": [
+                        {
+                            "name": "e2eflowtestingmobile",
+                            "avatar": "https://1.gravatar.com/avatar/7a4015c11be6a342f65e0e169092d402?s=96&d=identicon",
+                            "views": 145,
+                            "posts": [],
+                            "follow_data": {}
+                        }
+                    ]
                 }
             },
             "period": "day"

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_top-posts.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_top-posts.json
@@ -9,8 +9,18 @@
             "date": "{{now format='yyyy-MM-dd'}}",
             "days": {
                 "{{now format='yyyy-MM-dd'}}": {
-                    "postviews": [],
-                    "total_views": 0
+                    "postviews": [
+                        {
+                            "id": 0,
+                            "href": "https://e2eflowtestingmobile.wordpress.com/",
+                            "date": null,
+                            "title": "Home page / Archives",
+                            "type": "homepage",
+                            "views": 183,
+                            "video_play": false
+                        }
+                    ],
+                    "total_views": 183
                 }
             },
             "period": "day"

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/themes/v2_sites_106707880_themes.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/themes/v2_sites_106707880_themes.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/wp/v2/sites/106707880/themes"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": [
+    ],
+    "headers": {
+      "Content-Type": "application/json",
+      "Connection": "keep-alive",
+      "Cache-Control": "no-cache, must-revalidate, max-age=0"
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes the failing `WPScreenshotTest` test by adding a mocked endpoint for the v2 `themes` endpoint. It also add some data to 3 mocked endpoints for stats so they don't show up as empty sections.

**To test:**
* Run `WPScreenshotTest` and verify that it passes
* Run `WPScreenshotTest` for a different language code ([your choice from this list](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/fastlane/Fastfile#L4-L27)) and verify that it passes

To run the test for a different language code, go to `Run -> Edit Configurations -> Instrumentation arguments -> Instrumentation Extra Params` and add:
* `testLocale = {your_language_choice}`

---

Here are the screenshots I took from the Stats page with these mocked data: https://cloudup.com/c6VGwBx3zWv. I don't think we'll be showing all these in the Play Store screenshots, but I thought it might help us decide on the mocked data.

For the data, I pulled the name and such from other mocked data and put in some random numbers. We can modify them as we please. @mattmiklic @bummytime (or anyone else) any ideas for what we might want to change in the above screenshots? 

---

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
