### PR TITLE
Remove completed track todos

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -153,7 +153,6 @@ class ReaderPostCardActionsHandler @Inject constructor(
     }
 
     private suspend fun handleFollowClicked(post: ReaderPost) {
-        // todo: Annmarie add tracking dependent upon implementation (tracked in ReaderBlogActions)
         followUseCase.toggleFollow(post).collect {
             when (it) {
                 is FollowSiteState.Failed.NoNetwork -> {
@@ -184,7 +183,6 @@ class ReaderPostCardActionsHandler @Inject constructor(
         }
     }
 
-    // todo: Annmarie add tracking dependent upon implementation
     private suspend fun handleSiteNotificationsClicked(blogId: Long) {
         when (siteNotificationsUseCase.toggleNotification(blogId)) {
             is SiteNotificationState.Success, SiteNotificationState.Failed.AlreadyRunning -> { // Do Nothing
@@ -268,7 +266,6 @@ class ReaderPostCardActionsHandler @Inject constructor(
     }
 
     private suspend fun handleBookmarkClicked(postId: Long, blogId: Long, isBookmarkList: Boolean) {
-        // todo: Annmarie add tracking dependent upon implementation
         bookmarkUseCase.toggleBookmark(blogId, postId, isBookmarkList)
     }
 


### PR DESCRIPTION
Parent #12028 

This PR removes tracking event todos which are out-dated or have been tracked in the use cases.

To test:
No need to test anything

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
