### PR TITLE
Add style for figure

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -267,7 +267,6 @@ public class ReaderPostRenderer {
      */
     private String getPostContent() {
         String content = mPost.shouldShowExcerpt() ? mPost.getExcerpt() : mPost.getText();
-
         // some content (such as Vimeo embeds) don't have "http:" before links
         content = content.replace("src=\"//", "src=\"http://");
 
@@ -509,6 +508,7 @@ public class ReaderPostRenderer {
                 .append(" div.feedflare { display: none; }")
                 .append(" .sharedaddy, .jp-relatedposts, .mc4wp-form, .wpcnt, ")
                 .append(" .OUTBRAIN, .adsbygoogle { display: none; }")
+                .append(" figure { display: block; margin-inline-start: 0px; margin-inline-end: 0px; }")
                 .append("</style>");
 
         // add a custom CSS class to (any) tiled gallery elements to make them easier selectable for various rules


### PR DESCRIPTION
Parent Issue #12544 

This PR adds a style for the `figure` element with 0 left/right margins. 
The problem in the parent issue manifested itself because the default user agent style was being used for `figure` which added the unnecessary left/right spacing

Before|After
---|---
<img width="480" src="https://user-images.githubusercontent.com/506707/92723359-f4db0780-f336-11ea-8ba2-faa40e24d210.png">|<img width="480" src="https://user-images.githubusercontent.com/506707/92723374-f73d6180-f336-11ea-8743-72e525b40a8a.png">

To test:
Setup
- Create a new post.
- Add a Media & Text block.
- Tap "Add image or video".
- Tap "Choose from Free Photo Library".
- Search for, select, and insert an image.
- Tap the cog icon to open block settings.
- Turn on the "Crop image to fill entire column" option.
- Publish the post.

View the post in the reader
- With an account that is following the published post above
- Tap the Discover option
- Tap the following tab
- Navigate to the post created above
- Tap on the post to launch the detail view
- The image should fill the entire column

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
