### PR TITLE
WP Stories: remove unneeded mediaId replacement method

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadReadyListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadReadyListener.java
@@ -12,6 +12,5 @@ import org.wordpress.android.util.helpers.MediaFile;
 public interface MediaUploadReadyListener {
     PostModel replaceMediaFileWithUrlInPost(@Nullable PostModel post, String localMediaId, MediaFile mediaFile,
                                             String siteUrl);
-    PostModel replaceMediaLocalIdWithRemoteMediaIdInPost(@Nullable PostModel post, MediaFile mediaFile);
     PostModel markMediaUploadFailedInPost(@Nullable PostModel post, String localMediaId, MediaFile mediaFile);
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadReadyProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadReadyProcessor.java
@@ -20,9 +20,12 @@ public class MediaUploadReadyProcessor implements MediaUploadReadyListener {
             boolean showAztecEditor = AppPrefs.isAztecEditorEnabled();
             boolean showGutenbergEditor = AppPrefs.isGutenbergEditorEnabled();
 
-            if (showGutenbergEditor && PostUtils.contentContainsGutenbergBlocks(post.getContent())) {
+            if (PostUtils.contentContainsWPStoryGutenbergBlocks(post.getContent())) {
+                SaveStoryGutenbergBlockUseCase saveStoryGutenbergBlockUseCase = new SaveStoryGutenbergBlockUseCase();
+                saveStoryGutenbergBlockUseCase
+                        .replaceLocalMediaIdsWithRemoteMediaIdsInPost(post, mediaFile);
+            } else if (showGutenbergEditor && PostUtils.contentContainsGutenbergBlocks(post.getContent())) {
                 post.setContent(
-
                         PostUtils.replaceMediaFileWithUrlInGutenbergPost(post.getContent(), localMediaId, mediaFile,
                                 siteUrl));
             } else if (showAztecEditor) {
@@ -49,16 +52,6 @@ public class MediaUploadReadyProcessor implements MediaUploadReadyListener {
             }
         }
 
-        return post;
-    }
-
-    @Override public PostModel replaceMediaLocalIdWithRemoteMediaIdInPost(@Nullable PostModel post,
-                                                                          MediaFile mediaFile) {
-        if (PostUtils.contentContainsWPStoryGutenbergBlocks(post.getContent())) {
-            SaveStoryGutenbergBlockUseCase saveStoryGutenbergBlockUseCase = new SaveStoryGutenbergBlockUseCase();
-            saveStoryGutenbergBlockUseCase
-                    .replaceLocalMediaIdsWithRemoteMediaIdsInPost(post, mediaFile);
-        }
         return post;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -607,14 +607,9 @@ public class UploadService extends Service {
             // obtain site url used to generate attachment page url
             SiteModel site = sInstance.mSiteStore.getSiteByLocalId(media.getLocalSiteId());
 
-            if (PostUtils.contentContainsWPStoryGutenbergBlocks(post.getContent())) {
-                processor.replaceMediaLocalIdWithRemoteMediaIdInPost(
-                        post, FluxCUtils.mediaFileFromMediaModel(media));
-            } else {
-                // actually replace the media ID with the media uri
-                processor.replaceMediaFileWithUrlInPost(post, String.valueOf(media.getId()),
-                        FluxCUtils.mediaFileFromMediaModel(media), site.getUrl());
-            }
+            // actually replace the media ID with the media uri
+            processor.replaceMediaFileWithUrlInPost(post, String.valueOf(media.getId()),
+                    FluxCUtils.mediaFileFromMediaModel(media), site.getUrl());
 
             // we changed the post, so let’s mark this down
             if (!post.isLocalDraft()) {


### PR DESCRIPTION
Builds on top of #12697, that one should be reviewed first.

This PR removed the specific `replaceMediaLocalIdWithRemoteMediaIdInPost` method introduced in https://github.com/wordpress-mobile/WordPress-Android/commit/38902fddd3a9ecc01af5e6bac187c3e492d68b9d in favor of reusing the previously existing  `replaceMediaFileWithUrlInPost`.

To test:
1. create a Story post with images, videos, verify it uploads and renders correctly on the web
2. create a normal post with images, videos, verify it uploads and renders correctly on the web.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
