### PR TITLE
Integrate gutenberg hotfix release 1.33.2

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,10 @@
 -----
 * [***] Block Editor: New feature for WordPress.com and Jetpack sites: auto-complete username mentions. An auto-complete popup will show up when the user types the @ character in the block editor.
 
+15.4.1
+-----
+* [**] Block Editor: Fix for editing the Classic Block in the Unsupported block editor
+
 15.4
 -----
 * [***] The login and signup flows were unified and have a new design.


### PR DESCRIPTION
This PR incorporates the 1.33.2 hotfix release of gutenberg-mobile. The overview of the change can be seen from https://github.com/wordpress-mobile/WordPress-Android/pull/12685 which is a fix for this issue https://github.com/WordPress/gutenberg/issues/24563 for Unsupported block editor not working on the Classic Block

- [Diff of included gutenberg mobile changes]( https://github.com/wordpress-mobile/gutenberg-mobile/compare/v1.33.1...v1.33.2)
- [Diff of included gutenberg changes](https://github.com/WordPress/gutenberg/compare/rnmobile/1.33.1...rnmobile/1.33.2) 

Testing steps from the (already verified) only change in this PR:

1. Switch to html mode and write some text in-between two blocks, making sure the text is not inside the block delimiters
2. Switch back to visual mode
3. There should be an unsupported block displayed between the blocks the text was inserted
4. Use the "?" button of the unsupported block and then "Edit block in web browser" to launch the Unsupported Block editor
5. Notice the text being displayed inside a "Classic" block without an error 🎉
6. Make some changes to the text and hit the "✔️" icon in the upper right to commit the changes
7. Switch to html mode again and notice that the text includes the changes made inside the Unsupported Block editor 🎉


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
