### PR TITLE
Update memory for translators builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,8 @@ jobs:
     environment:
       APP_VERSION_PREFIX: << pipeline.parameters.translation_review_lang_id >>
     steps:
-      - git/shallow-checkout
+      - git/shallow-checkout:
+          init-submodules: true
       - checkout-submodules
       - bundle-install/bundle-install:
           cache_key_prefix: installable-build
@@ -341,9 +342,9 @@ jobs:
       - restore-gutenberg-bundle-cache
       - run:
           name: Ensure assets folder exists
-          command: mkdir -p libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+          command: mkdir -p libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/src/main/assets
       - attach_workspace:
-          at: libs/gutenberg-mobile/react-native-gutenberg-bridge/android/src/main/assets
+          at: libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/src/main/assets
       - run:
           name: Build APK
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,6 +336,7 @@ jobs:
       - run:
           name: Copy Secrets
           command: bundle exec fastlane run configure_apply
+      - update-gradle-memory
       - android/restore-gradle-cache
       - restore-gutenberg-bundle-cache
       - run:


### PR DESCRIPTION
This PR updates the CircleCI config for the Installable builds for translators. It brings in some changes made to other configurations that weren't applied to this one in the original PRs.

To test:
- Make sure the CI is green, including the `translation-review-build` task.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
