### PR TITLE
Issue/12028 add tests for discover vm

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.SITE_PIC
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.ReaderConstants
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState
@@ -56,7 +55,6 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private val readerImageScannerProvider: ReaderImageScannerProvider,
     private val readerUtilsWrapper: ReaderUtilsWrapper,
     private val readerPostTagsUiStateBuilder: ReaderPostTagsUiStateBuilder,
-    private val appPrefsWrapper: AppPrefsWrapper,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
     suspend fun mapPostToUiState(

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -420,6 +420,26 @@ class ReaderDiscoverViewModelTest {
         assertThat(navigaitonObserver.last().peekContent()).isInstanceOf(OpenEditorForReblog::class.java)
     }
 
+    @Test
+    fun `Data are refreshed when the user swipes down to refresh`() = test {
+        // Arrange
+        val navigaitonObserver = init()
+        // Act
+        viewModel.swipeToRefresh()
+        // Assert
+        verify(readerDiscoverDataProvider).refreshCards()
+    }
+
+    @Test
+    fun `Data are refreshed when the user clicks on retry`() = test {
+        // Arrange
+        val navigaitonObserver = init()
+        // Act
+        viewModel.onRetryButtonClick()
+        // Assert
+        verify(readerDiscoverDataProvider).refreshCards()
+    }
+
     private fun init(autoUpdateFeed: Boolean = true): Observers {
         val uiStates = mutableListOf<DiscoverUiState>()
         viewModel.uiState.observeForever {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -327,7 +327,7 @@ class ReaderDiscoverViewModelTest {
         // Arrange
         val observers = init()
         // Act
-        ((observers.uiStates.last() as ContentUiState).cards[1] as ReaderPostUiState).tagItems[0].onClick!!.invoke("Test")
+        ((observers.uiStates.last() as ContentUiState).cards[1] as ReaderPostUiState).tagItems[0].onClick!!.invoke("t")
         // Assert
         assertThat(observers.navigation[0].peekContent()).isInstanceOf(ShowPostsByTag::class.java)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.reader.discover
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
@@ -18,6 +19,7 @@ import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderTag
@@ -27,18 +29,34 @@ import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderPostCard
 import org.wordpress.android.models.discover.ReaderDiscoverCard.WelcomeBannerCard
 import org.wordpress.android.models.discover.ReaderDiscoverCards
 import org.wordpress.android.test
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ReaderInterestUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState.PostHeaderClickData
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderWelcomeBannerCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.LoadingUiState
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEditorForReblog
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.COMMENTS
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
+import org.wordpress.android.ui.reader.discover.interests.TagUiState
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication
+import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Error.NetworkUnavailable
+import org.wordpress.android.ui.reader.repository.ReaderDiscoverCommunication.Started
 import org.wordpress.android.ui.reader.repository.ReaderDiscoverDataProvider
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FIRST_PAGE
+import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_MORE
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.Event
@@ -46,6 +64,13 @@ import org.wordpress.android.viewmodel.ReactiveMutableLiveData
 
 private const val POST_PARAM_POSITION = 0
 private const val ON_ITEM_RENDERED_PARAM_POSITION = 8
+private const val ON_TAG_CLICKED_PARAM_POSITION = 14
+private const val ON_BUTTON_CLICKED_PARAM_POSITION = 6
+private const val ON_VIDEO_OVERLAY_CLICKED_PARAM_POSITION = 12
+private const val ON_POST_HEADER_CLICKED_PARAM_POSITION = 13
+private const val ON_POST_ITEM_CLICKED_PARAM_POSITION = 7
+private const val ON_MORE_MENU_CLICKED_PARAM_POSITION = 10
+private const val ON_MORE_MENU_DISMISSED_PARAM_POSITION = 11
 private const val NUMBER_OF_ITEMS = 10L
 
 @InternalCoroutinesApi
@@ -65,7 +90,9 @@ class ReaderDiscoverViewModelTest {
     @Mock private lateinit var displayUtilsWrapper: DisplayUtilsWrapper
 
     private val fakeDiscoverFeed = ReactiveMutableLiveData<ReaderDiscoverCards>()
-    private val communicationChannel = MutableLiveData<Event<ReaderDiscoverCommunication>>()
+    private val fakeCommunicationChannel = MutableLiveData<Event<ReaderDiscoverCommunication>>()
+    private val fakeNavigationFeed = MutableLiveData<Event<ReaderNavigationEvents>>()
+    private val fakeSnackBarFeed = MutableLiveData<Event<SnackbarMessageHolder>>()
 
     private lateinit var viewModel: ReaderDiscoverViewModel
 
@@ -85,6 +112,10 @@ class ReaderDiscoverViewModelTest {
                 TEST_DISPATCHER
         )
         whenever(readerDiscoverDataProvider.discoverFeed).thenReturn(fakeDiscoverFeed)
+        whenever(readerPostCardActionsHandler.navigationEvents).thenReturn(fakeNavigationFeed)
+        whenever(readerPostCardActionsHandler.snackbarEvents).thenReturn(fakeSnackBarFeed)
+        whenever(readerUtilsWrapper.getTagFromTagName(anyOrNull(), anyOrNull())).thenReturn(mock())
+        whenever(menuUiStateBuilder.buildMoreMenuItems(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(mock())
         whenever(
                 uiStateBuilder.mapPostToUiState(
                         anyOrNull(), anyBoolean(), anyInt(), anyInt(), anyOrNull(), anyBoolean(), anyOrNull(),
@@ -96,13 +127,22 @@ class ReaderDiscoverViewModelTest {
             // propagate some of the arguments
             createDummyReaderPostUiState(
                     post,
-                    it.getArgument<(ReaderCardUiState) -> Unit>(ON_ITEM_RENDERED_PARAM_POSITION)
+                    it.getArgument<(ReaderCardUiState) -> Unit>(ON_ITEM_RENDERED_PARAM_POSITION),
+                    it.getArgument<(String) -> Unit>(ON_TAG_CLICKED_PARAM_POSITION),
+                    it.getArgument<(Long, Long, ReaderPostCardActionType) -> Unit>(ON_BUTTON_CLICKED_PARAM_POSITION),
+                    it.getArgument<(Long, Long) -> Unit>(ON_VIDEO_OVERLAY_CLICKED_PARAM_POSITION),
+                    it.getArgument<(Long, Long) -> Unit>(ON_POST_HEADER_CLICKED_PARAM_POSITION),
+                    it.getArgument<(Long, Long) -> Unit>(ON_POST_ITEM_CLICKED_PARAM_POSITION),
+                    it.getArgument<(ReaderPostUiState) -> Unit>(ON_MORE_MENU_CLICKED_PARAM_POSITION),
+                    it.getArgument<(ReaderPostUiState) -> Unit>(ON_MORE_MENU_DISMISSED_PARAM_POSITION)
             )
         }
-        whenever(readerDiscoverDataProvider.communicationChannel).thenReturn(communicationChannel)
+        whenever(readerDiscoverDataProvider.communicationChannel).thenReturn(fakeCommunicationChannel)
         whenever(uiStateBuilder.mapTagListToReaderInterestUiState(anyOrNull(), anyOrNull())).thenReturn(
                 createReaderInterestsCardUiState(createReaderTagList())
         )
+        whenever(reblogUseCase.onReblogSiteSelected(anyInt(), anyOrNull())).thenReturn(mock())
+        whenever(reblogUseCase.convertReblogStateToNavigationEvent(anyOrNull())).thenReturn(mock<OpenEditorForReblog>())
     }
 
     @Test
@@ -263,13 +303,280 @@ class ReaderDiscoverViewModelTest {
                 assertThat(welcomeBannerCardUiState.titleRes).isEqualTo(R.string.reader_welcome_banner)
             }
 
-    private fun init() {
+    @Test
+    fun `Discover data provider is started when the vm is started`() = test {
+        // Act
+        viewModel.start()
+        // Assert
+        verify(readerDiscoverDataProvider).start()
+    }
+
+    @Test
+    fun `PTR progress shown when REQUEST_FIRST_PAGE event starts and a content is displayed`() = test {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.postValue(createDummyReaderCardsList())
+        // Act
+        fakeCommunicationChannel.postValue(Event(Started(REQUEST_FIRST_PAGE)))
+
+        // Assert
+        assertThat(uiStates.last().reloadProgressVisibility).isTrue()
+    }
+
+    @Test
+    fun `Load more progress shown when REQUEST_MORE event starts and a content is displayed`() = test {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.postValue(createDummyReaderCardsList())
+
+        // Act
+        fakeCommunicationChannel.postValue(Event(Started(REQUEST_MORE)))
+
+        // Assert
+        assertThat(uiStates.last().loadMoreProgressVisibility).isTrue()
+    }
+
+    @Test
+    fun `Fullscreen progress shown when an event starts and a content is not displayed`() = test {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+
+        // Act
+        fakeCommunicationChannel.postValue(Event(Started(mock())))
+
+        // Assert
+        assertThat(uiStates.last().fullscreenProgressVisibility).isTrue()
+    }
+
+    @Test
+    fun `Fullscreen error is shown on error event when there is no content`() = test {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+
+        // Act
+        fakeCommunicationChannel.postValue(Event(NetworkUnavailable(mock())))
+
+        // Assert
+        assertThat(uiStates.last().fullscreenErrorVisibility).isTrue()
+    }
+
+    @Test
+    fun `Progress indicators are hidden when an event results in error`() = test {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+
+        // Act
+        fakeCommunicationChannel.postValue(Event(NetworkUnavailable(mock())))
+
+        // Assert
+        assertThat(uiStates.last().fullscreenProgressVisibility).isFalse()
+        assertThat(uiStates.last().reloadProgressVisibility).isFalse()
+        assertThat(uiStates.last().loadMoreProgressVisibility).isFalse()
+    }
+
+    @Test
+    fun `Snackbar message is shown when an event results in error`() = test {
+        // Arrange
+        val msgs = mutableListOf<Event<SnackbarMessageHolder>>()
+        viewModel.snackbarEvents.observeForever {
+            msgs.add(it)
+        }
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.value = createDummyReaderCardsList() // mock finished loading
+
+        // Act
+        fakeCommunicationChannel.postValue(Event(NetworkUnavailable(mock())))
+
+        // Assert
+        assertThat(msgs[0].peekContent().message).isEqualTo(UiStringRes(string.reader_error_request_failed_title))
+    }
+
+    @Test
+    fun `When user clicks on a tag, a list of posts for that tag is shown`() = test {
+        // Arrange
+        val navigation = mutableListOf<Event<ReaderNavigationEvents>>()
+        viewModel.navigationEvents.observeForever {
+            navigation.add(it)
+        }
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.value = createDummyReaderCardsList() // mock finished loading
+        // Act
+        ((uiStates.last() as ContentUiState).cards[1] as ReaderPostUiState).tagItems[0].onClick!!.invoke("Test")
+        // Assert
+        assertThat(navigation[0].peekContent()).isInstanceOf(ShowPostsByTag::class.java)
+    }
+
+    @Test
+    fun `When user clicks on like button postActionHandler is invoked`() = test {
+        // Arrange
         val uiStates = mutableListOf<DiscoverUiState>()
         viewModel.uiState.observeForever {
             uiStates.add(it)
         }
         viewModel.start()
         fakeDiscoverFeed.value = createDummyReaderCardsList()
+        // Act
+        ((uiStates.last() as ContentUiState).cards[2] as ReaderPostUiState).likeAction.onClicked!!.invoke(2, 200, LIKE)
+        // Assert
+        verify(readerPostCardActionsHandler).onAction(
+                eq((fakeDiscoverFeed.value!!.cards[2] as ReaderPostCard).post),
+                eq(LIKE),
+                eq(false)
+        )
+    }
+
+    @Test
+    fun `When user clicks on video overlay post action handler is invoked`() = test {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.value = createDummyReaderCardsList()
+        // Act
+        ((uiStates.last() as ContentUiState).cards[2] as ReaderPostUiState).onVideoOverlayClicked(2, 200)
+        // Assert
+        verify(readerPostCardActionsHandler).handleVideoOverlayClicked(
+                eq((fakeDiscoverFeed.value!!.cards[2] as ReaderPostCard).post.featuredVideo)
+        )
+    }
+
+    @Test
+    fun `When user clicks on header post action handler is invoked`() = test {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.value = createDummyReaderCardsList()
+        // Act
+        ((uiStates.last() as ContentUiState).cards[2] as ReaderPostUiState)
+                .postHeaderClickData!!.onPostHeaderViewClicked!!.invoke(2, 200)
+        // Assert
+        verify(readerPostCardActionsHandler).handleHeaderClicked(
+                eq((fakeDiscoverFeed.value!!.cards[2] as ReaderPostCard).post.blogId),
+                eq((fakeDiscoverFeed.value!!.cards[2] as ReaderPostCard).post.feedId)
+        )
+    }
+
+    @Test
+    fun `When user clicks on list item post action handler is invoked`() = test {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.value = createDummyReaderCardsList()
+        // Act
+        ((uiStates.last() as ContentUiState).cards[2] as ReaderPostUiState)
+                .onItemClicked.invoke(2, 200)
+        // Assert
+        verify(readerPostCardActionsHandler).handleOnItemClicked(
+                eq((fakeDiscoverFeed.value!!.cards[2] as ReaderPostCard).post)
+        )
+    }
+
+    @Test
+    fun `When user clicks on more button menu is shown`() = test {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.value = createDummyReaderCardsList()
+        val cardUiState = ((uiStates.last() as ContentUiState).cards[2] as ReaderPostUiState)
+        // Act
+        cardUiState.onMoreButtonClicked.invoke(cardUiState)
+        // Assert
+        assertThat(((uiStates.last() as ContentUiState).cards[2] as ReaderPostUiState).moreMenuItems).isNotNull
+    }
+
+    @Test
+    fun `When user dismisses the menu the ui state is updated`() = test {
+        // Arrange
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.value = createDummyReaderCardsList()
+        var cardUiState = ((uiStates.last() as ContentUiState).cards[2] as ReaderPostUiState)
+        // Act
+        cardUiState.onMoreButtonClicked.invoke(cardUiState) // show menu
+        cardUiState = ((uiStates.last() as ContentUiState).cards[2] as ReaderPostUiState)
+        cardUiState.onMoreDismissed.invoke(cardUiState) // dismiss menu
+        // Assert
+        assertThat(((uiStates.last() as ContentUiState).cards[2] as ReaderPostUiState).moreMenuItems).isNull()
+    }
+
+    @Test
+    fun `When user picks a site for reblog action the app shows the editor`() {
+        // Arrange
+        val navigation = mutableListOf<Event<ReaderNavigationEvents>>()
+        viewModel.navigationEvents.observeForever {
+            navigation.add(it)
+        }
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.value = createDummyReaderCardsList()
+        fakeNavigationFeed.value = Event(ShowSitePickerForResult(mock(), mock(), mock()))
+        // Act
+        viewModel.onReblogSiteSelected(1)
+        // Assert
+        assertThat(navigation.last().peekContent()).isInstanceOf(OpenEditorForReblog::class.java)
+    }
+
+    private fun init(): Observers {
+        val uiStates = mutableListOf<DiscoverUiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        val navigation = mutableListOf<Event<ReaderNavigationEvents>>()
+        viewModel.navigationEvents.observeForever {
+            navigation.add(it)
+        }
+        val msgs = mutableListOf<Event<SnackbarMessageHolder>>()
+        viewModel.snackbarEvents.observeForever {
+            msgs.add(it)
+        }
+        viewModel.start()
+        fakeDiscoverFeed.value = createDummyReaderCardsList()
+        return Observers(uiStates, navigation, msgs)
     }
 
     // since we are adding an InterestsYouMayLikeCard we remove one item from the numberOfItems since it counts as 1.
@@ -285,19 +592,28 @@ class ReaderDiscoverViewModelTest {
 
     private fun createDummyReaderPost(id: Long): ReaderPost = ReaderPost().apply {
         this.postId = id
-        this.blogId = id
+        this.blogId = id * 100
+        this.feedId = id * 1000
         this.title = "DummyPost"
+        this.featuredVideo = id.toString()
     }
 
     private fun createDummyReaderPostUiState(
         post: ReaderPost,
-        onItemRendered: (ReaderCardUiState) -> Unit = mock()
+        onItemRendered: (ReaderCardUiState) -> Unit = mock(),
+        onTagClicked: (String) -> Unit,
+        onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit,
+        onVideoOverlayClicked: (Long, Long) -> Unit,
+        postHeaderClicked: (Long, Long) -> Unit,
+        onItemClicked: (Long, Long) -> Unit,
+        onMoreMenuClicked: (ReaderPostUiState) -> Unit,
+        onMoreMenuDismissed: (ReaderPostUiState) -> Unit
     ): ReaderPostUiState {
         return ReaderPostUiState(
                 postId = post.postId,
                 blogId = post.blogId,
                 blogUrl = "",
-                tagItems = mock(),
+                tagItems = listOf(TagUiState("", "", false, onTagClicked)),
                 dateLine = "",
                 avatarOrBlavatarUrl = "",
                 blogName = "",
@@ -314,17 +630,17 @@ class ReaderDiscoverViewModelTest {
                 fullVideoUrl = "",
                 discoverSection = mock(),
                 expandableTagsViewVisibility = false,
-                bookmarkAction = mock(),
-                likeAction = mock(),
-                reblogAction = mock(),
-                commentsAction = mock(),
-                onItemClicked = mock(),
+                bookmarkAction = PrimaryAction(true, onClicked = onButtonClicked, type = BOOKMARK),
+                likeAction = PrimaryAction(true, onClicked = onButtonClicked, type = LIKE),
+                reblogAction = PrimaryAction(true, onClicked = onButtonClicked, type = REBLOG),
+                commentsAction = PrimaryAction(true, onClicked = onButtonClicked, type = COMMENTS),
+                onItemClicked = onItemClicked,
                 onItemRendered = onItemRendered,
-                onMoreButtonClicked = mock(),
-                onVideoOverlayClicked = mock(),
-                postHeaderClickData = mock(),
+                onMoreButtonClicked = onMoreMenuClicked,
+                onVideoOverlayClicked = onVideoOverlayClicked,
+                postHeaderClickData = PostHeaderClickData(postHeaderClicked, 0),
                 moreMenuItems = mock(),
-                onMoreDismissed = mock()
+                onMoreDismissed = onMoreMenuDismissed
         )
     }
 
@@ -349,3 +665,9 @@ class ReaderDiscoverViewModelTest {
     private fun createInterestsYouMayLikeCardList() = listOf(InterestsYouMayLikeCard(createReaderTagList()))
     private fun createWelcomeBannerCard() = listOf(WelcomeBannerCard)
 }
+
+private data class Observers(
+    val uiStates: List<DiscoverUiState>,
+    val navigation: List<Event<ReaderNavigationEvents>>,
+    val snackbarMsgs: List<Event<SnackbarMessageHolder>>
+)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -33,7 +33,6 @@ import org.wordpress.android.models.ReaderPostDiscoverData.DiscoverType.SITE_PIC
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.test
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.BLOG_PREVIEW
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
@@ -69,7 +68,6 @@ class ReaderPostUiStateBuilderTest {
     @Mock lateinit var readerImageScannerProvider: ReaderImageScannerProvider
     @Mock lateinit var readerUtilsWrapper: ReaderUtilsWrapper
     @Mock lateinit var readerPostTagsUiStateBuilder: ReaderPostTagsUiStateBuilder
-    @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
 
     @Before
     fun setUp() = test {
@@ -81,7 +79,6 @@ class ReaderPostUiStateBuilderTest {
                 readerImageScannerProvider,
                 readerUtilsWrapper,
                 readerPostTagsUiStateBuilder,
-                appPrefsWrapper,
                 TEST_DISPATCHER
         )
         whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(anyOrNull())).thenReturn("")


### PR DESCRIPTION
Parent issue #12821 

Adds some missing unit tests for the Discover view model.


To test:
No need to test anything as long as CI jobs pass

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
