### PR TITLE
Filtering media items in picker to only show supported mime types

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 15.7
 -----
+* [*] Media: Fixed a bug that would allow you to pick unsupported media that then couldn't be uploaded.
  
 15.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/DeviceMediaListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/DeviceMediaListBuilder.kt
@@ -7,6 +7,7 @@ import android.provider.MediaStore.Images.Media
 import android.provider.MediaStore.Video
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.utils.MediaUtils
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.util.AppLog
@@ -64,12 +65,15 @@ class DeviceMediaListBuilder
             val idIndex = cursor.getColumnIndexOrThrow(ID_COL)
             while (cursor.moveToNext()) {
                 val id = cursor.getLong(idIndex)
+                val completeUri = Uri.withAppendedPath(baseUri, "" + id)
                 val item = PhotoPickerItem(
                         id,
-                        UriWrapper(Uri.withAppendedPath(baseUri, "" + id)),
+                        UriWrapper(completeUri),
                         isVideo
                 )
-                result.add(item)
+                if (MediaUtils.isSupportedMimeType(context.contentResolver.getType(completeUri))) {
+                    result.add(item)
+                }
             }
         } finally {
             SqlUtils.closeCursor(cursor)

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/mediapicker/DeviceListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/mediapicker/DeviceListBuilder.kt
@@ -9,6 +9,7 @@ import android.provider.MediaStore.Video
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.utils.MediaUtils
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.photopicker.mediapicker.MediaSource.MediaLoadingResult
 import org.wordpress.android.ui.photopicker.mediapicker.MediaType.AUDIO
@@ -70,13 +71,16 @@ class DeviceListBuilder
             val idIndex = cursor.getColumnIndexOrThrow(ID_COL)
             while (cursor.moveToNext()) {
                 val id = cursor.getLong(idIndex)
+                val completeUri = Uri.withAppendedPath(baseUri, "" + id)
                 val item = MediaItem(
                         id,
-                        UriWrapper(Uri.withAppendedPath(baseUri, "" + id)),
+                        UriWrapper(completeUri),
                         "",
                         isVideo
                 )
-                result.add(item)
+                if (MediaUtils.isSupportedMimeType(context.contentResolver.getType(completeUri))) {
+                    result.add(item)
+                }
             }
         } finally {
             SqlUtils.closeCursor(cursor)


### PR DESCRIPTION
Fixes #12822

I checked the FluxC code to see what is considered a valid MIME type, the check comes from [this here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/utils/MimeTypes.kt) based on the Wordpress documentation available here https://wordpress.com/support/accepted-filetypes/

I've tested an unsupported format such as `webp` to double check
 nevertheless on a self-hosted site and a .com site and was able to confirm the media section there does not allow you to upload other than supported file extensions.

<img width="426" alt="Screen Shot 2020-08-28 at 10 30 53" src="https://user-images.githubusercontent.com/6597771/91577759-9158df00-e91f-11ea-9da5-6975cf389752.png">


### Before
In these gifs, the first image to the left is a `webp` (unsupported mime type) image
Aztec:
![mimetypenofilter_aztec](https://user-images.githubusercontent.com/6597771/91577807-a59cdc00-e91f-11ea-9074-ceb7ff777cb0.gif)

Gutenberg:
![mimetypenofilter_gb](https://user-images.githubusercontent.com/6597771/91577796-a170be80-e91f-11ea-9b0f-e600808f73a9.gif)


### After
As you can see, the image with an unsupported mime type is filtered out, not allowing it to be inserted
Aztec:
![mimetypefilter_aztec](https://user-images.githubusercontent.com/6597771/91577870-c06f5080-e91f-11ea-9b9a-f268c9dbeff2.gif)

Gutenberg:
![mimetypefilter_gb](https://user-images.githubusercontent.com/6597771/91577878-c402d780-e91f-11ea-894a-1f03b5a7149e.gif)


To test:
1. download a webp or another WP-unsupported media file on Chrome on your device  / emulator. I used the examples given here https://developers.google.com/speed/webp/gallery1
2. go to the WP app, start a Post, and try uploading an image
3. observe the just downloaded image (as per step 1) is not shown

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
