### PR TITLE
State tests for photo picker view model

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModel.kt
@@ -55,6 +55,7 @@ import org.wordpress.android.util.distinct
 import org.wordpress.android.util.map
 import org.wordpress.android.util.merge
 import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.ScopedViewModel
 import java.util.HashMap
 import javax.inject.Inject
@@ -68,7 +69,8 @@ class PhotoPickerViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val permissionsHandler: PermissionsHandler,
     private val tenorFeatureConfig: TenorFeatureConfig,
-    private val context: Context
+    private val context: Context,
+    private val resourceProvider: ResourceProvider
 ) : ScopedViewModel(mainDispatcher) {
     private val _navigateToPreview = MutableLiveData<Event<UriWrapper>>()
     private val _onInsert = MutableLiveData<Event<List<UriWrapper>>>()
@@ -167,7 +169,7 @@ class PhotoPickerViewModel @Inject constructor(
         val title: UiString? = when {
             numSelected == 0 -> null
             browserType.canMultiselect() -> {
-                UiStringText(String.format(context.resources.getString(R.string.cab_selected), numSelected))
+                UiStringText(String.format(resourceProvider.getString(R.string.cab_selected), numSelected))
             }
             else -> {
                 if (browserType.isImagePicker && browserType.isVideoPicker) {
@@ -431,20 +433,19 @@ class PhotoPickerViewModel @Inject constructor(
 
     private fun showSoftAskView(show: Boolean, isAlwaysDenied: Boolean) {
         if (show) {
-            val resources = context.resources
-            val appName = "<strong>${resources.getString(R.string.app_name)}</strong>"
+            val appName = "<strong>${resourceProvider.getString(R.string.app_name)}</strong>"
             val label = if (isAlwaysDenied) {
                 val permissionName = ("<strong>${WPPermissionUtils.getPermissionName(
                         context,
                         permission.WRITE_EXTERNAL_STORAGE
                 )}</strong>")
                 String.format(
-                        resources.getString(R.string.photo_picker_soft_ask_permissions_denied), appName,
+                        resourceProvider.getString(R.string.photo_picker_soft_ask_permissions_denied), appName,
                         permissionName
                 )
             } else {
                 String.format(
-                        resources.getString(R.string.photo_picker_soft_ask_label),
+                        resourceProvider.getString(R.string.photo_picker_soft_ask_label),
                         appName
                 )
             }

--- a/WordPress/src/test/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModelTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.MEDIA_PICKER_PREVIE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.test
 import org.wordpress.android.ui.media.MediaBrowserType
+import org.wordpress.android.ui.media.MediaBrowserType.EDITOR_PICKER
 import org.wordpress.android.ui.media.MediaBrowserType.GUTENBERG_IMAGE_PICKER
 import org.wordpress.android.ui.media.MediaBrowserType.GUTENBERG_MEDIA_PICKER
 import org.wordpress.android.ui.media.MediaBrowserType.GUTENBERG_SINGLE_IMAGE_PICKER
@@ -282,6 +283,18 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
         selectItem(1)
 
         assertActionModeVisible(UiStringText("2 selected"))
+    }
+
+    @Test
+    fun `action mode shows confirmation action in EDITOR PICKER`() = test {
+        whenever(resourceProvider.getString(R.string.cab_selected)).thenReturn("%d selected")
+        setupViewModel(listOf(firstItem, secondItem), EDITOR_PICKER)
+
+        viewModel.refreshData(false)
+
+        selectItem(0)
+
+        assertActionModeVisible(UiStringText("1 selected"), showConfirmationAction = true)
     }
 
     private fun selectItem(position: Int) {


### PR DESCRIPTION
This PR adds tests for the functionality moved to the PhotoPickerViewModel.

To test:
- I don't think this needs to be tested if the unit tests pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
