### PR TITLE
Set prerelease flags for alpha/beta releases on GH

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -290,7 +290,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
     end
 
     if (options[:create_release])
-      create_gh_release(version: version)
+      create_gh_release(version: version, prerelease: true)
     end
   end
 
@@ -321,7 +321,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
     end
 
     if (options[:create_release])
-      create_gh_release(version: version)
+      create_gh_release(version: version, prerelease: true)
     end
   end
 
@@ -598,12 +598,14 @@ ENV["HAS_ALPHA_VERSION"]="true"
   end
 
   private_lane :create_gh_release do | options |
+    set_prerelease_flag = options["prerelease"].nil? ? false : options["prerelease"]
     version = options[:version]
     apk_file_path = universal_apk_file_path(version)
     aab_file_path = bundle_file_path(version)
     create_release(repository:GHHELPER_REPO, 
       version: version["name"], 
       release_notes_file_path:release_notes_path,
+      prerelease: set_prerelease_flag,
       release_assets:"#{apk_file_path},#{aab_file_path}"
     )
   end


### PR DESCRIPTION
This PR fixes an issue where GitHub releases for `alpha` and `beta` builds don't have the `pre-release` flag set. 
 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
