### PR TITLE
Increase no_output_timeout for lint task to 20m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
           environment:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
           command: ./gradlew --stacktrace lintVanillaRelease || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)
-          no_output_timeout: 15m
+          no_output_timeout: 20m
       - run:
           name: Violations
           when: on_fail


### PR DESCRIPTION
We have had some lint tasks failing in CI due to no output error. This PR increases the duration to 20m which is hopefully going to be enough.

This is a band-aid solution, but considering we are already working on build improvements, it should be good enough for the time being.