### PR TITLE
Media Editing: Delete old output files

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -86,6 +86,7 @@ import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
+import org.wordpress.android.ui.posts.editor.ImageEditorFileUtils;
 import org.wordpress.android.ui.posts.editor.ImageEditorInitializer;
 import org.wordpress.android.ui.posts.editor.ImageEditorTracker;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -133,6 +134,9 @@ import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasServiceInjector;
 import dagger.android.support.HasSupportFragmentInjector;
+import kotlinx.coroutines.CoroutineScope;
+
+import static org.wordpress.android.modules.ThreadModuleKt.DEFAULT_SCOPE;
 
 public class WordPress extends MultiDexApplication implements HasServiceInjector, HasSupportFragmentInjector,
         LifecycleObserver {
@@ -179,6 +183,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
     @Inject CrashLogging mCrashLogging;
     @Inject EncryptedLogging mEncryptedLogging;
     @Inject AppConfig mAppConfig;
+    @Inject ImageEditorFileUtils mImageEditorFileUtils;
+    @Inject @Named(DEFAULT_SCOPE) CoroutineScope mDefaultScope;
 
     // For development and production `AnalyticsTrackerNosara`, for testing a mocked `Tracker` will be injected.
     @Inject Tracker mTracker;
@@ -348,7 +354,12 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         UploadWorkerKt.enqueuePeriodicUploadWorkRequestForAllSites();
 
         mSystemNotificationsTracker.checkSystemNotificationsState();
-        ImageEditorInitializer.Companion.init(mImageManager, mImageEditorTracker);
+        ImageEditorInitializer.Companion.init(
+                mImageManager,
+                mImageEditorTracker,
+                mImageEditorFileUtils,
+                mDefaultScope
+        );
 
         initEmojiCompat();
         mStoryNotificationTrackerProvider = new StoryNotificationTrackerProvider();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorFileUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/ImageEditorFileUtils.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.posts.editor
+
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+
+class ImageEditorFileUtils
+@Inject constructor() {
+    suspend fun deleteFilesOlderThanDurationFromDirectory(directoryPath: String, duration: Long) = withContext(IO) {
+        val directory = File(directoryPath)
+        if (directory.exists()) {
+            directory.listFiles()?.let { files ->
+                for (file in files) {
+                    val ageMS: Long = System.currentTimeMillis() - file.lastModified()
+                    if (ageMS >= duration) {
+                        file.delete()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/ImageEditorFileUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/ImageEditorFileUtilsTest.kt
@@ -1,0 +1,68 @@
+package org.wordpress.android.ui.posts.editor
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.wordpress.android.test
+import java.io.File
+
+private const val TEST_OUTPUT_FOLDER = "outputFolder"
+private const val TEST_OUTPUT_FILE_NAME = "outputFile"
+private const val DURATION = 24 * 60 * 60 * 1000.toLong()
+class ImageEditorFileUtilsTest {
+    @Rule
+    @JvmField val temporaryFolder = TemporaryFolder()
+
+    // Class under test
+    private lateinit var fileUtils: ImageEditorFileUtils
+
+    @Before
+    fun setUp() {
+        fileUtils = ImageEditorFileUtils()
+    }
+
+    @Test
+    fun `if file inside directory is modified within given duration, it is not deleted`() {
+        // Arrange
+        val directory: File = temporaryFolder.newFolder(TEST_OUTPUT_FOLDER)
+        val directoryPath: String = directory.path
+
+        val outputFile = File(directory, TEST_OUTPUT_FILE_NAME)
+        outputFile.createNewFile()
+
+        // Act
+        test {
+            fileUtils.deleteFilesOlderThanDurationFromDirectory(directoryPath, DURATION)
+        }
+
+        // Assert
+        assertThat(outputFile.exists()).isTrue()
+    }
+
+    @Test
+    fun `if file inside directory is modified on or after given duration, it is deleted`() {
+        // Arrange
+        val directory: File = temporaryFolder.newFolder(TEST_OUTPUT_FOLDER)
+        val directoryPath: String = directory.path
+
+        val outputFile = File(directory, TEST_OUTPUT_FILE_NAME)
+        outputFile.createNewFile()
+        outputFile.setLastModified(System.currentTimeMillis() - DURATION)
+
+        // Act
+        test {
+            fileUtils.deleteFilesOlderThanDurationFromDirectory(directoryPath, DURATION)
+        }
+
+        // Assert
+        assertThat(outputFile.exists()).isFalse()
+    }
+
+    @After
+    fun tearDown() {
+        temporaryFolder.delete()
+    }
+}

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
@@ -193,6 +193,6 @@ class CropViewModel : ViewModel() {
         private const val COMPRESS_QUALITY_100 = 100
         private const val PNG = "png"
         private const val WEBP = "webp"
-        private const val MEDIA_EDITING = "media_editing"
+        const val MEDIA_EDITING = "media_editing"
     }
 }


### PR DESCRIPTION
This PR removes old output files from the media editor. 
(Tentatively chosen one week as this duration, can change to whatever we decide in this PR)

#### To test

1. Launch app and go to My Site
2. Create a post and choose an image block (Gutenberg editor)
3. Add Image to the block and edit it using the media editor
4. Notice in the Device File Explorer that the image is saved into `data/user/0/<app package>/cache/media_editing` directory
5. For testing, change duration to a small one (so that the image can be deleted) in the `ImageEditorInitialiser` 
6. Relaunch app
6. Notice in the Device File Explorer that the image is deleted from `data/user/0/<app package>/cache/media_editing `directory

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
