### PR TITLE
WP Stories: add permission denied dialog interface

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -14,6 +14,7 @@ import com.wordpress.stories.compose.ComposeLoopFrameActivity
 import com.wordpress.stories.compose.MediaPickerProvider
 import com.wordpress.stories.compose.MetadataProvider
 import com.wordpress.stories.compose.NotificationIntentLoader
+import com.wordpress.stories.compose.PermanentPermissionDenialDialogProvider
 import com.wordpress.stories.compose.PrepublishingEventProvider
 import com.wordpress.stories.compose.SnackbarProvider
 import com.wordpress.stories.compose.StoryDiscardListener
@@ -55,6 +56,7 @@ import org.wordpress.android.ui.utils.AuthenticationUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ListUtils
 import org.wordpress.android.util.WPMediaUtils
+import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.helpers.MediaFile
@@ -73,7 +75,8 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         StoryDiscardListener,
         EditPostActivityHook,
         PrepublishingEventProvider,
-        PrepublishingBottomSheetListener {
+        PrepublishingBottomSheetListener,
+        PermanentPermissionDenialDialogProvider {
     private var site: SiteModel? = null
 
     @Inject lateinit var storyEditorMedia: StoryEditorMedia
@@ -112,6 +115,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         setStoryDiscardListener(this)
         setNotificationTrackerProvider((application as WordPress).getStoryNotificationTrackerProvider())
         setPrepublishingEventProvider(this)
+        setPermissionDialogProvider(this)
 
         initViewModel(savedInstanceState)
     }
@@ -408,5 +412,9 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
 
     override fun onSubmitButtonClicked(publishPost: PublishPost) {
         viewModel.onSubmitButtonClicked()
+    }
+
+    override fun showPermissionPermanentlyDeniedDialog(permission: String) {
+        WPPermissionUtils.showPermissionAlwaysDeniedDialog(this, permission)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.util;
 
+import android.Manifest;
+import android.Manifest.permission;
 import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -160,6 +162,8 @@ public class WPPermissionUtils {
                 return context.getString(R.string.permission_storage);
             case android.Manifest.permission.CAMERA:
                 return context.getString(R.string.permission_camera);
+            case Manifest.permission.RECORD_AUDIO:
+                return context.getString(R.string.permission_microphone);
             default:
                 AppLog.w(AppLog.T.UTILS, "No name for requested permission");
                 return context.getString(R.string.unknown);
@@ -170,7 +174,7 @@ public class WPPermissionUtils {
      * called when the app detects that the user has permanently denied a permission, shows a dialog
      * alerting them to this fact and enabling them to visit the app settings to edit permissions
      */
-    private static void showPermissionAlwaysDeniedDialog(@NonNull final Activity activity,
+    public static void showPermissionAlwaysDeniedDialog(@NonNull final Activity activity,
                                                          @NonNull String permission) {
         String message = String.format(activity.getString(R.string.permissions_denied_message),
                 getPermissionName(activity, permission));

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2365,6 +2365,7 @@
     <string name="permissions_denied_message">It looks like you turned off permissions required for this feature.&lt;br/&gt;&lt;br/&gt;To change this, edit your permissions and make sure &lt;strong&gt;%s&lt;/strong&gt; is enabled.</string>
     <string name="permission_storage">Storage</string>
     <string name="permission_camera">Camera</string>
+    <string name="permission_microphone">Microphone</string>
 
     <!-- Image Optimization promo -->
     <string name="turn_on">Turn on</string>


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/418

This PR implements the `PermanentPermissionDenialDialogProvider` interface from the Stories library to show a consistent explanation to users when they try to access the Stories capture mode but then deny the permissions request and ask not to show again.

To test:
See test instructions in https://github.com/Automattic/stories-android/pull/511

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
