### PR TITLE
Fix discover shown in onResume

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -710,15 +710,6 @@ public class ReaderPostListFragment extends Fragment
             if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
                 return;
             }
-            ReaderTag discoverTag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
-            ReaderTag readerTag = AppPrefs.getReaderTag();
-
-            if (discoverTag != null && discoverTag.equals(readerTag)) {
-                setCurrentTag(readerTag);
-                updateCurrentTag();
-            } else if (discoverTag == null) {
-                AppLog.w(T.READER, "Discover tag not found; ReaderTagTable returned null");
-            }
         }
 
         if (shouldShowEmptyViewForSelfHostedCta()) {
@@ -1033,17 +1024,6 @@ public class ReaderPostListFragment extends Fragment
 
             @Override
             public FilterCriteria onRecallSelection() {
-                if (mIsTopLevel) {
-                    if (AppPrefs.getReaderTag() == null) {
-                        ReaderTag discoverTag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
-                        String discoverLabel = requireActivity().getString(R.string.reader_discover_display_name);
-
-                        if (discoverTag != null && discoverTag.getTagDisplayName().equals(discoverLabel)) {
-                            setCurrentTag(discoverTag);
-                        }
-                    }
-                }
-
                 if (hasCurrentTag()) {
                     ReaderTag defaultTag;
 
@@ -2536,9 +2516,7 @@ public class ReaderPostListFragment extends Fragment
         }
 
         AnalyticsTracker.Stat stat;
-        if (tag.isDiscover()) {
-            stat = AnalyticsTracker.Stat.READER_DISCOVER_VIEWED;
-        } else if (tag.isTagTopic()) {
+        if (tag.isTagTopic()) {
             stat = AnalyticsTracker.Stat.READER_TAG_LOADED;
         } else if (tag.isListTopic()) {
             stat = AnalyticsTracker.Stat.READER_LIST_LOADED;


### PR DESCRIPTION
Fixes #11957

This PR removes code which sets "discover" tag in "onResume" of the ReaderPostListFragment. This fragment is not used for discover tab anymore (ReaderDiscoverFragment is used instead) so the easiest fix is to simply remove the code.

To test:

1. Go to Reader > Discover.
2. Tap any topic.
3. Tap any post title.
4. Tap back button (top left).
5. Observe that discover.wordpress.com content is not loaded and content for the topic from step 2 is shown

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @oguzkocer We are targeting 15.7 with this PR. Could you please include it in the next beta. Thanks!