### PR TITLE
Disable release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -624,28 +624,28 @@ workflows:
           requires: [gutenberg-bundle-build]
       - promo-screenshots:
           requires: [raw-screenshots]
-  Release Build:
-    unless: << pipeline.parameters.translation_review_build >>
-    jobs:
-      - gutenberg-bundle-build:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d+(\.\d+)*(-rc-\d)?$/
-      - lint:
-          requires:
-            - gutenberg-bundle-build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d+(\.\d+)*(-rc-\d)?$/
-      - Release Build:
-          requires:
-            - lint 
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d+(\.\d+)*(-rc-\d)?$/
+#  Release Build:
+#    unless: << pipeline.parameters.translation_review_build >>
+#    jobs:
+#      - gutenberg-bundle-build:
+#          filters:
+#            branches:
+#              ignore: /.*/
+#            tags:
+#              only: /^\d+(\.\d+)*(-rc-\d)?$/
+#      - lint:
+#          requires:
+#            - gutenberg-bundle-build
+#          filters:
+#            branches:
+#              ignore: /.*/
+#            tags:
+#              only: /^\d+(\.\d+)*(-rc-\d)?$/
+#      - Release Build:
+#          requires:
+#            - lint 
+#          filters:
+#            branches:
+#              ignore: /.*/
+#            tags:
+#              only: /^\d+(\.\d+)*(-rc-\d)?$/


### PR DESCRIPTION
We have seen some weird issues with the latest beta build. The current gutenberg setup is very fragile and we already discovered some issues with it, so I think that we need to investigate better the issues. 
Let's disable the release builds on CI until we have a better picture. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
