### PR TITLE
Track which tag is followed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -54,6 +54,7 @@ import org.wordpress.android.widgets.WPViewPager;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -352,9 +353,10 @@ public class ReaderSubsActivity extends LocaleAwareActivity
                 getPageAdapter().refreshFollowedTagFragment();
 
                 if (succeeded) {
-                    AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_FOLLOWED);
                     showInfoSnackbar(getString(R.string.reader_label_added_tag, tag.getLabel()));
                     mLastAddedTagName = tag.getTagSlug();
+                    AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_FOLLOWED,
+                            new HashMap<String, String>() { { put("tag", mLastAddedTagName); }});
                 } else {
                     showInfoSnackbar(getString(R.string.reader_toast_err_add_tag));
                     mLastAddedTagName = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -475,7 +475,8 @@ public class ReaderSubsActivity extends LocaleAwareActivity
      */
     @Override
     public void onTagDeleted(ReaderTag tag) {
-        AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_UNFOLLOWED);
+        AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_UNFOLLOWED,
+                new HashMap<String, String>() { { put("tag", tag.getTagSlug()); }});
         if (mLastAddedTagName != null && mLastAddedTagName.equalsIgnoreCase(tag.getTagSlug())) {
             mLastAddedTagName = null;
         }


### PR DESCRIPTION
This PR adds the missing tag information for `reader_reader_tag_followed` and `reader_reader_tag_unfollowed`

To test:
1. Follow a new topic using the cog from within following tab
2. Check that a `reader_reader_tag_followed` event is triggered with a `tag` property
🔵 Tracked: reader_reader_tag_followed, Properties: {"tag":"tag"}

1. Remove a tag using the cog from within the following tab
2. Check that a `reader_reader_tag_followed` event is triggered with a `tag` property
 🔵 Tracked: reader_reader_tag_unfollowed, Properties: {"tag":"tag"}
PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
