### PR TITLE
Support AVI file in media upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = 'c27c8374af41f53dcd561433b4f77237d9302236'
+    fluxCVersion = '6820d2c52'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.18'
+    fluxCVersion = 'c27c8374af41f53dcd561433b4f77237d9302236'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '6820d2c52'
+    fluxCVersion = '1.6.19'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'


### PR DESCRIPTION
We realised in testing that the some of the AVI files cannot be uploaded because their mime type is `video/x-msvideo`. This is added in FluxC in this PR - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1666 and you can test it here.

To test:
- download a sample AVI file
- go to Media library
- Click on + and "Choose from device"
- Click on your downloaded AVI file
- Check that the upload successfully finishes
- The thumbnail will not be visible and the file will not be playable because this format is not supported by the Android system

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
