### PR TITLE
Fix load more functionality which expected only Post items in the list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -43,6 +43,7 @@ import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderPostActions;
 import org.wordpress.android.ui.reader.actions.ReaderTagActions;
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState;
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState;
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType;
 import org.wordpress.android.ui.reader.discover.ReaderPostUiStateBuilder;
@@ -73,6 +74,7 @@ import javax.inject.Inject;
 
 import kotlin.Unit;
 import kotlin.jvm.functions.Function0;
+import kotlin.jvm.functions.Function1;
 import kotlin.jvm.functions.Function2;
 import kotlin.jvm.functions.Function3;
 
@@ -423,7 +425,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             }
             return Unit.INSTANCE;
         };
-        Function2<Long, Long, Unit> onItemRendered = (postId, blogId) -> {
+        Function1<ReaderCardUiState, Unit> onItemRendered = (item) -> {
             checkLoadMore(position);
 
             // if we haven't already rendered this post and it has a "railcar" attached to it, add it

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -38,7 +38,7 @@ sealed class ReaderCardUiState {
         val moreMenuItems: List<SecondaryAction>,
         val postHeaderClickData: PostHeaderClickData?,
         val onItemClicked: (Long, Long) -> Unit,
-        val onItemRendered: (Long, Long) -> Unit,
+        val onItemRendered: (ReaderCardUiState) -> Unit,
         val onMoreButtonClicked: (Long, Long, View) -> Unit,
         val onVideoOverlayClicked: (Long, Long) -> Unit
     ) : ReaderCardUiState() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
-import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
@@ -86,7 +85,7 @@ class ReaderDiscoverViewModel @Inject constructor(
                                 photonHeight = photonHeight,
                                 isBookmarkList = false,
                                 onButtonClicked = this::onButtonClicked,
-                                onItemClicked = this::onItemClicked,
+                                onItemClicked = this::onPostItemClicked,
                                 onItemRendered = this::onItemRendered,
                                 onDiscoverSectionClicked = this::onDiscoverClicked,
                                 onMoreButtonClicked = this::onMoreButtonClicked,
@@ -137,21 +136,19 @@ class ReaderDiscoverViewModel @Inject constructor(
         // TODO malinjir implement action
     }
 
-    private fun onItemClicked(postId: Long, blogId: Long) {
+    private fun onPostItemClicked(postId: Long, blogId: Long) {
         AppLog.d(T.READER, "OnItemClicked")
     }
 
-    private fun onItemRendered(postId: Long, blogId: Long) {
-        initiateLoadMoreIfNecessary(postId, blogId)
+    private fun onItemRendered(itemUiState: ReaderCardUiState) {
+        initiateLoadMoreIfNecessary(itemUiState)
     }
 
-    private fun initiateLoadMoreIfNecessary(postId: Long, blogId: Long) {
+    private fun initiateLoadMoreIfNecessary(item: ReaderCardUiState) {
         (uiState.value as? ContentUiState)?.cards?.let {
             val closeToEndIndex = it.size - INITIATE_LOAD_MORE_OFFSET
             if (closeToEndIndex > 0) {
-                val isCardCloseToEnd: Boolean = (it.getOrNull(closeToEndIndex) as? ReaderPostUiState)?.let { card ->
-                    card.postId == postId && card.blogId == blogId
-                } == true
+                val isCardCloseToEnd: Boolean = it.getOrNull(closeToEndIndex) == item
                 // TODO malinjir we might want to show some kind of progress indicator when the request is in progress
                 if (isCardCloseToEnd) launch(bgDispatcher) { readerDiscoverDataProvider.loadMoreCards() }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -56,7 +56,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
         isBookmarkList: Boolean,
         onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit,
         onItemClicked: (Long, Long) -> Unit,
-        onItemRendered: (Long, Long) -> Unit,
+        onItemRendered: (ReaderCardUiState) -> Unit,
         onDiscoverSectionClicked: (Long, Long) -> Unit,
         onMoreButtonClicked: (Long, Long, View) -> Unit,
         onVideoOverlayClicked: (Long, Long) -> Unit,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -86,7 +86,7 @@ class ReaderPostViewHolder(
         updateActionButton(uiState.postId, uiState.blogId, uiState.commentsAction, count_comments)
         updateActionButton(uiState.postId, uiState.blogId, uiState.bookmarkAction, bookmark)
 
-        state.onItemRendered.invoke(uiState.postId, uiState.blogId)
+        state.onItemRendered.invoke(uiState)
     }
 
     private fun updateFeaturedImage(state: ReaderPostUiState) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -71,7 +71,10 @@ class ReaderDiscoverViewModelTest {
         ).thenAnswer {
             val post = it.getArgument<ReaderPost>(POST_PARAM_POSITION)
             // propagate some of the arguments
-            createDummyReaderPostUiState(post, it.getArgument<(Long, Long) -> Unit>(ON_ITEM_RENDERED_PARAM_POSITION))
+            createDummyReaderPostUiState(
+                    post,
+                    it.getArgument<(ReaderCardUiState) -> Unit>(ON_ITEM_RENDERED_PARAM_POSITION)
+            )
         }
         whenever(readerDiscoverDataProvider.communicationChannel).thenReturn(communicationChannel)
     }
@@ -116,7 +119,7 @@ class ReaderDiscoverViewModelTest {
 
         // Act
         ((viewModel.uiState.value as ContentUiState).cards[closeToEndIndex] as ReaderPostUiState).let {
-            it.onItemRendered.invoke(it.postId, it.blogId)
+            it.onItemRendered.invoke(it)
         }
         // Assert
         verify(readerDiscoverDataProvider).loadMoreCards()
@@ -131,7 +134,7 @@ class ReaderDiscoverViewModelTest {
         // Act
 
         ((viewModel.uiState.value as ContentUiState).cards[notCloseToEndIndex] as ReaderPostUiState).let {
-            it.onItemRendered.invoke(it.postId, it.blogId)
+            it.onItemRendered.invoke(it)
         }
         // Assert
         verify(readerDiscoverDataProvider, never()).loadMoreCards()
@@ -158,7 +161,7 @@ class ReaderDiscoverViewModelTest {
 
     private fun createDummyReaderPostUiState(
         post: ReaderPost,
-        onItemRendered: (Long, Long) -> Unit = mock()
+        onItemRendered: (ReaderCardUiState) -> Unit = mock()
     ): ReaderPostUiState {
         return ReaderPostUiState(
                 postId = post.postId,


### PR DESCRIPTION
Parent issue #12028

Follow up for https://github.com/wordpress-mobile/WordPress-Android/pull/12603

I realized an issue with the previous implementation. We will be displaying different types of cards in the discover tab - post cards, interests you might like, blogs you might like etc. The load more detection logic was expecting only post cards - so if the `size - 2` card wasn't a post card, the load more request wouldn't have been emitted. This PR fixes this issue.

To test:
1. Clear app data
2. Enable RI FF
3. Open Discover tab
4. Scroll down and notice more and more items are being loaded

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
