### PR TITLE
[Gutenberg] Dialog to replace image with gallery for multiple images

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
@@ -78,6 +78,7 @@ public class InsertMediaDialog extends AppCompatDialogFragment {
     private GalleryType mGalleryType;
     private InsertType mInsertType;
     private int mNumColumns;
+    private boolean mIsGutenbergEditor;
 
 
     public static InsertMediaDialog newInstance(@NonNull InsertMediaCallback callback, @NonNull SiteModel site) {
@@ -98,6 +99,10 @@ public class InsertMediaDialog extends AppCompatDialogFragment {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
             mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
+            // TODO: this may not be the most reliable way to be sure that we are in the Gutenberg editor for this post
+            if (mSite != null) {
+                mIsGutenbergEditor = mSite.getMobileEditor().equals("gutenberg");
+            }
         }
     }
 
@@ -123,37 +128,43 @@ public class InsertMediaDialog extends AppCompatDialogFragment {
             }
         });
 
-        // self-hosted sites don't support gallery types
-        boolean enableGalleryType = mSite != null && mSite.isUsingWpComRestApi();
-        if (enableGalleryType) {
-            mGalleryRadioGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
-                @Override
-                public void onCheckedChanged(RadioGroup group, @IdRes int checkedId) {
-                    GalleryType galleryType;
-                    switch (checkedId) {
-                        case R.id.radio_circles:
-                            galleryType = GalleryType.CIRCLES;
-                            break;
-                        case R.id.radio_slideshow:
-                            galleryType = GalleryType.SLIDESHOW;
-                            break;
-                        case R.id.radio_squares:
-                            galleryType = GalleryType.SQUARES;
-                            break;
-                        case R.id.radio_tiled:
-                            galleryType = GalleryType.TILED;
-                            break;
-                        default:
-                            galleryType = GalleryType.DEFAULT;
-                            break;
-                    }
-                    setGalleryType(galleryType);
-                }
-            });
-        } else {
+        if (mIsGutenbergEditor) {
             mGalleryRadioGroup.setVisibility(View.GONE);
-            mNumColumnsContainer.setVisibility(View.VISIBLE);
+            mNumColumnsContainer.setVisibility(View.GONE);
             mGalleryType = GalleryType.DEFAULT;
+        } else {
+            // self-hosted sites don't support gallery types
+            boolean enableGalleryType = mSite != null && mSite.isUsingWpComRestApi();
+            if (enableGalleryType) {
+                mGalleryRadioGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
+                    @Override
+                    public void onCheckedChanged(RadioGroup group, @IdRes int checkedId) {
+                        GalleryType galleryType;
+                        switch (checkedId) {
+                            case R.id.radio_circles:
+                                galleryType = GalleryType.CIRCLES;
+                                break;
+                            case R.id.radio_slideshow:
+                                galleryType = GalleryType.SLIDESHOW;
+                                break;
+                            case R.id.radio_squares:
+                                galleryType = GalleryType.SQUARES;
+                                break;
+                            case R.id.radio_tiled:
+                                galleryType = GalleryType.TILED;
+                                break;
+                            default:
+                                galleryType = GalleryType.DEFAULT;
+                                break;
+                        }
+                        setGalleryType(galleryType);
+                    }
+                });
+            } else {
+                mGalleryRadioGroup.setVisibility(View.GONE);
+                mNumColumnsContainer.setVisibility(View.VISIBLE);
+                mGalleryType = GalleryType.DEFAULT;
+            }
         }
 
         mNumColumnsSeekBar.setMax(MAX_COLUMN_COUNT - 1);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1171,6 +1171,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mContent.getText().insert(mContent.getSelectionEnd(), shortcode);
     }
 
+    @Override public void setShouldReplaceImageWithGallery(boolean shouldReplaceImageWithGallery) {
+        // noop for Gutenberg-only method
+    }
+
     @Override
     public void setUrlForVideoPressId(final String videoId, final String videoUrl, final String posterUrl) {
         VideoPressExtensionsKt.updateVideoPressThumb(mContent, posterUrl, videoUrl, videoId);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -35,6 +35,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract void appendMediaFile(MediaFile mediaFile, String imageUrl, ImageLoader imageLoader);
     public abstract void appendMediaFiles(Map<String, MediaFile> mediaList);
     public abstract void appendGallery(MediaGallery mediaGallery);
+    public abstract void setShouldReplaceImageWithGallery(boolean shouldReplaceImageWithGallery);
     public abstract void setUrlForVideoPressId(String videoPressId, String url, String posterUrl);
     public abstract boolean isUploadingMedia();
     public abstract boolean isActionInProgress();

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -178,6 +178,10 @@ public class GutenbergContainerFragment extends Fragment {
         mWPAndroidGlueCode.appendMediaFiles(mediaList);
     }
 
+    public void appendGalleryBlock(ArrayList<Media> mediaList) {
+        mWPAndroidGlueCode.appendNewGalleryBlock(mediaList);
+    }
+
     public void mediaFileUploadProgress(final int mediaId, final float progress) {
         mWPAndroidGlueCode.mediaFileUploadProgress(mediaId, progress);
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -120,6 +120,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     private boolean mEditorDidMount;
 
+    private boolean mShouldReplaceImageWithGallery;
+
     private ProgressDialog mSavingContentProgressDialog;
 
     public static GutenbergEditorFragment newInstance(String title,
@@ -894,6 +896,9 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void appendGallery(MediaGallery mediaGallery) {
+
+    @Override public void setShouldReplaceImageWithGallery(boolean shouldReplaceImageWithGallery) {
+        mShouldReplaceImageWithGallery = shouldReplaceImageWithGallery;
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -891,7 +891,12 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                     mediaEntry.getValue().getCaption()));
         }
 
-        getGutenbergContainerFragment().appendMediaFiles(rnMediaList);
+        if (mShouldReplaceImageWithGallery) {
+            getGutenbergContainerFragment().appendGalleryBlock(rnMediaList);
+            mShouldReplaceImageWithGallery = false;
+        } else {
+            getGutenbergContainerFragment().appendMediaFiles(rnMediaList);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Related PRs:

`gutenberg`: https://github.com/WordPress/gutenberg/pull/24437
`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2539

## Description
This PR is another step towards resolving this issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2255

To test:

tbd

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
