### PR TITLE
Add search to media picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaLoader.kt
@@ -9,8 +9,9 @@ import org.wordpress.android.ui.mediapicker.MediaLoader.LoadAction.Refresh
 import org.wordpress.android.ui.mediapicker.MediaLoader.LoadAction.Start
 import org.wordpress.android.ui.mediapicker.MediaSource.MediaLoadingResult.Failure
 import org.wordpress.android.ui.mediapicker.MediaSource.MediaLoadingResult.Success
+import org.wordpress.android.util.LocaleManagerWrapper
 
-data class MediaLoader(private val mediaSource: MediaSource) {
+data class MediaLoader(private val mediaSource: MediaSource, private val localeManagerWrapper: LocaleManagerWrapper) {
     suspend fun loadMedia(actions: Channel<LoadAction>): Flow<DomainModel> {
         return flow {
             var state = DomainState()
@@ -80,7 +81,15 @@ data class MediaLoader(private val mediaSource: MediaSource) {
 
     private fun buildDomainModel(state: DomainState): DomainModel {
         return if (!state.filter.isNullOrEmpty()) {
-            DomainModel(state.items.filter { it.name?.contains(state.filter) == true }, state.error, state.hasMore)
+            val filter = state.filter.toLowerCase(localeManagerWrapper.getLocale())
+            DomainModel(
+                    state.items.filter {
+                        it.name?.toLowerCase(localeManagerWrapper.getLocale())
+                                ?.contains(filter) == true
+                    },
+                    state.error,
+                    state.hasMore
+            )
         } else {
             DomainModel(state.items, state.error, state.hasMore)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactory.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactory.kt
@@ -4,13 +4,14 @@ import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.DEVICE
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.GIF_LIBRARY
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.STOCK_LIBRARY
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.WP_LIBRARY
+import org.wordpress.android.util.LocaleManagerWrapper
 import javax.inject.Inject
 
 class MediaLoaderFactory
-@Inject constructor(private val deviceListBuilder: DeviceListBuilder) {
+@Inject constructor(private val deviceListBuilder: DeviceListBuilder, private val localeManagerWrapper: LocaleManagerWrapper) {
     fun build(mediaSourceType: MediaPickerSetup.DataSource): MediaLoader {
         return when (mediaSourceType) {
-            DEVICE -> MediaLoader(deviceListBuilder)
+            DEVICE -> MediaLoader(deviceListBuilder, localeManagerWrapper)
             WP_LIBRARY -> throw NotImplementedError("Source not implemented yet")
             STOCK_LIBRARY -> throw NotImplementedError("Source not implemented yet")
             GIF_LIBRARY -> throw NotImplementedError("Source not implemented yet")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactory.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactory.kt
@@ -8,7 +8,10 @@ import org.wordpress.android.util.LocaleManagerWrapper
 import javax.inject.Inject
 
 class MediaLoaderFactory
-@Inject constructor(private val deviceListBuilder: DeviceListBuilder, private val localeManagerWrapper: LocaleManagerWrapper) {
+@Inject constructor(
+    private val deviceListBuilder: DeviceListBuilder,
+    private val localeManagerWrapper: LocaleManagerWrapper
+) {
     fun build(mediaSourceType: MediaPickerSetup.DataSource): MediaLoader {
         return when (mediaSourceType) {
             DEVICE -> MediaLoader(deviceListBuilder, localeManagerWrapper)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -6,10 +6,14 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.text.Html
 import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupMenu
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -63,6 +67,7 @@ class MediaPickerFragment : Fragment() {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(MediaPickerViewModel::class.java)
+        setHasOptionsMenu(true)
     }
 
     override fun onCreateView(
@@ -185,6 +190,31 @@ class MediaPickerFragment : Fragment() {
         })
 
         viewModel.start(selectedUris, mediaPickerSetup, lastTappedIcon, site)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_search, menu)
+
+        val actionMenuItem = checkNotNull(menu.findItem(R.id.action_search)) {
+            "Menu does not contain mandatory search item"
+        }
+        initializeSearchView(actionMenuItem)
+    }
+
+    private fun initializeSearchView(actionMenuItem: MenuItem) {
+        val searchView = actionMenuItem.actionView as SearchView
+        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextSubmit(query: String): Boolean {
+                viewModel.onSearch(query)
+                return true
+            }
+
+            override fun onQueryTextChange(query: String): Boolean {
+                viewModel.onSearch(query)
+                return true
+            }
+        })
     }
 
     private fun setupSoftAskView(uiModel: SoftAskViewUiModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -344,6 +344,12 @@ class MediaPickerViewModel @Inject constructor(
         }
     }
 
+    fun onSearch(query: String) {
+        launch(bgDispatcher) {
+            loadActions.send(LoadAction.Filter(query))
+        }
+    }
+
     data class MediaPickerUiState(
         val photoListUiModel: PhotoListUiModel,
         val softAskViewUiModel: SoftAskViewUiModel,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactoryTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mediapicker
 
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Before
@@ -11,22 +12,26 @@ import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.DEVICE
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.GIF_LIBRARY
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.STOCK_LIBRARY
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.WP_LIBRARY
+import org.wordpress.android.util.LocaleManagerWrapper
+import java.util.Locale
 
 @RunWith(MockitoJUnitRunner::class)
 class MediaLoaderFactoryTest {
     @Mock lateinit var deviceListBuilder: DeviceListBuilder
+    @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
     private lateinit var mediaLoaderFactory: MediaLoaderFactory
 
     @Before
     fun setUp() {
-        mediaLoaderFactory = MediaLoaderFactory(deviceListBuilder)
+        mediaLoaderFactory = MediaLoaderFactory(deviceListBuilder, localeManagerWrapper)
+        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
     }
 
     @Test
     fun `returns device list builder on DEVICE source`() {
         val mediaLoader = mediaLoaderFactory.build(DEVICE)
 
-        assertThat(mediaLoader).isEqualTo(MediaLoader(deviceListBuilder))
+        assertThat(mediaLoader).isEqualTo(MediaLoader(deviceListBuilder, localeManagerWrapper))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactoryTest.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.mediapicker
 
-import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.Before
@@ -13,7 +12,6 @@ import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.GIF_LIBR
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.STOCK_LIBRARY
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.WP_LIBRARY
 import org.wordpress.android.util.LocaleManagerWrapper
-import java.util.Locale
 
 @RunWith(MockitoJUnitRunner::class)
 class MediaLoaderFactoryTest {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactoryTest.kt
@@ -24,7 +24,6 @@ class MediaLoaderFactoryTest {
     @Before
     fun setUp() {
         mediaLoaderFactory = MediaLoaderFactory(deviceListBuilder, localeManagerWrapper)
-        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderTest.kt
@@ -16,20 +16,23 @@ import org.wordpress.android.ui.mediapicker.MediaLoader.LoadAction
 import org.wordpress.android.ui.mediapicker.MediaSource.MediaLoadingResult
 import org.wordpress.android.ui.mediapicker.MediaType.IMAGE
 import org.wordpress.android.ui.mediapicker.MediaType.VIDEO
+import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.UriWrapper
+import java.util.Locale
 
 class MediaLoaderTest : BaseUnitTest() {
     @Mock lateinit var mediaSource: MediaSource
+    @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
     @Mock lateinit var uri1: UriWrapper
     @Mock lateinit var uri2: UriWrapper
     private lateinit var mediaLoader: MediaLoader
-    private val mediaTypes = setOf(MediaType.IMAGE, VIDEO)
+    private val mediaTypes = setOf(IMAGE, VIDEO)
     private lateinit var firstMediaItem: MediaItem
     private lateinit var secondMediaItem: MediaItem
 
     @Before
     fun setUp() {
-        mediaLoader = MediaLoader(mediaSource)
+        mediaLoader = MediaLoader(mediaSource, localeManagerWrapper)
         firstMediaItem = MediaItem(uri1, "first item", IMAGE, "image/jpeg", 1)
         secondMediaItem = MediaItem(uri2, "second item", VIDEO, "video/mpeg", 2)
     }
@@ -107,6 +110,37 @@ class MediaLoaderTest : BaseUnitTest() {
         performAction(LoadAction.Refresh, true)
 
         resultModel.assertModel(listOf(secondMediaItem))
+    }
+
+    @Test
+    fun `filters out media item`() = withMediaLoader { resultModel, performAction ->
+        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
+        val mediaItems = listOf(firstMediaItem, secondMediaItem)
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(MediaLoadingResult.Success(mediaItems))
+
+        performAction(LoadAction.Start(mediaTypes), true)
+
+        performAction(LoadAction.Filter("second"), true)
+
+        resultModel.assertModel(listOf(secondMediaItem))
+
+        performAction(LoadAction.ClearFilter, true)
+
+        resultModel.assertModel(mediaItems)
+    }
+
+    @Test
+    fun `clears filter`() = withMediaLoader { resultModel, performAction ->
+        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
+        val mediaItems = listOf(firstMediaItem, secondMediaItem)
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(MediaLoadingResult.Success(mediaItems))
+
+        performAction(LoadAction.Start(mediaTypes), true)
+        performAction(LoadAction.Filter("second"), true)
+
+        performAction(LoadAction.ClearFilter, true)
+
+        resultModel.assertModel(mediaItems)
     }
 
     private fun List<DomainModel>.assertModel(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.MediaPickerUiSt
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.PhotoListUiModel
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.SoftAskViewUiModel
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.DEVICE
+import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.SearchUiModel
 import org.wordpress.android.ui.mediapicker.MediaType.AUDIO
 import org.wordpress.android.ui.mediapicker.MediaType.DOCUMENT
 import org.wordpress.android.ui.mediapicker.MediaType.IMAGE
@@ -298,6 +299,21 @@ class MediaPickerViewModelTest : BaseUnitTest() {
         assertActionModeVisible(UiStringText("1 selected"), showEditAction = false)
     }
 
+    @Test
+    fun `on search expanded updates state`() = test {
+        val query = "filter"
+        setupViewModel(listOf(firstItem), singleSelectMediaPickerSetup, filter = query)
+
+        viewModel.refreshData(false)
+
+        assertThat(uiStates).hasSize(2)
+        assertSearchCollapsed()
+
+        viewModel.onSearchExpanded()
+
+        assertSearchExpanded(query)
+    }
+
     private fun selectItem(position: Int) {
         (uiStates.last().photoListUiModel as PhotoListUiModel.Data).items[position].toggleAction.toggle()
     }
@@ -350,11 +366,13 @@ class MediaPickerViewModelTest : BaseUnitTest() {
     private suspend fun setupViewModel(
         domainModel: List<MediaItem>,
         mediaPickerSetup: MediaPickerSetup,
-        hasStoragePermissions: Boolean = true
+        hasStoragePermissions: Boolean = true,
+        filter: String? = null,
+        numberOfStates: Int = 2
     ) {
         whenever(permissionsHandler.hasStoragePermission()).thenReturn(hasStoragePermissions)
         whenever(mediaLoaderFactory.build(mediaPickerSetup.dataSource)).thenReturn(mediaLoader)
-        whenever(mediaLoader.loadMedia(any())).thenReturn(flow { emit(DomainModel(domainModel)) })
+        whenever(mediaLoader.loadMedia(any())).thenReturn(flow { emit(DomainModel(domainModel, filter = filter)) })
         viewModel.start(listOf(), mediaPickerSetup, null, site)
         viewModel.uiState.observeForever {
             if (it != null) {
@@ -366,7 +384,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
                 navigateEvents.add(it)
             }
         }
-        assertThat(uiStates).hasSize(2)
+        assertThat(uiStates).hasSize(numberOfStates)
     }
 
     private fun PhotoListUiModel.Data.assertSelection(
@@ -390,7 +408,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
 
     private fun MediaPickerUiItem.assertEqualToDomainItem(domainItem: MediaItem) {
         assertThat(this.uri).isEqualTo(domainItem.uri)
-        when(domainItem.type) {
+        when (domainItem.type) {
             IMAGE -> assertThat(this is MediaPickerUiItem.PhotoItem)
             VIDEO -> assertThat(this is MediaPickerUiItem.VideoItem)
             DOCUMENT, AUDIO -> assertThat(this is MediaPickerUiItem.FileItem)
@@ -410,6 +428,19 @@ class MediaPickerViewModelTest : BaseUnitTest() {
             val model = it as ActionModeUiModel.Visible
             assertThat(model.actionModeTitle).isEqualTo(title)
             assertThat(model.showEditAction).isEqualTo(showEditAction)
+        }
+    }
+
+    private fun assertSearchCollapsed() {
+        uiStates.last().searchUiModel.let { model ->
+            assertThat(model is SearchUiModel.Collapsed).isTrue()
+        }
+    }
+
+    private fun assertSearchExpanded(filter: String) {
+        uiStates.last().searchUiModel.let { model ->
+            assertThat(model is SearchUiModel.Expanded).isTrue()
+            assertThat((model as SearchUiModel.Expanded).filter).isEqualTo(filter)
         }
     }
 }


### PR DESCRIPTION
Fixes #12637 

This PR adds search capability to the Media picker. The search filters out the results by name from the currently showing items. The search should survive screen rotation. 

To test:
- Go to Media library/+/Choose from device
- Notice there is the search icon in the toolbar
- Click on the search icon
- The search field expands
- Rotate your device
- The search field is still expanded
- Input search query
- Notice that the results get filtered out
- Delete the query
- The results reappear
- Select an item in the search state
- The action mode appears over the search
- Confirm selection
- Selected item is uploaded

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
