### PR TITLE
[Platform] Screenshots automation: change location of screenshots on disk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,8 @@ jobs:
           command: mv libs/gutenberg-mobile/bundle/android/App.js libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/build/assets/index.android.bundle
       - save-gutenberg-bundle-cache
   test:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -131,9 +130,8 @@ jobs:
       - android/save-gradle-cache
       - android/save-test-results
   lint:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -177,9 +175,8 @@ jobs:
       - android/save-gradle-cache
       - android/save-lint-results
   Installable Build:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -228,9 +225,8 @@ jobs:
         description: Post to Slack when tests fail. SLACK_WEBHOOK ENV variable must be set.
         type: boolean
         default: false
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -273,9 +269,8 @@ jobs:
                 include_project_field: false
                 failure_message: ':red_circle: WordPress Android connected tests failed on \`${CIRCLE_BRANCH}\` branch after merge by ${CIRCLE_USERNAME}. See <https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670|Firebase console test results> for details.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'
   WordPressUtils Connected Tests:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     steps:
       - git/shallow-checkout:
           init-submodules: true
@@ -323,9 +318,8 @@ jobs:
           name: Validate login strings
           command: bundle exec fastlane validate_login_strings pr_url:$CIRCLE_PULL_REQUEST
   translation-review-build:
-    executor:
-      name: android/default
-      api-version: "28"
+    docker:
+      - image: circleci/android@sha256:061e2535826cc3fe4c4a440e716bf06c36c80401ee635c339c6803b3e427ebb3
     environment:
       APP_VERSION_PREFIX: << pipeline.parameters.translation_review_lang_id >>
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ fastlane/report.xml
 fastlane/README.md
 fastlane/metadata/android/screenshots.html
 fastlane/metadata/android/*/images/
-fastlane/screenshots_orig
+fastlane/screenshots
 default.profraw
 google-upload-credentials.json
 

--- a/fastlane/ScreenshotFastfile
+++ b/fastlane/ScreenshotFastfile
@@ -13,6 +13,11 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+RAW_SCREENSHOTS_DIR = File.join(Dir.pwd, "screenshots", "raw")
+RAW_SCREENSHOTS_PROCESSING_DIR = File.join(Dir.pwd, "screenshots", "raw_tmp")
+PROMO_SCREENSHOTS_PROCESSING_DIR = File.join(Dir.pwd, "screenshots", "promo_tmp")
+FINAL_METADATA_DIR = File.join(Dir.pwd, "metadata/android")
+
 default_platform(:android)
 
 platform :android do
@@ -88,7 +93,7 @@ platform :android do
     puts locales
 
     screenshot_options = {
-      output_directory: "fastlane/metadata/android",
+      output_directory: RAW_SCREENSHOTS_DIR,
       app_apk_path: "WordPress/build/outputs/apk/vanilla/debug/org.wordpress.android-vanilla-debug.apk",
       tests_apk_path: "WordPress/build/outputs/apk/androidTest/vanilla/debug/org.wordpress.android-vanilla-debug-androidTest.apk",
       use_tests_in_classes: "org.wordpress.android.ui.screenshots.WPScreenshotTest",
@@ -156,23 +161,19 @@ platform :android do
   #####################################################################################
   desc "Creates promo screenshots"
   lane :create_promo_screenshots do |options|
-
+    # Clean temporary folder from previous runs
+    FileUtils.rm_rf(PROMO_SCREENSHOTS_PROCESSING_DIR)
+    
     # Create a copy of the files to work with – this ensures that if we're doing multiple
     # screenshot generation tasks close together, we can keep reusing the same source files
-    original_screenshot_directory = File.join(Dir.pwd, "metadata/android/")
-    repaired_screenshot_directory = File.join(Dir.pwd, "metadata/tmp")
-    FileUtils.rm_rf(repaired_screenshot_directory)
-    FileUtils.copy_entry(original_screenshot_directory, repaired_screenshot_directory)
+    FileUtils.rm_rf(RAW_SCREENSHOTS_PROCESSING_DIR)
+    FileUtils.copy_entry(RAW_SCREENSHOTS_DIR, RAW_SCREENSHOTS_PROCESSING_DIR)
 
     # Remove the timestamps from filenames to make them easier to work with
-    Dir.glob(repaired_screenshot_directory + "/**/**")
-    .select{ |entry|
-      entry.end_with? ".png"
-    }
-    .each { |entry|
+    Dir.glob(RAW_SCREENSHOTS_PROCESSING_DIR + "/**/*.png").each do |entry|
       newfilename = File.dirname(entry) + "/" + File.basename(entry).split("_")[0] + File.extname(entry)
       File.rename( entry, newfilename.downcase )
-    }
+    end
 
     locales = SUPPORTED_LOCALES
       .select { |hsh| hsh[:promo_config] != false }
@@ -186,26 +187,42 @@ platform :android do
     end
 
     # Remove locales we're not interested in
-    Pathname(repaired_screenshot_directory)
+    Pathname(RAW_SCREENSHOTS_PROCESSING_DIR)
         .children
         .select(&:directory?)
