### PR TITLE
Pass followed tags to /cards endpoint

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -144,7 +144,9 @@ import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderUserAdapter;
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverFragment;
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsFragment;
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverJobService;
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic;
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverService;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.views.ReaderLikingUsersView;
 import org.wordpress.android.ui.reader.views.ReaderSiteHeaderView;
@@ -556,6 +558,10 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(ReaderDiscoverLogic object);
 
     void inject(PostListCreateMenuFragment object);
+
+    void inject(ReaderDiscoverJobService object);
+
+    void inject(ReaderDiscoverService object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverJobService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverJobService.kt
@@ -3,15 +3,27 @@ package org.wordpress.android.ui.reader.services.discover
 import android.app.job.JobParameters
 import android.app.job.JobService
 import android.content.Context
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.READER
 import org.wordpress.android.util.LocaleManager
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.coroutines.CoroutineContext
 
-class ReaderDiscoverJobService : JobService(), ServiceCompletionListener {
+class ReaderDiscoverJobService : JobService(), ServiceCompletionListener, CoroutineScope {
+    @Inject @field:Named("IO_THREAD") lateinit var ioDispatcher: CoroutineDispatcher
     private lateinit var readerDiscoverLogic: ReaderDiscoverLogic
+
+    private var job: Job = Job()
+
+    override val coroutineContext: CoroutineContext
+        get() = ioDispatcher + job
 
     override fun attachBaseContext(newBase: Context) {
         super.attachBaseContext(LocaleManager.setLocale(newBase))
@@ -34,12 +46,15 @@ class ReaderDiscoverJobService : JobService(), ServiceCompletionListener {
 
     override fun onCreate() {
         super.onCreate()
-        readerDiscoverLogic = ReaderDiscoverLogic(this, (application as WordPress).component())
+        val component = (application as WordPress).component()
+        component.inject(this)
+        readerDiscoverLogic = ReaderDiscoverLogic(this, this, component)
         AppLog.i(READER, "reader discover job service > created")
     }
 
     override fun onDestroy() {
         AppLog.i(READER, "reader discover job service > destroyed")
+        job.cancel()
         super.onDestroy()
     }
 


### PR DESCRIPTION
Parent issue #12319

Note: "Not ready for merge" label can be removed and the PR merged when https://github.com/wordpress-mobile/WordPress-Android/pull/12593  is merged. 

- Loads the tags the user follows and passes them to the /cards endpoint
- Moves the execution to the IO thread

To test:
1. Clear app data
2. Enable RI FF
3. Stetho/Charles
4. Open discover tab
5. Check the /cards endpoint request and make sure it contains all the tags the user follows
6. Make sure the data are correctly displayed on the UI 

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
