### PR TITLE
Enable Slack notification for connected tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,7 +391,7 @@ workflows:
       - Connected Tests:
           requires:
             - gutenberg-bundle-build
-          post-to-slack: false
+          post-to-slack: true
           # Always run connected tests on develop and release branches
           filters:
             branches:


### PR DESCRIPTION
We temporarily disabled Slack notifications for connected tests in #12285 due to Firebase issues. The tests have been working without issues for the last little while, so this PR enables the notifications again.