### PR TITLE
Fix comment render crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -684,7 +684,8 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                 WordPress.getContext()));
 
         int maxImageSz = getResources().getDimensionPixelSize(R.dimen.reader_comment_max_image_size);
-        CommentUtils.displayHtmlComment(mTxtContent, mComment.getContent(), maxImageSz);
+        CommentUtils.displayHtmlComment(mTxtContent, mComment.getContent(), maxImageSz,
+                getString(R.string.comment_unable_to_show_error));
 
         int avatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_large);
         String avatarUrl = "";

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
@@ -17,7 +17,7 @@ public class CommentUtils {
     /*
      * displays comment text as html, including retrieving images
      */
-    public static void displayHtmlComment(TextView textView, String content, int maxImageSize) {
+    public static void displayHtmlComment(TextView textView, String content, int maxImageSize, String errorParseMsg) {
         if (textView == null) {
             return;
         }
@@ -59,7 +59,11 @@ public class CommentUtils {
             end--;
         }
 
-        textView.setText(html.subSequence(start, end));
+        if (html.length() == 0) {
+            textView.setText(errorParseMsg);
+        } else {
+            textView.setText(html.subSequence(start, end));
+        }
     }
 
     // Assumes all lines after first line will not be indented

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -282,7 +282,8 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         }
 
         int maxImageWidth = mContentWidth - indentWidth;
-        CommentUtils.displayHtmlComment(commentHolder.mTxtText, comment.getText(), maxImageWidth);
+        CommentUtils.displayHtmlComment(commentHolder.mTxtText, comment.getText(), maxImageWidth,
+                commentHolder.mTxtText.getResources().getString(R.string.comment_unable_to_show_error));
 
         // different background for highlighted comment, with optional progress bar
         if (mHighlightCommentId != 0 && mHighlightCommentId == comment.commentId) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -416,6 +416,7 @@
     <string name="comment_read_source_post">Read the source post</string>
     <string name="comment_toast_err_share_intent">Unable to share</string>
     <string name="comment_share_link_via">Share via</string>
+    <string name="comment_unable_to_show_error">Unable to show this comment</string>
 
     <!-- comment menu and buttons on comment detail - keep these short! -->
     <string name="mnu_comment_approve">Approve</string>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/HtmlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/HtmlUtils.java
@@ -14,6 +14,8 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.wordpress.android.util.helpers.WPHtmlTagHandler;
 import org.wordpress.android.util.helpers.WPQuoteSpan;
 
+import static org.wordpress.android.util.AppLog.T.UTILS;
+
 public class HtmlUtils {
     /**
      * Removes html from the passed string - relies on Html.fromHtml which handles invalid HTML,
@@ -126,8 +128,15 @@ public class HtmlUtils {
             html = (SpannableStringBuilder) Html.fromHtml(source, imageGetter, new WPHtmlTagHandler());
         } catch (RuntimeException runtimeException) {
             // In case our tag handler fails
-            html = (SpannableStringBuilder) Html.fromHtml(source, imageGetter, null);
+            try {
+                html = (SpannableStringBuilder) Html.fromHtml(source, imageGetter, null);
+            } catch (IllegalArgumentException illegalArgumentException) {
+                // In case the html is missing a required parameter (for example: "src" missing from img)
+                html = new SpannableStringBuilder("");
+                AppLog.w(UTILS, "Could not parse html");
+            }
         }
+
         EmoticonsUtils.replaceEmoticonsWithEmoji(html);
         QuoteSpan[] spans = html.getSpans(0, html.length(), QuoteSpan.class);
         for (QuoteSpan span : spans) {


### PR DESCRIPTION
Fixes #12775 

This PR addresses a crash that occurred when trying to parse comment html. In the case of pceC9O-60-p2, the `<img>` tag was missing the `src` parameter. The method `android.text.fromHtml` will throw an exception if required parameters are null/missing. Instead of assuming we can fill in the empty src`, I added an additional try/catch wrap to handle the `IllegalArgumentException` and set the html to empty. The calling classes will pass along the message that they want to show in place of the comment that we can't parse. The default message is "Unable to show comment"

Note: I have not been able to recreate this crash, so it's my hope that this is a one-off situation ; however the fix will stop future IllegalArgumentException fromHtml crashes.

Before | After |
---|---|
NPE - Crash |  <img width="480" src="https://user-images.githubusercontent.com/506707/93127798-8aaac580-f69c-11ea-855c-953d3e65cef9.png" />

 
To test:
1. Log in to app
2. Navigate to the post listed above
3. Tap on the comments
4. Scroll down to the bottom and notice no crash.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
