### PR TITLE
Add support for loading more items on discover feed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -27,7 +27,7 @@ import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
-private const val INITIATE_LOAD_MORE_OFFSET = 3
+const val INITIATE_LOAD_MORE_OFFSET = 3
 
 class ReaderDiscoverViewModel @Inject constructor(
     private val postUiStateBuilder: ReaderPostUiStateBuilder,

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -4,6 +4,8 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -20,6 +22,7 @@ import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderPostCard
 import org.wordpress.android.models.discover.ReaderDiscoverCards
 import org.wordpress.android.test
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
@@ -28,6 +31,10 @@ import org.wordpress.android.ui.reader.repository.ReaderDiscoverDataProvider
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ReactiveMutableLiveData
+
+private const val POST_PARAM_POSITION = 0
+private const val ON_ITEM_RENDERED_PARAM_POSITION = 7
+private const val NUMBER_OF_ITEMS = 10L
 
 @InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -61,7 +68,11 @@ class ReaderDiscoverViewModelTest {
                         anyOrNull(), anyInt(), anyInt(), anyOrNull(), anyBoolean(), anyOrNull(),
                         anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
                 )
-        ).thenReturn(mock())
+        ).thenAnswer {
+            val post = it.getArgument<ReaderPost>(POST_PARAM_POSITION)
+            // propagate some of the arguments
+            createDummyReaderPostUiState(post, it.getArgument<(Long, Long) -> Unit>(ON_ITEM_RENDERED_PARAM_POSITION))
+        }
         whenever(readerDiscoverDataProvider.communicationChannel).thenReturn(communicationChannel)
     }
 
@@ -97,12 +108,87 @@ class ReaderDiscoverViewModelTest {
         assertThat(uiStates[1]).isInstanceOf(ContentUiState::class.java)
     }
 
-    private fun createDummyReaderCardsList(): ReaderDiscoverCards {
-        return ReaderDiscoverCards(listOf(ReaderPostCard(createDummyReaderPost())))
+    @Test
+    fun `load more action is initiated when we are close to the end of the list`() = test {
+        // Arrange
+        val closeToEndIndex = NUMBER_OF_ITEMS.toInt() - INITIATE_LOAD_MORE_OFFSET
+        init()
+
+        // Act
+        ((viewModel.uiState.value as ContentUiState).cards[closeToEndIndex] as ReaderPostUiState).let {
+            it.onItemRendered.invoke(it.postId, it.blogId)
+        }
+        // Assert
+        verify(readerDiscoverDataProvider).loadMoreCards()
     }
 
-    private fun createDummyReaderPost(): ReaderPost = ReaderPost().apply {
-        postId = 1
-        title = "DummyPost"
+    @Test
+    fun `load more action is NOT initiated when we are at the beggining of the list`() = test {
+        // Arrange
+        val notCloseToEndIndex = 2
+        init()
+
+        // Act
+
+        ((viewModel.uiState.value as ContentUiState).cards[notCloseToEndIndex] as ReaderPostUiState).let {
+            it.onItemRendered.invoke(it.postId, it.blogId)
+        }
+        // Assert
+        verify(readerDiscoverDataProvider, never()).loadMoreCards()
+    }
+
+    private fun init() {
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.value = createDummyReaderCardsList()
+    }
+
+    private fun createDummyReaderCardsList(numberOfItems: Long = NUMBER_OF_ITEMS): ReaderDiscoverCards {
+        return ReaderDiscoverCards((1..numberOfItems).map { ReaderPostCard(createDummyReaderPost(it)) }.toList())
+    }
+
+    private fun createDummyReaderPost(id: Long): ReaderPost = ReaderPost().apply {
+        this.postId = id
+        this.blogId = id
+        this.title = "DummyPost"
+    }
+
+    private fun createDummyReaderPostUiState(
+        post: ReaderPost,
+        onItemRendered: (Long, Long) -> Unit = mock()
+    ): ReaderPostUiState {
+        return ReaderPostUiState(
+                postId = post.postId,
+                blogId = post.blogId,
+                blogUrl = "",
+                dateLine = "",
+                avatarOrBlavatarUrl = "",
+                blogName = "",
+                excerpt = "",
+                title = "",
+                photoFrameVisibility = false,
+                photoTitle = "",
+                featuredImageUrl = "",
+                featuredImageCornerRadius = mock(),
+                thumbnailStripSection = mock(),
+                videoOverlayVisibility = false,
+                featuredImageVisibility = false,
+                moreMenuVisibility = false,
+                fullVideoUrl = "",
+                discoverSection = mock(),
+                bookmarkAction = mock(),
+                likeAction = mock(),
+                reblogAction = mock(),
+                commentsAction = mock(),
+                onItemClicked = mock(),
+                onItemRendered = onItemRendered,
+                onMoreButtonClicked = mock(),
+                onVideoOverlayClicked = mock(),
+                postHeaderClickData = mock(),
+                moreMenuItems = mock()
+        )
     }
 }


### PR DESCRIPTION
Parent issue #12028

Note: "Not ready for merge" label can be removed and the PR merged when https://github.com/wordpress-mobile/WordPress-Android/pull/12594 is merged.

Adds support for loading more items on the new discover tab in Reader. Request to load more items is initiated when an item close to an end is rendered. We don't show any form of progress indicator as of now, but I added a TODO so we don't forget about it.

To test:
1. Enable RI FF
2. Open Discover tab
3. Scroll down and notice more and more items are being loaded 


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
