### PR TITLE
Testing : reverted Use visibleElementWithId instead of onView(withId(elementId))

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -19,7 +19,6 @@ import androidx.test.espresso.action.GeneralLocation;
 import androidx.test.espresso.action.Press;
 import androidx.test.espresso.action.Tap;
 import androidx.test.espresso.action.ViewActions;
-import androidx.test.espresso.matcher.ViewMatchers.Visibility;
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObjectNotFoundException;
@@ -51,7 +50,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
-import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
@@ -65,12 +63,8 @@ import static org.hamcrest.Matchers.isA;
 public class WPSupportUtils {
     // HIGH-LEVEL METHODS
 
-    public static ViewInteraction visibleElementWithId(Integer elementID) {
-        return onView(allOf(withId(elementID), withEffectiveVisibility(Visibility.VISIBLE)));
-    }
-
     public static boolean isElementDisplayed(Integer elementID) {
-        return isElementDisplayed(visibleElementWithId(elementID));
+        return isElementDisplayed(onView(withId(elementID)));
     }
 
     public static boolean isElementDisplayed(ViewInteraction element) {
@@ -93,7 +87,7 @@ public class WPSupportUtils {
 
     public static void scrollToThenClickOn(Integer elementID) {
         waitForElementToBeDisplayed(elementID);
-        visibleElementWithId(elementID)
+        onView(withId(elementID))
                 .perform(scrollTo());
         clickOn(elementID);
     }
@@ -106,7 +100,7 @@ public class WPSupportUtils {
 
     public static void clickOn(Integer elementID) {
         waitForElementToBeDisplayed(elementID);
-        clickOn(visibleElementWithId(elementID));
+        clickOn(onView(withId(elementID)));
         idleFor(500); // allow for transitions
     }
 
@@ -197,7 +191,7 @@ public class WPSupportUtils {
 
     public static void longClickOn(Integer elementID) {
         waitForElementToBeDisplayed(elementID);
-        visibleElementWithId(elementID).perform(longClick());
+        onView(withId(elementID)).perform(longClick());
     }
 
     public static void longClickOn(ViewInteraction element) {
@@ -229,7 +223,7 @@ public class WPSupportUtils {
 
     public static void populateTextField(Integer elementID, String text) {
         waitForElementToBeDisplayed(elementID);
-        visibleElementWithId(elementID)
+        onView(withId(elementID))
                 .perform(replaceText(text))
                 .perform(closeSoftKeyboard());
     }
@@ -354,11 +348,11 @@ public class WPSupportUtils {
         Integer maxTries = 10;
 
         for (Integer i = 0; i < 10; i++) {
-            visibleElementWithId(elementID).perform(swipeRight());
+            onView(withId(elementID)).perform(swipeRight());
         }
 
         while (!tabLayoutHasTextDisplayed(elementID, string) && tries < maxTries) {
-            visibleElementWithId(elementID).perform(swipeLeft());
+            onView(withId(elementID)).perform(swipeLeft());
             tries++;
         }
 


### PR DESCRIPTION
Fixes #11898 

## Solution

The changes reverted here were made because we thought the tests were failing as a result of visibility issues. Since, some other changes may have fixed this issue, we are reverting the changes made in #11850 

The only change from that PR that wasn't reverted is the `post-to-slack` change / enabling. 

## Testing
Run the optional connected tests and verify all of them passes

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
