### PR TITLE
Fix attributes handling when importing strings from libraries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 8694d3d213e0069e45693437b44f91aa4ac8e435
-  ref: 8694d3d213e0069e45693437b44f91aa4ac8e435
+  revision: dd4dd1b1af753f7369f08715343d031be09a2c27
+  tag: 0.9.14
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.13)
+    fastlane-plugin-wpmreleasetoolkit (0.9.14)
       activesupport (~> 4)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -156,7 +156,7 @@ GEM
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 841e167dffc0f45fc36a513f8ba68a37689141e8
-  tag: 0.9.11
+  revision: 8694d3d213e0069e45693437b44f91aa4ac8e435
+  ref: 8694d3d213e0069e45693437b44f91aa4ac8e435
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.11)
+    fastlane-plugin-wpmreleasetoolkit (0.9.13)
       activesupport (~> 4)
+      bigdecimal (~> 1.4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
@@ -45,16 +46,17 @@ GEM
     aws-sigv4 (1.1.3)
       aws-eventstream (~> 1.0, >= 1.0.2)
     babosa (1.0.3)
+    bigdecimal (1.4.4)
     chroma (0.2.0)
     claide (1.0.3)
     colored (1.2)
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     declarative (0.0.10)
     declarative-option (0.1.0)
-    diffy (3.3.0)
+    diffy (3.4.0)
     digest-crc (0.5.1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -165,7 +167,7 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.7)
+    oj (3.10.13)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.0)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '8694d3d213e0069e45693437b44f91aa4ac8e435'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.14'
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,4 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.11'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '8694d3d213e0069e45693437b44f91aa4ac8e435'
+


### PR DESCRIPTION
This PR fixes an issue with importing strings from libraries where the attributes are not imported to the main `strings.xml`.

The actual changes are in the related `release-toolkit` PR: https://github.com/wordpress-mobile/release-toolkit/pull/162

**To Test**
1. `bundle install`

2. Test adding a new string:
2.1 Add a new string in one of the imported libraries' `strings.xml` (for example, in the `WP-Stories` one) and set the `translatable="false"` attribute. 
2.2 Run `bundle exec fastlane localize_libs` and verify that the string is imported in the main `strings.xml` and that the attribute is still present. 

3. Test updating a string:
3.1 Remove the `translatable="false"` attribute from the source string.
3.2 Run `bundle exec fastlane localize_libs` and verify that the attributes is removed in the main `strings.xml`.
3.3 Change the value of a string in the library's `string.xml`.
3.4 Run `bundle exec fastlane localize_libs` and verify that the value of the string is updated in the main `strings.xml`.


**Note**
Before merging this PR, a new version of `release-toolkit` should be created and the reference in this PR updated. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
