### PR TITLE
Reader: Show preview images in lists for more posts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+15.8
+-----
+* [**] Reader: Now displaying preview images for more posts when no feature image is set.
+
 15.7
 -----
 * [**] Block Editor: New block: Pullquote

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -14,26 +14,26 @@ public class ReaderHtmlUtils {
 
     // regex for matching oriwidth attributes in tags
     private static final Pattern ORIGINAL_WIDTH_ATTR_PATTERN = Pattern.compile(
-            "data-orig-size\\s*=\\s*(?:'|\") (.*?),.*?(?:'|\")",
+            "data-orig-size\\s*=\\s*(?:'|\")(.*?),.*?(?:'|\")",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     private static final Pattern ORIGINAL_HEIGHT_ATTR_PATTERN = Pattern.compile(
-            "data-orig-size\\s*=\\s*(?:'|\").*?,(.*?) (?:'|\")",
+            "data-orig-size\\s*=\\s*(?:'|\").*?,(.*?)(?:'|\")",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     // regex for matching width attributes in tags
     private static final Pattern WIDTH_ATTR_PATTERN = Pattern.compile(
-            "width\\s*=\\s*(?:'|\") (.*?) (?:'|\")",
+            "width\\s*=\\s*(?:'|\")(.*?)(?:'|\")",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     // regex for matching height attributes in tags
     private static final Pattern HEIGHT_ATTR_PATTERN = Pattern.compile(
-            "height\\s*=\\s*(?:'|\") (.*?) (?:'|\")",
+            "height\\s*=\\s*(?:'|\")(.*?)(?:'|\")",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     // regex for matching class attributes in tags
     private static final Pattern CLASS_ATTR_PATTERN = Pattern.compile(
-            "class\\s*=\\s*(?:'|\") (.*?) (?:'|\")",
+            "class\\s*=\\s*(?:'|\")(.*?)(?:'|\")",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -31,11 +31,6 @@ public class ReaderHtmlUtils {
             "height\\s*=\\s*(?:'|\") (.*?) (?:'|\")",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
-    // regex for matching src attributes in tags
-    private static final Pattern SRC_ATTR_PATTERN = Pattern.compile(
-            "src\\s*=\\s*(?:'|\") (.*?) (?:'|\")",
-            Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
-
     // regex for matching class attributes in tags
     private static final Pattern CLASS_ATTR_PATTERN = Pattern.compile(
             "class\\s*=\\s*(?:'|\") (.*?) (?:'|\")",
@@ -97,23 +92,6 @@ public class ReaderHtmlUtils {
             return StringUtils.stringToInt(tag.substring(matcher.start() + 8, matcher.end() - 1), 0);
         } else {
             return 0;
-        }
-    }
-
-    /*
-     * returns the value from the src attribute in the passed html tag
-     */
-    public static String getSrcAttrValue(final String tag) {
-        if (tag == null) {
-            return null;
-        }
-
-        Matcher matcher = SRC_ATTR_PATTERN.matcher(tag);
-        if (matcher.find()) {
-            // remove "src=" and quotes from the result
-            return tag.substring(matcher.start() + 5, matcher.end() - 1);
-        } else {
-            return null;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -48,6 +48,10 @@ public class ReaderHtmlUtils {
             "(\\S*?)\\s+(\\d*)w,?\\s*?",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
+    public static final Pattern DATA_LARGE_FILE_PATTERN = Pattern.compile(
+            "data-large-file\\s*=\\s*['\"](.*?)['\"]",
+            Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
+
     /*
     * returns the integer value from the data-orig-size attribute in the passed html tag
     */
@@ -165,6 +169,23 @@ public class ReaderHtmlUtils {
                 }
             }
             return bestImageUrl;
+        } else {
+            return null;
+        }
+    }
+
+    /*
+     * Returns the value from the data-large-file attribute in the passed html tag,
+     * or null if the attribute is not present.
+     */
+    @Nullable public static String getLargeFileAttr(final String tag) {
+        if (tag == null) {
+            return null;
+        }
+
+        Matcher matcher = DATA_LARGE_FILE_PATTERN.matcher(tag);
+        if (matcher.find()) {
+            return matcher.group(1);
         } else {
             return null;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -56,73 +56,29 @@ public class ReaderHtmlUtils {
     * returns the integer value from the data-orig-size attribute in the passed html tag
     */
     public static int getOriginalWidthAttrValue(final String tag) {
-        if (tag == null) {
-            return 0;
-        }
-
-        Matcher matcher = ORIGINAL_WIDTH_ATTR_PATTERN.matcher(tag);
-        if (matcher.find()) {
-            return StringUtils.stringToInt(matcher.group(1), 0);
-        } else {
-            return 0;
-        }
+        return StringUtils.stringToInt(matchTagAttrPattern(ORIGINAL_WIDTH_ATTR_PATTERN, tag), 0);
     }
 
     public static int getOriginalHeightAttrValue(final String tag) {
-        if (tag == null) {
-            return 0;
-        }
-
-        Matcher matcher = ORIGINAL_HEIGHT_ATTR_PATTERN.matcher(tag);
-        if (matcher.find()) {
-            return StringUtils.stringToInt(matcher.group(1), 0);
-        } else {
-            return 0;
-        }
+        return StringUtils.stringToInt(matchTagAttrPattern(ORIGINAL_HEIGHT_ATTR_PATTERN, tag), 0);
     }
 
     /*
     * returns the integer value from the width attribute in the passed html tag
     */
     public static int getWidthAttrValue(final String tag) {
-        if (tag == null) {
-            return 0;
-        }
-
-        Matcher matcher = WIDTH_ATTR_PATTERN.matcher(tag);
-        if (matcher.find()) {
-            return StringUtils.stringToInt(matcher.group(1), 0);
-        } else {
-            return 0;
-        }
+        return StringUtils.stringToInt(matchTagAttrPattern(WIDTH_ATTR_PATTERN, tag), 0);
     }
 
     public static int getHeightAttrValue(final String tag) {
-        if (tag == null) {
-            return 0;
-        }
-        Matcher matcher = HEIGHT_ATTR_PATTERN.matcher(tag);
-        if (matcher.find()) {
-            return StringUtils.stringToInt(matcher.group(1), 0);
-        } else {
-            return 0;
-        }
+        return StringUtils.stringToInt(matchTagAttrPattern(HEIGHT_ATTR_PATTERN, tag), 0);
     }
 
     /*
      * returns the value from class src attribute in the passed html tag
      */
     public static String getClassAttrValue(final String tag) {
-        if (tag == null) {
-            return null;
-        }
-
-        Matcher matcher = CLASS_ATTR_PATTERN.matcher(tag);
-        if (matcher.find()) {
-            return matcher.group(1);
-        } else {
-            return null;
-        }
+        return matchTagAttrPattern(CLASS_ATTR_PATTERN, tag);
     }
 
     /*
@@ -179,11 +135,15 @@ public class ReaderHtmlUtils {
      * or null if the attribute is not present.
      */
     @Nullable public static String getLargeFileAttr(final String tag) {
+        return matchTagAttrPattern(DATA_LARGE_FILE_PATTERN, tag);
+    }
+
+    @Nullable private static String matchTagAttrPattern(Pattern pattern, String tag) {
         if (tag == null) {
             return null;
         }
 
-        Matcher matcher = DATA_LARGE_FILE_PATTERN.matcher(tag);
+        Matcher matcher = pattern.matcher(tag);
         if (matcher.find()) {
             return matcher.group(1);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -76,8 +76,7 @@ public class ReaderHtmlUtils {
 
         Matcher matcher = WIDTH_ATTR_PATTERN.matcher(tag);
         if (matcher.find()) {
-            // remove "width=" and quotes from the result
-            return StringUtils.stringToInt(tag.substring(matcher.start() + 7, matcher.end() - 1), 0);
+            return StringUtils.stringToInt(matcher.group(1), 0);
         } else {
             return 0;
         }
@@ -89,7 +88,7 @@ public class ReaderHtmlUtils {
         }
         Matcher matcher = HEIGHT_ATTR_PATTERN.matcher(tag);
         if (matcher.find()) {
-            return StringUtils.stringToInt(tag.substring(matcher.start() + 8, matcher.end() - 1), 0);
+            return StringUtils.stringToInt(matcher.group(1), 0);
         } else {
             return 0;
         }
@@ -105,8 +104,7 @@ public class ReaderHtmlUtils {
 
         Matcher matcher = CLASS_ATTR_PATTERN.matcher(tag);
         if (matcher.find()) {
-            // remove "class=" and quotes from the result
-            return tag.substring(matcher.start() + 7, matcher.end() - 1);
+            return matcher.group(1);
         } else {
             return null;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -102,7 +102,7 @@ public class ReaderHtmlUtils {
      * larger than [minWidth].
      * Returns null if the srcset attribute is not present.
      */
-    @Nullable public static String getSrcsetImageForTag(final String tag, final int minWidth) {
+    @Nullable public static SrcsetImage getSrcsetImageForTag(final String tag, final int minWidth) {
         if (tag == null) {
             return null;
         }
@@ -124,10 +124,11 @@ public class ReaderHtmlUtils {
                     }
                 }
             }
-            return bestImageUrl;
-        } else {
-            return null;
+            if (bestImageUrl != null) {
+                return new SrcsetImage(bestWidth, bestImageUrl);
+            }
         }
+        return null;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -14,26 +14,26 @@ public class ReaderHtmlUtils {
 
     // regex for matching oriwidth attributes in tags
     private static final Pattern ORIGINAL_WIDTH_ATTR_PATTERN = Pattern.compile(
-            "data-orig-size\\s*=\\s*(?:'|\")(.*?),.*?(?:'|\")",
+            "data-orig-size\\s*=\\s*['\"](.*?),.*?['\"]",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     private static final Pattern ORIGINAL_HEIGHT_ATTR_PATTERN = Pattern.compile(
-            "data-orig-size\\s*=\\s*(?:'|\").*?,(.*?)(?:'|\")",
+            "data-orig-size\\s*=\\s*['\"].*?,(.*?)['\"]",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     // regex for matching width attributes in tags
     private static final Pattern WIDTH_ATTR_PATTERN = Pattern.compile(
-            "width\\s*=\\s*(?:'|\")(.*?)(?:'|\")",
+            "width\\s*=\\s*['\"](.*?)['\"]",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     // regex for matching height attributes in tags
     private static final Pattern HEIGHT_ATTR_PATTERN = Pattern.compile(
-            "height\\s*=\\s*(?:'|\")(.*?)(?:'|\")",
+            "height\\s*=\\s*['\"](.*?)['\"]",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     // regex for matching class attributes in tags
     private static final Pattern CLASS_ATTR_PATTERN = Pattern.compile(
-            "class\\s*=\\s*(?:'|\")(.*?)(?:'|\")",
+            "class\\s*=\\s*['\"](.*?)['\"]",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -98,11 +98,10 @@ public class ReaderHtmlUtils {
     }
 
     /*
-     * Extracts the srcset attribute from the given [tag], and returns the smallest image
-     * larger than [minWidth].
+     * Extracts the srcset attribute from the given [tag], and returns the largest image.
      * Returns null if the srcset attribute is not present.
      */
-    @Nullable public static SrcsetImage getSrcsetImageForTag(final String tag, final int minWidth) {
+    @Nullable public static SrcsetImage getLargestSrcsetImageForTag(final String tag) {
         if (tag == null) {
             return null;
         }
@@ -111,21 +110,17 @@ public class ReaderHtmlUtils {
         if (matcher.find()) {
             String srcsetBody = matcher.group(1);
             Matcher innerMatcher = SRCSET_INNER_PATTERN.matcher(srcsetBody);
-            int bestWidth = 0;
-            String bestImageUrl = null;
+            int largestWidth = 0;
+            String largestImageUrl = null;
             while (innerMatcher.find()) {
                 int currentWidth = StringUtils.stringToInt(innerMatcher.group(2));
-                // Only interested in images wider than minWidth
-                if (currentWidth > minWidth) {
-                    // Only keep currentWidth if it's closer to minWidth than the current bestWidth
-                    if (bestWidth == 0 || currentWidth < bestWidth) {
-                        bestWidth = currentWidth;
-                        bestImageUrl = innerMatcher.group(1);
-                    }
+                if (currentWidth > largestWidth) {
+                    largestWidth = currentWidth;
+                    largestImageUrl = innerMatcher.group(1);
                 }
             }
-            if (bestImageUrl != null) {
-                return new SrcsetImage(bestWidth, bestImageUrl);
+            if (largestImageUrl != null) {
+                return new SrcsetImage(largestWidth, largestImageUrl);
             }
         }
         return null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -105,8 +105,16 @@ public class ReaderImageScanner {
             if (width > currentMaxWidth) {
                 currentImageUrl = imageUrl;
                 currentMaxWidth = width;
-            } else if (currentImageUrl == null && hasSuitableClassForFeaturedImage(imageTag)) {
-                currentImageUrl = imageUrl;
+            } else {
+                // Inspect the image tag and look for clues for an image of the right size
+
+                // Look through the srcset attribute if set for the image best matching minImageWidth
+                currentImageUrl = ReaderHtmlUtils.getSrcsetImageForTag(imageTag, minImageWidth);
+
+                // Check if the image tag's class suggests it's a good enough size
+                if (currentImageUrl == null && hasSuitableClassForFeaturedImage(imageTag)) {
+                    currentImageUrl = imageUrl;
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -115,6 +115,11 @@ public class ReaderImageScanner {
                 if (currentImageUrl == null && hasSuitableClassForFeaturedImage(imageTag)) {
                     currentImageUrl = imageUrl;
                 }
+
+                // Look for a data-large-file attribute if set and use the associated url
+                if (currentImageUrl == null) {
+                    currentImageUrl = ReaderHtmlUtils.getLargeFileAttr(imageTag);
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -100,30 +100,33 @@ public class ReaderImageScanner {
             String imageTag = imgMatcher.group(0);
             String imageUrl = imgMatcher.group(1);
 
+            // Primary source: check the width attribute.
             int width = Math.max(ReaderHtmlUtils.getWidthAttrValue(imageTag),
                                  ReaderHtmlUtils.getIntQueryParam(imageUrl, "w"));
             if (width > currentMaxWidth) {
                 currentImageUrl = imageUrl;
                 currentMaxWidth = width;
-            } else {
-                // Inspect the image tag and look for clues for an image of the right size
+            }
 
-                // Look through the srcset attribute (if set) for the largest available size of this image
-                SrcsetImage bestFromSrcset = ReaderHtmlUtils.getLargestSrcsetImageForTag(imageTag);
-                if (bestFromSrcset != null && bestFromSrcset.getWidth() > currentMaxWidth) {
-                    currentMaxWidth = bestFromSrcset.getWidth();
-                    currentImageUrl = bestFromSrcset.getUrl();
-                }
+            // Look through the srcset attribute (if set) for the largest available size of this image.
+            SrcsetImage bestFromSrcset = ReaderHtmlUtils.getLargestSrcsetImageForTag(imageTag);
+            if (bestFromSrcset != null && bestFromSrcset.getWidth() > currentMaxWidth) {
+                currentMaxWidth = bestFromSrcset.getWidth();
+                currentImageUrl = bestFromSrcset.getUrl();
+            }
 
-                // Check if the image tag's class suggests it's a good enough size
-                if (currentImageUrl == null && hasSuitableClassForFeaturedImage(imageTag)) {
-                    currentImageUrl = imageUrl;
-                }
+            // Check if the image tag's class suggests it's a good enough size.
+            // Only do this if we don't already have a winner, since we can't be sure of the width
+            // and shouldn't replace an image we know for sure is larger than [minImageWidth].
+            if (currentImageUrl == null && hasSuitableClassForFeaturedImage(imageTag)) {
+                currentImageUrl = imageUrl;
+            }
 
-                // Look for a data-large-file attribute if set and use the associated url
-                if (currentImageUrl == null) {
-                    currentImageUrl = ReaderHtmlUtils.getLargeFileAttr(imageTag);
-                }
+            // Look for a data-large-file attribute if set and use the associated url.
+            // Only do this if we don't already have a winner, since we can't be sure of the width
+            // and shouldn't replace an image we know for sure is larger than [minImageWidth].
+            if (currentImageUrl == null) {
+                currentImageUrl = ReaderHtmlUtils.getLargeFileAttr(imageTag);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -109,7 +109,11 @@ public class ReaderImageScanner {
                 // Inspect the image tag and look for clues for an image of the right size
 
                 // Look through the srcset attribute if set for the image best matching minImageWidth
-                currentImageUrl = ReaderHtmlUtils.getSrcsetImageForTag(imageTag, minImageWidth);
+                SrcsetImage bestFromSrcset = ReaderHtmlUtils.getSrcsetImageForTag(imageTag, minImageWidth);
+                if (bestFromSrcset != null) {
+                    currentMaxWidth = bestFromSrcset.getWidth();
+                    currentImageUrl = bestFromSrcset.getUrl();
+                }
 
                 // Check if the image tag's class suggests it's a good enough size
                 if (currentImageUrl == null && hasSuitableClassForFeaturedImage(imageTag)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -108,9 +108,9 @@ public class ReaderImageScanner {
             } else {
                 // Inspect the image tag and look for clues for an image of the right size
 
-                // Look through the srcset attribute if set for the image best matching minImageWidth
-                SrcsetImage bestFromSrcset = ReaderHtmlUtils.getSrcsetImageForTag(imageTag, minImageWidth);
-                if (bestFromSrcset != null) {
+                // Look through the srcset attribute (if set) for the largest available size of this image
+                SrcsetImage bestFromSrcset = ReaderHtmlUtils.getLargestSrcsetImageForTag(imageTag);
+                if (bestFromSrcset != null && bestFromSrcset.getWidth() > currentMaxWidth) {
                     currentMaxWidth = bestFromSrcset.getWidth();
                     currentImageUrl = bestFromSrcset.getUrl();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/SrcsetImage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/SrcsetImage.kt
@@ -1,0 +1,3 @@
+package org.wordpress.android.ui.reader.utils
+
+data class SrcsetImage(val width: Int, val url: String)

--- a/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
@@ -116,22 +116,22 @@ class ReaderHtmlUtilsTest {
     }
 
     @Test
-    fun `getSrcsetImageForTag returns correct URL when it's first in the list`() {
+    fun `getLargestSrcsetImageForTag returns largest URL when it's first in the list`() {
         val test = "<img src=\"https://i0.wp.com/image.jpg?resize=525%2C700\" alt=\"\" class=\"wp-image-10\" " +
-                "srcset=\"https://i1.wp.com/image-scaled.jpg?resize=768%2C1024 768w, " +
+                "srcset=\"https://i1.wp.com/image-scaled.jpg?w=1920 1920w, " +
                 "https://i1.wp.com/image-scaled.jpg?resize=225%2C300 225w, " +
                 "https://i1.wp.com/image-scaled.jpg?resize=1152%2C1536 1152w, " +
                 "https://i1.wp.com/image-scaled.jpg?resize=1536%2C2048 1536w, " +
-                "https://i1.wp.com/image-scaled.jpg?w=1920 1920w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=768%2C1024 768w, " +
                 "https://i1.wp.com/image-scaled.jpg?w=1050 1050w\" " +
                 "sizes=\"(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px\">"
-        val bestImage = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
-        val expected = SrcsetImage(768, "https://i1.wp.com/image-scaled.jpg?resize=768%2C1024")
+        val bestImage = ReaderHtmlUtils.getLargestSrcsetImageForTag(test)
+        val expected = SrcsetImage(1920, "https://i1.wp.com/image-scaled.jpg?w=1920")
         assertEquals(expected, bestImage)
     }
 
     @Test
-    fun `getSrcsetImageForTag returns correct URL when larger sizes appear first`() {
+    fun `getLargestSrcsetImageForTag returns largest URL when other sizes appear before it`() {
         val test = "<img src=\"https://i0.wp.com/image.jpg?resize=525%2C700\" alt=\"\" class=\"wp-image-10\" " +
                 "srcset=\"https://i1.wp.com/image-scaled.jpg?resize=225%2C300 225w, " +
                 "https://i1.wp.com/image-scaled.jpg?resize=1152%2C1536 1152w, " +
@@ -140,24 +140,15 @@ class ReaderHtmlUtilsTest {
                 "https://i1.wp.com/image-scaled.jpg?resize=768%2C1024 768w, " +
                 "https://i1.wp.com/image-scaled.jpg?w=1050 1050w\" " +
                 "sizes=\"(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px\">"
-        val bestImage = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
-        val expected = SrcsetImage(768, "https://i1.wp.com/image-scaled.jpg?resize=768%2C1024")
+        val bestImage = ReaderHtmlUtils.getLargestSrcsetImageForTag(test)
+        val expected = SrcsetImage(1920, "https://i1.wp.com/image-scaled.jpg?w=1920")
         assertEquals(expected, bestImage)
     }
 
     @Test
-    fun `getSrcsetImageForTag returns null if srcset contains no image large enough`() {
-        val test = "<img src=\"https://i0.wp.com/image.jpg?resize=525%2C700\" alt=\"\" class=\"wp-image-10\" " +
-                "srcset=\"https://i1.wp.com/image-scaled.jpg?resize=600%2C1024 600w\" " +
-                "sizes=\"(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px\">"
-        val bestImage = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
-        assertEquals(null, bestImage)
-    }
-
-    @Test
-    fun `getSrcsetImageForTag returns null if tag is missing srcset attr`() {
+    fun `getLargestSrcsetImageForTag returns null if tag is missing srcset attr`() {
         val test = "<img src=\"https://i0.wp.com/image.jpg?resize=525%2C700\" alt=\"\" class=\"wp-image-10\">"
-        val bestImage = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
+        val bestImage = ReaderHtmlUtils.getLargestSrcsetImageForTag(test)
         assertEquals(null, bestImage)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
@@ -1,0 +1,79 @@
+package org.wordpress.android.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.wordpress.android.ui.reader.utils.ReaderHtmlUtils
+
+class ReaderHtmlUtilsTest {
+    @Test
+    fun `getOriginalHeightAttrValue extracts original height data correctly`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" class=\"wp-image-10\" data-orig-size=\"500,1000\" " +
+                "height=\"1000\" width=\"500\">"
+        val result = ReaderHtmlUtils.getOriginalHeightAttrValue(testTag)
+        assertEquals(1000, result)
+    }
+
+    @Test
+    fun `getOriginalHeightAttrValue returns 0 if tag is missing original size attr`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" class=\"wp-image-10\" height=\"1000\" width=\"500\">"
+        val result = ReaderHtmlUtils.getOriginalHeightAttrValue(testTag)
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun `getOriginalWidthAttrValue extracts original width data correctly`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" class=\"wp-image-10\" data-orig-size=\"500,1000\" " +
+                "height=\"1000\" width=\"500\">"
+        val result = ReaderHtmlUtils.getOriginalWidthAttrValue(testTag)
+        assertEquals(500, result)
+    }
+
+    @Test
+    fun `getOriginalWidthAttrValue returns 0 if tag is missing original size attr`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" class=\"wp-image-10\" height=\"1000\" width=\"500\">"
+        val result = ReaderHtmlUtils.getOriginalWidthAttrValue(testTag)
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun `getHeightAttrValue extracts height attribute data correctly`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" class=\"wp-image-10\" height=\"1000\" width=\"500\">"
+        val result = ReaderHtmlUtils.getHeightAttrValue(testTag)
+        assertEquals(1000, result)
+    }
+
+    @Test
+    fun `getHeightAttrValue returns 0 if tag is missing height attr`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" class=\"wp-image-10\" width=\"500\">"
+        val result = ReaderHtmlUtils.getHeightAttrValue(testTag)
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun `getWidthAttrValue extracts width attribute data correctly`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" class=\"wp-image-10\" height=\"1000\" width=\"500\">"
+        val result = ReaderHtmlUtils.getWidthAttrValue(testTag)
+        assertEquals(500, result)
+    }
+
+    @Test
+    fun `getWidthAttrValue returns 0 if tag is missing width attr`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" class=\"wp-image-10\" height=\"1000\">"
+        val result = ReaderHtmlUtils.getWidthAttrValue(testTag)
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun `getClassAttrValue extracts class attribute data correctly`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" class=\"wp-image-10 size-large example\" width=\"500\">"
+        val result = ReaderHtmlUtils.getClassAttrValue(testTag)
+        assertEquals("wp-image-10 size-large example", result)
+    }
+
+    @Test
+    fun `getClassAttrValue returns null if tag is missing class attr`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" width=\"500\">"
+        val result = ReaderHtmlUtils.getClassAttrValue(testTag)
+        assertEquals(null, result)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.util
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.ui.reader.utils.ReaderHtmlUtils
 
@@ -75,5 +76,85 @@ class ReaderHtmlUtilsTest {
         val testTag = "<img src=\"example.jpg\" alt=\"\" width=\"500\">"
         val result = ReaderHtmlUtils.getClassAttrValue(testTag)
         assertEquals(null, result)
+    }
+
+    @Test
+    fun `SRCSET_ATTR_PATTERN matches srcset attribute data correctly`() {
+        val test = "<img src=\"https://i0.wp.com/image.jpg?resize=525%2C700\" alt=\"\" class=\"wp-image-10\" " +
+                "srcset=\"https://i1.wp.com/image-scaled.jpg?resize=768%2C1024 768w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=225%2C300 225w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=1152%2C1536 1152w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=1536%2C2048 1536w, " +
+                "https://i1.wp.com/image-scaled.jpg?w=1920 1920w, " +
+                "https://i1.wp.com/image-scaled.jpg?w=1050 1050w\" " +
+                "sizes=\"(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px\">"
+        val matcher = ReaderHtmlUtils.SRCSET_ATTR_PATTERN.matcher(test)
+        assertTrue(matcher.find())
+    }
+
+    @Test
+    fun `SRCSET_INNER_PATTERN matches srcset entries correctly`() {
+        val test = "https://i1.wp.com/image-scaled.jpg?resize=768%2C1024 768w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=225%2C300 225w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=1152%2C1536 1152w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=1536%2C2048 1536w, " +
+                "https://i1.wp.com/image-scaled.jpg?w=1920 1920w, " +
+                "https://i1.wp.com/image-scaled.jpg?w=1050 1050w"
+        val matcher = ReaderHtmlUtils.SRCSET_INNER_PATTERN.matcher(test)
+        var count = 0
+        var lastMatchWidth = ""
+        var lastMatchUrl = ""
+        while (matcher.find()) {
+            count++
+            lastMatchUrl = matcher.group(1)
+            lastMatchWidth = matcher.group(2)
+        }
+        assertEquals("1050", lastMatchWidth)
+        assertEquals("https://i1.wp.com/image-scaled.jpg?w=1050", lastMatchUrl)
+        assertEquals(6, count)
+    }
+
+    @Test
+    fun `getSrcsetImageForTag returns correct URL when it's first in the list`() {
+        val test = "<img src=\"https://i0.wp.com/image.jpg?resize=525%2C700\" alt=\"\" class=\"wp-image-10\" " +
+                "srcset=\"https://i1.wp.com/image-scaled.jpg?resize=768%2C1024 768w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=225%2C300 225w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=1152%2C1536 1152w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=1536%2C2048 1536w, " +
+                "https://i1.wp.com/image-scaled.jpg?w=1920 1920w, " +
+                "https://i1.wp.com/image-scaled.jpg?w=1050 1050w\" " +
+                "sizes=\"(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px\">"
+        val bestUrl = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
+        assertEquals("https://i1.wp.com/image-scaled.jpg?resize=768%2C1024", bestUrl)
+    }
+
+    @Test
+    fun `getSrcsetImageForTag returns correct URL when larger sizes appear first`() {
+        val test = "<img src=\"https://i0.wp.com/image.jpg?resize=525%2C700\" alt=\"\" class=\"wp-image-10\" " +
+                "srcset=\"https://i1.wp.com/image-scaled.jpg?resize=225%2C300 225w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=1152%2C1536 1152w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=1536%2C2048 1536w, " +
+                "https://i1.wp.com/image-scaled.jpg?w=1920 1920w, " +
+                "https://i1.wp.com/image-scaled.jpg?resize=768%2C1024 768w, " +
+                "https://i1.wp.com/image-scaled.jpg?w=1050 1050w\" " +
+                "sizes=\"(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px\">"
+        val bestUrl = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
+        assertEquals("https://i1.wp.com/image-scaled.jpg?resize=768%2C1024", bestUrl)
+    }
+
+    @Test
+    fun `getSrcsetImageForTag returns null if srcset contains no image large enough`() {
+        val test = "<img src=\"https://i0.wp.com/image.jpg?resize=525%2C700\" alt=\"\" class=\"wp-image-10\" " +
+                "srcset=\"https://i1.wp.com/image-scaled.jpg?resize=600%2C1024 600w\" " +
+                "sizes=\"(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px\">"
+        val bestUrl = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
+        assertEquals(null, bestUrl)
+    }
+
+    @Test
+    fun `getSrcsetImageForTag returns null if tag is missing srcset attr`() {
+        val test = "<img src=\"https://i0.wp.com/image.jpg?resize=525%2C700\" alt=\"\" class=\"wp-image-10\">"
+        val bestUrl = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
+        assertEquals(null, bestUrl)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.ui.reader.utils.ReaderHtmlUtils
+import org.wordpress.android.ui.reader.utils.SrcsetImage
 
 class ReaderHtmlUtilsTest {
     @Test
@@ -124,8 +125,9 @@ class ReaderHtmlUtilsTest {
                 "https://i1.wp.com/image-scaled.jpg?w=1920 1920w, " +
                 "https://i1.wp.com/image-scaled.jpg?w=1050 1050w\" " +
                 "sizes=\"(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px\">"
-        val bestUrl = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
-        assertEquals("https://i1.wp.com/image-scaled.jpg?resize=768%2C1024", bestUrl)
+        val bestImage = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
+        val expected = SrcsetImage(768, "https://i1.wp.com/image-scaled.jpg?resize=768%2C1024")
+        assertEquals(expected, bestImage)
     }
 
     @Test
@@ -138,8 +140,9 @@ class ReaderHtmlUtilsTest {
                 "https://i1.wp.com/image-scaled.jpg?resize=768%2C1024 768w, " +
                 "https://i1.wp.com/image-scaled.jpg?w=1050 1050w\" " +
                 "sizes=\"(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px\">"
-        val bestUrl = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
-        assertEquals("https://i1.wp.com/image-scaled.jpg?resize=768%2C1024", bestUrl)
+        val bestImage = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
+        val expected = SrcsetImage(768, "https://i1.wp.com/image-scaled.jpg?resize=768%2C1024")
+        assertEquals(expected, bestImage)
     }
 
     @Test
@@ -147,15 +150,15 @@ class ReaderHtmlUtilsTest {
         val test = "<img src=\"https://i0.wp.com/image.jpg?resize=525%2C700\" alt=\"\" class=\"wp-image-10\" " +
                 "srcset=\"https://i1.wp.com/image-scaled.jpg?resize=600%2C1024 600w\" " +
                 "sizes=\"(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px\">"
-        val bestUrl = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
-        assertEquals(null, bestUrl)
+        val bestImage = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
+        assertEquals(null, bestImage)
     }
 
     @Test
     fun `getSrcsetImageForTag returns null if tag is missing srcset attr`() {
         val test = "<img src=\"https://i0.wp.com/image.jpg?resize=525%2C700\" alt=\"\" class=\"wp-image-10\">"
-        val bestUrl = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
-        assertEquals(null, bestUrl)
+        val bestImage = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
+        assertEquals(null, bestImage)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/ReaderHtmlUtilsTest.kt
@@ -157,4 +157,19 @@ class ReaderHtmlUtilsTest {
         val bestUrl = ReaderHtmlUtils.getSrcsetImageForTag(test, 640)
         assertEquals(null, bestUrl)
     }
+
+    @Test
+    fun `getLargeFileAttr extracts large file attribute data correctly`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" class=\"wp-image-10\" data-large-file=\"large-image.jpg\" " +
+                "height=\"1000\" width=\"500\">"
+        val result = ReaderHtmlUtils.getLargeFileAttr(testTag)
+        assertEquals("large-image.jpg", result)
+    }
+
+    @Test
+    fun `getLargeFileAttr returns null if tag is missing large file attr`() {
+        val testTag = "<img src=\"example.jpg\" alt=\"\" class=\"wp-image-10\" height=\"1000\" width=\"500\">"
+        val result = ReaderHtmlUtils.getLargeFileAttr(testTag)
+        assertEquals(null, result)
+    }
 }


### PR DESCRIPTION
Fixes #12894, allowing the reader to find suitable preview images for posts more often.

#### Feed list

![reader-android-feed-beforeafter](https://user-images.githubusercontent.com/9613966/92977369-cb051a80-f4c7-11ea-837e-b2afeaec2ce7.png)

#### Site list

![reader-android-site-beforeafter](https://user-images.githubusercontent.com/9613966/92296916-c9da6780-ef74-11ea-8987-edc345e7e4b3.png)

This PR has two parts:

### 1. Fixing an accidental regex breakage

A [huge checkstyle refactor from two years ago](https://github.com/wordpress-mobile/WordPress-Android/commit/ed574ea833797f71e28fb2abd060fee7d305376c#diff-981ccd25a498c16f8b2887442812b346) ended up accidentally adding spaces to a few regex patterns used by the Reader to parse images. This almost entirely broke support for preview images that weren't set as featured. I undid the breakage in 0379e37 (and added some tests).

### 2. Adding support for `srcset` and `data-large-file` `img` tag attributes

The above fix improves things a bit but still fails to recognize images in several kinds of posts. This is especially noticeable in the site view. As explained in #12894 the `/read/feed/` and `/read/sites/` endpoints return different content sometimes. For some reason one of the differences is that some images have no width attribute in the `/read/sites/` endpoint, so what works in the feed doesn't work sometimes in the site view.

To mitigate this, I added support for a few new `img` tag attributes that seem pretty common in WP posts: [srcset](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images) and data-large-file. These are checked for in a fallback style.

### To test:

With and without this patch, follow a few sites with a variety of posts containing images and compare.

Mainly looking for posts with a story block, and posts with image blocks (but no featured image set). (I can recommend a few.)

(For Automatticians: please proxy on your device to fully test posts with the Story block, since depending on the endpoint those won't work correctly otherwise. See pbArwn-14B-p2.)

You can also check the regex fix individually by checking out 86dedbe first and running the (failing) unit tests added.

Notes:
* Some stories (where the first slide is a video) still won't show a preview image - I'll look into that separately
* Detail view of stories is broken right now

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.