### PR TITLE
Browse items tracking in media picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -345,7 +345,7 @@ class MediaPickerViewModel @Inject constructor(
         if (mediaPickerSetup.allowedTypes.contains(VIDEO)) {
             items.add(PopupMenuItem(UiStringRes(R.string.photo_picker_choose_video)) {
                 clickIcon(
-                        MediaPickerIcon.ANDROID_CHOOSE_VIDEO
+                        ANDROID_CHOOSE_VIDEO
                 )
             })
         }


### PR DESCRIPTION
UPDATE: leaving it as a draft for now until the discussion about menu [here](https://github.com/wordpress-mobile/WordPress-Android/pull/12884#issuecomment-687137206) will be finalized.

This is related to the #12884 PR

It adds back tracking for `MEDIA_PICKER_OPEN_DEVICE_LIBRARY` with `is_video` true (for VIDEO items) and false (for IMAGE items). This is necessary since we added the Browse for items menu accessing the system browse files in the picker appbar.

### To test
- Be sure you activated events tracking in the app settings
- Create a new post 
- add VIDEO/IMAGE/GALLERY/MEDIA & TEXT blocks
- Try to set the above block content in the picker from the Browse for items menu
- Check in Logcat that you get (respectively when adding an IMAGE and a VIDEO)
    -  `Tracked: media_picker_device_library_opened, Properties: {"is_video":false}`
    - `Tracked: media_picker_device_library_opened, Properties: {"is_video":true}`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
