### PR TITLE
Fix crash on reader discover tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverService.kt
@@ -60,7 +60,7 @@ class ReaderDiscoverService : Service(), ServiceCompletionListener, CoroutineSco
         return START_NOT_STICKY
     }
 
-    override fun onCompleted(companion: Any) {
+    override fun onCompleted(companion: Any?) {
         AppLog.i(READER, "reader discover service > all tasks completed")
         stopSelf()
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/12837

The issue was that the `companion` parameter was specified as non-null. However, on older API versions (pre-jobService) we don't use this attribute and we intentionally send `null` there.

To test:
1. Enable RI FF
2. Open discover tab
3. Pull to refresh
4. Notice the app doesn't crash and the content refreshes

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
