### PR TITLE
Make local copy of media when using 3rd party URIs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -120,7 +120,7 @@ import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts.Companion.getPromptDetailsForTask
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts.Companion.isTargetingBottomNavBar
 import org.wordpress.android.ui.quickstart.QuickStartNoticeDetails
-import org.wordpress.android.ui.stories.StoriesMediaPickerResultHandler.Companion.handleMediaPickerResultForStories
+import org.wordpress.android.ui.stories.StoriesMediaPickerResultHandler
 import org.wordpress.android.ui.stories.StoriesTrackerHelper
 import org.wordpress.android.ui.stories.StoryComposerActivity
 import org.wordpress.android.ui.themes.ThemeBrowserActivity
@@ -189,6 +189,7 @@ class MySiteFragment : Fragment(),
     @Inject lateinit var uploadUtilsWrapper: UploadUtilsWrapper
     @Inject lateinit var meGravatarLoader: MeGravatarLoader
     @Inject lateinit var storiesTrackerHelper: StoriesTrackerHelper
+    @Inject lateinit var storiesMediaPickerResultHandler: StoriesMediaPickerResultHandler
     val selectedSite: SiteModel?
         get() {
             return (activity as? WPMainActivity)?.selectedSite
@@ -742,7 +743,7 @@ class MySiteFragment : Fragment(),
                 isDomainCreditAvailable = false
             }
             RequestCodes.PHOTO_PICKER -> if (resultCode == Activity.RESULT_OK && data != null) {
-                if (!handleMediaPickerResultForStories(data, activity, selectedSite)) {
+                if (!storiesMediaPickerResultHandler.handleMediaPickerResultForStories(data, activity, selectedSite)) {
                     if (data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_ID)) {
                         val mediaId = data.getLongExtra(PhotoPickerActivity.EXTRA_MEDIA_ID, 0).toInt()
                         showSiteIconProgressBar(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -90,6 +90,7 @@ class PostsListActivity : LocaleAwareActivity(),
     @Inject internal lateinit var uploadUtilsWrapper: UploadUtilsWrapper
     @Inject internal lateinit var systemNotificationTracker: SystemNotificationsTracker
     @Inject internal lateinit var editPostRepository: EditPostRepository
+    @Inject internal lateinit var storiesMediaPickerResultHandler: StoriesMediaPickerResultHandler
 
     private lateinit var site: SiteModel
 
@@ -460,7 +461,7 @@ class PostsListActivity : LocaleAwareActivity(),
         } else if (requestCode == RequestCodes.REMOTE_PREVIEW_POST) {
             viewModel.handleRemotePreviewClosing()
         } else if (requestCode == RequestCodes.PHOTO_PICKER && resultCode == Activity.RESULT_OK && data != null) {
-            StoriesMediaPickerResultHandler.handleMediaPickerResultForStories(data, this, site)
+            storiesMediaPickerResultHandler.handleMediaPickerResultForStories(data, this, site)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
@@ -69,8 +69,7 @@ class StoriesMediaPickerResultHandler @Inject constructor(
                 }
 
                 launch {
-                    val optimizedResult
-                            = fetchAndOptimizeLocalMediaIfNeededUseCase.copyAndOptimizeMedia(
+                    val optimizedResult = fetchAndOptimizeLocalMediaIfNeededUseCase.copyAndOptimizeMedia(
                             convertStringArrayIntoUrisList(mediaUriStringsArray),
                             requireNotNull(selectedSite),
                             false

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
@@ -2,70 +2,114 @@ package org.wordpress.android.ui.stories
 
 import android.app.Activity
 import android.content.Intent
+import android.net.Uri
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
+import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
 import org.wordpress.android.ui.media.MediaBrowserActivity
 import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity
+import org.wordpress.android.ui.stories.usecase.FetchAndOptimizeLocalMediaIfNeededUseCase
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.UTILS
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.coroutines.CoroutineContext
 
-class StoriesMediaPickerResultHandler {
-    companion object {
-        /* return true if MediaPickerResult was handled */
-        fun handleMediaPickerResultForStories(
-            data: Intent,
-            activity: Activity?,
-            selectedSite: SiteModel?
-        ): Boolean {
-            if (data.getBooleanExtra(PhotoPickerActivity.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED, false)) {
-                ActivityLauncher.addNewStoryForResult(
+class StoriesMediaPickerResultHandler @Inject constructor(
+    private val fetchAndOptimizeLocalMediaIfNeededUseCase: FetchAndOptimizeLocalMediaIfNeededUseCase,
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
+) : CoroutineScope {
+    // region Fields
+    private var job: Job = Job()
+
+    override val coroutineContext: CoroutineContext
+        get() = mainDispatcher + job
+
+    /* return true if MediaPickerResult was handled */
+    fun handleMediaPickerResultForStories(
+        data: Intent,
+        activity: Activity?,
+        selectedSite: SiteModel?
+    ): Boolean {
+        if (data.getBooleanExtra(PhotoPickerActivity.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED, false)) {
+            ActivityLauncher.addNewStoryForResult(
+                    activity,
+                    selectedSite,
+                    PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
+            )
+            return true
+        } else if (isWPStoriesMediaBrowserTypeResult(data)) {
+            if (data.hasExtra(MediaBrowserActivity.RESULT_IDS)) {
+                ActivityLauncher.addNewStoryWithMediaIdsForResult(
                         activity,
                         selectedSite,
-                        PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
+                        PagePostCreationSourcesDetail.STORY_FROM_MY_SITE,
+                        data.getLongArrayExtra(
+                                MediaBrowserActivity.RESULT_IDS
+                        )
                 )
                 return true
-            } else if (isWPStoriesMediaBrowserTypeResult(data)) {
-                if (data.hasExtra(MediaBrowserActivity.RESULT_IDS)) {
-                    ActivityLauncher.addNewStoryWithMediaIdsForResult(
-                            activity,
-                            selectedSite,
-                            PagePostCreationSourcesDetail.STORY_FROM_MY_SITE,
-                            data.getLongArrayExtra(
-                                    MediaBrowserActivity.RESULT_IDS
-                            )
+            } else {
+                val mediaUriStringsArray = data.getStringArrayExtra(
+                        PhotoPickerActivity.EXTRA_MEDIA_URIS
+                )
+                if (mediaUriStringsArray.isNullOrEmpty()) {
+                    AppLog.e(
+                            UTILS,
+                            "Can't resolve picked or captured image"
                     )
-                    return true
-                } else {
-                    val mediaUriStringsArray = data.getStringArrayExtra(
-                            PhotoPickerActivity.EXTRA_MEDIA_URIS
+                    return false
+                }
+
+                launch {
+                    val optimizedResult
+                            = fetchAndOptimizeLocalMediaIfNeededUseCase.copyAndOptimizeMedia(
+                            convertStringArrayIntoUrisList(mediaUriStringsArray),
+                            requireNotNull(selectedSite),
+                            false
                     )
-                    if (mediaUriStringsArray.isNullOrEmpty()) {
-                        AppLog.e(
-                                UTILS,
-                                "Can't resolve picked or captured image"
-                        )
-                        return false
-                    }
+
                     ActivityLauncher.addNewStoryWithMediaUrisForResult(
                             activity,
                             selectedSite,
-                            PagePostCreationSourcesDetail.STORY_FROM_MY_SITE,
-                            mediaUriStringsArray
+                            STORY_FROM_MY_SITE,
+                            convertUrisListToStringArray(optimizedResult.optimizedMediaUris)
                     )
-                    return true
                 }
+                return true
             }
-            return false
         }
+        return false
+    }
 
-        private fun isWPStoriesMediaBrowserTypeResult(data: Intent): Boolean {
-            if (data.hasExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)) {
-                val browserType = data.getSerializableExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)
-                return (browserType as MediaBrowserType).isWPStoriesPicker
-            }
-            return false
+    private fun isWPStoriesMediaBrowserTypeResult(data: Intent): Boolean {
+        if (data.hasExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)) {
+            val browserType = data.getSerializableExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)
+            return (browserType as MediaBrowserType).isWPStoriesPicker
         }
+        return false
+    }
+
+    private fun convertStringArrayIntoUrisList(stringArray: Array<String>): List<Uri> {
+        val uris: MutableList<Uri> = ArrayList(stringArray.size)
+        for (stringUri in stringArray) {
+            uris.add(Uri.parse(stringUri))
+        }
+        return uris
+    }
+
+    private fun convertUrisListToStringArray(uris: List<Uri?>): Array<String?>? {
+        val stringUris = arrayOfNulls<String>(uris.size)
+        for (i in uris.indices) {
+            stringUris[i] = uris[i].toString()
+        }
+        return stringUris
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/FetchAndOptimizeLocalMediaIfNeededUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/usecase/FetchAndOptimizeLocalMediaIfNeededUseCase.kt
@@ -1,0 +1,38 @@
+package org.wordpress.android.ui.stories.usecase
+
+import android.net.Uri
+import dagger.Reusable
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.posts.editor.media.CopyMediaToAppStorageUseCase
+import org.wordpress.android.ui.posts.editor.media.CopyMediaToAppStorageUseCase.CopyMediaResult
+import org.wordpress.android.ui.posts.editor.media.OptimizeMediaUseCase
+import org.wordpress.android.ui.posts.editor.media.OptimizeMediaUseCase.OptimizeMediaResult
+import javax.inject.Inject
+
+/**
+ * Processes a list of local media items in the background (optimizing, resizing, rotating, etc.)
+ */
+@Reusable
+class FetchAndOptimizeLocalMediaIfNeededUseCase @Inject constructor(
+    private val copyMediaToAppStorageUseCase: CopyMediaToAppStorageUseCase,
+    private val optimizeMediaUseCase: OptimizeMediaUseCase
+) {
+    /**
+     * Copies files to app storage and optimizes them
+     */
+    suspend fun copyAndOptimizeMedia(
+        uriList: List<Uri>,
+        site: SiteModel,
+        freshlyTaken: Boolean
+    ): OptimizeMediaResult {
+        // Copy files to apps storage to make sure they are permanently accessible.
+        val copyFilesResult: CopyMediaResult = copyMediaToAppStorageUseCase.copyFilesToAppStorageIfNecessary(uriList)
+
+        // Optimize and rotate the media
+        return optimizeMediaUseCase.optimizeMediaIfSupportedAsync(
+                        site,
+                        freshlyTaken,
+                        copyFilesResult.permanentlyAccessibleUris
+                )
+    }
+}


### PR DESCRIPTION
THIS IS WIP.

Fixes https://github.com/Automattic/stories-android/issues/493, https://github.com/Automattic/stories-android/issues/420

Related to the issue described and fixed in https://github.com/wordpress-mobile/WordPress-Android/pull/5963 for other parts of the app.

### Description of the issue

When a 3rd party app media URI is fetched, it lasts for about as much as the context where the content provider was queried exists.
In the Stories flow, when tapping on the FAB to create a new Story and then tap on  "add a story", we first show the media picker (that is, in the context of the main screen). From the app's photo picker you can go to the native picker, and from there you can open the list of apps that can expose filtered media (such as Google Photos app). Once you make your pick, a set of temporal URIs are provided, and these are valid for as long as the context of the original request lasts.
Hence, we could see strange behavior such as picking several pictures and only some of them added, or getting to add them all as slides (pick 5 images and get 5 slides added), and show as thumbnails OK given these were populated as soon as the Story composer is created, but then would show black boxes when switching story slides given those provided URIs were no longer valid.

If, for example, you'd start a Story and then would stay there (keeping the Activity as a context), then opening the media picker from the Story composer and picking Google Photos pictures from there would in turn work alright, given these URIs were still valid for the context.

### Solution
Then long term solution is to fetch and keep a copy of the media, as we do elsewhere.

The problem of our use case is that we _start our flow from the main screen_  and then pass the URis to another context.
We need to save those URI's image data and then pass the local copy URIs to the composer instead, all of this also taking into account it could be a lengthy operation so, we'll need to show a progress dialog and make sure the context doesn't go away until we're done.

This PR introduces a `FetchAndOptimizeLocalMediaIfNeededUseCase` and made `StoriesMediaPickerResultHandler` a CoroutineScope so URIs picked in the mediapicker from 3rd party apps are first copied locally and then fed into the Stories composer.

### To test:
You should have Google Photos installed and logged in, with a few pictures taken on another device (so we make sure these pics are not local to the device).

1. open the WP app
2. tap on the FAB, select Add story post
3. when the media picker shows up, tap on the left bottom button and then choose "Choose from device"
4. the native media picker appears. Tap on the hamburger icon on the top-left of the screen. At the bottom of the list, a few apps should appear. Look for Google Photos.
5. pick a few images
6. observe these get added to your new Story, and a dialog appears for a while if processing needs be done first.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
