### PR TITLE
UL&S: Fix minor tracking issues

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -146,7 +146,7 @@ class UnifiedLoginTracker
         SUCCESS("success"),
         HELP("help"),
         TWO_FACTOR_AUTHENTICATION("2fa"),
-        SHOW_EMAIL_HINTS("SHOW_EMAIL_HINTS")
+        SHOW_EMAIL_HINTS("show_email_hints")
     }
 
     enum class Click(val value: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -146,7 +146,8 @@ class UnifiedLoginTracker
         SUCCESS("success"),
         HELP("help"),
         TWO_FACTOR_AUTHENTICATION("2fa"),
-        SHOW_EMAIL_HINTS("show_email_hints")
+        SHOW_EMAIL_HINTS("show_email_hints"),
+        PASSWORD_CHALLENGE("password_challenge")
     }
 
     enum class Click(val value: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -129,6 +129,7 @@ class UnifiedLoginTracker
         PROLOGUE("prologue"),
         WORDPRESS_COM("wordpress_com"),
         GOOGLE_LOGIN("google_login"),
+        SMART_LOCK_LOGIN("smart_lock_login"),
         LOGIN_MAGIC_LINK("login_magic_link"),
         LOGIN_PASSWORD("login_password"),
         LOGIN_SITE_ADDRESS("login_site_address"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -56,6 +56,7 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     @Override
     public void trackLoginAutofillCredentialsFilled() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_AUTOFILL_CREDENTIALS_FILLED);
+        mUnifiedLoginTracker.track(Flow.SMART_LOCK_LOGIN, Step.START);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -135,9 +135,13 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
-    public void trackPasswordFormViewed() {
+    public void trackPasswordFormViewed(boolean isSocialChallenge) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_PASSWORD_FORM_VIEWED);
-        mUnifiedLoginTracker.track(Flow.LOGIN_PASSWORD, Step.START);
+        if (isSocialChallenge) {
+            mUnifiedLoginTracker.track(Flow.GOOGLE_LOGIN, Step.PASSWORD_CHALLENGE);
+        } else {
+            mUnifiedLoginTracker.track(Flow.LOGIN_PASSWORD, Step.START);
+        }
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -380,7 +380,9 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
     }
 
     private void show2FaError(String message) {
-        mAnalyticsListener.trackFailure(message);
+        if (!TextUtils.isEmpty(message)) {
+            mAnalyticsListener.trackFailure(message);
+        }
         m2FaInput.setError(message);
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.kt
@@ -23,7 +23,7 @@ interface LoginAnalyticsListener {
     fun trackLoginMagicLinkOpenEmailClientViewed()
     fun trackMagicLinkRequested()
     fun trackMagicLinkRequestFormViewed()
-    fun trackPasswordFormViewed()
+    fun trackPasswordFormViewed(isSocialChallenge: Boolean)
     fun trackSignupCanceled()
     fun trackSignupEmailButtonTapped()
     fun trackSignupEmailToLogin()

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -215,7 +215,7 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
         super.onActivityCreated(savedInstanceState);
 
         if (savedInstanceState == null) {
-            mAnalyticsListener.trackPasswordFormViewed();
+            mAnalyticsListener.trackPasswordFormViewed(mIsSocialLogin);
 
             if (!TextUtils.isEmpty(mPassword)) {
                 mPasswordInput.setText(mPassword);


### PR DESCRIPTION
This PR fixes three minor issues/inconsistencies with UL&S tracking:

1. **Smart Lock flow:** We were not updating the `flow` parameter value when the user selected an account from the Smart Lock dialog, so it stayed with value `prologue` until the end. This PR adds another flow value of `smart_lock_login` that is analogous to what we have in WPiOS with `icloud_keychain_login`.
1. **Google Login password challenge step:** We were not keeping the `flow` parameter value when the user logged in with a disconnected Google account*, so its value changed from `google_login` to `login_password`. This PR keeps the `flow` parameter value of `google_login` and adds a new step value like `password_challenge`.
\* By “disconnected Google account” I mean an account that matches an existing WordPress.com account (uses the same email), but that is currently not connected to it (as shown in the [Social Login page](https://wordpress.com/me/security/social-login)).
1. **2FA false failures:** We were tracking unnecessary failures on the 2FA screen when first opening it and when changing the text field value.

LoginFlow PR: wordpress-mobile/WordPress-Login-Flow-Android/pull/44

## To test

**1. Smart Lock flow:**

0. Clear app data.
1. On the Prologue screen, notice the Smart Lock dialog*.
1. Pick any valid WordPress credentials.
1. Using `logcat`, make sure you see some events like the following:
    - `unified_login_step, Properties: {"source":"default","flow":"smart_lock_login","step":"2fa"}` (if you have 2FA enabled)
    - `unified_login_step, Properties: {"source":"default","flow":"smart_lock_login","step":"success"}` (after the Epilogue screen is shown)

\* Make sure you’re using a device that has a Google account with one or more saved WordPress credentials.

**2. Google Login password challenge step:**

0. Clear app data.
1. On the Prologue screen, if the Smart Lock dialog appears, dismiss it.
1. Tap **Continue with WordPress.com**.
1. On the Get Started screen, tap **Continue with Google**.
1. On the Google Sign-In dialog, pick a Google account that _is associated_ but currently _not connected_ with a 2FA WordPress.com account.
1. Notice the Password screen.
1. Using `logcat`, make sure you see an event like the following:
    - `unified_login_step, Properties: {"source":"default","flow":"google_login","step":"password_challenge"}`

Note: to connect/disconnect a Google account, go to the [Social Login page](https://wordpress.com/me/security/social-login).

**3. 2FA false failures:**

0. Clear app data.
1. On the Prologue screen, if the Smart Lock dialog appears, dismiss it.
1. Tap **Continue with WordPress.com**.
1. On the Get Started screen, enter an email address that _is_ associated with a 2FA WordPress.com account.
1. Tap **Continue**.
1. Notice the Login Magic Link screen.
1. Tap **Or type your password**.
1. Notice the Email/Password screen.
1. Enter the WordPress.com account password.
1. Tap **Continue**.
1. Notice the 2FA screen.
1. Type a verification code.
1. Using `logcat`, make sure you _don't see_ any events like the following:
    - `unified_login_failure, Properties: {"source":"default","flow":"login_password","step":"2fa"}`

Note: to enable/disable two-factor authentication, go to the [Two-Step Authentication page](https://wordpress.com/me/security/two-step).

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
