### PR TITLE
RI: Enable Follow button for logged out user(self-hosted site)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -277,7 +277,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             }
         } else if (holder instanceof TagHeaderViewHolder) {
             TagHeaderViewHolder tagHolder = (TagHeaderViewHolder) holder;
-            renderTagHeader(mCurrentTag, tagHolder, true, false);
+            renderTagHeader(mCurrentTag, tagHolder, true);
         } else if (holder instanceof GapMarkerViewHolder) {
             GapMarkerViewHolder gapHolder = (GapMarkerViewHolder) holder;
             gapHolder.mGapMarkerView.setCurrentTag(mCurrentTag);
@@ -289,8 +289,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private void renderTagHeader(
         ReaderTag currentTag,
         TagHeaderViewHolder tagHolder,
-        Boolean isFollowButtonEnabled,
-        Boolean shouldFollowButtonAnimate
+        Boolean isFollowButtonEnabled
     ) {
         if (currentTag == null) {
             return;
@@ -304,10 +303,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             currentTag.getLabel(),
             new FollowButtonUiState(
                 onFollowButtonClicked,
-                mAccountStore.hasAccessToken(),
                 ReaderTagTable.isFollowedTagName(currentTag.getTagSlug()),
-                isFollowButtonEnabled,
-                shouldFollowButtonAnimate
+                isFollowButtonEnabled
             )
         );
         tagHolder.onBind(uiState);
@@ -330,7 +327,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         : R.string.reader_toast_err_remove_tag;
                 ToastUtils.showToast(context, errResId);
             }
-            renderTagHeader(currentTag, tagHolder, true, false);
+            renderTagHeader(currentTag, tagHolder, true);
         };
 
         boolean success;
@@ -341,7 +338,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         if (success) {
-            renderTagHeader(currentTag, tagHolder, false, false);
+            renderTagHeader(currentTag, tagHolder, false);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
@@ -68,7 +68,7 @@ class ReaderFollowButton @JvmOverloads constructor(
         setIsFollowed(isFollowed, true)
     }
 
-    fun setIsFollowed(isFollowed: Boolean, animateChanges: Boolean) {
+    private fun setIsFollowed(isFollowed: Boolean, animateChanges: Boolean) {
         if (isFollowed == this.isFollowed && isSelected == isFollowed) {
             return
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
@@ -35,8 +35,7 @@ class ReaderTagHeaderView @JvmOverloads constructor(
     fun updateUi(uiState: ReaderTagHeaderUiState) {
         text_tag.text = uiState.title
         with(uiState.followButtonUiState) {
-            uiHelpers.updateVisibility(follow_button, isVisible)
-            follow_button.setIsFollowed(isFollowed, shouldAnimate)
+            follow_button.setIsFollowed(isFollowed)
             follow_button.isEnabled = isEnabled
             onFollowBtnClicked = onFollowButtonClicked
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderViewUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderViewUiState.kt
@@ -7,10 +7,8 @@ sealed class ReaderTagHeaderViewUiState {
     ) : ReaderTagHeaderViewUiState() {
         data class FollowButtonUiState(
             val onFollowButtonClicked: (() -> Unit)?,
-            val isVisible: Boolean,
             val isFollowed: Boolean,
-            val isEnabled: Boolean,
-            val shouldAnimate: Boolean
+            val isEnabled: Boolean
         )
     }
 }

--- a/WordPress/src/main/res/layout/reader_interests_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_interests_fragment_layout.xml
@@ -5,6 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?attr/colorSurface"
     android:contentDescription="@string/reader_choose_interests_content_description">
 
     <ScrollView


### PR DESCRIPTION
Parent Issue: #12318

This PR 
- Enables "Follow" button for logged out user(self-hosted site).
- Displays "Interests Picker" on switch from "Followed" to "Discover" tab if no followed tags found for user.

#### To test

Prerequisites - Reader Improvements feature flag is enabled

 **01. Tag/ topic is followed/ unfollowed**

1. Login using a self hosted site
2. Go to Reader tab
3. Go to Topic details screen 
(via Followed tab -> Filter bar -> Select tag (from bottom sheet) -> Select post -> Click a tag on post)
4. Notice that Follow button is shown
5. Follow/ Unfollow topic
6. Notice that selected topic gets followed/ unfollowed properly and corresponding tag is shown/ hidden respectively under 
Followed tab -> Filter bar -> Bottom sheet Tags section

 **02. Interest picker shown on switch to discover tab if no followed tags found for user**
1. Login using a self hosted site or wp.com account with followed tags
2. Go to Reader => Followed tab
3. Unfollow all followed tags
[**Logged in user**
Followed tab -> Click Filter bar -> Gear icon
**Logged out user**
Followed tab -> Click Filter bar -> Select tag (from bottom sheet) -> Select post for tag -> Click selected tag on post -> Unfollow]
4. Switch from Followed tab to Discover tab
5. Notice that Interests Picker is shown

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
