### PR TITLE
Photo Picker: remove white background from photo picker

### DIFF
--- a/WordPress/src/main/res/layout/photo_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/photo_picker_fragment.xml
@@ -13,8 +13,6 @@
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
         android:visibility="gone"
-        android:backgroundTint="@color/pink_50"
-        android:tint="@color/white"
         android:src="@drawable/ic_photo_camera_24px"
         android:layout_margin="@dimen/fab_margin"
         tools:ignore="InconsistentLayout"/>

--- a/WordPress/src/main/res/layout/photo_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/photo_picker_fragment.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:background="@android:color/white">
+    >
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/wp_stories_take_picture"


### PR DESCRIPTION
Fixes #12622 

h/t @khaykov for pointing out where the problem was introduced - citing him here:
> We should avoid manually settings background colors to root view and buttons :slightly_smiling_face:
> the background color was changed in this commit -> https://github.com/wordpress-mobile/WordPress-Android/commit/87de3411bcfd9c031945917c19eb34a1a5c28776#diff-c5c957b8f5a17d13e5f31686e94e1f51

To test:
On API 29:

**CASE A: Dark mode off**
1. turn dark mode off
2. open the block editor and try adding an image block.
3. tap on `add image`.
4. observe the media picker shows up and the background is white.

Also:
1. turn dark mode off
2. on the main screen, select a .com site and tap the FAB
3. tap on create new Story
4. observe the media picker shows up and the background is white.

**CASE B: Dark mode on**
1. turn dark mode on
2. open the block editor and try adding an image block.
3. tap on `add image`.
4. observe the media picker shows up and the background is *not* white.
![whitedark](https://user-images.githubusercontent.com/6597771/91116169-27f87800-e662-11ea-92c1-f3cfa93286f5.gif)

Also:
1. turn dark mode on
2. on the main screen, select a .com site and tap the FAB
3. tap on create new Story
4. observe the media picker shows up and the background is *not* white.

![whitetdarkstory](https://user-images.githubusercontent.com/6597771/91116175-2b8bff00-e662-11ea-8210-f8f67fd5495e.gif)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
