### PR TITLE
Fix undo block site action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
 import android.text.TextUtils;
+import android.util.Pair;
 
 import androidx.annotation.NonNull;
 
@@ -26,7 +27,10 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.SqlUtils;
 
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * tbl_posts contains all reader posts - the primary key is pseudo_id + tag_name + tag_type,
@@ -949,6 +953,16 @@ public class ReaderPostTable {
         }
     }
 
+    public static Map<Pair<String, ReaderTagType>, ReaderPostList> getTagPostMap(long blogId) {
+        String sql = "SELECT * FROM tbl_posts WHERE blog_id=?";
+        Cursor cursor = ReaderDatabase.getReadableDb().rawQuery(sql, new String[]{Long.toString(blogId)});
+        try {
+            return getTagPostMapFromCursor(cursor);
+        } finally {
+            SqlUtils.closeCursor(cursor);
+        }
+    }
+
     public static ReaderPostList getPostsInFeed(long feedId, int maxPosts, boolean excludeTextColumn) {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "*");
         String sql =
@@ -1049,6 +1063,16 @@ public class ReaderPostTable {
         }
     }
 
+    private static Pair<String, ReaderTagType> getTagNameAndTypeFromCursor(Cursor c) {
+        if (c == null) {
+            throw new IllegalArgumentException("getPostFromCursor > null cursor");
+        }
+        return new Pair<>(
+                c.getString(c.getColumnIndex("tag_name")),
+                ReaderTagType.fromInt(c.getInt(c.getColumnIndex("tag_type")))
+        );
+    }
+
     private static ReaderPost getPostFromCursor(Cursor c) {
         if (c == null) {
             throw new IllegalArgumentException("getPostFromCursor > null cursor");
@@ -1130,6 +1154,25 @@ public class ReaderPostTable {
             if (cursor != null && cursor.moveToFirst()) {
                 do {
                     posts.add(getPostFromCursor(cursor));
+                } while (cursor.moveToNext());
+            }
+        } catch (IllegalStateException e) {
+            AppLog.e(AppLog.T.READER, e);
+        }
+        return posts;
+    }
+
+    private static Map<Pair<String, ReaderTagType>, ReaderPostList> getTagPostMapFromCursor(Cursor cursor) {
+        Map<Pair<String, ReaderTagType>, ReaderPostList> posts = new LinkedHashMap<>();
+        try {
+            if (cursor != null && cursor.moveToFirst()) {
+                do {
+                    ReaderPost post = getPostFromCursor(cursor);
+                    Pair<String, ReaderTagType> tagNameAndType = getTagNameAndTypeFromCursor(cursor);
+                    if (!posts.containsKey(tagNameAndType)) {
+                        posts.put(tagNameAndType, new ReaderPostList());
+                    }
+                    Objects.requireNonNull(posts.get(tagNameAndType)).add(post);
                 } while (cursor.moveToNext());
             }
         } catch (IllegalStateException e) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.reader.actions;
 
 import android.text.TextUtils;
+import android.util.Pair;
 
 import com.android.volley.Request;
 import com.android.volley.Response;
@@ -13,9 +14,12 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.datasets.ReaderBlogTable;
 import org.wordpress.android.datasets.ReaderPostTable;
+import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.models.ReaderBlog;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderPostList;
+import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.reader.actions.ReaderActions.ActionListener;
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateBlogInfoListener;
 import org.wordpress.android.util.AppLog;
@@ -25,11 +29,13 @@ import org.wordpress.android.util.VolleyUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.net.HttpURLConnection;
+import java.util.Map;
 
 public class ReaderBlogActions {
     public static class BlockedBlogResult {
         public long blogId;
-        public ReaderPostList deletedPosts;
+        // Key: Pair<ReaderTagSlug, ReaderTagType>, Value: ReaderPostList
+        public Map<Pair<String, ReaderTagType>, ReaderPostList> deleteRows;
         public boolean wasFollowing;
     }
 
@@ -443,7 +449,7 @@ public class ReaderBlogActions {
     public static BlockedBlogResult blockBlogFromReader(final long blogId, final ActionListener actionListener) {
         final BlockedBlogResult blockResult = new BlockedBlogResult();
         blockResult.blogId = blogId;
-        blockResult.deletedPosts = ReaderPostTable.getPostsInBlog(blogId, 0, false);
+        blockResult.deleteRows = ReaderPostTable.getTagPostMap(blogId);
         blockResult.wasFollowing = ReaderBlogTable.isFollowedBlog(blogId);
 
         ReaderPostTable.deletePostsInBlog(blogId);
@@ -459,7 +465,7 @@ public class ReaderBlogActions {
             @Override
             public void onErrorResponse(VolleyError volleyError) {
                 AppLog.e(T.READER, volleyError);
-                ReaderPostTable.addOrUpdatePosts(null, blockResult.deletedPosts);
+                undoBlockBlogLocal(blockResult);
                 if (blockResult.wasFollowing) {
                     ReaderBlogTable.setIsFollowedBlogId(blogId, true);
                 }
@@ -478,9 +484,7 @@ public class ReaderBlogActions {
         if (blockResult == null) {
             return;
         }
-        if (blockResult.deletedPosts != null) {
-            ReaderPostTable.addOrUpdatePosts(null, blockResult.deletedPosts);
-        }
+       undoBlockBlogLocal(blockResult);
 
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -504,5 +508,14 @@ public class ReaderBlogActions {
         AppLog.i(T.READER, "unblocking blog " + blockResult.blogId);
         String path = "me/block/sites/" + Long.toString(blockResult.blogId) + "/delete";
         WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
+    }
+
+    private static void undoBlockBlogLocal(final BlockedBlogResult blockResult) {
+        if (blockResult.deleteRows != null) {
+            for (Pair<String, ReaderTagType> tagInfo : blockResult.deleteRows.keySet()) {
+                ReaderTag tag = ReaderTagTable.getTag(tagInfo.first, tagInfo.second);
+                ReaderPostTable.addOrUpdatePosts(tag, blockResult.deleteRows.get(tagInfo));
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #12790 

This PR fixes two issues both related to the "undo block site" action. 

1. When a user clicks on “block site” we perform three actions 
 - load posts which are about to be deleted and we store them into BlockedBlogResult
 - delete all posts with the provided blogId in our local db
 - we send a request to the server to block that site
2. When the user clicks on undo
- we re-add the posts retained in BlockedBlogResult
- we send a request to the server to unblock the site

This sounds ok, but there were two bugs in the code
1. When we loaded the posts into BlockedBlogResult we used -`ReaderPostTable.getPostsInBlog` which returns only posts with `tag_name=""`. But the delete method removes all posts no matter the "tag_name". So when there weren't any posts with `tag_name=""`, the BlockedBlogResult was empty and the undo action didn't restore any posts.
2. Our post table can have multiple instances of the same post (one per tag). But the delete method removes all posts no matter their tag. The undo action inserts all posts from `BlockedBlogResult` under an empty tag. So if the user is lets say on "Nature" tag screen -> the posts disappear when they click on "block site" but they never reappear as they are re-inserted with `tag_name=""`.

I decided to store Map<Pair<reader_tag, reader_type>, ReaderPostList> into the BlockedBlogResult, so we actually restore all the deleted rows.

To test:

1. Open Reader
2. Click on the "more" button on one of the items
3. Click on "Block Site"
4. Notice posts from that blog disappear
5. Click on "undo" in the snackbar
6. Notice the posts re-appear

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
