### PR TITLE
Add "refresh" parameter (seed) to "/cards" endpoint calls

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -148,6 +148,8 @@ public class AppPrefs {
         READER_CSS_UPDATED_TIMESTAMP,
         // Identifier of the next page for the discover /cards endpoint
         READER_CARDS_ENDPOINT_PAGE_HANDLE,
+        // used to tell the server to return a different set of data so the content on discover tab doesn't look static
+        READER_CARDS_ENDPOINT_REFRESH_COUNTER,
 
         // Used to delete recommended tags saved as followed tags in tbl_tags
         // Need to be done just once for a logged out user
@@ -1174,6 +1176,14 @@ public class AppPrefs {
 
     public static void setReaderCardsPageHandle(String pageHandle) {
         setString(DeletablePrefKey.READER_CARDS_ENDPOINT_PAGE_HANDLE, pageHandle);
+    }
+
+    public static int getReaderCardsRefreshCounter() {
+        return getInt(DeletablePrefKey.READER_CARDS_ENDPOINT_REFRESH_COUNTER, 0);
+    }
+
+    public static void incrementReaderCardsRefreshCounter() {
+        setInt(DeletablePrefKey.READER_CARDS_ENDPOINT_REFRESH_COUNTER, getReaderCardsRefreshCounter() + 1);
     }
 
     public static boolean getReaderRecommendedTagsDeletedForLoggedOutUser() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -79,6 +79,8 @@ class AppPrefsWrapper @Inject constructor() {
     fun setAppWidgetSiteId(siteId: Long, appWidgetId: Int) = AppPrefs.setStatsWidgetSelectedSiteId(siteId, appWidgetId)
     fun removeAppWidgetSiteId(appWidgetId: Int) = AppPrefs.removeStatsWidgetSelectedSiteId(appWidgetId)
     fun isGutenbergEditorEnabled() = AppPrefs.isGutenbergEditorEnabled()
+    fun getReaderCardsRefreshCounter() = AppPrefs.getReaderCardsRefreshCounter()
+    fun incrementReaderCardsRefreshCounter() = AppPrefs.incrementReaderCardsRefreshCounter()
 
     fun getAppWidgetColor(appWidgetId: Int): Color? {
         return when (AppPrefs.getStatsWidgetColorModeId(appWidgetId)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -80,7 +80,15 @@ class ReaderDiscoverLogic(
             params["tags"] = getFollowedTagsUseCase.get().joinToString { it.tagSlug }
 
             when (taskType) {
-                REQUEST_FIRST_PAGE -> appPrefsWrapper.readerCardsPageHandle = null
+                REQUEST_FIRST_PAGE -> {
+                    appPrefsWrapper.readerCardsPageHandle = null
+                    /* "refresh" parameter is used to tell the server to return a different set of data so we don't
+                    present a static content to the user. We need to include it only for the first page (when
+                    page_handle is empty). The server will take care of including the "refresh" parameter within the
+                    page_handle so the user will stay on the same shard while they’re paging through the cards. */
+                    params["refresh"] = appPrefsWrapper.getReaderCardsRefreshCounter().toString()
+                    appPrefsWrapper.incrementReaderCardsRefreshCounter()
+                }
                 REQUEST_MORE -> {
                     val pageHandle = appPrefsWrapper.readerCardsPageHandle
                     if (pageHandle?.isNotEmpty() == true) {


### PR DESCRIPTION
Fixes #12028 

Adds "refresh" parameter to "/cards" calls. It's used to tell the server to return a different set of data so we don't                     present a static content to the user. We need to include it only for the first page (when page_handle is empty). The server will take care of including the "refresh" parameter within the page_handle so the user will stay on the same shard while they’re paging through the cards.

To test:
1. Enable RI FF
2. Open discover tab
3. Open a network sniffer eg Stetho (or use a debugger)
4. Pull to refresh and notice "refresh" parameter is included in the query
5. Pull to refresh again and notice "refresh" parameter gets incremented
6. Scroll down and notice the "refresh" parameter is NOT included when loading next pages

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
