### PR TITLE
Issue/12028 add tests for action handler

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -423,7 +423,7 @@ public class ReaderPostListFragment extends Fragment
                         ShowSitePickerForResult data = (ShowSitePickerForResult) navTarget;
                         ActivityLauncher.showSitePickerForResult(
                                 ReaderPostListFragment.this,
-                                data.getSite(),
+                                data.getPreselectedSite(),
                                 data.getMode()
                         );
                     } else if (navTarget instanceof OpenEditorForReblog) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -110,7 +110,7 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
                     is ShowReaderComments -> ReaderActivityLauncher.showReaderComments(context, blogId, postId)
                     is ShowNoSitesToReblog -> ReaderActivityLauncher.showNoSiteToReblog(activity)
                     is ShowSitePickerForResult -> ActivityLauncher
-                            .showSitePickerForResult(this@ReaderDiscoverFragment, this.site, this.mode)
+                            .showSitePickerForResult(this@ReaderDiscoverFragment, this.preselectedSite, this.mode)
                     is OpenEditorForReblog -> ActivityLauncher
                             .openEditorForReblog(activity, this.site, this.post, this.source)
                     is ShowBookmarkedTab -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -15,7 +15,7 @@ sealed class ReaderNavigationEvents {
     data class ShowPostsByTag(val tag: ReaderTag) : ReaderNavigationEvents()
     data class ShowReaderComments(val blogId: Long, val postId: Long) : ReaderNavigationEvents()
     object ShowNoSitesToReblog : ReaderNavigationEvents()
-    data class ShowSitePickerForResult(val site: SiteModel, val post: ReaderPost, val mode: SitePickerMode) :
+    data class ShowSitePickerForResult(val preselectedSite: SiteModel, val post: ReaderPost, val mode: SitePickerMode) :
             ReaderNavigationEvents()
 
     data class OpenEditorForReblog(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -61,7 +61,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
-import org.wordpress.android.widgets.AppRatingDialog.incrementInteractions
+import org.wordpress.android.widgets.AppRatingDialogWrapper
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -78,6 +78,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
     private val dispatcher: Dispatcher,
     private val resourceProvider: ResourceProvider,
     private val htmlMessageUtils: HtmlMessageUtils,
+    private val appRatingDialogWrapper: AppRatingDialogWrapper,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     @Named(UI_SCOPE) private val uiScope: CoroutineScope,
     @Named(DEFAULT_SCOPE) private val defaultScope: CoroutineScope
@@ -120,7 +121,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
 
     suspend fun handleOnItemClicked(post: ReaderPost) {
         withContext(bgDispatcher) {
-            incrementInteractions(APP_REVIEWS_EVENT_INCREMENTED_BY_OPENING_READER_POST)
+            appRatingDialogWrapper.incrementInteractions(APP_REVIEWS_EVENT_INCREMENTED_BY_OPENING_READER_POST)
 
             if (post.isBookmarked) {
                 analyticsTrackerWrapper.track(READER_SAVED_POST_OPENED_FROM_OTHER_POST_LIST)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogState.kt
@@ -3,33 +3,9 @@ package org.wordpress.android.ui.reader.reblog
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.ReaderPost
 
-/**
- * Represents the Reblog View State
- */
-sealed class ReblogState
-
-/**
- * Represents the Site Picker View State
- *
- * @property site the preselected site
- * @property post the post to be reblogged (saved for later)
- */
-class SitePicker(val site: SiteModel, val post: ReaderPost) : ReblogState()
-
-/**
- * Represents the Post Editor View State
- *
- * @property site the site to reblog to
- * @property post the post to be reblogged
- */
-class PostEditor(val site: SiteModel, val post: ReaderPost) : ReblogState()
-
-/**
- * Represents the No Site View State
- */
-object NoSite : ReblogState()
-
-/**
- * Represents the Unknown/Error State
- */
-object Unknown : ReblogState()
+sealed class ReblogState {
+    class MultipleSites(val site: SiteModel, val post: ReaderPost) : ReblogState()
+    class SingleSite(val site: SiteModel, val post: ReaderPost) : ReblogState()
+    object NoSite : ReblogState()
+    object Unknown : ReblogState()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogState.kt
@@ -4,7 +4,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.ReaderPost
 
 sealed class ReblogState {
-    class MultipleSites(val site: SiteModel, val post: ReaderPost) : ReblogState()
+    class MultipleSites(val defaultSite: SiteModel, val post: ReaderPost) : ReblogState()
     class SingleSite(val site: SiteModel, val post: ReaderPost) : ReblogState()
     object NoSite : ReblogState()
     object Unknown : ReblogState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogUseCase.kt
@@ -69,7 +69,7 @@ class ReblogUseCase @Inject constructor(
     fun convertReblogStateToNavigationEvent(state: ReblogState): ReaderNavigationEvents? {
         return when (state) {
             is NoSite -> ShowNoSitesToReblog
-            is MultipleSites -> ShowSitePickerForResult(state.site, state.post, REBLOG_SELECT_MODE)
+            is MultipleSites -> ShowSitePickerForResult(state.defaultSite, state.post, REBLOG_SELECT_MODE)
             is SingleSite -> OpenEditorForReblog(state.site, state.post, POST_FROM_REBLOG)
             Unknown -> null
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/reblog/ReblogUseCase.kt
@@ -13,6 +13,10 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEditorForReblog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowNoSitesToReblog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
+import org.wordpress.android.ui.reader.reblog.ReblogState.MultipleSites
+import org.wordpress.android.ui.reader.reblog.ReblogState.NoSite
+import org.wordpress.android.ui.reader.reblog.ReblogState.SingleSite
+import org.wordpress.android.ui.reader.reblog.ReblogState.Unknown
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.BuildConfig
@@ -32,12 +36,12 @@ class ReblogUseCase @Inject constructor(
                 0 -> NoSite
                 1 -> {
                     sites.firstOrNull()?.let {
-                        PostEditor(it, post)
+                        SingleSite(it, post)
                     } ?: Unknown
                 }
                 else -> {
                     sites.firstOrNull()?.let {
-                        SitePicker(it, post)
+                        MultipleSites(it, post)
                     } ?: Unknown
                 }
             }
@@ -49,7 +53,7 @@ class ReblogUseCase @Inject constructor(
             when {
                 post != null -> {
                     val site: SiteModel? = siteStore.getSiteByLocalId(siteLocalId)
-                    if (site != null) PostEditor(site, post) else Unknown
+                    if (site != null) SingleSite(site, post) else Unknown
                 }
                 BuildConfig.DEBUG -> {
                     throw IllegalStateException("Site Selected without passing the SitePicker state")
@@ -65,8 +69,8 @@ class ReblogUseCase @Inject constructor(
     fun convertReblogStateToNavigationEvent(state: ReblogState): ReaderNavigationEvents? {
         return when (state) {
             is NoSite -> ShowNoSitesToReblog
-            is SitePicker -> ShowSitePickerForResult(state.site, state.post, REBLOG_SELECT_MODE)
-            is PostEditor -> OpenEditorForReblog(state.site, state.post, POST_FROM_REBLOG)
+            is MultipleSites -> ShowSitePickerForResult(state.site, state.post, REBLOG_SELECT_MODE)
+            is SingleSite -> OpenEditorForReblog(state.site, state.post, POST_FROM_REBLOG)
             Unknown -> null
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialogWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialogWrapper.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.widgets
+
+import org.wordpress.android.analytics.AnalyticsTracker
+import javax.inject.Inject
+
+/**
+ * Mockable wrapper created for testing purposes.
+ */
+class AppRatingDialogWrapper @Inject constructor() {
+    fun incrementInteractions(tracker: AnalyticsTracker.Stat) = AppRatingDialog.incrementInteractions(tracker)
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostD
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SITE_NOTIFICATIONS
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.repository.usecases.BlockBlogUseCase
 import org.wordpress.android.ui.reader.repository.usecases.PostLikeUseCase
@@ -46,6 +47,7 @@ import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSi
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.Failed.RequestFailed
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.PostFollowStatusChanged
 import org.wordpress.android.ui.reader.usecases.ReaderSiteNotificationsUseCase
+import org.wordpress.android.ui.reader.usecases.ReaderSiteNotificationsUseCase.SiteNotificationState
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -278,6 +280,61 @@ class ReaderPostCardActionsHandlerTest {
         assertThat(observedValues.snackbarMsgs).isNotEmpty
     }
     /** FOLLOW ACTION end **/
+
+    /** SITE NOTIFICATIONS ACTION Begin **/
+    @Test
+    fun `ToggleNotifications when user clicks on Notifcations button`() = test {
+        // Arrange
+        whenever(siteNotificationsUseCase.toggleNotification(anyLong())).thenReturn(SiteNotificationState.Success)
+        // Act
+        actionHandler.onAction(mock(), SITE_NOTIFICATIONS, false)
+
+        // Assert
+        verify(siteNotificationsUseCase).toggleNotification(anyLong())
+    }
+
+    @Test
+    fun `Show snackbar message when toggleNotification return network error`() = test {
+        // Arrange
+        whenever(siteNotificationsUseCase.toggleNotification(anyLong()))
+                .thenReturn(SiteNotificationState.Failed.NoNetwork)
+        val observedValues = startObserving()
+
+        // Act
+        actionHandler.onAction(mock(), SITE_NOTIFICATIONS, false)
+
+        // Assert
+        assertThat(observedValues.snackbarMsgs).isNotEmpty
+    }
+
+    @Test
+    fun `Show snackbar message when toggleNotification returns request error`() = test {
+        // Arrange
+        whenever(siteNotificationsUseCase.toggleNotification(anyLong()))
+                .thenReturn(SiteNotificationState.Failed.RequestFailed)
+        val observedValues = startObserving()
+
+        // Act
+        actionHandler.onAction(mock(), SITE_NOTIFICATIONS, false)
+
+        // Assert
+        assertThat(observedValues.snackbarMsgs).isNotEmpty
+    }
+
+    @Test
+    fun `Do not Show snackbar message when toggleNotification returns alreadyRunning error`() = test {
+        // Arrange
+        whenever(siteNotificationsUseCase.toggleNotification(anyLong()))
+                .thenReturn(SiteNotificationState.Failed.AlreadyRunning)
+        val observedValues = startObserving()
+
+        // Act
+        actionHandler.onAction(mock(), SITE_NOTIFICATIONS, false)
+
+        // Assert
+        assertThat(observedValues.snackbarMsgs).isEmpty()
+    }
+    /** SITE NOTIFICATIONS ACTION end **/
 
     @Test
     fun `Clicking on a post opens post detail`() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/reblog/ReblogUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/reblog/ReblogUseCaseTest.kt
@@ -15,6 +15,10 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.test
+import org.wordpress.android.ui.reader.reblog.ReblogState.MultipleSites
+import org.wordpress.android.ui.reader.reblog.ReblogState.NoSite
+import org.wordpress.android.ui.reader.reblog.ReblogState.SingleSite
+import org.wordpress.android.ui.reader.reblog.ReblogState.Unknown
 
 @InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -54,9 +58,9 @@ class ReblogUseCaseTest {
 
         val state = reblogUseCase.onReblogButtonClicked(post)
 
-        Assertions.assertThat(state).isInstanceOf(PostEditor::class.java)
+        Assertions.assertThat(state).isInstanceOf(SingleSite::class.java)
 
-        val peState = state as? PostEditor
+        val peState = state as? SingleSite
         Assertions.assertThat(peState?.site).isEqualTo(site)
         Assertions.assertThat(peState?.post).isEqualTo(post)
     }
@@ -71,9 +75,9 @@ class ReblogUseCaseTest {
 
         val state = reblogUseCase.onReblogButtonClicked(post)
 
-        Assertions.assertThat(state).isInstanceOf(SitePicker::class.java)
+        Assertions.assertThat(state).isInstanceOf(MultipleSites::class.java)
 
-        val spState = state as? SitePicker
+        val spState = state as? MultipleSites
         Assertions.assertThat(spState?.site).isEqualTo(site)
         Assertions.assertThat(spState?.post).isEqualTo(post)
     }
@@ -89,12 +93,12 @@ class ReblogUseCaseTest {
         whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(site)
         whenever(siteStore.visibleSitesAccessedViaWPCom).thenReturn(visibleWPComSites)
 
-        val afterButtonClickedState = reblogUseCase.onReblogButtonClicked(post) as SitePicker
+        val afterButtonClickedState = reblogUseCase.onReblogButtonClicked(post) as MultipleSites
         val state = reblogUseCase.onReblogSiteSelected(siteId, afterButtonClickedState.post)
 
-        Assertions.assertThat(state).isInstanceOf(PostEditor::class.java)
+        Assertions.assertThat(state).isInstanceOf(SingleSite::class.java)
 
-        val peState = state as? PostEditor
+        val peState = state as? SingleSite
         Assertions.assertThat(peState?.site).isEqualTo(site)
         Assertions.assertThat(peState?.post).isEqualTo(post)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/reblog/ReblogUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/reblog/ReblogUseCaseTest.kt
@@ -78,7 +78,7 @@ class ReblogUseCaseTest {
         Assertions.assertThat(state).isInstanceOf(MultipleSites::class.java)
 
         val spState = state as? MultipleSites
-        Assertions.assertThat(spState?.site).isEqualTo(site)
+        Assertions.assertThat(spState?.defaultSite).isEqualTo(site)
         Assertions.assertThat(spState?.post).isEqualTo(post)
     }
 


### PR DESCRIPTION
Partially fixes #12028

Adds tests for the ReaderPostActionHandler. I also renamed ReblogStates.

I can split the PR into multiple PRs if you prefer. Since 98% of changes are just new tests I felt like it's not necessary. Let me know.

To test:
No need to test anything as long as the CI jobs pass

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
