### PR TITLE
AppBar refresh - Me, Editor, Site Creation, Media Picker and Site Preview

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -211,7 +211,7 @@
         <!-- Posts activities -->
         <activity
             android:name=".ui.posts.EditPostActivity"
-            android:theme="@style/WordPress.Editor.NoActionBar"
+            android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="stateHidden|adjustResize">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
@@ -266,7 +266,7 @@
         <activity
             android:name=".ui.history.HistoryDetailActivity"
             android:label="@string/history_detail_title"
-            android:theme="@style/WordPress.Editor.NoActionBar" />
+            android:theme="@style/WordPress.NoActionBar" />
 
         <!-- plans -->
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FullScreenDialogFragment.java
@@ -30,6 +30,8 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
+import com.google.android.material.appbar.AppBarLayout;
+
 import org.wordpress.android.R;
 import org.wordpress.android.util.ColorUtils;
 import org.wordpress.android.util.ContextExtensionsKt;
@@ -50,11 +52,13 @@ public class FullScreenDialogFragment extends DialogFragment {
     private String mTitle;
     private Toolbar mToolbar;
     private boolean mHideActivityBar;
+    private boolean mIsLiftOnScroll;
     private int mToolbarTheme;
     private int mToolbarColor;
 
     private static final String ARG_ACTION = "ARG_ACTION";
-    private static final String ARG_HIDE_ACTIVITY_BAR = "ARG_HIDE_ACTIVITY_BAR";
+    private static final String ARG_HIDE_ACTIVITY_BAR = "ARG_IS_LIFT_ON_SCROLL";
+    private static final String ARG_IS_LIFT_ON_SCROLL = "ARG_LIFT_ON_SCROLL";
     private static final String ARG_SUBTITLE = "ARG_SUBTITLE";
     private static final String ARG_TITLE = "ARG_TITLE";
     private static final String ARG_TOOLBAR_THEME = "ARG_TOOLBAR_THEME";
@@ -94,6 +98,7 @@ public class FullScreenDialogFragment extends DialogFragment {
         dialog.setOnConfirmListener(builder.mOnConfirmListener);
         dialog.setOnDismissListener(builder.mOnDismissListener);
         dialog.setHideActivityBar(builder.mHideActivityBar);
+        dialog.setLiftOnScroll(builder.mIsLiftOnScroll);
         return dialog;
     }
 
@@ -105,6 +110,7 @@ public class FullScreenDialogFragment extends DialogFragment {
         bundle.putInt(ARG_TOOLBAR_THEME, builder.mToolbarTheme);
         bundle.putInt(ARG_TOOLBAR_COLOR, builder.mToolbarColor);
         bundle.putBoolean(ARG_HIDE_ACTIVITY_BAR, builder.mHideActivityBar);
+        bundle.putBoolean(ARG_IS_LIFT_ON_SCROLL, builder.mIsLiftOnScroll);
         return bundle;
     }
 
@@ -259,6 +265,7 @@ public class FullScreenDialogFragment extends DialogFragment {
         mToolbarTheme = bundle.getInt(ARG_TOOLBAR_THEME);
         mToolbarColor = bundle.getInt(ARG_TOOLBAR_COLOR);
         mHideActivityBar = bundle.getBoolean(ARG_HIDE_ACTIVITY_BAR);
+        mIsLiftOnScroll = bundle.getBoolean(ARG_IS_LIFT_ON_SCROLL);
     }
 
     /**
@@ -284,6 +291,12 @@ public class FullScreenDialogFragment extends DialogFragment {
 
         if (mToolbarColor > 0) {
             mToolbar.setBackgroundColor(getResources().getColor(mToolbarColor));
+        }
+
+        AppBarLayout appBarLayout = view.findViewById(R.id.appbar_main);
+        appBarLayout.setLiftOnScroll(mIsLiftOnScroll);
+        if (!mIsLiftOnScroll) {
+            appBarLayout.setLifted(false);
         }
 
         if (!mAction.isEmpty()) {
@@ -341,6 +354,15 @@ public class FullScreenDialogFragment extends DialogFragment {
      */
     public void setHideActivityBar(boolean hide) {
         this.mHideActivityBar = hide;
+    }
+
+    /**
+     * Set flag to enable or disable AppBar's lift on scroll.
+     *
+     * @param isLiftOnScroll boolean to toggle lift on scroll
+     */
+    public void setLiftOnScroll(boolean isLiftOnScroll) {
+        this.mIsLiftOnScroll = isLiftOnScroll;
     }
 
     /**
@@ -429,6 +451,7 @@ public class FullScreenDialogFragment extends DialogFragment {
         String mSubtitle = "";
         String mTitle = "";
         boolean mHideActivityBar = false;
+        boolean mIsLiftOnScroll = true;
         int mToolbarTheme = 0;
         int mToolbarColor = 0;
 
@@ -580,6 +603,17 @@ public class FullScreenDialogFragment extends DialogFragment {
          */
         public Builder setOnDismissListener(@Nullable OnDismissListener listener) {
             this.mOnDismissListener = listener;
+            return this;
+        }
+
+        /**
+         * Set flag to enable or disable AppBar's lift on scroll.
+         *
+         * @param isLifOnScroll boolean to toggle lift on scroll
+         * @return {@link Builder} object to allow for chaining of calls to set methods
+         */
+        public Builder setIsLifOnScroll(Boolean isLifOnScroll) {
+            this.mIsLiftOnScroll = isLifOnScroll;
             return this;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -946,7 +946,7 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
         if (event.isError()) {
             AppLog.e(AppLog.T.MAIN,
                     "Failed to load private AT cookie. " + event.error.type + " - " + event.error.message);
-            WPSnackbar.make(findViewById(R.id.snackbar_anchor), R.string.media_accessing_failed, Snackbar.LENGTH_LONG)
+            WPSnackbar.make(findViewById(R.id.webview_wrapper), R.string.media_accessing_failed, Snackbar.LENGTH_LONG)
                       .show();
         } else {
             CookieManager.getInstance().setCookie(mPrivateAtomicCookie.getDomain(),
@@ -962,7 +962,7 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
 
     @Override
     public void onCookieProgressDialogCancelled() {
-        WPSnackbar.make(findViewById(R.id.snackbar_anchor), R.string.media_accessing_failed, Snackbar.LENGTH_LONG)
+        WPSnackbar.make(findViewById(R.id.webview_wrapper), R.string.media_accessing_failed, Snackbar.LENGTH_LONG)
                   .show();
         loadWebContent();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import kotlinx.android.synthetic.main.help_activity.*
-import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -38,6 +38,7 @@ import androidx.lifecycle.ViewModelProviders;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
+import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
@@ -163,6 +164,7 @@ import org.wordpress.android.ui.utils.AuthenticationUtils;
 import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AniUtils;
+import org.wordpress.android.util.AppBarLayoutExtensionsKt;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AutolinkUtils;
@@ -330,6 +332,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
     // For opening the context menu after permissions have been granted
     private View mMenuView = null;
 
+
+    private AppBarLayout mAppBarLayout;
+
     private Handler mShowPrepublishingBottomSheetHandler;
     private Runnable mShowPrepublishingBottomSheetRunnable;
 
@@ -457,6 +462,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
+
+        mAppBarLayout = findViewById(R.id.appbar_main);
 
         FragmentManager fragmentManager = getSupportFragmentManager();
         Bundle extras = getIntent().getExtras();
@@ -651,15 +658,19 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 invalidateOptionsMenu();
                 if (position == PAGE_CONTENT) {
                     setTitle(SiteUtils.getSiteNameOrHomeURL(mSite));
+                    AppBarLayoutExtensionsKt.setLiftOnScrollTargetViewIdAndRequestLayout(mAppBarLayout, View.NO_ID);
                 } else if (position == PAGE_SETTINGS) {
                     setTitle(mEditPostRepository.isPage() ? R.string.page_settings : R.string.post_settings);
                     mEditorPhotoPicker.hidePhotoPicker();
+                    mAppBarLayout.setLiftOnScrollTargetViewId(R.id.settings_fragment_root);
                 } else if (position == PAGE_PUBLISH_SETTINGS) {
                     setTitle(R.string.publish_date);
                     mEditorPhotoPicker.hidePhotoPicker();
+                    AppBarLayoutExtensionsKt.setLiftOnScrollTargetViewIdAndRequestLayout(mAppBarLayout, View.NO_ID);
                 } else if (position == PAGE_HISTORY) {
                     setTitle(R.string.history_title);
                     mEditorPhotoPicker.hidePhotoPicker();
+                    mAppBarLayout.setLiftOnScrollTargetViewId(R.id.empty_recycler_view);
                 }
             }
         });
@@ -963,7 +974,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
             ((AztecEditorFragment) mEditorFragment).enableMediaMode(false);
         }
     }
