### PR TITLE
Use API 27 for Connected Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
           apk-path: WordPress/build/outputs/apk/vanilla/debug/org.wordpress.android-vanilla-debug.apk
           test-apk-path: WordPress/build/outputs/apk/androidTest/vanilla/debug/org.wordpress.android-vanilla-debug-androidTest.apk
           test-targets: notPackage org.wordpress.android.ui.screenshots
-          device: model=Nexus5X,version=26,locale=en,orientation=portrait
+          device: model=Nexus5X,version=27,locale=en,orientation=portrait
           project: api-project-108380595987
           timeout: 10m
           num-flaky-test-attempts: 2
@@ -492,7 +492,7 @@ jobs:
           type: instrumentation
           apk-path: WordPress/build/outputs/apk/vanilla/debug/org.wordpress.android-vanilla-debug.apk
           test-apk-path: libs/utils/WordPressUtils/build/outputs/apk/androidTest/debug/WordPressUtils-debug-androidTest.apk
-          device: model=Nexus5X,version=26,locale=en,orientation=portrait
+          device: model=Nexus5X,version=27,locale=en,orientation=portrait
           project: api-project-108380595987
           timeout: 10m
           results-history-name: CircleCI WPUtils Connected Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
           apk-path: WordPress/build/outputs/apk/vanilla/debug/org.wordpress.android-vanilla-debug.apk
           test-apk-path: WordPress/build/outputs/apk/androidTest/vanilla/debug/org.wordpress.android-vanilla-debug-androidTest.apk
           test-targets: notPackage org.wordpress.android.ui.screenshots
-          device: model=Nexus5X,version=27,locale=en,orientation=portrait
+          device: model=Pixel2,version=27,locale=en,orientation=portrait
           project: api-project-108380595987
           timeout: 10m
           num-flaky-test-attempts: 2
@@ -492,7 +492,7 @@ jobs:
           type: instrumentation
           apk-path: WordPress/build/outputs/apk/vanilla/debug/org.wordpress.android-vanilla-debug.apk
           test-apk-path: libs/utils/WordPressUtils/build/outputs/apk/androidTest/debug/WordPressUtils-debug-androidTest.apk
-          device: model=Nexus5X,version=27,locale=en,orientation=portrait
+          device: model=Pixel2,version=27,locale=en,orientation=portrait
           project: api-project-108380595987
           timeout: 10m
           results-history-name: CircleCI WPUtils Connected Tests


### PR DESCRIPTION
Fixes an issue where CI was failing because of WPStories integration.

**To test:**
- Ensure CI passes

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
