### PR TITLE
Fix postcard with empty title in Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -19,7 +19,7 @@ sealed class ReaderCardUiState {
         val postId: Long,
         val blogId: Long,
         val dateLine: String,
-        val title: String?,
+        val title: UiString?,
         val blogName: String?,
         val excerpt: String?, // mTxtText
         val blogUrl: String?,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
 import org.wordpress.android.ui.reader.utils.ReaderImageScannerProvider
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.utils.UiDimen.UIDimenRes
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DateTimeUtilsWrapper
@@ -187,8 +188,14 @@ class ReaderPostUiStateBuilder @Inject constructor(
                     post.cardType != GALLERY
 
     // TODO malinjir show title only when buildPhotoTitle == null
-    private fun buildTitle(post: ReaderPost) =
-            post.takeIf { post.cardType != PHOTO && it.hasTitle() }?.title
+    private fun buildTitle(post: ReaderPost): UiString? {
+        return if (post.cardType != PHOTO) {
+            post.takeIf { it.hasTitle() }?.title?.let { UiStringText(it) }
+                    ?: UiStringRes(R.string.untitled_in_parentheses)
+        } else {
+            null
+        }
+    }
 
     // TODO malinjir show excerpt only when buildPhotoTitle == null
     private fun buildExcerpt(post: ReaderPost) =

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -295,7 +295,7 @@ class ReaderDiscoverViewModelTest {
                 avatarOrBlavatarUrl = "",
                 blogName = "",
                 excerpt = "",
-                title = "",
+                title = mock(),
                 photoFrameVisibility = false,
                 photoTitle = "",
                 featuredImageUrl = "",

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -15,6 +15,7 @@ import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.ReaderCardType
 import org.wordpress.android.models.ReaderCardType.DEFAULT
@@ -41,6 +42,8 @@ import org.wordpress.android.ui.reader.models.ReaderImageList
 import org.wordpress.android.ui.reader.utils.ReaderImageScanner
 import org.wordpress.android.ui.reader.utils.ReaderImageScannerProvider
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.GravatarUtilsWrapper
 import org.wordpress.android.util.UrlUtilsWrapper
@@ -415,7 +418,7 @@ class ReaderPostUiStateBuilderTest {
             // Act
             val uiState = mapPostToUiState(post)
             // Assert
-            assertThat(uiState.title).isNotNull()
+            assertThat((uiState.title as UiStringText).text).isEqualTo(post.title)
         }
     }
 
@@ -430,13 +433,13 @@ class ReaderPostUiStateBuilderTest {
     }
 
     @Test
-    fun `title is not displayed when the post doesn't have a title`() {
+    fun `default title is displayed when the post doesn't have a title`() {
         // Arrange
         val post = createPost(cardType = DEFAULT, hasTitle = false)
         // Act
         val uiState = mapPostToUiState(post)
         // Assert
-        assertThat(uiState.title).isNull()
+        assertThat((uiState.title as UiStringRes).stringRes).isEqualTo(R.string.untitled_in_parentheses)
     }
 
     @Test


### PR DESCRIPTION
Fixes #12308

Updated on 9/2:

Show "(Untitled)" when a post card doesn't have a title -> for example a post with photos in it's content and no title.

To test:
1. Follow "upm59krakatit.wordpress.com"
2. Open reader - following tab
3. Notice the newest post has title "(Untitled)"

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