-    
+
     /*
      * called by PhotoPickerFragment when media is selected - may be a single item or a list of items
      */
@@ -1958,7 +1969,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     public class SectionsPagerAdapter extends FragmentPagerAdapter {
         private static final int NUM_PAGES_EDITOR = 4;
         SectionsPagerAdapter(FragmentManager fm) {
-            super(fm);
+            super(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -334,6 +334,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
 
     private AppBarLayout mAppBarLayout;
+    private Toolbar mToolbar;
 
     private Handler mShowPrepublishingBottomSheetHandler;
     private Runnable mShowPrepublishingBottomSheetRunnable;
@@ -456,8 +457,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
         }
 
         // Set up the action bar.
-        Toolbar toolbar = findViewById(R.id.toolbar_main);
-        setSupportActionBar(toolbar);
+        mToolbar = findViewById(R.id.toolbar_main);
+        setSupportActionBar(mToolbar);
         final ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true);
@@ -659,18 +660,22 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 if (position == PAGE_CONTENT) {
                     setTitle(SiteUtils.getSiteNameOrHomeURL(mSite));
                     AppBarLayoutExtensionsKt.setLiftOnScrollTargetViewIdAndRequestLayout(mAppBarLayout, View.NO_ID);
+                    mToolbar.setBackgroundResource(R.drawable.tab_layout_background);
                 } else if (position == PAGE_SETTINGS) {
                     setTitle(mEditPostRepository.isPage() ? R.string.page_settings : R.string.post_settings);
                     mEditorPhotoPicker.hidePhotoPicker();
                     mAppBarLayout.setLiftOnScrollTargetViewId(R.id.settings_fragment_root);
+                    mToolbar.setBackground(null);
                 } else if (position == PAGE_PUBLISH_SETTINGS) {
                     setTitle(R.string.publish_date);
                     mEditorPhotoPicker.hidePhotoPicker();
                     AppBarLayoutExtensionsKt.setLiftOnScrollTargetViewIdAndRequestLayout(mAppBarLayout, View.NO_ID);
+                    mToolbar.setBackground(null);
                 } else if (position == PAGE_HISTORY) {
                     setTitle(R.string.history_title);
                     mEditorPhotoPicker.hidePhotoPicker();
                     mAppBarLayout.setLiftOnScrollTargetViewId(R.id.empty_recycler_view);
+                    mToolbar.setBackground(null);
                 }
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -14,11 +14,13 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
+import android.widget.ListView;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.view.ViewCompat;
 
 import com.google.android.material.snackbar.BaseTransientBottomBar;
 import com.google.android.material.snackbar.Snackbar;
@@ -111,6 +113,10 @@ public class AccountSettingsFragment extends PreferenceFragment implements OnPre
         View coordinatorView = inflater.inflate(R.layout.preference_coordinator, container, false);
         CoordinatorLayout coordinator = coordinatorView.findViewById(R.id.coordinator);
         View preferenceView = super.onCreateView(inflater, coordinator, savedInstanceState);
+        final ListView listOfPreferences = preferenceView.findViewById(android.R.id.list);
+        if (listOfPreferences != null) {
+            ViewCompat.setNestedScrollingEnabled(listOfPreferences, true);
+        }
         coordinator.addView(preferenceView);
         return coordinatorView;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -372,6 +372,7 @@ public class AccountSettingsFragment extends PreferenceFragment implements OnPre
                 .setAction(R.string.username_changer_action)
                 .setOnConfirmListener(this)
                 .setHideActivityBar(true)
+                .setIsLifOnScroll(false)
                 .setOnDismissListener(null)
                 .setContent(SettingsUsernameChangerFragment.class, bundle)
                 .build()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -14,9 +14,15 @@ import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 import android.text.TextUtils;
 import android.util.Pair;
+import android.view.LayoutInflater;
 import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ListView;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.ViewCompat;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -181,6 +187,18 @@ public class AppSettingsFragment extends PreferenceFragment
         if (!BuildConfig.OFFER_GUTENBERG) {
             removeExperimentalCategory();
         }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View view = super.onCreateView(inflater, container, savedInstanceState);
+
+        final ListView listOfPreferences = view.findViewById(android.R.id.list);
+        if (listOfPreferences != null) {
+            ViewCompat.setNestedScrollingEnabled(listOfPreferences, true);
+        }
+        return view;
     }
 
     private void removeExperimentalCategory() {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/NestedWebView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/NestedWebView.kt
@@ -1,0 +1,192 @@
+package org.wordpress.android.widgets
+
+import android.R.attr
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.webkit.WebView
+import androidx.core.view.MotionEventCompat
+import androidx.core.view.NestedScrollingChild3
+import androidx.core.view.NestedScrollingChildHelper
+import androidx.core.view.ViewCompat
+
+/**
+ * To make WebView work with AppBar in Coordinator layout we need to put into a NestedScrollView
+ * Which leads to some issues related to scrolling, and while majority of them could be solved through modifying layout
+ * hierarchy, some are not so easily fixable.
+ *
+ * NestedWebView implements nested scroll properties and works well inside NestedScrollView.
+ *
+ * Variation of https://stackoverflow.com/a/45026679/569430 with NestedScrollingChild3
+ */
+class NestedWebView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = attr.webViewStyle
+) : WebView(context, attrs, defStyleAttr), NestedScrollingChild3 {
+    private var lastY = 0
+    private val scrollOffset = IntArray(2)
+    private val scrollConsumed = IntArray(2)
+    private var nestedOffsetY = 0
+    private val nestedScrollingChildHelper: NestedScrollingChildHelper = NestedScrollingChildHelper(this)
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouchEvent(ev: MotionEvent): Boolean {
+        var returnValue = false
+        val event = MotionEvent.obtain(ev)
+        val action = MotionEventCompat.getActionMasked(event)
+        if (action == MotionEvent.ACTION_DOWN) {
+            nestedOffsetY = 0
+        }
+        val eventY = event.y.toInt()
+        event.offsetLocation(0f, nestedOffsetY.toFloat())
+        when (action) {
+            MotionEvent.ACTION_MOVE -> {
+                var totalScrollOffset = 0
+                var deltaY = lastY - eventY
+                // NestedPreScroll
+                if (dispatchNestedPreScroll(0, deltaY, scrollConsumed, scrollOffset)) {
+                    totalScrollOffset += scrollOffset[1]
+                    deltaY -= scrollConsumed[1]
+                    event.offsetLocation(0f, (-scrollOffset[1]).toFloat())
+                    nestedOffsetY += scrollOffset[1]
+                }
+                returnValue = super.onTouchEvent(event)
+
+                // NestedScroll
+                if (dispatchNestedScroll(0, scrollOffset[1], 0, deltaY, scrollOffset)) {
+                    totalScrollOffset += scrollOffset[1]
+                    event.offsetLocation(0f, scrollOffset[1].toFloat())
+                    nestedOffsetY += scrollOffset[1]
+                    lastY -= scrollOffset[1]
+                }
+                lastY = eventY - totalScrollOffset
+            }
+            MotionEvent.ACTION_DOWN -> {
+                returnValue = super.onTouchEvent(event)
+                lastY = eventY
+                // start NestedScroll
+                startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL)
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                // end NestedScroll
+                stopNestedScroll()
+                returnValue = super.onTouchEvent(event)
+            }
+        }
+        return returnValue
+    }
+
+    override fun setNestedScrollingEnabled(enabled: Boolean) {
+        nestedScrollingChildHelper.isNestedScrollingEnabled = enabled
+    }
+
+    override fun isNestedScrollingEnabled(): Boolean {
+        return nestedScrollingChildHelper.isNestedScrollingEnabled
+    }
+
+    override fun startNestedScroll(axes: Int, type: Int): Boolean {
+        return nestedScrollingChildHelper.startNestedScroll(axes, type)
+    }
+
+    override fun startNestedScroll(axes: Int): Boolean {
+        return nestedScrollingChildHelper.startNestedScroll(axes)
+    }
+
+    override fun stopNestedScroll(type: Int) {
+        nestedScrollingChildHelper.stopNestedScroll(type)
+    }
+
+    override fun stopNestedScroll() {
+        nestedScrollingChildHelper.stopNestedScroll()
+    }
+
+    override fun hasNestedScrollingParent(type: Int): Boolean {
+        return nestedScrollingChildHelper.hasNestedScrollingParent(type)
+    }
+
+    override fun hasNestedScrollingParent(): Boolean {
+        return nestedScrollingChildHelper.hasNestedScrollingParent()
+    }
+
+    override fun dispatchNestedScroll(
+        dxConsumed: Int,
+        dyConsumed: Int,
+        dxUnconsumed: Int,
+        dyUnconsumed: Int,
+        offsetInWindow: IntArray?,
+        type: Int,
+        consumed: IntArray
+    ) {
+        nestedScrollingChildHelper.dispatchNestedScroll(
+                dxConsumed,
+                dyConsumed,
+                dxUnconsumed,
+                dyUnconsumed,
+                offsetInWindow,
+                type,
+                consumed
+        )
+    }
+
+    override fun dispatchNestedScroll(
+        dxConsumed: Int,
+        dyConsumed: Int,
+        dxUnconsumed: Int,
+        dyUnconsumed: Int,
+        offsetInWindow: IntArray?,
+        type: Int
+    ): Boolean {
+        return nestedScrollingChildHelper.dispatchNestedScroll(
+                dxConsumed,
+                dyConsumed,
+                dxUnconsumed,
+                dyUnconsumed,
+                offsetInWindow,
+                type
+        )
+    }
+
+    override fun dispatchNestedScroll(
+        dxConsumed: Int,
+        dyConsumed: Int,
+        dxUnconsumed: Int,
+        dyUnconsumed: Int,
+        offsetInWindow: IntArray?
+    ): Boolean {
+        return nestedScrollingChildHelper.dispatchNestedScroll(
+                dxConsumed,
+                dyConsumed,
+                dxUnconsumed,
+                dyUnconsumed,
+                offsetInWindow
+        )
+    }
+
+    override fun dispatchNestedPreScroll(
+        dx: Int,
+        dy: Int,
+        consumed: IntArray?,
+        offsetInWindow: IntArray?,
+        type: Int
+    ): Boolean {
+        return nestedScrollingChildHelper.dispatchNestedPreScroll(dx, dy, consumed, offsetInWindow, type)
+    }
+
+    override fun dispatchNestedPreScroll(dx: Int, dy: Int, consumed: IntArray?, offsetInWindow: IntArray?): Boolean {
+        return nestedScrollingChildHelper.dispatchNestedPreScroll(dx, dy, consumed, offsetInWindow)
+    }
+
+    override fun dispatchNestedFling(velocityX: Float, velocityY: Float, consumed: Boolean): Boolean {
+        return nestedScrollingChildHelper.dispatchNestedFling(velocityX, velocityY, consumed)
+    }
+
+    override fun dispatchNestedPreFling(velocityX: Float, velocityY: Float): Boolean {
+        return nestedScrollingChildHelper.dispatchNestedPreFling(velocityX, velocityY)
+    }
+
+    init {
+        isNestedScrollingEnabled = true
+    }
+}

