### PR TITLE
WP Stories: fix stories media Uris handling 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -252,7 +252,6 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         requestCodes.PHOTO_PICKER = RequestCodes.PHOTO_PICKER
         requestCodes.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED =
                 PhotoPickerActivity.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED
-        requestCodes.EXTRA_MEDIA_URIS = PhotoPickerActivity.EXTRA_MEDIA_URIS
         // we're handling EXTRA_MEDIA_URIS at the app level (not at the Stories library level)
         // hence we set the requestCode to UNUSED
         requestCodes.EXTRA_MEDIA_URIS = UNUSED_KEY

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -99,6 +99,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         const val STATE_KEY_POST_LOCAL_ID = "state_key_post_model_local_id"
         const val STATE_KEY_EDITOR_SESSION_DATA = "stateKeyEditorSessionData"
         const val KEY_POST_LOCAL_ID = "key_post_model_local_id"
+        const val UNUSED_KEY = "unused_key"
         const val BASE_FRAME_MEDIA_ERROR_NOTIFICATION_ID: Int = 72300
     }
 
@@ -252,6 +253,9 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         requestCodes.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED =
                 PhotoPickerActivity.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED
         requestCodes.EXTRA_MEDIA_URIS = PhotoPickerActivity.EXTRA_MEDIA_URIS
+        // we're handling EXTRA_MEDIA_URIS at the app level (not at the Stories library level)
+        // hence we set the requestCode to UNUSED
+        requestCodes.EXTRA_MEDIA_URIS = UNUSED_KEY
     }
 
     override fun showProvidedMediaPicker() {
@@ -269,17 +273,24 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     }
 
     private fun handleMediaPickerIntentData(data: Intent) {
-        // TODO move this to EditorMedia
-        val ids = ListUtils.fromLongArray(
-                data.getLongArrayExtra(
-                        MediaBrowserActivity.RESULT_IDS
-                )
-        )
-        if (ids == null || ids.size == 0) {
-            return
+        if (data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)) {
+            val uriList: List<Uri> = convertStringArrayIntoUrisList(
+                    data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)
+            )
+            if (uriList.isNotEmpty()) {
+                storyEditorMedia.onPhotoPickerMediaChosen(uriList)
+            }
+        } else if (data.hasExtra(MediaBrowserActivity.RESULT_IDS)) {
+            val ids = ListUtils.fromLongArray(
+                    data.getLongArrayExtra(
+                            MediaBrowserActivity.RESULT_IDS
+                    )
+            )
+            if (ids == null || ids.size == 0) {
+                return
+            }
+            storyEditorMedia.addExistingMediaToEditorAsync(WP_MEDIA_LIBRARY, ids)
         }
-
-        storyEditorMedia.addExistingMediaToEditorAsync(WP_MEDIA_LIBRARY, ids)
     }
 
     private fun setupStoryEditorMediaObserver() {


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/493, https://github.com/Automattic/stories-android/issues/420

Supersedes #12661 

Related to the issue described and fixed in https://github.com/wordpress-mobile/WordPress-Android/pull/5963 for other parts of the app.

### Description of the issue

When a 3rd party app media URI is fetched, it lasts for about as much as the context where the content provider was queried exists.
In the Stories flow, when tapping on the FAB to create a new Story and then tap on  "add a story", we first show the media picker (that is, in the context of the main screen). From the app's photo picker you can go to the native picker, and from there you can open the list of apps that can expose filtered media (such as Google Photos app). Once you make your pick, a set of temporal URIs are provided, and these are valid for a brief time, as the [documentation](https://developer.android.com/training/secure-file-sharing/request-file.html#OpenFile) says _"The permissions are temporary, so once the client app's task stack is finished, the file is no longer accessible outside the server app. "_
Hence, we could see strange behavior such as picking several pictures and only some of them added, or getting to add them all as slides (pick 5 images and get 5 slides added), and show as thumbnails OK given these were populated as soon as the Story composer is created, but then would show black boxes when switching story slides given those provided URIs were no longer valid.

If, for example, you'd start a Story and then would stay there (keeping the Activity as a context), then opening the media picker from the Story composer and picking Google Photos pictures from there would in turn work alright, given these URIs were still valid for the context (also, we're following the path of making a local copy here as well).

### Solution
Then long term solution is to fetch and keep a copy of the media, as we do elsewhere.

After attempting the approach described in #12661, I realized we were already doing everything we needed in `StoryEditorMedia`'s `addNewMediaItemsToEditorAsync()`, which is called in `onPhotoPickerMediaChosen()`.
The trick in this PR is to avoid having the super class (ComposeLoopFrameActivity) try to handle `EXTRA_MEDIA_URIS` in this case, given we really need to proceed with making a local copy as is performed by `CopyMediaToAppStorageUseCase`.

The PR is fairly simple: we initialize the `EXTRA_MEDIA_URIS` requestCode to something we know is not used so we never mistakingly use it in ComposeLoopFrameActivity, and instead let the StoryComposerActivity handle that in `handleMediaPickerIntentData().` The problem with feeding mediaUris directly to ComposeLoopFrameActivity is that the Stories library doesn't know how to handle these, and will just add them as Story slides. As explained above, these would seemingly work for a few seconds and then would just stop working. Hence, we leave the responsibility of feeding valid Uris to the consumer of the Stories library, in this case the `StoryComposerActivity`.

### To test:
You should have Google Photos installed and logged in, with a few pictures taken on another device (so we make sure these pics are not local to the device).

1. open the WP app
2. tap on the FAB, select Add story post
3. when the media picker shows up, tap on the left bottom button and then choose "Choose from device"
4. the native media picker appears. Tap on the hamburger icon on the top-left of the screen. At the bottom of the list, a few apps should appear. Look for Google Photos.
5. pick a few images
6. observe these get added to your new Story, and a dialog appears for a while if processing needs be done first.

Also, test that you can still _start_ a Story by picking media from all other sources (device video, free photo gallery, WordPress media, take a picture/video with capture mode), and you can also use all supported sources to include media on an ongoing Story (that is, after you made your first selection).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
