### PR TITLE
Fixing magiclink backstack issue when passwordless

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -565,6 +565,10 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
     @Override
     public void showMagicLinkSentScreen(String email, boolean allowPassword) {
+        if (!allowPassword) {
+            getSupportFragmentManager().popBackStackImmediate();
+        }
+
         LoginMagicLinkSentFragment loginMagicLinkSentFragment =
                 LoginMagicLinkSentFragment.newInstance(email, allowPassword);
         slideInFragment(loginMagicLinkSentFragment, true, LoginMagicLinkSentFragment.TAG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -564,10 +564,6 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
     @Override
     public void showMagicLinkSentScreen(String email, boolean allowPassword) {
-        if (!allowPassword) {
-            getSupportFragmentManager().popBackStackImmediate();
-        }
-
         LoginMagicLinkSentFragment loginMagicLinkSentFragment =
                 LoginMagicLinkSentFragment.newInstance(email, allowPassword);
         slideInFragment(loginMagicLinkSentFragment, true, LoginMagicLinkSentFragment.TAG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -9,7 +9,6 @@ import android.view.MenuItem;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
 import com.google.android.gms.auth.api.credentials.Credential;

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
@@ -21,7 +21,6 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
@@ -21,6 +21,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -352,6 +353,14 @@ public class LoginMagicLinkRequestFragment extends Fragment {
         mAnalyticsListener.trackMagicLinkRequested();
 
         if (mLoginListener != null) {
+            // when magic link request if forced we want to remove this fragment from backstack so user will not be
+            // able to navigate back to it from "Magic Link Sent" Screen
+            if (mForceRequestAtStart) {
+                FragmentManager fragmentManager = getFragmentManager();
+                if (fragmentManager != null) {
+                    fragmentManager.popBackStackImmediate();
+                }
+            }
             mLoginListener.showMagicLinkSentScreen(mEmail, mAllowPassword);
         }
     }


### PR DESCRIPTION
@renanferrari As we discussed, I did quite a bit of research on the problem and tried a couple of different approaches (back stack listener, adding "artificial" back stack entries). I think that poping back stack when navigating to the "magic link sent" fragment is the least hacky, and relatively smooth for the user. For a brief moment between transitions, you can see the email input fragment appearing, but if you are not looking for it it's hard to tell.

It's a bit of a shame there is no "appropriate" way to do this, but maybe, as you mentioned, we will be able to do it with the new Navigation component at some point.

To test:
- Using the passwordless account, input email, continue and notice that magic link is getting automatically requested, and you are transferred to email check fragment. Press back/up button and confirm that you are back in the email input fragment.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
