### PR TITLE
Refactor request more check

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProvider.kt
@@ -60,12 +60,13 @@ class ReaderDiscoverDataProvider @Inject constructor(
     private var hasMoreCards = true
 
     private val _communicationChannel = MutableLiveData<Event<ReaderDiscoverCommunication>>()
-    val communicationChannel: LiveData<Event<ReaderDiscoverCommunication>> = _communicationChannel.perform {
-        if (it.peekContent().isRequestMore() && it.peekContent() !is Started) {
-            AppLog.w(READER, "reader discover load more cards task is finished")
-            isLoadMoreRequestInProgress = false
-        }
-    }
+    val communicationChannel: LiveData<Event<ReaderDiscoverCommunication>> = _communicationChannel
+            .perform {
+                if (it.peekContent().task == REQUEST_MORE && it.peekContent() !is Started) {
+                    AppLog.w(READER, "reader discover load more cards task is finished")
+                    isLoadMoreRequestInProgress = false
+                }
+            }
 
     fun start() {
         if (isStarted) return

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderRepositoryEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderRepositoryEvents.kt
@@ -1,6 +1,10 @@
 package org.wordpress.android.ui.reader.repository
 
+import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Error
+import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Started
+import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Success
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_MORE
 
 sealed class ReaderRepositoryEvent {
     object ReaderPostTableActionEnded : ReaderRepositoryEvent()
@@ -10,11 +14,28 @@ sealed class ReaderRepositoryEvent {
         val isAskingToLike: Boolean,
         val wpComUserId: Long
     ) : ReaderRepositoryEvent() {
-        class PostLikeSuccess(postId: Long, blogId: Long, isAskingToLike: Boolean, wpComUserId: Long) :
+        class PostLikeSuccess(
+            postId: Long,
+            blogId: Long,
+            isAskingToLike: Boolean,
+            wpComUserId: Long
+        ) :
                 PostLikeEnded(postId, blogId, isAskingToLike, wpComUserId)
-        class PostLikeFailure(postId: Long, blogId: Long, isAskingToLike: Boolean, wpComUserId: Long) :
+
+        class PostLikeFailure(
+            postId: Long,
+            blogId: Long,
+            isAskingToLike: Boolean,
+            wpComUserId: Long
+        ) :
                 PostLikeEnded(postId, blogId, isAskingToLike, wpComUserId)
-        class PostLikeUnChanged(postId: Long, blogId: Long, isAskingToLike: Boolean, wpComUserId: Long) :
+
+        class PostLikeUnChanged(
+            postId: Long,
+            blogId: Long,
+            isAskingToLike: Boolean,
+            wpComUserId: Long
+        ) :
                 PostLikeEnded(postId, blogId, isAskingToLike, wpComUserId)
     }
 }
@@ -39,5 +60,13 @@ sealed class ReaderDiscoverCommunication {
     sealed class Error(open val task: DiscoverTasks) : ReaderDiscoverCommunication() {
         data class NetworkUnavailable(override val task: DiscoverTasks) : Error(task)
         data class RemoteRequestFailure(override val task: DiscoverTasks) : Error(task)
+        data class ServiceNotStarted(override val task: DiscoverTasks) : Error(task)
     }
 }
+
+fun ReaderDiscoverCommunication.isRequestMore(): Boolean =
+        when (this) {
+            is Success -> this.task == REQUEST_MORE
+            is Started -> this.task == REQUEST_MORE
+            is Error -> this.task == REQUEST_MORE
+        }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderRepositoryEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderRepositoryEvents.kt
@@ -1,10 +1,6 @@
 package org.wordpress.android.ui.reader.repository
 
-import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Error
-import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Started
-import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Success
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks
-import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_MORE
 
 sealed class ReaderRepositoryEvent {
     object ReaderPostTableActionEnded : ReaderRepositoryEvent()
@@ -55,18 +51,12 @@ sealed class ReaderRepositoryCommunication {
 }
 
 sealed class ReaderDiscoverCommunication {
-    data class Started(val task: DiscoverTasks) : ReaderDiscoverCommunication()
-    data class Success(val task: DiscoverTasks) : ReaderDiscoverCommunication()
-    sealed class Error(open val task: DiscoverTasks) : ReaderDiscoverCommunication() {
-        data class NetworkUnavailable(override val task: DiscoverTasks) : Error(task)
-        data class RemoteRequestFailure(override val task: DiscoverTasks) : Error(task)
-        data class ServiceNotStarted(override val task: DiscoverTasks) : Error(task)
+    abstract val task: DiscoverTasks
+    data class Started(override val task: DiscoverTasks) : ReaderDiscoverCommunication()
+    data class Success(override val task: DiscoverTasks) : ReaderDiscoverCommunication()
+    sealed class Error : ReaderDiscoverCommunication() {
+        data class NetworkUnavailable(override val task: DiscoverTasks) : Error()
+        data class RemoteRequestFailure(override val task: DiscoverTasks) : Error()
+        data class ServiceNotStarted(override val task: DiscoverTasks) : Error()
     }
 }
-
-fun ReaderDiscoverCommunication.isRequestMore(): Boolean =
-        when (this) {
-            is Success -> this.task == REQUEST_MORE
-            is Started -> this.task == REQUEST_MORE
-            is Error -> this.task == REQUEST_MORE
-        }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/FetchDiscoverCardsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/FetchDiscoverCardsUseCase.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.reader.repository.usecases
 
 import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication
 import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Error.NetworkUnavailable
+import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Error.ServiceNotStarted
 import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Started
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverServiceStarter
@@ -18,8 +19,12 @@ class FetchDiscoverCardsUseCase @Inject constructor(
             return NetworkUnavailable(discoverTask)
         }
 
-        ReaderDiscoverServiceStarter.startService(contextProvider.getContext(), discoverTask)
+        val isStarted =
+                ReaderDiscoverServiceStarter.startService(contextProvider.getContext(), discoverTask)
 
-        return Started(discoverTask)
+        return if (isStarted)
+            Started(discoverTask)
+        else
+            ServiceNotStarted(discoverTask)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverServiceStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverServiceStarter.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.util.AppLog.T.READER
 object ReaderDiscoverServiceStarter {
     const val ARG_DISCOVER_TASK = "discover_task"
 
-    fun startService(context: Context, task: DiscoverTasks) {
+    fun startService(context: Context, task: DiscoverTasks): Boolean {
         if (VERSION.SDK_INT < VERSION_CODES.O) {
             val intent = Intent(context, ReaderDiscoverService::class.java)
             intent.putExtra(ARG_DISCOVER_TASK, task)
@@ -44,7 +44,9 @@ object ReaderDiscoverServiceStarter {
                 AppLog.i(READER, "reader discover service > job scheduled")
             } else {
                 AppLog.e(READER, "reader discover service > job could not be scheduled")
+                return false
             }
         }
+        return true
     }
 }


### PR DESCRIPTION
Parent issue #12039 

This PR handles the instance in which the Discover service job does not get scheduled, which could lead to a forever progress spinner. It also introduces an extension function on ReaderDiscoverCommunication to determine if the task returned is a REQUEST_MORE. This is then used in the communication channel to flip the `isLoadMoreRequestInProgress` to false.

To Test
- Fire up the app and ensure the FF flag is flipped on
- Tap reader -> discover
- Scroll down to trigger the loading more request
- View the logcat for READER: reader discover load more cards task is finished

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
