### PR TITLE
Remove iOS specific editor release note

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,6 @@
  
 15.6
 -----
-* [***] Block Editor: Fixed empty text fields on RTL layout. Now they are selectable and placeholders are visible.
 * [**] Block Editor: Add settings to allow changing column widths
 * [**] Block Editor: Media editing support in Gallery block.
 * [*] Block Editor: Improved logic for creating undo levels.


### PR DESCRIPTION
Removes release note about an iOS specific editor update

PR related to his release note: https://github.com/WordPress/gutenberg/pull/24510

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
