### PR TITLE
Issue/12028 clean up clicks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -15,13 +15,6 @@ public class ReaderInterfaces {
     }
 
     /*
-     * Called by the [ReaderPostAdapter] to trigger the reblog action
-     */
-    public interface ReblogActionListener {
-        void reblog(ReaderPost post);
-    }
-
-    /*
      * Called by the [ReaderPostAdapter] to trigger the block site action
      */
     public interface BlockSiteActionListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -15,13 +15,6 @@ public class ReaderInterfaces {
     }
 
     /*
-     * Called by the [ReaderPostAdapter] to trigger the block site action
-     */
-    public interface BlockSiteActionListener {
-        void blockSite(ReaderPost post);
-    }
-
-    /*
      * called from post detail fragment so toolbar can animate in/out when scrolling
      */
     public interface AutoHideToolbarListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -45,11 +45,4 @@ public class ReaderInterfaces {
     public interface OnPostListItemButtonListener {
         void onButtonClicked(ReaderPost post, ReaderPostCardActionType actionType);
     }
-
-    /*
-     * used by adapters to notify when post bookmarked state has changed
-     */
-    public interface OnPostBookmarkedListener {
-        void onBookmarkClicked(long blogId, long postId);
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2572,9 +2572,11 @@ public class ReaderPostListFragment extends Fragment
             case LIKE:
                 mViewModel.onLikeButtonClicked(post, isBookmarksList());
                 break;
+            case REBLOG:
+                mViewModel.onReblogButtonClicked(post, isBookmarksList());
+                break;
             case BLOCK_SITE:
             case BOOKMARK:
-            case REBLOG:
             case COMMENTS:
                 throw new IllegalStateException("These actoins should be handled in ReaderPostAdapter.");
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -83,8 +83,6 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
 import org.wordpress.android.ui.reader.ReaderEvents.TagAdded;
-import org.wordpress.android.ui.reader.ReaderInterfaces.BlockSiteActionListener;
-import org.wordpress.android.ui.reader.ReaderInterfaces.ReblogActionListener;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
@@ -1893,9 +1891,6 @@ public class ReaderPostListFragment extends Fragment
         }
     };
 
