### PR TITLE
Build MoreMenuUiState after the user actually clicks on the more button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -46,6 +46,7 @@ import org.wordpress.android.ui.reader.actions.ReaderTagActions;
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState;
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState;
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType;
+import org.wordpress.android.ui.reader.discover.ReaderPostMoreButtonUiStateBuilder;
 import org.wordpress.android.ui.reader.discover.ReaderPostUiStateBuilder;
 import org.wordpress.android.ui.reader.discover.viewholders.ReaderPostViewHolder;
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostId;
@@ -132,6 +133,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
     @Inject ReaderPostUiStateBuilder mReaderPostUiStateBuilder;
+    @Inject ReaderPostMoreButtonUiStateBuilder mReaderPostMoreButtonUiStateBuilder;
 
     /*
      * cross-post
@@ -264,7 +266,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     @Override
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         if (holder instanceof ReaderPostViewHolder) {
-            renderPost(position, (ReaderPostViewHolder) holder);
+            renderPost(position, (ReaderPostViewHolder) holder, false);
         } else if (holder instanceof ReaderXPostViewHolder) {
             renderXPost(position, (ReaderXPostViewHolder) holder);
         } else if (holder instanceof ReaderRemovedPostViewHolder) {
@@ -382,7 +384,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
     }
 
-    private void renderPost(final int position, final ReaderPostViewHolder holder) {
+    private void renderPost(final int position, final ReaderPostViewHolder holder, boolean showMoreMenu) {
         final ReaderPost post = getItem(position);
         ReaderPostListType postListType = getPostListType();
         if (post == null) {
@@ -395,7 +397,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     switch (type) {
                         case BOOKMARK:
                             toggleBookmark(post.blogId, post.postId);
-                            renderPost(position, holder);
+                            renderPost(position, holder, false);
                             break;
                         case LIKE:
                             toggleLike(ctx, post, position, holder);
@@ -412,7 +414,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         case VISIT_SITE:
                         case BLOCK_SITE:
                             mOnPostListItemButtonListener.onButtonClicked(post, type);
-                            renderPost(position, holder);
+                            renderPost(position, holder, false);
                             break;
                     }
                     return Unit.INSTANCE;
@@ -455,8 +457,13 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             }
             return Unit.INSTANCE;
         };
-        Function3<Long, Long, View, Unit> onMoreButtonClicked = (postId, blogId, view) -> {
-            // noop
+        Function1<ReaderPostUiState, Unit> onMoreButtonClicked = (uiState) -> {
+            renderPost(position, holder, true);
+            return Unit.INSTANCE;
+        };
+
+        Function1<ReaderPostUiState, Unit> onMoreDismissed = (uiState) -> {
+            renderPost(position, holder, false);
             return Unit.INSTANCE;
         };
 
@@ -488,9 +495,12 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         onItemRendered,
                         onDiscoverSectionClicked,
                         onMoreButtonClicked,
+                        onMoreDismissed,
                         onVideoOverlayClicked,
                         onPostHeaderClicked,
-                        onTagItemClicked
+                        onTagItemClicked,
+                        showMoreMenu ? mReaderPostMoreButtonUiStateBuilder
+                                .buildMoreMenuItems(post, postListType, onButtonClicked) : null
                 );
         holder.onBind(uiState);
     }
@@ -772,7 +782,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         ReaderPost updatedPost = ReaderPostTable.getBlogPost(post.blogId, post.postId, true);
         if (updatedPost != null && positionInReaderPostList > -1) {
             mPosts.set(positionInReaderPostList, updatedPost);
-            renderPost(listPosition, holder);
+            renderPost(listPosition, holder, false);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.reader.discover
 
 import android.text.Spanned
-import android.view.View
 import androidx.annotation.AttrRes
 import androidx.annotation.DrawableRes
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -38,11 +38,12 @@ sealed class ReaderCardUiState {
         val likeAction: PrimaryAction,
         val reblogAction: PrimaryAction,
         val commentsAction: PrimaryAction,
-        val moreMenuItems: List<SecondaryAction>,
+        val moreMenuItems: List<SecondaryAction>? = null,
         val postHeaderClickData: PostHeaderClickData?,
         val onItemClicked: (Long, Long) -> Unit,
         val onItemRendered: (ReaderCardUiState) -> Unit,
-        val onMoreButtonClicked: (Long, Long, View) -> Unit,
+        val onMoreButtonClicked: (ReaderPostUiState) -> Unit,
+        val onMoreDismissed: (ReaderPostUiState) -> Unit,
         val onVideoOverlayClicked: (Long, Long) -> Unit
     ) : ReaderCardUiState() {
         val dotSeparatorVisibility: Boolean = blogUrl != null

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -215,9 +215,9 @@ class ReaderDiscoverViewModel @Inject constructor(
         changeMoreMenuVisibility(postUiState, false)
     }
 
-    private fun changeMoreMenuVisibility(postUiState: ReaderPostUiState, show: Boolean) {
-        findPost(postUiState.postId, postUiState.blogId)?.let { post ->
-            val updateUiState = postUiState.copy(
+    private fun changeMoreMenuVisibility(currentUiState: ReaderPostUiState, show: Boolean) {
+        findPost(currentUiState.postId, currentUiState.blogId)?.let { post ->
+            val updatedUiState = currentUiState.copy(
                     moreMenuItems = if (show) readerPostMoreButtonUiStateBuilder.buildMoreMenuItems(
                             post,
                             TAG_FOLLOWED,
@@ -226,16 +226,16 @@ class ReaderDiscoverViewModel @Inject constructor(
                     else null
             )
 
-            replaceUiStateItem(postUiState, updateUiState)
+            replaceUiStateItem(currentUiState, updatedUiState)
         }
     }
 
-    private fun replaceUiStateItem(postUiState: ReaderPostUiState, updateUiState: ReaderPostUiState) {
+    private fun replaceUiStateItem(before: ReaderPostUiState, after: ReaderPostUiState) {
         (_uiState.value as? ContentUiState)?.let {
             val updatedList = it.cards.toMutableList()
-            val index = it.cards.indexOf(postUiState)
+            val index = it.cards.indexOf(before)
             if (index != -1) {
-                updatedList[index] = updateUiState
+                updatedList[index] = after
                 _uiState.value = it.copy(cards = updatedList)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader.discover
 
-import android.view.View
 import dagger.Reusable
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.AccountStore
@@ -13,9 +12,9 @@ import org.wordpress.android.models.ReaderPostDiscoverData
 import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.EDITOR_PICK
 import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.OTHER
 import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.SITE_PICK
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.ReaderConstants
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiSt
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState.GalleryThumbnailStripData
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState.PostHeaderClickData
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
@@ -50,7 +51,6 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
     private val readerImageScannerProvider: ReaderImageScannerProvider,
     private val readerUtilsWrapper: ReaderUtilsWrapper,
-    private val readerPostMoreButtonUiStateBuilder: ReaderPostMoreButtonUiStateBuilder,
     private val readerPostTagsUiStateBuilder: ReaderPostTagsUiStateBuilder,
     private val appPrefsWrapper: AppPrefsWrapper
 ) {
@@ -68,10 +68,12 @@ class ReaderPostUiStateBuilder @Inject constructor(
         onItemClicked: (Long, Long) -> Unit,
         onItemRendered: (ReaderCardUiState) -> Unit,
         onDiscoverSectionClicked: (Long, Long) -> Unit,
-        onMoreButtonClicked: (Long, Long, View) -> Unit,
+        onMoreButtonClicked: (ReaderPostUiState) -> Unit,
+        onMoreDismissed: (ReaderPostUiState) -> Unit,
         onVideoOverlayClicked: (Long, Long) -> Unit,
         onPostHeaderViewClicked: (Long, Long) -> Unit,
-        onTagItemClicked: (String) -> Unit
+        onTagItemClicked: (String) -> Unit,
+        moreMenuItems: List<SecondaryAction>? = null
     ): ReaderPostUiState {
         return ReaderPostUiState(
                 postId = post.postId,
@@ -92,6 +94,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 videoOverlayVisibility = buildVideoOverlayVisibility(post),
                 featuredImageVisibility = buildFeaturedImageVisibility(post),
                 moreMenuVisibility = accountStore.hasAccessToken() && postListType == ReaderPostListType.TAG_FOLLOWED,
+                moreMenuItems = moreMenuItems,
                 fullVideoUrl = buildFullVideoUrl(post),
                 discoverSection = buildDiscoverSection(post, onDiscoverSectionClicked),
                 bookmarkAction = buildBookmarkSection(post, onButtonClicked),
@@ -101,13 +104,9 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 onItemClicked = onItemClicked,
                 onItemRendered = onItemRendered,
                 onMoreButtonClicked = onMoreButtonClicked,
+                onMoreDismissed = onMoreDismissed,
                 onVideoOverlayClicked = onVideoOverlayClicked,
-                postHeaderClickData = buildOnPostHeaderViewClicked(onPostHeaderViewClicked, postListType),
-                moreMenuItems = readerPostMoreButtonUiStateBuilder.buildMoreMenuItems(
-                        post,
-                        postListType,
-                        onButtonClicked
-                )
+                postHeaderClickData = buildOnPostHeaderViewClicked(onPostHeaderViewClicked, postListType)
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -52,7 +52,7 @@ class ReaderPostViewHolder(
         uiHelpers.updateVisibility(dot_separator, state.dotSeparatorVisibility)
         uiHelpers.setTextOrHide(text_dateline, state.dateLine)
         uiHelpers.updateVisibility(image_more, state.moreMenuVisibility)
-        image_more.setOnClickListener { onMoreClicked(uiState, uiState.moreMenuItems, it) }
+        image_more.setOnClickListener { uiState.onMoreButtonClicked.invoke(state) }
         layout_post_header.setBackgroundResource(
                 layout_post_header.context.getDrawableResIdFromAttribute(uiState.postHeaderClickData?.background ?: 0)
         )
@@ -89,6 +89,10 @@ class ReaderPostViewHolder(
         updateActionButton(uiState.postId, uiState.blogId, uiState.reblogAction, reblog)
         updateActionButton(uiState.postId, uiState.blogId, uiState.commentsAction, count_comments)
         updateActionButton(uiState.postId, uiState.blogId, uiState.bookmarkAction, bookmark)
+
+        state.moreMenuItems?.let {
+            renderMoreMenu(state, state.moreMenuItems, image_more)
+        }
 
         state.onItemRendered.invoke(uiState)
     }
@@ -173,7 +177,7 @@ class ReaderPostViewHolder(
         }
     }
 
-    private fun onMoreClicked(uiState: ReaderPostUiState, actions: List<SecondaryAction>, v: View) {
+    private fun renderMoreMenu(uiState: ReaderPostUiState, actions: List<SecondaryAction>, v: View) {
         // TODO malinjir the popup menu was reused from the legacy implementation. It needs to be refactored.
         val listPopup = ListPopupWindow(v.context)
         listPopup.width = v.context.resources.getDimensionPixelSize(R.dimen.menu_item_width)
@@ -186,6 +190,7 @@ class ReaderPostViewHolder(
             val item = actions[position]
             item.onClicked.invoke(uiState.postId, uiState.blogId, item.type)
         }
+        listPopup.setOnDismissListener { uiState.onMoreDismissed.invoke(uiState) }
         listPopup.show()
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -50,6 +50,7 @@ class ReaderDiscoverViewModelTest {
 
     @Mock private lateinit var readerDiscoverDataProvider: ReaderDiscoverDataProvider
     @Mock private lateinit var uiStateBuilder: ReaderPostUiStateBuilder
+    @Mock private lateinit var menuUiStateBuilder: ReaderPostMoreButtonUiStateBuilder
     @Mock private lateinit var readerPostCardActionsHandler: ReaderPostCardActionsHandler
     @Mock private lateinit var reblogUseCase: ReblogUseCase
     @Mock private lateinit var readerUtilsWrapper: ReaderUtilsWrapper
@@ -63,6 +64,7 @@ class ReaderDiscoverViewModelTest {
     fun setUp() = test {
         viewModel = ReaderDiscoverViewModel(
                 uiStateBuilder,
+                menuUiStateBuilder,
                 readerPostCardActionsHandler,
                 readerDiscoverDataProvider,
                 reblogUseCase,
@@ -74,7 +76,8 @@ class ReaderDiscoverViewModelTest {
         whenever(
                 uiStateBuilder.mapPostToUiState(
                         anyOrNull(), anyBoolean(), anyInt(), anyInt(), anyOrNull(), anyBoolean(), anyOrNull(),
-                        anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
+                        anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(),
+                        anyOrNull()
                 )
         ).thenAnswer {
             val post = it.getArgument<ReaderPost>(POST_PARAM_POSITION)
@@ -247,7 +250,8 @@ class ReaderDiscoverViewModelTest {
                 onMoreButtonClicked = mock(),
                 onVideoOverlayClicked = mock(),
                 postHeaderClickData = mock(),
-                moreMenuItems = mock()
+                moreMenuItems = mock(),
+                onMoreDismissed = mock()
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -77,7 +77,7 @@ class ReaderDiscoverViewModelTest {
                 uiStateBuilder.mapPostToUiState(
                         anyOrNull(), anyBoolean(), anyInt(), anyInt(), anyOrNull(), anyBoolean(), anyOrNull(),
                         anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(),
-                        anyOrNull()
+                        anyOrNull(), anyOrNull()
                 )
         ).thenAnswer {
             val post = it.getArgument<ReaderPost>(POST_PARAM_POSITION)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -61,7 +61,6 @@ class ReaderPostUiStateBuilderTest {
     @Mock lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
     @Mock lateinit var readerImageScannerProvider: ReaderImageScannerProvider
     @Mock lateinit var readerUtilsWrapper: ReaderUtilsWrapper
-    @Mock lateinit var readerPostMoreButtonUiStateBuilder: ReaderPostMoreButtonUiStateBuilder
     @Mock lateinit var readerPostTagsUiStateBuilder: ReaderPostTagsUiStateBuilder
     @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
 
@@ -74,7 +73,6 @@ class ReaderPostUiStateBuilderTest {
                 dateTimeUtilsWrapper,
                 readerImageScannerProvider,
                 readerUtilsWrapper,
-                readerPostMoreButtonUiStateBuilder,
                 readerPostTagsUiStateBuilder,
                 appPrefsWrapper
         )
@@ -837,7 +835,8 @@ class ReaderPostUiStateBuilderTest {
                 onMoreButtonClicked = mock(),
                 onVideoOverlayClicked = mock(),
                 onPostHeaderViewClicked = mock(),
-                onTagItemClicked = mock()
+                onTagItemClicked = mock(),
+                onMoreDismissed = mock()
         )
     }
 


### PR DESCRIPTION
Parent issue #12028

Before this PR a UIState for more popup menu on Reader post list items was build for each item no-matter if the user actually ever opened the menu. Since the build action needs to hit the database for each item we decided to build the uistate only after the user actually clicks on the more button. This will improve performance and also ensures that the "follow/unfollow and notifications on/off" states are up-to-date and we don't need to manually handle their states.

To test: RI FF OFF
1. Open Reader
2. Open Followed tab
3. Click on the More menu on one of the items
4. Test some actions + scroll + rotation + anything you can think of

To test: RI FF ON
1. Perform the same testing steps on the discover tab

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
