### PR TITLE
Issue/12028 fix quick start

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -125,7 +125,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
                         updateTabs(it)
                     }
                 }
-                app_bar.setExpanded(uiState.appBarExpanded)
+                app_bar.setExpanded(uiState.appBarExpanded, false)
                 uiHelpers.updateVisibility(tab_layout, uiState.tabLayoutVisible)
                 searchMenuItem?.isVisible = uiState.searchIconVisible
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -492,7 +492,7 @@ public class ReaderPostListFragment extends Fragment
 
     private void showSnackbar(SnackbarMessageHolder holder) {
         WPSnackbar snackbar = WPSnackbar.make(
-                requireView(),
+                getSnackbarParent(),
                 mUiHelpers.getTextOfUiString(requireContext(), holder.getMessage()),
                 Snackbar.LENGTH_LONG
         );
@@ -894,7 +894,7 @@ public class ReaderPostListFragment extends Fragment
                     R.string.quick_start_dialog_follow_sites_message_short_search,
                     R.drawable.ic_search_white_24dp);
 
-            WPDialogSnackbar snackbar = WPDialogSnackbar.make(requireActivity().findViewById(R.id.coordinator), title,
+            WPDialogSnackbar snackbar = WPDialogSnackbar.make(getSnackbarParent(), title,
                     getResources().getInteger(R.integer.quick_start_snackbar_duration_ms));
 
             ((WPMainActivity) getActivity()).showQuickStartSnackBar(snackbar);


### PR DESCRIPTION
Parent issue #12028

This PR
- disables Reader enter animation (appbar.setExpanded) as we don't use this animation on other bottom navigation destinations
- fixes Snackbar's parent in ReaderPostListFragment to ensure the snackbar appears above the bottom navigation component

To test:
1. Make sure you don't follow any tags
2. Restart the app
3. CLick on my Site
4. Click on "Switch Site"
5. Click on the "+" icon in the top right corner
6. Go through the site creation wizard
7. After you create a site, click on "Accept" button on the QuickStart dialog
8. Click on Grow your audience
9. Select "Follow other sites"
10. Click on "Reader"
11. Pick some topics
12. Click on Done
13. Notice a quick start snackbar is shown and it appears above (y-axis) the bottom navigation bar

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
