### PR TITLE
Fixing connected tests issues

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/components/MasterbarComponent.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/components/MasterbarComponent.java
@@ -3,7 +3,7 @@ package org.wordpress.android.e2e.components;
 import org.wordpress.android.R;
 
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static org.wordpress.android.support.BetterScrollToAction.scrollTo;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -8,7 +8,7 @@ import androidx.test.espresso.ViewInteraction;
 import org.wordpress.android.R;
 
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static org.wordpress.android.support.BetterScrollToAction.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/SiteSettingsPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/SiteSettingsPage.java
@@ -6,7 +6,7 @@ import org.wordpress.android.R;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static org.wordpress.android.support.BetterScrollToAction.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.PreferenceMatchers.withTitle;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BetterScrollToAction.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BetterScrollToAction.kt
@@ -1,0 +1,41 @@
+package org.wordpress.android.support
+
+import android.view.View
+import android.widget.HorizontalScrollView
+import android.widget.ScrollView
+import androidx.core.widget.NestedScrollView
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.ScrollToAction
+import androidx.test.espresso.action.ViewActions.actionWithAssertions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers
+import org.hamcrest.Matchers.allOf
+
+/**
+ * ScrollToAction that supports scrolling of all kinds of scrollable containers, including nested ones.
+ */
+class BetterScrollToAction(
+    private val original: ScrollToAction = ScrollToAction()
+) : ViewAction by original {
+    override fun getConstraints(): Matcher<View> {
+        return allOf(
+                ViewMatchers.withEffectiveVisibility(VISIBLE), ViewMatchers.isDescendantOfA(
+                Matchers.anyOf(
+                        isAssignableFrom(ScrollView::class.java),
+                        isAssignableFrom(HorizontalScrollView::class.java),
+                        isAssignableFrom(NestedScrollView::class.java)
+                )
+        )
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        fun scrollTo(): ViewAction {
+            return actionWithAssertions(BetterScrollToAction())
+        }
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BetterScrollToAction.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BetterScrollToAction.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.support
 
 import android.view.View
 import android.widget.HorizontalScrollView
+import android.widget.ListView
 import android.widget.ScrollView
 import androidx.core.widget.NestedScrollView
 import androidx.test.espresso.ViewAction
@@ -26,7 +27,8 @@ class BetterScrollToAction(
                 Matchers.anyOf(
                         isAssignableFrom(ScrollView::class.java),
                         isAssignableFrom(HorizontalScrollView::class.java),
-                        isAssignableFrom(NestedScrollView::class.java)
+                        isAssignableFrom(NestedScrollView::class.java),
+                        isAssignableFrom(ListView::class.java)
                 )
         )
         )

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -39,7 +39,7 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.action.ViewActions.replaceText;
-import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static org.wordpress.android.support.BetterScrollToAction.scrollTo;
 import static androidx.test.espresso.action.ViewActions.swipeLeft;
 import static androidx.test.espresso.action.ViewActions.swipeRight;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
@@ -298,7 +298,7 @@ public class WPSupportUtils {
 
         // Let the layout settle down before attempting to scroll
         idleFor(100);
-        
+
         while (recyclerView.getLayoutManager().canScrollVertically() && !isElementCompletelyDisplayed(view)) {
             getCurrentActivity().runOnUiThread(new Runnable() {
                 @Override public void run() {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/MySiteTitleAndSubtitleLabelView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/MySiteTitleAndSubtitleLabelView.kt
@@ -31,12 +31,12 @@ class MySiteTitleAndSubtitleLabelView @JvmOverloads constructor(
         val guideline = findViewById<View>(R.id.guideline)
 
         title.viewTreeObserver.addOnGlobalLayoutListener {
-            if (title.lineCount == 1) {
+            if (title.lineCount == 1 && (title.layoutParams as LayoutParams).bottomToTop == View.NO_ID) {
                 val constraintSet = ConstraintSet()
                 constraintSet.clone(this@MySiteTitleAndSubtitleLabelView)
                 constraintSet.connect(title.id, ConstraintSet.BOTTOM, guideline.id, ConstraintSet.TOP, 0)
                 constraintSet.applyTo(this@MySiteTitleAndSubtitleLabelView)
-            } else if (title.lineCount == 2) {
+            } else if (title.lineCount == 2 && (title.layoutParams as LayoutParams).bottomToTop == guideline.id)  {
                 val constraintSet = ConstraintSet()
                 constraintSet.clone(this@MySiteTitleAndSubtitleLabelView)
                 constraintSet.clear(title.id, ConstraintSet.BOTTOM)

--- a/WordPress/src/main/java/org/wordpress/android/widgets/MySiteTitleAndSubtitleLabelView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/MySiteTitleAndSubtitleLabelView.kt
@@ -36,7 +36,7 @@ class MySiteTitleAndSubtitleLabelView @JvmOverloads constructor(
                 constraintSet.clone(this@MySiteTitleAndSubtitleLabelView)
                 constraintSet.connect(title.id, ConstraintSet.BOTTOM, guideline.id, ConstraintSet.TOP, 0)
                 constraintSet.applyTo(this@MySiteTitleAndSubtitleLabelView)
-            } else if (title.lineCount == 2 && (title.layoutParams as LayoutParams).bottomToTop == guideline.id)  {
+            } else if (title.lineCount == 2 && (title.layoutParams as LayoutParams).bottomToTop == guideline.id) {
                 val constraintSet = ConstraintSet()
                 constraintSet.clone(this@MySiteTitleAndSubtitleLabelView)
                 constraintSet.clear(title.id, ConstraintSet.BOTTOM)


### PR DESCRIPTION
This PR fixes connected test issues:
- Custom Site title layout update loop prevented My Site screen from becoming idle.
- `scrollTo` was not working with nested scroll views.

To test (single line Site Title has a bigger font size then multiline Site Title):
- Set a long site title, so it would wrap to the second line. Confirm that the site title size is reduced compared to a single-line title.
- Set a long site title, so it would wrap to the second line. Rotate your device into a landscape orientation, so the title will take a single line. Confirm that the title size is bigger.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
