### PR TITLE
Suppress default item animation in ReaderDiscoverAdapter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
@@ -70,5 +70,12 @@ class ReaderDiscoverAdapter(
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
             return oldItems[oldItemPosition] == newItems[newItemPosition]
         }
+
+        override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any? {
+            /* Returning true suppresses the default item animation. That's all we need - posts in Reader are static
+            except of the like/follow/bookmark/... action states. We don't want to play the default animation when
+            one of these states changes. */
+            return true
+        }
     }
 }


### PR DESCRIPTION
Parent issue #12028

Suppresses default list item animation which the OS plays when an item's state changes. The animation looks weird when the user clicks eg on bookmark action - the only thing that changes is the bookmark button state, however, the systems plays the animation for the whole list item.



You can see the difference on the following gifs (focus on the titles of the posts).

| Before | After |
|-----|----|
| ![before](https://user-images.githubusercontent.com/2261188/90598368-2d356d00-e1f3-11ea-9374-07aba2e9503b.gif) | ![after](https://user-images.githubusercontent.com/2261188/90598377-30c8f400-e1f3-11ea-9587-631940e1927e.gif) |

To test:
1. Enable RI FF
2. Open discover tab
3. Click on "bookmark" action and notice the state of the bookmark button changes but the list item animation is not played

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
