### PR TITLE
WP Stories: build the VideoPress URL if mimeType is `video/videopress`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.PostUtils
+import org.wordpress.android.util.ShortcodeUtils
 import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.helpers.MediaFile
 import javax.inject.Inject
@@ -85,12 +86,22 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor() {
         }
 
         // now replace the same in the mediaFileObjects, obtain the URLs and replace
+        val mediaUrl = getMediaFileUrl(mediaFile)
         storyBlockData?.mediaFiles?.filter { it.id == localMediaId }?.get(0)?.apply {
             id = mediaFile.mediaId.toInt()
-            link = mediaFile.fileURL
-            url = mediaFile.fileURL
+            link = mediaUrl
+            url = mediaUrl
         }
         post.setContent(createGBStoryBlockStringFromJson(requireNotNull(storyBlockData)))
+    }
+
+    private fun getMediaFileUrl(mediaFile: MediaFile): String {
+        if (VIDEOPRESS_MIME_TYPE.equals(mediaFile.mimeType)) {
+            return VIDEOPRESS_BASE_URL + ShortcodeUtils.getVideoPressIdFromShortCode(mediaFile.videoPressShortCode) +
+                    "/" + mediaFile.fileName
+        } else {
+            return StringUtils.notNullStr(mediaFile.fileURL)
+        }
     }
 
     private fun createGBStoryBlockStringFromJson(storyBlock: StoryBlockData): String {
@@ -119,5 +130,10 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor() {
         const val headingEnd = " -->\n"
         const val divPart = "<div class=\"wp-story wp-block-jetpack-story\"></div>\n"
         const val closingtag = "<!-- /wp:jetpack/story -->"
+        const val VIDEOPRESS_MIME_TYPE =  "video/videopress"
+        // TODO verify this base URL is constant - or update FluxC to bring the VideoPress video URL from REST API, i.e.
+        // media_details.original.url
+        // "media_details":{"original":{"url":"https:\/\/videos.files.wordpress.com\/Si7WwFlU\/wp-1597773400767.mp4"}
+        const val VIDEOPRESS_BASE_URL =  "https://videos.files.wordpress.com/"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -130,10 +130,10 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor() {
         const val headingEnd = " -->\n"
         const val divPart = "<div class=\"wp-story wp-block-jetpack-story\"></div>\n"
         const val closingtag = "<!-- /wp:jetpack/story -->"
-        const val VIDEOPRESS_MIME_TYPE =  "video/videopress"
+        const val VIDEOPRESS_MIME_TYPE = "video/videopress"
         // TODO verify this base URL is constant - or update FluxC to bring the VideoPress video URL from REST API, i.e.
         // media_details.original.url
         // "media_details":{"original":{"url":"https:\/\/videos.files.wordpress.com\/Si7WwFlU\/wp-1597773400767.mp4"}
-        const val VIDEOPRESS_BASE_URL =  "https://videos.files.wordpress.com/"
+        const val VIDEOPRESS_BASE_URL = "https://videos.files.wordpress.com/"
     }
 }


### PR DESCRIPTION
Fixes #12711

The problem described in the aforementioned issue was due to having the target site enable VideoPress, but we had no 
support for VideoPress as of yet.

This PR fixes that by simply building up the VideoPress URL correctly for the case when the video's `mime` type is `video/videopress`.

**Note:** this other branch [here  ](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/12711-fix-video-press-url?expand=1) explores what I had in mind, but it turns out the SiteModel being passed around is not needed (the value for `mIsVideoPressSupported`  is false for our whitelisted test site anyway), and we'd also need to do more work than what can be seen on that branch to actually support the original file URL in FluxC. I think it may not be a great idea to do all of that for VideoPress URLs given the content subdomain seems to have been fixed for a long time and has been kept as is.
If / when the case happens that different sites may have different URLs for VideoPress videos, we can go ahead and implement support for this on FLuxC to correctly populate a new field with this information.
Added a `TODO` comment there to remind our future selves when/if this is needed.


To test:
1. switch site to a whitelisted story site create a story
2. cretae a new story
3. add a video slide
4. tap NEXT and then add some title to the post
5. upload
6. verify the url is OK and the video plays correctly


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