-    private final ReaderInterfaces.OnPostBookmarkedListener mOnPostBookmarkedListener =
-            (blogId, postId) -> mViewModel.onBookmarkButtonClicked(blogId, postId, isBookmarksList());
-
     private void announceListStateForAccessibility() {
         if (getView() != null) {
             getView().announceForAccessibility(getString(R.string.reader_acessibility_list_loaded,
@@ -1980,13 +1975,10 @@ public class ReaderPostListFragment extends Fragment
                     mIsTopLevel
             );
             mPostAdapter.setOnFollowListener(this);
-            mPostAdapter.setReblogActionListener(this);
-            mPostAdapter.setBlockSiteActionListener(this);
             mPostAdapter.setOnPostSelectedListener(this);
             mPostAdapter.setOnPostListItemButtonListener(this);
             mPostAdapter.setOnDataLoadedListener(mDataLoadedListener);
             mPostAdapter.setOnDataRequestedListener(mDataRequestedListener);
-            mPostAdapter.setOnPostBookmarkedListener(mOnPostBookmarkedListener);
             if (getActivity() instanceof ReaderSiteHeaderView.OnBlogInfoLoadedListener) {
                 mPostAdapter.setOnBlogInfoLoadedListener((ReaderSiteHeaderView.OnBlogInfoLoadedListener) getActivity());
             }
@@ -2577,6 +2569,8 @@ public class ReaderPostListFragment extends Fragment
                 mViewModel.onBlockSiteButtonClicked(post, isBookmarksList());
                 break;
             case BOOKMARK:
+                mViewModel.onBookmarkButtonClicked(post.blogId, post.postId, isBookmarksList());
+                break;
             case COMMENTS:
                 throw new IllegalStateException("These actoins should be handled in ReaderPostAdapter.");
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2572,7 +2572,8 @@ public class ReaderPostListFragment extends Fragment
                 mViewModel.onBookmarkButtonClicked(post.blogId, post.postId, isBookmarksList());
                 break;
             case COMMENTS:
-                throw new IllegalStateException("These actoins should be handled in ReaderPostAdapter.");
+                ReaderActivityLauncher.showReaderComments(requireContext(), post.blogId, post.postId);
+                break;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -151,9 +151,7 @@ public class ReaderPostListFragment extends Fragment
         ReaderInterfaces.OnFollowListener,
         ReaderInterfaces.OnPostListItemButtonListener,
         WPMainActivity.OnActivityBackPressedListener,
-        WPMainActivity.OnScrollToTopListener,
-        ReblogActionListener,
-        BlockSiteActionListener {
+        WPMainActivity.OnScrollToTopListener {
     private static final int TAB_POSTS = 0;
     private static final int TAB_SITES = 1;
     private static final int NO_POSITION = -1;
@@ -2576,6 +2574,8 @@ public class ReaderPostListFragment extends Fragment
                 mViewModel.onReblogButtonClicked(post, isBookmarksList());
                 break;
             case BLOCK_SITE:
+                mViewModel.onBlockSiteButtonClicked(post, isBookmarksList());
+                break;
             case BOOKMARK:
             case COMMENTS:
                 throw new IllegalStateException("These actoins should be handled in ReaderPostAdapter.");
@@ -2655,16 +2655,6 @@ public class ReaderPostListFragment extends Fragment
         if (isAdded() && getCurrentPosition() > 0) {
             mRecyclerView.smoothScrollToPosition(0);
         }
-    }
-
-    @Override
-    public void reblog(ReaderPost post) {
-        mViewModel.onReblogButtonClicked(post, isBookmarksList());
-    }
-
-    @Override
-    public void blockSite(ReaderPost post) {
-        mViewModel.onBlockSiteButtonClicked(post, isBookmarksList());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -94,7 +94,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private ReaderInterfaces.OnFollowListener mFollowListener;
     private ReaderInterfaces.OnPostSelectedListener mPostSelectedListener;
     private ReaderInterfaces.DataLoadedListener mDataLoadedListener;
-    private ReaderInterfaces.OnPostBookmarkedListener mOnPostBookmarkedListener;
     private ReaderActions.DataRequestedListener mDataRequestedListener;
     private ReaderSiteHeaderView.OnBlogInfoLoadedListener mBlogInfoLoadedListener;
 
@@ -359,7 +358,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private void undoPostUnbookmarked(final ReaderPost post, final int position) {
         if (!post.isBookmarked) {
-            mOnPostBookmarkedListener.onBookmarkClicked(post.blogId, post.postId);
+            mOnPostListItemButtonListener.onButtonClicked(post, ReaderPostCardActionType.BOOKMARK);
         }
     }
 
@@ -374,12 +373,10 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 (postId, blogId, type) -> {
                     //noinspection EnumSwitchStatementWhichMissesCases
                     switch (type) {
-                        case BOOKMARK:
-                            mOnPostBookmarkedListener.onBookmarkClicked(blogId, postId);
-                            break;
                         case COMMENTS:
                             ReaderActivityLauncher.showReaderComments(ctx, post.blogId, post.postId);
                             break;
+                        case BOOKMARK:
                         case BLOCK_SITE:
                         case REBLOG:
                         case LIKE:
@@ -545,10 +542,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     public void setOnDataLoadedListener(ReaderInterfaces.DataLoadedListener listener) {
         mDataLoadedListener = listener;
-    }
-
-    public void setOnPostBookmarkedListener(ReaderInterfaces.OnPostBookmarkedListener listener) {
-        mOnPostBookmarkedListener = listener;
     }
 
     public void setOnDataRequestedListener(ReaderActions.DataRequestedListener listener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -371,23 +371,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         Context ctx = holder.getViewContext();
         Function3<Long, Long, ReaderPostCardActionType, Unit> onButtonClicked =
                 (postId, blogId, type) -> {
-                    //noinspection EnumSwitchStatementWhichMissesCases
-                    switch (type) {
-                        case COMMENTS:
-                            ReaderActivityLauncher.showReaderComments(ctx, post.blogId, post.postId);
-                            break;
-                        case BOOKMARK:
-                        case BLOCK_SITE:
-                        case REBLOG:
-                        case LIKE:
-                        case FOLLOW:
-                        case SITE_NOTIFICATIONS:
-                        case SHARE:
-                        case VISIT_SITE:
-                            mOnPostListItemButtonListener.onButtonClicked(post, type);
-                            renderPost(position, holder, false);
-                            break;
-                    }
+                    mOnPostListItemButtonListener.onButtonClicked(post, type);
+                    renderPost(position, holder, false);
                     return Unit.INSTANCE;
                 };
         Function2<Long, Long, Unit> onItemClicked = (postId, blogId) -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -33,7 +33,6 @@ import org.wordpress.android.ui.reader.ReaderInterfaces;
 import org.wordpress.android.ui.reader.ReaderInterfaces.BlockSiteActionListener;
 import org.wordpress.android.ui.reader.ReaderInterfaces.OnFollowListener;
 import org.wordpress.android.ui.reader.ReaderInterfaces.OnPostListItemButtonListener;
-import org.wordpress.android.ui.reader.ReaderInterfaces.ReblogActionListener;
 import org.wordpress.android.ui.reader.ReaderTypes;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
@@ -99,7 +98,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private ReaderInterfaces.OnPostBookmarkedListener mOnPostBookmarkedListener;
     private ReaderActions.DataRequestedListener mDataRequestedListener;
     private ReaderSiteHeaderView.OnBlogInfoLoadedListener mBlogInfoLoadedListener;
-    private ReblogActionListener mReblogActionListener;
     private BlockSiteActionListener mBlockSiteActionListener;
 
     // the large "tbl_posts.text" column is unused here, so skip it when querying
@@ -381,15 +379,13 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         case BOOKMARK:
                             mOnPostBookmarkedListener.onBookmarkClicked(blogId, postId);
                             break;
-                        case REBLOG:
-                            mReblogActionListener.reblog(post);
-                            break;
                         case COMMENTS:
                             ReaderActivityLauncher.showReaderComments(ctx, post.blogId, post.postId);
                             break;
                         case BLOCK_SITE:
                             mBlockSiteActionListener.blockSite(post);
                             break;
+                        case REBLOG:
                         case LIKE:
                         case FOLLOW:
                         case SITE_NOTIFICATIONS:
@@ -545,10 +541,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     public void setOnFollowListener(OnFollowListener listener) {
         mFollowListener = listener;
-    }
-
-    public void setReblogActionListener(ReblogActionListener reblogActionListener) {
-        mReblogActionListener = reblogActionListener;
     }
 
     public void setBlockSiteActionListener(BlockSiteActionListener blockSiteActionListener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -30,7 +30,6 @@ import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.ReaderInterfaces;
-import org.wordpress.android.ui.reader.ReaderInterfaces.BlockSiteActionListener;
 import org.wordpress.android.ui.reader.ReaderInterfaces.OnFollowListener;
 import org.wordpress.android.ui.reader.ReaderInterfaces.OnPostListItemButtonListener;
 import org.wordpress.android.ui.reader.ReaderTypes;
@@ -98,7 +97,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private ReaderInterfaces.OnPostBookmarkedListener mOnPostBookmarkedListener;
     private ReaderActions.DataRequestedListener mDataRequestedListener;
     private ReaderSiteHeaderView.OnBlogInfoLoadedListener mBlogInfoLoadedListener;
-    private BlockSiteActionListener mBlockSiteActionListener;
 
     // the large "tbl_posts.text" column is unused here, so skip it when querying
     private static final boolean EXCLUDE_TEXT_COLUMN = true;
@@ -383,8 +381,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                             ReaderActivityLauncher.showReaderComments(ctx, post.blogId, post.postId);
                             break;
                         case BLOCK_SITE:
-                            mBlockSiteActionListener.blockSite(post);
-                            break;
                         case REBLOG:
                         case LIKE:
                         case FOLLOW:
@@ -541,10 +537,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     public void setOnFollowListener(OnFollowListener listener) {
         mFollowListener = listener;
-    }
-
-    public void setBlockSiteActionListener(BlockSiteActionListener blockSiteActionListener) {
-        mBlockSiteActionListener = blockSiteActionListener;
     }
 
     public void setOnPostSelectedListener(ReaderInterfaces.OnPostSelectedListener listener) {


### PR DESCRIPTION
Cleans up on button click listener in ReaderPostAdapter.

This PR can be merged into both 15.7 or 15.8. There are no user facing changes.

To test:
1. Open Reader - Following tab
2. Click on "Reblog" on any of the posts - notice site picker is shown
3. Go back to Reader
4. Click on more menu -> block site
5. Notice a snackbar is shown and posts from that site disapper
6. Click on "Undo" and notice the post is re-added
7. Click on Bookmark action
8. Notice the post gets bookmarked

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
