### PR TITLE
Stories: Only show stories for sites that support them

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -484,14 +484,14 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     getMySiteFragment().requestNextStepOfActiveQuickStartTask(false);
                 }
             }
-            mViewModel.onFabClicked(hasFullAccessToContent(), shouldShowPublishPostQuickStartTask);
+            mViewModel.onFabClicked(mSelectedSite, shouldShowPublishPostQuickStartTask);
         });
 
         mFloatingActionButton.setOnLongClickListener(v -> {
             if (v.isHapticFeedbackEnabled()) {
                 v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
             }
-            mViewModel.onFabLongPressed(hasFullAccessToContent());
+            mViewModel.onFabLongPressed(mSelectedSite);
 
             int messageId = hasFullAccessToContent()
                     ? R.string.create_post_page_fab_tooltip
@@ -504,7 +504,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         ViewUtilsKt.redirectContextClickToLongPressListener(mFloatingActionButton);
 
         mFabTooltip.setOnClickListener(v -> {
-            mViewModel.onTooltipTapped(hasFullAccessToContent());
+            mViewModel.onTooltipTapped(mSelectedSite);
         });
 
         mViewModel.isBottomSheetShowing().observe(this, event -> {
@@ -560,8 +560,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         mViewModel.start(
                 mSiteStore.hasSite() && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE,
-                hasFullAccessToContent()
-        );
+                mSelectedSite);
 
         mMLPViewModel.init(DisplayUtils.isLandscape(this));
     }
@@ -810,7 +809,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         ProfilingUtils.dump();
         ProfilingUtils.stop();
 
-        mViewModel.onResume(hasFullAccessToContent());
+        mViewModel.onResume(mSelectedSite);
 
         mFirstResume = false;
     }
@@ -876,8 +875,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         mViewModel.onPageChanged(
                 mSiteStore.hasSite() && pageType == PageType.MY_SITE,
-                hasFullAccessToContent()
-        );
+                mSelectedSite);
     }
 
     // user tapped the new post button in the bottom navbar

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -493,9 +493,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
             }
             mViewModel.onFabLongPressed(mSelectedSite);
 
-            int messageId = SiteUtils.hasFullAccessToContent(getSelectedSite())
-                    ? R.string.create_post_page_fab_tooltip
-                    : R.string.create_post_page_fab_tooltip_contributors;
+            int messageId = mViewModel.getCreateContentMessageId(mSelectedSite);
 
             Toast.makeText(v.getContext(), messageId, Toast.LENGTH_SHORT).show();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -493,7 +493,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
             }
             mViewModel.onFabLongPressed(mSelectedSite);
 
-            int messageId = hasFullAccessToContent()
+            int messageId = SiteUtils.hasFullAccessToContent(getSelectedSite())
                     ? R.string.create_post_page_fab_tooltip
                     : R.string.create_post_page_fab_tooltip_contributors;
 
@@ -558,6 +558,11 @@ public class WPMainActivity extends LocaleAwareActivity implements
             });
         });
 
+        // At this point we still haven't initialized mSelectedSite, which will mean that the ViewModel
+        // will act as though SiteUtils.hasFullAccessToContent() is false, and as such the state will be
+        // initialized with the most restrictive rights case. This is OK and will be frequently checked
+        // to normalize the UI state whenever mSelectedSite changes.
+        // It also means that the ViewModel must accept a nullable SiteModel.
         mViewModel.start(
                 mSiteStore.hasSite() && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE,
                 mSelectedSite);
@@ -1524,14 +1529,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
             mQuickStartSnackbar.dismiss();
             mQuickStartSnackbar = null;
         }
-    }
-
-    // The first time this is called in onCreate -> initViewModel we still haven't initialized mSelectedSite,
-    // which hasFullAccessToContent depends on, and as such the state will be initialized with the most restrictive
-    // rights case (that is, will assume hasFullAccessToContent is false). This is OK and will be frequently checked
-    // to normalize the UI state whenever mSelectedSite changes.
-    private boolean hasFullAccessToContent() {
-        return SiteUtils.hasFullAccessToContent(getSelectedSite());
     }
 
     // We dismiss the QuickStart SnackBar every time activity is paused because

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -186,7 +186,7 @@ class PagesFragment : Fragment() {
                 newPageButton.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
             }
 
-            Toast.makeText(newPageButton.context, R.string.pages_empty_list_button, Toast.LENGTH_SHORT).show()
+            Toast.makeText(newPageButton.context, R.string.create_page_fab_tooltip, Toast.LENGTH_SHORT).show()
             return@setOnLongClickListener true
         }
         newPageButton.redirectContextClickToLongPressListener()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -46,6 +46,7 @@ import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils
