### PR TITLE
Login: Enable autofill framework for email and password fields

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -224,7 +224,7 @@ dependencies {
 
     implementation 'com.android.volley:volley:1.1.1'
     implementation 'com.google.firebase:firebase-messaging:20.1.5'
-    implementation 'com.google.android.gms:play-services-auth:18.0.0'
+    implementation 'com.google.android.gms:play-services-auth:18.1.0'
     implementation 'com.google.android.gms:play-services-places:17.0.0'
     implementation 'com.android.installreferrer:installreferrer:1.0'
     implementation 'com.github.chrisbanes.photoview:library:1.2.4'

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation "androidx.core:core-ktx:$kotlin_ktx_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    api 'com.google.android.gms:play-services-auth:15.0.1'
+    api 'com.google.android.gms:play-services-auth:18.1.0'
 
     // Share FluxC version from host project if defined, otherwise fallback to default
     if (project.hasProperty("fluxCVersion")) {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -5,6 +5,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
+import android.os.Build;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.Html;
@@ -14,6 +15,7 @@ import android.util.Patterns;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.view.autofill.AutofillManager;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -193,8 +195,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             public void onFocusChange(View view, boolean hasFocus) {
                 if (hasFocus && !mIsDisplayingEmailHints && !mHasDismissedEmailHints) {
                     mAnalyticsListener.trackSelectEmailField();
-                    mIsDisplayingEmailHints = true;
-                    getEmailHints();
+                    showHintPickerDialogIfNeeded();
                 }
             }
         });
@@ -204,8 +205,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 mAnalyticsListener.trackSelectEmailField();
                 if (!mIsDisplayingEmailHints && !mHasDismissedEmailHints) {
                     mAnalyticsListener.trackSelectEmailField();
-                    mIsDisplayingEmailHints = true;
-                    getEmailHints();
+                    showHintPickerDialogIfNeeded();
                 }
             }
         });
@@ -656,7 +656,22 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         AppLog.d(T.NUX, LOG_TAG + ": Google API client connection suspended");
     }
 
