### PR TITLE
UL&S: Fix nullable parameter in AvatarHelper

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/AvatarHelper.kt
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/AvatarHelper.kt
@@ -39,7 +39,7 @@ object AvatarHelper {
                 .listener(object : RequestListener<Drawable?> {
                     override fun onLoadFailed(
                         e: GlideException?,
-                        model: Any,
+                        model: Any?,
                         target: Target<Drawable?>,
                         isFirstResource: Boolean
                     ): Boolean {
@@ -49,7 +49,7 @@ object AvatarHelper {
 
                     override fun onResourceReady(
                         drawable: Drawable?,
-                        model: Any,
+                        model: Any?,
                         target: Target<Drawable?>,
                         dataSource: DataSource,
                         isFirstResource: Boolean


### PR DESCRIPTION
Fixes #12730

This PR makes the `model` parameter used by Glide's `RequestListener` in `AvatarHelper` nullable.

To test:

I actually have not been able to reproduce the issue, but I'm assuming this is the correct way to go, considering the [stack trace logged in Sentry](https://sentry.io/share/issue/704c7d1782b146e38dbd470f3456c32c/) and some other similar issues we found recently, like #12794 and #12804

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
