### PR TITLE
Safe cast site model in PhotoPickerFragment.kt

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -105,7 +105,7 @@ class PhotoPickerFragment : Fragment() {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
         browserType = requireArguments().getSerializable(MediaBrowserActivity.ARG_BROWSER_TYPE) as MediaBrowserType
-        site = requireArguments().getSerializable(WordPress.SITE) as SiteModel
+        site = requireArguments().getSerializable(WordPress.SITE) as? SiteModel
         if (savedInstanceState != null) {
             val savedLastTappedIconName = savedInstanceState.getString(KEY_LAST_TAPPED_ICON)
             lastTappedIcon = savedLastTappedIconName?.let { PhotoPickerIcon.valueOf(it) }

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -116,7 +116,7 @@ Language: ar
     <string name="create_account">إنشاء حساب</string>
     <string name="send_link_by_email">إرسال الرابط عبر البريد الإلكتروني</string>
     <string name="login_promo_text_unlock_the_power">أطلق العنان لقدرات منشئ المواقع الأكثر مرونة.</string>
-    <string name="login_promo_title_37_percent">37% من مواقع الويب مبنية على ووردبريس.</string>
+    <string name="login_promo_title_37_percent">37\% من مواقع الويب مبنية على ووردبريس.</string>
     <string name="reset_your_password">إعادة تعيين كلمة المرور الخاصة بك</string>
     <string name="reader_error_request_failed_title">حدثت مشكلة أثناء معالجة الطلب. يرجى المحاولة مرة أخرى لاحقاً.</string>
     <string name="quick_start_list_update_site_title_subtitle">حدِّد اسمًا لموقعك يعكس هويته وموضوعه. الاعتماد على الانطباعات الأولى!</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -116,7 +116,7 @@ Language: de
     <string name="create_account">Konto erstellen</string>
     <string name="send_link_by_email">Link per E-Mail senden</string>
     <string name="login_promo_text_unlock_the_power">Nutze alle Vorteile des flexibelsten Website-Baukastens.</string>
-    <string name="login_promo_title_37_percent">37 % des Webs wurde mit WordPress erstellt.</string>
+    <string name="login_promo_title_37_percent">37\% des Webs wurde mit WordPress erstellt.</string>
     <string name="reset_your_password">Dein Passwort zurücksetzen</string>
     <string name="reader_error_request_failed_title">Bei der Bearbeitung der Anfrage ist ein Problem aufgetreten. Bitte versuche es später erneut.</string>
     <string name="quick_start_list_update_site_title_subtitle">Wähle einen Namen für deine Website, der am besten zu ihrer Persönlichkeit und Ausrichtung passt. Erste Eindrücke zählen!</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -36,7 +36,7 @@ Language: en_CA
     <string name="create_account">Create account</string>
     <string name="send_link_by_email">Send link by email</string>
     <string name="login_promo_text_unlock_the_power">Unlock the power of the most flexible website builder.</string>
-    <string name="login_promo_title_37_percent">37% of the web is built on WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% of the web is built on WordPress.</string>
     <string name="reset_your_password">Reset your password</string>
     <string name="quick_start_list_update_site_title_subtitle">Give your site a name that reflects its personality and topic. First impressions count!</string>
     <string name="quick_start_list_update_site_title_title">Set your site title</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -116,7 +116,7 @@ Language: en_GB
     <string name="create_account">Create account</string>
     <string name="send_link_by_email">Send link by email</string>
     <string name="login_promo_text_unlock_the_power">Unlock the power of the most flexible website builder.</string>
-    <string name="login_promo_title_37_percent">37% of the web is built on WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% of the web is built on WordPress.</string>
     <string name="reset_your_password">Reset your password</string>
     <string name="reader_error_request_failed_title">There was a problem handling the request. Please try again later.</string>
     <string name="quick_start_list_update_site_title_subtitle">Give your site a name that reflects its personality and topic. First impressions count!</string>

--- a/WordPress/src/main/res/values-es-rMX/strings.xml
+++ b/WordPress/src/main/res/values-es-rMX/strings.xml
@@ -116,7 +116,7 @@ Language: es_MX
     <string name="create_account">Crear una cuenta</string>
     <string name="send_link_by_email">Enviar el enlace por correo electrónico</string>
     <string name="login_promo_text_unlock_the_power">Desbloquea el poder del creador de webs más flexible.</string>
-    <string name="login_promo_title_37_percent">El 37 % de la web está creada con WordPress.</string>
+    <string name="login_promo_title_37_percent">El 37\% de la web está creada con WordPress.</string>
     <string name="reset_your_password">Restablecer tu contraseña</string>
     <string name="reader_error_request_failed_title">Ha habido un problema al gestionar la solicitud. Por favor, inténtalo de nuevo más tarde.</string>
     <string name="quick_start_list_update_site_title_subtitle">Dale a tu sitio un nombre que refleje su personalidad y temática. ¡Las primeras impresiones cuentan!</string>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -110,7 +110,7 @@ Language: es_VE
     <string name="continue_google_button_suffix">Continuar con Google</string>
     <string name="login_or">o</string>
     <string name="reset_your_password">Restablecer tu contraseña</string>
-    <string name="login_promo_title_37_percent">El 37 % de la web está creada con WordPress.</string>
+    <string name="login_promo_title_37_percent">El 37\% de la web está creada con WordPress.</string>
     <string name="login_promo_text_unlock_the_power">Desbloquea el poder del creador de webs más flexible.</string>
     <string name="send_link_by_email">Enviar el enlace por correo electrónico</string>
     <string name="create_account">Crear una cuenta</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -116,7 +116,7 @@ Language: es
     <string name="create_account">Crear una cuenta</string>
     <string name="send_link_by_email">Enviar el enlace por correo electrónico</string>
     <string name="login_promo_text_unlock_the_power">Desbloquea el poder del creador de webs más flexible.</string>
-    <string name="login_promo_title_37_percent">El 37 % de la web está creada con WordPress.</string>
+    <string name="login_promo_title_37_percent">El 37\% de la web está creada con WordPress.</string>
     <string name="reset_your_password">Restablecer tu contraseña</string>
     <string name="reader_error_request_failed_title">Ha habido un problema al gestionar la solicitud. Por favor, inténtalo de nuevo más tarde.</string>
     <string name="quick_start_list_update_site_title_subtitle">Dale a tu sitio un nombre que refleje su personalidad y temática. ¡Las primeras impresiones cuentan!</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -94,7 +94,7 @@ Language: fr
     <string name="create_account">Créer un compte</string>
     <string name="send_link_by_email">Envoyer un lien par e-mail</string>
     <string name="login_promo_text_unlock_the_power">Libérez la puissance de l’outil de création de sites Web le plus flexible.</string>
-    <string name="login_promo_title_37_percent">37 % du Web est intégré à WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% du Web est intégré à WordPress.</string>
     <string name="reset_your_password">Réinitialiser votre mot de passe</string>
     <string name="quick_start_list_update_site_title_subtitle">Donnez à votre site un nom qui reflète sa personnalité et son thème. La première impression est importante !</string>
     <string name="quick_start_list_update_site_title_title">Définir un titre pour votre site</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -116,7 +116,7 @@ Language: he_IL
     <string name="create_account">ליצור חשבון</string>
     <string name="send_link_by_email">לשלוח את הקישור באימייל</string>
     <string name="login_promo_text_unlock_the_power">לעבוד עם בונה האתרים הכי הגמיש שיש.</string>
-    <string name="login_promo_title_37_percent">37% מהאתרים ברשת בנויים על הפלטפורמה של WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% מהאתרים ברשת בנויים על הפלטפורמה של WordPress.</string>
     <string name="reset_your_password">יש לאפס את הסיסמה שלך</string>
     <string name="quick_start_list_update_site_title_subtitle">כדאי לתת לאתר שלך שם שמשקף את האישיות שלו והנושאים שמוצגים בו. הרושם הראשוני חשוב!</string>
     <string name="quick_start_list_update_site_title_title">להגדיר את שם האתר שלך</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -116,7 +116,7 @@ Language: id
     <string name="create_account">Buat akun</string>
     <string name="send_link_by_email">Kirim tautan lewat email</string>
     <string name="login_promo_text_unlock_the_power">Kenali kekuatan dari pembuat situs web yang paling andal.</string>
-    <string name="login_promo_title_37_percent">37% dari situs web dikembangkan dari WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% dari situs web dikembangkan dari WordPress.</string>
     <string name="reset_your_password">Reset kata sandi</string>
     <string name="quick_start_list_update_site_title_subtitle">Berikan nama situs yang mencerminkan karakteristik dan topik situs Anda. Kesan pertama sangat berarti!</string>
     <string name="quick_start_list_update_site_title_title">Atur judul situs Anda</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -116,7 +116,7 @@ Language: it
     <string name="create_account">Crea account</string>
     <string name="send_link_by_email">Invia link tramite e-mail</string>
     <string name="login_promo_text_unlock_the_power">Libera tutto il potenziale del costruttore di siti più flessibile al mondo.</string>
-    <string name="login_promo_title_37_percent">Il 37% del web viene costruito con WordPress.</string>
+    <string name="login_promo_title_37_percent">Il 37\% del web viene costruito con WordPress.</string>
     <string name="reset_your_password">Reimposta la password</string>
     <string name="quick_start_list_update_site_title_subtitle">Dai al tuo sito un nome che rifletta la tua personalità e l\'argomento. La prima impressione conta.</string>
     <string name="quick_start_list_update_site_title_title">Imposta il titolo del sito</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -116,7 +116,7 @@ Language: ja_JP
     <string name="create_account">アカウントを作成</string>
     <string name="send_link_by_email">リンクをメールで送信</string>
     <string name="login_promo_text_unlock_the_power">柔軟性の高いサイトビルダー機能を活用しましょう。</string>
-    <string name="login_promo_title_37_percent">Web の37% が WordPress で構築されています。</string>
+    <string name="login_promo_title_37_percent">Web の37\% が WordPress で構築されています。</string>
     <string name="reset_your_password">パスワードをリセット</string>
     <string name="quick_start_list_update_site_title_subtitle">サイトにその特徴とトピックがわかるような名前を付けてください。 第一印象が大事です。</string>
     <string name="quick_start_list_update_site_title_title">サイトのタイトルを設定</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -110,7 +110,7 @@ Language: ko_KR
     <string name="continue_google_button_suffix">Google로 계속하기</string>
     <string name="login_or">또는</string>
     <string name="reset_your_password">비밀번호 재설정하기</string>
-    <string name="login_promo_title_37_percent">웹의 37%가 워드프레스로 만들어졌습니다.</string>
+    <string name="login_promo_title_37_percent">웹의 37\%가 워드프레스로 만들어졌습니다.</string>
     <string name="login_promo_text_unlock_the_power">가장 유연한 웹사이트 제작 도구의 능력을 직접 경험해보세요.</string>
     <string name="send_link_by_email">이메일로 링크 보내기</string>
     <string name="create_account">계정 만들기</string>

--- a/WordPress/src/main/res/values-nb/strings.xml
+++ b/WordPress/src/main/res/values-nb/strings.xml
@@ -89,7 +89,7 @@ Language: nb_NO
     <string name="create_account">Opprett konto</string>
     <string name="send_link_by_email">Send lenke med e-post</string>
     <string name="login_promo_text_unlock_the_power">Lås opp kraften til en mest fleksible nettstedsbyggeren.</string>
-    <string name="login_promo_title_37_percent">37% av alle nettsteder er bygget på WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% av alle nettsteder er bygget på WordPress.</string>
     <string name="reset_your_password">Tilbakestill ditt passord</string>
     <string name="quick_start_list_update_site_title_subtitle">Gi ditt nettsted et navn som reflekterer des personlighet og emne Førsteinntrykket teller!</string>
     <string name="quick_start_list_update_site_title_title">Bestem din nettstedstittel</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -116,7 +116,7 @@ Language: nl
     <string name="create_account">Account aanmaken</string>
     <string name="send_link_by_email">Link per e-mail verzenden</string>
     <string name="login_promo_text_unlock_the_power">Ontgrendel de kracht van de meest flexibele sitebouwer.</string>
-    <string name="login_promo_title_37_percent">37% van het web is gebouwd op WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% van het web is gebouwd op WordPress.</string>
     <string name="reset_your_password">Stel je wachtwoord opnieuw in</string>
     <string name="reader_error_request_failed_title">Er is een probleem opgetreden bij het verwerken van de aanvraag. Probeer het later opnieuw.</string>
     <string name="quick_start_list_update_site_title_subtitle">Geef je site een naam die zijn personaliteit en onderwerp reflecteerd. De eerste indruk telt!</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -116,7 +116,7 @@ Language: pl
     <string name="create_account">Utwórz konto</string>
     <string name="send_link_by_email">Wyślij odnośnik przez email</string>
     <string name="login_promo_text_unlock_the_power">Wykorzystaj możliwości najbardziej elastycznego kreatora witryny.</string>
-    <string name="login_promo_title_37_percent">37% internetu jest oparte na WordPressie.</string>
+    <string name="login_promo_title_37_percent">37\% internetu jest oparte na WordPressie.</string>
     <string name="reset_your_password">Zresetuj hasło</string>
     <string name="reader_error_request_failed_title">Wystąpił błąd podczas obsługi tego zapytania. Proszę spróbować ponownie później.</string>
     <string name="quick_start_list_update_site_title_title">Ustaw tytuł witryny</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -116,7 +116,7 @@ Language: pt_BR
     <string name="create_account">Criar conta</string>
     <string name="send_link_by_email">Enviar link por e-mail</string>
     <string name="login_promo_text_unlock_the_power">Descubra o poder do criador de sites mais flexível.</string>
-    <string name="login_promo_title_37_percent">37% da internet é construída com o WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% da internet é construída com o WordPress.</string>
     <string name="reset_your_password">Redefinir sua senha</string>
     <string name="reader_error_request_failed_title">Houve um problema ao completar a solicitação. Tente novamente mais tarde.</string>
     <string name="quick_start_list_update_site_title_subtitle">Dê ao seu site um nome que reflita sua personalidade e tópico. As primeiras impressões contam!</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -116,7 +116,7 @@ Language: ro
     <string name="create_account">Creează un cont</string>
     <string name="send_link_by_email">Trimite legătura prin email</string>
     <string name="login_promo_text_unlock_the_power">Deblochează puterea celui mai flexibil constructor de situri web.</string>
-    <string name="login_promo_title_37_percent">37% din web este construit cu WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% din web este construit cu WordPress.</string>
     <string name="reset_your_password">Resetează-ți parola</string>
     <string name="reader_error_request_failed_title">A fost o problemă la gestionarea cererii. Te rog reîncearcă mai târziu.</string>
     <string name="quick_start_list_update_site_title_subtitle">Dă-i sitului un nume care să-i reflecte personalitatea și subiectul (tema). Prima impresie este foarte importantă!</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -116,7 +116,7 @@ Language: ru
     <string name="create_account">Создать учётную запись</string>
     <string name="send_link_by_email">Прислать ссылку по электронной почте</string>
     <string name="login_promo_text_unlock_the_power">Раскройте потенциал самой гибкой платформы для создания сайтов.</string>
-    <string name="login_promo_title_37_percent">37% всех сайтов сети основаны на WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% всех сайтов сети основаны на WordPress.</string>
     <string name="reset_your_password">Сбросить пароль</string>
     <string name="reader_error_request_failed_title">При выполнении запроса возникла проблема. Повторите попытку позже.</string>
     <string name="quick_start_list_update_site_title_subtitle">Первое впечатление важно! Назовите свой сайт так, как это отразит его индивидуальность и содержание.</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -114,7 +114,7 @@ Language: sq_AL
     <string name="create_account">Krijo llogari</string>
     <string name="send_link_by_email">Dërgoje lidhjen me email</string>
     <string name="login_promo_text_unlock_the_power">Çlironi fuqinë e krijuesit më të zhdërvjellët të sajteve.</string>
-    <string name="login_promo_title_37_percent">37% e web-it ngrihet mbi WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% e web-it ngrihet mbi WordPress.</string>
     <string name="reset_your_password">Ricaktoni fjalëkalimi tuaj</string>
     <string name="reader_error_request_failed_title">Pati një problem me trajtimin e kërkesës. Ju lutemi, riprovoni.</string>
     <string name="quick_start_list_update_site_title_subtitle">Jepini sajtit tuaj një emër që pasqyron personalitetin dhe subjektin e tij. Përshtypja e parë ka vlerë!</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -116,7 +116,7 @@ Language: sv_SE
     <string name="create_account">Skapa konto</string>
     <string name="send_link_by_email">Skicka länk via e-post</string>
     <string name="login_promo_text_unlock_the_power">Ta vara på kraften hos den mest flexibla webbplatsskaparen.</string>
-    <string name="login_promo_title_37_percent">37&amp;nbsp;% av webben är byggd på WordPress.</string>
+    <string name="login_promo_title_37_percent">37\% av webben är byggd på WordPress.</string>
     <string name="reset_your_password">Återställ ditt lösenord</string>
     <string name="reader_error_request_failed_title">Ett problem inträffade när din begäran skulle behandlas. Försök igen senare.</string>
     <string name="quick_start_list_update_site_title_subtitle">Ge din webbplats ett namn som återspeglar dess personlighet och ämne. Första intrycket har betydelse!</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -110,7 +110,6 @@ Language: tr
     <string name="create_account">Hesap oluştur</string>
     <string name="get_started">Başlayın</string>
     <string name="check_email">E-postayı kontrol et</string>
-    <string name="login_promo_title_37_percent">Web\'in %37\'si WordPress üzerine kurulmuştur.</string>
     <string name="send_link_by_email">Bağlantıyı e-postayla gönder</string>
     <string name="or_type_your_password">Veya parolanızı yazın</string>
     <string name="enter_email_to_continue_wordpress_com">Giriş yapmak veya bir WordPress.com hesabı oluşturmak için e-posta adresinizi girin.</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -114,7 +114,7 @@ Language: zh_CN
     <string name="create_account">创建帐户</string>
     <string name="send_link_by_email">通过电子邮件发送链接</string>
     <string name="login_promo_text_unlock_the_power">发挥最灵活的网站生成器的强大功能。</string>
-    <string name="login_promo_title_37_percent">网上有 37% 的内容是在 WordPress 上构建的。</string>
+    <string name="login_promo_title_37_percent">网上有 37\% 的内容是在 WordPress 上构建的。</string>
     <string name="reset_your_password">重置密码</string>
     <string name="quick_start_list_update_site_title_subtitle">为您的站点提供一个反映其个性和主题的名称。 第一印象很重要！</string>
     <string name="quick_start_list_update_site_title_title">设置您的站点标题</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -116,7 +116,7 @@ Language: zh_TW
     <string name="create_account">建立帳號</string>
     <string name="send_link_by_email">以電子郵件傳送連結</string>
     <string name="login_promo_text_unlock_the_power">最具彈性、功能最強大的網站建置系統，釋放無限可能。</string>
-    <string name="login_promo_title_37_percent">37% 的網站皆選用 WordPress 建置。</string>
+    <string name="login_promo_title_37_percent">37\% 的網站皆選用 WordPress 建置。</string>
     <string name="reset_your_password">重設密碼</string>
     <string name="quick_start_list_update_site_title_subtitle">為網站取一個能反映出自我風格和主題的名稱。 第一印象很重要！</string>
     <string name="quick_start_list_update_site_title_title">設定你的網站標題</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -116,7 +116,7 @@ Language: zh_TW
     <string name="create_account">建立帳號</string>
     <string name="send_link_by_email">以電子郵件傳送連結</string>
     <string name="login_promo_text_unlock_the_power">最具彈性、功能最強大的網站建置系統，釋放無限可能。</string>
-    <string name="login_promo_title_37_percent">37% 的網站皆選用 WordPress 建置。</string>
+    <string name="login_promo_title_37_percent">37\% 的網站皆選用 WordPress 建置。</string>
     <string name="reset_your_password">重設密碼</string>
     <string name="quick_start_list_update_site_title_subtitle">為網站取一個能反映出自我風格和主題的名稱。 第一印象很重要！</string>
     <string name="quick_start_list_update_site_title_title">設定你的網站標題</string>


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Android/issues/12696

This crash is caused by not safe casting SiteModel which could be nullable. 

Steps to reproduce:
- Start with a clean install
- Create a new account
- On the signup confirmation click on Add Avatar
- The app crashes

To test:
- Start with a clean install
- Create a new account
- On the signup confirmation click on Add Avatar
- The app doesn't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
