### PR TITLE
Fix incorrect bundle location in the Release build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,9 +242,9 @@ jobs:
       - restore-gutenberg-bundle-cache
       - run:
           name: Ensure assets folder exists
-          command: mkdir -p libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/src/main/assets
+          command: mkdir -p libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/build/assets
       - attach_workspace:
-          at: libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/src/main/assets
+          at: libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/build/assets
       - run:
           name: Install other tools
           command: |


### PR DESCRIPTION
This PR applies the same fix of https://github.com/wordpress-mobile/WordPress-Android/pull/12862 to the `Release Builds` job. 
The job was merged into `develop` after 12862 was created, so it didn't get fixed there. 


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
