### PR TITLE
Issue 12633/contact us string update

### DIFF
--- a/WordPress/src/main/res/layout/help_activity.xml
+++ b/WordPress/src/main/res/layout/help_activity.xml
@@ -19,7 +19,7 @@
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/contact_us_button"
                 style="@style/HelpActivitySingleText"
-                android:text="@string/contact_us" />
+                android:text="@string/contact_support" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/faq_button"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1877,7 +1877,6 @@
     <!-- Help view -->
     <string name="help">Help</string>
     <string name="forgot_password" tools:ignore="UnusedResources">Lost your password?</string>
-    <string name="contact_us">Contact us</string>
     <string name="browse_our_faq_button">Browse our FAQ</string>
     <string name="my_tickets">My Tickets</string>
     <string name="application_log_button">Application log</string>
@@ -1885,6 +1884,7 @@
     <string name="support_contact_email_not_set">Not set</string>
     <string name="support_push_notification_title">WordPress</string>
     <string name="support_push_notification_message">New message from \'Help &amp; Support\'</string>
+    <string name="contact_fragment_title">@string/contact_support</string>
 
     <!--My Site-->
     <string name="my_site_header_external">External</string>
@@ -2236,7 +2236,7 @@
     <string name="start_over_email_intent_error">Unable to send an email</string>
     <string name="let_us_help">Let Us Help</string>
     <string name="start_over_text">If you want a site but don\'t want any of the posts and pages you have now, our support team can delete your posts, pages, media and comments for you.\n\nThis will keep your site and URL active, but give you a fresh start on your content creation. Just contact us to have your current content cleared out.</string>
-    <string name="contact_support">Contact support</string>
+    <string name="contact_support">Contact Support</string>
     <string name="confirm_delete_site">Confirm Delete Site</string>
     <string name="confirm_delete_site_prompt">Please type in %1$s in the field below to confirm. Your site will then be gone forever.</string>
     <string name="site_settings_export_content_title">Export content</string>


### PR DESCRIPTION
Fixes #12633

## Solution

1. Overrided the "Contact Us" toolbar title in the Zendesk Support SDK. 
2. Changed "Contact us" to "Contact Support" throughout the app to avoid the confusion. 

## Testing
1. Go to Me screen. 
2. Open Help & Support. 
3. See Contact Support. 
4. Click Contact Support and see the title of Contact Support in the Zendesk activity. 

N.B

- This change also changes the string for three other locations. One for `handleStartOver()` and another for `showDeleteSiteErrorDialog()` in `SiteSettingsFragment`.
- `fullscreen_error_with_retry.xml` also utilizes this string so it was updated for consistency as well.

Before | After 
--------|-------
  <kbd><img src="https://user-images.githubusercontent.com/1509205/90300089-881b3d00-de5e-11ea-95e5-191eb16e3d4b.png" width="320"></kbd>    |     <kbd><img src="https://user-images.githubusercontent.com/1509205/90300122-a97c2900-de5e-11ea-9ec9-57789c066e3f.png" width="320"></kbd>

Before | After 
--------|-------
  <kbd><img src="https://user-images.githubusercontent.com/1509205/90300115-a41ede80-de5e-11ea-81c4-74d22407a1a8.png" width="320"></kbd>  |       <kbd><img src="https://user-images.githubusercontent.com/1509205/90300124-ada84680-de5e-11ea-9b5e-d2e39b7ea689.png" width="320"></kbd>

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 