--- a/WordPress/src/main/res/color/primary_disabled_selector.xml
+++ b/WordPress/src/main/res/color/primary_disabled_selector.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:alpha="@dimen/material_emphasis_disabled" android:color="?attr/colorPrimary" android:state_enabled="false" />
-    <item android:color="?attr/colorPrimary" />
-
-</selector>

--- a/WordPress/src/main/res/layout/account_settings_activity.xml
+++ b/WordPress/src/main/res/layout/account_settings_activity.xml
@@ -1,15 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <include layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/nested_scroll_view">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <fragment
         android:id="@+id/fragment"
         android:name="org.wordpress.android.ui.prefs.AccountSettingsFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/app_settings_activity.xml
+++ b/WordPress/src/main/res/layout/app_settings_activity.xml
@@ -1,15 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <include layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/nested_scroll_view">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <fragment
         android:id="@+id/fragment"
         android:name="org.wordpress.android.ui.prefs.AppSettingsFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/settings_fragment_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -298,4 +298,4 @@
         </LinearLayout>
 
     </LinearLayout>
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/WordPress/src/main/res/layout/help_activity.xml
+++ b/WordPress/src/main/res/layout/help_activity.xml
@@ -1,15 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/toolbar_main" />
-
-    <ScrollView
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/nested_scroll_view">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/nested_scroll_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -74,5 +89,5 @@
                 android:background="?android:attr/listDivider" />
 
         </LinearLayout>
