### PR TITLE
Issue/12951 report site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -140,7 +140,9 @@ import java.util.Stack;
 import javax.inject.Inject;
 
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.APP_REVIEWS_EVENT_INCREMENTED_BY_OPENING_READER_POST;
+import static org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_REPORTED;
 import static org.wordpress.android.fluxc.generated.AccountActionBuilder.newUpdateSubscriptionNotificationPostAction;
+import static org.wordpress.android.ui.reader.ReaderActivityLauncher.OpenUrlType.INTERNAL;
 
 import kotlin.Unit;
 
@@ -2551,6 +2553,18 @@ public class ReaderPostListFragment extends Fragment
                 break;
             case COMMENTS:
                 ReaderActivityLauncher.showReaderComments(requireContext(), post.blogId, post.postId);
+                break;
+            case REPORT_POST:
+                HashMap<String, Object> properties = new HashMap();
+                properties.put("blog_id", post.blogId);
+                properties.put("is_jetpack", post.isJetpack);
+                properties.put("post_id", post.postId);
+                AnalyticsTracker.track(READER_POST_REPORTED, properties);
+                ReaderActivityLauncher.openUrl(
+                        getContext(),
+                        ReaderUtils.getReportPostUrl(post.getUrl()),
+                        INTERNAL
+                );
                 break;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -112,5 +112,6 @@ enum class ReaderPostCardActionType {
     LIKE,
     BOOKMARK,
     REBLOG,
-    COMMENTS
+    COMMENTS,
+    REPORT_POST
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.main.SitePickerActivity
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.ReaderActivityLauncher
+import org.wordpress.android.ui.reader.ReaderActivityLauncher.OpenUrlType.INTERNAL
 import org.wordpress.android.ui.reader.ReaderPostWebViewCachingFragment
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.ReaderDiscoverViewModel.DiscoverUiState.ErrorUiState
@@ -36,9 +37,11 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowNoSit
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostDetail
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReportPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
+import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -54,6 +57,7 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
     @Inject lateinit var imageManager: ImageManager
     private lateinit var viewModel: ReaderDiscoverViewModel
     @Inject lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Inject lateinit var readerUtilsWrapper: ReaderUtilsWrapper
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -124,6 +128,13 @@ class ReaderDiscoverFragment : Fragment(R.layout.reader_discover_fragment_layout
                             this.siteId,
                             this.feedId
                     )
+                    is ShowReportPost -> {
+                        ReaderActivityLauncher.openUrl(
+                                context,
+                                readerUtilsWrapper.getReportPostUrl(url),
+                                INTERNAL
+                        )
+                    }
                 }
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -32,4 +32,5 @@ sealed class ReaderNavigationEvents {
     }
     data class ShowVideoViewer(val videoUrl: String) : ReaderNavigationEvents()
     data class ShowBlogPreview(val siteId: Long, val feedId: Long) : ReaderNavigationEvents()
+    data class ShowReportPost(val url: String) : ReaderNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.APP_REVIEWS_EVENT_INCREMENTED_BY_OPENING_READER_POST
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.FOLLOWED_BLOG_NOTIFICATIONS_READER_ENABLED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTICLE_VISITED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_REPORTED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_SAVED_LIST_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_SAVED_POST_OPENED_FROM_OTHER_POST_LIST
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.SHARED_ITEM_READER
@@ -31,6 +32,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookm
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostDetail
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReportPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
@@ -38,6 +40,7 @@ import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.COMMENT
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REPORT_POST
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SHARE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SITE_NOTIFICATIONS
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.VISIT_SITE
@@ -62,6 +65,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.widgets.AppRatingDialogWrapper
+import java.util.HashMap
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -115,6 +119,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
                 BOOKMARK -> handleBookmarkClicked(post.postId, post.blogId, isBookmarkList)
                 REBLOG -> handleReblogClicked(post)
                 COMMENTS -> handleCommentsClicked(post.postId, post.blogId)
+                REPORT_POST -> handleReportPostClicked(post)
             }
         }
     }
