### PR TITLE
Fix navigation to bookmarked tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -18,7 +18,6 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.datasets.ReaderPostTable;
-import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.fluxc.model.PostImmutableModel;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -64,7 +63,6 @@ import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.posts.PostsListActivity;
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType;
 import org.wordpress.android.ui.prefs.AccountSettingsActivity;
-import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.AppSettingsActivity;
 import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
 import org.wordpress.android.ui.prefs.MyProfileActivity;
@@ -101,8 +99,8 @@ import static org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTIC
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTICLE_REBLOGGED;
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_ACCESS_ERROR;
 import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG_EDIT_IMAGE_DATA;
-import static org.wordpress.android.ui.media.MediaBrowserActivity.ARG_BROWSER_TYPE;
 import static org.wordpress.android.login.LoginMode.WPCOM_LOGIN_ONLY;
+import static org.wordpress.android.ui.media.MediaBrowserActivity.ARG_BROWSER_TYPE;
 import static org.wordpress.android.ui.pages.PagesActivityKt.EXTRA_PAGE_REMOTE_ID_KEY;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_ID_KEY;
 
@@ -409,14 +407,12 @@ public class ActivityLauncher {
     }
 
     public static void viewSavedPostsListInReader(Context context) {
-        // Easiest way to show reader with saved posts filter is to update the "last used filter" preference and make
-        // WPMainActivity restart itself with Intent.FLAG_ACTIVITY_CLEAR_TOP
-        if (!ReaderTagTable.getBookmarkTags().isEmpty()) {
-            AppPrefs.setReaderTag(ReaderTagTable.getBookmarkTags().get(0));
-        }
         ReaderPostTable.purgeUnbookmarkedPostsWithBookmarkTag();
-
-        viewReader(context);
+        Intent intent = new Intent(context, WPMainActivity.class);
+        intent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_READER);
+        intent.putExtra(WPMainActivity.ARG_READER_BOOKMARK_TAB, true);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        context.startActivity(intent);
     }
 
     public static void viewBlogStats(Context context, SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -101,6 +101,7 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.AppSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsFragment;
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
+import org.wordpress.android.ui.reader.ReaderFragment;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
@@ -169,6 +170,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     public static final String ARG_MY_SITE = "show_my_site";
     public static final String ARG_NOTIFICATIONS = "show_notifications";
     public static final String ARG_READER = "show_reader";
+    public static final String ARG_READER_BOOKMARK_TAB = "show_reader_bookmark_tab";
     public static final String ARG_EDITOR = "show_editor";
     public static final String ARG_SHOW_ZENDESK_NOTIFICATIONS = "show_zendesk_notifications";
     public static final String ARG_STATS = "show_stats";
@@ -597,7 +599,12 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     mBottomNav.setCurrentSelectedPage(PageType.NOTIFS);
                     break;
                 case ARG_READER:
-                    mBottomNav.setCurrentSelectedPage(PageType.READER);
+                    if (intent.getBooleanExtra(ARG_READER_BOOKMARK_TAB, false) && mBottomNav
+                            .getActiveFragment() instanceof ReaderFragment) {
+                        ((ReaderFragment) mBottomNav.getActiveFragment()).requestBookmarkTab();
+                    } else {
+                        mBottomNav.setCurrentSelectedPage(PageType.READER);
+                    }
                     break;
                 case ARG_EDITOR:
                     if (mSelectedSite == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -132,8 +132,8 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
         })
 
         viewModel.selectTab.observe(viewLifecycleOwner, Observer { selectTabAction ->
-            selectTabAction.getContentIfNotHandled()?.let { tabPosition ->
-                view_pager.setCurrentItem(tabPosition, false)
+            selectTabAction.getContentIfNotHandled()?.let { navTarget ->
+                view_pager.setCurrentItem(navTarget.position, navTarget.smoothAnimation)
             }
         })
 
@@ -165,6 +165,10 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
         TabLayoutMediator(tab_layout, view_pager) { tab, position ->
             tab.text = uiState.tabTitles[position]
         }.attach()
+    }
+
+    fun requestBookmarkTab() {
+        viewModel.bookmarkTabRequested()
     }
 
     private class TabsAdapter(parent: Fragment, private val tags: ReaderTagList) : FragmentStateAdapter(parent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -442,9 +442,6 @@ public class ReaderPostListFragment extends Fragment
                         ReaderActivityLauncher.showNoSiteToReblog(getActivity());
                     } else if (navTarget instanceof ShowBookmarkedTab) {
                         ActivityLauncher.viewSavedPostsListInReader(getActivity());
-                        if (requireActivity() instanceof WPMainActivity) {
-                            requireActivity().overridePendingTransition(0, 0);
-                        }
                     } else if (navTarget instanceof ShowBookmarkedSavedOnlyLocallyDialog) {
                         showBookmarksSavedLocallyDialog((ShowBookmarkedSavedOnlyLocallyDialog) navTarget);
                     } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -116,9 +116,6 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
                             .openEditorForReblog(activity, this.site, this.post, this.source)
                     is ShowBookmarkedTab -> {
                         ActivityLauncher.viewSavedPostsListInReader(activity)
-                        if (requireActivity() is WPMainActivity) {
-                            requireActivity().overridePendingTransition(0, 0)
-                        }
                     }
                     is ShowBookmarkedSavedOnlyLocallyDialog -> showBookmarkSavedLocallyDialog(this)
                     is ShowPostsByTag -> ReaderActivityLauncher.showReaderTagPreview(context, this.tag)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.main.SitePickerActivity