-    </ScrollView>
-</LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/history_detail_activity.xml
+++ b/WordPress/src/main/res/layout/history_detail_activity.xml
@@ -1,15 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/theme_listview">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/history_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/history_detail_fragment.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_alignParentTop="true"
+    android:id="@+id/history_detail_nested_scroll_view"
     android:background="?attr/colorSurface"
     android:fillViewport="true">
 
@@ -62,4 +62,4 @@
 
     </LinearLayout>
 
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/WordPress/src/main/res/layout/logviewer_activity.xml
+++ b/WordPress/src/main/res/layout/logviewer_activity.xml
@@ -1,16 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <include layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@android:id/list">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <ListView
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:divider="@null"
-        android:dividerHeight="0dp" />
+        android:dividerHeight="0dp"
+        android:nestedScrollingEnabled="true"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -1,14 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <include layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/scroll_view">
 
-    <ScrollView
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
         android:id="@+id/scroll_view"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -206,5 +220,5 @@
             <View style="@style/MeListSectionDividerView" />
 
         </LinearLayout>
-    </ScrollView>
-</LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/my_profile_activity.xml
+++ b/WordPress/src/main/res/layout/my_profile_activity.xml
@@ -1,15 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <include layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/nested_scroll_view">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <fragment
         android:id="@+id/fragment"
         android:name="org.wordpress.android.ui.prefs.MyProfileFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/my_profile_fragment.xml
