### PR TITLE
Add support for on item click event to discover reader tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -101,5 +101,6 @@ enum class ReaderPostCardActionType {
     LIKE,
     BOOKMARK,
     REBLOG,
-    COMMENTS
+    COMMENTS,
+    ITEM_CLICK
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -101,6 +101,5 @@ enum class ReaderPostCardActionType {
     LIKE,
     BOOKMARK,
     REBLOG,
-    COMMENTS,
-    ITEM_CLICK
+    COMMENTS
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.reader.ReaderPostWebViewCachingFragment
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEditorForReblog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenPost
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostDetail
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.SharePost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab
@@ -83,6 +84,7 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
         viewModel.navigationEvents.observe(viewLifecycleOwner, Observer {
             it.applyIfNotHandled {
                 when (this) {
+                    is ShowPostDetail -> ReaderActivityLauncher.showReaderPostDetail(context, post.blogId, post.postId)
                     is SharePost -> ReaderActivityLauncher.sharePost(context, post)
                     is OpenPost -> ReaderActivityLauncher.openPost(context, post)
                     is ShowReaderComments -> ReaderActivityLauncher.showReaderComments(context, blogId, postId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.Discover
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.ITEM_CLICK
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.repository.ReaderDiscoverDataProvider
 import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
@@ -153,8 +152,11 @@ class ReaderDiscoverViewModel @Inject constructor(
     }
 
     private fun onPostItemClicked(postId: Long, blogId: Long) {
-        // TODO malinjir inline
-        onButtonClicked(postId, blogId, ITEM_CLICK)
+        launch {
+            findPost(postId, blogId)?.let {
+                readerPostCardActionsHandler.handleOnItemClicked(it)
+            }
+        }
     }
 
     private fun onItemRendered(itemUiState: ReaderCardUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.Discover
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.ITEM_CLICK
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.repository.ReaderDiscoverDataProvider
 import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
@@ -149,7 +150,8 @@ class ReaderDiscoverViewModel @Inject constructor(
     }
 
     private fun onPostItemClicked(postId: Long, blogId: Long) {
-        AppLog.d(T.READER, "OnItemClicked")
+        // TODO malinjir inline
+        onButtonClicked(postId, blogId, ITEM_CLICK)
     }
 
     private fun onItemRendered(itemUiState: ReaderCardUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.ui.PagePostCreationSourcesDetail
 import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode
 
 sealed class ReaderNavigationEvents {
-    data class ShowPostDetail(val post: ReaderPost): ReaderNavigationEvents()
+    data class ShowPostDetail(val post: ReaderPost) : ReaderNavigationEvents()
     data class SharePost(val post: ReaderPost) : ReaderNavigationEvents()
     data class OpenPost(val post: ReaderPost) : ReaderNavigationEvents()
     data class ShowPostsByTag(val tag: ReaderTag) : ReaderNavigationEvents()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.ui.PagePostCreationSourcesDetail
 import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode
 
 sealed class ReaderNavigationEvents {
+    data class ShowPostDetail(val post: ReaderPost): ReaderNavigationEvents()
     data class SharePost(val post: ReaderPost) : ReaderNavigationEvents()
     data class OpenPost(val post: ReaderPost) : ReaderNavigationEvents()
     data class ShowPostsByTag(val tag: ReaderTag) : ReaderNavigationEvents()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -6,18 +6,22 @@ import androidx.lifecycle.MediatorLiveData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.APP_REVIEWS_EVENT_INCREMENTED_BY_OPENING_READER_POST
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTICLE_VISITED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_SAVED_POST_OPENED_FROM_OTHER_POST_LIST
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.SHARED_ITEM_READER
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.modules.UI_SCOPE
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.SharePost
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostDetail
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.COMMENTS
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.ITEM_CLICK
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SHARE
@@ -29,6 +33,7 @@ import org.wordpress.android.ui.reader.usecases.ReaderPostBookmarkUseCase
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.widgets.AppRatingDialog.incrementInteractions
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -73,7 +78,17 @@ class ReaderPostCardActionsHandler @Inject constructor(
             BOOKMARK -> handleBookmarkClicked(post.postId, post.blogId, isBookmarkList)
             REBLOG -> handleReblogClicked(post)
             COMMENTS -> handleCommentsClicked(post.postId, post.blogId)
+            ITEM_CLICK -> handleOnItemClicked(post)
         }
+    }
+
+    private fun handleOnItemClicked(post: ReaderPost) {
+        incrementInteractions(APP_REVIEWS_EVENT_INCREMENTED_BY_OPENING_READER_POST)
+
+        if (post.isBookmarked) {
+            analyticsTrackerWrapper.track(READER_SAVED_POST_OPENED_FROM_OTHER_POST_LIST)
+        }
+        _navigationEvents.postValue(Event(ShowPostDetail(post)))
     }
 
     private fun handleFollowClicked(post: ReaderPost) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -22,7 +22,6 @@ import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_S
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.COMMENTS
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
-import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.ITEM_CLICK
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SHARE
@@ -79,11 +78,10 @@ class ReaderPostCardActionsHandler @Inject constructor(
             BOOKMARK -> handleBookmarkClicked(post.postId, post.blogId, isBookmarkList)
             REBLOG -> handleReblogClicked(post)
             COMMENTS -> handleCommentsClicked(post.postId, post.blogId)
-            ITEM_CLICK -> handleOnItemClicked(post)
         }
     }
 
-    private fun handleOnItemClicked(post: ReaderPost) {
+    fun handleOnItemClicked(post: ReaderPost) {
         incrementInteractions(APP_REVIEWS_EVENT_INCREMENTED_BY_OPENING_READER_POST)
 
         if (post.isBookmarked) {


### PR DESCRIPTION
Parent issue #12028 

Merge instruction
1. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/12706 is merged first
2. Remove "Not ready for merge" label
3. Merge this PR

Adds onItemClick listener to list items on Discover Reader tab.

To test:
1. Enable RI FF
2. Open "Discover" tab
3. Click on one of the items and notice a post detail is opened

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
