### PR TITLE
Convert SnackbarMessageHolder message to CharSequence

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -82,7 +82,7 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
 
                 showSubtitle(page.date, page.author, page.subtitle)
 
-                labels.text = page.labels.map { uiHelper.getTextOfUiString(parent.context, it) }.sorted()
+                labels.text = page.labels.map { uiHelper.getTextOfUiString(parent.context, it).toString() }.sorted()
                         .joinToString(separator = " · ")
                 page.labelsColor?.let { labelsColor ->
                     labels.setTextColor(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicFragmentDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicFragmentDialog.kt
@@ -12,11 +12,11 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
  */
 class BasicFragmentDialog : AppCompatDialogFragment() {
     private lateinit var mTag: String
-    private lateinit var mMessage: String
-    private lateinit var mPositiveButtonLabel: String
-    private var mTitle: String? = null
-    private var mNegativeButtonLabel: String? = null
-    private var mCancelButtonLabel: String? = null
+    private lateinit var mMessage: CharSequence
+    private lateinit var mPositiveButtonLabel: CharSequence
+    private var mTitle: CharSequence? = null
+    private var mNegativeButtonLabel: CharSequence? = null
+    private var mCancelButtonLabel: CharSequence? = null
     private var dismissedByPositiveButton = false
     private var dismissedByNegativeButton = false
     private var dismissedByCancelButton = false
@@ -35,11 +35,11 @@ class BasicFragmentDialog : AppCompatDialogFragment() {
 
     fun initialize(
         tag: String,
-        title: String?,
-        message: String,
-        positiveButtonLabel: String,
-        negativeButtonLabel: String? = null,
-        cancelButtonLabel: String? = null
+        title: CharSequence?,
+        message: CharSequence,
+        positiveButtonLabel: CharSequence,
+        negativeButtonLabel: CharSequence? = null,
+        cancelButtonLabel: CharSequence? = null
     ) {
         mTag = tag
         mTitle = title
@@ -57,21 +57,21 @@ class BasicFragmentDialog : AppCompatDialogFragment() {
 
         if (savedInstanceState != null) {
             mTag = savedInstanceState.getString(STATE_KEY_TAG)
-            mTitle = savedInstanceState.getString(STATE_KEY_TITLE)
-            mMessage = savedInstanceState.getString(STATE_KEY_MESSAGE)
-            mPositiveButtonLabel = savedInstanceState.getString(STATE_KEY_POSITIVE_BUTTON_LABEL)
-            mNegativeButtonLabel = savedInstanceState.getString(STATE_KEY_NEGATIVE_BUTTON_LABEL)
-            mCancelButtonLabel = savedInstanceState.getString(STATE_KEY_CANCEL_BUTTON_LABEL)
+            mTitle = savedInstanceState.getCharSequence(STATE_KEY_TITLE)
+            mMessage = savedInstanceState.getCharSequence(STATE_KEY_MESSAGE)
+            mPositiveButtonLabel = savedInstanceState.getCharSequence(STATE_KEY_POSITIVE_BUTTON_LABEL)
+            mNegativeButtonLabel = savedInstanceState.getCharSequence(STATE_KEY_NEGATIVE_BUTTON_LABEL)
+            mCancelButtonLabel = savedInstanceState.getCharSequence(STATE_KEY_CANCEL_BUTTON_LABEL)
         }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putString(STATE_KEY_TAG, mTag)
-        outState.putString(STATE_KEY_TITLE, mTitle)
-        outState.putString(STATE_KEY_MESSAGE, mMessage)
-        outState.putString(STATE_KEY_POSITIVE_BUTTON_LABEL, mPositiveButtonLabel)
-        outState.putString(STATE_KEY_NEGATIVE_BUTTON_LABEL, mNegativeButtonLabel)
-        outState.putString(STATE_KEY_CANCEL_BUTTON_LABEL, mCancelButtonLabel)
+        outState.putCharSequence(STATE_KEY_TITLE, mTitle)
+        outState.putCharSequence(STATE_KEY_MESSAGE, mMessage)
+        outState.putCharSequence(STATE_KEY_POSITIVE_BUTTON_LABEL, mPositiveButtonLabel)
+        outState.putCharSequence(STATE_KEY_NEGATIVE_BUTTON_LABEL, mNegativeButtonLabel)
+        outState.putCharSequence(STATE_KEY_CANCEL_BUTTON_LABEL, mCancelButtonLabel)
         super.onSaveInstanceState(outState)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
@@ -62,7 +62,7 @@ public class ReaderMenuAdapter extends BaseAdapter {
         }
 
         SecondaryAction item = mMenuItems.get(position);
-        String textRes = mUiHelpers.getTextOfUiString(convertView.getContext(), item.getLabel()).toString();
+        CharSequence textRes = mUiHelpers.getTextOfUiString(convertView.getContext(), item.getLabel());
         int textColorRes =
                 ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getLabelColor());
         int iconColorRes =

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
@@ -62,7 +62,7 @@ public class ReaderMenuAdapter extends BaseAdapter {
         }
 
         SecondaryAction item = mMenuItems.get(position);
-        String textRes = mUiHelpers.getTextOfUiString(convertView.getContext(), item.getLabel());
+        String textRes = mUiHelpers.getTextOfUiString(convertView.getContext(), item.getLabel()).toString();
         int textColorRes =
                 ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getLabelColor());
         int iconColorRes =

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -197,7 +197,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
             val newText = uiHelpers.getTextOfUiString(progress_text.context, loadingTextResId)
             AppLog.d(AppLog.T.MAIN, "Changing text - animation: $animate")
             if (animate) {
-                updateLoadingTextWithFadeAnimation(newText)
+                updateLoadingTextWithFadeAnimation(newText.toString())
             } else {
                 progress_text.text = newText
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -197,14 +197,14 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
             val newText = uiHelpers.getTextOfUiString(progress_text.context, loadingTextResId)
             AppLog.d(AppLog.T.MAIN, "Changing text - animation: $animate")
             if (animate) {
-                updateLoadingTextWithFadeAnimation(newText.toString())
+                updateLoadingTextWithFadeAnimation(newText)
             } else {
                 progress_text.text = newText
             }
         }
     }
 
-    private fun updateLoadingTextWithFadeAnimation(newText: String) {
+    private fun updateLoadingTextWithFadeAnimation(newText: CharSequence) {
         val animationDuration = AniUtils.Duration.SHORT
         val fadeOut = AniUtils.getFadeOutAnim(progress_text_layout, animationDuration, View.VISIBLE)
         val fadeIn = AniUtils.getFadeInAnim(progress_text_layout, animationDuration)

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -658,7 +658,7 @@ public class PostUploadHandler implements UploadHandler<PostModel>, OnAutoSavePo
             Context context = WordPress.getContext();
             String errorMessage = mUiHelpers.getTextOfUiString(context,
                     UploadUtils.getErrorMessageResIdFromPostError(PostStatus.fromPost(event.post), event.post.isPage(),
-                            event.error, mUploadActionUseCase.isEligibleForAutoUpload(site, event.post)));
+                            event.error, mUploadActionUseCase.isEligibleForAutoUpload(site, event.post))).toString();
             String notificationMessage = UploadUtils.getErrorMessage(context, event.post.isPage(), errorMessage, false);
             mPostUploadNotifier.removePostInfoFromForegroundNotification(event.post,
                     mMediaStore.getMediaForPost(event.post));

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -25,7 +25,7 @@ class UiHelpers @Inject constructor() {
                 is UIDimenDPInt -> DisplayUtils.dpToPx(context, uiDimen.dimensionDP)
             }
 
-    fun getTextOfUiString(context: Context, uiString: UiString): String =
+    fun getTextOfUiString(context: Context, uiString: UiString): CharSequence =
             when (uiString) {
                 is UiStringRes -> context.getString(uiString.stringRes)
                 is UiStringText -> uiString.text

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
@@ -7,7 +7,7 @@ import androidx.annotation.StringRes
  * represented as both string resource and text.
  */
 sealed class UiString {
-    data class UiStringText(val text: String) : UiString()
+    data class UiStringText(val text: CharSequence) : UiString()
     data class UiStringRes(@StringRes val stringRes: Int) : UiString()
     data class UiStringResWithParams(@StringRes val stringRes: Int, val params: List<UiString>) : UiString()
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/DialogHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/DialogHolder.kt
@@ -17,10 +17,10 @@ class DialogHolder(
         val dialog = BasicFragmentDialog()
         dialog.initialize(
                 tag = tag,
-                title = title?.let { uiHelpers.getTextOfUiString(context, title).toString() },
-                message = uiHelpers.getTextOfUiString(context, message).toString(),
-                positiveButtonLabel = uiHelpers.getTextOfUiString(context, positiveButton).toString(),
-                negativeButtonLabel = uiHelpers.getTextOfUiString(context, negativeButton).toString(),
+                title = title?.let { uiHelpers.getTextOfUiString(context, title) },
+                message = uiHelpers.getTextOfUiString(context, message),
+                positiveButtonLabel = uiHelpers.getTextOfUiString(context, positiveButton),
+                negativeButtonLabel = uiHelpers.getTextOfUiString(context, negativeButton),
                 cancelButtonLabel = null
         )
         dialog.show(fragmentManager, tag)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/DialogHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/DialogHolder.kt
@@ -17,10 +17,10 @@ class DialogHolder(
         val dialog = BasicFragmentDialog()
         dialog.initialize(
                 tag = tag,
-                title = title?.let { uiHelpers.getTextOfUiString(context, title) },
-                message = uiHelpers.getTextOfUiString(context, message),
-                positiveButtonLabel = uiHelpers.getTextOfUiString(context, positiveButton),
-                negativeButtonLabel = uiHelpers.getTextOfUiString(context, negativeButton),
+                title = title?.let { uiHelpers.getTextOfUiString(context, title).toString() },
+                message = uiHelpers.getTextOfUiString(context, message).toString(),
+                positiveButtonLabel = uiHelpers.getTextOfUiString(context, positiveButton).toString(),
+                negativeButtonLabel = uiHelpers.getTextOfUiString(context, negativeButton).toString(),
                 cancelButtonLabel = null
         )
         dialog.show(fragmentManager, tag)


### PR DESCRIPTION
Parent PR: #12740

This PR converts `SnackbarMessageHolder`'s message param to `CharSequence` to accept html formatted `spanned` text.

To test

That the project compiles and tests run successfully using the command
./gradlew :WordPress:testVanillaDebugUnitTest

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
