### PR TITLE
Remove possibility of anonymous identity in Zendesk

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -123,14 +123,14 @@ class ZendeskHelper(
         require(isZendeskEnabled) {
             zendeskNeedsToBeEnabledError
         }
-        val identitySet = isIdentitySet()
+        val isIdentitySet = isIdentitySet()
         val builder = HelpCenterActivity.builder()
                 .withArticlesForCategoryIds(ZendeskConstants.mobileCategoryId)
-                .withContactUsButtonVisible(identitySet)
+                .withContactUsButtonVisible(isIdentitySet)
                 .withLabelNames(ZendeskConstants.articleLabel)
-                .withShowConversationsMenuButton(identitySet)
+                .withShowConversationsMenuButton(isIdentitySet)
         AnalyticsTracker.track(Stat.SUPPORT_HELP_CENTER_VIEWED)
-        if (identitySet) {
+        if (isIdentitySet) {
             builder.show(
                 context,
                 buildZendeskConfig(


### PR DESCRIPTION
There is a request coming saying that there are requests coming to the queue that have the user set as "Mobile App User". This means (based on the documentation) that there is an AnonymousIdentity set. I don't think it's possible to write a ticket from the app without setting an email. The check I'm changing in this PR used to check whether the identity is null. Based [on documentation](https://develop.zendesk.com/hc/en-us/articles/360001069587-How-anonymous-identities-work-in-the-mobile-SDKs) it seems that the AnonymousIdentity is the default identity (I'm kind of grasping at straws here). Do you think it's possible that we can get to a state (maybe after a 401) where have the `supportEmail` set and the `identity` is set to `AnonymousIdentity` and not set to null? Does this solution make any sense? I'm pinging you here @oguzkocer because you implemented the original solution but feel free to ignore this ping.

To test:
- Check that you can't send a zendesk ticket without an email
- Check that you can send a zendesk ticket after you set an email

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
