### PR TITLE
RI: Fix tags action for logged out users

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -145,6 +145,7 @@ import org.wordpress.android.ui.reader.SubfilterBottomSheetFragment;
 import org.wordpress.android.ui.reader.adapters.ReaderBlogAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderCommentAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
+import org.wordpress.android.ui.reader.adapters.ReaderTagAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderUserAdapter;
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverFragment;
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsFragment;
@@ -393,6 +394,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(ReaderCommentAdapter object);
 
     void inject(ReaderPostAdapter object);
+
+    void inject(ReaderTagAdapter object);
 
     void inject(PlansListFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader.actions;
 
-import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
 
 import org.greenrobot.eventbus.EventBus;
@@ -31,44 +30,57 @@ public class ReaderTagActions {
     }
 
     public static boolean deleteTag(final ReaderTag tag,
-                                    final ReaderActions.ActionListener actionListener) {
+                                    final ReaderActions.ActionListener actionListener,
+                                    final boolean isLoggedIn) {
         if (tag == null) {
             ReaderActions.callActionListener(actionListener, false);
             return false;
         }
 
+        boolean result;
+        if (!isLoggedIn) {
+            result = deleteTagsLocallyOnly(actionListener, tag);
+        } else {
+            result = deleteTagsLocallyAndRemotely(actionListener, tag);
+        }
+
+        return result;
+    }
+
+    private static boolean deleteTagsLocallyOnly(ActionListener actionListener, ReaderTag tag) {
+        ReaderTagTable.deleteTag(tag);
+        ReaderActions.callActionListener(actionListener, true);
+        EventBus.getDefault().post(new ReaderEvents.FollowedTagsChanged(true));
+
+        return true;
+    }
+
+    private static boolean deleteTagsLocallyAndRemotely(ActionListener actionListener, ReaderTag tag) {
         final String tagNameForApi = ReaderUtils.sanitizeWithDashes(tag.getTagSlug());
         final String path = "read/tags/" + tagNameForApi + "/mine/delete";
 
-        com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
-            @Override
-            public void onResponse(JSONObject jsonObject) {
-                AppLog.i(T.READER, "delete tag succeeded");
+        com.wordpress.rest.RestRequest.Listener listener = jsonObject -> {
+            AppLog.i(T.READER, "delete tag succeeded");
+            ReaderActions.callActionListener(actionListener, true);
+        };
+
+        RestRequest.ErrorListener errorListener = volleyError -> {
+            // treat it as a success if the error says the user isn't following the deleted tag
+            String error = VolleyUtils.errStringFromVolleyError(volleyError);
+            if (error.equals("not_subscribed")) {
+                AppLog.w(T.READER, "delete tag succeeded with error " + error);
                 ReaderActions.callActionListener(actionListener, true);
+                return;
             }
+
+            AppLog.w(T.READER, " delete tag failed");
+            AppLog.e(T.READER, volleyError);
+
+            // add back original tag
+            ReaderTagTable.addOrUpdateTag(tag);
+
+            ReaderActions.callActionListener(actionListener, false);
         };
-
-        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError volleyError) {
-                // treat it as a success if the error says the user isn't following the deleted tag
-                String error = VolleyUtils.errStringFromVolleyError(volleyError);
-                if (error.equals("not_subscribed")) {
-                    AppLog.w(T.READER, "delete tag succeeded with error " + error);
-                    ReaderActions.callActionListener(actionListener, true);
-                    return;
-                }
-
-                AppLog.w(T.READER, " delete tag failed");
-                AppLog.e(T.READER, volleyError);
-
-                // add back original tag
-                ReaderTagTable.addOrUpdateTag(tag);
-
-                ReaderActions.callActionListener(actionListener, false);
-            }
-        };
-
         ReaderTagTable.deleteTag(tag);
         WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
 
@@ -104,21 +116,25 @@ public class ReaderTagActions {
                     ReaderTagType.FOLLOWED);
             newTags.add(newTag);
         }
+        boolean result;
         if (!isLoggedIn) {
-            saveTagsLocallyOnly(newTags);
+            result = saveTagsLocallyOnly(actionListener, newTags);
         } else {
-            saveTagsLocallyAndRemotely(actionListener, newTags);
+            result = saveTagsLocallyAndRemotely(actionListener, newTags);
         }
