### PR TITLE
Enable like and comments action on bookmark list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -445,7 +445,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         mPhotonWidth,
                         mPhotonHeight,
                         postListType,
-                        isBookmarksList(),
                         onButtonClicked,
                         onItemClicked,
                         onItemRendered,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -158,7 +158,6 @@ class ReaderDiscoverViewModel @Inject constructor(
                         isDiscover = true,
                         photonWidth = photonWidth,
                         photonHeight = photonHeight,
-                        isBookmarkList = false,
                         onButtonClicked = this@ReaderDiscoverViewModel::onButtonClicked,
                         onItemClicked = this@ReaderDiscoverViewModel::onPostItemClicked,
                         onItemRendered = this@ReaderDiscoverViewModel::onItemRendered,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -63,7 +63,6 @@ class ReaderPostUiStateBuilder @Inject constructor(
         photonWidth: Int,
         photonHeight: Int,
         postListType: ReaderPostListType,
-        isBookmarkList: Boolean,
         onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit,
         onItemClicked: (Long, Long) -> Unit,
         onItemRendered: (ReaderCardUiState) -> Unit,
@@ -82,7 +81,6 @@ class ReaderPostUiStateBuilder @Inject constructor(
                     photonWidth,
                     photonHeight,
                     postListType,
-                    isBookmarkList,
                     onButtonClicked,
                     onItemClicked,
                     onItemRendered,
@@ -103,7 +101,6 @@ class ReaderPostUiStateBuilder @Inject constructor(
         photonWidth: Int,
         photonHeight: Int,
         postListType: ReaderPostListType,
-        isBookmarkList: Boolean,
         onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit,
         onItemClicked: (Long, Long) -> Unit,
         onItemRendered: (ReaderCardUiState) -> Unit,
@@ -138,9 +135,9 @@ class ReaderPostUiStateBuilder @Inject constructor(
                 fullVideoUrl = buildFullVideoUrl(post),
                 discoverSection = buildDiscoverSection(post, onDiscoverSectionClicked),
                 bookmarkAction = buildBookmarkSection(post, onButtonClicked),
-                likeAction = buildLikeSection(post, isBookmarkList, onButtonClicked),
+                likeAction = buildLikeSection(post, onButtonClicked),
                 reblogAction = buildReblogSection(post, onButtonClicked),
-                commentsAction = buildCommentsSection(post, isBookmarkList, onButtonClicked),
+                commentsAction = buildCommentsSection(post, onButtonClicked),
                 onItemClicked = onItemClicked,
                 onItemRendered = onItemRendered,
                 onMoreButtonClicked = onMoreButtonClicked,
@@ -304,13 +301,9 @@ class ReaderPostUiStateBuilder @Inject constructor(
 
     private fun buildLikeSection(
         post: ReaderPost,
-        isBookmarkList: Boolean,
         onClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ): PrimaryAction {
-        /* TODO malinjir why we don't show likes on bookmark list??? I think we wanted
-             to keep the card as simple as possible. However, since we are showing all the actions now, some of them
-             are just disabled, I think it's ok to enable the action. */
-        val likesEnabled = !isBookmarkList && post.canLikePost() && accountStore.hasAccessToken()
+        val likesEnabled = post.canLikePost() && accountStore.hasAccessToken()
 
         return PrimaryAction(
                 isEnabled = likesEnabled,
@@ -339,20 +332,15 @@ class ReaderPostUiStateBuilder @Inject constructor(
 
     private fun buildCommentsSection(
         post: ReaderPost,
-        isBookmarkList: Boolean,
         onCommentsClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ): PrimaryAction {
         val showComments = when {
-            /* TODO malinjir why we don't show comments on bookmark list??? I think we wanted
-                 to keep the card as simple as possible. However, since we are showing all the actions now, some of them
-                 are just disabled, I think it's ok to enable the action. */
-            post.isDiscoverPost || isBookmarkList -> false
+            post.isDiscoverPost -> false
             !accountStore.hasAccessToken() -> post.numReplies > 0
             else -> post.isWP && (post.isCommentsOpen || post.numReplies > 0)
         }
         val contentDescription = UiStringRes(R.string.comments)
 
-        // TODO Add content description
         return if (showComments) {
             PrimaryAction(
                     isEnabled = true,

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -62,14 +62,14 @@ import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ReactiveMutableLiveData
 
 private const val POST_PARAM_POSITION = 0
-private const val ON_ITEM_RENDERED_PARAM_POSITION = 8
-private const val ON_TAG_CLICKED_PARAM_POSITION = 14
-private const val ON_BUTTON_CLICKED_PARAM_POSITION = 6
-private const val ON_VIDEO_OVERLAY_CLICKED_PARAM_POSITION = 12
-private const val ON_POST_HEADER_CLICKED_PARAM_POSITION = 13
-private const val ON_POST_ITEM_CLICKED_PARAM_POSITION = 7
-private const val ON_MORE_MENU_CLICKED_PARAM_POSITION = 10
-private const val ON_MORE_MENU_DISMISSED_PARAM_POSITION = 11
+private const val ON_ITEM_RENDERED_PARAM_POSITION = 7
+private const val ON_TAG_CLICKED_PARAM_POSITION = 13
+private const val ON_BUTTON_CLICKED_PARAM_POSITION = 5
+private const val ON_VIDEO_OVERLAY_CLICKED_PARAM_POSITION = 11
+private const val ON_POST_HEADER_CLICKED_PARAM_POSITION = 12
+private const val ON_POST_ITEM_CLICKED_PARAM_POSITION = 6
+private const val ON_MORE_MENU_CLICKED_PARAM_POSITION = 9
+private const val ON_MORE_MENU_DISMISSED_PARAM_POSITION = 10
 private const val NUMBER_OF_ITEMS = 10L
 
 @InternalCoroutinesApi

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -117,7 +117,7 @@ class ReaderDiscoverViewModelTest {
         whenever(menuUiStateBuilder.buildMoreMenuItems(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(mock())
         whenever(
                 uiStateBuilder.mapPostToUiState(
-                        anyOrNull(), anyBoolean(), anyInt(), anyInt(), anyOrNull(), anyBoolean(), anyOrNull(),
+                        anyOrNull(), anyBoolean(), anyInt(), anyInt(), anyOrNull(), anyOrNull(),
                         anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(),
                         anyOrNull(), anyOrNull()
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -590,16 +590,6 @@ class ReaderPostUiStateBuilderTest {
     }
 
     @Test
-    fun `like button is disabled on bookmark list`() = test {
-        // Arrange
-        val post = createPost()
-        // Act
-        val uiState = mapPostToUiState(post, isBookmarkList = true)
-        // Assert
-        assertThat(uiState.likeAction.isEnabled).isFalse()
-    }
-
-    @Test
     fun `like button is disabled when the user is logged off`() = test {
         // Arrange
         val post = createPost()
@@ -742,16 +732,6 @@ class ReaderPostUiStateBuilderTest {
     }
 
     @Test
-    fun `Comments button is disabled on bookmark list`() = test {
-        // Arrange
-        val post = createPost()
-        // Act
-        val uiState = mapPostToUiState(post, isBookmarkList = true)
-        // Assert
-        assertThat(uiState.commentsAction.isEnabled).isFalse()
-    }
-
-    @Test
     fun `Count on Comments button corresponds to number of comments on the post`() = test {
         // Arrange
         val numReplies = 15
@@ -823,8 +803,7 @@ class ReaderPostUiStateBuilderTest {
     private suspend fun mapPostToUiState(
         post: ReaderPost,
         postListType: ReaderPostListType = TAG_FOLLOWED,
-        onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit = mock(),
-        isBookmarkList: Boolean = false
+        onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit = mock()
     ): ReaderPostUiState {
         return builder.mapPostToUiState(
                 post = post,
@@ -832,7 +811,6 @@ class ReaderPostUiStateBuilderTest {
                 photonWidth = 0,
                 photonHeight = 0,
                 postListType = postListType,
-                isBookmarkList = isBookmarkList,
                 onButtonClicked = onButtonClicked,
                 onItemClicked = mock(),
                 onItemRendered = mock(),


### PR DESCRIPTION
This PR enables comments and like actions on the saved tab in Reader. These actions were disabled in the past to make the cards on this tab as simple as possible. However, we started showing even disabled actions on post cards a few months ago (disabled actions were hidden before that). Since showing disabled actions doesn't make the card simpler we decided to enable these actions on the saved tab.

To test:
1. Open Reader
2. Bookmark a few posts from the Following and Discover tabs
3. Click on "Saved" tab
4. Notice comments and like actions are enabled - if they are disabled make sure the post has them disabled even on the original tab (following/discover)
5. Like + unlike some posts
6. Open comments of some posts

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
