### PR TITLE
Stop "activity icon" from being read allowed

### DIFF
--- a/WordPress/src/main/res/layout/activity_log_list_event_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_event_item.xml
@@ -17,6 +17,7 @@
         android:layout_centerVertical="true"
         android:layout_margin="@dimen/activity_log_icon_margin"
         android:contentDescription="@string/activity_log_icon"
+        android:importantForAccessibility="no"
         android:padding="@dimen/margin_medium"
         tools:background="@drawable/bg_oval_neutral_30"
         tools:src="@drawable/ic_comment_white_24dp" />

--- a/WordPress/src/main/res/layout/activity_log_list_event_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_event_item.xml
@@ -16,7 +16,6 @@
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
         android:layout_margin="@dimen/activity_log_icon_margin"
-        android:contentDescription="@string/activity_log_icon"
         android:importantForAccessibility="no"
         android:padding="@dimen/margin_medium"
         tools:background="@drawable/bg_oval_neutral_30"


### PR DESCRIPTION
Fixes #10935 

To test:
1. Go to Settings > Accessibility > TalkBack > "Use service" or use the [Volume key shortcut](https://support.google.com/accessibility/android/answer/6006966?hl=en).
2. In the WordPress app, go to My Site > Activity.
3. Swipe right to read through several items in the log.
4. You will hear the activity text and summary read aloud with "activity icon" ommitted.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
