### PR TITLE
Sync 15.6 with develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,6 @@
  
 15.6
 -----
-* [***] Block Editor: Fixed empty text fields on RTL layout. Now they are selectable and placeholders are visible.
 * [**] Block Editor: Add settings to allow changing column widths
 * [**] Block Editor: Media editing support in Gallery block.
 * [*] Block Editor: Improved logic for creating undo levels.

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -135,7 +135,7 @@ class WPMainActivityViewModel @Inject constructor(
         }
     }
 
-    private fun disableTooltip(site: SiteModel) {
+    private fun disableTooltip(site: SiteModel?) {
         appPrefsWrapper.setMainFabTooltipDisabled(true)
 
         val oldState = _fabUiState.value
@@ -148,7 +148,7 @@ class WPMainActivityViewModel @Inject constructor(
         }
     }
 
-    fun onFabClicked(site: SiteModel, shouldShowQuickStartFocusPoint: Boolean = false) {
+    fun onFabClicked(site: SiteModel?, shouldShowQuickStartFocusPoint: Boolean = false) {
         appPrefsWrapper.setMainFabTooltipDisabled(true)
         setMainFabUiState(true, site)
 
@@ -177,15 +177,15 @@ class WPMainActivityViewModel @Inject constructor(
         }
     }
 
-    fun onPageChanged(showFab: Boolean, site: SiteModel) {
+    fun onPageChanged(showFab: Boolean, site: SiteModel?) {
         setMainFabUiState(showFab, site)
     }
 
-    fun onTooltipTapped(site: SiteModel) {
+    fun onTooltipTapped(site: SiteModel?) {
         disableTooltip(site)
     }
 
-    fun onFabLongPressed(site: SiteModel) {
+    fun onFabLongPressed(site: SiteModel?) {
         disableTooltip(site)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -193,7 +193,7 @@ class WPMainActivityViewModel @Inject constructor(
         _startLoginFlow.value = Event(true)
     }
 
-    fun onResume(site: SiteModel) {
+    fun onResume(site: SiteModel?) {
         val oldState = _fabUiState.value
         oldState?.let {
             _fabUiState.value = MainFabUiState(


### PR DESCRIPTION
Merges the latest changes from `release/15.6` into develop. This is mostly to add the changes from #12783 so that login e2e tests can be fixed in `develop`. An updated beta will be released in a few days (see https://github.com/wordpress-mobile/WordPress-Android/pull/12783#issuecomment-679938779).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
