### PR TITLE
Increase the no output timeout on CircleCI during linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs:
           environment:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
           command: ./gradlew --stacktrace lintVanillaRelease || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)
+          no_output_timeout: 15m
       - run:
           name: Violations
           when: on_fail


### PR DESCRIPTION
We've seen some random failures on CI where the `lintVanillaRelease` task hit the `no output timeout` limit on CircleCI. 
Since the failures are random and rerunning the task often fixes them, my best guess is that when CI is busy the task runs a bit slower and hits the timeout. 
This PR tries to fix it by increasing the timeout to 15m (default is 10m). 

To test:
- Verify that CI is green.

cc/ @zwarm 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
