### PR TITLE
e2e tests: Use Espresso method to find overflow menus

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
@@ -1,22 +1,22 @@
 package org.wordpress.android.e2e.pages;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 
 import org.wordpress.android.R;
 
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 
 public class BlockEditorPage {
-    private static ViewInteraction optionsButton = onView(withContentDescription("More options"));
     private static ViewInteraction titleField = onView(withHint("Add title"));
 
     private ViewInteraction mEditor;
@@ -35,7 +35,7 @@ public class BlockEditorPage {
     }
 
     public void switchToClassic() {
-        clickOn(optionsButton);
+        openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
         clickOn("Switch to classic editor");
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
@@ -1,11 +1,13 @@
 package org.wordpress.android.e2e.pages;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 
 import org.wordpress.android.R;
 
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.typeText;
@@ -13,7 +15,6 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -28,7 +29,6 @@ import static org.wordpress.android.support.WPSupportUtils.withIndex;
 
 public class EditorPage {
     private static ViewInteraction publishButton = onView(withId(R.id.menu_primary_action));
-    private static ViewInteraction optionsButton = onView(withContentDescription("More options"));
     private static ViewInteraction editor = onView(withId(R.id.aztec));
     private static ViewInteraction titleField = onView(allOf(withId(R.id.title),
             withHint("Title")));
@@ -87,8 +87,8 @@ public class EditorPage {
     }
 
     public void openSettings() {
-        clickOn(optionsButton);
-        clickOn("Post settings");
+        openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
+        clickOn(onView(withText(R.string.post_settings)));
     }
 
     public void addACategory(String category) {
@@ -118,7 +118,7 @@ public class EditorPage {
     }
 
     public void previewPost() {
-        clickOn(optionsButton);
+        openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
         clickOn(onView(withText(R.string.menu_preview)));
     }
 }


### PR DESCRIPTION
Fixes (I think) the current e2e test breakage caused by changing the emulator used to Pixel API 28, by changing the way the tests detect overflow menus.

### Background

1. https://github.com/wordpress-mobile/WordPress-Android/pull/12845 caused connected the tests to break due to an Android OS bug in stock Android API 26. (See https://github.com/wordpress-mobile/WordPress-Android/pull/12908#pullrequestreview-484342586 for a full explanation.)
2. https://github.com/wordpress-mobile/WordPress-Android/pull/12908 changed the connected tests to use a Pixel 2 API 27, but the above OS bug was still present on that emulator
3. https://github.com/wordpress-mobile/WordPress-Android/pull/12909 updated the API level to 28 (still Pixel 2)

After 3, it looks like the original issue introduced by https://github.com/wordpress-mobile/WordPress-Android/pull/12845 was resolved, but one test (`e2e.EditorTests.testPublishFullPost`) now fails continuously.

The point of failure is [here](https://github.com/wordpress-mobile/WordPress-Android/blob/5d1661cbf21c52c9b29f785737e5bf9597dda642/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java#L90) - the test is trying to open the overflow menu in the editor, and appears not to be finding it.

The way we're finding it is a bit error-prone - we're looking for a UI element with content description "More options", which is set by the system and not by us (and subject to change).

### The fix

I haven't been able to confirm this directly (my own API 28 Pixel 2 emulator runs the tests successfully without this branch), but I suspect Firebase's emulator does not have "More options" as the content description for overflow menus. Maybe it's missing, or it's called something else, or the system UI is in French 🙂 (Actually it looks like it's missing for certain versions of [ActionBarActivityCompat](https://android.googlesource.com/platform/frameworks/testing/+/android-support-test/espresso/core/src/main/java/android/support/test/espresso/Espresso.java#146).)

It turns out that there's an Espresso function we can use instead: [openActionBarOverflowOrOptionsMenu](https://developer.android.com/training/testing/espresso/recipes#matching-view-inside-action-bar). This does the same job but seems to cover more cases (from looking at [the implementation](https://android.googlesource.com/platform/frameworks/testing/+/android-support-test/espresso/core/src/main/java/android/support/test/espresso/Espresso.java#146) it looks like it'll target by class name if "More options" fails). With that change I was able to get the tests to pass on Firebase. I replaced all the usages of this I found in the tests.

### To test:

I'm triggering the connected tests for this PR (I think it's the same job as runs on merge to develop?), but you also like to:

1. Run the test suite on firebase yourself, like so:

```
$ ./gradlew WordPress:assembleVanillaDebug WordPress:assembleVanillaDebugAndroidTest

$ gcloud firebase test android run \
--type instrumentation \
--app WordPress/build/outputs/apk/vanilla/debug/org.wordpress.android-vanilla-debug.apk \
--test WordPress/build/outputs/apk/androidTest/vanilla/debug/org.wordpress.android-vanilla-debug-androidTest.apk \
--device model=Pixel2,version=28,locale=en,orientation=portrait \
--test-targets="notPackage org.wordpress.android.ui.screenshots" \
--project api-project-108380595987 \
--no-record-video \
--timeout 10m
```

(I have and things seem to be working)

or

2. Merge the PR and watch the automated connected test run - they're broken right now anyway 😅 

#### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
