### PR TITLE
Hide fab for stories when item selected

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -282,12 +282,12 @@ class MediaPickerFragment : Fragment() {
 
     private fun setupFab(fabUiModel: FabUiModel) {
         if (fabUiModel.show) {
-            wp_stories_take_picture.visibility = View.VISIBLE
+            wp_stories_take_picture.show()
             wp_stories_take_picture.setOnClickListener {
                 fabUiModel.action()
             }
         } else {
-            wp_stories_take_picture.visibility = View.GONE
+            wp_stories_take_picture.hide()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -92,7 +92,7 @@ class MediaPickerViewModel @Inject constructor(
         MediaPickerUiState(
                 buildUiModel(photoPickerItems, selectedUris),
                 buildSoftAskView(softAskRequest),
-                FabUiModel(mediaPickerSetup.cameraEnabled) {
+                FabUiModel(mediaPickerSetup.cameraEnabled && selectedUris.isNullOrEmpty()) {
                     clickIcon(WP_STORIES_CAPTURE)
                 },
                 buildActionModeUiModel(selectedUris, photoPickerItems),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.test
 import org.wordpress.android.ui.mediapicker.MediaLoader.DomainModel
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.DEVICE
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ActionModeUiModel
+import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.FabUiModel
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.MediaPickerUiState
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.PhotoListUiModel
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.SoftAskViewUiModel
@@ -344,6 +345,30 @@ class MediaPickerViewModelTest : BaseUnitTest() {
         assertSearchExpanded(query)
     }
 
+    @Test
+    fun `camera FAB is shown in stories when no selected items`() = test {
+        setupViewModel(listOf(firstItem), MediaPickerSetup(DEVICE, true, setOf(IMAGE, VIDEO), true))
+        assertStoriesFabIsVisible()
+    }
+
+    @Test
+    fun `camera FAB is not shown in stories when selected items`() = test {
+        whenever(resourceProvider.getString(R.string.cab_selected)).thenReturn("%d selected")
+        setupViewModel(listOf(firstItem), MediaPickerSetup(DEVICE, true, setOf(IMAGE, VIDEO), true))
+
+        selectItem(0)
+
+        assertStoriesFabIsHidden()
+    }
+
+    @Test
+    fun `camera FAB is not shown when no stories`() = test {
+        whenever(resourceProvider.getString(R.string.cab_selected)).thenReturn("%d selected")
+        setupViewModel(listOf(firstItem), MediaPickerSetup(DEVICE, true, setOf(IMAGE, VIDEO), false))
+
+        assertStoriesFabIsHidden()
+    }
+
     private fun selectItem(position: Int) {
         (uiStates.last().photoListUiModel as PhotoListUiModel.Data).items[position].toggleAction.toggle()
     }
@@ -471,6 +496,20 @@ class MediaPickerViewModelTest : BaseUnitTest() {
         uiStates.last().searchUiModel.let { model ->
             assertThat(model is SearchUiModel.Expanded).isTrue()
             assertThat((model as SearchUiModel.Expanded).filter).isEqualTo(filter)
+        }
+    }
+
+    private fun assertStoriesFabIsVisible() {
+        uiStates.last().fabUiModel.let { model ->
+            assertThat(model is FabUiModel).isTrue()
+            assertThat((model as FabUiModel).show).isEqualTo(true)
+        }
+    }
+
+    private fun assertStoriesFabIsHidden() {
+        uiStates.last().fabUiModel.let { model ->
+            assertThat(model is FabUiModel).isTrue()
+            assertThat((model as FabUiModel).show).isEqualTo(false)
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
@@ -363,7 +363,6 @@ class MediaPickerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `camera FAB is not shown when no stories`() = test {
-        whenever(resourceProvider.getString(R.string.cab_selected)).thenReturn("%d selected")
         setupViewModel(listOf(firstItem), MediaPickerSetup(DEVICE, true, setOf(IMAGE, VIDEO), false))
 
         assertStoriesFabIsHidden()


### PR DESCRIPTION
Fixes #12644

This PR hides the FAB in the Media Picker for stories when an item get selected. No FAB is visible when the picker is not open in a story flow.

### To test

- Create a story
- Notice the Media Picker is opened and the FAB is visible
- Select one or more items and notice the FAB is hidden at the first selected item and stay hidden
- Unselect all items and notice the FAB is visible again
- Smoke test story slide creation
- Open the picker in other flows (GB blocks, Site/Avatar change) and check the FAB is always hidden independently from selected items.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
