### PR TITLE
Enable swipe to refresh gesture on the discover tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReade
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
@@ -59,6 +60,9 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
     private fun setupViews() {
         recycler_view.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
         recycler_view.adapter = ReaderDiscoverAdapter(uiHelpers, imageManager)
+        WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(ptr_layout) {
+            viewModel.swipeToRefresh()
+        }
     }
 
     private fun initViewModel() {
@@ -72,6 +76,8 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
             uiHelpers.updateVisibility(recycler_view, it.contentVisiblity)
             uiHelpers.updateVisibility(progress_bar, it.progressVisibility)
             uiHelpers.updateVisibility(progress_text, it.progressVisibility)
+            ptr_layout.isEnabled = it.swipeToRefreshEnabled
+            ptr_layout.isRefreshing = it.swipeToRefreshIsRefreshing
         })
         viewModel.navigationEvents.observe(viewLifecycleOwner, Observer {
             it.applyIfNotHandled {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -94,7 +94,8 @@ class ReaderDiscoverViewModel @Inject constructor(
                                 onPostHeaderViewClicked = this::onPostHeaderClicked,
                                 postListType = TAG_FOLLOWED
                         )
-                    }
+                    },
+                    swipeToRefreshIsRefreshing = false
             )
         }
 
@@ -185,11 +186,25 @@ class ReaderDiscoverViewModel @Inject constructor(
         readerDiscoverDataProvider.stop()
     }
 
+    fun swipeToRefresh() {
+        launch {
+            (uiState.value as ContentUiState).copy(swipeToRefreshIsRefreshing = true)
+            readerDiscoverDataProvider.refreshCards()
+        }
+    }
+
     sealed class DiscoverUiState(
         val contentVisiblity: Boolean = false,
-        val progressVisibility: Boolean = false
+        val progressVisibility: Boolean = false,
+        val swipeToRefreshEnabled: Boolean = false
     ) {
-        data class ContentUiState(val cards: List<ReaderCardUiState>) : DiscoverUiState(contentVisiblity = true)
+        open val swipeToRefreshIsRefreshing: Boolean = false
+
+        data class ContentUiState(
+            val cards: List<ReaderCardUiState>,
+            override val swipeToRefreshIsRefreshing: Boolean
+        ) : DiscoverUiState(contentVisiblity = true, swipeToRefreshEnabled = true)
+
         object LoadingUiState : DiscoverUiState(progressVisibility = true)
         object ErrorUiState : DiscoverUiState()
     }

--- a/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
@@ -29,13 +29,19 @@
         app:layout_constraintTop_toBottomOf="@+id/progress_bar"
         app:layout_constraintVertical_bias="0" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler_view"
+    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+        android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Parent issue #12028

Note: "Not ready for merge" label can be removed and the PR merged when https://github.com/wordpress-mobile/WordPress-Android/pull/12603 is merged.

Adds support for pull-to-refresh gesture on the discover tab.


To test:
1. Enable RI FF
2. Open discover tab
3. Wait until some data are loaded
4. (optionally open stetho/charles)
5. Pull to refresh and notice the content refreshes ( the api currently returns the same data)
6. (optional: verify that the call didn't have "page_handle" query parameter)
7. Make sure you can pull to refresh again. Also make sure the progress indicator disappears.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
