### PR TITLE
Fix translatable attributes

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2909,8 +2909,8 @@
     <string name="dialog_discard_story_title">Discard story post?</string>
     <string name="dialog_discard_story_message">Your story post will not be saved as a draft.</string>
     <string name="dialog_discard_story_ok_button">Discard</string>
-    <string name="pref_camera_selection">pref_camera_selection</string>
-    <string name="pref_flash_mode_selection">pref_flash_mode_selection</string>
+    <string name="pref_camera_selection" translatable="false">pref_camera_selection</string>
+    <string name="pref_flash_mode_selection" translatable="false">pref_flash_mode_selection</string>
     <string name="story_saving_untitled">Untitled</string>
     <string name="story_saving_title">Saving "%1$s"…</string>
     <string name="story_saving_title_several">several stories</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2909,9 +2909,8 @@
     <string name="dialog_discard_story_title">Discard story post?</string>
     <string name="dialog_discard_story_message">Your story post will not be saved as a draft.</string>
     <string name="dialog_discard_story_ok_button">Discard</string>
-    <string name="pref_camera_selection">pref_camera_selection</string>
-    <string name="pref_flash_mode_selection">pref_flash_mode_selection</string>
-    <string name="pref_key_send_crash">pref_key_send_crash</string>
+    <string name="pref_camera_selection" translatable="false">pref_camera_selection</string>
+    <string name="pref_flash_mode_selection" translatable="false">pref_flash_mode_selection</string>
     <string name="story_saving_untitled">Untitled</string>
     <string name="story_saving_title">Saving "%1$s"…</string>
     <string name="story_saving_title_several">several stories</string>


### PR DESCRIPTION
This PR brings back the `translatable=false` attribute to some strings imported from libraries. They add the attribute in the original source code, but it got lost during the import. 

I'll address the bug in the importer script in another PR.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
