### PR TITLE
Test WordPressProcessors in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,11 @@ jobs:
           environment:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
           command: cd libs/utils && ./gradlew --stacktrace testReleaseUnitTest
+      - run:
+          name: Test WordPressProcessors
+          environment:
+            SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
+          command: ./gradlew :libs:WordPressProcessors:test --stacktrace
       - android/save-gradle-cache
       - android/save-test-results
   lint:


### PR DESCRIPTION
This PR adds `Test WordPressProcessors` to CircleCI. We recently found and fixed failing unit tests in the project in #12864 which was missed because CI wasn't running it.

**To test:**
Make sure `Test WordPressProcessors` task is run as part of `ci/circleci: test` and verify that it is successful. (which I already did 😄 )
 
**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
