### PR TITLE
Track like action on discover tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActionsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActionsWrapper.kt
@@ -1,11 +1,12 @@
 package org.wordpress.android.ui.reader.actions
 
 import dagger.Reusable
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.models.ReaderPost
 import javax.inject.Inject
 
 @Reusable
-class ReaderPostActionsWrapper @Inject constructor() {
+class ReaderPostActionsWrapper @Inject constructor(private val siteStore: SiteStore) {
     fun addToBookmarked(post: ReaderPost) = ReaderPostActions.addToBookmarked(post)
     fun removeFromBookmarked(post: ReaderPost) = ReaderPostActions.removeFromBookmarked(post)
     fun performLikeAction(
@@ -13,4 +14,6 @@ class ReaderPostActionsWrapper @Inject constructor() {
         isAskingToLike: Boolean,
         wpComUserId: Long
     ): Boolean = ReaderPostActions.performLikeAction(post, isAskingToLike, wpComUserId)
+
+    fun bumpPageViewForPost(post: ReaderPost) = ReaderPostActions.bumpPageViewForPost(siteStore, post)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
@@ -6,6 +6,7 @@ import dagger.Reusable
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
 
@@ -25,4 +26,7 @@ class AnalyticsUtilsWrapper @Inject constructor(private val appContext: Context)
             AnalyticsUtils.trackEditorCreatedPost(action, intent, site, post)
 
     fun trackWithSiteId(stat: AnalyticsTracker.Stat, blogId: Long) = AnalyticsUtils.trackWithSiteId(stat, blogId)
+
+    fun trackWithReaderPostDetails(stat: AnalyticsTracker.Stat, post: ReaderPost) =
+            AnalyticsUtils.trackWithReaderPostDetails(stat, post)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/usecases/PostLikeUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/usecases/PostLikeUseCaseTest.kt
@@ -62,7 +62,7 @@ class PostLikeUseCaseTest {
     }
 
     private fun createDummyReaderPost(
-        id: Long = 1,
+        id: Long = POST_AND_BLOG_ID,
         isLikedByCurrentUser: Boolean = false
     ): ReaderPost =
             ReaderPost().apply {


### PR DESCRIPTION
Parent issue #12028

Adds a missing tracking for like action on the new discover tab.

To test:
1. Enable RI FF
2. Open Discover tab
3. Click on "Like" and notice "reader_article_liked" gets tracked
4. Click on "UnLike" and notice "reader_article_unliked" gets tracked

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
