### PR TITLE
Enable @mentions feature in vanilla flavors for version 15.4

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 15.5
 -----
- 
+* [***] Block Editor: New feature for WordPress.com and Jetpack sites: auto-complete username mentions. An auto-complete popup will show up when the user types the @ character in the block editor.
+
 15.4
 -----
 * [***] The login and signup flows were unified and have a new design.

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -96,7 +96,7 @@ android {
             buildConfigField "boolean", "TENOR_AVAILABLE", "false"
             buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
-            buildConfigField "boolean", "GUTENBERG_MENTIONS", "false"
+            buildConfigField "boolean", "GUTENBERG_MENTIONS", "true"
         }
 
         zalpha { // alpha version - enable experimental features


### PR DESCRIPTION
The `GUTENBERG_MENTIONS` feature flag is always true, but we'll keep the flag in case we want to revert it quickly.

Note: the feature was enabled and tested in alpha releases. This doesn't require a new beta release.