### PR TITLE
Make SiteModel params nullable on WPMainActivity VM event handler methods

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -135,7 +135,7 @@ class WPMainActivityViewModel @Inject constructor(
         }
     }
 
-    private fun disableTooltip(site: SiteModel) {
+    private fun disableTooltip(site: SiteModel?) {
         appPrefsWrapper.setMainFabTooltipDisabled(true)
 
         val oldState = _fabUiState.value
@@ -148,7 +148,7 @@ class WPMainActivityViewModel @Inject constructor(
         }
     }
 
-    fun onFabClicked(site: SiteModel, shouldShowQuickStartFocusPoint: Boolean = false) {
+    fun onFabClicked(site: SiteModel?, shouldShowQuickStartFocusPoint: Boolean = false) {
         appPrefsWrapper.setMainFabTooltipDisabled(true)
         setMainFabUiState(true, site)
 
@@ -177,15 +177,15 @@ class WPMainActivityViewModel @Inject constructor(
         }
     }
 
-    fun onPageChanged(showFab: Boolean, site: SiteModel) {
+    fun onPageChanged(showFab: Boolean, site: SiteModel?) {
         setMainFabUiState(showFab, site)
     }
 
-    fun onTooltipTapped(site: SiteModel) {
+    fun onTooltipTapped(site: SiteModel?) {
         disableTooltip(site)
     }
 
-    fun onFabLongPressed(site: SiteModel) {
+    fun onFabLongPressed(site: SiteModel?) {
         disableTooltip(site)
     }
 


### PR DESCRIPTION
Builds on top of #12783 

As detected by @renanferrari (also reported by @ashiagr) and expressed in #12783, [this commit](https://github.com/wordpress-mobile/WordPress-Android/commit/c9854692e53e302b4ae3bc42a4ff5af35e519065#diff-1cf6428dcfe0d429dfdcf7398ef4c056R812) in #12728 unintentionally introduced a behavior change that enforced `SiteModel` to be non-null even when having an uninitialized selectedSite is a temporarily possible state.

As suggested in #12783 and agreed there, I [checked](https://github.com/wordpress-mobile/WordPress-Android/pull/12783#issuecomment-679955167) all of the places where `hasFullAccessToContent()` was being called previous to that change to verify `site`  is not enforced as non-null, and made the changes accordingly.

Note: pinging people involved but only 1 approval needed. @ashiagr if you can give it a test, since you could reproduce easily? 🙏 

To test:
- Smoke test the app
- logout and verify you can log in with self hosted sites only
- logout and verify you can login with your wp.com account


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
