### PR TITLE
RI: Fix follow button design on older Android API

### DIFF
--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -228,7 +228,7 @@
         <item name="iconPadding">@dimen/margin_small</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:textColor">@color/primary_success_selector</item>
-        <item name="android:backgroundTint">@color/transparent</item>
+        <item name="backgroundTint">@color/transparent</item>
         <item name="android:textAppearance">?attr/textAppearanceBody2</item>
         <item name="strokeColor">@color/transparent</item>
         <item name="iconTint">@color/primary_success_selector</item>
@@ -240,7 +240,7 @@
 
     <style name="Reader.Follow.Button.New" parent="Reader.Follow.Button">
         <item name="android:textColor">@color/on_secondary_on_background_selector</item>
-        <item name="android:backgroundTint">@color/secondary_surface_selector</item>
+        <item name="backgroundTint">@color/secondary_surface_selector</item>
         <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
         <item name="strokeColor">@color/transparent_on_background_selector</item>
         <item name="iconTint">@color/on_secondary_on_background_selector</item>


### PR DESCRIPTION
Fixes #12839

Tested on Pixel 2 API 22 emulator

Follow | Following
-------| ----------
![device-2020-09-01-095841](https://user-images.githubusercontent.com/1405144/91795575-a42f2480-ec3b-11ea-8c24-6f34810c527b.png) | ![device-2020-09-01-095852](https://user-images.githubusercontent.com/1405144/91795584-a7c2ab80-ec3b-11ea-81f2-559d9e1c803a.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
