### PR TITLE
Issue/fix missed appbar and status bar color

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -636,7 +636,7 @@
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
             android:label="@string/edit_photo_screen_title"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
+            android:theme="@style/WordPress.NoActionBar"/>
 
         <!-- Services -->
         <service

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -145,6 +145,23 @@
             android:name=".ui.accounts.HelpActivity"
             android:label="@string/help_screen_title"
             android:theme="@style/WordPress.NoActionBar" />
+
+        <activity
+            android:name="zendesk.support.guide.HelpCenterActivity"
+            android:theme="@style/WordPress.ZenDesk" />
+
+        <activity
+            android:name="zendesk.support.guide.ViewArticleActivity"
+            android:theme="@style/WordPress.ZenDesk" />
+
+        <activity
+            android:name="zendesk.support.request.RequestActivity"
+            android:theme="@style/WordPress.ZenDesk" />
+
+        <activity
+            android:name="zendesk.support.requestlist.RequestListActivity"
+            android:theme="@style/WordPress.ZenDesk" />
+
         <!-- empty title -->
 
         <!-- Preferences activities -->

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -687,7 +687,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             ));
             options.setToolbarColor(ContextExtensionsKt.getColorFromAttribute(context, R.attr.wpColorAppBar));
             options.setToolbarWidgetColor(ContextExtensionsKt.getColorFromAttribute(
-                    context, R.attr.colorOnPrimarySurface
+                    context, R.attr.colorOnSurface
             ));
             options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.NONE);
             options.setHideBottomControls(true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerActivity.kt
@@ -91,7 +91,7 @@ class GifPickerActivity : LocaleAwareActivity() {
      * Show the back arrow.
      */
     private fun initializeToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(toolbar_main)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -384,7 +384,7 @@ class MeFragment : Fragment(), OnScrollToTopListener {
         options.setShowCropGrid(false)
         options.setStatusBarColor(context.getColorFromAttribute(android.R.attr.statusBarColor))
         options.setToolbarColor(context.getColorFromAttribute(R.attr.wpColorAppBar))
-        options.setToolbarWidgetColor(context.getColorFromAttribute(attr.colorOnPrimarySurface))
+        options.setToolbarWidgetColor(context.getColorFromAttribute(attr.colorOnSurface))
         options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.NONE)
         options.setHideBottomControls(true)
         UCrop.of(uri, Uri.fromFile(File(context.cacheDir, "cropped_for_gravatar.jpg")))

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -931,7 +931,7 @@ class MySiteFragment : Fragment(),
         options.setShowCropGrid(false)
         options.setStatusBarColor(context.getColorFromAttribute(android.R.attr.statusBarColor))
         options.setToolbarColor(context.getColorFromAttribute(R.attr.wpColorAppBar))
-        options.setToolbarWidgetColor(context.getColorFromAttribute(attr.colorOnPrimarySurface))
+        options.setToolbarWidgetColor(context.getColorFromAttribute(attr.colorOnSurface))
         options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.NONE)
         options.setHideBottomControls(true)
         UCrop.of(uri, Uri.fromFile(File(context.cacheDir, "cropped_for_site_icon.jpg")))

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -137,7 +137,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
         mThumbWidth = displayWidth / getColumnCount();
         mThumbHeight = (int) (mThumbWidth * 0.75f);
 
-        Toolbar toolbar = findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(toolbar);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {

--- a/WordPress/src/main/res/layout/media_picker_activity.xml
+++ b/WordPress/src/main/res/layout/media_picker_activity.xml
@@ -1,38 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:elevation="@dimen/appbar_elevation"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/recycler">
 
-        <androidx.appcompat.widget.SearchView
-            android:id="@+id/search_view"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:imeOptions="flagNoExtractUi"
-            app:iconifiedByDefault="false"
-            app:queryHint="@string/stock_media_picker_search_hint"
-            app:searchIcon="@null" />
-    </com.google.android.material.appbar.MaterialToolbar>
+            app:theme="@style/WordPress.ActionBar">
+
+            <androidx.appcompat.widget.SearchView
+                android:id="@+id/search_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="flagNoExtractUi"
+                app:iconifiedByDefault="false"
+                app:queryHint="@string/stock_media_picker_search_hint"
+                app:searchIcon="@null" />
+
+        </com.google.android.material.appbar.MaterialToolbar>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@+id/toolbar">
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recycler"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fadeScrollbars="true"
             android:contentDescription="@string/stock_media_picker_list_content_description"
+            android:fadeScrollbars="true"
             android:scrollbars="vertical"
             tools:listitem="@layout/media_picker_thumbnail" />
 
@@ -106,4 +115,4 @@
             tools:visibility="visible" />
     </RelativeLayout>
 
-</RelativeLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -118,4 +118,18 @@
         <item name="android:background">?android:attr/listDivider</item>
     </style>
 
+    <style name="WordPress.ZenDesk" parent="ZendeskSdkTheme.Dark" />
+
+    <!-- Overload of Zendesk FAB style -->
+    <style name="zs_contact_us_fab">
+        <item name="android:gravity">bottom|end</item>
+        <item name="android:layout_margin">@dimen/zs_fab_margin</item>
+        <item name="android:contentDescription">
+            @string/zs_general_contact_us_button_label_accessibility
+        </item>
+        <item name="android:visibility">gone</item>
+        <item name="android:src">@drawable/zs_create_ticket_fab</item>
+        <item name="android:backgroundTint">@color/pink_50</item>
+    </style>
+
 </resources>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -86,11 +86,6 @@
         <item name="theme">@style/WordPress.ActionMode.Theme</item>
     </style>
 
-    <style name="WordPress.ActionMode.Theme" parent="ThemeOverlay.AppCompat.Dark">
-        <item name="android:textColorSecondary">?attr/colorOnSurface</item>
-        <item name="colorControlActivated">@android:color/transparent</item>
-    </style>
-
     <style name="WordPress" parent="Base.Wordpress">
         <item name="android:navigationBarColor">?attr/colorSurface</item>
     </style>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -101,6 +101,10 @@
         <item name="theme">@style/WordPress.ActionMode.Theme</item>
     </style>
 
+    <style name="WordPress.ActionMode.Theme" parent="ThemeOverlay.AppCompat.DayNight">
+        <item name="android:textColorSecondary">?attr/colorOnSurface</item>
+    </style>
+
     <style name="WordPress.ActionMode.TitleTextStyle" parent="@android:style/TextAppearance.Material.Widget.ActionBar.Title">
         <item name="android:textColor">?attr/colorOnSurface</item>
     </style>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -130,6 +130,22 @@
         <item name="windowNoTitle">true</item>
     </style>
 
+    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
+        <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
+        <item name="android:statusBarColor">?attr/colorPrimaryDark</item>
+        <item name="titleTextColor">?attr/colorOnSurface</item>
+        <item name="toolbarNavigationButtonStyle">
+            @style/Widget.AppCompat.Toolbar.Button.Navigation
+        </item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+    </style>
+
+    <style name="WordPress.ZenDesk.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
+        <item name="titleTextColor">?attr/colorOnPrimary</item>
+        <item name="colorControlNormal">?attr/colorOnPrimary</item>
+    </style>
+
     <style name="WordPress.Stories.Immersive" parent="WordPress.NoActionBar">
         <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:immersive">true</item>


### PR DESCRIPTION
This PR fixes the status bar color in image crop activity and appbar layout in Gif/Stock image picker activity.

[![Image from Gyazo](https://i.gyazo.com/15a39a2e3aed993e9c25ab7859f8ea26.jpg)](https://gyazo.com/15a39a2e3aed993e9c25ab7859f8ea26)

[![Image from Gyazo](https://i.gyazo.com/80c64c267f2463b316acdd10add027e4.jpg)](https://gyazo.com/80c64c267f2463b316acdd10add027e4)

I also fixed the ripple effect in ActionMode buttons and the style of Zendesk screens. Zendesk is hard to style as always, so I mostly restored its previous look (at least in Light mode). Dark mode looks mostly ok.

To test:
- Navigate to image cropping activity by taping on editable blavatar and gravatar.
- Make sure the icons and text in status bar and toolbar are visible.
- Navigate to Media Browser, tap on the + sign and select "Free Photo Library" or "Tenor"
- Maker sure appbar is correctly styled. 
 - In Site Picker or any other screen with ActionMode, long press on list element so the ActionMode appear. Press any button in action mode an confirm that there is feedback (ripple).
- Check Zendesk screens in both light and dark mode and make sure they look acceptable.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