+++ b/WordPress/src/main/res/layout/my_profile_fragment.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:id="@+id/nested_scroll_view">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -75,4 +76,4 @@
         <View style="@style/MyProfileDividerView" />
 
     </LinearLayout>
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/WordPress/src/main/res/layout/new_edit_post_activity.xml
+++ b/WordPress/src/main/res/layout/new_edit_post_activity.xml
@@ -1,17 +1,28 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/editor_activity"
-    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <include
-        android:id="@+id/toolbar_container"
-        layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <RelativeLayout
             android:layout_width="match_parent"
@@ -47,4 +58,4 @@
 
         </RelativeLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/new_edit_post_activity.xml
+++ b/WordPress/src/main/res/layout/new_edit_post_activity.xml
@@ -14,6 +14,8 @@
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_main"
             android:layout_width="match_parent"
+            android:duplicateParentState="true"
+            android:background="@drawable/tab_layout_background"
             android:layout_height="wrap_content"
             app:theme="@style/WordPress.ActionBar" />
 

--- a/WordPress/src/main/res/layout/photo_picker_activity.xml
+++ b/WordPress/src/main/res/layout/photo_picker_activity.xml
@@ -1,16 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
-    android:orientation="vertical"
     android:layout_height="match_parent">
 
-    <include layout="@layout/toolbar_main" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/recycler">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:ignore="UnknownIdInLayout"/>
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/site_creation_form_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_form_screen.xml
@@ -1,70 +1,88 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/toolbar_main"/>
-
-   <androidx.core.widget.NestedScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_above="@+id/bottom_buttons"
-        android:layout_below="@+id/toolbar"
-        android:fillViewport="true"
-        android:scrollbars="vertical">
-
-        <ViewStub
-            android:id="@+id/site_creation_form_content_stub"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/site_creation_content_margin"
-            android:layout_marginStart="@dimen/site_creation_content_margin"/>
-
-   </androidx.core.widget.NestedScrollView>
-
-    <View
-        android:id="@+id/bottom_shadow"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/button_container_shadow_height"
-        android:background="@drawable/login_shadow"
-        android:layout_above="@+id/bottom_buttons"
-        android:visibility="gone"
-        tools:visibility="visible"/>
-
-    <RelativeLayout
-        android:id="@+id/bottom_buttons"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/margin_medium_large"
-        android:paddingBottom="@dimen/margin_medium_large"
-        android:layout_alignParentBottom="true"
-        android:clipToPadding="false"
-        android:visibility="gone"
-        tools:visibility="visible">
+        app:liftOnScrollTargetViewId="@+id/site_creation_nested_scroll_view">
 
-        <androidx.appcompat.widget.AppCompatButton
-            style="@style/WordPress.Button.Primary"
-            android:id="@+id/primary_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_medium_large"
-            android:layout_alignParentEnd="true"
-            android:text="@string/next"
-            android:visibility="gone"
-            tools:visibility="visible"/>
-
-        <androidx.appcompat.widget.AppCompatButton
-            style="@style/WordPress.Button.Primary"
-            android:id="@+id/finish_button"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_extra_large"
-            android:layout_marginEnd="@dimen/margin_extra_large"
-            android:text="@string/site_creation_domain_finish_button"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/site_creation_nested_scroll_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_above="@+id/bottom_buttons"
+            android:layout_alignParentTop="true"
+            android:fillViewport="true"
+            android:scrollbars="vertical">
+
+            <ViewStub
+                android:id="@+id/site_creation_form_content_stub"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/site_creation_content_margin"
+                android:layout_marginEnd="@dimen/site_creation_content_margin" />
+
+        </androidx.core.widget.NestedScrollView>
+
+        <View
+            android:id="@+id/bottom_shadow"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/button_container_shadow_height"
+            android:layout_above="@+id/bottom_buttons"
+            android:background="@drawable/login_shadow"
             android:visibility="gone"
-            tools:visibility="visible"/>
+            tools:visibility="visible" />
+
+        <RelativeLayout
+            android:id="@+id/bottom_buttons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:clipToPadding="false"
+            android:paddingTop="@dimen/margin_medium_large"
+            android:paddingBottom="@dimen/margin_medium_large"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/primary_button"
+                style="@style/WordPress.Button.Primary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_marginEnd="@dimen/margin_medium_large"
+                android:text="@string/next"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/finish_button"
+                style="@style/WordPress.Button.Primary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_marginEnd="@dimen/margin_extra_large"
+                android:text="@string/site_creation_domain_finish_button"
+                android:visibility="gone"
+                tools:visibility="visible" />
+        </RelativeLayout>
     </RelativeLayout>
-</RelativeLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/webview.xml
+++ b/WordPress/src/main/res/layout/webview.xml
@@ -1,26 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/webview_wrapper"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <include
-        layout="@layout/toolbar_main"
-        android:id="@+id/toolbar" />
-
-    <org.wordpress.android.ui.WPWebView
-        android:id="@+id/webView"
-        android:layout_below="@+id/toolbar"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/nested_scroll_view">
 
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/nested_scroll_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <org.wordpress.android.ui.WPWebView
+            android:nestedScrollingEnabled="true"
+            android:id="@+id/webView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </androidx.core.widget.NestedScrollView>
     <ProgressBar
         android:id="@+id/progress_bar"
         style="@android:style/Widget.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="@dimen/progress_bar_height"
-        android:indeterminate="false"
         android:layout_alignTop="@+id/webView"
-        android:progressDrawable="@drawable/progressbar_horizontal" />
+        android:indeterminate="false"
+        android:progressDrawable="@drawable/progressbar_horizontal"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-</RelativeLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/wpwebview_activity.xml
+++ b/WordPress/src/main/res/layout/wpwebview_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/webview_wrapper"
@@ -8,15 +8,14 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar"
+        app:liftOnScrollTargetViewId="@+id/nested_scroll_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="?attr/colorSurface"
             app:contentInsetEnd="@dimen/toolbar_content_offset_end"
             app:contentInsetLeft="@dimen/toolbar_content_offset"
             app:contentInsetRight="@dimen/toolbar_content_offset_end"
