### PR TITLE
Fix encrypted logging crash

### DIFF
--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -73,6 +73,12 @@
 -keep class com.facebook.hermes.unicode.** { *; }
 ###### React Native - end
 
+###### Encrypted Logs - begin
+-dontwarn java.awt.*
+-keep class com.sun.jna.* { *; }
+-keepclassmembers class * extends com.sun.jna.* { public *; }
+###### Encrypted Logs - end
+
 ###### Main resource class - begin
 -keepattributes InnerClasses
 


### PR DESCRIPTION
Fixes a crash in encrypted logging in release mode.

To Test:
1. Switch to `release/15.5`.
2. Apply [this patch](https://github.com/wordpress-mobile/WordPress-Android/files/5071963/0001-Enqueue-a-log-file-when-the-pages-activity-is-launch.patch.zip) to the repo.
3. Under "Build Variants" in WPAndroid, switch to `vanillaRelease`, and run on-device.
4. Navigate to "Site Pages" – the activity should crash, sending you back to the "My Site" screen.
5. Close the app using the app switcher, and try to relaunch. It should always crash at launch.
6. Delete the app from your device.
7. Switch to this branch.
8. Apply the patch again.
9. Run the `vanillaRelease` build variant on your device again, and navigate to "Site Pages"
10. The app should no longer crash.



