### PR TITLE
Update chart library

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -345,7 +345,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 
-    implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0-alpha'
+    implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
 
     implementation "org.jsoup:jsoup:1.10.3"
     implementation 'androidx.emoji:emoji:1.0.0'

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LargeValueFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LargeValueFormatter.kt
@@ -2,8 +2,7 @@ package org.wordpress.android.ui.stats.refresh.utils
 
 import com.github.mikephil.charting.components.AxisBase
 import com.github.mikephil.charting.data.Entry
-import com.github.mikephil.charting.formatter.IAxisValueFormatter
-import com.github.mikephil.charting.formatter.IValueFormatter
+import com.github.mikephil.charting.formatter.ValueFormatter
 import com.github.mikephil.charting.utils.ViewPortHandler
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
@@ -14,7 +13,7 @@ import kotlin.math.round
  * This class is based on the {@link com.github.mikephil.charting.formatter.LargeValueFormatter} and fixes the issue
  * with Locale other than US (in some languages is the DecimalFormat different).
  */
-class LargeValueFormatter : IValueFormatter, IAxisValueFormatter {
+class LargeValueFormatter : ValueFormatter() {
     private var mSuffix = arrayOf("", "k", "m", "b", "t")
     private var mMaxLength = 5
     private val mFormat: DecimalFormat = DecimalFormat("###E00", DecimalFormatSymbols(Locale.US))
@@ -28,7 +27,7 @@ class LargeValueFormatter : IValueFormatter, IAxisValueFormatter {
         return makePretty(round(value).toDouble())
     }
 
-    override fun getFormattedValue(value: Float, axis: AxisBase): String {
+    override fun getFormattedValue(value: Float): String {
         return makePretty(round(value).toDouble())
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LargeValueFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LargeValueFormatter.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
-import com.github.mikephil.charting.components.AxisBase
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.formatter.ValueFormatter
 import com.github.mikephil.charting.utils.ViewPortHandler


### PR DESCRIPTION
This PR updates the MPAndroidChart library from the alpha version to the stable 3.1.0. The only change necessary was the the use of `ValueFormatter` abstract class instead of the interfaces.

To test:
- Go to stats - granular view
- Check that the views graph looks as expected
- Check on a site with high numbers that the values on the left axis get properly formatted (10,000 -> 10k)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
