### PR TITLE
Fix indents in RemoteConfigDefaultsBuilderTest.kt

### DIFF
--- a/libs/WordPressProcessors/src/test/kotlin/org/wordpress/android/processor/RemoteConfigDefaultsBuilderTest.kt
+++ b/libs/WordPressProcessors/src/test/kotlin/org/wordpress/android/processor/RemoteConfigDefaultsBuilderTest.kt
@@ -18,7 +18,7 @@ class RemoteConfigDefaultsBuilderTest {
 
         val fileContent = remoteConfigDefaultsBuilder.getContent()
 
-        assertThat(fileContent.toString()).isEqualTo(
+        assertThat(fileContent.toString().trimIndent()).isEqualTo(
                 """
             // Automatically generated file. DO NOT MODIFY
             package org.wordpress.android.util.config
@@ -28,12 +28,11 @@ class RemoteConfigDefaultsBuilderTest {
             import kotlin.collections.Map
             
             object RemoteConfigDefaults {
-              val remoteConfigDefaults: Map<String, Any> = mapOf(
-                  "$keyA" to "$valueA",
-                  "$keyB" to "$valueB"
-                  )
+                val remoteConfigDefaults: Map<String, Any> = mapOf(
+                        "$keyA" to "$valueA",
+                        "$keyB" to "$valueB"
+                        )
             }
-            
         """.trimIndent()
         )
     }

--- a/libs/WordPressProcessors/src/test/kotlin/org/wordpress/android/processor/RemoteConfigDefaultsBuilderTest.kt
+++ b/libs/WordPressProcessors/src/test/kotlin/org/wordpress/android/processor/RemoteConfigDefaultsBuilderTest.kt
@@ -18,7 +18,7 @@ class RemoteConfigDefaultsBuilderTest {
 
         val fileContent = remoteConfigDefaultsBuilder.getContent()
 
-        assertThat(fileContent.toString().trimIndent()).isEqualTo(
+        assertThat(fileContent.toString()).isEqualTo(
                 """
             // Automatically generated file. DO NOT MODIFY
             package org.wordpress.android.util.config
@@ -33,6 +33,7 @@ class RemoteConfigDefaultsBuilderTest {
                         "$keyB" to "$valueB"
                         )
             }
+            
         """.trimIndent()
         )
     }


### PR DESCRIPTION
The RemoteConfigDefaultsBuilderTest wasn't run by CI so we haven't noticed this test was failing. The failure was caused by some indentation changes to the generated file. This is fixed by this PR (I've run the test manually and it succeeds).

To test:
- Run the updated unit test manually

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