@@ -316,6 +321,15 @@ class ReaderPostCardActionsHandler @Inject constructor(
 
     private fun handleCommentsClicked(postId: Long, blogId: Long) {
         _navigationEvents.postValue(Event(ShowReaderComments(blogId, postId)))
+    }
+
+    private fun handleReportPostClicked(post: ReaderPost) {
+        val properties: MutableMap<String, Any> = HashMap()
+        properties["blog_id"] = post.blogId
+        properties["is_jetpack"] = post.isJetpack
+        properties["post_id"] = post.postId
+        analyticsTrackerWrapper.track(READER_POST_REPORTED, properties)
+        _navigationEvents.postValue(Event(ShowReportPost(post.blogUrl)))
     }
 
     private fun prepareEnableNotificationSnackbarAction(blogName: String?, blogId: Long): () -> Unit {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -158,7 +158,6 @@ class ReaderPostCardActionsHandler @Inject constructor(
         }
     }
 
-
     private suspend fun handleFollowClicked(post: ReaderPost) {
         followUseCase.toggleFollow(post).collect {
             when (it) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -147,6 +147,18 @@ class ReaderPostCardActionsHandler @Inject constructor(
         }
     }
 
+    suspend fun handleReportPostClicked(post: ReaderPost) {
+        withContext(bgDispatcher) {
+            val properties: MutableMap<String, Any> = HashMap()
+            properties["blog_id"] = post.blogId
+            properties["is_jetpack"] = post.isJetpack
+            properties["post_id"] = post.postId
+            analyticsTrackerWrapper.track(READER_POST_REPORTED, properties)
+            _navigationEvents.postValue(Event(ShowReportPost(post.blogUrl)))
+        }
+    }
+
+
     private suspend fun handleFollowClicked(post: ReaderPost) {
         followUseCase.toggleFollow(post).collect {
             when (it) {
@@ -321,15 +333,6 @@ class ReaderPostCardActionsHandler @Inject constructor(
 
     private fun handleCommentsClicked(postId: Long, blogId: Long) {
         _navigationEvents.postValue(Event(ShowReaderComments(blogId, postId)))
-    }
-
-    private fun handleReportPostClicked(post: ReaderPost) {
-        val properties: MutableMap<String, Any> = HashMap()
-        properties["blog_id"] = post.blogId
-        properties["is_jetpack"] = post.isJetpack
-        properties["post_id"] = post.postId
-        analyticsTrackerWrapper.track(READER_POST_REPORTED, properties)
-        _navigationEvents.postValue(Event(ShowReportPost(post.blogUrl)))
     }
 
     private fun prepareEnableNotificationSnackbarAction(blogName: String?, blogId: Long): () -> Unit {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOW
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REPORT_POST
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SHARE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SITE_NOTIFICATIONS
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.VISIT_SITE
@@ -122,6 +123,17 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
                     SecondaryAction(
                             type = BLOCK_SITE,
                             label = UiStringRes(R.string.reader_menu_block_blog),
+                            labelColor = R.attr.colorOnSurface,
+                            iconRes = R.drawable.ic_block_white_24dp,
+                            iconColor = R.attr.wpColorOnSurfaceMedium,
+                            onClicked = onButtonClicked
+                    )
+            )
+
+            menuItems.add(
+                    SecondaryAction(
+                            type = REPORT_POST,
+                            label = UiStringRes(R.string.reader_menu_report_post),
                             labelColor = R.attr.colorOnSurface,
                             iconRes = R.drawable.ic_block_white_24dp,
                             iconColor = R.attr.wpColorOnSurfaceMedium,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -458,4 +458,8 @@ public class ReaderUtils {
     public static boolean isExternalFeed(long blogId, long feedId) {
          return (blogId == 0 && feedId != 0) || blogId == feedId;
     }
+
+    public static String getReportPostUrl(String blogUrl) {
+        return "https://wordpress.com/abuse/?report_url=" + blogUrl;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
@@ -32,4 +32,6 @@ class ReaderUtilsWrapper @Inject constructor(
             ReaderUtils.getLongLikeLabelText(appContext, numLikes, isLikedByCurrentUser)
 
     fun isExternalFeed(blogId: Long, feedId: Long): Boolean = ReaderUtils.isExternalFeed(blogId, feedId)
+
+    fun getReportPostUrl(blogUrl: String): String = ReaderUtils.getReportPostUrl(blogUrl)
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1701,6 +1701,7 @@
     <!-- menu text -->
     <string name="reader_menu_tags">Edit tags and sites</string>
     <string name="reader_menu_block_blog">Block this site</string>
+    <string name="reader_menu_report_post">Report this post</string>
 
     <!-- button text -->
     <string name="reader_btn_share">Share</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookm
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowNoSitesToReblog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostDetail
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReportPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
@@ -702,6 +703,18 @@ class ReaderPostCardActionsHandlerTest {
 
         // Assert
         assertThat(observedValues.navigation[0]).isInstanceOf(ShowBlogPreview::class.java)
+    }
+
+    @Test
+    fun `Clicking on a report this post opens internal browswer`() = test {
+        // Arrange
+        val observedValues = startObserving()
+
+        // Act
+        actionHandler.handleReportPostClicked(dummyReaderPostModel())
+
+        // Assert
+        assertThat(observedValues.navigation[0]).isInstanceOf(ShowReportPost::class.java)
     }
 
     private fun startObserving(): Observers {

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -654,6 +654,7 @@ public final class AnalyticsTracker {
         READER_CHIPS_MORE_TOGGLED,
         ENCRYPTED_LOGGING_UPLOAD_SUCCESSFUL,
         ENCRYPTED_LOGGING_UPLOAD_FAILED,
+        READER_POST_REPORTED,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1819,6 +1819,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "encrypted_logging_upload_successful";
             case ENCRYPTED_LOGGING_UPLOAD_FAILED:
                 return "encrypted_logging_upload_failed";
+            case READER_POST_REPORTED:
+                return "reader_post_reported";
         }
         return null;
     }


### PR DESCRIPTION
Fixes #12951 

This PR adds a "Report this Post" option to the Overflow menu on reader post cards.

NOTE: This is a draft PR because details surrounding how the webview closes haven't been decided yet. They may stay as they are or they may include some JS. At the very least, we may add a snackbar indicating the request was submitted.

To test:
1. Open the App 
2. Navigate to reader "Following"
3. Tap on the overflow menu
4. Tap on the Report this Post option
5. An internal browser will open showing the abuse form for the post selected
6. Repeat 2-5, but switch "Discover" for "Following" tab

* Probably not a good idea to actually follow through with the form submittal, unless you are using your own site and leave a valid message.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
