### PR TITLE
Add on video overlay handler for discover items

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowNoSit
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
 import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.WPSwipeToRefreshHelper
@@ -99,6 +100,7 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
                     }
                     is ShowBookmarkedSavedOnlyLocallyDialog -> showBookmarkSavedLocallyDialog(this)
                     is ShowPostsByTag -> ReaderActivityLauncher.showReaderTagPreview(context, this.tag)
+                    is ShowVideoViewer -> ReaderActivityLauncher.showReaderVideoViewer(context, this.videoUrl)
                 }
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.MediatorLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
-import org.wordpress.android.datasets.ReaderPostTable
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderTagType.INTERESTS
 import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderPostCard
@@ -129,14 +128,18 @@ class ReaderDiscoverViewModel @Inject constructor(
 
     private fun onButtonClicked(postId: Long, blogId: Long, type: ReaderPostCardActionType) {
         launch {
-            // TODO malinjir replace with repository. Also consider if we need to load the post form db in on click.
-            val post = ReaderPostTable.getBlogPost(blogId, postId, true)
-            readerPostCardActionsHandler.onAction(post, type, isBookmarkList = false)
+            findPost(postId, blogId)?.let {
+                readerPostCardActionsHandler.onAction(it, type, isBookmarkList = false)
+            }
         }
     }
 
     private fun onVideoOverlayClicked(postId: Long, blogId: Long) {
-        // TODO malinjir implement action
+        launch {
+            findPost(postId, blogId)?.let {
+                readerPostCardActionsHandler.handleVideoOverlayClicked(it.featuredVideo)
+            }
+        }
     }
 
     private fun onPostHeaderClicked(postId: Long, blogId: Long) {
@@ -154,6 +157,14 @@ class ReaderDiscoverViewModel @Inject constructor(
 
     private fun onItemRendered(itemUiState: ReaderCardUiState) {
         initiateLoadMoreIfNecessary(itemUiState)
+    }
+
+    private fun findPost(postId: Long, blogId: Long): ReaderPost? {
+        return readerDiscoverDataProvider.discoverFeed.value?.cards?.let {
+            it.filterIsInstance<ReaderPostCard>()
+                    .find { card -> card.post.postId == postId && card.post.blogId == blogId }
+                    ?.post
+        }
     }
 
     private fun initiateLoadMoreIfNecessary(item: ReaderCardUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -29,4 +29,5 @@ sealed class ReaderNavigationEvents {
         @StringRes val message: Int = R.string.reader_save_posts_locally_dialog_message
         @StringRes val buttonLabel: Int = R.string.dialog_button_ok
     }
+    data class ShowVideoViewer(val videoUrl: String) : ReaderNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.SharePost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.COMMENTS
@@ -74,6 +75,10 @@ class ReaderPostCardActionsHandler @Inject constructor(
             REBLOG -> handleReblogClicked(post)
             COMMENTS -> handleCommentsClicked(post.postId, post.blogId)
         }
+    }
+
+    fun handleVideoOverlayClicked(videoUrl: String) {
+        _navigationEvents.postValue(Event(ShowVideoViewer(videoUrl)))
     }
 
     private fun handleFollowClicked(post: ReaderPost) {


### PR DESCRIPTION
Parent issue #12028 

Adds on video overlay listener to list items on Discover Reader tab.

To test:
1. Enable RI FF
2. Open "Discover" tab
3. Scroll down until you find a post with a video overlay
4. Click on the "play" icon

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
