### PR TITLE
Update CI config for release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
       steps:
         - run:
             name: Update memory setting
-            command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-Xmx1537m -XX:+HeapDumpOnOutOfMemoryError/" gradle.properties
+            command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError/" gradle.properties
   npm-install:
     steps:
       - restore_cache:
@@ -258,17 +258,18 @@ jobs:
             APP_VERSION=$(./gradlew -q printVersionName | tail -1)
             echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress Android $APP_VERSION failed!'" >> $BASH_ENV
             echo "export SLACK_SUCCESS_MESSAGE=':tada: WordPress Android $APP_VERSION has been deployed!'" >> $BASH_ENV
+            bundle check
             if [[ $APP_VERSION == *"-rc-"* ]]; then
-              bundle exec fastlane build_and_upload_pre_releases skip_confirm:true create_release:true
+              bundle exec fastlane build_and_upload_pre_releases skip_confirm:true skip_prechecks:true create_release:true
             else
-              bundle exec fastlane build_and_upload_release skip_confirm:true create_release:true
+              bundle exec fastlane build_and_upload_release skip_confirm:true skip_prechecks:true create_release:true
             fi
       - android/save-gradle-cache
       - slack/status:
           include_job_number_field: false
           include_project_field: false
           include_visit_job_action: false
-          webhook: '${SLACK_BUILD_WEBHOOK}'
+          webhook: '${SLACK_BUILD_WEBHOOK_2}'
           failure_message: '${SLACK_FAILURE_MESSAGE}'
           success_message: '${SLACK_SUCCESS_MESSAGE}'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,8 @@ jobs:
           command: mv libs/gutenberg-mobile/bundle/android/App.js libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/build/assets/index.android.bundle
       - save-gutenberg-bundle-cache
   test:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -131,9 +130,8 @@ jobs:
       - android/save-gradle-cache
       - android/save-test-results
   lint:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -177,9 +175,8 @@ jobs:
       - android/save-gradle-cache
       - android/save-lint-results
   Installable Build:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -279,9 +276,8 @@ jobs:
         description: Post to Slack when tests fail. SLACK_WEBHOOK ENV variable must be set.
         type: boolean
         default: false
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -324,9 +320,8 @@ jobs:
                 include_project_field: false
                 failure_message: ':red_circle: WordPress Android connected tests failed on \`${CIRCLE_BRANCH}\` branch after merge by ${CIRCLE_USERNAME}. See <https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670|Firebase console test results> for details.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'
   WordPressUtils Connected Tests:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -374,9 +369,8 @@ jobs:
           name: Validate login strings
           command: bundle exec fastlane validate_login_strings pr_url:$CIRCLE_PULL_REQUEST
   translation-review-build:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     environment:
       APP_VERSION_PREFIX: << pipeline.parameters.translation_review_lang_id >>
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,56 @@ jobs:
       - store_artifacts:
           path: Artifacts
           destination: Artifacts
+  Release Build:
+    executor:
+      name: android/default
+      api-version: "28"
+    steps:
+      - git/shallow-checkout:
+          init-submodules: true
+      - checkout-submodules
+      - bundle-install/bundle-install:
+          cache_key_prefix: installable-build
+      - run:
+          name: Copy Secrets
+          command: bundle exec fastlane run configure_apply
+      - update-gradle-memory
+      - android/restore-gradle-cache
+      - restore-gutenberg-bundle-cache
+      - run:
+          name: Ensure assets folder exists
+          command: mkdir -p libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/src/main/assets
+      - attach_workspace:
+          at: libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/src/main/assets
+      - run:
+          name: Install other tools
+          command: |
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+            eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+            echo "export PATH='/home/linuxbrew/.linuxbrew/Cellar/bundletool/1.0.0/bin:$PATH'" >> $BASH_ENV
+            brew install bundletool
+      - run:
+          name: Build APK
+          environment:
+            SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
+          command: |
+            APP_VERSION=$(./gradlew -q printVersionName | tail -1)
+            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress Android $APP_VERSION failed!'" >> $BASH_ENV
+            echo "export SLACK_SUCCESS_MESSAGE=':tada: WordPress Android $APP_VERSION has been deployed!'" >> $BASH_ENV
+            if [[ $APP_VERSION == *"-rc-"* ]]; then
+              bundle exec fastlane build_and_upload_pre_releases skip_confirm:true create_release:true
+            else
+              bundle exec fastlane build_and_upload_release skip_confirm:true create_release:true
+            fi
+      - android/save-gradle-cache
+      - slack/status:
+          include_job_number_field: false
+          include_project_field: false
+          include_visit_job_action: false
+          webhook: '${SLACK_BUILD_WEBHOOK}'
+          failure_message: '${SLACK_FAILURE_MESSAGE}'
+          success_message: '${SLACK_SUCCESS_MESSAGE}'
+
   Connected Tests:
     parameters:
       post-to-slack:
