### PR TITLE
Update play store screenshot strings for new designs

### DIFF
--- a/WordPress/metadata/screenshot_1.txt
+++ b/WordPress/metadata/screenshot_1.txt
@@ -1,2 +1,3 @@
-Enjoy your
-favorite sites
+The world’s most
+popular website
+builder

--- a/WordPress/metadata/screenshot_2.txt
+++ b/WordPress/metadata/screenshot_2.txt
@@ -1,2 +1,2 @@
-Share your ideas
-with the world
+Create a site or
+start a blog

--- a/WordPress/metadata/screenshot_3.txt
+++ b/WordPress/metadata/screenshot_3.txt
@@ -1,2 +1,2 @@
-Manage your site
-everywhere you go
+Discover
+new reads

--- a/WordPress/metadata/screenshot_4.txt
+++ b/WordPress/metadata/screenshot_4.txt
@@ -1,2 +1,2 @@
-Get notified
-in real-time
+Build an
+audience

--- a/WordPress/metadata/screenshot_5.txt
+++ b/WordPress/metadata/screenshot_5.txt
@@ -1,2 +1,2 @@
-All the stats
-in your hand
+Keep tabs on
+your site

--- a/WordPress/metadata/screenshot_6.txt
+++ b/WordPress/metadata/screenshot_6.txt
@@ -1,0 +1,2 @@
+Reply in
+real time

--- a/WordPress/metadata/screenshot_7.txt
+++ b/WordPress/metadata/screenshot_7.txt
@@ -1,0 +1,2 @@
+Upload
+on the go

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -107,6 +107,8 @@ ENV["HAS_ALPHA_VERSION"]="true"
       play_store_screenshot_3: prj_folder + "/WordPress/metadata/screenshot_3.txt",
       play_store_screenshot_4: prj_folder + "/WordPress/metadata/screenshot_4.txt",
       play_store_screenshot_5: prj_folder + "/WordPress/metadata/screenshot_5.txt",
+      play_store_screenshot_6: prj_folder + "/WordPress/metadata/screenshot_6.txt",
+      play_store_screenshot_7: prj_folder + "/WordPress/metadata/screenshot_7.txt",
 
       enhanced_app_store_screenshot_1: prj_folder + "/WordPress/metadata/enhanced_screenshot_1.html",
       enhanced_app_store_screenshot_2: prj_folder + "/WordPress/metadata/enhanced_screenshot_2.html",


### PR DESCRIPTION
Updates the play store screenshot strings (and adds 2 strings, for a total of 7) to match the new designs:

![image](https://user-images.githubusercontent.com/8658164/92469800-567f6280-f1cd-11ea-8d54-8109334d518f.png)


The changes to use these new strings for screenshot composition will come in a later PR.

(Internal ref: paaHJt-1kJ-p2)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.