@@ -30,14 +29,22 @@
         android:id="@+id/preview_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@+id/appbar">
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <org.wordpress.android.ui.WPWebView
-            android:id="@+id/webView"
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/nested_scroll_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_above="@+id/navbar_container"
-            android:layout_alignParentTop="true" />
+            android:layout_alignParentTop="true">
+
+            <org.wordpress.android.ui.WPWebView
+                android:id="@+id/webView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:nestedScrollingEnabled="true" />
+
+        </androidx.core.widget.NestedScrollView>
 
         <include
             layout="@layout/progress_layout"
@@ -122,12 +129,12 @@
         android:id="@+id/actionable_empty_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@+id/appbar"
         android:visibility="gone"
         app:aevButton="@string/retry"
         app:aevImage="@drawable/img_illustration_cloud_off_152dp"
         app:aevSubtitle="@string/error_network_connection"
         app:aevTitle="@string/error_browser_no_network"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:visibility="gone" />
 
     <ProgressBar
@@ -135,8 +142,8 @@
         style="@android:style/Widget.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="@dimen/progress_bar_height"
-        android:layout_alignTop="@+id/preview_container"
         android:indeterminate="false"
-        android:progressDrawable="@drawable/progressbar_horizontal" />
+        android:progressDrawable="@drawable/progressbar_horizontal"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-</RelativeLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/wpwebview_activity.xml
+++ b/WordPress/src/main/res/layout/wpwebview_activity.xml
@@ -15,21 +15,21 @@
             android:id="@+id/appbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:liftOnScrollTargetViewId="@+id/nested_scroll_view">
+            app:liftOnScrollTargetViewId="@+id/webView">
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
-                android:duplicateParentState="true"
-                android:background="@drawable/tab_layout_background"
                 android:layout_height="wrap_content"
+                android:background="@drawable/tab_layout_background"
+                android:duplicateParentState="true"
                 app:contentInsetEnd="@dimen/toolbar_content_offset_end"
                 app:contentInsetLeft="@dimen/toolbar_content_offset"
                 app:contentInsetRight="@dimen/toolbar_content_offset_end"
                 app:contentInsetStart="@dimen/toolbar_content_offset"
                 app:layout_scrollFlags="scroll|enterAlways"
                 app:subtitleTextColor="?attr/wpColorOnSurfaceMedium"
-                app:theme="@style/WordPress.WebPreview.ActionBar" />
+                app:theme="@style/WordPress.ActionBar" />
 
         </com.google.android.material.appbar.AppBarLayout>
 
@@ -39,20 +39,10 @@
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <androidx.core.widget.NestedScrollView
-                android:id="@+id/nested_scroll_view"
+            <org.wordpress.android.widgets.NestedWebView
+                android:id="@+id/webView"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_above="@+id/navbar_container"
-                android:layout_alignParentTop="true">
-
-                <org.wordpress.android.ui.WPWebView
-                    android:id="@+id/webView"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:nestedScrollingEnabled="true" />
-
-            </androidx.core.widget.NestedScrollView>
+                android:layout_height="match_parent" />
 
             <include
                 layout="@layout/progress_layout"
@@ -61,14 +51,6 @@
                 android:layout_above="@+id/navbar_container"
                 android:layout_alignParentTop="true"
                 tools:visibility="gone" />
-
-
-            <androidx.coordinatorlayout.widget.CoordinatorLayout
-                android:id="@+id/snackbar_anchor"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_above="@+id/navbar_container" />
-
 
         </RelativeLayout>
 
@@ -93,9 +75,7 @@
             android:progressDrawable="@drawable/progressbar_horizontal"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
 
     <TextView
         android:id="@+id/desktop_preview_hint"

--- a/WordPress/src/main/res/layout/wpwebview_activity.xml
+++ b/WordPress/src/main/res/layout/wpwebview_activity.xml
@@ -16,6 +16,7 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:layout_scrollFlags="scroll|enterAlways"
             app:contentInsetEnd="@dimen/toolbar_content_offset_end"
             app:contentInsetLeft="@dimen/toolbar_content_offset"
             app:contentInsetRight="@dimen/toolbar_content_offset_end"

--- a/WordPress/src/main/res/layout/wpwebview_activity.xml
+++ b/WordPress/src/main/res/layout/wpwebview_activity.xml
@@ -8,7 +8,6 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/webview_wrapper"
         android:layout_width="match_parent"
-
         android:layout_height="match_parent"
         android:layout_above="@+id/navbar_container">
 
@@ -21,6 +20,8 @@
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
+                android:duplicateParentState="true"
+                android:background="@drawable/tab_layout_background"
                 android:layout_height="wrap_content"
                 app:contentInsetEnd="@dimen/toolbar_content_offset_end"
                 app:contentInsetLeft="@dimen/toolbar_content_offset"

--- a/WordPress/src/main/res/layout/wpwebview_activity.xml
+++ b/WordPress/src/main/res/layout/wpwebview_activity.xml
@@ -1,150 +1,163 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/webview_wrapper"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/appbar"
-        app:liftOnScrollTargetViewId="@+id/nested_scroll_view"
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/webview_wrapper"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
+        android:layout_height="match_parent"
+        android:layout_above="@+id/navbar_container">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_scrollFlags="scroll|enterAlways"
-            app:contentInsetEnd="@dimen/toolbar_content_offset_end"
-            app:contentInsetLeft="@dimen/toolbar_content_offset"
-            app:contentInsetRight="@dimen/toolbar_content_offset_end"
-            app:contentInsetStart="@dimen/toolbar_content_offset"
-            app:subtitleTextColor="?attr/wpColorOnSurfaceMedium"
-            app:theme="@style/WordPress.WebPreview.ActionBar" />
+            app:liftOnScrollTargetViewId="@+id/nested_scroll_view">
 