-    public void getEmailHints() {
+    private void showHintPickerDialogIfNeeded() {
+        // If autofill is available and enabled, we favor the active autofill service over the hint picker dialog.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final AutofillManager autofillManager = requireContext().getSystemService(AutofillManager.class);
+            if (autofillManager != null && autofillManager.isEnabled()) {
+                AppLog.d(T.NUX, LOG_TAG + ": Autofill framework is enabled. Disabling hint picker dialog.");
+                return;
+            }
+        }
+
+        AppLog.d(T.NUX, LOG_TAG + ": Autofill framework is unavailable or disabled. Showing hint picker dialog.");
+
+        showHintPickerDialog();
+    }
+
+    private void showHintPickerDialog() {
         GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
         if (getContext() == null
             || googleApiAvailability.isGooglePlayServicesAvailable(getContext()) != ConnectionResult.SUCCESS) {
@@ -674,6 +689,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
 
         try {
             startIntentSenderForResult(intent.getIntentSender(), EMAIL_CREDENTIALS_REQUEST_CODE, null, 0, 0, 0, null);
+            mIsDisplayingEmailHints = true;
         } catch (IntentSender.SendIntentException exception) {
             AppLog.d(T.NUX, LOG_TAG + "Could not start email hint picker" + exception);
         } catch (ActivityNotFoundException exception) {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
@@ -77,6 +77,13 @@ public class WPLoginInputRow extends RelativeLayout {
                     mEditText.setHint(hint);
                     // Makes the hint transparent, so the TalkBack can read it, when the field is prefilled
                     mEditText.setHintTextColor(getResources().getColor(android.R.color.transparent));
+
+                    // Passes autofill hints values forward to child views
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        if (isImportantForAutofill()) {
+                            mEditText.setAutofillHints(getAutofillHints());
+                        }
+                    }
                 }
                 if (a.hasValue(R.styleable.wpLoginInputRow_passwordToggleEnabled)) {
                     mTextInputLayout.setEndIconMode(TextInputLayout.END_ICON_PASSWORD_TOGGLE);

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
@@ -29,10 +29,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_extra_large"
+        android:autofillHints="password"
         android:hint="@string/password"
-        android:importantForAutofill="noExcludeDescendants"
+        android:importantForAutofill="yes"
         android:inputType="textPassword"
-        app:passwordToggleEnabled="true" />
+        app:passwordToggleEnabled="true"
+        tools:ignore="UnusedAttribute" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/login_reset_password"

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
@@ -16,15 +16,18 @@
         android:layout_marginStart="@dimen/margin_extra_large"
         tools:text="@string/enter_email_wordpress_com" />
 
+    <!-- Even though this field only accepts email addresses, we also include "username" as an
+    autofill hint value to ensure that the default autofill service works well with it -->
     <org.wordpress.android.login.widgets.WPLoginInputRow
         android:id="@+id/login_email_row"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_extra_large"
         android:layout_marginStart="@dimen/margin_extra_large"
+        android:autofillHints="emailAddress,username"
         android:hint="@string/email_address"
         android:imeOptions="actionNext"
-        android:importantForAutofill="noExcludeDescendants"
+        android:importantForAutofill="yes"
         android:inputType="textEmailAddress"
         tools:ignore="UnusedAttribute" />
 


### PR DESCRIPTION
This PR does 3 things:
- It bumps the Google Play Services authentication library version for both the main project and the Login-Flow library (I did some extensive testing on this and couldn't find any problems with it):
    - WPAndroid: `18.0.0` → `18.1.0`
    - Login-Flow: `15.0.1` → `18.1.0`
- It enables the use of the autofill framework for both the email and the password fields of the login flow (located on `LoginEmailFragment` and `LoginEmailPasswordFragment`, respectively) and updates the custom view we use for those fields (`WPLoginInputRow`) to make sure the values set by `autofillHints` are properly applied to its inner `EditText`.
- It updates `LoginEmailFragment` to check if autofill is enabled and if so, it disabled the Hint Picker dialog we used to show when the user tapped the email field.

Please check the following internal references for more info:
- pbArwn-Lb-p2 for more context on the motivation.
- pbArwn-Xo-p2 for more context on the exploration on this and the UX implications.

## To test

First, a disclaimer: due to the way the autofill framework works on Android, its behavior can be quite inconsistent when testing using different autofill services (a.k.a. password managers) from different devices with different Android versions, which can make it pretty hard to test, even under normal circumstances, but even more so given we have a layout that is considered an edge-case scenario, since it separates the email field from the password one by a couple of screens.

That said, we do have an expected behavior that we can use as a baseline here, which I'll detail below.

**Prerequisites**

1. Since we rely on Google APIs, make sure to build the app with a valid debug certificate. Internal ref on how to setup one: paqN3M-9M-p2
1. This step is optional, but recommended: use a device that is already linked to a Google account, but that doesn't have any WordPress credentials saved. If using an emulator, make sure it has Google APIs enabled. To check which credentials are currently saved in the Google account:
    - On your device, go to **Settings > System > Google > Autofill > Autofill with Google > Passwords**.
    - Search for WordPress or something like `beta.android.wordpress.org` if you're using a different build variant.

**Setup**

1. On your device, go to **Settings > System > Languages & input**.
1. If you can't see a **Tools** section, then you may need to tap **Advanced**.
1. Under the **Tools** section, go to **Autofill service > Autofill service** and select Google.
    - Note: you can test with other services later, but selecting Google now will allow us to test the baseline behavior I mentioned above.

**Test 1: Save dialog**

0. Clear app data.
1. On the Prologue screen, if the Smart Lock dialog appears, dismiss it.
1. Tap **Continue with WordPress.com**.
1. On the Get Started screen, tap the email field.
    - If you don't have any WordPress.com credentials saved on the Google account associated with the device, you should see hints like the ones shown in **Screenshot 2** below, which just lists emails associated with accounts in the device.
    - If you do have saved WordPress.com credentials, then you should see hints like in **Screenshot 3**.
1. Enter an email address that corresponds with an existing WordPress.com account but that is not saved in the Google account associated with the device yet.
1. Tap **Continue**.
1. Notice the Login Magic Link screen.
1. Tap **Or type your password**.
1. Notice the Email/Password screen.
1. Enter the WordPress.com account password.
1. Tap **Continue**.
1. On the Epilogue screen, you should see a dialog asking you to save your credentials, like shown in **Screenshot 1**.

**Test 2: Autofill hints**

Repeat the steps above and notice the following changes:

1. On the Prologue screen, the Smart Lock dialog should now appear and contain the credential you just saved.
1. On the Get Started screen, you should see a hint with the newly saved credential after tapping the email field, just like shown in **Screenshot 3**.
1. On the Email/Password screen, you should see a hint with the password for the newly saved credential, like in **Screenshot 4**.

**Reference screenshots**

| Screenshot 1 | Screenshot 2 | Screenshot 3 | Screenshot 4 |
| --- | --- | --- | --- |
| ![image1](https://user-images.githubusercontent.com/830056/91459166-b89aa800-e85c-11ea-9927-c9cea031935f.jpeg) | ![image2](https://user-images.githubusercontent.com/830056/91459159-b6d0e480-e85c-11ea-87f7-0e3519fbae1f.jpeg) | ![image3](https://user-images.githubusercontent.com/830056/91459170-b9333e80-e85c-11ea-9e83-c1bbff31b4e7.jpeg) | ![image4](https://user-images.githubusercontent.com/830056/91459174-b9cbd500-e85c-11ea-8e97-945fb8ee1a48.jpeg)

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.