-import org.wordpress.android.ui.main.WPMainActivity
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.ReaderActivityLauncher
 import org.wordpress.android.ui.reader.ReaderPostWebViewCachingFragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -35,8 +35,6 @@ import javax.inject.Named
 const val UPDATE_TAGS_THRESHOLD = 1000 * 60 * 60
 const val TRACK_TAB_CHANGED_THROTTLE = 100L
 
-typealias TabPosition = Int
-
 class ReaderViewModel @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
@@ -58,8 +56,8 @@ class ReaderViewModel @Inject constructor(
     private val _updateTags = MutableLiveData<Event<Unit>>()
     val updateTags: LiveData<Event<Unit>> = _updateTags
 
-    private val _selectTab = MutableLiveData<Event<TabPosition>>()
-    val selectTab: LiveData<Event<TabPosition>> = _selectTab
+    private val _selectTab = MutableLiveData<Event<TabNavigation>>()
+    val selectTab: LiveData<Event<TabNavigation>> = _selectTab
 
     private val _showSearch = MutableLiveData<Event<Unit>>()
     val showSearch: LiveData<Event<Unit>> = _showSearch
@@ -110,7 +108,7 @@ class ReaderViewModel @Inject constructor(
             val selectTab = { it: ReaderTag ->
                 val index = tagList.indexOf(it)
                 if (index != -1) {
-                    _selectTab.postValue(Event(index))
+                    _selectTab.postValue(Event(TabNavigation(index, smoothAnimation = false)))
                 }
             }
             appPrefsWrapper.getReaderTag()?.let {
@@ -187,7 +185,13 @@ class ReaderViewModel @Inject constructor(
         uiState.value?.let {
             val currentUiState = it as ContentUiState
             val position = currentUiState.readerTagList.indexOfTagName(tag.tagSlug)
-            _selectTab.postValue(Event(position))
+            _selectTab.postValue(Event(TabNavigation(position, smoothAnimation = true)))
+        }
+    }
+
+    fun bookmarkTabRequested() {
+        (_uiState.value as? ContentUiState)?.readerTagList?.find { it.isBookmarked }?.let {
+            selectedTabChange(it)
         }
     }
 
@@ -236,3 +240,5 @@ class ReaderViewModel @Inject constructor(
         }
     }
 }
+
+data class TabNavigation(val position: Int, val smoothAnimation: Boolean)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -162,14 +162,14 @@ class ReaderViewModelTest {
         // Arrange
         whenever(appPrefsWrapper.getReaderTag()).thenReturn(nonEmptyReaderTagList[3])
 
-        var tabPosition: TabPosition? = null
+        var tabNavigation: TabNavigation? = null
         viewModel.selectTab.observeForever {
-            tabPosition = it.getContentIfNotHandled()
+            tabNavigation = it.getContentIfNotHandled()
         }
         // Act
         triggerReaderTabContentDisplay()
         // Assert
-        assertThat(tabPosition).isEqualTo(3)
+        assertThat(tabNavigation!!.position).isEqualTo(3)
     }
 
     @Test
@@ -177,27 +177,27 @@ class ReaderViewModelTest {
         // Arrange
         whenever(appPrefsWrapper.getReaderTag()).thenReturn(null)
 
-        var tabPosition: TabPosition? = null
+        var tabNavigation: TabNavigation? = null
         viewModel.selectTab.observeForever {
-            tabPosition = it.getContentIfNotHandled()
+            tabNavigation = it.getContentIfNotHandled()
         }
         // Act
         triggerReaderTabContentDisplay()
         // Assert
-        assertThat(tabPosition).isGreaterThan(-1)
+        assertThat(tabNavigation!!.position).isGreaterThan(-1)
     }
 
     @Test
     fun `SelectTab when tags are empty`() = testWithEmptyTags {
         // Arrange
-        var tabPosition: TabPosition? = null
+        var tabNavigation: TabNavigation? = null
         viewModel.selectTab.observeForever {
-            tabPosition = it.getContentIfNotHandled()
+            tabNavigation = it.getContentIfNotHandled()
         }
         // Act
         triggerReaderTabContentDisplay()
         // Assert
-        assertThat(tabPosition).isNull()
+        assertThat(tabNavigation).isNull()
     }
 
     @Test
@@ -210,9 +210,9 @@ class ReaderViewModelTest {
 
         viewModel.uiState.observeForever { }
 
-        var tabPosition: TabPosition? = null
-            viewModel.selectTab.observeForever {
-                tabPosition = it.getContentIfNotHandled()
+        var tabNavigation: TabNavigation? = null
+        viewModel.selectTab.observeForever {
+            tabNavigation = it.getContentIfNotHandled()
         }
 
         // Act
@@ -220,7 +220,7 @@ class ReaderViewModelTest {
         viewModel.selectedTabChange(readerTag)
 
         // Assert
-        assertThat(tabPosition).isEqualTo(2)
+        assertThat(tabNavigation!!.position).isEqualTo(2)
     }
 
     @Test
@@ -386,6 +386,21 @@ class ReaderViewModelTest {
                 assertThat(viewModel.showReaderInterests.value).isNull()
             }
 
+    @Test
+    fun `Bookmark tab is selected when bookmarkTabRequested is invoked`() = testWithNonMockedNonEmptyTags {
+        // Arrange
+        var tabNavigation: TabNavigation? = null
+        viewModel.uiState.observeForever {}
+        viewModel.selectTab.observeForever {
+            tabNavigation = it.getContentIfNotHandled()
+        }
+        // Act
+        triggerReaderTabContentDisplay()
+        viewModel.bookmarkTabRequested()
+        // Assert
+        assertThat(tabNavigation!!.position).isEqualTo(3)
+    }
+
     private fun triggerReaderTabContentDisplay() {
         viewModel.start()
         if (appPrefsWrapper.isReaderImprovementsPhase2Enabled()) {
@@ -437,7 +452,7 @@ class ReaderViewModelTest {
             add(ReaderTag("Following", "Following", "Following", FOLLOWING_PATH, ReaderTagType.DEFAULT))
             add(ReaderTag("Discover", "Discover", "Discover", DISCOVER_PATH, ReaderTagType.DEFAULT))
             add(ReaderTag("Like", "Like", "Like", LIKED_PATH, ReaderTagType.DEFAULT))
-            add(ReaderTag("Saved", "Saved", "Saved", "Saved", ReaderTagType.DEFAULT))
+            add(ReaderTag("Saved", "Saved", "Saved", "Saved", ReaderTagType.BOOKMARKED))
         }
     }
 }


### PR DESCRIPTION
This PR improves animation when we navigate from "View All" action on bookmarked snackbar to the bookmark tab in Reader. 

| Before | After |
|-----|----|
| ![before](https://user-images.githubusercontent.com/2261188/92107979-f06a9800-ede6-11ea-8b63-c2fedfdaf18f.gif) | ![after](https://user-images.githubusercontent.com/2261188/92108019-fceef080-ede6-11ea-8e5a-1c955b7ca082.gif) |

To test:
1. Enable RI FF
2. Open Reader on Discover
3. Bookmark a post -> click on "View all"
--------------
1. Enable RI FF
2. Open Reader on Following
3. Bookmark a post -> click on "View all"
--------------
1. Enable RI FF
2. Open Reader on Discover
3. Open Post detail
4. Bookmark the post -> click on "View all"
--------------

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