@@ -419,3 +469,12 @@ workflows:
     when: << pipeline.parameters.translation_review_build >>
     jobs:
       - translation-review-build
+  Release Build:
+    unless: << pipeline.parameters.translation_review_build >>
+    jobs:
+      - Release Build:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+(\.\d+)*(-rc-\d)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,6 +472,7 @@ workflows:
   Release Build:
     unless: << pipeline.parameters.translation_review_build >>
     jobs:
+      - gutenberg-bundle-build
       - Release Build:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,9 +220,8 @@ jobs:
           path: Artifacts
           destination: Artifacts
   Release Build:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
           command: |
             if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-              bundle exec fastlane build_alpha skip_confirm:true skip_prechecks:true create_release:true
+              bundle exec fastlane build_alpha skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
             fi 
           no_output_timeout: 15m
       - run: 
@@ -275,9 +275,9 @@ jobs:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
           command: |
             if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-              bundle exec fastlane build_beta skip_confirm:true skip_prechecks:true create_release:true
+              bundle exec fastlane build_beta skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
             else
-              bundle exec fastlane build_and_upload_release skip_confirm:true skip_prechecks:true create_release:true
+              bundle exec fastlane build_and_upload_release skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
             fi
           no_output_timeout: 15m
       - android/save-gradle-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
           include_job_number_field: false
           include_project_field: false
           include_visit_job_action: false
-          webhook: '${SLACK_BUILD_WEBHOOK_2}'
+          webhook: '${SLACK_BUILD_WEBHOOK}'
           failure_message: '${SLACK_FAILURE_MESSAGE}'
           success_message: '${SLACK_SUCCESS_MESSAGE}'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,8 +250,9 @@ jobs:
           command: |
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
             eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-            echo "export PATH='/home/linuxbrew/.linuxbrew/Cellar/bundletool/1.0.0/bin:$PATH'" >> $BASH_ENV
+            brew install openjdk
             brew install bundletool
+            echo "export PATH='/home/linuxbrew/.linuxbrew/Cellar/bundletool/1.2.0/bin:$PATH'" >> $BASH_ENV
       - run: 
           name: Prepare build
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
       steps:
         - run:
             name: Update memory setting
-            command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError/" gradle.properties
+            command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-Xmx3500m -XX:+HeapDumpOnOutOfMemoryError/" gradle.properties
   npm-install:
     steps:
       - restore_cache:
@@ -255,6 +255,7 @@ jobs:
             echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress Android $APP_VERSION failed!'" >> $BASH_ENV
             echo "export SLACK_SUCCESS_MESSAGE=':tada: WordPress Android $APP_VERSION has been deployed!'" >> $BASH_ENV
             bundle check
+            ./gradlew --stacktrace lintVanillaRelease
             if [[ $APP_VERSION == *"-rc-"* ]]; then
               bundle exec fastlane build_and_upload_pre_releases skip_confirm:true skip_prechecks:true create_release:true
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
       steps:
         - run:
             name: Update memory setting
-            command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-Xmx3500m -XX:+HeapDumpOnOutOfMemoryError/" gradle.properties
+            command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-Xmx1537m -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false /" gradle.properties
   npm-install:
     steps:
       - restore_cache:
@@ -222,7 +222,13 @@ jobs:
   Release Build:
     docker:
       - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
+    environment:
+      JVM_OPTS: -Xmx2048m
     steps:
+      - run: 
+          name: Init messages
+          command: |
+            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress Android failed!'" >> $BASH_ENV
       - git/shallow-checkout:
           init-submodules: true
       - checkout-submodules
@@ -246,22 +252,38 @@ jobs:
             eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
             echo "export PATH='/home/linuxbrew/.linuxbrew/Cellar/bundletool/1.0.0/bin:$PATH'" >> $BASH_ENV
             brew install bundletool
+      - run: 
+          name: Prepare build
+          command: |
+            echo "export APP_VERSION=$(./gradlew -q printVersionName | tail -1)" >> $BASH_ENV 
+            SLACK_MESSAGE_VERSION=$(./gradlew -q printVersionName | tail -1)
+            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress Android $SLACK_MESSAGE_VERSION failed!'" >> $BASH_ENV
+            echo "export SLACK_SUCCESS_MESSAGE=':tada: WordPress Android $SLACK_MESSAGE_VERSION has been deployed!'" >> $BASH_ENV
+            bundle check
       - run:
-          name: Build APK
+          name: Build Zalpha 
           environment:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
           command: |