-        .select { |dir|
-        !locales.include? File.basename(dir)
-    }
-    .each { |dir|
-        FileUtils.rm_rf(dir)
-    }
+        .reject { |dir| locales.include? File.basename(dir) }
+        .each do |dir|
+          FileUtils.rm_rf(dir)
+        end
 
     # Run screenshots generator tool
     promo_screenshots(
-      orig_folder: repaired_screenshot_directory,
-      metadata_folder: repaired_screenshot_directory,
-      output_folder: File.join(Dir.pwd, "/promo_screenshots"),
+      orig_folder: RAW_SCREENSHOTS_PROCESSING_DIR,
+      metadata_folder: FINAL_METADATA_DIR,
+      output_folder: PROMO_SCREENSHOTS_PROCESSING_DIR,
       force: options[:force],
     )
 
-    # Clean up the temp directory
-    FileUtils.rm_rf(repaired_screenshot_directory)
+    # Remove old screenshots from FINAL_METADATA_DIR subfolders of the targetted locales
+    UI.message("Cleaning old promo screenshots from #{FINAL_METADATA_DIR} for #{locales.count} selected locales...")
+    locales.each do |locale|
+      screenshot_files = Dir.glob("#{FINAL_METADATA_DIR}/#{locale}/images/*/*.png")
+      FileUtils.rm( screenshot_files )
+    end
+
+    # Finally move generated screenshots from PROMO_SCREENSHOTS_PROCESSING_DIR to FINAL_METADATA_DIR subfolders
+    relative_paths = Dir.chdir(PROMO_SCREENSHOTS_PROCESSING_DIR) { Dir.glob("*/images/*/*.png") }
+    UI.message("Moving #{relative_paths.count} new promo screenshots to #{FINAL_METADATA_DIR}...")
+    relative_paths.each do |entry|
+      old_path = File.join( PROMO_SCREENSHOTS_PROCESSING_DIR, entry )
+      new_path = File.join( FINAL_METADATA_DIR, entry )
+      FileUtils.mkdir_p( File.dirname(new_path) )
+      File.rename( old_path, new_path )
+    end
+
+    # Clean up the temp directories
+    FileUtils.rm_rf(RAW_SCREENSHOTS_PROCESSING_DIR)
+    FileUtils.rm_rf(PROMO_SCREENSHOTS_PROCESSING_DIR)
   end
 
 


### PR DESCRIPTION
Fix parts of #12601

_This PR sits on top of #12723 and should only be merged after #12723. See below for details_

## Scope

This PR updates the `android screenshots` and `android create_promo_screenshot` fastlane lanes in order to store the generated (raw+promo) screenshots in more reasonable and idiomatic locations on disk, especially move raw screenshots away from `fastlane/metadata` and move promo screenshots in here instead.

#### State up until now

 * raw screenshots were generated in the `fastlane/metadata/android` subfolder, which is [where Fastlane expects _final_ screenshots (and metadata) to be located when it automates their uploads to GooglePlay](https://docs.fastlane.tools/actions/supply/#images-and-screenshots). But those are not the ones we want to upload to the PlayStore
 * promo screenshots, which are the one we want to use for PlayStore, were generated in `fastlane/promo_screenshots` and thus not considered for being uploaded to the PlayStore when we decide to automate that upload

#### What this PR changes

 * raw screenshots are now generated in the `fastlane/screenshots/raw` folder
 * promo screenshots are now generated in the `fastlane/screenshots/promo_tmp` folder during the progress of the generation, then once all promo screenshots are finished being generated, they are moved over to `fastlane/metadata/android/` in their corresponding `<locale>/images/<devicetype>` subfolders

## PR branch/fork context, + reduced diff

[EDIT] #12723 has since been merged.

~This PR is originally supposed to be targeting the `feature/screenshots-phase2a` and sits on top of it (Which is what I'd have done if I had push access to the original repo)~

~The real plan is thus to merge #12723 (`feature/screenshots-phase2a` branch into `feature/build-screenshots-on-ci`) first, then rebase this PR on top of `feature/build-screenshots-on-ci` next.~

⚠️  ~Because I'm working on a fork and can't make the PR in this repo while making the PR target `feature/screenshots-phase2a`, the current state of this PR includes both the code from `feature/screenshots-phase2a` / #12723 and the code from `feature/screenshots-phase2b`.~
💡  ~To review only the [reduced diff of what will eventually be included by this PR after rebase (diff from phase2a to phase2b), click here](https://github.com/AliSoftware/WordPress-Android/compare/feature/screenshots-phase2a...AliSoftware:feature/screenshots-phase2b)~


## To test

 - Run `bundle exec fastlane android screenshots` to generate the raw screenshots in the new location (`fastlane/screenshots/raw`).
   - Alternatively, if you already have old raw screenshots and want to avoid waiting ~100mn for them to be generated, move or copy the previous raw screenshots that you had in `fastlane/metadata/android/*/images/**` into their corresponding `fastlane/screenshots/raw/*/images` (keeping the folder hierarchy of `<locale>images/<devicetype>/*.png`)
 - Run `bundle exec fastlane create_promo_screenshots`.
   - Check that it generate temporary directories `fastlane/screenshots/raw_tmp` and `fastlane/screenshots/promo_tmp` during the generation
   - Check that those temporary folders are removed once the promo screenshots generation has finished
   - Check that the final promo screenshots are in `fastlane/metadata/android/*/images/*/*.png` – where fastlane will expect them for when we will automate their upload into GooglePlay

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
