### PR TITLE
AppBar refresh - Reader and Notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ViewPagerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ViewPagerFragment.kt
@@ -10,6 +10,27 @@ abstract class ViewPagerFragment : Fragment {
 
     constructor(@LayoutRes contentLayoutId: Int) : super(contentLayoutId)
 
+    companion object {
+        @JvmStatic
+        fun restoreOriginalViewId(view: View) {
+            val originalId = view.getTag(R.id.original_view_pager_fragment_id_tag_key)
+            if (originalId != null) {
+                view.id = originalId as Int
+            }
+        }
+
+        @JvmStatic
+        fun setUniqueIdToView(view: View): Int {
+            val newId = View.generateViewId()
+            if (view.getTag(R.id.original_view_pager_fragment_id_tag_key) == null) {
+                view.setTag(R.id.original_view_pager_fragment_id_tag_key, view.id)
+            }
+            view.id = newId
+            return newId
+        }
+    }
+
+
     /**
      * Provide a scrollable view that will be used with "lift on scroll" functionality of AppBar in parent
      * fragment/activity. ID will of the scrollable view be set to unique one using View.generateViewId()
@@ -57,21 +78,5 @@ abstract class ViewPagerFragment : Fragment {
             // restore original view ID, so it's state could be restored correctly
             restoreOriginalViewId(scrollableContainer)
         }
-    }
-
-    fun restoreOriginalViewId(view: View) {
-        val originalId = view.getTag(R.id.original_view_pager_fragment_id_tag_key)
-        if (originalId != null) {
-            view.id = originalId as Int
-        }
-    }
-
-    private fun setUniqueIdToView(view: View): Int {
-        val newId = View.generateViewId()
-        if (view.getTag(R.id.original_view_pager_fragment_id_tag_key) == null) {
-            view.setTag(R.id.original_view_pager_fragment_id_tag_key, view.id)
-        }
-        view.id = newId
-        return newId
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ViewPagerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ViewPagerFragment.kt
@@ -30,7 +30,6 @@ abstract class ViewPagerFragment : Fragment {
         }
     }
 
-
     /**
      * Provide a scrollable view that will be used with "lift on scroll" functionality of AppBar in parent
      * fragment/activity. ID will of the scrollable view be set to unique one using View.generateViewId()

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -17,6 +17,8 @@ import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
+import com.google.android.material.appbar.AppBarLayout;
+
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -35,6 +37,7 @@ import org.wordpress.android.push.GCMMessageHandler;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.CollapseFullScreenDialogFragment;
 import org.wordpress.android.ui.LocaleAwareActivity;
+import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.comments.CommentActions;
 import org.wordpress.android.ui.comments.CommentDetailFragment;
@@ -48,6 +51,7 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.ui.stats.StatsViewType;
+import org.wordpress.android.util.AppBarLayoutExtensionsKt;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -69,7 +73,7 @@ import static org.wordpress.android.ui.notifications.services.NotificationsUpdat
 
 public class NotificationsDetailActivity extends LocaleAwareActivity implements
         CommentActions.OnNoteCommentActionListener,
-        BasicFragmentDialog.BasicDialogPositiveClickInterface {
+        BasicFragmentDialog.BasicDialogPositiveClickInterface, ScrollableViewInitializedListener {
     private static final String ARG_TITLE = "activityTitle";
     private static final String DOMAIN_WPCOM = "wordpress.com";
 
@@ -83,6 +87,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
     private WPViewPager mViewPager;
     private ViewPager.OnPageChangeListener mOnPageChangeListener;
     private NotificationDetailFragmentAdapter mAdapter;
+    private AppBarLayout mAppBarLayout;
 
     @Override
     public void onBackPressed() {
@@ -106,6 +111,8 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
 
         Toolbar toolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(toolbar);
+
+        mAppBarLayout = findViewById(R.id.appbar_main);
 
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
@@ -487,6 +494,11 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
         if (fragment instanceof BasicFragmentDialog.BasicDialogPositiveClickInterface) {
             ((BasicDialogPositiveClickInterface) fragment).onPositiveClicked(instanceTag);
         }
+    }
+
+    @Override
+    public void onScrollableViewInitialized(int containerId) {
+        AppBarLayoutExtensionsKt.setLiftOnScrollTargetViewIdAndRequestLayout(mAppBarLayout, containerId);
     }
 
     private class NotificationDetailFragmentAdapter extends FragmentStatePagerAdapter {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -493,7 +493,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
         private final ArrayList<Note> mNoteList;
 
         NotificationDetailFragmentAdapter(FragmentManager fm, ArrayList<Note> notes) {
-            super(fm);
+            super(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
             mNoteList = (ArrayList<Note>) notes.clone();
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -28,6 +28,8 @@ import org.wordpress.android.fluxc.model.CommentStatus;
 import org.wordpress.android.fluxc.tools.FormattableContent;
 import org.wordpress.android.fluxc.tools.FormattableRange;
 import org.wordpress.android.models.Note;
+import org.wordpress.android.ui.ScrollableViewInitializedListener;
+import org.wordpress.android.ui.ViewPagerFragment;
 import org.wordpress.android.ui.notifications.adapters.NoteBlockAdapter;
 import org.wordpress.android.ui.notifications.blocks.BlockType;
 import org.wordpress.android.ui.notifications.blocks.CommentUserNoteBlock;
@@ -123,6 +125,12 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     public void onResume() {
         super.onResume();
 
+        ViewPagerFragment.Companion.setUniqueIdToView(getListView());
+
+        if (getActivity() instanceof ScrollableViewInitializedListener) {
+            ((ScrollableViewInitializedListener) getActivity()).onScrollableViewInitialized(getListView().getId());
+        }
+
         // Set the note if we retrieved the noteId from savedInstanceState
         if (!TextUtils.isEmpty(mRestoredNoteId)) {
             setNote(mRestoredNoteId);
@@ -139,7 +147,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     public void onPause() {
         // Stop the reader comment service if it is running
         ReaderCommentService.stopService(getActivity());
-
+        ViewPagerFragment.Companion.restoreOriginalViewId(getListView());
         super.onPause();
     }
 
@@ -231,7 +239,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
                     }
 
                     ReaderActivityLauncher.showReaderComments(getActivity(), mNote.getSiteId(), mNote.getPostId(),
-                                                              mNote.getCommentId());
+                            mNote.getCommentId());
                 }
 
                 @Override
@@ -266,9 +274,9 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
                         case COMMENT:
                             // Load the comment in the reader list if it exists, otherwise show a webview
                             if (ReaderUtils.postAndCommentExists(clickedSpan.getSiteId(), clickedSpan.getPostId(),
-                                                                 clickedSpan.getId())) {
+                                    clickedSpan.getId())) {
                                 activity.showReaderCommentsList(clickedSpan.getSiteId(), clickedSpan.getPostId(),
-                                                                clickedSpan.getId());
+                                        clickedSpan.getId());
                             } else {
                                 activity.showWebViewActivityForUrl(clickedSpan.getUrl());
                             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.java
@@ -14,7 +14,6 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 import androidx.preference.PreferenceManager;
 
-import com.google.android.material.elevation.ElevationOverlayProvider;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -24,7 +23,6 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.prefs.notifications.PrefMasterSwitchToolbarView.MasterSwitchToolbarListener;
-import org.wordpress.android.util.ContextExtensionsKt;
 
 // Simple wrapper activity for NotificationsSettingsFragment
 public class NotificationsSettingsActivity extends LocaleAwareActivity
@@ -123,14 +121,6 @@ public class NotificationsSettingsActivity extends LocaleAwareActivity
         // Set master switch state from shared preferences.
         boolean isMasterChecked = mSharedPreferences.getBoolean(getString(R.string.wp_pref_notifications_master), true);
         masterSwitchToolBarView.loadInitialState(isMasterChecked);
-
-        ElevationOverlayProvider elevationOverlayProvider = new ElevationOverlayProvider(this);
-        float cardElevation = getResources().getDimension(R.dimen.card_elevation);
-        int appBarColor = elevationOverlayProvider
-                .compositeOverlay(ContextExtensionsKt.getColorFromAttribute(this, R.attr.wpColorAppBar), cardElevation);
-
-        masterSwitchToolBarView.setBackgroundColor(appBarColor);
-
         hideDisabledView(isMasterChecked);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -18,10 +18,14 @@ import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.ListView;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SearchView;
+import androidx.core.view.ViewCompat;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -159,6 +163,16 @@ public class NotificationsSettingsFragment extends PreferenceFragment
             mRestoredQuery = savedInstanceState.getString(KEY_SEARCH_QUERY);
         }
     }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        final ListView lv = (ListView) view.findViewById(android.R.id.list);
+        if (lv != null) {
+            ViewCompat.setNestedScrollingEnabled(lv, true);
+        }
+    }
+
 
     @Override
     public void onStart() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -29,6 +29,7 @@ import androidx.recyclerview.widget.LinearSmoothScroller;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.RecyclerView.LayoutManager;
 
+import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.snackbar.Snackbar;
 
 import org.greenrobot.eventbus.EventBus;
@@ -144,6 +145,8 @@ public class ReaderCommentListActivity extends LocaleAwareActivity {
         setContentView(R.layout.reader_activity_comment_list);
         mViewModel = mViewModelFactory.create(ReaderCommentListViewModel.class);
 
+        AppBarLayout appBarLayout = findViewById(R.id.appbar_main);
+
         mViewModel.getScrollTo().observe(this, scrollPositionEvent -> {
             ScrollPosition content = scrollPositionEvent.getContentIfNotHandled();
             LayoutManager layoutManager = mRecyclerView.getLayoutManager();
@@ -159,6 +162,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity {
                 } else {
                     ((LinearLayoutManager) layoutManager).scrollToPositionWithOffset(content.getPosition(), 0);
                 }
+                appBarLayout.post(appBarLayout::requestLayout);
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -27,7 +27,6 @@ import android.widget.TextView
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.Fragment
 import com.google.android.material.elevation.ElevationOverlayProvider
 import com.google.android.material.snackbar.Snackbar
 import org.greenrobot.eventbus.EventBus

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -70,6 +70,7 @@ import org.wordpress.android.ui.PagePostCreationSourcesDetail
 import org.wordpress.android.ui.PrivateAtCookieRefreshProgressDialog
 import org.wordpress.android.ui.PrivateAtCookieRefreshProgressDialog.PrivateAtCookieProgressDialogOnDismissListener
 import org.wordpress.android.ui.RequestCodes
+import org.wordpress.android.ui.ViewPagerFragment
 import org.wordpress.android.ui.main.SitePickerActivity
 import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode.REBLOG_SELECT_MODE
 import org.wordpress.android.ui.main.WPMainActivity
@@ -127,7 +128,7 @@ import org.wordpress.android.widgets.WPTextView
 import java.util.EnumSet
 import javax.inject.Inject
 
-class ReaderPostDetailFragment : Fragment(),
+class ReaderPostDetailFragment : ViewPagerFragment(),
         WPMainActivity.OnActivityBackPressedListener,
         ScrollDirectionListener,
         ReaderCustomViewListener,
@@ -232,6 +233,10 @@ class ReaderPostDetailFragment : Fragment(),
             }
             postSlugsResolutionUnderway = args.getBoolean(ReaderConstants.KEY_POST_SLUGS_RESOLUTION_UNDERWAY)
         }
+    }
+
+    override fun getScrollableViewForUniqueIdProvision(): View? {
+        return scrollView
     }
 
     override fun onAttach(context: Context) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1077,14 +1077,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         int spacingVertical = getResources().getDimensionPixelSize(R.dimen.reader_card_gutters);
         mRecyclerView.addItemDecoration(new RecyclerItemDecoration(spacingHorizontal, spacingVertical, false));
 
-        // the following will change the look and feel of the toolbar to match the current design
-        ElevationOverlayProvider elevationOverlayProvider = new ElevationOverlayProvider(mRecyclerView.getContext());
-        float appbarElevation = getResources().getDimension(R.dimen.appbar_elevation);
-        int elevatedAppBarColor = elevationOverlayProvider
-                .compositeOverlayIfNeeded(
-                        ContextExtensionsKt.getColorFromAttribute(mRecyclerView.getContext(), R.attr.wpColorAppBar),
-                        appbarElevation);
-        mRecyclerView.setToolbarBackgroundColor(elevatedAppBarColor);
+        mRecyclerView.setToolbarBackgroundColor(0);
         mRecyclerView.setToolbarSpinnerDrawable(R.drawable.ic_dropdown_primary_30_24dp);
 
         if (mIsTopLevel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -120,7 +120,6 @@ import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
-import org.wordpress.android.util.ContextExtensionsKt;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.QuickStartUtils;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -20,6 +20,8 @@ import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
+import com.google.android.material.appbar.AppBarLayout;
+
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -39,6 +41,7 @@ import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.RequestCodes;
+import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.WPLaunchActivity;
 import org.wordpress.android.ui.posts.BasicFragmentDialog;
 import org.wordpress.android.ui.posts.EditPostActivity;
@@ -90,7 +93,7 @@ import javax.inject.Inject;
  */
 public class ReaderPostPagerActivity extends LocaleAwareActivity
         implements ReaderInterfaces.AutoHideToolbarListener,
-        BasicFragmentDialog.BasicDialogPositiveClickInterface {
+        BasicFragmentDialog.BasicDialogPositiveClickInterface, ScrollableViewInitializedListener {
     /**
      * Type of URL intercepted
      */
@@ -113,6 +116,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity
     private WPViewPager mViewPager;
     private ProgressBar mProgress;
     private Toolbar mToolbar;
+    private AppBarLayout mAppBar;
 
     private ReaderTag mCurrentTag;
     private boolean mIsFeed;
@@ -149,6 +153,8 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity
 
         mToolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(mToolbar);
+
+        mAppBar = findViewById(R.id.appbar_main);
 
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
@@ -870,7 +876,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity
     @Override
     public void onShowHideToolbar(boolean show) {
         if (!isFinishing()) {
-            AniUtils.animateTopBar(mToolbar, show);
+            AniUtils.animateTopBar(mAppBar, show);
         }
     }
 
@@ -889,7 +895,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity
         private final SparseArray<Fragment> mFragmentMap = new SparseArray<>();
 
         PostPagerAdapter(FragmentManager fm, ReaderBlogIdPostIdList ids) {
-            super(fm);
+            super(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
             mIdList = (ReaderBlogIdPostIdList) ids.clone();
         }
 
@@ -1058,5 +1064,10 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity
                     null,
                     site);
         }
+    }
+
+    @Override
+    public void onScrollableViewInitialized(int containerId) {
+        mAppBar.setLiftOnScrollTargetViewId(containerId);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderUserListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderUserListActivity.java
@@ -7,6 +7,8 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.LinearLayoutManager;
 
+import com.google.android.material.appbar.AppBarLayout;
+
 import org.wordpress.android.R;
 import org.wordpress.android.datasets.ReaderCommentTable;
 import org.wordpress.android.datasets.ReaderPostTable;
@@ -25,6 +27,7 @@ import org.wordpress.android.widgets.RecyclerItemDecoration;
 public class ReaderUserListActivity extends LocaleAwareActivity {
     private ReaderRecyclerView mRecyclerView;
     private ReaderUserAdapter mAdapter;
+    private AppBarLayout mAppBarLayout;
     private int mRestorePosition;
 
     @Override
@@ -60,6 +63,8 @@ public class ReaderUserListActivity extends LocaleAwareActivity {
         mRecyclerView = (ReaderRecyclerView) findViewById(R.id.recycler_view);
         mRecyclerView.addItemDecoration(new RecyclerItemDecoration(spacingHorizontal, spacingVertical));
 
+        mAppBarLayout = findViewById(R.id.appbar_main);
+
         long blogId = getIntent().getLongExtra(ReaderConstants.ARG_BLOG_ID, 0);
         long postId = getIntent().getLongExtra(ReaderConstants.ARG_POST_ID, 0);
         long commentId = getIntent().getLongExtra(ReaderConstants.ARG_COMMENT_ID, 0);
@@ -83,6 +88,7 @@ public class ReaderUserListActivity extends LocaleAwareActivity {
                 public void onDataLoaded(boolean isEmpty) {
                     if (!isEmpty && mRestorePosition > 0) {
                         mRecyclerView.scrollToPosition(mRestorePosition);
+                        mAppBarLayout.post(mAppBarLayout::requestLayout);
                     }
                     mRestorePosition = 0;
                 }

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPScrollView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPScrollView.java
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
-import android.widget.ScrollView;
 
 import androidx.core.widget.NestedScrollView;
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPScrollView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPScrollView.java
@@ -6,10 +6,12 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.widget.ScrollView;
 
+import androidx.core.widget.NestedScrollView;
+
 /**
  * ScrollView which reports when user has scrolled up or down, and when scrolling has completed
  */
-public class WPScrollView extends ScrollView {
+public class WPScrollView extends NestedScrollView {
     public interface ScrollDirectionListener {
         void onScrollUp(float distanceY);
 

--- a/WordPress/src/main/res/layout/comments_detail_activity.xml
+++ b/WordPress/src/main/res/layout/comments_detail_activity.xml
@@ -4,8 +4,7 @@
     android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="org.wordpress.android.ui.comments.CommentsDetailActivity"
-    tools:ignore="MergeRootFrame">
+    tools:context="org.wordpress.android.ui.comments.CommentsDetailActivity">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"
@@ -24,7 +23,6 @@
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/toolbar"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <ProgressBar

--- a/WordPress/src/main/res/layout/filtered_list_component.xml
+++ b/WordPress/src/main/res/layout/filtered_list_component.xml
@@ -9,7 +9,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/recycler_view">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_with_spinner"

--- a/WordPress/src/main/res/layout/notifications_detail_activity.xml
+++ b/WordPress/src/main/res/layout/notifications_detail_activity.xml
@@ -1,29 +1,36 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <include layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <FrameLayout
-        android:id="@+id/notifications_detail_container"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <org.wordpress.android.widgets.WPViewPager
+        android:id="@+id/viewpager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context="org.wordpress.android.ui.notifications.NotificationsDetailActivity"
-        tools:ignore="MergeRootFrame">
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-        <org.wordpress.android.widgets.WPViewPager
-            android:id="@+id/viewpager"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+    <ProgressBar
+        android:id="@+id/progress_loading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:visibility="visible" />
 
-        <ProgressBar
-            android:id="@+id/progress_loading"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:visibility="gone" />
-
-    </FrameLayout>
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/notifications_fragment_detail_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_detail_list.xml
@@ -13,6 +13,7 @@
         tools:ignore="UselessParent">
 
         <ListView
+            android:nestedScrollingEnabled="true"
             android:id="@id/android:list"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/notifications_settings_activity.xml
+++ b/WordPress/src/main/res/layout/notifications_settings_activity.xml
@@ -9,6 +9,7 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar_layout"
+        app:liftOnScrollTargetViewId="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -24,7 +25,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:focusableInTouchMode="true"
-                app:liftOnScrollTargetViewId="@android:id/list"
                 app:theme="@style/WordPress.ActionBar" />
 
             <org.wordpress.android.ui.prefs.notifications.PrefMasterSwitchToolbarView

--- a/WordPress/src/main/res/layout/notifications_settings_activity.xml
+++ b/WordPress/src/main/res/layout/notifications_settings_activity.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -11,82 +12,98 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar_with_search"
+        <LinearLayout
+            android:duplicateParentState="true"
             android:layout_width="match_parent"
-            android:layout_height="@dimen/toolbar_height"
-            android:focusableInTouchMode="true"
-            app:theme="@style/WordPress.ActionBar" />
+            android:layout_height="wrap_content"
+            android:background="@drawable/tab_layout_background"
+            android:orientation="vertical">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar_with_search"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusableInTouchMode="true"
+                app:liftOnScrollTargetViewId="@android:id/list"
+                app:theme="@style/WordPress.ActionBar" />
+
+            <org.wordpress.android.ui.prefs.notifications.PrefMasterSwitchToolbarView
+                android:id="@+id/master_switch"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/toolbar_height"
+
+                app:masterContentDescription="@string/notification_settings_switch_desc"
+                app:masterHintOff="@string/notification_settings_master_hint_off"
+                app:masterHintOn="@string/notification_settings_master_hint_on"
+                app:masterTitleOff="@string/notification_settings_master_status_off"
+                app:masterTitleOn="@string/notification_settings_master_status_on" />
+
+
+        </LinearLayout>
+
 
     </com.google.android.material.appbar.AppBarLayout>
 
-
-    <org.wordpress.android.ui.prefs.notifications.PrefMasterSwitchToolbarView
-        android:id="@+id/master_switch"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/app_bar_layout"
-        app:masterContentDescription="@string/notification_settings_switch_desc"
-        app:masterHintOff="@string/notification_settings_master_hint_off"
-        app:masterHintOn="@string/notification_settings_master_hint_on"
-        app:masterTitleOff="@string/notification_settings_master_status_off"
-        app:masterTitleOn="@string/notification_settings_master_status_on" />
-
-    <LinearLayout
-        android:id="@+id/fragment_container"
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/master_switch"
-        android:orientation="vertical" />
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <LinearLayout
-        android:id="@+id/notification_settings_disabled_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@id/master_switch"
-        android:clickable="true"
-        android:focusable="true"
-        android:orientation="vertical">
-
-        <TextView
-            style="@style/TextAppearance.AppCompat.Subhead"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_extra_medium_large"
-            android:paddingStart="@dimen/toolbar_content_offset"
-            android:paddingEnd="@dimen/margin_extra_large"
-            android:text="@string/notification_settings_master_off_title" />
-
-        <TextView
-            style="@style/TextAppearance.AppCompat.Body1"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            android:layout_marginBottom="@dimen/margin_extra_large"
-            android:paddingStart="@dimen/toolbar_content_offset"
-            android:paddingEnd="@dimen/margin_extra_large"
-            android:text="@string/notification_settings_master_off_message" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/notifications_settings_message_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/background_default"
-        android:orientation="vertical"
-        android:visibility="gone"
-        tools:visibility="invisible">
-
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/notifications_settings_message"
-            style="@style/WordPress.EmptyList.Title"
+        <LinearLayout
+            android:id="@+id/fragment_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_gravity="center"
-            app:fixWidowWords="true"
-            tools:text="Loading..." />
+            android:orientation="vertical" />
 
-    </LinearLayout>
+        <LinearLayout
+            android:id="@+id/notification_settings_disabled_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clickable="true"
+            android:focusable="true"
+            android:orientation="vertical">
 
-</RelativeLayout>
+            <TextView
+                style="@style/TextAppearance.AppCompat.Subhead"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_medium_large"
+                android:paddingStart="@dimen/toolbar_content_offset"
+                android:paddingEnd="@dimen/margin_extra_large"
+                android:text="@string/notification_settings_master_off_title" />
+
+            <TextView
+                style="@style/TextAppearance.AppCompat.Body1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:layout_marginBottom="@dimen/margin_extra_large"
+                android:paddingStart="@dimen/toolbar_content_offset"
+                android:paddingEnd="@dimen/margin_extra_large"
+                android:text="@string/notification_settings_master_off_message" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/notifications_settings_message_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/background_default"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="invisible">
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/notifications_settings_message"
+                style="@style/WordPress.EmptyList.Title"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                app:fixWidowWords="true"
+                tools:text="Loading..." />
+
+        </LinearLayout>
+
+    </FrameLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/reader_activity_comment_list.xml
+++ b/WordPress/src/main/res/layout/reader_activity_comment_list.xml
@@ -1,16 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/recycler_view">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/text_empty"
@@ -21,7 +34,6 @@
             android:visibility="gone"
             app:fixWidowWords="true"
             tools:visibility="visible" />
-
 
         <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
             android:id="@+id/swipe_to_refresh"
@@ -73,4 +85,4 @@
             tools:visibility="visible" />
 
     </RelativeLayout>
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/reader_activity_post_list.xml
+++ b/WordPress/src/main/res/layout/reader_activity_post_list.xml
@@ -1,14 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/recycler_view">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/reader_activity_post_pager.xml
+++ b/WordPress/src/main/res/layout/reader_activity_post_pager.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/root_view"
+    android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -11,22 +11,25 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/toolbar_main" />
-
     <ProgressBar
         android:id="@+id/progress_loading"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
+        android:layout_gravity="center"
         android:visibility="gone"
         tools:visibility="visible" />
 
-    <!-- this coordinator exists only for snackbars -->
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/coordinator"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="wrap_content">
 
-</RelativeLayout>
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/reader_activity_userlist.xml
+++ b/WordPress/src/main/res/layout/reader_activity_userlist.xml
@@ -1,20 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/recycler_view">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <org.wordpress.android.ui.reader.views.ReaderRecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:listitem="@layout/reader_listitem_user" />
 
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
This PR updates AppBar design and adds lift on scroll functionality to the following screens (and related nested screens):

- Reader
- Notifications

Main Reader and Notification screens accessible from the bottom nav are already updated, so no need to check them.

To test:

For all screens:
- Make sure nothing looks out of place (including ActionMode) :)
- Make sure the toolbar state is restored on configuration change.


Test 1:

Navigate to the Reader.
Check the following screens, and make make sure that lift on scroll works:
- Search (there is a pre-existing issue with the whole AppBAr being focused alongside the search input field).
- Blog's post list.
- Post details (+swipe right/left in ViewPager)
- Post Comments
- Post "Liked By" screen.


Test 2:

Navigate to the Notifications.
- Check various notification detail pages and make sure that lift on scroll works  (+swipe right/left in ViewPager).
- Check Notification settings.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
