### PR TITLE
Adds tag followed tracking to the select interests view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_TAG_FOLLOWED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.SELECT_INTERESTS_PICKED
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
@@ -131,8 +132,6 @@ class ReaderInterestsViewModel @Inject constructor(
     }
 
     fun onDoneButtonClick() {
-        trackerWrapper.track(SELECT_INTERESTS_PICKED)
-
         val contentUiState = uiState.value as ContentUiState
 
         updateUiState(
@@ -141,6 +140,8 @@ class ReaderInterestsViewModel @Inject constructor(
                         doneButtonUiState = DoneButtonDisabledUiState(titleRes = R.string.reader_btn_done)
                 )
         )
+
+        trackInterests(contentUiState.getSelectedInterests())
 
         viewModelScope.launch {
             readerTagRepository.clearTagLastUpdated(ReaderTag.createDiscoverPostCardsTag())
@@ -191,6 +192,13 @@ class ReaderInterestsViewModel @Inject constructor(
 
     private fun updateUiState(uiState: UiState) {
         _uiState.value = uiState
+    }
+
+    private fun trackInterests(tags: List<ReaderTag>) {
+        tags.forEach { it ->
+            trackerWrapper.track(READER_TAG_FOLLOWED, mapOf("tag" to it.tagSlug ))
+        }
+        trackerWrapper.track(SELECT_INTERESTS_PICKED, mapOf("quantity" to tags.size ))
     }
 
     sealed class UiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -196,9 +196,9 @@ class ReaderInterestsViewModel @Inject constructor(
 
     private fun trackInterests(tags: List<ReaderTag>) {
         tags.forEach { it ->
-            trackerWrapper.track(READER_TAG_FOLLOWED, mapOf("tag" to it.tagSlug ))
+            trackerWrapper.track(READER_TAG_FOLLOWED, mapOf("tag" to it.tagSlug))
         }
-        trackerWrapper.track(SELECT_INTERESTS_PICKED, mapOf("quantity" to tags.size ))
+        trackerWrapper.track(SELECT_INTERESTS_PICKED, mapOf("quantity" to tags.size))
     }
 
     sealed class UiState(


### PR DESCRIPTION
This PR Adds `READER_TAG_FOLLOWED` tracking for tags chosen on the selected interests view, including the tag slug. It also updates the tracking event for `SELECT_INTERESTS_PICKED` to include the quantity property.

To test:
1. Launch the app
2. Tap on the Reader tab
3. Delete all of your followed tags if needed
4. Tap on the Discover view
5. Select some interests
6. Hit the 'Done' button
7. Verify you see the following track message in console for each tag you selected:

🔵 Tracked: reader_reader_tag_followed, Properties: {"tag":"slugname"}
🔵 Tracked: select_interests_picked, Properties: {"quantity":a number}

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
