### PR TITLE
Issue/12915 permission label overlap

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -260,11 +260,16 @@ class MediaPickerFragment : Fragment() {
                         requestStoragePermission()
                     }
                 }
+
+                recycler.setEmptyView(null)
+                actionable_empty_view.visibility = View.GONE
+
                 soft_ask_view.visibility = View.VISIBLE
             }
             is SoftAskViewUiModel.Hidden -> {
                 if (soft_ask_view.visibility == View.VISIBLE) {
                     AniUtils.fadeOut(soft_ask_view, MEDIUM)
+                    recycler.setEmptyView(actionable_empty_view)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -31,6 +31,9 @@ import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.FabUiModel
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.PermissionsRequested.CAMERA
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.PermissionsRequested.STORAGE
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.PhotoListUiModel
+import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.PhotoListUiModel.Data
+import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.PhotoListUiModel.Empty
+import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.PhotoListUiModel.Hidden
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.SearchUiModel
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.SoftAskViewUiModel
 import org.wordpress.android.util.AccessibilityUtils
@@ -261,40 +264,46 @@ class MediaPickerFragment : Fragment() {
                     }
                 }
 
-                recycler.setEmptyView(null)
-                actionable_empty_view.visibility = View.GONE
-
                 soft_ask_view.visibility = View.VISIBLE
             }
             is SoftAskViewUiModel.Hidden -> {
                 if (soft_ask_view.visibility == View.VISIBLE) {
                     AniUtils.fadeOut(soft_ask_view, MEDIUM)
-                    recycler.setEmptyView(actionable_empty_view)
                 }
             }
         }
     }
 
     private fun setupPhotoList(uiModel: PhotoListUiModel) {
-        if (uiModel is PhotoListUiModel.Data) {
-            if (recycler.adapter == null) {
-                recycler.adapter = MediaPickerAdapter(
-                        imageManager
-                )
-            }
-            val adapter = recycler.adapter as MediaPickerAdapter
+        when (uiModel) {
+            is Data -> {
+                recycler.setEmptyViewIfNull(actionable_empty_view)
+                if (recycler.adapter == null) {
+                    recycler.adapter = MediaPickerAdapter(
+                            imageManager
+                    )
+                }
+                val adapter = recycler.adapter as MediaPickerAdapter
 
-            (recycler.layoutManager as? GridLayoutManager)?.spanSizeLookup =
-                    object : GridLayoutManager.SpanSizeLookup() {
-                        override fun getSpanSize(position: Int) = if (uiModel.items[position].fullWidthItem) {
-                            NUM_COLUMNS
-                        } else {
-                            1
+                (recycler.layoutManager as? GridLayoutManager)?.spanSizeLookup =
+                        object : GridLayoutManager.SpanSizeLookup() {
+                            override fun getSpanSize(position: Int) = if (uiModel.items[position].fullWidthItem) {
+                                NUM_COLUMNS
+                            } else {
+                                1
+                            }
                         }
-                    }
-            val recyclerViewState = recycler.layoutManager?.onSaveInstanceState()
-            adapter.loadData(uiModel.items)
-            recycler.layoutManager?.onRestoreInstanceState(recyclerViewState)
+                val recyclerViewState = recycler.layoutManager?.onSaveInstanceState()
+                adapter.loadData(uiModel.items)
+                recycler.layoutManager?.onRestoreInstanceState(recyclerViewState)
+            }
+            Empty -> {
+                recycler.setEmptyView(actionable_empty_view)
+            }
+            Hidden -> {
+                recycler.setEmptyView(null)
+                actionable_empty_view.visibility = View.GONE
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -93,7 +93,7 @@ class MediaPickerViewModel @Inject constructor(
             _searchExpanded
     ) { domainModel, selectedUris, softAskRequest, searchExpanded ->
         MediaPickerUiState(
-                buildUiModel(domainModel, selectedUris),
+                buildUiModel(domainModel, selectedUris, softAskRequest),
                 buildSoftAskView(softAskRequest),
                 FabUiModel(mediaPickerSetup.cameraEnabled && selectedUris.isNullOrEmpty()) {
                     clickIcon(WP_STORIES_CAPTURE)
@@ -118,10 +118,13 @@ class MediaPickerViewModel @Inject constructor(
 
     private fun buildUiModel(
         domainModel: DomainModel?,
-        selectedUris: List<UriWrapper>?
+        selectedUris: List<UriWrapper>?,
+        softAskRequest: SoftAskRequest?
     ): PhotoListUiModel {
         val data = domainModel?.domainItems
-        return if (data != null) {
+        return if (null != softAskRequest && softAskRequest.show) {
+            PhotoListUiModel.Hidden
+        } else if (data != null) {
             val uiItems = data.map {
                 val showOrderCounter = mediaPickerSetup.canMultiselect
                 val toggleAction = ToggleAction(it.uri, showOrderCounter, this::toggleItem)
@@ -411,6 +414,7 @@ class MediaPickerViewModel @Inject constructor(
                 PhotoListUiModel()
 
         object Empty : PhotoListUiModel()
+        object Hidden : PhotoListUiModel()
     }
 
     sealed class SoftAskViewUiModel {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/EmptyViewRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/EmptyViewRecyclerView.java
@@ -82,6 +82,12 @@ public class EmptyViewRecyclerView extends RecyclerView {
         toggleEmptyView();
     }
 
+    public void setEmptyViewIfNull(View emptyView) {
+        if (null != mEmptyView) return;
+
+        setEmptyView(emptyView);
+    }
+
     private void toggleEmptyView() {
         if (mEmptyView != null && getAdapter() != null) {
             final boolean empty = getAdapter().getItemCount() == 0;

--- a/WordPress/src/main/res/layout/media_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/media_picker_fragment.xml
@@ -27,6 +27,13 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
+            <org.wordpress.android.ui.prefs.EmptyViewRecyclerView
+                android:id="@+id/recycler"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fadeScrollbars="true"
+                android:scrollbars="vertical" />
+
             <org.wordpress.android.ui.ActionableEmptyView
                 android:id="@+id/actionable_empty_view"
                 android:layout_width="match_parent"
@@ -46,12 +53,6 @@
                 app:aevTitle="@string/photo_picker_soft_ask_label"
                 tools:visibility="visible" />
 
-            <org.wordpress.android.ui.prefs.EmptyViewRecyclerView
-                android:id="@+id/recycler"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:fadeScrollbars="true"
-                android:scrollbars="vertical" />
         </RelativeLayout>
     </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes #12915 

### To test

- Make a clean install, 
- Create a new post and add an Image Block
- Open the media picker to add an image from device
- Check you get the following image without overlapping labels
<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/92833182-dd545b00-f3d8-11ea-865d-bd823355736f.png>
</p>

- Press the `Allow` button and grant permission
- Note the empty view is briefly shown while background is loading images
- Note the images are loaded and empty view is hidden
- Use the search and type a string with some matched images. Note the matched images are shown
- Use the search and type a string with no matched images. Note the empty state image is shown

<p align="center">
  <img width="300" src=https://user-images.githubusercontent.com/47797566/92833675-6370a180-f3d9-11ea-8fd7-f24a0d7534bf.png>
</p> 

- Smoke test the picker

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