-    </com.google.android.material.appbar.AppBarLayout>
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:contentInsetEnd="@dimen/toolbar_content_offset_end"
+                app:contentInsetLeft="@dimen/toolbar_content_offset"
+                app:contentInsetRight="@dimen/toolbar_content_offset_end"
+                app:contentInsetStart="@dimen/toolbar_content_offset"
+                app:layout_scrollFlags="scroll|enterAlways"
+                app:subtitleTextColor="?attr/wpColorOnSurfaceMedium"
+                app:theme="@style/WordPress.WebPreview.ActionBar" />
 
-    <RelativeLayout
-        android:id="@+id/preview_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        </com.google.android.material.appbar.AppBarLayout>
 
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/nested_scroll_view"
+        <RelativeLayout
+            android:id="@+id/preview_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_above="@+id/navbar_container"
-            android:layout_alignParentTop="true">
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <org.wordpress.android.ui.WPWebView
-                android:id="@+id/webView"
+            <androidx.core.widget.NestedScrollView
+                android:id="@+id/nested_scroll_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:nestedScrollingEnabled="true" />
+                android:layout_above="@+id/navbar_container"
+                android:layout_alignParentTop="true">
 
-        </androidx.core.widget.NestedScrollView>
+                <org.wordpress.android.ui.WPWebView
+                    android:id="@+id/webView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:nestedScrollingEnabled="true" />
 
-        <include
-            layout="@layout/progress_layout"
+            </androidx.core.widget.NestedScrollView>
+
+            <include
+                layout="@layout/progress_layout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_above="@+id/navbar_container"
+                android:layout_alignParentTop="true"
+                tools:visibility="gone" />
+
+
+            <androidx.coordinatorlayout.widget.CoordinatorLayout
+                android:id="@+id/snackbar_anchor"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_above="@+id/navbar_container" />
+
+
+        </RelativeLayout>
+
+        <org.wordpress.android.ui.ActionableEmptyView
+            android:id="@+id/actionable_empty_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_above="@+id/navbar_container"
-            android:layout_alignParentTop="true"
+            android:visibility="gone"
+            app:aevButton="@string/retry"
+            app:aevImage="@drawable/img_illustration_cloud_off_152dp"
+            app:aevSubtitle="@string/error_network_connection"
+            app:aevTitle="@string/error_browser_no_network"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
             tools:visibility="gone" />
 
-        <TextView
-            android:id="@+id/desktop_preview_hint"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_above="@+id/navbar_container"
-            android:layout_alignParentEnd="true"
-            android:background="@drawable/preview_mode_indicator_background"
-            android:padding="@dimen/margin_medium"
-            android:text="@string/web_preview_desktop"
-            android:textColor="?attr/colorOnPrimarySurface" />
-
-        <androidx.coordinatorlayout.widget.CoordinatorLayout
-            android:id="@+id/snackbar_anchor"
+        <ProgressBar
+            android:id="@+id/progress_bar"
+            style="@android:style/Widget.ProgressBar.Horizontal"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_above="@+id/navbar_container" />
+            android:layout_height="@dimen/progress_bar_height"
+            android:indeterminate="false"
+            android:progressDrawable="@drawable/progressbar_horizontal"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+
+    <TextView
+        android:id="@+id/desktop_preview_hint"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/navbar_container"
+        android:layout_alignParentEnd="true"
+        android:layout_gravity="bottom|end"
+        android:background="@drawable/preview_mode_indicator_background"
+        android:padding="@dimen/margin_medium"
+        android:text="@string/web_preview_desktop"
+        android:textColor="?attr/colorOnPrimarySurface" />
+
+    <LinearLayout
+        android:id="@+id/navbar_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:orientation="vertical">
+
+        <View
+            android:id="@+id/divider"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/divider_size"
+            android:background="?android:attr/listDivider" />
 
         <LinearLayout
-            android:id="@+id/navbar_container"
+            android:id="@+id/navbar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:orientation="vertical">
+            android:layout_height="@dimen/web_preview_navbar_height"
+            android:orientation="horizontal"
+            android:weightSum="100">
 
-            <View
-                android:id="@+id/divider"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/divider_size"
-                android:background="?android:attr/listDivider" />
+            <ImageButton
+                android:id="@+id/back_button"
+                style="@style/WebPreviewNavbarButton"
+                android:contentDescription="@string/navigate_back_desc"
+                android:src="@drawable/ic_arrow_left_white_24dp" />
 
-            <LinearLayout
-                android:id="@+id/navbar"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/web_preview_navbar_height"
-                android:orientation="horizontal"
-                android:weightSum="100">
+            <ImageButton
+                android:id="@+id/forward_button"
+                style="@style/WebPreviewNavbarButton"
+                android:contentDescription="@string/navigate_forward_desc"
+                android:src="@drawable/ic_arrow_right_white_24dp" />
 
-                <ImageButton
-                    android:id="@+id/back_button"
-                    style="@style/WebPreviewNavbarButton"
-                    android:contentDescription="@string/navigate_back_desc"
-                    android:src="@drawable/ic_arrow_left_white_24dp" />
+            <ImageButton
+                android:id="@+id/share_button"
+                style="@style/WebPreviewNavbarButton"
+                android:contentDescription="@string/share_desc"
+                android:src="@drawable/ic_share_white_24dp" />
 
-                <ImageButton
-                    android:id="@+id/forward_button"
-                    style="@style/WebPreviewNavbarButton"
-                    android:contentDescription="@string/navigate_forward_desc"
-                    android:src="@drawable/ic_arrow_right_white_24dp" />
+            <ImageButton
+                android:id="@+id/external_browser_button"
+                style="@style/WebPreviewNavbarButton"
+                android:contentDescription="@string/open_external_link_desc"
+                android:src="@drawable/ic_globe_white_24dp" />
 
