### PR TITLE
Convert SnackbarMessageHolder message and button title to UIString 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -356,9 +356,17 @@ class PagesFragment : Fragment() {
             val parent = activity.findViewById<View>(R.id.coordinatorLayout)
             if (holder != null && parent != null) {
                 if (holder.buttonTitleRes == null) {
-                    WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG).show()
+                    WPSnackbar.make(
+                            parent,
+                            uiHelpers.getTextOfUiString(requireContext(), holder.message),
+                            Snackbar.LENGTH_LONG
+                    ).show()
                 } else {
-                    val snackbar = WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG)
+                    val snackbar = WPSnackbar.make(
+                            parent,
+                            uiHelpers.getTextOfUiString(requireContext(), holder.message),
+                            Snackbar.LENGTH_LONG
+                    )
                     snackbar.setAction(getString(holder.buttonTitleRes)) { holder.buttonAction() }
                     snackbar.show()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -355,7 +355,7 @@ class PagesFragment : Fragment() {
         viewModel.showSnackbarMessage.observe(viewLifecycleOwner, Observer { holder ->
             val parent = activity.findViewById<View>(R.id.coordinatorLayout)
             if (holder != null && parent != null) {
-                if (holder.buttonTitleRes == null) {
+                if (holder.buttonTitle == null) {
                     WPSnackbar.make(
                             parent,
                             uiHelpers.getTextOfUiString(requireContext(), holder.message),
@@ -367,7 +367,10 @@ class PagesFragment : Fragment() {
                             uiHelpers.getTextOfUiString(requireContext(), holder.message),
                             Snackbar.LENGTH_LONG
                     )
-                    snackbar.setAction(getString(holder.buttonTitleRes)) { holder.buttonAction() }
+                    snackbar.setAction(
+                            uiHelpers.getTextOfUiString(requireContext(),
+                            holder.buttonTitle)) { holder.buttonAction()
+                    }
                     snackbar.show()
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
@@ -1,9 +1,10 @@
 package org.wordpress.android.ui.pages
 
 import androidx.annotation.StringRes
+import org.wordpress.android.ui.utils.UiString
 
 data class SnackbarMessageHolder(
-    @StringRes val messageRes: Int,
+    val message: UiString,
     @StringRes val buttonTitleRes: Int? = null,
     val buttonAction: () -> Unit = {},
     val onDismissAction: () -> Unit = {}

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SnackbarMessageHolder.kt
@@ -1,11 +1,10 @@
 package org.wordpress.android.ui.pages
 
-import androidx.annotation.StringRes
 import org.wordpress.android.ui.utils.UiString
 
 data class SnackbarMessageHolder(
     val message: UiString,
-    @StringRes val buttonTitleRes: Int? = null,
+    val buttonTitle: UiString? = null,
     val buttonAction: () -> Unit = {},
     val onDismissAction: () -> Unit = {}
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -679,10 +679,12 @@ public class EditPostActivity extends LocaleAwareActivity implements
         });
         mEditorMedia.getSnackBarMessage().observe(this, event -> {
             SnackbarMessageHolder messageHolder = event.getContentIfNotHandled();
-            if (messageHolder != null && messageHolder.getMessage() instanceof UiStringRes) {
-                UiStringRes message = (UiStringRes) messageHolder.getMessage();
-                WPSnackbar
-                        .make(findViewById(R.id.editor_activity), message.getStringRes(), Snackbar.LENGTH_SHORT)
+            if (messageHolder != null) {
+                WPSnackbar.make(
+                                findViewById(R.id.editor_activity),
+                                mUiHelpers.getTextOfUiString(this, messageHolder.getMessage()),
+                                Snackbar.LENGTH_SHORT
+                        )
                         .show();
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -161,6 +161,7 @@ import org.wordpress.android.ui.uploads.UploadUtilsWrapper;
 import org.wordpress.android.ui.uploads.VideoOptimizer;
 import org.wordpress.android.ui.utils.AuthenticationUtils;
 import org.wordpress.android.ui.utils.UiHelpers;
+import org.wordpress.android.ui.utils.UiString.UiStringRes;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
@@ -678,9 +679,10 @@ public class EditPostActivity extends LocaleAwareActivity implements
         });
         mEditorMedia.getSnackBarMessage().observe(this, event -> {
             SnackbarMessageHolder messageHolder = event.getContentIfNotHandled();
-            if (messageHolder != null) {
+            if (messageHolder != null && messageHolder.getMessage() instanceof UiStringRes) {
+                UiStringRes message = (UiStringRes) messageHolder.getMessage();
                 WPSnackbar
-                        .make(findViewById(R.id.editor_activity), messageHolder.getMessageRes(), Snackbar.LENGTH_SHORT)
+                        .make(findViewById(R.id.editor_activity), message.getStringRes(), Snackbar.LENGTH_SHORT)
                         .show();
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -161,7 +161,6 @@ import org.wordpress.android.ui.uploads.UploadUtilsWrapper;
 import org.wordpress.android.ui.uploads.VideoOptimizer;
 import org.wordpress.android.ui.utils.AuthenticationUtils;
 import org.wordpress.android.ui.utils.UiHelpers;
-import org.wordpress.android.ui.utils.UiString.UiStringRes;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.posts.PostUploadAction.PublishPost
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadUtils
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
@@ -127,7 +128,7 @@ class PostActionHandler(
 
     private fun cancelPendingAutoUpload(post: PostModel) {
         val msgRes = UploadUtils.cancelPendingAutoUpload(post, dispatcher)
-        showSnackbar.invoke(SnackbarMessageHolder(msgRes))
+        showSnackbar.invoke(SnackbarMessageHolder(UiStringRes(msgRes)))
     }
 
     fun newPost() {
@@ -189,7 +190,7 @@ class PostActionHandler(
         criticalPostActionTracker.add(localPostId, MOVING_POST_TO_DRAFT)
 
         val snackBarHolder = SnackbarMessageHolder(
-                messageRes = R.string.post_moving_to_draft,
+                message = UiStringRes(R.string.post_moving_to_draft),
                 onDismissAction = {
                     criticalPostActionTracker.remove(localPostId, MOVING_POST_TO_DRAFT)
                 }
@@ -285,7 +286,7 @@ class PostActionHandler(
             TRASHING_POST
         }
 
-        showSnackbar.invoke(SnackbarMessageHolder(R.string.post_trashing))
+        showSnackbar.invoke(SnackbarMessageHolder(UiStringRes(R.string.post_trashing)))
         criticalPostActionTracker.add(localPostId = LocalId(post.id), criticalPostAction = criticalPostAction)
 
         triggerPostUploadAction.invoke(CancelPostAndMediaUpload(post))
@@ -307,7 +308,7 @@ class PostActionHandler(
         } else {
             val snackBarHolder = when (criticalAction) {
                 TRASHING_POST -> SnackbarMessageHolder(
-                        messageRes = R.string.post_trashed,
+                        message = UiStringRes(R.string.post_trashed),
                         buttonTitleRes = R.string.undo,
                         buttonAction = {
                             val post = postStore.getPostByLocalPostId(localPostId.value)
@@ -316,7 +317,7 @@ class PostActionHandler(
                             }
                         }
                 )
-                TRASHING_POST_WITH_LOCAL_CHANGES -> SnackbarMessageHolder(messageRes = R.string.post_trashed)
+                TRASHING_POST_WITH_LOCAL_CHANGES -> SnackbarMessageHolder(message = UiStringRes(R.string.post_trashed))
                 else -> throw IllegalStateException("Unexpected action in handlePostTrashed(): $criticalAction")
             }
             showSnackbar.invoke(snackBarHolder)
@@ -328,7 +329,7 @@ class PostActionHandler(
         if (!checkNetworkConnection.invoke()) {
             return
         }
-        showSnackbar.invoke(SnackbarMessageHolder(messageRes = R.string.post_restoring))
+        showSnackbar.invoke(SnackbarMessageHolder(message = UiStringRes(R.string.post_restoring)))
         criticalPostActionTracker.add(localPostId = LocalId(post.id), criticalPostAction = RESTORING_POST)
         dispatcher.dispatch(PostActionBuilder.newRestorePostAction(RemotePostPayload(post, site)))
     }
@@ -345,7 +346,7 @@ class PostActionHandler(
         if (isError) {
             showToast.invoke(ToastMessageHolder(R.string.error_restoring_post, Duration.SHORT))
         } else {
-            showSnackbar.invoke(SnackbarMessageHolder(messageRes = R.string.post_restored))
+            showSnackbar.invoke(SnackbarMessageHolder(message = UiStringRes(R.string.post_restored)))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -309,7 +309,7 @@ class PostActionHandler(
             val snackBarHolder = when (criticalAction) {
                 TRASHING_POST -> SnackbarMessageHolder(
                         message = UiStringRes(R.string.post_trashed),
-                        buttonTitleRes = R.string.undo,
+                        buttonTitle = UiStringRes(R.string.undo),
                         buttonAction = {
                             val post = postStore.getPostByLocalPostId(localPostId.value)
                             if (post != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 
@@ -71,7 +72,7 @@ class PostConflictResolver(
             }
         }
         val snackBarHolder = SnackbarMessageHolder(
-                R.string.snackbar_conflict_web_version_discarded,
+                UiStringRes(R.string.snackbar_conflict_web_version_discarded),
                 R.string.snackbar_conflict_undo, undoAction, onDismissAction
         )
         showSnackbar.invoke(snackBarHolder)
@@ -109,7 +110,7 @@ class PostConflictResolver(
             originalPostCopyForConflictUndo = null
         }
         val snackBarHolder = SnackbarMessageHolder(
-                R.string.snackbar_conflict_local_version_discarded,
+                UiStringRes(R.string.snackbar_conflict_local_version_discarded),
                 R.string.snackbar_conflict_undo, undoAction, onDismissAction
         )
         showSnackbar.invoke(snackBarHolder)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolver.kt
@@ -73,7 +73,9 @@ class PostConflictResolver(
         }
         val snackBarHolder = SnackbarMessageHolder(
                 UiStringRes(R.string.snackbar_conflict_web_version_discarded),
-                R.string.snackbar_conflict_undo, undoAction, onDismissAction
+                UiStringRes(R.string.snackbar_conflict_undo),
+                undoAction,
+                onDismissAction
         )
         showSnackbar.invoke(snackBarHolder)
     }
@@ -111,7 +113,9 @@ class PostConflictResolver(
         }
         val snackBarHolder = SnackbarMessageHolder(
                 UiStringRes(R.string.snackbar_conflict_local_version_discarded),
-                R.string.snackbar_conflict_undo, undoAction, onDismissAction
+                UiStringRes(R.string.snackbar_conflict_undo),
+                undoAction,
+                onDismissAction
         )
         showSnackbar.invoke(snackBarHolder)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_AUTHOR_FILTER_CHANGED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_SEARCH_ACCESSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.POST_LIST_TAB_CHANGED
@@ -44,6 +45,7 @@ import org.wordpress.android.ui.posts.PostListViewLayoutTypeMenuUiState.Standard
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadStarter
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.ToastUtils.Duration
@@ -393,7 +395,7 @@ class PostListMainViewModel @Inject constructor(
     fun showTargetPost(targetPostId: Int) {
         val postModel = postStore.getPostByLocalPostId(targetPostId)
         if (postModel == null) {
-            _snackBarMessage.value = SnackbarMessageHolder(R.string.error_post_does_not_exist)
+            _snackBarMessage.value = SnackbarMessageHolder(UiStringRes(string.error_post_does_not_exist))
         } else {
             launch(mainDispatcher) {
                 val targetTab = PostListType.fromPostStatus(PostStatus.fromPost(postModel))
@@ -417,7 +419,7 @@ class PostListMainViewModel @Inject constructor(
         if (post != null) {
             _postListAction.postValue(PostListAction.EditPost(site, post, loadAutoSaveRevision = true))
         } else {
-            _snackBarMessage.value = SnackbarMessageHolder(R.string.error_post_does_not_exist)
+            _snackBarMessage.value = SnackbarMessageHolder(UiStringRes((R.string.error_post_does_not_exist)))
         }
     }
 
@@ -426,7 +428,7 @@ class PostListMainViewModel @Inject constructor(
         if (post != null) {
             _postListAction.postValue(PostListAction.EditPost(site, post, loadAutoSaveRevision = false))
         } else {
-            _snackBarMessage.value = SnackbarMessageHolder(R.string.error_post_does_not_exist)
+            _snackBarMessage.value = SnackbarMessageHolder(UiStringRes(R.string.error_post_does_not_exist))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -58,7 +58,6 @@ import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString
-import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.RtlUtils
 import org.wordpress.android.util.SnackbarItem
@@ -408,12 +407,12 @@ class PostsListActivity : LocaleAwareActivity(),
                     SnackbarItem(
                             SnackbarItem.Info(
                                 view = parent,
-                                textRes = holder.message as UiStringRes,
+                                textRes = holder.message,
                                 duration = Snackbar.LENGTH_LONG
                             ),
                             holder.buttonTitle?.let {
                                 SnackbarItem.Action(
-                                    textRes = holder.buttonTitle as UiStringRes,
+                                    textRes = holder.buttonTitle,
                                     clickListener = OnClickListener { holder.buttonAction() }
                                 )
                             },

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -408,7 +408,7 @@ class PostsListActivity : LocaleAwareActivity(),
                     SnackbarItem(
                             SnackbarItem.Info(
                                 view = parent,
-                                textRes = UiStringRes(holder.messageRes),
+                                textRes = holder.message as UiStringRes,
                                 duration = Snackbar.LENGTH_LONG
                             ),
                             holder.buttonTitleRes?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -411,9 +411,9 @@ class PostsListActivity : LocaleAwareActivity(),
                                 textRes = holder.message as UiStringRes,
                                 duration = Snackbar.LENGTH_LONG
                             ),
-                            holder.buttonTitleRes?.let {
+                            holder.buttonTitle?.let {
                                 SnackbarItem.Action(
-                                    textRes = UiStringRes(holder.buttonTitleRes),
+                                    textRes = holder.buttonTitle as UiStringRes,
                                     clickListener = OnClickListener { holder.buttonAction() }
                                 )
                             },

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -129,7 +129,7 @@ class EditorMedia @Inject constructor(
                     true
             )
             if (!allMediaSucceed) {
-                _snackBarMessage.value = Event(SnackbarMessageHolder(R.string.gallery_error))
+                _snackBarMessage.value = Event(SnackbarMessageHolder(UiStringRes(R.string.gallery_error)))
             }
             _uiState.value = AddingMediaIdle
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -493,7 +493,7 @@ public class ReaderPostListFragment extends Fragment
     private void showSnackbar(SnackbarMessageHolder holder) {
         WPSnackbar snackbar = WPSnackbar.make(
                 requireView(),
-                holder.getMessageRes(),
+                mUiHelpers.getTextOfUiString(requireContext(), holder.getMessage()),
                 Snackbar.LENGTH_LONG
         );
         if (holder.getButtonTitleRes() != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -496,8 +496,11 @@ public class ReaderPostListFragment extends Fragment
                 mUiHelpers.getTextOfUiString(requireContext(), holder.getMessage()),
                 Snackbar.LENGTH_LONG
         );
-        if (holder.getButtonTitleRes() != null) {
-            snackbar.setAction(getString(holder.getButtonTitleRes()), v -> holder.getButtonAction().invoke());
+        if (holder.getButtonTitle() != null) {
+            snackbar.setAction(
+                    mUiHelpers.getTextOfUiString(requireContext(), holder.getButtonTitle()),
+                    v -> holder.getButtonAction().invoke()
+            );
         }
         snackbar.show();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -151,8 +151,8 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
                 uiHelpers.getTextOfUiString(requireContext(), this.message),
                 Snackbar.LENGTH_LONG
         )
-        if (this.buttonTitleRes != null) {
-            snackbar.setAction(getString(this.buttonTitleRes)) {
+        if (this.buttonTitle != null) {
+            snackbar.setAction(uiHelpers.getTextOfUiString(requireContext(), this.buttonTitle)) {
                 this.buttonAction.invoke()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -146,7 +146,11 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
     }
 
     private fun SnackbarMessageHolder.showSnackbar() {
-        val snackbar = WPSnackbar.make(constraint_layout, getString(this.messageRes), Snackbar.LENGTH_LONG)
+        val snackbar = WPSnackbar.make(
+                constraint_layout,
+                uiHelpers.getTextOfUiString(requireContext(), this.message),
+                Snackbar.LENGTH_LONG
+        )
         if (this.buttonTitleRes != null) {
             snackbar.setAction(getString(this.buttonTitleRes)) {
                 this.buttonAction.invoke()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.repository.ReaderDiscoverDataProvider
 import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.viewmodel.Event
@@ -217,7 +218,7 @@ class ReaderDiscoverViewModel @Inject constructor(
         if (navigationTarget != null) {
             _navigationEvents.postValue(Event(navigationTarget))
         } else {
-            _snackbarEvents.postValue(Event(SnackbarMessageHolder(R.string.reader_reblog_error)))
+            _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.reader_reblog_error))))
         }
         pendingReblogPost = null
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.VISIT_S
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
 import org.wordpress.android.ui.reader.usecases.ReaderPostBookmarkUseCase
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.Event
@@ -112,7 +113,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
         try {
             _navigationEvents.postValue(Event(SharePost(post)))
         } catch (ex: ActivityNotFoundException) {
-            _snackbarEvents.postValue(Event(SnackbarMessageHolder(R.string.reader_toast_err_share_intent)))
+            _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.reader_toast_err_share_intent))))
         }
     }
 
@@ -141,7 +142,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
         if (navigationTarget != null) {
             _navigationEvents.postValue(Event(navigationTarget))
         } else {
-            _snackbarEvents.postValue(Event(SnackbarMessageHolder(R.string.reader_reblog_error)))
+            _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.reader_reblog_error))))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -119,7 +119,11 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
     }
 
     private fun SnackbarMessageHolder.showSnackbar() {
-        val snackbar = WPSnackbar.make(bottom_bar, getString(this.messageRes), Snackbar.LENGTH_LONG)
+        val snackbar = WPSnackbar.make(
+                bottom_bar,
+                uiHelpers.getTextOfUiString(requireContext(), this.message),
+                Snackbar.LENGTH_LONG
+        )
         if (this.buttonTitleRes != null) {
             snackbar.setAction(getString(this.buttonTitleRes)) {
                 this.buttonAction.invoke()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -124,8 +124,8 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
                 uiHelpers.getTextOfUiString(requireContext(), this.message),
                 Snackbar.LENGTH_LONG
         )
-        if (this.buttonTitleRes != null) {
-            snackbar.setAction(getString(this.buttonTitleRes)) {
+        if (this.buttonTitle != null) {
+            snackbar.setAction(uiHelpers.getTextOfUiString(requireContext(), this.buttonTitle)) {
                 this.buttonAction.invoke()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
@@ -25,6 +26,7 @@ import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.SuccessWithData
 import org.wordpress.android.ui.reader.repository.ReaderTagRepository
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
@@ -140,11 +142,11 @@ class ReaderInterestsViewModel @Inject constructor(
                 is Error -> {
                     if (result is NetworkUnavailable) {
                         _snackbarEvents.postValue(
-                            Event(SnackbarMessageHolder(R.string.no_network_message))
+                            Event(SnackbarMessageHolder(UiStringRes(string.no_network_message)))
                         )
                     } else if (result is RemoteRequestFailure) {
                         _snackbarEvents.postValue(
-                            Event(SnackbarMessageHolder(R.string.reader_error_request_failed_title))
+                            Event(SnackbarMessageHolder(UiStringRes(R.string.reader_error_request_failed_title)))
                         )
                     }
                     updateUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import org.wordpress.android.R.string
+import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_SAVED_FROM_OTHER_POST_LIST
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_SAVED_FROM_SAVED_POST_LIST
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_UNSAVED_FROM_SAVED_POST_LIST
@@ -111,8 +111,8 @@ class ReaderPostBookmarkUseCase @Inject constructor(
             _snackbarEvents.postValue(
                     Event(
                             SnackbarMessageHolder(
-                                    UiStringRes(string.reader_bookmark_snack_title),
-                                    string.reader_bookmark_snack_btn,
+                                    UiStringRes(R.string.reader_bookmark_snack_title),
+                                    UiStringRes(R.string.reader_bookmark_snack_btn),
                                     buttonAction = {
                                         analyticsTrackerWrapper
                                                 .track(READER_SAVED_LIST_VIEWED_FROM_POST_LIST_NOTICE)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.reader.actions.ReaderPostActionsWrapper
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.Event
@@ -110,7 +111,7 @@ class ReaderPostBookmarkUseCase @Inject constructor(
             _snackbarEvents.postValue(
                     Event(
                             SnackbarMessageHolder(
-                                    string.reader_bookmark_snack_title,
+                                    UiStringRes(string.reader_bookmark_snack_title),
                                     string.reader_bookmark_snack_btn,
                                     buttonAction = {
                                         analyticsTrackerWrapper

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.tracker.ReaderTrackerType
 import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.viewmodel.Event
@@ -100,7 +101,7 @@ class ReaderPostListViewModel @Inject constructor(
         if (navigationTarget != null) {
             _navigationEvents.postValue(Event(navigationTarget))
         } else {
-            _snackbarEvents.postValue(Event(SnackbarMessageHolder(R.string.reader_reblog_error)))
+            _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.reader_reblog_error))))
         }
         pendingReblogPost = null
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider.SiteUpdateResult
+import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.widgets.WPSnackbar
@@ -39,6 +40,7 @@ private val statsSections = listOf(INSIGHTS, DAYS, WEEKS, MONTHS, YEARS)
 
 class StatsFragment : DaggerFragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var uiHelpers: UiHelpers
     private lateinit var viewModel: StatsViewModel
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
     private val selectedTabListener: SelectedTabListener
@@ -114,9 +116,17 @@ class StatsFragment : DaggerFragment() {
             val parent = activity.findViewById<View>(R.id.coordinatorLayout)
             if (holder != null && parent != null) {
                 if (holder.buttonTitleRes == null) {
-                    WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG).show()
+                    WPSnackbar.make(
+                            parent,
+                            uiHelpers.getTextOfUiString(requireContext(), holder.message),
+                            Snackbar.LENGTH_LONG
+                    ).show()
                 } else {
-                    val snackbar = WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG)
+                    val snackbar = WPSnackbar.make(
+                            parent,
+                            uiHelpers.getTextOfUiString(requireContext(), holder.message),
+                            Snackbar.LENGTH_LONG
+                    )
                     snackbar.setAction(getString(holder.buttonTitleRes)) { holder.buttonAction() }
                     snackbar.show()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -115,7 +115,7 @@ class StatsFragment : DaggerFragment() {
         viewModel.showSnackbarMessage.observe(viewLifecycleOwner, Observer { holder ->
             val parent = activity.findViewById<View>(R.id.coordinatorLayout)
             if (holder != null && parent != null) {
-                if (holder.buttonTitleRes == null) {
+                if (holder.buttonTitle == null) {
                     WPSnackbar.make(
                             parent,
                             uiHelpers.getTextOfUiString(requireContext(), holder.message),
@@ -127,7 +127,9 @@ class StatsFragment : DaggerFragment() {
                             uiHelpers.getTextOfUiString(requireContext(), holder.message),
                             Snackbar.LENGTH_LONG
                     )
-                    snackbar.setAction(getString(holder.buttonTitleRes)) { holder.buttonAction() }
+                    snackbar.setAction(uiHelpers.getTextOfUiString(requireContext(), holder.buttonTitle)) {
+                        holder.buttonAction()
+                    }
                     snackbar.show()
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDa
 import org.wordpress.android.ui.stats.refresh.utils.StatsNavigator
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.drawDateSelector
+import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
@@ -46,6 +47,7 @@ class StatsViewAllFragment : DaggerFragment() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var navigator: StatsNavigator
     @Inject lateinit var statsSiteProvider: StatsSiteProvider
+    @Inject lateinit var uiHelpers: UiHelpers
     private lateinit var viewModel: StatsViewAllViewModel
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
 
@@ -167,9 +169,17 @@ class StatsViewAllFragment : DaggerFragment() {
                 val parent = activity.findViewById<View>(R.id.coordinatorLayout)
                 if (parent != null) {
                     if (holder.buttonTitleRes == null) {
-                        WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG).show()
+                        WPSnackbar.make(
+                                parent,
+                                uiHelpers.getTextOfUiString(requireContext(), holder.message),
+                                Snackbar.LENGTH_LONG
+                        ).show()
                     } else {
-                        val snackbar = WPSnackbar.make(parent, getString(holder.messageRes), Snackbar.LENGTH_LONG)
+                        val snackbar = WPSnackbar.make(
+                                parent,
+                                uiHelpers.getTextOfUiString(requireContext(), holder.message),
+                                Snackbar.LENGTH_LONG
+                        )
                         snackbar.setAction(getString(holder.buttonTitleRes)) { holder.buttonAction() }
                         snackbar.show()
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -168,7 +168,7 @@ class StatsViewAllFragment : DaggerFragment() {
             event?.getContentIfNotHandled()?.let { holder ->
                 val parent = activity.findViewById<View>(R.id.coordinatorLayout)
                 if (parent != null) {
-                    if (holder.buttonTitleRes == null) {
+                    if (holder.buttonTitle == null) {
                         WPSnackbar.make(
                                 parent,
                                 uiHelpers.getTextOfUiString(requireContext(), holder.message),
@@ -180,7 +180,9 @@ class StatsViewAllFragment : DaggerFragment() {
                                 uiHelpers.getTextOfUiString(requireContext(), holder.message),
                                 Snackbar.LENGTH_LONG
                         )
-                        snackbar.setAction(getString(holder.buttonTitleRes)) { holder.buttonAction() }
+                        snackbar.setAction(
+                                uiHelpers.getTextOfUiString(requireContext(), holder.buttonTitle)
+                        ) { holder.buttonAction() }
                         snackbar.show()
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModel.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.Us
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateSelector
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.map
 import org.wordpress.android.util.mapNullable
 import org.wordpress.android.util.throttle
@@ -88,7 +89,9 @@ class StatsViewAllViewModel(
             if (statsSiteProvider.hasLoadedSite()) {
                 useCase.fetch(refresh, forced)
             } else {
-                mutableSnackbarMessage.postValue(Event(SnackbarMessageHolder(R.string.stats_site_not_loaded_yet)))
+                mutableSnackbarMessage.postValue(
+                        Event(SnackbarMessageHolder(UiStringRes(R.string.stats_site_not_loaded_yet)))
+                )
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.ui.stats.refresh.utils.SelectedSectionManager
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.toStatsGranularity
 import org.wordpress.android.ui.stats.refresh.utils.trackGranular
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.mapNullable
@@ -169,7 +170,7 @@ class StatsViewModel
             }
         } else {
             _isRefreshing.value = false
-            _showSnackbarMessage.value = SnackbarMessageHolder(R.string.no_network_title)
+            _showSnackbarMessage.value = SnackbarMessageHolder(UiStringRes(R.string.no_network_title))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseParam
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.PackageUtils
 import org.wordpress.android.util.combineMap
 import org.wordpress.android.util.distinct
@@ -70,7 +71,7 @@ class BaseListUseCase(
 
     private val mutableSnackbarMessage = MutableLiveData<Int>()
     val snackbarMessage: LiveData<SnackbarMessageHolder> = mutableSnackbarMessage.map {
-        SnackbarMessageHolder(it)
+        SnackbarMessageHolder(UiStringRes(it))
     }
 
     private val mutableListSelected = SingleLiveEvent<Unit>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateSelector
 import org.wordpress.android.ui.stats.refresh.utils.StatsPostProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.mergeNotNull
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -78,7 +79,7 @@ class StatsDetailViewModel
             refresh()
         } else {
             _isRefreshing.value = false
-            _showSnackbarMessage.value = SnackbarMessageHolder(R.string.no_network_title)
+            _showSnackbarMessage.value = SnackbarMessageHolder(UiStringRes(R.string.no_network_title))
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -312,7 +312,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                         WPSnackbar
                                 .make(
                                         findViewById(id.editor_activity),
-                                        messageHolder.messageRes,
+                                        uiHelpers.getTextOfUiString(this, messageHolder.message),
                                         Snackbar.LENGTH_SHORT
                                 )
                                 .show()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
@@ -85,7 +85,7 @@ class StoryEditorMedia @Inject constructor(
                                             // when finished composing
             )
             if (!allMediaSucceed) {
-                _snackBarMessage.value = Event(SnackbarMessageHolder(R.string.gallery_error))
+                _snackBarMessage.value = Event(SnackbarMessageHolder(UiStringRes(R.string.gallery_error)))
             }
             _uiState.value = AddingMediaToStoryIdle
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
@@ -7,7 +7,7 @@ import androidx.annotation.StringRes
  * represented as both string resource and text.
  */
 sealed class UiString {
-    data class UiStringText(val text: String) : UiString()
+    data class UiStringText(val text: CharSequence) : UiString()
     data class UiStringRes(@StringRes val stringRes: Int) : UiString()
     data class UiStringResWithParams(@StringRes val stringRes: Int, val params: List<UiString>) : UiString()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
@@ -7,7 +7,7 @@ import androidx.annotation.StringRes
  * represented as both string resource and text.
  */
 sealed class UiString {
-    data class UiStringText(val text: CharSequence) : UiString()
+    data class UiStringText(val text: String) : UiString()
     data class UiStringRes(@StringRes val stringRes: Int) : UiString()
     data class UiStringResWithParams(@StringRes val stringRes: Int, val params: List<UiString>) : UiString()
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -56,6 +56,7 @@ import org.wordpress.android.ui.posts.getAuthorFilterItems
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.ui.uploads.UploadUtils
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.PAGES
 import org.wordpress.android.util.EventBusWrapper
@@ -276,7 +277,7 @@ class PagesViewModel
                     val result = pageStore.requestPagesFromServer(site, forced)
                     if (result.isError) {
                         _listState.setOnUi(ERROR)
-                        showSnackbar(SnackbarMessageHolder(R.string.error_refresh_pages))
+                        showSnackbar(SnackbarMessageHolder(UiStringRes(R.string.error_refresh_pages)))
                         AppLog.e(AppLog.T.PAGES, "An error occurred while fetching the Pages")
                     } else {
                         _listState.setOnUi(DONE)
@@ -359,7 +360,7 @@ class PagesViewModel
             if (page != null) {
                 _scrollToPage.postValue(page)
             } else {
-                _showSnackbarMessage.postValue(SnackbarMessageHolder(R.string.pages_open_page_error))
+                _showSnackbarMessage.postValue(SnackbarMessageHolder(UiStringRes(R.string.pages_open_page_error)))
             }
         } else {
             scrollToPageId = remotePageId
@@ -452,7 +453,7 @@ class PagesViewModel
     private fun cancelPendingAutoUpload(pageId: LocalId) {
         val page = postStore.getPostByLocalPostId(pageId.value)
         val msgRes = UploadUtils.cancelPendingAutoUpload(page, dispatcher)
-        _showSnackbarMessage.postValue(SnackbarMessageHolder(msgRes))
+        _showSnackbarMessage.postValue(SnackbarMessageHolder(UiStringRes(msgRes)))
     }
 
     private fun setParent(page: Page) {
@@ -480,12 +481,12 @@ class PagesViewModel
                             R.string.page_homepage_successfully_updated
                         }
                     }
-                    _showSnackbarMessage.postValue(SnackbarMessageHolder(message))
+                    _showSnackbarMessage.postValue(SnackbarMessageHolder(UiStringRes(message)))
                 }
             } else {
                 _showSnackbarMessage.postValue(
                         SnackbarMessageHolder(
-                                messageRes = R.string.page_cannot_set_homepage
+                                message = UiStringRes(R.string.page_cannot_set_homepage)
                         )
                 )
             }
@@ -509,12 +510,12 @@ class PagesViewModel
                             R.string.page_posts_page_successfully_updated
                         }
                     }
-                    _showSnackbarMessage.postValue(SnackbarMessageHolder(message))
+                    _showSnackbarMessage.postValue(SnackbarMessageHolder(UiStringRes(message)))
                 }
             } else {
                 _showSnackbarMessage.postValue(
                         SnackbarMessageHolder(
-                                messageRes = R.string.page_cannot_set_posts_page
+                                message = UiStringRes(R.string.page_cannot_set_posts_page)
                         )
                 )
             }
@@ -535,7 +536,7 @@ class PagesViewModel
             performAction()
             true
         } else {
-            _showSnackbarMessage.postValue(SnackbarMessageHolder(R.string.no_network_message))
+            _showSnackbarMessage.postValue(SnackbarMessageHolder(UiStringRes(R.string.no_network_message)))
             false
         }
     }
@@ -545,7 +546,7 @@ class PagesViewModel
             performAction()
             true
         } else {
-            _showSnackbarMessage.postValue(SnackbarMessageHolder(R.string.no_network_message))
+            _showSnackbarMessage.postValue(SnackbarMessageHolder(UiStringRes(R.string.no_network_message)))
             false
         }
     }
@@ -629,9 +630,13 @@ class PagesViewModel
 
                 showSnackbar(
                         if (action.undo != null) {
-                            SnackbarMessageHolder(R.string.page_parent_changed, R.string.undo, action.undo!!)
+                            SnackbarMessageHolder(
+                                    UiStringRes(R.string.page_parent_changed),
+                                    R.string.undo,
+                                    action.undo!!
+                            )
                         } else {
-                            SnackbarMessageHolder(R.string.page_parent_changed)
+                            SnackbarMessageHolder(UiStringRes(R.string.page_parent_changed))
                         }
                 )
             }
@@ -640,7 +645,7 @@ class PagesViewModel
             launch(defaultDispatcher) {
                 refreshPages()
 
-                showSnackbar(SnackbarMessageHolder(R.string.page_parent_change_error))
+                showSnackbar(SnackbarMessageHolder(UiStringRes(R.string.page_parent_change_error)))
             }
         }
 
@@ -681,14 +686,14 @@ class PagesViewModel
                 delay(ACTION_DELAY)
                 reloadPages()
 
-                showSnackbar(SnackbarMessageHolder(R.string.page_permanently_deleted))
+                showSnackbar(SnackbarMessageHolder(UiStringRes(R.string.page_permanently_deleted)))
             }
         }
         action.onError = {
             launch(defaultDispatcher) {
                 refreshPages()
 
-                showSnackbar(SnackbarMessageHolder(R.string.page_delete_error))
+                showSnackbar(SnackbarMessageHolder(UiStringRes(R.string.page_delete_error)))
             }
         }
 
@@ -748,7 +753,7 @@ class PagesViewModel
                     launch(defaultDispatcher) {
                         action.undo?.let { it() }
 
-                        showSnackbar(SnackbarMessageHolder(R.string.page_status_change_error))
+                        showSnackbar(SnackbarMessageHolder(UiStringRes(R.string.page_status_change_error)))
                     }
                 }
 
@@ -779,9 +784,9 @@ class PagesViewModel
         }
 
         return if (undo != null) {
-            SnackbarMessageHolder(message, R.string.undo, undo)
+            SnackbarMessageHolder(UiStringRes(message), R.string.undo, undo)
         } else {
-            SnackbarMessageHolder(message)
+            SnackbarMessageHolder(UiStringRes(message))
         }
     }
 
@@ -800,7 +805,7 @@ class PagesViewModel
     private fun handleRemoteAutoSave(post: PostModel, isError: Boolean) {
         if (isError || hasRemoteAutoSavePreviewError()) {
             updatePreviewAndDialogState(PostListRemotePreviewState.NONE, PostInfoType.PostNoInfo)
-            _showSnackbarMessage.postValue(SnackbarMessageHolder(R.string.remote_preview_operation_error))
+            _showSnackbarMessage.postValue(SnackbarMessageHolder(UiStringRes(R.string.remote_preview_operation_error)))
         } else {
             updatePreviewAndDialogState(
                     PostListRemotePreviewState.PREVIEWING,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -632,7 +632,7 @@ class PagesViewModel
                         if (action.undo != null) {
                             SnackbarMessageHolder(
                                     UiStringRes(R.string.page_parent_changed),
-                                    R.string.undo,
+                                    UiStringRes(R.string.undo),
                                     action.undo!!
                             )
                         } else {
@@ -784,7 +784,7 @@ class PagesViewModel
         }
 
         return if (undo != null) {
-            SnackbarMessageHolder(UiStringRes(message), R.string.undo, undo)
+            SnackbarMessageHolder(UiStringRes(message), UiStringRes(R.string.undo), undo)
         } else {
             SnackbarMessageHolder(UiStringRes(message))
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload
 import org.wordpress.android.test
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.editor.media.EditorMedia.AddMediaToPostUiState
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -101,7 +102,8 @@ class EditorMediaTest : BaseUnitTest() {
         editorMedia.addNewMediaItemsToEditorAsync(mock(), false)
         // Assert
         verify(observer, times(1)).onChanged(captor.capture())
-        assertThat(captor.firstValue.getContentIfNotHandled()?.messageRes).isEqualTo(R.string.gallery_error)
+        val message = captor.firstValue.getContentIfNotHandled()?.message as? UiStringRes
+        assertThat(message?.stringRes).isEqualTo(R.string.gallery_error)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.SuccessWithData
 import org.wordpress.android.ui.reader.repository.ReaderTagRepository
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 
 private const val CURRENT_LANGUAGE = "en"
 @RunWith(MockitoJUnitRunner::class)
@@ -452,7 +453,7 @@ class ReaderInterestsViewModelTest {
 
             // Then
             assertThat(requireNotNull(viewModel.snackbarEvents.value).peekContent())
-                    .isEqualTo(SnackbarMessageHolder(R.string.no_network_message))
+                    .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.no_network_message)))
         }
 
     @ExperimentalCoroutinesApi
@@ -470,7 +471,7 @@ class ReaderInterestsViewModelTest {
 
             // Then
             assertThat(requireNotNull(viewModel.snackbarEvents.value).peekContent())
-                .isEqualTo(SnackbarMessageHolder(R.string.reader_error_request_failed_title))
+                .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.reader_error_request_failed_title)))
         }
 
     private fun initViewModel() = viewModel.start(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/usecase/StoryEditorMediaTest.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.posts.editor.media.AddLocalMediaToPostUseCase
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
 import org.wordpress.android.ui.stories.media.StoryEditorMedia
 import org.wordpress.android.ui.stories.media.StoryEditorMedia.AddMediaToStoryPostUiState
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.viewmodel.Event
 
@@ -95,7 +96,8 @@ class StoryEditorMediaTest : BaseUnitTest() {
 
         // Assert
         verify(observer, times(1)).onChanged(captor.capture())
-        assertThat(captor.firstValue.getContentIfNotHandled()?.messageRes).isEqualTo(R.string.gallery_error)
+        val message = captor.firstValue.getContentIfNotHandled()?.message as? UiStringRes
+        assertThat(message?.stringRes).isEqualTo(R.string.gallery_error)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -49,6 +49,7 @@ import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.uploads.UploadStarter
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.DONE
@@ -280,7 +281,8 @@ class PagesViewModelTest {
         )
 
         // Assert
-        assertThat(snackbarMessages[0].messageRes).isEqualTo(R.string.page_homepage_successfully_updated)
+        val message = snackbarMessages[0].message as UiStringRes
+        assertThat(message.stringRes).isEqualTo(R.string.page_homepage_successfully_updated)
     }
 
     @Test
@@ -302,7 +304,8 @@ class PagesViewModelTest {
         )
 
         // Assert
-        assertThat(snackbarMessages[0].messageRes).isEqualTo(R.string.page_homepage_update_failed)
+        val message = snackbarMessages[0].message as UiStringRes
+        assertThat(message.stringRes).isEqualTo(R.string.page_homepage_update_failed)
     }
 
     @Test
@@ -323,7 +326,8 @@ class PagesViewModelTest {
         )
 
         // Assert
-        assertThat(snackbarMessages[0].messageRes).isEqualTo(R.string.page_posts_page_successfully_updated)
+        val message = snackbarMessages[0].message as UiStringRes
+        assertThat(message.stringRes).isEqualTo(R.string.page_posts_page_successfully_updated)
     }
 
     @Test
@@ -345,7 +349,8 @@ class PagesViewModelTest {
         )
 
         // Assert
-        assertThat(snackbarMessages[0].messageRes).isEqualTo(R.string.page_posts_page_update_failed)
+        val message = snackbarMessages[0].message as UiStringRes
+        assertThat(message.stringRes).isEqualTo(R.string.page_posts_page_update_failed)
     }
 
     private fun getPublishedPage(remoteId: Long): PublishedPage = PublishedPage(


### PR DESCRIPTION
This PR converts `SnackbarMessageHolder`'s params for message and button title to `UIString`. Earlier it accepted only string res id, with this change it now accepts both string res id as well as text.   

**To test**

That the project compiles and tests run successfully using the command
`./gradlew :WordPress:testVanillaDebugUnitTest`

**Open Question**

Should we change param type from `String` to `CharSequence` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt#L10) so that we can send html text with markup? I'll need it in the FollowUseCase [here](https://github.com/wordpress-mobile/WordPress-Android/blob/ea7b0115e2d36f498a3004be7e2f65126f8688ee/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostFollowUseCase.kt#L101-L108).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
