### PR TITLE
Issue/12578 quick start prompt after login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -946,6 +946,17 @@ public class ActivityLauncher {
         activity.startActivityForResult(intent, RequestCodes.CREATE_SITE);
     }
 
+    public static void showMainActivityAndSiteCreationActivity(Activity activity) {
+        // If we just wanted to have WPMainActivity in the back stack after starting SiteCreationActivity, we could have
+        // used a TaskStackBuilder to do so. However, since we want to handle the SiteCreationActivity result in
+        // WPMainActivity, we must start it this way.
+        final Intent intent = new Intent(activity, WPMainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+        intent.putExtra(WPMainActivity.ARG_SHOW_SITE_CREATION, true);
+        activity.startActivity(intent);
+    }
+
     public static void showSignInForResult(Activity activity) {
         showSignInForResult(activity, false);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
@@ -51,7 +51,7 @@ class PostSignupInterstitialActivity : LocaleAwareActivity() {
     }
 
     private fun startSiteCreationFlow() {
-        ActivityLauncher.newBlogForResult(this)
+        ActivityLauncher.showMainActivityAndSiteCreationActivity(this)
         finish()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -160,6 +160,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     public static final String ARG_OPENED_FROM_PUSH = "opened_from_push";
     public static final String ARG_SHOW_LOGIN_EPILOGUE = "show_login_epilogue";
     public static final String ARG_SHOW_SIGNUP_EPILOGUE = "show_signup_epilogue";
+    public static final String ARG_SHOW_SITE_CREATION = "show_site_creation";
     public static final String ARG_OPEN_PAGE = "open_page";
     public static final String ARG_MY_SITE = "show_my_site";
     public static final String ARG_NOTIFICATIONS = "show_notifications";
@@ -344,6 +345,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     getIntent().getStringExtra(SignupEpilogueActivity.EXTRA_SIGNUP_EMAIL_ADDRESS),
                     getIntent().getStringExtra(SignupEpilogueActivity.EXTRA_SIGNUP_PHOTO_URL),
                     getIntent().getStringExtra(SignupEpilogueActivity.EXTRA_SIGNUP_USERNAME), false);
+        } else if (getIntent().getBooleanExtra(ARG_SHOW_SITE_CREATION, false) && savedInstanceState == null) {
+            canShowAppRatingPrompt = false;
+            ActivityLauncher.newBlogForResult(this);
         }
 
         if (isGooglePlayServicesAvailable(this)) {


### PR DESCRIPTION
Fixes #12578

This PR updates the `PostSignupInterstitialActivity` so it starts the `SiteCreationActivity` from `WPMainActivity` instead of starting it directly. This allows the result from the site creation flow to be handled by our main activity, instead of getting lost.

## To test

0. Clear app data.
1. On the Prologue screen, if the Smart Lock dialog appears, dismiss it.
1. Tap **Continue with WordPress.com**.
1. On the Get Started screen, enter an email address that **_is not_** associated with a WordPress.com account.
1. Tap **Continue**.
1. Continue with the signup flow normally.
1. On the Post Signup Interstitial screen, tap **Create WordPress.com Site**.
1. Continue with the site creation flow normally.
1. On the Site Preview screen, tap **Ok**.
1. Notice the Quick Start dialog on top of the Main screen.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
