### PR TITLE
Adds upload_and_replace_screenshots_in_play_store lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -360,6 +360,33 @@ ENV["HAS_ALPHA_VERSION"]="true"
   end
 
   #####################################################################################
+  # upload_and_replace_screenshots_in_play_store
+  # -----------------------------------------------------------------------------------
+  # This lane uploads the screenshots in /metadata/android/{locale}/images to Play
+  # Store and replaces the existing ones.
+  # If a locale doesn't have any screenshots, it'll be skipped.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane upload_and_replace_screenshots_in_play_store
+  #
+  # Example:
+  # bundle exec fastlane upload_and_replace_screenshots_in_play_store
+  #####################################################################################
+  desc "Upload Screenshots to Play Store and Replaces the existing ones"
+  lane :upload_and_replace_screenshots_in_play_store do | options |
+    upload_to_play_store(
+      package_name: 'org.wordpress.android',
+      skip_upload_apk: true,
+      skip_upload_aab: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: false,
+      json_key: './google-upload-credentials.json',
+    )
+  end
+
+  #####################################################################################
   # download_metadata_string
   # -----------------------------------------------------------------------------------
   # This lane downloads the translated metadata (release notes,


### PR DESCRIPTION
Unfortunately it's difficult to test this PR since new screenshots will need to be generated first. Considering the update can't be created as a draft, it's probably better to just not test this. Suffice to say, I've tested this extensively and the script is running as we speak to update all screenshots.

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
