### PR TITLE
Issue/12028 refactor bookmark action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -366,8 +366,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private void undoPostUnbookmarked(final ReaderPost post, final int position) {
         if (!post.isBookmarked) {
-            toggleBookmark(post.blogId, post.postId);
-            notifyItemChanged(position);
+            mOnPostBookmarkedListener.onBookmarkClicked(post.blogId, post.postId);
         }
     }
 
@@ -383,8 +382,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     //noinspection EnumSwitchStatementWhichMissesCases
                     switch (type) {
                         case BOOKMARK:
-                            toggleBookmark(post.blogId, post.postId);
-                            renderPost(position, holder, false);
+                            mOnPostBookmarkedListener.onBookmarkClicked(blogId, postId);
                             break;
                         case LIKE:
                             toggleLike(ctx, post, position, holder);
@@ -762,23 +760,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         if (updatedPost != null && positionInReaderPostList > -1) {
             mPosts.set(positionInReaderPostList, updatedPost);
             renderPost(listPosition, holder, false);
-        }
-    }
-
-    /*
-     * triggered when user taps the bookmark post button
-     */
-    private void toggleBookmark(final long blogId, final long postId) {
-        // update post in array and on screen
-        ReaderPost post = ReaderPostTable.getBlogPost(blogId, postId, true);
-        int position = mPosts.indexOfPost(post);
-        if (post != null && position > -1) {
-            post.isBookmarked = !post.isBookmarked;
-            mPosts.set(position, post);
-        }
-
-        if (mOnPostBookmarkedListener != null) {
-            mOnPostBookmarkedListener.onBookmarkClicked(blogId, postId);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -39,7 +39,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPosts
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
-import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
+import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -33,7 +33,7 @@ import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Su
 import org.wordpress.android.ui.reader.repository.ReaderDiscoverDataProvider
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FIRST_PAGE
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_MORE
-import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
+import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DisplayUtilsWrapper

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.APP_REVIEWS_EVENT_INCREMENTED_BY_OPENING_READER_POST
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.FOLLOWED_BLOG_NOTIFICATIONS_READER_ENABLED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTICLE_VISITED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_SAVED_LIST_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_SAVED_POST_OPENED_FROM_OTHER_POST_LIST
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.SHARED_ITEM_READER
 import org.wordpress.android.fluxc.Dispatcher
@@ -22,9 +23,12 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.DEFAULT_SCOPE
 import org.wordpress.android.modules.UI_SCOPE
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.SharePost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBlogPreview
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostDetail
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
@@ -47,7 +51,8 @@ import org.wordpress.android.ui.reader.repository.usecases.BlockBlogUseCase
 import org.wordpress.android.ui.reader.repository.usecases.BlockSiteState
 import org.wordpress.android.ui.reader.repository.usecases.PostLikeUseCase
 import org.wordpress.android.ui.reader.repository.usecases.UndoBlockBlogUseCase
-import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
+import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
+import org.wordpress.android.ui.reader.usecases.BookmarkPostState.Success
 import org.wordpress.android.ui.reader.usecases.ReaderPostBookmarkUseCase
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState
@@ -73,6 +78,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
     private val likeUseCase: PostLikeUseCase,
     private val siteNotificationsUseCase: ReaderSiteNotificationsUseCase,
     private val undoBlockBlogUseCase: UndoBlockBlogUseCase,
+    private val appPrefsWrapper: AppPrefsWrapper,
     private val dispatcher: Dispatcher,
     private val resourceProvider: ResourceProvider,
     private val htmlMessageUtils: HtmlMessageUtils,
@@ -98,18 +104,6 @@ class ReaderPostCardActionsHandler @Inject constructor(
 
     init {
         dispatcher.register(siteNotificationsUseCase)
-
-        _navigationEvents.addSource(bookmarkUseCase.navigationEvents) { event ->
-            _navigationEvents.value = event
-        }
-
-        _snackbarEvents.addSource(bookmarkUseCase.snackbarEvents) { event ->
-            _snackbarEvents.value = event
-        }
-
-        _preloadPostEvents.addSource(bookmarkUseCase.preloadPostEvents) { event ->
-            _preloadPostEvents.value = event
-        }
     }
 
     suspend fun onAction(post: ReaderPost, type: ReaderPostCardActionType, isBookmarkList: Boolean) {
@@ -252,7 +246,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
 
     private suspend fun handleLikeClicked(post: ReaderPost) {
         when (likeUseCase.perform(post, !post.isLikedByCurrentUser)) {
-            is Started, is ReaderRepositoryCommunication.Success, is SuccessWithData<*> -> {}
+            is Started, is ReaderRepositoryCommunication.Success, is SuccessWithData<*> -> { }
             is NetworkUnavailable -> {
                 _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.no_network_message))))
             }
@@ -265,7 +259,44 @@ class ReaderPostCardActionsHandler @Inject constructor(
     }
 
     private suspend fun handleBookmarkClicked(postId: Long, blogId: Long, isBookmarkList: Boolean) {
-        bookmarkUseCase.toggleBookmark(blogId, postId, isBookmarkList)
+        bookmarkUseCase.toggleBookmark(blogId, postId, isBookmarkList).collect {
+            when (it) {
+                is PreLoadPostContent -> _preloadPostEvents.postValue(Event(PreLoadPostContent(blogId, postId)))
+                is Success -> {
+                    val showSnackbarAction = {
+                        _snackbarEvents.postValue(
+                                Event(
+                                        SnackbarMessageHolder(
+                                                UiStringRes(R.string.reader_bookmark_snack_title),
+                                                UiStringRes(R.string.reader_bookmark_snack_btn),
+                                                buttonAction = {
+                                                    analyticsTrackerWrapper.track(
+                                                            READER_SAVED_LIST_SHOWN,
+                                                            mapOf("source" to "post_list_saved_post_notice")
+                                                    )
+                                                    _navigationEvents.postValue(Event(ShowBookmarkedTab))
+                                                })
+                                )
+                        )
+                    }
+                    if (it.bookmarked && !isBookmarkList) {
+                        if (appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog()) {
+                            _navigationEvents.postValue(
+                                    Event(
+                                            ShowBookmarkedSavedOnlyLocallyDialog(
+                                                    okButtonAction = {
+                                                        appPrefsWrapper.setBookmarksSavedLocallyDialogShown()
+                                                        showSnackbarAction.invoke()
+                                                    })
+                                    )
+                            )
+                        } else {
+                            showSnackbarAction.invoke()
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private suspend fun handleReblogClicked(post: ReaderPost) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -52,6 +52,7 @@ import org.wordpress.android.ui.reader.repository.usecases.BlockSiteState
 import org.wordpress.android.ui.reader.repository.usecases.PostLikeUseCase
 import org.wordpress.android.ui.reader.repository.usecases.UndoBlockBlogUseCase
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
+import org.wordpress.android.ui.reader.usecases.BookmarkPostState.RefreshPosts
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.Success
 import org.wordpress.android.ui.reader.usecases.ReaderPostBookmarkUseCase
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase
@@ -262,6 +263,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
         bookmarkUseCase.toggleBookmark(blogId, postId, isBookmarkList).collect {
             when (it) {
                 is PreLoadPostContent -> _preloadPostEvents.postValue(Event(PreLoadPostContent(blogId, postId)))
+                is RefreshPosts -> _refreshPosts.postValue(Event(Unit))
                 is Success -> {
                     val showSnackbarAction = {
                         _snackbarEvents.postValue(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -52,7 +52,6 @@ import org.wordpress.android.ui.reader.repository.usecases.BlockSiteState
 import org.wordpress.android.ui.reader.repository.usecases.PostLikeUseCase
 import org.wordpress.android.ui.reader.repository.usecases.UndoBlockBlogUseCase
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
-import org.wordpress.android.ui.reader.usecases.BookmarkPostState.RefreshPosts
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.Success
 import org.wordpress.android.ui.reader.usecases.ReaderPostBookmarkUseCase
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase
@@ -263,8 +262,10 @@ class ReaderPostCardActionsHandler @Inject constructor(
         bookmarkUseCase.toggleBookmark(blogId, postId, isBookmarkList).collect {
             when (it) {
                 is PreLoadPostContent -> _preloadPostEvents.postValue(Event(PreLoadPostContent(blogId, postId)))
-                is RefreshPosts -> _refreshPosts.postValue(Event(Unit))
                 is Success -> {
+                    // Content needs to be manually refreshed in the legacy ReaderPostListAdapter
+                    _refreshPosts.postValue(Event(Unit))
+
                     val showSnackbarAction = {
                         _snackbarEvents.postValue(
                                 Event(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
@@ -8,7 +8,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_UNSAVED
 import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.ui.reader.actions.ReaderPostActionsWrapper
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
-import org.wordpress.android.ui.reader.usecases.BookmarkPostState.RefreshPosts
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.Success
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -27,8 +26,6 @@ class ReaderPostBookmarkUseCase @Inject constructor(
     suspend fun toggleBookmark(blogId: Long, postId: Long, isBookmarkList: Boolean) = flow<BookmarkPostState> {
         val bookmarked = updatePostInDb(blogId, postId)
         trackEvent(bookmarked, isBookmarkList)
-        // The refresh posts action needs to be invoked so the (legacy) ReaderPostList adapter refreshes its content
-        emit(RefreshPosts)
         preloadPostContentIfNecessary(bookmarked, isBookmarkList, blogId, postId)
         emit(Success(bookmarked))
     }
@@ -72,7 +69,6 @@ class ReaderPostBookmarkUseCase @Inject constructor(
 }
 
 sealed class BookmarkPostState {
-    object RefreshPosts : BookmarkPostState()
     data class PreLoadPostContent(val blogId: Long, val postId: Long) : BookmarkPostState()
     data class Success(val bookmarked: Boolean) : BookmarkPostState()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_UNSAVED
 import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.ui.reader.actions.ReaderPostActionsWrapper
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
+import org.wordpress.android.ui.reader.usecases.BookmarkPostState.RefreshPosts
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.Success
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -26,6 +27,8 @@ class ReaderPostBookmarkUseCase @Inject constructor(
     suspend fun toggleBookmark(blogId: Long, postId: Long, isBookmarkList: Boolean) = flow<BookmarkPostState> {
         val bookmarked = updatePostInDb(blogId, postId)
         trackEvent(bookmarked, isBookmarkList)
+        // The refresh posts action needs to be invoked so the (legacy) ReaderPostList adapter refreshes its content
+        emit(RefreshPosts)
         preloadPostContentIfNecessary(bookmarked, isBookmarkList, blogId, postId)
         emit(Success(bookmarked))
     }
@@ -69,6 +72,7 @@ class ReaderPostBookmarkUseCase @Inject constructor(
 }
 
 sealed class BookmarkPostState {
+    object RefreshPosts : BookmarkPostState()
     data class PreLoadPostContent(val blogId: Long, val postId: Long) : BookmarkPostState()
     data class Success(val bookmarked: Boolean) : BookmarkPostState()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderPostBookmarkUseCase.kt
@@ -1,28 +1,17 @@
 package org.wordpress.android.ui.reader.usecases
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
-import org.wordpress.android.R
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_SAVED_FROM_OTHER_POST_LIST
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_SAVED_FROM_SAVED_POST_LIST
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_UNSAVED_FROM_SAVED_POST_LIST
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_SAVED_LIST_SHOWN
 import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
-import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.ui.pages.SnackbarMessageHolder
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.actions.ReaderPostActionsWrapper
-import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
-import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog
-import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab
-import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
+import org.wordpress.android.ui.reader.usecases.BookmarkPostState.Success
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
-import javax.inject.Named
 
 /**
  * This class handles bookmark/saveForLater button click events.
@@ -30,44 +19,18 @@ import javax.inject.Named
  */
 class ReaderPostBookmarkUseCase @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
-    private val appPrefsWrapper: AppPrefsWrapper,
     private val readerPostActionsWrapper: ReaderPostActionsWrapper,
     private val readerPostTableWrapper: ReaderPostTableWrapper
 ) {
-    private val _navigationEvents = MutableLiveData<Event<ReaderNavigationEvents>>()
-    val navigationEvents: LiveData<Event<ReaderNavigationEvents>> = _navigationEvents
-
-    private val _snackbarEvents = MutableLiveData<Event<SnackbarMessageHolder>>()
-    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
-
-    private val _preloadPostEvents = MutableLiveData<Event<PreLoadPostContent>>()
-    val preloadPostEvents = _preloadPostEvents
-
-    suspend fun toggleBookmark(blogId: Long, postId: Long, isBookmarkList: Boolean) {
-        return withContext(bgDispatcher) {
-            val bookmarked = updatePostInDb(blogId, postId)
-            trackEvent(bookmarked, isBookmarkList)
-            preloadContent(bookmarked, isBookmarkList, blogId, postId)
-
-            val showSnackbarAction = prepareSnackbarAction()
-            if (bookmarked && !isBookmarkList) {
-                if (appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog()) {
-                    _navigationEvents.postValue(Event(ShowBookmarkedSavedOnlyLocallyDialog(
-                            okButtonAction = {
-                                appPrefsWrapper.setBookmarksSavedLocallyDialogShown()
-                                showSnackbarAction.invoke()
-                            })
-                    ))
-                } else {
-                    showSnackbarAction.invoke()
-                }
-            }
-        }
+    suspend fun toggleBookmark(blogId: Long, postId: Long, isBookmarkList: Boolean) = flow<BookmarkPostState> {
+        val bookmarked = updatePostInDb(blogId, postId)
+        trackEvent(bookmarked, isBookmarkList)
+        preloadPostContentIfNecessary(bookmarked, isBookmarkList, blogId, postId)
+        emit(Success(bookmarked))
     }
 
-    private fun preloadContent(
+    private suspend fun FlowCollector<BookmarkPostState>.preloadPostContentIfNecessary(
         bookmarked: Boolean,
         isBookmarkList: Boolean,
         blogId: Long,
@@ -75,7 +38,7 @@ class ReaderPostBookmarkUseCase @Inject constructor(
     ) {
         val cachePostContent = bookmarked && networkUtilsWrapper.isNetworkAvailable() && !isBookmarkList
         if (cachePostContent) {
-            _preloadPostEvents.postValue(Event(PreLoadPostContent(blogId, postId)))
+            emit(PreLoadPostContent(blogId, postId))
         }
     }
 
@@ -103,25 +66,9 @@ class ReaderPostBookmarkUseCase @Inject constructor(
         }
         analyticsTrackerWrapper.track(trackingEvent)
     }
-
-    private fun prepareSnackbarAction(): () -> Unit {
-        return {
-            _snackbarEvents.postValue(
-                    Event(
-                            SnackbarMessageHolder(
-                                    UiStringRes(R.string.reader_bookmark_snack_title),
-                                    UiStringRes(R.string.reader_bookmark_snack_btn),
-                                    buttonAction = {
-                                        analyticsTrackerWrapper.track(
-                                                READER_SAVED_LIST_SHOWN,
-                                                mapOf("source" to "post_list_saved_post_notice")
-                                        )
-                                        _navigationEvents.postValue(Event(ShowBookmarkedTab))
-                                    })
-                    )
-            )
-        }
-    }
 }
 
-data class PreLoadPostContent(val blogId: Long, val postId: Long)
+sealed class BookmarkPostState {
+    data class PreLoadPostContent(val blogId: Long, val postId: Long) : BookmarkPostState()
+    data class Success(val bookmarked: Boolean) : BookmarkPostState()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.tracker.ReaderTrackerType
-import org.wordpress.android.ui.reader.usecases.PreLoadPostContent
+import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.PostFollowStatusChanged
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
@@ -1,0 +1,198 @@
+package org.wordpress.android.ui.reader.discover
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.TEST_SCOPE
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.test
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
+import org.wordpress.android.ui.reader.reblog.ReblogUseCase
+import org.wordpress.android.ui.reader.repository.usecases.BlockBlogUseCase
+import org.wordpress.android.ui.reader.repository.usecases.PostLikeUseCase
+import org.wordpress.android.ui.reader.repository.usecases.UndoBlockBlogUseCase
+import org.wordpress.android.ui.reader.usecases.BookmarkPostState.Success
+import org.wordpress.android.ui.reader.usecases.ReaderPostBookmarkUseCase
+import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase
+import org.wordpress.android.ui.reader.usecases.ReaderSiteNotificationsUseCase
+import org.wordpress.android.ui.utils.HtmlMessageUtils
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ResourceProvider
+
+@ExperimentalCoroutinesApi
+@InternalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class ReaderPostCardActionsHandlerTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    private lateinit var actionHandler: ReaderPostCardActionsHandler
+    @Mock private lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Mock private lateinit var reblogUseCase: ReblogUseCase
+    @Mock private lateinit var bookmarkUseCase: ReaderPostBookmarkUseCase
+    @Mock private lateinit var followUseCase: ReaderSiteFollowUseCase
+    @Mock private lateinit var blockBlogUseCase: BlockBlogUseCase
+    @Mock private lateinit var likeUseCase: PostLikeUseCase
+    @Mock private lateinit var siteNotificationsUseCase: ReaderSiteNotificationsUseCase
+    @Mock private lateinit var undoBlockBlogUseCase: UndoBlockBlogUseCase
+    @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var resourceProvider: ResourceProvider
+    @Mock private lateinit var htmlMessageUtils: HtmlMessageUtils
+
+    @Before
+    fun setUp() {
+        actionHandler = ReaderPostCardActionsHandler(
+                analyticsTrackerWrapper,
+                reblogUseCase,
+                bookmarkUseCase,
+                followUseCase,
+                blockBlogUseCase,
+                likeUseCase,
+                siteNotificationsUseCase,
+                undoBlockBlogUseCase,
+                appPrefsWrapper,
+                dispatcher,
+                resourceProvider,
+                htmlMessageUtils,
+                TEST_DISPATCHER,
+                TEST_SCOPE,
+                TEST_SCOPE
+        )
+        whenever(appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog()).thenReturn(false)
+    }
+
+    /** BOOKMARK ACTION begin **/
+    @Test
+    fun `shows dialog when bookmark action is successful and shouldShowDialog returns true`() = test {
+        // Arrange
+        whenever(bookmarkUseCase.toggleBookmark(anyLong(), anyLong(), anyBoolean())).thenReturn(flowOf(Success(true)))
+        whenever(appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog()).thenReturn(true)
+
+        var observedValue: Event<ReaderNavigationEvents>? = null
+        actionHandler.navigationEvents.observeForever {
+            observedValue = it
+        }
+        // Act
+        actionHandler.onAction(dummyReaderPostModel(), BOOKMARK, false)
+
+        // Assert
+        assertThat(observedValue!!.peekContent()).isInstanceOf(ShowBookmarkedSavedOnlyLocallyDialog::class.java)
+    }
+
+    @Test
+    fun `doesn't shows when dialog bookmark action is successful and shouldShowDialog returns false`() = test {
+        // Arrange
+        whenever(bookmarkUseCase.toggleBookmark(anyLong(), anyLong(), anyBoolean())).thenReturn(flowOf(Success(true)))
+        whenever(appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog()).thenReturn(false)
+
+        var observedValue: Event<ReaderNavigationEvents>? = null
+        actionHandler.navigationEvents.observeForever {
+            observedValue = it
+        }
+        // Act
+        actionHandler.onAction(dummyReaderPostModel(), BOOKMARK, false)
+
+        // Assert
+        assertThat(observedValue).isNull()
+    }
+
+    @Test
+    fun `shows snackbar on successful bookmark action`() = test {
+        // Arrange
+        whenever(bookmarkUseCase.toggleBookmark(anyLong(), anyLong(), anyBoolean())).thenReturn(flowOf(Success(true)))
+
+        var observedValue: Event<SnackbarMessageHolder>? = null
+        actionHandler.snackbarEvents.observeForever {
+            observedValue = it
+        }
+        // Act
+        actionHandler.onAction(dummyReaderPostModel(), BOOKMARK, false)
+
+        // Assert
+        assertThat(observedValue!!.peekContent()).isNotNull
+    }
+
+    @Test
+    fun `Doesn't show snackbar on successful bookmark action when on bookmark(saved) tab`() = test {
+        // Arrange
+        whenever(bookmarkUseCase.toggleBookmark(anyLong(), anyLong(), anyBoolean())).thenReturn(flowOf(Success(true)))
+
+        var observedValue: Event<SnackbarMessageHolder>? = null
+        actionHandler.snackbarEvents.observeForever {
+            observedValue = it
+        }
+        val isBookmarkList = true
+        // Act
+        actionHandler.onAction(dummyReaderPostModel(), BOOKMARK, isBookmarkList)
+
+        // Assert
+        assertThat(observedValue).isNull()
+    }
+
+    @Test
+    fun `Doesn't show snackbar on successful UNbookmark action`() = test {
+        // Arrange
+        whenever(bookmarkUseCase.toggleBookmark(anyLong(), anyLong(), anyBoolean())).thenReturn(flowOf(Success(false)))
+
+        var observedValue: Event<SnackbarMessageHolder>? = null
+        actionHandler.snackbarEvents.observeForever {
+            observedValue = it
+        }
+        val isBookmarkList = true
+        // Act
+        actionHandler.onAction(dummyReaderPostModel(), BOOKMARK, isBookmarkList)
+
+        // Assert
+        assertThat(observedValue).isNull()
+    }
+
+    @Test
+    fun `navigates to bookmark tab on bookmark snackbar action clicked`() = test {
+        // Arrange
+        whenever(bookmarkUseCase.toggleBookmark(anyLong(), anyLong(), anyBoolean())).thenReturn(flowOf(Success(true)))
+
+        var snackBarObservedValue: Event<SnackbarMessageHolder>? = null
+        actionHandler.snackbarEvents.observeForever {
+            snackBarObservedValue = it
+        }
+
+        var navigationObservedValue: Event<ReaderNavigationEvents>? = null
+        actionHandler.navigationEvents.observeForever {
+            navigationObservedValue = it
+        }
+
+        // Act
+        actionHandler.onAction(dummyReaderPostModel(), BOOKMARK, false)
+        snackBarObservedValue!!.peekContent().buttonAction.invoke()
+
+        // Assert
+        assertThat(navigationObservedValue!!.peekContent()).isEqualTo(ShowBookmarkedTab)
+    }
+    /** BOOKMARK ACTION end **/
+
+    private fun dummyReaderPostModel(): ReaderPost {
+        return ReaderPost().apply {
+            postId = 1
+            blogId = 1
+        }
+    }
+}


### PR DESCRIPTION
Parent issue #12028

This PR is targeting 15.7 but it can be merged even to 15.8. 

This PR refactors the BookmarkAction:
1. Replaces LiveData living inside a usecase with Flow
2. Moves snackbar logic outside of the usecase
3.  Removes logic related to refreshing the content on bookmark action from the ReaderPostListAdapter
4. Fixes tests
5. Adds tests related to bookmark action for the ReaderPostActionHandler

To test:
Test this action on following and discover tabs (enable RI FF if the PR which removes it hasn't been merged yet)

Dialog
1. Clear app data
2. Open Reader - Following tab
3. Click on Bookmark action on one of the items
4. Notice a dialog is shown
5. Click on OK and go to Saved tab
6. Notice the post is saved there

Snackbar
1. Open Reader - Following tab
1. Click on Bookmark action on another item
2. Notice Snackbar is shown
3. Click on "View All" action in the snackbar
4. Notice the "Saved" tab is shown and the post is there

Offline
1. Open Reader - Following tab
1. Click on Bookmark action on yet another item
2. Notice snackbar is shown
3. Wait for cca 10s
4. Turn on airplane mode
5. Go to Saved tab
6. Open the post and notice the content (even images) are loaded correctly even though you are offline

Unbookmark
1. Click on unbookmark action on one of the saved items
2. Notice the post gets unbookmarked and is removed from the saved tab (it might still be there but in a collapsed mode with "Undo" action)




PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