-            APP_VERSION=$(./gradlew -q printVersionName | tail -1)
-            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress Android $APP_VERSION failed!'" >> $BASH_ENV
-            echo "export SLACK_SUCCESS_MESSAGE=':tada: WordPress Android $APP_VERSION has been deployed!'" >> $BASH_ENV
-            bundle check
-            ./gradlew --stacktrace lintVanillaRelease
-            if [[ $APP_VERSION == *"-rc-"* ]]; then
-              bundle exec fastlane build_and_upload_pre_releases skip_confirm:true skip_prechecks:true create_release:true
+            if [[ ${APP_VERSION} == *"-rc-"* ]]; then
+              bundle exec fastlane build_alpha skip_confirm:true skip_prechecks:true create_release:true
+            fi 
+          no_output_timeout: 15m
+      - run: 
+          name: Build Vanilla
+          environment:
+            SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
+          command: |
+            if [[ ${APP_VERSION} == *"-rc-"* ]]; then
+              bundle exec fastlane build_beta skip_confirm:true skip_prechecks:true create_release:true
             else
               bundle exec fastlane build_and_upload_release skip_confirm:true skip_prechecks:true create_release:true
             fi
+          no_output_timeout: 15m
       - android/save-gradle-cache
+      - store_artifacts:
+          path: build
+          destination: Artifacts
       - slack/status:
           include_job_number_field: false
           include_project_field: false
@@ -467,8 +489,23 @@ workflows:
   Release Build:
     unless: << pipeline.parameters.translation_review_build >>
     jobs:
-      - gutenberg-bundle-build
+      - gutenberg-bundle-build:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+(\.\d+)*(-rc-\d)?$/
+      - lint:
+          requires:
+            - gutenberg-bundle-build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+(\.\d+)*(-rc-\d)?$/
       - Release Build:
+          requires:
+            - lint 
           filters:
             branches:
               ignore: /.*/

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -414,6 +414,12 @@ task violationCommentsToGitHub(type: se.bjurr.violations.comments.github.plugin.
     ]
 }
 
+task printVersionName {
+    doLast {
+        println android.productFlavors.vanilla.versionName
+    }
+}
+
 def checkGradlePropertiesFile() {
     def inputFile = file("${rootDir}/gradle.properties")
     if (!inputFile.exists()) {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -258,7 +258,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
       alpha: true,
       beta: true,
       final: false)
-    android_build_preflight()
+    android_build_preflight() unless (options[:skip_prechecks])
     build_alpha(skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release])
     build_beta(skip_prechecks: true, skip_confirm: options[:skip_confirm], upload_to_play_store: true, create_release: options[:create_release])
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -522,10 +522,12 @@ ENV["HAS_ALPHA_VERSION"]="true"
       sh("mkdir -p #{build_dir}")
       UI.message("Running lint...")
       sh("echo \"Running lint...\" >> #{logfile_path}")
-      sh("./gradlew lint#{options[:flavor]}Release >> #{logfile_path} 2>&1")
+      #sh("./gradlew lint#{options[:flavor]}Release >> #{logfile_path} 2>&1")
+      sh("./gradlew lint#{options[:flavor]}Release")
       UI.message("Building #{version["name"]} / #{version["code"]} - #{aab_file}...")
       sh("echo \"Building #{version["name"]} / #{version["code"]} - #{aab_file}...\" >> #{logfile_path}")
-      sh("./gradlew bundle#{options[:flavor]}Release >> #{logfile_path} 2>&1")
+      #sh("./gradlew bundle#{options[:flavor]}Release >> #{logfile_path} 2>&1")
+      sh("./gradlew bundle#{options[:flavor]}Release")
 
       UI.crash!("Unable to find a bundle at #{bundle_path}") unless File.file?(bundle_path)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -611,14 +611,21 @@ ENV["HAS_ALPHA_VERSION"]="true"
     apk_path=options[:apk_path]
     temp_dir = Dir.mktmpdir()
 
-    command = "source ./tools/gradle-functions.sh"
-    command << "&& bundletool build-apks --bundle=\"#{bundle_path}\" \\
-    --output=\"#{temp_dir}/universal.apks\" \\
-    --mode=universal \\
-    --ks=\"$(get_gradle_property gradle.properties storeFile)\" \\
-    --ks-pass=\"pass:$(get_gradle_property gradle.properties storePassword)\" \\
-    --ks-key-alias=\"$(get_gradle_property gradle.properties keyAlias)\" \\
-    --key-pass=\"pass:$(get_gradle_property gradle.properties keyPassword)\""
+    command = ""
+    if is_ci 
+      command << "bundletool build-apks --bundle=\"#{bundle_path}\" \\
+      --output=\"#{temp_dir}/universal.apks\" \\
+      --mode=universal"
+    else
+      command = "source ./tools/gradle-functions.sh"
+      command << "&& bundletool build-apks --bundle=\"#{bundle_path}\" \\
+      --output=\"#{temp_dir}/universal.apks\" \\
+      --mode=universal \\
+      --ks=\"$(get_gradle_property gradle.properties storeFile)\" \\
+      --ks-pass=\"pass:$(get_gradle_property gradle.properties storePassword)\" \\
+      --ks-key-alias=\"$(get_gradle_property gradle.properties keyAlias)\" \\
+      --key-pass=\"pass:$(get_gradle_property gradle.properties keyPassword)\""
+    end
     sh(command)
 
     sh("unzip \"#{temp_dir}/universal.apks\" -d \"#{temp_dir}\"")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -286,7 +286,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
     build_bundle(version: version, flavor:"zalpha", buildType: "release")
 
     if (options[:upload_to_play_store]) then
