### PR TITLE
Bump Tracks library version to 1.2.1

### DIFF
--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.automattic:tracks:1.1.6'
+    implementation 'com.automattic:tracks:1.2.1'
     implementation 'org.wordpress:utils:1.19.0'
 
     lintChecks 'org.wordpress:lint:1.0.1'


### PR DESCRIPTION
Updates to the latest version of the Tracks library, `1.2.1`.

This includes a fix to height/width tracking, which was using deprecated params which were being ignored server-side. See https://github.com/Automattic/Automattic-Tracks-Android/pull/48 for the details and behavior changes.

To test: Follow the same steps laid out in https://github.com/Automattic/Automattic-Tracks-Android/pull/48 to verify that the `commonProps` sent to tracks reflect the changes.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
