### PR TITLE
Add a super secret button that crashes after being tapped 10 times

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
@@ -18,6 +18,8 @@ import org.wordpress.android.widgets.WPTextView;
 import java.util.Calendar;
 
 public class AboutActivity extends LocaleAwareActivity implements OnClickListener {
+    private int mCurrentTapCountForSecretCrash = 0;
+
     @Override
     public void onCreate(Bundle icicle) {
         super.onCreate(icicle);
@@ -49,6 +51,15 @@ public class AboutActivity extends LocaleAwareActivity implements OnClickListene
 
         View about = findViewById(R.id.about_url);
         about.setOnClickListener(this);
+
+        View secretCrash = findViewById(R.id.about_secret_crash);
+        secretCrash.setOnClickListener(view -> {
+            mCurrentTapCountForSecretCrash++;
+            if (mCurrentTapCountForSecretCrash >= 10) {
+                throw new IllegalStateException("This is a secret crash triggered from an invisible button in "
+                                                + "the about page in case it's necessary to test a crash");
+            }
+        });
     }
 
     @Override

--- a/WordPress/src/main/res/layout/about_activity.xml
+++ b/WordPress/src/main/res/layout/about_activity.xml
@@ -124,6 +124,16 @@
                     android:textAppearance="?attr/textAppearanceBody2"
                     android:textColor="?attr/colorOnPrimarySurface" />
 
+                <!-- This is just a super secret crash button, so it shouldn't interfere with
+                any real element -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/about_secret_crash"
+                    style="@style/Widget.MaterialComponents.Button"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:alpha="0"
+                    android:gravity="center" />
             </org.wordpress.android.widgets.WPLinearLayoutSizeBound>
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
This PR adds a secret button to the about page that will crash the app after being tapped 10 times. This will be useful to us in testing encrypted logging changes. Here it is in action: https://cloudup.com/cv3_wSmhxgw (taps are not visible, so it takes a while for something to happen)

To test:
* Go to about page from Me -> App Settings -> WordPress for Android
* Tap a little below the "automattic.com" for 10+ times (since the button is invisible, it might be a bit difficult to tap the right place)
* Verify the app crashes

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
