### PR TITLE
Switch translation reviewers builds to release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,13 +354,14 @@ jobs:
             VERSION_NAME="${APP_VERSION_PREFIX}-build-${TODAY_DATE}-${CIRCLE_BUILD_NUM}"
             echo "export VERSION_NAME=$VERSION_NAME" >> $BASH_ENV
 
+            cp ~/.android/debug_a8c.keystore ~/.android/debug.keystore
             bundle exec fastlane build_for_translation_review custom_version:"$VERSION_NAME"
       - android/save-gradle-cache
       - run:
           name: Prepare APK
           command: |
             mkdir -p Artifacts
-            mv WordPress/build/outputs/apk/jalapeno/debug/org.wordpress.android-jalapeno-debug.apk "Artifacts/WordPress-${VERSION_NAME}.apk"
+            mv WordPress/build/outputs/apk/jalapeno/release/org.wordpress.android-jalapeno-release.apk "Artifacts/WordPress-${VERSION_NAME}.apk"
       - run: 
           name: Upload APK
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,8 @@ jobs:
           command: mv libs/gutenberg-mobile/bundle/android/App.js libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/build/assets/index.android.bundle
       - save-gutenberg-bundle-cache
   test:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -131,9 +130,8 @@ jobs:
       - android/save-gradle-cache
       - android/save-test-results
   lint:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -177,9 +175,8 @@ jobs:
       - android/save-gradle-cache
       - android/save-lint-results
   Installable Build:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -228,9 +225,8 @@ jobs:
         description: Post to Slack when tests fail. SLACK_WEBHOOK ENV variable must be set.
         type: boolean
         default: false
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -273,9 +269,8 @@ jobs:
                 include_project_field: false
                 failure_message: ':red_circle: WordPress Android connected tests failed on \`${CIRCLE_BRANCH}\` branch after merge by ${CIRCLE_USERNAME}. See <https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670|Firebase console test results> for details.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'
   WordPressUtils Connected Tests:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -323,9 +318,8 @@ jobs:
           name: Validate login strings
           command: bundle exec fastlane validate_login_strings pr_url:$CIRCLE_PULL_REQUEST
   translation-review-build:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     environment:
       APP_VERSION_PREFIX: << pipeline.parameters.translation_review_lang_id >>
     steps:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -592,7 +592,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
     sh("../tools/update-translations.sh review fuzzy")
 
     android_merge_translators_strings(strings_folder:"./WordPress/src/main/res/")
-    sh("export SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD=1 && cd .. && ./gradlew --stacktrace assembleJalapenoDebug #{cmd_params}")
+    sh("export SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD=1 && cd .. && ./gradlew --stacktrace assembleJalapenoRelease #{cmd_params}")
   end 
 
 #####################################################################################


### PR DESCRIPTION
This PR switches to release builds for the "Translation Reviewers" build task. 

cc @akirk 

To test:
- Make sure CI is green. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
