### PR TITLE
Add on header clicked handler for discover items

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -26,11 +26,12 @@ import org.wordpress.android.ui.reader.ReaderPostWebViewCachingFragment
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEditorForReblog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenPost
-import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostDetail
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.SharePost
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBlogPreview
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowNoSitesToReblog
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostDetail
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
@@ -103,6 +104,11 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
                     is ShowBookmarkedSavedOnlyLocallyDialog -> showBookmarkSavedLocallyDialog(this)
                     is ShowPostsByTag -> ReaderActivityLauncher.showReaderTagPreview(context, this.tag)
                     is ShowVideoViewer -> ReaderActivityLauncher.showReaderVideoViewer(context, this.videoUrl)
+                    is ShowBlogPreview -> ReaderActivityLauncher.showReaderBlogOrFeedPreview(
+                            context,
+                            this.siteId,
+                            this.feedId
+                    )
                 }
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -143,7 +143,11 @@ class ReaderDiscoverViewModel @Inject constructor(
     }
 
     private fun onPostHeaderClicked(postId: Long, blogId: Long) {
-        // TODO malinjir implement action
+        launch {
+            findPost(postId, blogId)?.let {
+                readerPostCardActionsHandler.handleHeaderClicked(it.blogId, it.feedId)
+            }
+        }
     }
 
     private fun onTagItemClicked(tagSlug: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -31,4 +31,5 @@ sealed class ReaderNavigationEvents {
         @StringRes val buttonLabel: Int = R.string.dialog_button_ok
     }
     data class ShowVideoViewer(val videoUrl: String) : ReaderNavigationEvents()
+    data class ShowBlogPreview(val siteId: Long, val feedId: Long) : ReaderNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.modules.UI_SCOPE
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.SharePost
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBlogPreview
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostDetail
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
@@ -92,6 +93,10 @@ class ReaderPostCardActionsHandler @Inject constructor(
 
     fun handleVideoOverlayClicked(videoUrl: String) {
         _navigationEvents.postValue(Event(ShowVideoViewer(videoUrl)))
+    }
+
+    fun handleHeaderClicked(siteId: Long, feedId: Long) {
+        _navigationEvents.postValue(Event(ShowBlogPreview(siteId, feedId)))
     }
 
     private fun handleFollowClicked(post: ReaderPost) {


### PR DESCRIPTION
Parent issue #12028 

Merge instruction
1. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/12705 is merged first
2. Remove "Not ready for merge" label
3. Merge this PR

Adds on header clicked listener to list items on Discover Reader tab.

To test:
1. Enable RI FF
2. Open "Discover" tab
3. Click on one of the list item headers and notice a blog detail is opened

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
