### PR TITLE
WP Stories: fix double adding when permission request in progress

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -272,6 +272,10 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     }
 
     private fun handleMediaPickerIntentData(data: Intent) {
+        if (permissionsRequestForCameraInProgress) {
+            return
+        }
+
         if (data.hasExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)) {
             val uriList: List<Uri> = convertStringArrayIntoUrisList(
                     data.getStringArrayExtra(PhotoPickerActivity.EXTRA_MEDIA_URIS)


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/501
Related Stories PR: https://github.com/Automattic/stories-android/pull/505

To test:
First, remove all permissions. Then, follow next steps and allow each permission request as it pops up.
1. tap on the FAB and create a new story
2. pick 2 images from the picker (right the first one, don't try device picker). When prompted about image optimization, tap on LEAVE OFF.
3. now tap on + on the story composer.
4. now tap on the camera FAB, and agree o permissions
5. observe now it opens the camera
6. capture something (image or video)
7. observe it gets added as a new slide to the ones you already had, and there are no repeated slides.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
