### PR TITLE
RI: Remove RI FF for topic details header

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -80,11 +80,8 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
 
         if (getPostListType() == ReaderPostListType.TAG_PREVIEW
             || getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
-            // show an X in the toolbar which closes the activity - if this is tag preview, then
-            // using the back button will navigate through tags if the user explores beyond a single tag
-            boolean showCrossButton = (!AppPrefs.isReaderImprovementsPhase2Enabled()
-                                       && getPostListType() == ReaderPostListType.TAG_PREVIEW)
-                                      || getPostListType() == ReaderPostListType.BLOG_PREVIEW;
+            // show an X in the toolbar which closes the activity - if this is blog preview
+            boolean showCrossButton = getPostListType() == ReaderPostListType.BLOG_PREVIEW;
             if (showCrossButton) {
                 toolbar.setNavigationIcon(R.drawable.ic_cross_white_24dp);
             }
@@ -253,9 +250,6 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
                 .beginTransaction()
                 .replace(R.id.fragment_container, fragment, getString(R.string.fragment_tag_reader_post_list))
                 .commit();
-        if (!AppPrefs.isReaderImprovementsPhase2Enabled()) {
-            setTitle(tag.getTagDisplayName());
-        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -306,7 +306,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             new FollowButtonUiState(
                 onFollowButtonClicked,
                 ReaderTagTable.isFollowedTagName(currentTag.getTagSlug()),
-                isFollowButtonEnabled
+                isFollowButtonEnabled,
+                AppPrefs.isReaderImprovementsPhase2Enabled() || mAccountStore.hasAccessToken()
             )
         );
         tagHolder.onBind(uiState);
@@ -539,8 +540,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     private boolean hasTagHeader() {
-        return AppPrefs.isReaderImprovementsPhase2Enabled()
-               && ((getPostListType() == ReaderPostListType.TAG_PREVIEW) && !isEmpty());
+        return (getPostListType() == ReaderPostListType.TAG_PREVIEW) && !isEmpty();
     }
 
     private boolean isDiscover() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
@@ -37,6 +37,7 @@ class ReaderTagHeaderView @JvmOverloads constructor(
         with(uiState.followButtonUiState) {
             follow_button.setIsFollowed(isFollowed)
             follow_button.isEnabled = isEnabled
+            uiHelpers.updateVisibility(follow_button, isVisible)
             onFollowBtnClicked = onFollowButtonClicked
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderViewUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderViewUiState.kt
@@ -8,7 +8,8 @@ sealed class ReaderTagHeaderViewUiState {
         data class FollowButtonUiState(
             val onFollowButtonClicked: (() -> Unit)?,
             val isFollowed: Boolean,
-            val isEnabled: Boolean
+            val isEnabled: Boolean,
+            val isVisible: Boolean
         )
     }
 }


### PR DESCRIPTION
This PR removes RI feature flag to display follow button on topic details screen
(so that Site and Topic (Tag) header changes can be released before RI Phase 2 release. ([internal ref](https://app.slack.com/client/T024FN1V2/CVASUPH2M)))

Follow button is  
- shown if user is logged in using WP.com user account
- hidden if user is logged in using self-hosted site (logged-out behaviour)

**To test**
Prerequisite: RI feature flag is disabled

Test 1
1. Log in to app using WP.com account 
2. Go to Reader
3. Go to topic details screen
4. Notice that Follow button is shown

Test 2
1. Log in to app using self-hosted site
2. Go to Reader
3. Go to topic details screen
4. Notice that Follow button is not shown

Logged In Follow | Logged In Following | Logged Out
-----------|----------|-----------
![logged_in_follow](https://user-images.githubusercontent.com/1405144/90333883-17ebf300-dfe7-11ea-8893-da5a99887c33.png)| ![logged_in_following](https://user-images.githubusercontent.com/1405144/90333888-1de1d400-dfe7-11ea-87a3-02ccbef6f8bf.png) |![logged_out](https://user-images.githubusercontent.com/1405144/90333889-220df180-dfe7-11ea-841c-eb31de2f5c52.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
