### PR TITLE
Issue/remove code related to status bar color update

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -57,7 +57,6 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.URLFilteredWebViewClient;
 import org.wordpress.android.util.UrlUtils;
-import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.WPWebViewClient;
 import org.wordpress.android.util.helpers.WPWebChromeClient;

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -157,7 +157,6 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
     @Override
     public void onCreate(Bundle savedInstanceState) {
         ((WordPress) getApplication()).component().inject(this);
-        WPActivityUtils.setLightStatusBar(getWindow(), true);
         super.onCreate(savedInstanceState);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -46,7 +46,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ListUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper.RefreshListener;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -794,7 +794,6 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
             inflater.inflate(R.menu.media_multiselect, menu);
             setSwipeToRefreshEnabled(false);
             getAdapter().setInMultiSelect(true);
-            WPActivityUtils.setStatusBarColor(getActivity().getWindow(), R.color.neutral_60);
             updateActionModeTitle(selectCount);
             return true;
         }
@@ -820,7 +819,6 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         public void onDestroyActionMode(ActionMode mode) {
             setSwipeToRefreshEnabled(true);
             getAdapter().setInMultiSelect(false);
-            WPActivityUtils.setStatusBarColor(getActivity().getWindow(), R.color.status_bar);
             mActionMode = null;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
-import org.wordpress.android.util.WPActivityUtils
 import org.wordpress.android.util.setVisible
 import org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel
 import org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel.UiState.ContentUiState

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -108,7 +108,6 @@ class ModalLayoutPickerFragment : BottomSheetDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?) = BottomSheetDialog(requireContext(), getTheme()).apply {
         fillTheScreen(this)
-        setStatusBarColor(this)
     }
 
     override fun onAttach(context: Context) {
@@ -122,7 +121,6 @@ class ModalLayoutPickerFragment : BottomSheetDialogFragment() {
     }
 
     private fun closeModal() {
-        WPActivityUtils.setLightStatusBar(activity?.window, false)
         viewModel.dismiss()
     }
 
@@ -172,14 +170,5 @@ class ModalLayoutPickerFragment : BottomSheetDialogFragment() {
         val layoutParams = bottomSheet.layoutParams
         layoutParams.height = WindowManager.LayoutParams.MATCH_PARENT
         bottomSheet.layoutParams = layoutParams
-    }
-
-    private fun setStatusBarColor(dialog: BottomSheetDialog) {
-        dialog.behavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
-            override fun onSlide(bottomSheet: View, slideOffset: Float) {}
-            override fun onStateChanged(bottomSheet: View, newState: Int) {
-                WPActivityUtils.setLightStatusBar(activity?.window, newState == BottomSheetBehavior.STATE_EXPANDED)
-            }
-        })
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -37,7 +37,6 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        WPActivityUtils.setLightStatusBar(requireActivity().window, true)
         initDoneButton()
         initRetryButton()
         initViewModel()
@@ -147,11 +146,6 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
             interests_chip_group.addView(chip)
         }
         return chip
-    }
-
-    override fun onDestroyView() {
-        WPActivityUtils.setLightStatusBar(requireActivity().window, false)
-        super.onDestroyView()
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewMod
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.LocaleManager
-import org.wordpress.android.util.WPActivityUtils
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -6,20 +6,15 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
-import android.view.Window;
-import android.view.WindowManager;
 import android.widget.ListView;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
-import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
 
 import com.google.android.material.appbar.AppBarLayout;
@@ -123,29 +118,6 @@ public class WPActivityUtils {
 
         if (root.getChildAt(0) instanceof Toolbar) {
             root.removeViewAt(0);
-        }
-    }
-
-    public static void setStatusBarColor(Window window, int color) {
-        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-        window.setStatusBarColor(window.getContext().getResources().getColor(color));
-    }
-
-    public static void setLightStatusBar(Window window, boolean showInLightMode) {
-        Context context = window.getContext();
-        boolean isDarkTheme = ConfigurationExtensionsKt.isDarkTheme(context.getResources().getConfiguration());
-        if (!isDarkTheme) {
-            int newColor = showInLightMode ? ContextExtensionsKt.getColorFromAttribute(context, R.attr.colorSurface)
-                    : ContextCompat.getColor(context, R.color.status_bar);
-            window.setStatusBarColor(newColor);
-
-            if (VERSION.SDK_INT >= VERSION_CODES.M) {
-                int systemVisibility = window.getDecorView().getSystemUiVisibility();
-                int newSystemVisibility = showInLightMode ? systemVisibility | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-                        : systemVisibility ^ View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-                window.getDecorView().setSystemUiVisibility(newSystemVisibility);
-            }
         }
     }
 

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -13,8 +13,6 @@
     <color name="background_snackbar">@color/neutral_80</color>
     <color name="link_reader">@color/primary</color>
     <color name="link_stats">@color/accent</color>
-    <color name="status_bar">@color/primary</color>
-    <color name="status_bar_action_mode">@color/neutral</color>
 
     <!-- Switch to attribute after dropping support for api 21-23 -->
     <color name="placeholder">#1A000000</color>


### PR DESCRIPTION
This PR removes the manual setting of the status bar color. Since AppBar refresh feature got merged, we use light status bar by default, and there is no need to switch between white and blue colors anymore.

In addition, I was also safe to remove it from MediaGridFragment, since action mode related code was moved into the new media picker.

@malinajirka @ashiagr most prominent location for status bar color update was in Reader, so I would really appreciate if you could make sure everything is ok there :)

To test:
- Toggle between My Site, Reader, and Notification tabs and make sure the status bar color does not change.
- Navigate to Site Preview and confirm that the status bar color is white in light mode.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
