### PR TITLE
Updated WordPress Lint version

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -325,7 +325,7 @@ dependencies {
 
     implementation 'com.github.Tenor-Inc:tenor-android-core:0.5.1'
 
-    lintChecks 'org.wordpress:lint:1.0.1'
+    lintChecks 'org.wordpress:lint:1.0.2'
 
     // Sentry
     implementation 'io.sentry:sentry-android:2.1.3'

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -411,6 +411,7 @@ class MySiteFragment : Fragment(),
                     selectedSite
             )
         }
+        row_sharing.setPadding(5, 5, 5, 5)
         row_sharing.setOnClickListener {
             if (isQuickStartTaskActive(ENABLE_POST_SHARING)) {
                 requestNextStepOfActiveQuickStartTask()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -951,6 +951,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     private void hideOverlay() {
         View overlay = findViewById(R.id.view_overlay);
         overlay.setVisibility(View.GONE);
+        overlay.setPadding(5, 5, 5, 5);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.posts
 
 import android.os.Bundle
 import android.os.Parcelable
+import android.widget.TextView
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -56,6 +57,7 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
         if (isStarted) return
         isStarted = true
 
+        val text:TextView
         this.site = site
         this.currentScreen = currentScreenFromSavedState ?: HOME
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -57,7 +57,7 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
         if (isStarted) return
         isStarted = true
 
-        val text:TextView
+        val text: TextView
         this.site = site
         this.currentScreen = currentScreenFromSavedState ?: HOME
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/TesterViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/TesterViewModel.java
@@ -7,5 +7,4 @@ import androidx.lifecycle.ViewModel;
 
 public class TesterViewModel extends ViewModel {
     @SuppressLint("StaticFieldLeak") TextView mTextView;
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/TesterViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/TesterViewModel.java
@@ -1,0 +1,11 @@
+package org.wordpress.android.ui.posts;
+
+import android.annotation.SuppressLint;
+import android.widget.TextView;
+
+import androidx.lifecycle.ViewModel;
+
+public class TesterViewModel extends ViewModel {
+    @SuppressLint("StaticFieldLeak") TextView mTextView;
+
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.discover
 
+import android.widget.TextView
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import kotlinx.coroutines.CoroutineDispatcher
@@ -89,6 +90,7 @@ class ReaderDiscoverViewModel @Inject constructor(
     }
 
     private fun init() {
+        val textView: TextView
         // Start with loading state
         _uiState.value = LoadingUiState
 


### PR DESCRIPTION
Fixes #12846 

The lint library now has a lint rule that will report an issue when an Android import is utilized in a ViewModel. So if a ViewModel contains references to a TextView the build should fail. 

To test:
Nothing to test here specifically. But if you create a ViewModel with any of the [disallowed imports](https://github.com/wordpress-mobile/WordPress-Lint-Android/pull/3/files#diff-94c7c153dda6dd511ec0f2a5f93a44c1R26-R29) there should be a lint failure. 
 For more details, you can view this PR https://github.com/wordpress-mobile/WordPress-Lint-Android/pull/3

Let me know if you have any thoughts about this. Does this PR being merged in require a P2 post or it's fine since by default most peeps aren't creating PRs with Android APIs? Let me know 👍 
