### PR TITLE
Unified Login & Sign-Up: Stop tracking unnecessary error when signing up with Google

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -12,7 +12,6 @@ import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
-import org.wordpress.android.fluxc.store.AccountStore.AccountSocialErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnSocialChanged;
 import org.wordpress.android.fluxc.store.AccountStore.PushSocialPayload;
@@ -21,6 +20,8 @@ import org.wordpress.android.util.AppLog.T;
 
 import static android.app.Activity.RESULT_CANCELED;
 import static android.app.Activity.RESULT_OK;
+import static org.wordpress.android.fluxc.store.AccountStore.AccountSocialErrorType.UNKNOWN_USER;
+import static org.wordpress.android.fluxc.store.AccountStore.AccountSocialErrorType.USER_EXISTS;
 
 import dagger.android.support.AndroidSupportInjection;
 
@@ -189,7 +190,8 @@ public class LoginGoogleFragment extends GoogleFragment {
         if (event.isError()) {
             AppLog.e(T.API, "LoginGoogleFragment.onSocialChanged: " + event.error.type + " - " + event.error.message);
 
-            if (event.error.type != AccountSocialErrorType.USER_EXISTS) {
+            // We don't want to track these errors: USER_EXISTS and UNKNOWN_USER (if signup from login is enabled)
+            if (event.error.type != USER_EXISTS && (!mIsSignupFromLoginEnabled || event.error.type != UNKNOWN_USER)) {
                 mAnalyticsListener.trackLoginFailed(event.getClass().getSimpleName(),
                         event.error.type.toString(), event.error.message);
 


### PR DESCRIPTION
After shipping the unified login & sign-up flow we noticed an increased number of "social login failures", which would indicate more people were not being able to login with their Google accounts. Upon further examination we determined that this wasn't true and that the increased number of failures was because we now always try to login first and only start the signup flow after we receive an `UNKNOWN_USER` error.

Since this is an expected error and is needed for the flow to continue, this PR introduces a change to prevent it from being tracked.

Login-Flow counterpart: https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/43

## To test

Note: before you start, make sure you have setup your environment to support Google Sign-Ins (internal reference: paqN3M-9M-p2).

0. Clear app data.
1. On the Prologue Screen, tap **Continue with WordPress.com**.
1. On the Email Screen, tap **Continue with Google**.
1. Pick a Google account that **_is not_** associated with a WordPress.com account.
1. Notice the Sign-Up Confirmation screen.
1. Notice the following events in Logcat:
    - `unified_login_step, Properties: {"source":"default","flow":"google_login","step":"start"}`
    - `unified_login_step, Properties: {"source":"default","flow":"google_signup","step":"start"}`
1. Verify that you _don't see_ any of the following events:
    - `login_failed_to_login, Properties: {"error_context":"OnSocialChanged","error_description":"[...]","error_type":"UNKNOWN_USER"}`
    - `login_social_failure, Properties: {"error_context":"OnSocialChanged","error_description":"[...]","error_type":"UNKNOWN_USER"}`

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.