+
+        return result;
+    }
+
+    private static boolean saveTagsLocallyOnly(ActionListener actionListener, ReaderTagList newTags) {
+        ReaderTagTable.addOrUpdateTags(newTags);
+        ReaderActions.callActionListener(actionListener, true);
+        EventBus.getDefault().post(new ReaderEvents.FollowedTagsChanged(true));
 
         return true;
     }
 
-    private static void saveTagsLocallyOnly(ReaderTagList newTags) {
-        ReaderTagTable.addOrUpdateTags(newTags);
-        EventBus.getDefault().post(new ReaderEvents.FollowedTagsChanged(true));
-    }
-
-    private static void saveTagsLocallyAndRemotely(ActionListener actionListener,
+    private static boolean saveTagsLocallyAndRemotely(ActionListener actionListener,
                                                    ReaderTagList newTags) {
         ReaderTagList existingFollowedTags = ReaderTagTable.getFollowedTags();
 
@@ -166,6 +182,8 @@ public class ReaderTagActions {
         params.put("tags", newTagSlugs);
 
         WordPress.getRestClientUtilsV1_2().post(path, params, null, listener, errorListener);
+
+        return true;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -321,13 +321,14 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         };
 
         boolean success;
+        boolean isLoggedIn = mAccountStore.hasAccessToken();
         if (isAskingToFollow) {
-            success = ReaderTagActions.addTag(mCurrentTag, listener, mAccountStore.hasAccessToken());
+            success = ReaderTagActions.addTag(mCurrentTag, listener, isLoggedIn);
         } else {
-            success = ReaderTagActions.deleteTag(mCurrentTag, listener);
+            success = ReaderTagActions.deleteTag(mCurrentTag, listener, isLoggedIn);
         }
 
-        if (success) {
+        if (isLoggedIn && success) {
             renderTagHeader(currentTag, tagHolder, false);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -12,7 +12,9 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderTagTable;
+import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagList;
 import org.wordpress.android.ui.reader.ReaderInterfaces;
@@ -27,11 +29,14 @@ import org.wordpress.android.util.ViewUtilsKt;
 
 import java.lang.ref.WeakReference;
 
+import javax.inject.Inject;
+
 public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagViewHolder> {
     public interface TagDeletedListener {
         void onTagDeleted(ReaderTag tag);
     }
 
+    @Inject AccountStore mAccountStore;
     private final WeakReference<Context> mWeakContext;
     private final ReaderTagList mTags = new ReaderTagList();
     private TagDeletedListener mTagDeletedListener;
@@ -39,6 +44,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
 
     public ReaderTagAdapter(Context context) {
         super();
+        ((WordPress) context.getApplicationContext()).component().inject(this);
         setHasStableIds(true);
         mWeakContext = new WeakReference<>(context);
     }
@@ -114,7 +120,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
             }
         };
 
-        boolean success = ReaderTagActions.deleteTag(tag, actionListener);
+        boolean success = ReaderTagActions.deleteTag(tag, actionListener, mAccountStore.hasAccessToken());
 
         if (success) {
             int index = mTags.indexOfTagName(tag.getTagSlug());


### PR DESCRIPTION
This PR fixes logged out behaviour for tag actions. 

(Follow button got disabled after an optimistic update and was not reverted to enabled state as the action listener was not notified after local save/delete action.)

**Merge instructions**

1. Make sure #12859 is merged
2. Change branch to "develop"
3. Remove "Not Ready for Merge" 
4. Merge this PR

### To test

**Test follow/unfollow in logged out scenario** 
(login from self-hosted site)

1. Launch app and login with a self-hosted site
2. Select a tag/ topic from a post on the Reader -> Discover tab
3. Toggle follow once to follow and then to unfollow the topic on the Topic details page
4. Notice that follow button is toggled both times

---------------------------
**Test add/delete tag action from "Manage Tags & Sites"** 
(since we now pass logged in status from `ReaderTagsAdapter`)

1. Launch app and login with wp.com account
2. Go to Manage Tags & Sites 
3. Delete a followed tag
4. Notice that tag is deleted
5. Follow a tag from input box in the footer
6. Notice that tag is added to the list of followed tags

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