@@ -352,7 +353,7 @@ class PostListMainViewModel @Inject constructor(
     }
 
     fun fabClicked() {
-        if (wpStoriesFeatureConfig.isEnabled()) {
+        if (wpStoriesFeatureConfig.isEnabled() && SiteUtils.supportsStoriesFeature(site)) {
             _onFabClicked.postValue(Event(Unit))
         } else {
             newPost()
@@ -581,7 +582,7 @@ class PostListMainViewModel @Inject constructor(
     }
 
     fun onFabLongPressed() {
-        if (wpStoriesFeatureConfig.isEnabled()) {
+        if (wpStoriesFeatureConfig.isEnabled() && SiteUtils.supportsStoriesFeature(site)) {
             _onFabLongPressedForCreateMenu.postValue(Event(Unit))
         } else {
             _onFabLongPressedForPostList.postValue(Event(Unit))

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -392,13 +392,14 @@ class PostsListActivity : LocaleAwareActivity(),
             event.applyIfNotHandled {
                 postListCreateMenuViewModel.onFabLongPressed()
             }
+            Toast.makeText(fab.context, R.string.create_post_story_fab_tooltip, Toast.LENGTH_SHORT).show()
         })
 
         viewModel.onFabLongPressedForPostList.observe(this, Observer {
             if (fab.isHapticFeedbackEnabled) {
                 fab.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
             }
-            Toast.makeText(fab.context, R.string.posts_empty_list_button, Toast.LENGTH_SHORT).show()
+            Toast.makeText(fab.context, R.string.create_post_fab_tooltip, Toast.LENGTH_SHORT).show()
         })
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -288,7 +288,7 @@ class PostsListActivity : LocaleAwareActivity(),
             }
         })
 
-        postListCreateMenuViewModel.start()
+        postListCreateMenuViewModel.start(site)
     }
 
     private fun initViewModel(initPreviewState: PostListRemotePreviewState, currentBottomSheetPostId: LocalId) {

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -27,6 +27,8 @@ public class SiteUtils {
     public static final String GB_EDITOR_NAME = "gutenberg";
     public static final String AZTEC_EDITOR_NAME = "aztec";
     public static final String WP_STORIES_CREATOR_NAME = "wp_stories_creator";
+    // TODO Update to the first version with the story block as a production and not a beta block
+    public static final String WP_STORIES_JETPACK_VERSION = "8.8";
     private static final int GB_ROLLOUT_PERCENTAGE_PHASE_1 = 100;
     private static final int GB_ROLLOUT_PERCENTAGE_PHASE_2 = 100;
 
@@ -285,6 +287,10 @@ public class SiteUtils {
             }
         }
         return false;
+    }
+
+    public static boolean supportsStoriesFeature(SiteModel site) {
+        return site != null && (site.isWPCom() || checkMinimalJetpackVersion(site, WP_STORIES_JETPACK_VERSION));
     }
 
     public static boolean isNonAtomicBusinessPlanSite(@Nullable SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -229,7 +229,7 @@ class WPMainActivityViewModel @Inject constructor(
         _fabUiState.value = newState
     }
 
-    private fun getCreateContentMessageId(site: SiteModel?): Int {
+    fun getCreateContentMessageId(site: SiteModel?): Int {
         return if (shouldShowStories(site))
             getCreateContentMessageId_StoriesFlagOn(hasFullAccessToContent(site))
         else
@@ -239,9 +239,9 @@ class WPMainActivityViewModel @Inject constructor(
     // create_post_page_fab_tooltip_stories_feature_flag_on
     private fun getCreateContentMessageId_StoriesFlagOn(hasFullAccessToContent: Boolean): Int {
         return if (hasFullAccessToContent)
-            R.string.create_post_page_fab_tooltip_stories_feature_flag_on
+            R.string.create_post_page_fab_tooltip_stories_enabled
         else
-            R.string.create_post_page_fab_tooltip_contributors_stories_feature_flag_on
+            R.string.create_post_page_fab_tooltip_contributors_stories_enabled
     }
 
     private fun getCreateContentMessageId_StoriesFlagOff(hasFullAccessToContent: Boolean): Int {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
@@ -18,6 +19,7 @@ import org.wordpress.android.ui.main.MainFabUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider
 import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.SiteUtils.hasFullAccessToContent
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.WPStoriesFeatureConfig
 import org.wordpress.android.util.merge
@@ -72,18 +74,18 @@ class WPMainActivityViewModel @Inject constructor(
     private val _completeBottomSheetQuickStartTask = SingleLiveEvent<Unit>()
     val completeBottomSheetQuickStartTask: LiveData<Unit> = _completeBottomSheetQuickStartTask
 
-    fun start(isFabVisible: Boolean, hasFullAccessToContent: Boolean) {
+    fun start(isFabVisible: Boolean, site: SiteModel?) {
         if (isStarted) return
         isStarted = true
 
-        setMainFabUiState(isFabVisible, hasFullAccessToContent)
+        setMainFabUiState(isFabVisible, site)
 
-        loadMainActions(hasFullAccessToContent)
+        loadMainActions(site)
 
         updateFeatureAnnouncements()
     }
 
-    private fun loadMainActions(hasFullAccessToContent: Boolean) {
+    private fun loadMainActions(site: SiteModel?) {
         val actionsList = ArrayList<MainActionListItem>()
 
         actionsList.add(CreateAction(
@@ -98,7 +100,7 @@ class WPMainActivityViewModel @Inject constructor(
                 labelRes = R.string.my_site_bottom_sheet_add_post,
                 onClickAction = ::onCreateActionClicked
         ))
-        if (hasFullAccessToContent) {
+        if (hasFullAccessToContent(site)) {
             actionsList.add(CreateAction(
                     actionType = CREATE_NEW_PAGE,
                     iconRes = R.drawable.ic_pages_white_24dp,
@@ -132,7 +134,7 @@ class WPMainActivityViewModel @Inject constructor(
         }
     }
 
-    private fun disableTooltip(hasFullAccessToContent: Boolean) {
+    private fun disableTooltip(site: SiteModel) {
         appPrefsWrapper.setMainFabTooltipDisabled(true)
 
         val oldState = _fabUiState.value
@@ -140,19 +142,19 @@ class WPMainActivityViewModel @Inject constructor(
             _fabUiState.value = MainFabUiState(
                     isFabVisible = it.isFabVisible,
                     isFabTooltipVisible = false,
-                    CreateContentMessageId = getCreateContentMessageId(hasFullAccessToContent)
+                    CreateContentMessageId = getCreateContentMessageId(site)
             )
         }
     }
 
-    fun onFabClicked(hasFullAccessToContent: Boolean, shouldShowQuickStartFocusPoint: Boolean = false) {
+    fun onFabClicked(site: SiteModel, shouldShowQuickStartFocusPoint: Boolean = false) {
         appPrefsWrapper.setMainFabTooltipDisabled(true)
-        setMainFabUiState(true, hasFullAccessToContent)
+        setMainFabUiState(true, site)
 
         _showQuickStarInBottomSheet.postValue(shouldShowQuickStartFocusPoint)
 
         if (wpStoriesFeatureConfig.isEnabled()) {
-            loadMainActions(hasFullAccessToContent)
+            loadMainActions(site)
             _isBottomSheetShowing.value = Event(true)
         } else {
             // NOTE: this whole piece of code and comment below to be removed when we remove the feature flag.
@@ -163,10 +165,10 @@ class WPMainActivityViewModel @Inject constructor(
             // We should evaluate to re-introduce the bottom sheet also for users without full access to content
             // if user has at least 2 options (eventually filtering the content not accessible like pages in this case)
             // See p5T066-1cA-p2/#comment-4463
-            if (hasFullAccessToContent) {
+            if (hasFullAccessToContent(site)) {
                 // reload main actions given the first time this is initialized, the SiteModel may not contain the
                 // latest info
-                loadMainActions(hasFullAccessToContent)
+                loadMainActions(site)
                 _isBottomSheetShowing.value = Event(true)
             } else {
                 _createAction.postValue(CREATE_NEW_POST)
@@ -174,29 +176,29 @@ class WPMainActivityViewModel @Inject constructor(
         }
     }
 
-    fun onPageChanged(showFab: Boolean, hasFullAccessToContent: Boolean) {
-        setMainFabUiState(showFab, hasFullAccessToContent)
+    fun onPageChanged(showFab: Boolean, site: SiteModel) {
+        setMainFabUiState(showFab, site)
     }
 
-    fun onTooltipTapped(hasFullAccessToContent: Boolean) {
-        disableTooltip(hasFullAccessToContent)
+    fun onTooltipTapped(site: SiteModel) {
+        disableTooltip(site)
     }
 
-    fun onFabLongPressed(hasFullAccessToContent: Boolean) {
-        disableTooltip(hasFullAccessToContent)
+    fun onFabLongPressed(site: SiteModel) {
+        disableTooltip(site)
     }
 
     fun onOpenLoginPage() {
         _startLoginFlow.value = Event(true)
     }
 
-    fun onResume(hasFullAccessToContent: Boolean) {
+    fun onResume(site: SiteModel) {
         val oldState = _fabUiState.value
         oldState?.let {
             _fabUiState.value = MainFabUiState(
                     isFabVisible = it.isFabVisible,
                     isFabTooltipVisible = it.isFabTooltipVisible,
-                    CreateContentMessageId = getCreateContentMessageId(hasFullAccessToContent)
+                    CreateContentMessageId = getCreateContentMessageId(site)
             )
         }
 
@@ -216,21 +218,21 @@ class WPMainActivityViewModel @Inject constructor(
         }
     }
 
-    private fun setMainFabUiState(isFabVisible: Boolean, hasFullAccessToContent: Boolean) {
+    private fun setMainFabUiState(isFabVisible: Boolean, site: SiteModel?) {
         val newState = MainFabUiState(
                 isFabVisible = isFabVisible,
                 isFabTooltipVisible = if (appPrefsWrapper.isMainFabTooltipDisabled()) false else isFabVisible,
-                CreateContentMessageId = getCreateContentMessageId(hasFullAccessToContent)
+                CreateContentMessageId = getCreateContentMessageId(site)
         )
 
         _fabUiState.value = newState
     }
 
-    private fun getCreateContentMessageId(hasFullAccessToContent: Boolean): Int {
+    private fun getCreateContentMessageId(site: SiteModel?): Int {
         return if (wpStoriesFeatureConfig.isEnabled())
-            return getCreateContentMessageId_StoriesFlagOn(hasFullAccessToContent)
+            getCreateContentMessageId_StoriesFlagOn(hasFullAccessToContent(site))
         else
-            return getCreateContentMessageId_StoriesFlagOff(hasFullAccessToContent)
+            getCreateContentMessageId_StoriesFlagOff(hasFullAccessToContent(site))
     }
 
     // create_post_page_fab_tooltip_stories_feature_flag_on

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.main.MainFabUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider
 import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.SiteUtils.hasFullAccessToContent
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.WPStoriesFeatureConfig
@@ -108,7 +109,7 @@ class WPMainActivityViewModel @Inject constructor(
                     onClickAction = ::onCreateActionClicked
             ))
         }
-        if (wpStoriesFeatureConfig.isEnabled()) {
+        if (shouldShowStories(site)) {
             actionsList.add(CreateAction(
                     actionType = CREATE_NEW_STORY,
                     iconRes = R.drawable.ic_story_icon_24dp,
@@ -153,7 +154,7 @@ class WPMainActivityViewModel @Inject constructor(
 
         _showQuickStarInBottomSheet.postValue(shouldShowQuickStartFocusPoint)
 
-        if (wpStoriesFeatureConfig.isEnabled()) {
+        if (shouldShowStories(site)) {
             loadMainActions(site)
             _isBottomSheetShowing.value = Event(true)
         } else {
@@ -229,7 +230,7 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     private fun getCreateContentMessageId(site: SiteModel?): Int {
-        return if (wpStoriesFeatureConfig.isEnabled())
+        return if (shouldShowStories(site))
             getCreateContentMessageId_StoriesFlagOn(hasFullAccessToContent(site))
         else
             getCreateContentMessageId_StoriesFlagOff(hasFullAccessToContent(site))
@@ -262,5 +263,9 @@ class WPMainActivityViewModel @Inject constructor(
         return cachedAnnouncement != null &&
                 cachedAnnouncement.canBeDisplayedOnAppUpgrade(buildConfigWrapper.getAppVersionName()) &&
                 appPrefsWrapper.featureAnnouncementShownVersion < cachedAnnouncement.announcementVersion
+    }
+
+    private fun shouldShowStories(site: SiteModel?): Boolean {
+        return wpStoriesFeatureConfig.isEnabled() && SiteUtils.supportsStoriesFeature(site)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
@@ -3,9 +3,9 @@ package org.wordpress.android.viewmodel.posts
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import org.wordpress.android.R
 import org.wordpress.android.R.drawable
 import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
@@ -14,14 +14,18 @@ import org.wordpress.android.ui.main.MainActionListItem.ActionType.NO_ACTION
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.main.MainFabUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.config.WPStoriesFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 
 class PostListCreateMenuViewModel @Inject constructor(
-    private val appPrefsWrapper: AppPrefsWrapper
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val wpStoriesFeatureConfig: WPStoriesFeatureConfig
 ) : ViewModel() {
     private var isStarted = false
+    private lateinit var site: SiteModel
 
     private val _fabUiState = MutableLiveData<MainFabUiState>()
     val fabUiState: LiveData<MainFabUiState> = _fabUiState
@@ -35,9 +39,11 @@ class PostListCreateMenuViewModel @Inject constructor(
     private val _isBottomSheetShowing = MutableLiveData<Event<Boolean>>()
     val isBottomSheetShowing: LiveData<Event<Boolean>> = _isBottomSheetShowing
 
-    fun start() {
+    fun start(site: SiteModel) {
         if (isStarted) return
         isStarted = true
+
+        this.site = site
 
         setMainFabUiState()
 
@@ -86,7 +92,7 @@ class PostListCreateMenuViewModel @Inject constructor(
         val newState = MainFabUiState(
                 isFabVisible = true,
                 isFabTooltipVisible = !appPrefsWrapper.isPostListFabTooltipDisabled(),
-                CreateContentMessageId = R.string.create_post_page_fab_tooltip_contributors_stories_enabled
+                CreateContentMessageId = getCreateContentMessageId()
         )
 
         _fabUiState.value = newState
@@ -114,7 +120,7 @@ class PostListCreateMenuViewModel @Inject constructor(
             _fabUiState.value = MainFabUiState(
                     isFabVisible = it.isFabVisible,
                     isFabTooltipVisible = false,
-                    CreateContentMessageId = R.string.create_post_page_fab_tooltip_contributors_stories_enabled
+                    CreateContentMessageId = getCreateContentMessageId()
             )
         }
     }
@@ -125,8 +131,16 @@ class PostListCreateMenuViewModel @Inject constructor(
             _fabUiState.value = MainFabUiState(
                     isFabVisible = it.isFabVisible,
                     isFabTooltipVisible = it.isFabTooltipVisible,
-                    CreateContentMessageId = R.string.create_post_page_fab_tooltip_contributors_stories_enabled
+                    CreateContentMessageId = getCreateContentMessageId()
             )
+        }
+    }
+
+    private fun getCreateContentMessageId(): Int {
+        return if (wpStoriesFeatureConfig.isEnabled() && SiteUtils.supportsStoriesFeature(site)) {
+            string.create_post_story_fab_tooltip
+        } else {
+            string.create_post_fab_tooltip
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
@@ -86,7 +86,7 @@ class PostListCreateMenuViewModel @Inject constructor(
         val newState = MainFabUiState(
                 isFabVisible = true,
                 isFabTooltipVisible = !appPrefsWrapper.isPostListFabTooltipDisabled(),
-                CreateContentMessageId = R.string.create_post_page_fab_tooltip_contributors_stories_feature_flag_on
+                CreateContentMessageId = R.string.create_post_page_fab_tooltip_contributors_stories_enabled
         )
 
         _fabUiState.value = newState
@@ -114,7 +114,7 @@ class PostListCreateMenuViewModel @Inject constructor(
             _fabUiState.value = MainFabUiState(
                     isFabVisible = it.isFabVisible,
                     isFabTooltipVisible = false,
-                    CreateContentMessageId = R.string.create_post_page_fab_tooltip_contributors_stories_feature_flag_on
+                    CreateContentMessageId = R.string.create_post_page_fab_tooltip_contributors_stories_enabled
             )
         }
     }
@@ -125,7 +125,7 @@ class PostListCreateMenuViewModel @Inject constructor(
             _fabUiState.value = MainFabUiState(
                     isFabVisible = it.isFabVisible,
                     isFabTooltipVisible = it.isFabTooltipVisible,
-                    CreateContentMessageId = R.string.create_post_page_fab_tooltip_contributors_stories_feature_flag_on
+                    CreateContentMessageId = R.string.create_post_page_fab_tooltip_contributors_stories_enabled
             )
         }
     }

--- a/WordPress/src/main/res/layout/post_list_activity.xml
+++ b/WordPress/src/main/res/layout/post_list_activity.xml
@@ -110,7 +110,7 @@
             app:layout_constraintHorizontal_bias="1.0"
             app:layout_constraintStart_toStartOf="parent"
             app:wpArrowHorizontalOffsetFromEnd="@dimen/main_fab_tooltip_offset_end"
-            app:wpTooltipMessage="@string/create_post_page_fab_tooltip_contributors_stories_feature_flag_on"
+            app:wpTooltipMessage="@string/create_post_story_fab_tooltip"
             app:wpTooltipPosition="above"
             tools:visibility="visible" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2775,6 +2775,10 @@
     <string name="create_post_page_fab_tooltip">Create a post or page</string>
     <string name="create_post_page_fab_tooltip_contributors">Create a post</string>
 
+    <string name="create_post_fab_tooltip">Create a post</string>
+    <string name="create_page_fab_tooltip">Create a page</string>
+    <string name="create_post_story_fab_tooltip">Create a post or story</string>
+
     <string name="create_post_page_fab_tooltip_stories_enabled">Create a post, page or story</string>
     <string name="create_post_page_fab_tooltip_contributors_stories_enabled">Create a post or story</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2775,10 +2775,8 @@
     <string name="create_post_page_fab_tooltip">Create a post or page</string>
     <string name="create_post_page_fab_tooltip_contributors">Create a post</string>
 
-    <!--  these are needed while WPStories sits behind a feature flag  -->
-    <!--  TODO we'll need to replace them when the feature flag is gone -->
-    <string name="create_post_page_fab_tooltip_stories_feature_flag_on">Create a post, page or story</string>
-    <string name="create_post_page_fab_tooltip_contributors_stories_feature_flag_on">Create a post or story</string>
+    <string name="create_post_page_fab_tooltip_stories_enabled">Create a post, page or story</string>
+    <string name="create_post_page_fab_tooltip_contributors_stories_enabled">Create a post or story</string>
 
     <!-- News Card -->
     <!-- When announcing a new feature, add new strings and make sure to update LocalNewsItem.kt -->

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -29,7 +29,7 @@ import org.wordpress.android.util.config.WPStoriesFeatureConfig
 import org.wordpress.android.viewmodel.Event
 
 class PostListMainViewModelTest : BaseUnitTest() {
-    lateinit var site: SiteModel
+    @Mock lateinit var site: SiteModel
     private val currentBottomSheetPostId = LocalId(0)
     @Mock lateinit var uploadStarter: UploadStarter
     @Mock lateinit var dispatcher: Dispatcher
@@ -45,8 +45,6 @@ class PostListMainViewModelTest : BaseUnitTest() {
         val prefs = mock<AppPrefsWrapper> {
             on { postListViewLayoutType } doReturn STANDARD
         }
-
-        site = SiteModel()
 
         whenever(editPostRepository.postChanged).thenReturn(MutableLiveData(Event(PostModel())))
 
@@ -194,8 +192,9 @@ class PostListMainViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `if wpStoriesFeatureConfig is true and onFabClicked then _onFabClicked is called`() {
+    fun `if stories is enabled and onFabClicked then _onFabClicked is called`() {
         whenever(wpStoriesFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(site.isWPCom).thenReturn(true)
 
         viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository, mock())
         viewModel.fabClicked()
@@ -204,7 +203,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `if wpStoriesFeatureConfig is false and onFabClicked then _onFabClicked is not called`() {
+    fun `if stories is disabled and onFabClicked then _onFabClicked is not called`() {
         whenever(wpStoriesFeatureConfig.isEnabled()).thenReturn(false)
 
         viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository, mock())
@@ -214,8 +213,9 @@ class PostListMainViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `if wpStoriesFeatureConfig is true and onFabLongPressed then onFabLongPressedForCreateMenu is called`() {
+    fun `if stories is enabled and onFabLongPressed then onFabLongPressedForCreateMenu is called`() {
         whenever(wpStoriesFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(site.isWPCom).thenReturn(true)
 
         viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository, mock())
         viewModel.onFabLongPressed()
@@ -224,7 +224,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `if wpStoriesFeatureConfig is false and onFabLongPressed then onFabLongPressedForPostList is called`() {
+    fun `if stories is disabled and onFabLongPressed then onFabLongPressedForPostList is called`() {
         whenever(wpStoriesFeatureConfig.isEnabled()).thenReturn(false)
 
         viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository, mock())

--- a/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
@@ -134,4 +134,46 @@ class SiteUtilsTest {
 
         assertThat(isAccessedViaWPComRest).isTrue()
     }
+
+    @Test
+    fun `supportsStoriesFeature returns true when origin is wpcom rest`() {
+        val site = SiteModel().apply {
+            origin = SiteModel.ORIGIN_WPCOM_REST
+            setIsWPCom(true)
+        }
+
+        val supportsStoriesFeature = SiteUtils.supportsStoriesFeature(site)
+
+        assertTrue(supportsStoriesFeature)
+    }
+
+    @Test
+    fun `supportsStoriesFeature returns true when Jetpack site meets requirement`() {
+        val site = initJetpackSite().apply {
+            jetpackVersion = SiteUtils.WP_STORIES_JETPACK_VERSION
+        }
+
+        val supportsStoriesFeature = SiteUtils.supportsStoriesFeature(site)
+
+        assertTrue(supportsStoriesFeature)
+    }
+
+    @Test
+    fun `supportsStoriesFeature returns false when Jetpack site does not meet requirement`() {
+        val site = initJetpackSite().apply {
+            jetpackVersion = (SiteUtils.WP_STORIES_JETPACK_VERSION.toFloat() - 1).toString()
+        }
+
+        val supportsStoriesFeature = SiteUtils.supportsStoriesFeature(site)
+
+        assertFalse(supportsStoriesFeature)
+    }
+
+    private fun initJetpackSite(): SiteModel {
+        return SiteModel().apply {
+            origin = SiteModel.ORIGIN_WPCOM_REST
+            setIsJetpackInstalled(true)
+            setIsJetpackConnected(true)
+        }
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -240,6 +240,15 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `new post action is triggered from FAB when no full access to content if stories enabled but unavailable`() {
+        setupWPStoriesFeatureConfigEnabled(buildConfigValue = true)
+        startViewModelWithDefaultParameters()
+        viewModel.onFabClicked(site = initSite(hasFullAccessToContent = false, supportsStories = false))
+        assertThat(viewModel.isBottomSheetShowing.value).isNull()
+        assertThat(viewModel.createAction.value).isEqualTo(CREATE_NEW_POST)
+    }
+
+    @Test
     fun `bottom sheet is visualized when user has full access to content and has all 3 options if stories enabled`() {
         setupWPStoriesFeatureConfigEnabled(buildConfigValue = true)
         startViewModelWithDefaultParameters()
@@ -403,12 +412,13 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     private fun startViewModelWithDefaultParameters() {
-        viewModel.start(isFabVisible = true, site = initSite(hasFullAccessToContent = true))
+        viewModel.start(isFabVisible = true, site = initSite(hasFullAccessToContent = true, supportsStories = true))
     }
 
-    private fun initSite(hasFullAccessToContent: Boolean = true): SiteModel {
+    private fun initSite(hasFullAccessToContent: Boolean = true, supportsStories: Boolean = true): SiteModel {
         return SiteModel().apply {
             hasCapabilityEditPages = hasFullAccessToContent
+            setIsWPCom(supportsStories)
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -15,6 +15,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.FEATURE_ANNOUNCEMENT_SHOWN_ON_APP_UPGRADE
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.test
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PAGE
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
@@ -85,35 +86,35 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `fab visible when asked`() {
         startViewModelWithDefaultParameters()
-        viewModel.onPageChanged(showFab = true, hasFullAccessToContent = true)
+        viewModel.onPageChanged(showFab = true, site = initSite(hasFullAccessToContent = true))
         assertThat(viewModel.fabUiState.value?.isFabVisible).isEqualTo(true)
     }
 
     @Test
     fun `fab hidden when asked`() {
         startViewModelWithDefaultParameters()
-        viewModel.onPageChanged(showFab = false, hasFullAccessToContent = true)
+        viewModel.onPageChanged(showFab = false, site = initSite(hasFullAccessToContent = true))
         assertThat(viewModel.fabUiState.value?.isFabVisible).isEqualTo(false)
     }
 
     @Test
     fun `fab tooltip visible when asked`() {
         startViewModelWithDefaultParameters()
-        viewModel.onPageChanged(showFab = true, hasFullAccessToContent = true)
+        viewModel.onPageChanged(showFab = true, site = initSite(hasFullAccessToContent = true))
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(true)
     }
 
     @Test
     fun `fab tooltip hidden when asked`() {
         startViewModelWithDefaultParameters()
-        viewModel.onPageChanged(showFab = false, hasFullAccessToContent = true)
+        viewModel.onPageChanged(showFab = false, site = initSite(hasFullAccessToContent = true))
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
 
     @Test
     fun `fab tooltip disabled when tapped`() {
         startViewModelWithDefaultParameters()
-        viewModel.onTooltipTapped(true)
+        viewModel.onTooltipTapped(initSite(hasFullAccessToContent = true))
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
@@ -122,7 +123,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `fab tooltip disabled when user without full access to content uses the fab`() {
         startViewModelWithDefaultParameters()
         whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(true)
-        viewModel.onFabClicked(false)
+        viewModel.onFabClicked(initSite(hasFullAccessToContent = false))
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
@@ -131,7 +132,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `fab tooltip disabled when bottom sheet opened`() {
         startViewModelWithDefaultParameters()
         whenever(appPrefsWrapper.isMainFabTooltipDisabled()).thenReturn(true)
-        viewModel.onFabClicked(true)
+        viewModel.onFabClicked(initSite(hasFullAccessToContent = true))
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
@@ -139,7 +140,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `fab tooltip disabled when fab long pressed`() {
         startViewModelWithDefaultParameters()
-        viewModel.onFabLongPressed(true)
+        viewModel.onFabLongPressed(initSite(hasFullAccessToContent = true))
         verify(appPrefsWrapper).setMainFabTooltipDisabled(true)
         assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isEqualTo(false)
     }
@@ -165,7 +166,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `bottom sheet action is new story when new story is tapped if stories enabled`() {
         setupWPStoriesFeatureConfigEnabled(buildConfigValue = true)
-        viewModel.start(isFabVisible = true, hasFullAccessToContent = true)
+        viewModel.start(isFabVisible = true, site = initSite(hasFullAccessToContent = true))
         val action = viewModel.mainActions.value?.first { it.actionType == CREATE_NEW_STORY } as CreateAction
         assertThat(action).isNotNull
         action.onClickAction?.invoke(CREATE_NEW_STORY)
@@ -173,10 +174,10 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `bottom sheet is visualized when user has full access to content if stories disabled`() {
+    fun `bottom sheet is shown when user has full access to content if stories feature flag disabled`() {
         setupWPStoriesFeatureConfigEnabled(buildConfigValue = false)
         startViewModelWithDefaultParameters()
-        viewModel.onFabClicked(hasFullAccessToContent = true)
+        viewModel.onFabClicked(site = initSite(hasFullAccessToContent = true))
         assertThat(viewModel.createAction.value).isNull()
         assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isEqualTo(true)
     }
@@ -184,7 +185,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `bottom sheet does not show quick start focus point by default`() {
         startViewModelWithDefaultParameters()
-        viewModel.onFabClicked(hasFullAccessToContent = true)
+        viewModel.onFabClicked(site = initSite(hasFullAccessToContent = true))
         assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isEqualTo(true)
         assertThat(viewModel.mainActions.value?.any { it is CreateAction && it.showQuickStartFocusPoint }).isEqualTo(
                 false
@@ -194,7 +195,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `CREATE_NEW_POST action in bottom sheet with active Quick Start completes task and hides the focus point`() {
         startViewModelWithDefaultParameters()
-        viewModel.onFabClicked(hasFullAccessToContent = true, shouldShowQuickStartFocusPoint = true)
+        viewModel.onFabClicked(site = initSite(hasFullAccessToContent = true), shouldShowQuickStartFocusPoint = true)
         assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isEqualTo(true)
         assertThat(viewModel.mainActions.value?.any { it is CreateAction && it.showQuickStartFocusPoint }).isEqualTo(
                 true
@@ -213,7 +214,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `actions that are not CREATE_NEW_POST will not complete quick start task`() {
         startViewModelWithDefaultParameters()
-        viewModel.onFabClicked(hasFullAccessToContent = true, shouldShowQuickStartFocusPoint = true)
+        viewModel.onFabClicked(site = initSite(hasFullAccessToContent = true), shouldShowQuickStartFocusPoint = true)
         assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isEqualTo(true)
         assertThat(viewModel.mainActions.value?.any { it is CreateAction && it.showQuickStartFocusPoint }).isEqualTo(
                 true
@@ -233,7 +234,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `new post action is triggered from FAB when user has not full access to content if stories disabled`() {
         setupWPStoriesFeatureConfigEnabled(buildConfigValue = false)
         startViewModelWithDefaultParameters()
-        viewModel.onFabClicked(hasFullAccessToContent = false)
+        viewModel.onFabClicked(site = initSite(hasFullAccessToContent = false))
         assertThat(viewModel.isBottomSheetShowing.value).isNull()
         assertThat(viewModel.createAction.value).isEqualTo(CREATE_NEW_POST)
     }
@@ -242,7 +243,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `bottom sheet is visualized when user has full access to content and has all 3 options if stories enabled`() {
         setupWPStoriesFeatureConfigEnabled(buildConfigValue = true)
         startViewModelWithDefaultParameters()
-        viewModel.onFabClicked(hasFullAccessToContent = true)
+        viewModel.onFabClicked(site = initSite(hasFullAccessToContent = true))
         assertThat(viewModel.createAction.value).isNull()
         assertThat(viewModel.mainActions.value?.size).isEqualTo(4) // 3 options plus NO_ACTION, first in list
         assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isEqualTo(true)
@@ -252,7 +253,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `bottom sheet is visualized when user has partial access and has only 2 options if stories enabled`() {
         setupWPStoriesFeatureConfigEnabled(buildConfigValue = true)
         startViewModelWithDefaultParameters()
-        viewModel.onFabClicked(hasFullAccessToContent = false)
+        viewModel.onFabClicked(site = initSite(hasFullAccessToContent = false))
         assertThat(viewModel.createAction.value).isNull()
         assertThat(viewModel.mainActions.value?.size).isEqualTo(3) // 2 options plus NO_ACTION, first in list
         assertThat(viewModel.isBottomSheetShowing.value!!.peekContent()).isEqualTo(true)
@@ -270,7 +271,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `onResume set expected content message when user has full access to content if stories not enabled`() {
         setupWPStoriesFeatureConfigEnabled(false)
         startViewModelWithDefaultParameters()
-        viewModel.onResume(true)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = true))
         assertThat(viewModel.fabUiState.value!!.CreateContentMessageId).isEqualTo(R.string.create_post_page_fab_tooltip)
     }
 
@@ -278,7 +279,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `onResume set expected content message when user has not full access to content if stories not enabled`() {
         setupWPStoriesFeatureConfigEnabled(false)
         startViewModelWithDefaultParameters()
-        viewModel.onResume(false)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = false))
         assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
                 .isEqualTo(R.string.create_post_page_fab_tooltip_contributors)
     }
@@ -287,7 +288,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `onResume set expected content message when user has full access to content if stories enabled`() {
         setupWPStoriesFeatureConfigEnabled(true)
         startViewModelWithDefaultParameters()
-        viewModel.onResume(true)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = true))
         assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
                 .isEqualTo(R.string.create_post_page_fab_tooltip_stories_feature_flag_on)
     }
@@ -296,7 +297,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `onResume set expected content message when user has not full access to content if stories enabled`() {
         setupWPStoriesFeatureConfigEnabled(true)
         startViewModelWithDefaultParameters()
-        viewModel.onResume(false)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = false))
         assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
                 .isEqualTo(R.string.create_post_page_fab_tooltip_contributors_stories_feature_flag_on)
     }
@@ -310,7 +311,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         )
 
         startViewModelWithDefaultParameters()
-        viewModel.onResume(true)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = true))
 
         verify(onFeatureAnnouncementRequestedObserver).onChanged(anyOrNull())
         verify(analyticsTrackerWrapper).track(FEATURE_ANNOUNCEMENT_SHOWN_ON_APP_UPGRADE)
@@ -325,7 +326,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         )
 
         startViewModelWithDefaultParameters()
-        viewModel.onResume(true)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = true))
 
         verify(onFeatureAnnouncementRequestedObserver).onChanged(anyOrNull())
         verify(analyticsTrackerWrapper).track(FEATURE_ANNOUNCEMENT_SHOWN_ON_APP_UPGRADE)
@@ -339,7 +340,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         )
 
         startViewModelWithDefaultParameters()
-        viewModel.onResume(true)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = true))
 
         verify(onFeatureAnnouncementRequestedObserver, never()).onChanged(anyOrNull())
         verify(featureAnnouncementProvider).getLatestFeatureAnnouncement(false)
@@ -350,7 +351,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         whenever(appPrefsWrapper.lastFeatureAnnouncementAppVersionCode).thenReturn(0)
 
         startViewModelWithDefaultParameters()
-        viewModel.onResume(true)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = true))
 
         verify(onFeatureAnnouncementRequestedObserver, never()).onChanged(anyOrNull())
         verify(appPrefsWrapper).lastFeatureAnnouncementAppVersionCode = 850
@@ -362,7 +363,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         whenever(appPrefsWrapper.lastFeatureAnnouncementAppVersionCode).thenReturn(840)
 
         startViewModelWithDefaultParameters()
-        viewModel.onResume(true)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = true))
 
         verify(onFeatureAnnouncementRequestedObserver, never()).onChanged(anyOrNull())
     }
@@ -377,7 +378,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
                 )
 
                 startViewModelWithDefaultParameters()
-                viewModel.onResume(true)
+                viewModel.onResume(site = initSite(hasFullAccessToContent = true))
 
                 verify(onFeatureAnnouncementRequestedObserver, never()).onChanged(anyOrNull())
                 verify(featureAnnouncementProvider).getLatestFeatureAnnouncement(false)
@@ -392,7 +393,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         )
 
         startViewModelWithDefaultParameters()
-        viewModel.onResume(true)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = true))
 
         verify(onFeatureAnnouncementRequestedObserver).onChanged(anyOrNull())
 
@@ -402,7 +403,13 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     private fun startViewModelWithDefaultParameters() {
-        viewModel.start(isFabVisible = true, hasFullAccessToContent = true)
+        viewModel.start(isFabVisible = true, site = initSite(hasFullAccessToContent = true))
+    }
+
+    private fun initSite(hasFullAccessToContent: Boolean = true): SiteModel {
+        return SiteModel().apply {
+            hasCapabilityEditPages = hasFullAccessToContent
+        }
     }
 
     private fun setupWPStoriesFeatureConfigEnabled(buildConfigValue: Boolean) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -299,7 +299,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         startViewModelWithDefaultParameters()
         viewModel.onResume(site = initSite(hasFullAccessToContent = true))
         assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
-                .isEqualTo(R.string.create_post_page_fab_tooltip_stories_feature_flag_on)
+                .isEqualTo(R.string.create_post_page_fab_tooltip_stories_enabled)
     }
 
     @Test
@@ -308,7 +308,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         startViewModelWithDefaultParameters()
         viewModel.onResume(site = initSite(hasFullAccessToContent = false))
         assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
-                .isEqualTo(R.string.create_post_page_fab_tooltip_contributors_stories_feature_flag_on)
+                .isEqualTo(R.string.create_post_page_fab_tooltip_contributors_stories_enabled)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModelTest.kt
@@ -8,24 +8,29 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_STORY
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.config.WPStoriesFeatureConfig
 
 class PostListCreateMenuViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: PostListCreateMenuViewModel
     @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock lateinit var wpStoriesFeatureConfig: WPStoriesFeatureConfig
+    @Mock lateinit var site: SiteModel
 
     @Before
     fun setUp() {
-        viewModel = PostListCreateMenuViewModel(appPrefsWrapper)
+        viewModel = PostListCreateMenuViewModel(appPrefsWrapper, wpStoriesFeatureConfig)
     }
 
     @Test
     fun `bottom sheet action is new post when new post is tapped`() {
-        viewModel.start()
+        viewModel.start(site)
         val action = getCreateAction(CREATE_NEW_POST)
         action.onClickAction?.invoke(CREATE_NEW_POST)
 
@@ -34,7 +39,7 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
 
     @Test
     fun `bottom sheet action is new story when new story is tapped`() {
-        viewModel.start()
+        viewModel.start(site)
         val action = getCreateAction(CREATE_NEW_STORY)
         action.onClickAction?.invoke(CREATE_NEW_STORY)
 
@@ -43,7 +48,7 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
 
     @Test
     fun `bottom sheet showing is triggered with false once an action is tapped`() {
-        viewModel.start()
+        viewModel.start(site)
         val action = getCreateAction(CREATE_NEW_POST)
         action.onClickAction?.invoke(CREATE_NEW_POST)
 
@@ -67,7 +72,7 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
     @Test
     fun `if appPrefsWrapper's isPostListFabTooltipDisabled is false then isFabTooltipVisible is true`() {
         whenever(appPrefsWrapper.isPostListFabTooltipDisabled()).thenReturn(false)
-        viewModel.start()
+        viewModel.start(site)
 
         Assertions.assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isTrue()
     }
@@ -75,7 +80,7 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
     @Test
     fun `if appPrefsWrapper's isPostListFabTooltipDisabled is true then isFabTooltipVisible is false`() {
         whenever(appPrefsWrapper.isPostListFabTooltipDisabled()).thenReturn(true)
-        viewModel.start()
+        viewModel.start(site)
 
         Assertions.assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isFalse()
     }
@@ -89,12 +94,35 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when tooltipTapped then isFabTooltipVisible is false`() {
-        viewModel.start()
+        viewModel.start(site)
         viewModel.onTooltipTapped()
 
         Assertions.assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isFalse()
     }
 
+    @Test
+    fun `start set expected content message if stories not enabled`() {
+        setupWPStoriesFeatureConfigEnabled(false)
+
+        viewModel.start(site)
+        Assertions.assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
+                .isEqualTo(R.string.create_post_fab_tooltip)
+    }
+
+    @Test
+    fun `start set expected content message if stories enabled`() {
+        setupWPStoriesFeatureConfigEnabled(true)
+        whenever(site.isWPCom).thenReturn(true)
+
+        viewModel.start(site)
+        Assertions.assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
+                .isEqualTo(R.string.create_post_story_fab_tooltip)
+    }
+
     private fun getCreateAction(actionType: ActionType) =
             viewModel.mainActions.value?.first { it.actionType == actionType } as CreateAction
+
+    private fun setupWPStoriesFeatureConfigEnabled(buildConfigValue: Boolean) {
+        whenever(wpStoriesFeatureConfig.isEnabled()).thenReturn(buildConfigValue)
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/417.

In addition to the check for the stories feature flag being enabled, this PR now checks that the site is able to support the stories feature. This means either:

1. A WordPress.com simple site, or
2. A Jetpack-connected site with version 8.8 or higher

8.8 is the first Jetpack version to include the story block. The block is flagged as a beta block, which requires some extra steps to actually enable it on the site. When we're ready to release the stories feature, we'll want to update the minimum version set in this PR - this would be the sequence of events:

1. The story block in Jetpack is switched from beta to production
2. A new Jetpack version is released with the change (probably Jetpack 9.0)
3. We update the minimum version set in this PR to 9.0
4. The next WPAndroid release after step 3 is the first one we could use for a public beta

(This is being tracked on the stories project board.)

I also fixed the description toasts shown when long-pressing the FABs in the main activity and the post list. In the main activity we weren't accounting for stories, and in the post list no toast was being shown at all when stories were enabled.

Also, the FAB tooltip in the post list was always mentioning stories whether the feature was available or not - I fixed this as well.

Only one reviewer is really needed, ccing you @develric in case I missed anything important since I had to restructure `WPMainActivityViewModel` a bit.

### To test:
There's no need to test actually pushing a story to the site in this PR - a follow-up PR will remove the gallery fallback logic and call for this kind of test. Any site that isn't Tug's test site will just upload a gallery still as of this PR.

Instead, check that, for each site type:
- The options presented in the main activity and post list bottom sheets make sense
- The toasts shown when long pressing the FABs are consistent with the FAB options
- The tooltips shown over the FABs in both screens are consistent with the FAB options

These are the site type cases.

1. Simple WP.com site -> Story option shown ✅
2. Jetpack-connected site, version 8.8+ -> Story option shown ✅
3. Jetpack-connected site, version < 8.8 -> Story option not shown 🙅‍♂️
4. Self-hosted site -> Story option not shown 🙅‍♂️
5. (Optional) Atomic on WordPress.com site -> Story option shown ✅ (this is essentially the same as case 2, Atomic sites for this purpose are Jetpack-connected sites kept on the latest stable Jetpack version)

There's another degree of freedom in the main activity, which is whether the user has the ability to edit pages on the site. If not, there's no bottom sheet in the main activity if stories are disabled or unsupported.

(This is what the unit tests are mostly checking.)

Also check that the option is never shown if the feature flag is disabled, by e.g. [setting this to false](https://github.com/wordpress-mobile/WordPress-Android/blob/a3a756330e9cbf71dc75048563ed958a02bffda4/WordPress/build.gradle#L77).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