-                <ImageButton
-                    android:id="@+id/share_button"
-                    style="@style/WebPreviewNavbarButton"
-                    android:contentDescription="@string/share_desc"
-                    android:src="@drawable/ic_share_white_24dp" />
+            <ImageButton
+                android:id="@+id/preview_type_selector_button"
+                style="@style/WebPreviewNavbarButton"
+                android:contentDescription="@string/preview_type_desc"
+                android:src="@drawable/ic_devices_white_24dp" />
 
-                <ImageButton
-                    android:id="@+id/external_browser_button"
-                    style="@style/WebPreviewNavbarButton"
-                    android:contentDescription="@string/open_external_link_desc"
-                    android:src="@drawable/ic_globe_white_24dp" />
-
-                <ImageButton
-                    android:id="@+id/preview_type_selector_button"
-                    style="@style/WebPreviewNavbarButton"
-                    android:contentDescription="@string/preview_type_desc"
-                    android:src="@drawable/ic_devices_white_24dp" />
-
-            </LinearLayout>
         </LinearLayout>
-    </RelativeLayout>
-
-    <org.wordpress.android.ui.ActionableEmptyView
-        android:id="@+id/actionable_empty_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone"
-        app:aevButton="@string/retry"
-        app:aevImage="@drawable/img_illustration_cloud_off_152dp"
-        app:aevSubtitle="@string/error_network_connection"
-        app:aevTitle="@string/error_browser_no_network"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        tools:visibility="gone" />
-
-    <ProgressBar
-        android:id="@+id/progress_bar"
-        style="@android:style/Widget.ProgressBar.Horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/progress_bar_height"
-        android:indeterminate="false"
-        android:progressDrawable="@drawable/progressbar_horizontal"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
-
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+    </LinearLayout>
+</RelativeLayout>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -68,7 +68,7 @@
 
         <item name="actionModeStyle">@style/WordPress.ActionMode</item>
         <item name="actionModeCloseButtonStyle">@style/WordPress.ActionMode.CloseButton</item>
-        <item name="actionMenuTextColor">@color/primary_disabled_selector</item>
+        <item name="actionMenuTextColor">@color/on_surface_disabled_selector</item>
         <item name="toolbarNavigationButtonStyle">
             @style/WordPress.ActionBar.Navigation
         </item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -232,7 +232,7 @@
     <style name="WordPress.ToolBar" parent="Widget.MaterialComponents.Toolbar.Surface">
         <item name="titleTextColor">?attr/colorOnSurface</item>
         <item name="android:background">@null</item>
-        <item name="popupTheme">@style/ThemeOverlay.AppCompat.Light</item>
+        <item name="popupTheme">@style/ThemeOverlay.AppCompat.DayNight</item>
         <item name="titleTextAppearance">@style/WordPress.ToolBar.Title</item>
         <item name="android:elevation">0dp</item>
         <item name="colorControlNormal">?attr/colorOnSurface</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -126,10 +126,6 @@
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 
-    <style name="WordPress.Editor.NoActionBar" parent="WordPress.NoActionBar">
-        <item name="actionMenuTextColor">?attr/colorOnPrimarySurface</item>
-    </style>
-
     <style name="WordPress.NoActionBar.DarkNavbar" parent="WordPress.NoActionBar">
         <item name="android:windowLightNavigationBar">false</item>
         <item name="android:navigationBarColor">?attr/wpColorAppBar</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -79,7 +79,7 @@
 
         <item name="actionModeStyle">@style/WordPress.ActionMode</item>
         <item name="actionModeCloseButtonStyle">@style/WordPress.ActionMode.CloseButton</item>
-        <item name="actionMenuTextColor">@color/primary_disabled_selector</item>
+        <item name="actionMenuTextColor">@color/on_surface_disabled_selector</item>
         <item name="actionOverflowButtonStyle">
             @style/WordPress.ActionMode.OverflowButtonStyle
         </item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -252,10 +252,6 @@
         <item name="android:textStyle">bold</item>
     </style>
 
-    <style name="WordPress.WebPreview.ActionBar" parent="Theme.MaterialComponents.DayNight">
-        <item name="android:textColorSecondary">?attr/colorOnSurface</item>
-    </style>
-
     <style name="WordPress.ActionBar.LightDark" parent="Theme.AppCompat.Light">
         <item name="titleTextColor">?attr/colorOnSurface</item>
         <item name="toolbarNavigationButtonStyle">


### PR DESCRIPTION
This PR updates AppBar design and adds lift on scroll functionality to the following screens (and related nested screens)

- Me screen and all the nested screens (excluding Zendesk).
- Editor screens - Post Settings and Revisions.
- Site Creation flow (only the first step)
- Media Picker.
- Site Preview.

@osullivanchris Unfortunately I was not able to get a lift on scroll working in editor :( Any ideas on what we can do there instead?

To test:

For all screens:

- Make sure nothing looks out of place (including ActionMode) :)
- Make sure the toolbar state is restored on configuration change.

Test 1:

- Navigate to the Me screen and confirm that lift on scroll works (you might need to check the screen in landscape orientation).
- Check My Profile,  Account Settings, App Settings, and Help screens and confirm that lift on scroll works.

Test 2:

- Navigate to the Editor screen and check Post Settings and History + History Details screens to confirm that lift on scroll works.

Test 3:

- Start Site Creation flow and confirm that lift on scroll works on the first step.

Test 4:

- Open media picker (from the editor or by tapping on Blavatar on My Site screen) and confirm that lift on scroll works.

Test 4:

- Open Site Preview and confirm that lift on scroll works.



PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
