### PR TITLE
[Platform] Fix rmagick version to be compatible with imagemagick 7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rmagick (3.2.0)
+    rmagick (4.1.2)
     rouge (2.0.7)
     rubyzip (1.3.0)
     sawyer (0.8.2)
@@ -234,7 +234,7 @@ DEPENDENCIES
   fastlane (= 2.146.1)!
   fastlane-plugin-wpmreleasetoolkit!
   nokogiri!
-  rmagick (~> 3.2.0)
+  rmagick (~> 4.1)
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 841e167dffc0f45fc36a513f8ba68a37689141e8
-  tag: 0.9.11
+  revision: eaca947d0c41602d2048d0a54afb8528f8398c62
+  tag: 0.9.13
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.11)
+    fastlane-plugin-wpmreleasetoolkit (0.9.13)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -51,10 +51,10 @@ GEM
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     declarative (0.0.10)
     declarative-option (0.1.0)
-    diffy (3.3.0)
+    diffy (3.4.0)
     digest-crc (0.5.1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -165,7 +165,7 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.7)
+    oj (3.10.8)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.0)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,7 +3,7 @@
 # Ensure this file is checked in to source control!
 
 group :screenshots, optional: true do
-  gem 'rmagick', '~> 3.2.0'
+  gem 'rmagick', '~> 4.1'
 end
 
 gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.11'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,4 +6,4 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.11'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.13'


### PR DESCRIPTION
### Context

When creating images for the PlayStore, we're supposed to run `fastlane screenshots` to generate the screenshots, then run `fastlane create_promo_screenshots` to create promotional images for the PlayStore from those screenshots.

The `create_promo_screenshots` lane requires the RMagick gem to be installed (via `bundle install --with screenshots`), which in turn requires `imagemagick` – which you are supposed to install via `brew install imagemagick` on Mac.

### Issue and Fix

* `brew install` always installs the latest version of a formula, which for `imagemagick` is `7.x` as of today
* But the `rmagick` gem we're currently using in our `Gemfile` is `~> 3.2.0`, which [is not compatible with imagemagick 7](https://github.com/rmagick/rmagick/issues/256)

The fix is to update rmagick to `~> 4.1` – as the support for imagemagick 7 was implemented starting rmagick 4.1.0.rc2

Note that this new major version of rmagick has removed the `CopyOpacityCompositeOp` constant (which was already deprecated in 3.x) to rename it `CopyAlphaCompositeOp`. This means that in order to be able to use `rmagick ~> 4.1`, we need to use the new constants in our release-toolkit scripts too. This is what [this dependant PR on the toolkit](https://github.com/wordpress-mobile/release-toolkit/pull/154) fixes.

### PR Dependency

This PR depends [on a fix on the release-toolkit](https://github.com/wordpress-mobile/release-toolkit/pull/154) ~to be merged first~ [EDIT] which has now been merged [/EDIT].

To undraft this PR, one first needs to:
 - [x] merge https://github.com/wordpress-mobile/release-toolkit/pull/154
 - [x] release a new version of the release-toolkit
 - [x] revert commit 380918e511be8aef72127eeee1199642de1161ec of this PR which points to the fork, and instead make it point to the new version of `release-toolkit`
 - [x] re-test the code and undraft the PR

### To test:

 * Run `brew uninstall imagemagick` then `brew install imagemagick` to simulate that it's your first time installing imagemagick, and to thus get the only version of imagemagick available via brew today (7.x)
 * Run `bundle install --with screenshots` to install rmagick
 * Run `bundle exec fastlane screenshots` then `bundle exec fastlane create_promo_screenshots`

---

PR submission checklist:

- [x] I have considered ~adding unit tests where possible~.
- [x] I have considered ~adding accessibility improvements for my changes~.
- [x] I have considered if ~this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~
