### PR TITLE
Add safe click logic on PostListItemViewHolder clickable items

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -113,6 +113,8 @@ sealed class PostListItemViewHolder(
             }
         }
 
+        // Purpose of this method is to prevent 2 Editors
+        // from being launched simultaneously and then producing a crash, etc
         private fun isSafeClick(view: View): Boolean {
             if (isClickEnabled.getAndSet(false)) {
                 view.postDelayed({

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -114,7 +114,7 @@ sealed class PostListItemViewHolder(
         }
 
         // Purpose of this method is to prevent 2 Editors
-        // from being launched simultaneously and then producing a crash, etc
+        // from being launched simultaneously and then producing a crash
         private fun isSafeClick(view: View): Boolean {
             if (isClickEnabled.getAndSet(false)) {
                 view.postDelayed({

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiStat
 import org.wordpress.android.viewmodel.posts.PostListItemUiStateData
 import org.wordpress.android.widgets.PostListButton
 import org.wordpress.android.widgets.WPTextView
+import java.util.concurrent.atomic.AtomicBoolean
 
 sealed class PostListItemViewHolder(
     @LayoutRes layout: Int,
@@ -56,6 +57,10 @@ sealed class PostListItemViewHolder(
      */
     private var loadedFeaturedImgUrl: String? = null
 
+    companion object {
+        var isClickEnabled = AtomicBoolean(true)
+    }
+
     abstract fun onBind(item: PostListItemUiState)
 
     class Standard(
@@ -74,7 +79,11 @@ sealed class PostListItemViewHolder(
             setBasicValues(item.data)
 
             uiHelpers.setTextOrHide(excerptTextView, item.data.excerpt)
-            itemView.setOnClickListener { item.onSelected.invoke() }
+            itemView.setOnClickListener {
+                if (isSafeClick(it)) {
+                    item.onSelected.invoke()
+                }
+            }
 
             actionButtons.forEachIndexed { index, button ->
                 updateMenuItem(button, item.actions.getOrNull(index))
@@ -87,7 +96,11 @@ sealed class PostListItemViewHolder(
                 when (action) {
                     is SingleItem -> {
                         postListButton.updateButtonType(action.buttonType)
-                        postListButton.setOnClickListener { action.onButtonClicked.invoke(action.buttonType) }
+                        postListButton.setOnClickListener {
+                            if (isSafeClick(it)) {
+                                action.onButtonClicked.invoke(action.buttonType)
+                            }
+                        }
                     }
                     is MoreItem -> {
                         postListButton.updateButtonType(action.buttonType)
@@ -98,6 +111,16 @@ sealed class PostListItemViewHolder(
                     }
                 }
             }
+        }
+
+        private fun isSafeClick(view: View): Boolean {
+            if (isClickEnabled.getAndSet(false)) {
+                view.postDelayed({
+                    isClickEnabled.set(true)
+                },1000 )
+                return true
+            }
+            return false
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -117,7 +117,7 @@ sealed class PostListItemViewHolder(
             if (isClickEnabled.getAndSet(false)) {
                 view.postDelayed({
                     isClickEnabled.set(true)
-                },1000 )
+                }, 1000)
                 return true
             }
             return false


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/10493

To test:

1. Open the WordPress Android app.
2. Navigate to Post list
3. Click twice quickly on the edit button for a post, or on the post itself
4. Notice you can no longer get to Editors to open up simultaneously. (check linked issue #10493 for more info).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
