### PR TITLE
Fix major accessibility issues in reader discover tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -280,21 +280,23 @@ class ReaderPostUiStateBuilder @Inject constructor(
         post: ReaderPost,
         onClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ): PrimaryAction {
-        val contentDescription = if (post.isBookmarked) {
-            R.string.reader_remove_bookmark
-        } else {
-            R.string.reader_add_bookmark
-        }
+        val contentDescription = UiStringRes(
+                if (post.isBookmarked) {
+                    R.string.reader_remove_bookmark
+                } else {
+                    R.string.reader_add_bookmark
+                }
+        )
         return if (post.postId != 0L && post.blogId != 0L) {
             PrimaryAction(
                     isEnabled = true,
                     isSelected = post.isBookmarked,
-                    contentDescription = UiStringRes(contentDescription),
+                    contentDescription = contentDescription,
                     onClicked = onClicked,
                     type = BOOKMARK
             )
         } else {
-            PrimaryAction(isEnabled = false, type = BOOKMARK)
+            PrimaryAction(isEnabled = false, contentDescription = contentDescription, type = BOOKMARK)
         }
     }
 
@@ -325,12 +327,12 @@ class ReaderPostUiStateBuilder @Inject constructor(
         onReblogClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ): PrimaryAction {
         val canReblog = !post.isPrivate && accountStore.hasAccessToken()
-        return if (canReblog) {
-            // TODO Add content description
-            PrimaryAction(isEnabled = true, onClicked = onReblogClicked, type = REBLOG)
-        } else {
-            PrimaryAction(isEnabled = false, type = REBLOG)
-        }
+        return PrimaryAction(
+                isEnabled = canReblog,
+                contentDescription = UiStringRes(R.string.reader_view_reblog),
+                onClicked = if (canReblog) onReblogClicked else null,
+                type = REBLOG
+        )
     }
 
     private fun buildCommentsSection(
@@ -346,18 +348,21 @@ class ReaderPostUiStateBuilder @Inject constructor(
             !accountStore.hasAccessToken() -> post.numReplies > 0
             else -> post.isWP && (post.isCommentsOpen || post.numReplies > 0)
         }
+        val contentDescription = UiStringRes(R.string.comments)
 
         // TODO Add content description
         return if (showComments) {
             PrimaryAction(
                     isEnabled = true,
                     count = post.numReplies,
+                    contentDescription = contentDescription,
                     onClicked = onCommentsClicked,
                     type = ReaderPostCardActionType.COMMENTS
             )
         } else {
             PrimaryAction(
                     isEnabled = false,
+                    contentDescription = contentDescription,
                     type = ReaderPostCardActionType.COMMENTS
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderExpandableTagsView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderExpandableTagsView.kt
@@ -123,6 +123,10 @@ class ReaderExpandableTagsView @JvmOverloads constructor(
     private fun updateOverflowIndicatorChip() {
         val showOverflowIndicatorChip = hiddenTagChipsCount > 0 || !isSingleLine
         uiHelpers.updateVisibility(overflowIndicatorChip, showOverflowIndicatorChip)
+        overflowIndicatorChip.contentDescription = String.format(
+                resources.getString(R.string.show_n_hidden_items_desc),
+                hiddenTagChipsCount
+        )
 
         overflowIndicatorChip.text = if (isSingleLine) {
             String.format(

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -144,6 +144,7 @@
             android:id="@+id/layout_post_header"
             android:layout_width="0dp"
             android:layout_height="@dimen/reader_post_header_height"
+            android:importantForAccessibility="no"
             android:layout_marginEnd="@dimen/margin_medium"
             android:background="?android:selectableItemBackground"
             android:visibility="visible"

--- a/WordPress/src/main/res/layout/reader_cardview_welcome_banner.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_welcome_banner.xml
@@ -17,7 +17,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:src="@drawable/bg_colorful_dots"
-            android:contentDescription="@string/reader_welcome_banner_content_description"
+            android:contentDescription="@null"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintBottom_toTopOf="parent"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1313,6 +1313,7 @@
     <string name="reader_expandable_tags_view_overflow_indicator_expand_title" translatable="false">%1$s+</string>
     <string name="reader_expandable_tags_view_overflow_indicator_collapse_title">Hide</string>
     <string name="reader_discover_interests_header">You might like</string>
+    <string name="show_n_hidden_items_desc">%1$s more items</string>
 
     <!-- editor -->
     <string name="editor_post_saved_online">Post saved online</string>
@@ -1753,7 +1754,6 @@
     <string name="reader_label_choose_your_interests">Choose your interests</string>
     <string name="reader_view_comments">View comments</string>
     <string name="reader_welcome_banner">Welcome to Reader. Discover millions of blogs at your fingertips.</string>
-    <string name="reader_welcome_banner_content_description">Welcome to Reader</string>
 
     <string name="reader_excerpt_link">Visit %s for more</string>
 


### PR DESCRIPTION
This PR fixes some major accessibility issues in Reader. 

1. All action on post card items are read by TalkBack
2. The overflow eg "3+" chip at the top of some post cards is announced as "three more items, checkbox, tap to activate"
3. Removed "reader_welcome_banner_content_description" as both this and the text content was read by TalkBack

**To test** 
- enable RI FF
- enable talkback (if you don't have it installed, it can be found on Google Play under "Android Accessibility Suite"
Actions
1. Open Discover tab
2. Notice all action - bookmark, reblog, comments, like - are read by talkback

Overflow chip
1. Open discover tab
2. Scroll to a post which has the overflow chip displayed
3. Click on that chip and notice it gets read by talkback

Welcome Card
1. Open Discover tab (after you delete app data)
2. Click on the "Welcome to Reader" card
3. Notice it doesn't announce "Welcome to Reader" twice


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
