### PR TITLE
Add paging and refresh to media picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
@@ -13,7 +13,6 @@ import android.provider.MediaStore.Video
 import android.webkit.MimeTypeMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.utils.MediaUtils
 import org.wordpress.android.fluxc.utils.MimeTypes

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
@@ -44,23 +44,21 @@ class DeviceListBuilder
         mediaTypes: Set<MediaType>,
         offset: Int,
         pageSize: Int?
-    ) = flow {
-        withContext(bgDispatcher) {
-            val result = mutableListOf<MediaItem>()
-            val deferredJobs = mediaTypes.map { mediaType ->
-                when (mediaType) {
-                    IMAGE -> async { addMedia(Media.EXTERNAL_CONTENT_URI, IMAGE) }
-                    VIDEO -> async { addMedia(Video.Media.EXTERNAL_CONTENT_URI, VIDEO) }
-                    AUDIO -> async { addMedia(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, AUDIO) }
-                    DOCUMENT -> async { addDownloads() }
-                }
+    ) = withContext(bgDispatcher) {
+        val result = mutableListOf<MediaItem>()
+        val deferredJobs = mediaTypes.map { mediaType ->
+            when (mediaType) {
+                IMAGE -> async { addMedia(Media.EXTERNAL_CONTENT_URI, IMAGE) }
+                VIDEO -> async { addMedia(Video.Media.EXTERNAL_CONTENT_URI, VIDEO) }
+                AUDIO -> async { addMedia(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, AUDIO) }
+                DOCUMENT -> async { addDownloads() }
             }
-            deferredJobs.forEach { result.addAll(it.await()) }
-            result.sortByDescending { it.dataModified }
-            cachedData.clear()
-            cachedData.addAll(result)
-            emit(MediaLoadingResult.Success(false))
         }
+        deferredJobs.forEach { result.addAll(it.await()) }
+        result.sortByDescending { it.dataModified }
+        cachedData.clear()
+        cachedData.addAll(result)
+        MediaLoadingResult.Success(false)
     }
 
     override suspend fun get(mediaTypes: Set<MediaType>, filter: String?): List<MediaItem> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
@@ -13,9 +13,10 @@ import android.provider.MediaStore.Video
 import android.webkit.MimeTypeMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.utils.MimeTypes
 import org.wordpress.android.fluxc.utils.MediaUtils
+import org.wordpress.android.fluxc.utils.MimeTypes
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mediapicker.MediaSource.MediaLoadingResult
 import org.wordpress.android.ui.mediapicker.MediaType.AUDIO
@@ -24,6 +25,7 @@ import org.wordpress.android.ui.mediapicker.MediaType.IMAGE
 import org.wordpress.android.ui.mediapicker.MediaType.VIDEO
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MEDIA
+import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.SqlUtils
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
@@ -32,16 +34,18 @@ import javax.inject.Named
 class DeviceListBuilder
 @Inject constructor(
     val context: Context,
+    private val localeManagerWrapper: LocaleManagerWrapper,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : MediaSource {
     private val mimeTypes = MimeTypes()
+    private val cachedData = mutableListOf<MediaItem>()
 
     override suspend fun load(
         mediaTypes: Set<MediaType>,
         offset: Int,
         pageSize: Int?
-    ): MediaLoadingResult {
-        return withContext(bgDispatcher) {
+    ) = flow {
+        withContext(bgDispatcher) {
             val result = mutableListOf<MediaItem>()
             val deferredJobs = mediaTypes.map { mediaType ->
                 when (mediaType) {
@@ -53,7 +57,21 @@ class DeviceListBuilder
             }
             deferredJobs.forEach { result.addAll(it.await()) }
             result.sortByDescending { it.dataModified }
-            MediaLoadingResult.Success(result, false)
+            cachedData.clear()
+            cachedData.addAll(result)
+            emit(MediaLoadingResult.Success(false))
+        }
+    }
+
+    override suspend fun get(mediaTypes: Set<MediaType>, filter: String?): List<MediaItem> {
+        return if (filter == null) {
+            cachedData
+        } else {
+            val lowerCaseFilter = filter.toLowerCase(localeManagerWrapper.getLocale())
+            cachedData.filter {
+                it.name?.toLowerCase(localeManagerWrapper.getLocale())
+                        ?.contains(lowerCaseFilter) == true
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/FileThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/FileThumbnailViewHolder.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import org.wordpress.android.R
-import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.FileItem
 
 class FileThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailViewUtils: MediaThumbnailViewUtils) :
         ThumbnailViewHolder(parent, R.layout.media_picker_file_item) {
@@ -15,7 +14,7 @@ class FileThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailViewU
     private val fileName: TextView = itemView.findViewById(R.id.media_item_name)
     private val txtSelectionCount: TextView = itemView.findViewById(R.id.text_selection_count)
 
-    fun bind(item: FileItem, animateSelection: Boolean, updateCount: Boolean) {
+    fun bind(item: MediaPickerUiItem.FileItem, animateSelection: Boolean, updateCount: Boolean) {
         val isSelected = item.isSelected
         mediaThumbnailViewUtils.setupTextSelectionCount(
                 txtSelectionCount,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/FileThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/FileThumbnailViewHolder.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import org.wordpress.android.R
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.FileItem
 
 class FileThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailViewUtils: MediaThumbnailViewUtils) :
         ThumbnailViewHolder(parent, R.layout.media_picker_file_item) {
@@ -14,7 +15,7 @@ class FileThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailViewU
     private val fileName: TextView = itemView.findViewById(R.id.media_item_name)
     private val txtSelectionCount: TextView = itemView.findViewById(R.id.text_selection_count)
 
-    fun bind(item: MediaPickerUiItem.FileItem, animateSelection: Boolean, updateCount: Boolean) {
+    fun bind(item: FileItem, animateSelection: Boolean, updateCount: Boolean) {
         val isSelected = item.isSelected
         mediaThumbnailViewUtils.setupTextSelectionCount(
                 txtSelectionCount,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/LoaderViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/LoaderViewHolder.kt
@@ -1,0 +1,30 @@
+package org.wordpress.android.ui.mediapicker
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.recyclerview.widget.StaggeredGridLayoutManager.LayoutParams
+import org.wordpress.android.R
+import org.wordpress.android.widgets.WPTextView
+
+class LoaderViewHolder(parent: ViewGroup) :
+        ThumbnailViewHolder(parent, R.layout.media_picker_loader_item) {
+    private val progress: View = itemView.findViewById(R.id.progress)
+    private val error: WPTextView = itemView.findViewById(R.id.error)
+    fun bind(item: MediaPickerUiItem.NextPageLoader) {
+        setFullWidth()
+        if (item.isLoading) {
+            progress.visibility = View.VISIBLE
+            error.visibility = View.GONE
+        } else if (item.error != null) {
+            progress.visibility = View.GONE
+            error.visibility = View.VISIBLE
+            error.text = item.error
+        }
+    }
+
+    private fun setFullWidth() {
+        val layoutParams = itemView.layoutParams as? LayoutParams
+        layoutParams?.isFullSpan = true
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/LoaderViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/LoaderViewHolder.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.mediapicker
 
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.recyclerview.widget.StaggeredGridLayoutManager.LayoutParams
 import org.wordpress.android.R
 import org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/LoaderViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/LoaderViewHolder.kt
@@ -14,6 +14,7 @@ class LoaderViewHolder(parent: ViewGroup) :
     fun bind(item: MediaPickerUiItem.NextPageLoader) {
         setFullWidth()
         if (item.isLoading) {
+            item.loadAction()
             progress.visibility = View.VISIBLE
             error.visibility = View.GONE
         } else if (item.error != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaLoader.kt
@@ -25,18 +25,18 @@ data class MediaLoader(
                 when (loadAction) {
                     is Start -> {
                         if (state.domainItems.isEmpty() || state.error != null) {
-                            emit(state.copy(isLoading = true))
                             state = buildDomainModel(mediaSource.load(allowedTypes), state)
                             emit(state)
                         }
                     }
                     is Refresh -> {
-                        emit(state.copy(isLoading = true))
-                        state = buildDomainModel(mediaSource.load(allowedTypes), state)
-                        emit(state)
+                        if (loadAction.forced || state.domainItems.isEmpty()) {
+                            emit(state.copy(isLoading = true))
+                            state = buildDomainModel(mediaSource.load(allowedTypes), state)
+                            emit(state)
+                        }
                     }
                     is NextPage -> {
-                        emit(state.copy(isLoading = true))
                         val load = mediaSource.load(mediaTypes = allowedTypes, offset = state.domainItems.size)
                         state = buildDomainModel(load, state)
                         emit(state)
@@ -74,7 +74,7 @@ data class MediaLoader(
 
     sealed class LoadAction {
         data class Start(val filter: String? = null) : LoadAction()
-        object Refresh : LoadAction()
+        data class Refresh(val forced: Boolean) : LoadAction()
         data class Filter(val filter: String) : LoadAction()
         object NextPage : LoadAction()
         object ClearFilter : LoadAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactory.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactory.kt
@@ -12,9 +12,9 @@ class MediaLoaderFactory
     private val deviceListBuilder: DeviceListBuilder,
     private val localeManagerWrapper: LocaleManagerWrapper
 ) {
-    fun build(mediaSourceType: MediaPickerSetup.DataSource): MediaLoader {
-        return when (mediaSourceType) {
-            DEVICE -> MediaLoader(deviceListBuilder, localeManagerWrapper)
+    fun build(mediaPickerSetup: MediaPickerSetup): MediaLoader {
+        return when (mediaPickerSetup.dataSource) {
+            DEVICE -> MediaLoader(deviceListBuilder, localeManagerWrapper, mediaPickerSetup.allowedTypes)
             WP_LIBRARY -> throw NotImplementedError("Source not implemented yet")
             STOCK_LIBRARY -> throw NotImplementedError("Source not implemented yet")
             GIF_LIBRARY -> throw NotImplementedError("Source not implemented yet")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.RecyclerView.Adapter
 import org.wordpress.android.ui.mediapicker.MediaPickerAdapterDiffCallback.Payload.COUNT_CHANGE
 import org.wordpress.android.ui.mediapicker.MediaPickerAdapterDiffCallback.Payload.SELECTION_CHANGE
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.FileItem
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.NextPageLoader
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.PhotoItem
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.Type
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.VideoItem
@@ -32,6 +33,7 @@ class MediaPickerAdapter internal constructor(imageManager: ImageManager) : Adap
             Type.PHOTO.ordinal -> PhotoThumbnailViewHolder(parent, thumbnailViewUtils)
             Type.VIDEO.ordinal -> VideoThumbnailViewHolder(parent, thumbnailViewUtils)
             Type.FILE.ordinal -> FileThumbnailViewHolder(parent, thumbnailViewUtils)
+            Type.NEXT_PAGE_LOADER.ordinal -> LoaderViewHolder(parent)
             else -> throw IllegalArgumentException("Unexpected view type")
         }
     }
@@ -60,6 +62,7 @@ class MediaPickerAdapter internal constructor(imageManager: ImageManager) : Adap
             is PhotoItem -> (holder as PhotoThumbnailViewHolder).bind(item, animateSelection, updateCount)
             is VideoItem -> (holder as VideoThumbnailViewHolder).bind(item, animateSelection, updateCount)
             is FileItem -> (holder as FileThumbnailViewHolder).bind(item, animateSelection, updateCount)
+            is NextPageLoader -> (holder as LoaderViewHolder).bind(item)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerAdapterDiffCallback.kt
@@ -3,6 +3,10 @@ package org.wordpress.android.ui.mediapicker
 import androidx.recyclerview.widget.DiffUtil
 import org.wordpress.android.ui.mediapicker.MediaPickerAdapterDiffCallback.Payload.COUNT_CHANGE
 import org.wordpress.android.ui.mediapicker.MediaPickerAdapterDiffCallback.Payload.SELECTION_CHANGE
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.FileItem
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.NextPageLoader
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.PhotoItem
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.VideoItem
 
 class MediaPickerAdapterDiffCallback(
     private val oldItems: List<MediaPickerUiItem>,
@@ -17,7 +21,15 @@ class MediaPickerAdapterDiffCallback(
     }
 
     override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        return oldItems[oldItemPosition].uri == updatedItems[newItemPosition].uri
+        val oldItem = oldItems[oldItemPosition]
+        val updatedItem = updatedItems[newItemPosition]
+        return when {
+            oldItem is PhotoItem && updatedItem is PhotoItem -> oldItem.uri == updatedItem.uri
+            oldItem is VideoItem && updatedItem is VideoItem -> oldItem.uri == updatedItem.uri
+            oldItem is FileItem && updatedItem is FileItem -> oldItem.uri == updatedItem.uri
+            oldItem is NextPageLoader && updatedItem is NextPageLoader -> true
+            else -> false
+        }
     }
 
     override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
@@ -25,14 +37,16 @@ class MediaPickerAdapterDiffCallback(
     }
 
     override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any? {
-        val oldItem = oldItems[oldItemPosition]
-        val updatedItem = updatedItems[newItemPosition]
-        if (oldItem.isSelected != updatedItem.isSelected) {
-            return SELECTION_CHANGE
-        }
-        if (oldItem.showOrderCounter == updatedItem.showOrderCounter &&
-                oldItem.selectedOrder != updatedItem.selectedOrder) {
-            return COUNT_CHANGE
+        val oldItem = oldItems[oldItemPosition].toSelectableItem()
+        val updatedItem = updatedItems[newItemPosition].toSelectableItem()
+        if (oldItem != null && updatedItem != null) {
+            if (oldItem.isSelected != updatedItem.isSelected) {
+                return SELECTION_CHANGE
+            }
+            if (oldItem.showOrderCounter == updatedItem.showOrderCounter &&
+                    oldItem.selectedOrder != updatedItem.selectedOrder) {
+                return COUNT_CHANGE
+            }
         }
         return super.getChangePayload(oldItemPosition, newItemPosition)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -280,6 +280,14 @@ class MediaPickerFragment : Fragment() {
                 )
             }
             val adapter = recycler.adapter as MediaPickerAdapter
+
+            (recycler.layoutManager as? GridLayoutManager)?.spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
+                override fun getSpanSize(position: Int) = if (uiModel.items[position].fullWidthItem) {
+                    NUM_COLUMNS
+                } else {
+                    1
+                }
+            }
             val recyclerViewState = recycler.layoutManager?.onSaveInstanceState()
             adapter.loadData(uiModel.items)
             recycler.layoutManager?.onRestoreInstanceState(recyclerViewState)
@@ -319,20 +327,6 @@ class MediaPickerFragment : Fragment() {
 
     fun setMediaPickerListener(listener: MediaPickerListener?) {
         this.listener = listener
-    }
-
-    /*
-     * similar to the above but only repopulates if changes are detected
-     */
-    fun refresh() {
-        if (!isAdded) {
-            AppLog.w(
-                    POSTS,
-                    "Photo picker > can't refresh when not added"
-            )
-            return
-        }
-        viewModel.refreshData(false)
     }
 
     private val isStoragePermissionAlwaysDenied: Boolean

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.util.AppLog.T.POSTS
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.WPPermissionUtils
+import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.config.TenorFeatureConfig
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
@@ -113,6 +114,10 @@ class MediaPickerFragment : Fragment() {
 
         recycler.layoutManager = layoutManager
 
+        val swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
+            viewModel.onPullToRefresh()
+        }
+
         var isShowingActionMode = false
         viewModel.uiState.observe(viewLifecycleOwner, Observer {
             it?.let { uiState ->
@@ -129,6 +134,7 @@ class MediaPickerFragment : Fragment() {
                     isShowingActionMode = false
                 }
                 uiState.fabUiModel.let(this::setupFab)
+                swipeToRefreshHelper.isRefreshing = uiState.isRefreshing
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -36,8 +36,6 @@ import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.SoftAskViewUiMo
 import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AniUtils.Duration.MEDIUM
-import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.AppLog.T.POSTS
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.WPPermissionUtils
@@ -281,13 +279,14 @@ class MediaPickerFragment : Fragment() {
             }
             val adapter = recycler.adapter as MediaPickerAdapter
 
-            (recycler.layoutManager as? GridLayoutManager)?.spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
-                override fun getSpanSize(position: Int) = if (uiModel.items[position].fullWidthItem) {
-                    NUM_COLUMNS
-                } else {
-                    1
-                }
-            }
+            (recycler.layoutManager as? GridLayoutManager)?.spanSizeLookup =
+                    object : GridLayoutManager.SpanSizeLookup() {
+                        override fun getSpanSize(position: Int) = if (uiModel.items[position].fullWidthItem) {
+                            NUM_COLUMNS
+                        } else {
+                            1
+                        }
+                    }
             val recyclerViewState = recycler.layoutManager?.onSaveInstanceState()
             adapter.loadData(uiModel.items)
             recycler.layoutManager?.onRestoreInstanceState(recyclerViewState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerUiItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerUiItem.kt
@@ -7,7 +7,8 @@ import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.Type.VIDEO
 import org.wordpress.android.util.UriWrapper
 
 sealed class MediaPickerUiItem(
-    open val type: Type
+    val type: Type,
+    val fullWidthItem: Boolean = false
 ) {
     data class PhotoItem(
         val uri: UriWrapper? = null,
@@ -39,7 +40,7 @@ sealed class MediaPickerUiItem(
     ) : MediaPickerUiItem(FILE)
 
     data class NextPageLoader(val isLoading: Boolean, val error: String? = null, val loadAction: () -> Unit) :
-            MediaPickerUiItem(NEXT_PAGE_LOADER)
+            MediaPickerUiItem(NEXT_PAGE_LOADER, fullWidthItem = true)
 
     data class ToggleAction(
         val uri: UriWrapper,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerUiItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerUiItem.kt
@@ -1,47 +1,45 @@
 package org.wordpress.android.ui.mediapicker
 
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.Type.FILE
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.Type.NEXT_PAGE_LOADER
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.Type.PHOTO
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.Type.VIDEO
 import org.wordpress.android.util.UriWrapper
 
 sealed class MediaPickerUiItem(
-    val type: Type,
-    open val uri: UriWrapper?,
-    open val isSelected: Boolean,
-    open val selectedOrder: Int?,
-    open val showOrderCounter: Boolean,
-    open val toggleAction: ToggleAction,
-    open val clickAction: ClickAction
+    open val type: Type
 ) {
     data class PhotoItem(
-        override val uri: UriWrapper? = null,
-        override val isSelected: Boolean = false,
-        override val selectedOrder: Int? = null,
-        override val showOrderCounter: Boolean = false,
-        override val toggleAction: ToggleAction,
-        override val clickAction: ClickAction
-    ) : MediaPickerUiItem(PHOTO, uri, isSelected, selectedOrder, showOrderCounter, toggleAction, clickAction)
+        val uri: UriWrapper? = null,
+        val isSelected: Boolean = false,
+        val selectedOrder: Int? = null,
+        val showOrderCounter: Boolean = false,
+        val toggleAction: ToggleAction,
+        val clickAction: ClickAction
+    ) : MediaPickerUiItem(PHOTO)
 
     data class VideoItem(
-        override val uri: UriWrapper? = null,
-        override val isSelected: Boolean = false,
-        override val selectedOrder: Int? = null,
-        override val showOrderCounter: Boolean = false,
-        override val toggleAction: ToggleAction,
-        override val clickAction: ClickAction
-    ) : MediaPickerUiItem(VIDEO, uri, isSelected, selectedOrder, showOrderCounter, toggleAction, clickAction)
+        val uri: UriWrapper? = null,
+        val isSelected: Boolean = false,
+        val selectedOrder: Int? = null,
+        val showOrderCounter: Boolean = false,
+        val toggleAction: ToggleAction,
+        val clickAction: ClickAction
+    ) : MediaPickerUiItem(VIDEO)
 
     data class FileItem(
-        override val uri: UriWrapper? = null,
+        val uri: UriWrapper? = null,
         val fileName: String,
         val fileExtension: String? = null,
-        override val isSelected: Boolean = false,
-        override val selectedOrder: Int? = null,
-        override val showOrderCounter: Boolean = false,
-        override val toggleAction: ToggleAction,
-        override val clickAction: ClickAction
-    ) : MediaPickerUiItem(FILE, uri, isSelected, selectedOrder, showOrderCounter, toggleAction, clickAction)
+        val isSelected: Boolean = false,
+        val selectedOrder: Int? = null,
+        val showOrderCounter: Boolean = false,
+        val toggleAction: ToggleAction,
+        val clickAction: ClickAction
+    ) : MediaPickerUiItem(FILE)
+
+    data class NextPageLoader(val isLoading: Boolean, val error: String? = null, val retryAction: () -> Unit) :
+            MediaPickerUiItem(NEXT_PAGE_LOADER)
 
     data class ToggleAction(
         val uri: UriWrapper,
@@ -60,6 +58,6 @@ sealed class MediaPickerUiItem(
     }
 
     enum class Type {
-        PHOTO, VIDEO, FILE
+        PHOTO, VIDEO, FILE, NEXT_PAGE_LOADER
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerUiItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerUiItem.kt
@@ -38,7 +38,7 @@ sealed class MediaPickerUiItem(
         val clickAction: ClickAction
     ) : MediaPickerUiItem(FILE)
 
-    data class NextPageLoader(val isLoading: Boolean, val error: String? = null, val retryAction: () -> Unit) :
+    data class NextPageLoader(val isLoading: Boolean, val error: String? = null, val loadAction: () -> Unit) :
             MediaPickerUiItem(NEXT_PAGE_LOADER)
 
     data class ToggleAction(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -19,10 +19,14 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.mediapicker.MediaLoader.DomainModel
 import org.wordpress.android.ui.mediapicker.MediaLoader.LoadAction
+import org.wordpress.android.ui.mediapicker.MediaLoader.LoadAction.NextPage
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerIcon
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerIcon.WP_STORIES_CAPTURE
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.ClickAction
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.FileItem
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.PhotoItem
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.ToggleAction
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.VideoItem
 import org.wordpress.android.ui.mediapicker.MediaType.AUDIO
 import org.wordpress.android.ui.mediapicker.MediaType.DOCUMENT
 import org.wordpress.android.ui.mediapicker.MediaType.IMAGE
@@ -88,15 +92,15 @@ class MediaPickerViewModel @Inject constructor(
             _softAskRequest,
             _searchExpanded
     ) { domainModel, selectedUris, softAskRequest, searchExpanded ->
-        val photoPickerItems = domainModel?.domainItems
         MediaPickerUiState(
-                buildUiModel(photoPickerItems, selectedUris),
+                buildUiModel(domainModel, selectedUris),
                 buildSoftAskView(softAskRequest),
                 FabUiModel(mediaPickerSetup.cameraEnabled) {
                     clickIcon(WP_STORIES_CAPTURE)
                 },
-                buildActionModeUiModel(selectedUris, photoPickerItems),
-                buildSearchUiModel(domainModel?.filter, searchExpanded)
+                buildActionModeUiModel(selectedUris, domainModel?.domainItems),
+                buildSearchUiModel(domainModel?.filter, searchExpanded),
+                isRefreshing = !domainModel?.domainItems.isNullOrEmpty() && domainModel?.isLoading == true
         )
     }
 
@@ -113,9 +117,10 @@ class MediaPickerViewModel @Inject constructor(
     private var site: SiteModel? = null
 
     private fun buildUiModel(
-        data: List<MediaItem>?,
+        domainModel: DomainModel?,
         selectedUris: List<UriWrapper>?
     ): PhotoListUiModel {
+        val data = domainModel?.domainItems
         return if (data != null) {
             val uiItems = data.map {
                 val showOrderCounter = mediaPickerSetup.canMultiselect
@@ -133,7 +138,15 @@ class MediaPickerViewModel @Inject constructor(
                     mediaUtilsWrapper.getExtensionForMimeType(mimeType).toUpperCase(localeManagerWrapper.getLocale())
                 }
                 when (it.type) {
-                    IMAGE -> MediaPickerUiItem.PhotoItem(
+                    IMAGE -> PhotoItem(
+                            uri = it.uri,
+                            isSelected = isSelected,
+                            selectedOrder = selectedOrder,
+                            showOrderCounter = showOrderCounter,
+                            toggleAction = toggleAction,
+                            clickAction = clickAction
+                    ) as MediaPickerUiItem
+                    VIDEO -> VideoItem(
                             uri = it.uri,
                             isSelected = isSelected,
                             selectedOrder = selectedOrder,
@@ -141,15 +154,7 @@ class MediaPickerViewModel @Inject constructor(
                             toggleAction = toggleAction,
                             clickAction = clickAction
                     )
-                    VIDEO -> MediaPickerUiItem.VideoItem(
-                            uri = it.uri,
-                            isSelected = isSelected,
-                            selectedOrder = selectedOrder,
-                            showOrderCounter = showOrderCounter,
-                            toggleAction = toggleAction,
-                            clickAction = clickAction
-                    )
-                    AUDIO, DOCUMENT -> MediaPickerUiItem.FileItem(
+                    AUDIO, DOCUMENT -> FileItem(
                             uri = it.uri,
                             fileName = it.name ?: "",
                             fileExtension = fileExtension,
@@ -161,7 +166,17 @@ class MediaPickerViewModel @Inject constructor(
                     )
                 }
             }
-            PhotoListUiModel.Data(uiItems)
+            if (domainModel.hasMore) {
+                val updatedItems = uiItems.toMutableList()
+                updatedItems.add(MediaPickerUiItem.NextPageLoader(true, domainModel.error) {
+                    launch {
+                        loadActions.send(NextPage)
+                    }
+                })
+                PhotoListUiModel.Data(updatedItems)
+            } else {
+                PhotoListUiModel.Data(uiItems)
+            }
         } else {
             PhotoListUiModel.Empty
         }
@@ -227,7 +242,7 @@ class MediaPickerViewModel @Inject constructor(
         this.lastTappedIcon = lastTappedIcon
         this.site = site
         if (_domainModel.value == null) {
-            this.mediaLoader = mediaLoaderFactory.build(mediaPickerSetup.dataSource)
+            this.mediaLoader = mediaLoaderFactory.build(mediaPickerSetup)
             launch(bgDispatcher) {
                 mediaLoader.loadMedia(loadActions).collect { domainModel ->
                     withContext(mainDispatcher) {
@@ -236,7 +251,7 @@ class MediaPickerViewModel @Inject constructor(
                 }
             }
             launch(bgDispatcher) {
-                loadActions.send(LoadAction.Start(mediaPickerSetup.allowedTypes))
+                loadActions.send(LoadAction.Start())
             }
         }
     }
@@ -378,12 +393,19 @@ class MediaPickerViewModel @Inject constructor(
         }
     }
 
+    fun onPullToRefresh() {
+        launch {
+            loadActions.send(LoadAction.Refresh)
+        }
+    }
+
     data class MediaPickerUiState(
         val photoListUiModel: PhotoListUiModel,
         val softAskViewUiModel: SoftAskViewUiModel,
         val fabUiModel: FabUiModel,
         val actionModeUiModel: ActionModeUiModel,
-        val searchUiModel: SearchUiModel
+        val searchUiModel: SearchUiModel,
+        val isRefreshing: Boolean
     )
 
     sealed class PhotoListUiModel {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -219,7 +219,7 @@ class MediaPickerViewModel @Inject constructor(
             return
         }
         launch(bgDispatcher) {
-            loadActions.send(LoadAction.Refresh)
+            loadActions.send(LoadAction.Refresh(forceReload))
         }
     }
 
@@ -394,9 +394,7 @@ class MediaPickerViewModel @Inject constructor(
     }
 
     fun onPullToRefresh() {
-        launch {
-            loadActions.send(LoadAction.Refresh)
-        }
+        refreshData(true)
     }
 
     data class MediaPickerUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaSource.kt
@@ -1,14 +1,19 @@
 package org.wordpress.android.ui.mediapicker
 
+import kotlinx.coroutines.flow.Flow
+
 interface MediaSource {
     suspend fun load(
         mediaTypes: Set<MediaType>,
         offset: Int = 0,
         pageSize: Int? = null
-    ): MediaLoadingResult
+    ): Flow<MediaLoadingResult>
+
+    suspend fun get(mediaTypes: Set<MediaType>, filter: String? = null): List<MediaItem>
 
     sealed class MediaLoadingResult {
-        data class Success(val mediaItems: List<MediaItem>, val hasMore: Boolean = false) : MediaLoadingResult()
+        object Loading: MediaLoadingResult()
+        data class Success(val hasMore: Boolean = false) : MediaLoadingResult()
         data class Failure(val message: String) : MediaLoadingResult()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaSource.kt
@@ -1,18 +1,15 @@
 package org.wordpress.android.ui.mediapicker
 
-import kotlinx.coroutines.flow.Flow
-
 interface MediaSource {
     suspend fun load(
         mediaTypes: Set<MediaType>,
         offset: Int = 0,
         pageSize: Int? = null
-    ): Flow<MediaLoadingResult>
+    ): MediaLoadingResult
 
     suspend fun get(mediaTypes: Set<MediaType>, filter: String? = null): List<MediaItem>
 
     sealed class MediaLoadingResult {
-        object Loading: MediaLoadingResult()
         data class Success(val hasMore: Boolean = false) : MediaLoadingResult()
         data class Failure(val message: String) : MediaLoadingResult()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/SelectableItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/SelectableItem.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui.mediapicker
+
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.FileItem
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.PhotoItem
+import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.VideoItem
+
+
+data class SelectableItem(val isSelected: Boolean, val showOrderCounter: Boolean, val selectedOrder: Int?)
+
+fun MediaPickerUiItem.toSelectableItem(): SelectableItem? {
+    return when (this) {
+        is PhotoItem -> SelectableItem(
+                this.isSelected,
+                this.showOrderCounter,
+                this.selectedOrder
+        )
+        is VideoItem -> SelectableItem(
+                this.isSelected,
+                this.showOrderCounter,
+                this.selectedOrder
+        )
+        is FileItem -> SelectableItem(
+                this.isSelected,
+                this.showOrderCounter,
+                this.selectedOrder
+        )
+        else -> null
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/SelectableItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/SelectableItem.kt
@@ -4,7 +4,6 @@ import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.FileItem
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.PhotoItem
 import org.wordpress.android.ui.mediapicker.MediaPickerUiItem.VideoItem
 
-
 data class SelectableItem(val isSelected: Boolean, val showOrderCounter: Boolean, val selectedOrder: Int?)
 
 fun MediaPickerUiItem.toSelectableItem(): SelectableItem? {

--- a/WordPress/src/main/res/layout/media_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/media_picker_fragment.xml
@@ -4,47 +4,54 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    >
+    android:orientation="vertical">
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/wp_stories_take_picture"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
-        android:visibility="gone"
-        android:src="@drawable/ic_photo_camera_24px"
         android:layout_margin="@dimen/fab_margin"
-        tools:ignore="InconsistentLayout"/>
+        android:src="@drawable/ic_photo_camera_24px"
+        android:visibility="gone"
+        tools:ignore="InconsistentLayout" />
 
-    <RelativeLayout
+    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+        android:id="@+id/pullToRefresh"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:layout_below="@id/toolbar"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <org.wordpress.android.ui.prefs.EmptyViewRecyclerView
-            android:id="@+id/recycler"
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fadeScrollbars="true"
-            android:scrollbars="vertical" />
+            android:layout_height="match_parent">
 
-        <org.wordpress.android.ui.ActionableEmptyView
-            android:id="@+id/actionable_empty_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone"
-            app:aevImage="@drawable/img_illustration_media_105dp"
-            app:aevTitle="@string/media_empty_list"
-            tools:visibility="visible" />
+            <org.wordpress.android.ui.ActionableEmptyView
+                android:id="@+id/actionable_empty_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="gone"
+                app:aevImage="@drawable/img_illustration_media_105dp"
+                app:aevTitle="@string/media_empty_list"
+                tools:visibility="visible" />
 
-        <org.wordpress.android.ui.ActionableEmptyView
-            android:id="@+id/soft_ask_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone"
-            app:aevButton="@string/photo_picker_soft_ask_allow"
-            app:aevImage="@drawable/img_illustration_add_media_150dp"
-            app:aevTitle="@string/photo_picker_soft_ask_label"
-            tools:visibility="visible" />
-    </RelativeLayout>
+            <org.wordpress.android.ui.ActionableEmptyView
+                android:id="@+id/soft_ask_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="gone"
+                app:aevButton="@string/photo_picker_soft_ask_allow"
+                app:aevImage="@drawable/img_illustration_add_media_150dp"
+                app:aevTitle="@string/photo_picker_soft_ask_label"
+                tools:visibility="visible" />
+
+            <org.wordpress.android.ui.prefs.EmptyViewRecyclerView
+                android:id="@+id/recycler"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fadeScrollbars="true"
+                android:scrollbars="vertical" />
+        </RelativeLayout>
+    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/media_picker_loader_item.xml
+++ b/WordPress/src/main/res/layout/media_picker_loader_item.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:foregroundGravity="center_horizontal"
-    android:background="@android:color/transparent">
+    android:background="@android:color/transparent"
+    android:foregroundGravity="center_horizontal">
 
     <ProgressBar
         android:id="@+id/progress"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:progressTint="?attr/colorPrimary"
         android:layout_gravity="center"
-        android:indeterminate="true" />
+        android:indeterminate="true"
+        android:progressTint="?attr/colorPrimary" />
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/error"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:visibility="gone" />
 
 </FrameLayout>

--- a/WordPress/src/main/res/layout/media_picker_loader_item.xml
+++ b/WordPress/src/main/res/layout/media_picker_loader_item.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:foregroundGravity="center_horizontal"
+    android:background="@android:color/transparent">
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:progressTint="?attr/colorPrimary"
+        android:layout_gravity="center"
+        android:indeterminate="true" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/media_picker_loader_item.xml
+++ b/WordPress/src/main/res/layout/media_picker_loader_item.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
     android:foregroundGravity="center_horizontal"
     android:background="@android:color/transparent">
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactoryTest.kt
@@ -18,6 +18,7 @@ class MediaLoaderFactoryTest {
     @Mock lateinit var deviceListBuilder: DeviceListBuilder
     @Mock lateinit var localeManagerWrapper: LocaleManagerWrapper
     private lateinit var mediaLoaderFactory: MediaLoaderFactory
+    private val mediaPickerSetup = MediaPickerSetup(DEVICE, true, setOf(), false)
 
     @Before
     fun setUp() {
@@ -26,17 +27,31 @@ class MediaLoaderFactoryTest {
 
     @Test
     fun `returns device list builder on DEVICE source`() {
-        val mediaLoader = mediaLoaderFactory.build(DEVICE)
+        val mediaLoader = mediaLoaderFactory.build(mediaPickerSetup)
 
-        assertThat(mediaLoader).isEqualTo(MediaLoader(deviceListBuilder, localeManagerWrapper))
+        assertThat(mediaLoader).isEqualTo(
+                MediaLoader(
+                        deviceListBuilder,
+                        localeManagerWrapper,
+                        mediaPickerSetup.allowedTypes
+                )
+        )
     }
 
     @Test
     fun `throws exception on not implemented sources`() {
-        assertThatExceptionOfType(NotImplementedError::class.java).isThrownBy { mediaLoaderFactory.build(GIF_LIBRARY) }
         assertThatExceptionOfType(NotImplementedError::class.java).isThrownBy {
-            mediaLoaderFactory.build(STOCK_LIBRARY)
+            mediaLoaderFactory.build(
+                    mediaPickerSetup.copy(dataSource = GIF_LIBRARY)
+            )
         }
-        assertThatExceptionOfType(NotImplementedError::class.java).isThrownBy { mediaLoaderFactory.build(WP_LIBRARY) }
+        assertThatExceptionOfType(NotImplementedError::class.java).isThrownBy {
+            mediaLoaderFactory.build(mediaPickerSetup.copy(dataSource = STOCK_LIBRARY))
+        }
+        assertThatExceptionOfType(NotImplementedError::class.java).isThrownBy {
+            mediaLoaderFactory.build(
+                    mediaPickerSetup.copy(dataSource = WP_LIBRARY)
+            )
+        }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -21,7 +20,6 @@ import org.wordpress.android.ui.mediapicker.MediaType.IMAGE
 import org.wordpress.android.ui.mediapicker.MediaType.VIDEO
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.UriWrapper
-import java.util.Locale
 
 class MediaLoaderTest : BaseUnitTest() {
     @Mock lateinit var mediaSource: MediaSource
@@ -43,7 +41,7 @@ class MediaLoaderTest : BaseUnitTest() {
     @Test
     fun `loads media items on start`() = withMediaLoader { resultModel, performAction ->
         val mediaItems = listOf(firstMediaItem)
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(MediaLoadingResult.Success()))
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(MediaLoadingResult.Success())
         whenever(mediaSource.get(mediaTypes)).thenReturn(mediaItems)
 
         performAction(LoadAction.Start(), true)
@@ -54,7 +52,7 @@ class MediaLoaderTest : BaseUnitTest() {
     @Test
     fun `shows an error when loading fails`() = withMediaLoader { resultModel, performAction ->
         val errorMessage = "error"
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(MediaLoadingResult.Failure(errorMessage)))
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(MediaLoadingResult.Failure(errorMessage))
 
         performAction(LoadAction.Start(), true)
 
@@ -65,8 +63,8 @@ class MediaLoaderTest : BaseUnitTest() {
     fun `loads next page`() = withMediaLoader { resultModel, performAction ->
         val firstPage = MediaLoadingResult.Success(hasMore = true)
         val secondPage = MediaLoadingResult.Success()
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(firstPage))
-        whenever(mediaSource.load(mediaTypes, 1, null)).thenReturn(flowOf(secondPage))
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(firstPage)
+        whenever(mediaSource.load(mediaTypes, 1, null)).thenReturn(secondPage)
         whenever(mediaSource.get(mediaTypes)).thenReturn(
                 listOf(firstMediaItem),
                 listOf(firstMediaItem, secondMediaItem)
@@ -87,8 +85,8 @@ class MediaLoaderTest : BaseUnitTest() {
         whenever(mediaSource.get(mediaTypes)).thenReturn(listOf(firstMediaItem))
         val message = "error"
         val secondPage = MediaLoadingResult.Failure(message)
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(firstPage))
-        whenever(mediaSource.load(mediaTypes, 1, null)).thenReturn(flowOf(secondPage))
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(firstPage)
+        whenever(mediaSource.load(mediaTypes, 1, null)).thenReturn(secondPage)
 
         performAction(LoadAction.Start(), true)
 
@@ -102,14 +100,14 @@ class MediaLoaderTest : BaseUnitTest() {
     @Test
     fun `refresh overrides data`() = withMediaLoader { resultModel, performAction ->
         val firstResult = MediaLoadingResult.Success()
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(firstResult))
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(firstResult)
         whenever(mediaSource.get(mediaTypes)).thenReturn(listOf(firstMediaItem), listOf(secondMediaItem))
 
         performAction(LoadAction.Start(), true)
 
         resultModel.assertModel(listOf(firstMediaItem))
 
-        performAction(LoadAction.Refresh, true)
+        performAction(LoadAction.Refresh(true), true)
 
         resultModel.assertModel(listOf(secondMediaItem))
     }
@@ -117,7 +115,7 @@ class MediaLoaderTest : BaseUnitTest() {
     @Test
     fun `filters out media item`() = withMediaLoader { resultModel, performAction ->
         val mediaItems = listOf(firstMediaItem, secondMediaItem)
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(MediaLoadingResult.Success()))
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(MediaLoadingResult.Success())
         whenever(mediaSource.get(mediaTypes)).thenReturn(mediaItems)
         val filter = "second"
         whenever(mediaSource.get(mediaTypes, filter)).thenReturn(listOf(secondMediaItem))
@@ -136,7 +134,7 @@ class MediaLoaderTest : BaseUnitTest() {
     @Test
     fun `clears filter`() = withMediaLoader { resultModel, performAction ->
         val mediaItems = listOf(firstMediaItem, secondMediaItem)
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(MediaLoadingResult.Success()))
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(MediaLoadingResult.Success())
         val filter = "second"
         whenever(mediaSource.get(eq(mediaTypes), eq(filter))).thenReturn(listOf(secondMediaItem))
         whenever(mediaSource.get(eq(mediaTypes), isNull())).thenReturn(mediaItems)
@@ -195,6 +193,5 @@ class MediaLoaderTest : BaseUnitTest() {
             counter++
             delay(1)
         }
-        assertThat(this).hasSize(count)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderTest.kt
@@ -1,9 +1,12 @@
 package org.wordpress.android.ui.mediapicker
 
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -32,7 +35,7 @@ class MediaLoaderTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        mediaLoader = MediaLoader(mediaSource, localeManagerWrapper)
+        mediaLoader = MediaLoader(mediaSource, localeManagerWrapper, mediaTypes)
         firstMediaItem = MediaItem(uri1, "first item", IMAGE, "image/jpeg", 1)
         secondMediaItem = MediaItem(uri2, "second item", VIDEO, "video/mpeg", 2)
     }
@@ -40,9 +43,10 @@ class MediaLoaderTest : BaseUnitTest() {
     @Test
     fun `loads media items on start`() = withMediaLoader { resultModel, performAction ->
         val mediaItems = listOf(firstMediaItem)
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(MediaLoadingResult.Success(mediaItems))
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(MediaLoadingResult.Success()))
+        whenever(mediaSource.get(mediaTypes)).thenReturn(mediaItems)
 
-        performAction(LoadAction.Start(mediaTypes), true)
+        performAction(LoadAction.Start(), true)
 
         resultModel.assertModel(mediaItems)
     }
@@ -50,28 +54,25 @@ class MediaLoaderTest : BaseUnitTest() {
     @Test
     fun `shows an error when loading fails`() = withMediaLoader { resultModel, performAction ->
         val errorMessage = "error"
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(MediaLoadingResult.Failure(errorMessage))
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(MediaLoadingResult.Failure(errorMessage)))
 
-        performAction(LoadAction.Start(mediaTypes), true)
+        performAction(LoadAction.Start(), true)
 
         resultModel.assertModel(errorMessage = errorMessage)
     }
 
     @Test
-    fun `does not load media without start`() = withMediaLoader { resultModel, performAction ->
-        performAction(LoadAction.Refresh, false)
-
-        assertThat(resultModel).isEmpty()
-    }
-
-    @Test
     fun `loads next page`() = withMediaLoader { resultModel, performAction ->
-        val firstPage = MediaLoadingResult.Success(listOf(firstMediaItem), hasMore = true)
-        val secondPage = MediaLoadingResult.Success(listOf(secondMediaItem))
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(firstPage)
-        whenever(mediaSource.load(mediaTypes, 1, null)).thenReturn(secondPage)
+        val firstPage = MediaLoadingResult.Success(hasMore = true)
+        val secondPage = MediaLoadingResult.Success()
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(firstPage))
+        whenever(mediaSource.load(mediaTypes, 1, null)).thenReturn(flowOf(secondPage))
+        whenever(mediaSource.get(mediaTypes)).thenReturn(
+                listOf(firstMediaItem),
+                listOf(firstMediaItem, secondMediaItem)
+        )
 
-        performAction(LoadAction.Start(mediaTypes), true)
+        performAction(LoadAction.Start(), true)
 
         resultModel.assertModel(listOf(firstMediaItem), hasMore = true)
 
@@ -82,13 +83,14 @@ class MediaLoaderTest : BaseUnitTest() {
 
     @Test
     fun `shows an error when loading next page fails`() = withMediaLoader { resultModel, performAction ->
-        val firstPage = MediaLoadingResult.Success(listOf(firstMediaItem), hasMore = true)
+        val firstPage = MediaLoadingResult.Success(hasMore = true)
+        whenever(mediaSource.get(mediaTypes)).thenReturn(listOf(firstMediaItem))
         val message = "error"
         val secondPage = MediaLoadingResult.Failure(message)
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(firstPage)
-        whenever(mediaSource.load(mediaTypes, 1, null)).thenReturn(secondPage)
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(firstPage))
+        whenever(mediaSource.load(mediaTypes, 1, null)).thenReturn(flowOf(secondPage))
 
-        performAction(LoadAction.Start(mediaTypes), true)
+        performAction(LoadAction.Start(), true)
 
         resultModel.assertModel(listOf(firstMediaItem), hasMore = true)
 
@@ -99,11 +101,11 @@ class MediaLoaderTest : BaseUnitTest() {
 
     @Test
     fun `refresh overrides data`() = withMediaLoader { resultModel, performAction ->
-        val firstResult = MediaLoadingResult.Success(listOf(firstMediaItem))
-        val refreshedResult = MediaLoadingResult.Success(listOf(secondMediaItem))
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(firstResult, refreshedResult)
+        val firstResult = MediaLoadingResult.Success()
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(firstResult))
+        whenever(mediaSource.get(mediaTypes)).thenReturn(listOf(firstMediaItem), listOf(secondMediaItem))
 
-        performAction(LoadAction.Start(mediaTypes), true)
+        performAction(LoadAction.Start(), true)
 
         resultModel.assertModel(listOf(firstMediaItem))
 
@@ -114,13 +116,15 @@ class MediaLoaderTest : BaseUnitTest() {
 
     @Test
     fun `filters out media item`() = withMediaLoader { resultModel, performAction ->
-        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
         val mediaItems = listOf(firstMediaItem, secondMediaItem)
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(MediaLoadingResult.Success(mediaItems))
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(MediaLoadingResult.Success()))
+        whenever(mediaSource.get(mediaTypes)).thenReturn(mediaItems)
+        val filter = "second"
+        whenever(mediaSource.get(mediaTypes, filter)).thenReturn(listOf(secondMediaItem))
 
-        performAction(LoadAction.Start(mediaTypes), true)
+        performAction(LoadAction.Start(), true)
 
-        performAction(LoadAction.Filter("second"), true)
+        performAction(LoadAction.Filter(filter), true)
 
         resultModel.assertModel(listOf(secondMediaItem))
 
@@ -131,12 +135,14 @@ class MediaLoaderTest : BaseUnitTest() {
 
     @Test
     fun `clears filter`() = withMediaLoader { resultModel, performAction ->
-        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
         val mediaItems = listOf(firstMediaItem, secondMediaItem)
-        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(MediaLoadingResult.Success(mediaItems))
+        whenever(mediaSource.load(mediaTypes, 0, null)).thenReturn(flowOf(MediaLoadingResult.Success()))
+        val filter = "second"
+        whenever(mediaSource.get(eq(mediaTypes), eq(filter))).thenReturn(listOf(secondMediaItem))
+        whenever(mediaSource.get(eq(mediaTypes), isNull())).thenReturn(mediaItems)
 
-        performAction(LoadAction.Start(mediaTypes), true)
-        performAction(LoadAction.Filter("second"), true)
+        performAction(LoadAction.Start(), true)
+        performAction(LoadAction.Filter(filter), true)
 
         performAction(LoadAction.ClearFilter, true)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
@@ -377,7 +377,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
             is PhotoItem -> item.clickAction.click()
             is VideoItem -> item.clickAction.click()
             is FileItem -> item.clickAction.click()
-            is NextPageLoader -> item.retryAction()
+            is NextPageLoader -> item.loadAction()
         }
     }
 


### PR DESCRIPTION
This PR adds to media picker:
- the swipe to refresh - you can now refresh the data that are visible by pulling down. This doesn't make much sense with the current implementation but in theory the media in the library could change and you could reload it.
- pagination - this cannot be tested right now because we always load all of the media from the device. This is more of a preparation for the implementation of the WP media library. 

There are a few details that are worth noting:
- I've changed the data source to the Flux pattern. This means that now there are 2 methods on the data source. One triggers the data loading and returns a success/failure result if the operation succeeds/fails. The second operation loads the current cached data. This approach is more flexible because it supports database (if needed) as a single source of truth. The current implementation uses in-memory cache because it's cheap and fast to load the media from the provider. The main reason for this change is that the filtering didn't make sense in the `MediaLoader` so it's now moved to the `MediaSource` as part of the `get` operation.
- There is some simplification to the `MediaLoader` now based on these changes. 
- Instead of sending supported media types to the `MediaLoader` with the `Start` event they are now set when the loader is built. I think it makes sense because it's more of a setup of the loader and it never changes.
- The `MediaPickerUiItem`s now don't share as many fields as before. This is because now we have a `NextPageLoader` item which is not selectable. This requires some changes to the diff callback but I think the result is better now.

To test:
- Test that the media picker behaves as expected
- Try pull to refresh on the media picker screen
- It shows the "Refreshing" item which quickly disappears
- More tests will be necessary with the future changes

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