-        upload_build_to_play_store(version: version, track: "alpha")
+       upload_build_to_play_store(version: version, track: "alpha")
     end
 
     if (options[:create_release])
@@ -317,7 +317,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
     build_bundle(version: version, flavor:"vanilla", buildType: "release")
 
     if (options[:upload_to_play_store]) then
-        upload_build_to_play_store(version: version, track: "beta")
+       upload_build_to_play_store(version: version, track: "beta")
     end
 
     if (options[:create_release])
@@ -522,12 +522,10 @@ ENV["HAS_ALPHA_VERSION"]="true"
       sh("mkdir -p #{build_dir}")
       UI.message("Running lint...")
       sh("echo \"Running lint...\" >> #{logfile_path}")
-      #sh("./gradlew lint#{options[:flavor]}Release >> #{logfile_path} 2>&1")
-      sh("./gradlew lint#{options[:flavor]}Release")
+      sh("./gradlew lint#{options[:flavor]}Release >> #{logfile_path} 2>&1") unless is_ci
       UI.message("Building #{version["name"]} / #{version["code"]} - #{aab_file}...")
       sh("echo \"Building #{version["name"]} / #{version["code"]} - #{aab_file}...\" >> #{logfile_path}")
-      #sh("./gradlew bundle#{options[:flavor]}Release >> #{logfile_path} 2>&1")
-      sh("./gradlew bundle#{options[:flavor]}Release")
+      sh("./gradlew bundle#{options[:flavor]}Release >> #{logfile_path} 2>&1")
 
       UI.crash!("Unable to find a bundle at #{bundle_path}") unless File.file?(bundle_path)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -230,7 +230,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
 
     # Create the file names
     version=android_get_release_version()
-    build_bundle(version: version, flavor:"Vanilla", buildType: "release")
+    build_bundle(version: version, flavor:"vanilla", buildType: "release")
 
     upload_build_to_play_store(version: version, track: "production")
 
@@ -283,7 +283,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
 
     # Create the file names
     version=android_get_alpha_version()
-    build_bundle(version: version, flavor:"Zalpha", buildType: "release")
+    build_bundle(version: version, flavor:"zalpha", buildType: "release")
 
     if (options[:upload_to_play_store]) then
         upload_build_to_play_store(version: version, track: "alpha")
@@ -314,7 +314,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
 
     # Create the file names
     version=android_get_release_version()
-    build_bundle(version: version, flavor:"Vanilla", buildType: "release")
+    build_bundle(version: version, flavor:"vanilla", buildType: "release")
 
     if (options[:upload_to_play_store]) then
         upload_build_to_play_store(version: version, track: "beta")


### PR DESCRIPTION
This PR enables release builds on CI.
The build is triggered by release tags. It:

- Creates the app bundle and a universal apk (signed with the shared debug key).
- Uploads the app bundle to the Play Store.
- Creates a draft release on GitHub and uploads the app bundle (only for final releases) and universal apk.

**Known issues**
It looks like the CI container we can use has issues with running the linter for this project when it's called by Fastlane. I made several tests and it fails because of out of memory about 70% of times. 
For this reason, I updated our lanes to run the linter only on local builds, and added back the lint step in the CI config file. I run this configuration multiple times and I never had a failure.
While this is not ideal, I can't see major downside other than a more complex maintenance, but let me know if you can think about others. 
I also want to revisit this after we'll manage to revert mobile Gutenberg to be a binary dependency to see if a smaller project helps. 

To Test:

- Create a new branch out of this one.
- Update the `versionName` and `versionCode` in `build.gradle` to avoid conflicts during the upload.
- Commit and tag. Push the tag.
- Verify that the "Release Build" job is started on CircleCI.
- Verify that the job finishes without errors.
- Verify that the binary has been uploaded to the PlayStore.
- Verify that a new GitHub release has been created and the artifact(s) uploaded.
- Delete the draft release on GitHub.
- Delete the artifact on the Play Store.
- Delete the test tag and branch on this repository.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
