### PR TITLE
Revert removal of reader improvements feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,8 @@
 -----
 * [**] Block Editor: New block: Pullquote
 * [**] Block Editor: Block settings now immediately reflect changes from menu sliders.
+ * [*] Reader: Added "(un)follow" button to the site and topic detail screens.
+
 * [*] Media: Fixed a bug that would allow you to pick unsupported media that then couldn't be uploaded.
  
 15.6

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,9 +5,6 @@
 -----
 * [**] Block Editor: New block: Pullquote
 * [**] Block Editor: Block settings now immediately reflect changes from menu sliders.
- * [***] Reader: Introduced a new Discover tab tailored for each user.
- * [*] Reader: Added "(un)follow" button to the site and topic detail screens.
-
 * [*] Media: Fixed a bug that would allow you to pick unsupported media that then couldn't be uploaded.
  
 15.6

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -68,6 +68,7 @@ android {
 
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
         buildConfigField "boolean", "TENOR_AVAILABLE", "true"
+        buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "true"
         buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "10"
         buildConfigField "boolean", "FEATURE_ANNOUNCEMENT_AVAILABLE", "false"
         buildConfigField "boolean", "GUTENBERG_MENTIONS", "true"
@@ -97,6 +98,7 @@ android {
             versionCode 918
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "boolean", "TENOR_AVAILABLE", "false"
+            buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
             buildConfigField "boolean", "GUTENBERG_MENTIONS", "true"
             buildConfigField "boolean", "MODAL_LAYOUT_PICKER", "false"
@@ -108,6 +110,7 @@ android {
             applicationId "org.wordpress.android"
             dimension "buildType"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
+            buildConfigField "boolean", "READER_IMPROVEMENTS_PHASE_2", "false"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -8,7 +8,6 @@ import org.greenrobot.eventbus.EventBus;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.ReaderPostList;
 import org.wordpress.android.models.ReaderTagList;
-import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryEvent.ReaderPostTableActionEnded;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -203,8 +202,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
                 db.execSQL("ALTER TABLE tbl_posts ADD tags TEXT;");
                 currentVersion++;
             case 141:
-                String[] args = {Integer.toString(ReaderTagType.FOLLOWED.toInt())};
-                db.execSQL("DELETE FROM tbl_tags WHERE tag_type=?", args);
+                // no-op
                 currentVersion++;
         }
         if (currentVersion != newVersion) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -7,6 +7,7 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -239,6 +240,9 @@ public class AppPrefs {
 
         // last app version code feature announcement was shown for
         LAST_FEATURE_ANNOUNCEMENT_APP_VERSION_CODE,
+
+        // feature flag for Reader Improvements Phase 2
+        FF_READER_IMPROVEMENTS_PHASE_2,
 
         // used to indicate that we do not need to show the Post List FAB tooltip
         IS_POST_LIST_FAB_TOOLTIP_DISABLED,
@@ -692,7 +696,7 @@ public class AppPrefs {
     }
 
     /**
-     * @deprecated As of release 13.0, replaced by SiteSettings mobile editor value
+     * @deprecated  As of release 13.0, replaced by SiteSettings mobile editor value
      */
     @Deprecated
     public static boolean isGutenbergDefaultForNewPosts() {
@@ -1234,5 +1238,18 @@ public class AppPrefs {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Feature Flag for Reader Improvements Phase 2. Both BuildTime and RunTime feature flag is used.
+     *
+     * BuildTime feature flag is used to make sure we never enable the feature in production builds - even when the
+     * user manually overrides the shared preferences record using adb.
+     *
+     * RunTime feature flag is used for us to enable the feature during development.
+     */
+    public static boolean isReaderImprovementsPhase2Enabled() {
+        return BuildConfig.READER_IMPROVEMENTS_PHASE_2 && getBoolean(UndeletablePrefKey.FF_READER_IMPROVEMENTS_PHASE_2,
+                false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -152,6 +152,8 @@ class AppPrefsWrapper @Inject constructor() {
     fun setReaderActiveTab(selectedTab: ReaderTab?) = AppPrefs.setReaderActiveTab(selectedTab)
     fun getReaderActiveTab(): ReaderTab? = AppPrefs.getReaderActiveTab()
 
+    fun isReaderImprovementsPhase2Enabled(): Boolean = AppPrefs.isReaderImprovementsPhase2Enabled()
+
     fun shouldShowBookmarksSavedLocallyDialog(): Boolean = AppPrefs.shouldShowBookmarksSavedLocallyDialog()
     fun setBookmarksSavedLocallyDialogShown() = AppPrefs.setBookmarksSavedLocallyDialogShown()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.WordPress
 import org.wordpress.android.models.ReaderTagList
+import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverFragment
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsFragment
@@ -174,7 +175,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout) {
         override fun getItemCount(): Int = tags.size
 
         override fun createFragment(position: Int): Fragment {
-            return if (tags[position].isDiscover) {
+            return if (AppPrefs.isReaderImprovementsPhase2Enabled() && tags[position].isDiscover) {
                 ReaderDiscoverFragment()
             } else {
                 ReaderPostListFragment.newInstanceForTag(tags[position], ReaderPostListType.TAG_FOLLOWED, true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -710,6 +710,15 @@ public class ReaderPostListFragment extends Fragment
             if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
                 return;
             }
+            ReaderTag discoverTag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
+            ReaderTag readerTag = AppPrefs.getReaderTag();
+
+            if (discoverTag != null && discoverTag.equals(readerTag)) {
+                setCurrentTag(readerTag);
+                updateCurrentTag();
+            } else if (discoverTag == null) {
+                AppLog.w(T.READER, "Discover tag not found; ReaderTagTable returned null");
+            }
         }
 
         if (shouldShowEmptyViewForSelfHostedCta()) {
@@ -1024,6 +1033,17 @@ public class ReaderPostListFragment extends Fragment
 
             @Override
             public FilterCriteria onRecallSelection() {
+                if (mIsTopLevel) {
+                    if (AppPrefs.getReaderTag() == null) {
+                        ReaderTag discoverTag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
+                        String discoverLabel = requireActivity().getString(R.string.reader_discover_display_name);
+
+                        if (discoverTag != null && discoverTag.getTagDisplayName().equals(discoverLabel)) {
+                            setCurrentTag(discoverTag);
+                        }
+                    }
+                }
+
                 if (hasCurrentTag()) {
                     ReaderTag defaultTag;
 
@@ -2516,7 +2536,9 @@ public class ReaderPostListFragment extends Fragment
         }
 
         AnalyticsTracker.Stat stat;
-        if (tag.isTagTopic()) {
+        if (tag.isDiscover()) {
+            stat = AnalyticsTracker.Stat.READER_DISCOVER_VIEWED;
+        } else if (tag.isTagTopic()) {
             stat = AnalyticsTracker.Stat.READER_TAG_LOADED;
         } else if (tag.isListTopic()) {
             stat = AnalyticsTracker.Stat.READER_LIST_LOADED;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -710,15 +710,6 @@ public class ReaderPostListFragment extends Fragment
             if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
                 return;
             }
-            ReaderTag discoverTag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
-            ReaderTag readerTag = AppPrefs.getReaderTag();
-
-            if (discoverTag != null && discoverTag.equals(readerTag)) {
-                setCurrentTag(readerTag);
-                updateCurrentTag();
-            } else if (discoverTag == null) {
-                AppLog.w(T.READER, "Discover tag not found; ReaderTagTable returned null");
-            }
         }
 
         if (shouldShowEmptyViewForSelfHostedCta()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
@@ -11,6 +11,7 @@ import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagList;
 import org.wordpress.android.models.ReaderTagType;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.ReaderEvents;
 import org.wordpress.android.ui.reader.actions.ReaderActions.ActionListener;
@@ -117,7 +118,7 @@ public class ReaderTagActions {
             newTags.add(newTag);
         }
         boolean result;
-        if (!isLoggedIn) {
+        if (!isLoggedIn && AppPrefs.isReaderImprovementsPhase2Enabled()) {
             result = saveTagsLocallyOnly(actionListener, newTags);
         } else {
             result = saveTagsLocallyAndRemotely(actionListener, newTags);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -27,6 +27,7 @@ import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderPostDiscoverData;
 import org.wordpress.android.models.ReaderPostList;
 import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.ReaderInterfaces;
@@ -292,7 +293,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             new FollowButtonUiState(
                 onFollowButtonClicked,
                 ReaderTagTable.isFollowedTagName(currentTag.getTagSlug()),
-                isFollowButtonEnabled
+                isFollowButtonEnabled,
+                AppPrefs.isReaderImprovementsPhase2Enabled() || mAccountStore.hasAccessToken()
             )
         );
         tagHolder.onBind(uiState);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -202,7 +202,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
                     ?.let { post.featuredVideo }
 
     private fun buildExpandedTagsViewVisibility(post: ReaderPost, isDiscover: Boolean) =
-            post.tags.isNotEmpty() && isDiscover
+            appPrefsWrapper.isReaderImprovementsPhase2Enabled() && post.tags.isNotEmpty() && isDiscover
 
     private fun buildTagItems(post: ReaderPost, onClicked: (String) -> Unit) =
             readerPostTagsUiStateBuilder.mapPostTagsToTagUiStates(post, onClicked)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -155,7 +155,11 @@ public class ReaderUpdateLogic {
 
                 boolean displayNameUpdateWasNeeded = displayNameUpdateWasNeeded(serverTopics);
 
-                serverTopics.addAll(parseTags(jsonObject, "subscribed", ReaderTagType.FOLLOWED));
+                if (!mAccountStore.hasAccessToken() && !AppPrefs.isReaderImprovementsPhase2Enabled()) {
+                    serverTopics.addAll(parseTags(jsonObject, "recommended", ReaderTagType.FOLLOWED));
+                } else {
+                    serverTopics.addAll(parseTags(jsonObject, "subscribed", ReaderTagType.FOLLOWED));
+                }
 
                 // manually insert Bookmark tag, as server doesn't support bookmarking yet
                 // and check if we are going to change it to trigger UI update in case of downgrade
@@ -186,7 +190,7 @@ public class ReaderUpdateLogic {
                     AppLog.d(AppLog.T.READER, "reader service > followed topics changed "
                                               + "updatedDisplayNames [" + displayNameUpdateWasNeeded + "]");
 
-                    if (!mAccountStore.hasAccessToken()) {
+                    if (!mAccountStore.hasAccessToken() && AppPrefs.isReaderImprovementsPhase2Enabled()) {
                         // Do not delete locally saved tags for logged out user
                         ReaderTagTable.addOrUpdateTags(serverTopics);
                     } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
@@ -37,6 +37,7 @@ class ReaderTagHeaderView @JvmOverloads constructor(
         with(uiState.followButtonUiState) {
             follow_button.setIsFollowed(isFollowed)
             follow_button.isEnabled = isEnabled
+            uiHelpers.updateVisibility(follow_button, isVisible)
             onFollowBtnClicked = onFollowButtonClicked
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderViewUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderViewUiState.kt
@@ -8,7 +8,8 @@ sealed class ReaderTagHeaderViewUiState {
         data class FollowButtonUiState(
             val onFollowButtonClicked: (() -> Unit)?,
             val isFollowed: Boolean,
-            val isEnabled: Boolean
+            val isEnabled: Boolean,
+            val isVisible: Boolean
         )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -342,6 +342,8 @@ class ReaderViewModelTest {
 
     @Test
     fun `Choose interests screen shown on first start`() = testWithEmptyTags {
+        // Arrange
+        whenever(appPrefsWrapper.isReaderImprovementsPhase2Enabled()).thenReturn(true)
         // Act
         viewModel.start()
         // Assert
@@ -362,6 +364,7 @@ class ReaderViewModelTest {
     fun `Choose interests screen shown if tag changed to discover and followed tags not found for user`() =
             testWithEmptyUserTags {
                 // Arrange
+                whenever(appPrefsWrapper.isReaderImprovementsPhase2Enabled()).thenReturn(true)
                 val selectedTag: ReaderTag = mock()
                 whenever(selectedTag.isDiscover).thenReturn(true)
                 // Act
@@ -374,6 +377,7 @@ class ReaderViewModelTest {
     fun `Choose interests screen not shown if tag changed to discover and followed tags found for user`() =
             testWithNonEmptyUserTags {
                 // Arrange
+                whenever(appPrefsWrapper.isReaderImprovementsPhase2Enabled()).thenReturn(true)
                 val selectedTag: ReaderTag = mock()
                 whenever(selectedTag.isDiscover).thenReturn(true)
                 // Act
@@ -399,7 +403,9 @@ class ReaderViewModelTest {
 
     private fun triggerReaderTabContentDisplay() {
         viewModel.start()
-        viewModel.onCloseReaderInterests()
+        if (appPrefsWrapper.isReaderImprovementsPhase2Enabled()) {
+            viewModel.onCloseReaderInterests()
+        }
     }
 
     private fun <T> testWithEmptyTags(block: suspend CoroutineScope.() -> T) {


### PR DESCRIPTION
This Draft PR reverts introduction of the new Discover tab in Reader. We still haven't made a decision yet, if we'll delay the release of the new Discover. So don't merge this PR yet.

What I did
1. I run `git revert -m 1 72fa96aa59a540bfab4bb7a5ad820be2c9efea9a` to revert the removal of FF - https://github.com/wordpress-mobile/WordPress-Android/commit/712729d998db58ae9f3e47f9ccca11442591590a
2. Fixed a minor conflict - I double checked the conflict resolution with Ashita
3. I removed the deletion of tbl_tags table in the migration. I decided to keep the migration version with "no-op" comment so beta testers don't need to re-install the app. https://github.com/wordpress-mobile/WordPress-Android/commit/5dbb6acef631d40f6d59704b685feb02ee9d8940
4. I updated release notes - https://github.com/wordpress-mobile/WordPress-Android/commit/a3f6ffd35d08dea4867e98636d71bbc37caecc6c https://github.com/wordpress-mobile/WordPress-Android/commit/25910e6151c4dc0624871a9a8d04e279d104a92f
5. I run `git revert -m 1 7491d6ec9063f949a1148ea1bc520893491346f3` to revert changes done in https://github.com/wordpress-mobile/WordPress-Android/pull/12930 - https://github.com/wordpress-mobile/WordPress-Android/commit/f055516ee59dff86617b45c53a29088a6a1c7ac8
6. I fixed the issue reverted in `5.` by removing the relevant code from `onResume` - https://github.com/wordpress-mobile/WordPress-Android/commit/12a7f9440c8ce9e39cc937187d4faa0f60eae50c


To test:
1. Clear app data and test that the legacy discover tab is shown and all works as expected
2. Follow the testing steps from #12930 and make sure the bug is fixed


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
