### PR TITLE
WP Stories: Make story bottom sheet thumbnail background transparent

### DIFF
--- a/WordPress/src/main/res/drawable/story_title_thumbnail_background.xml
+++ b/WordPress/src/main/res/drawable/story_title_thumbnail_background.xml
@@ -6,7 +6,7 @@
         android:top="-5dp">
         <shape android:shape="rectangle">
             <corners android:bottomRightRadius="10dp" />
-            <solid android:color="#fff" />
+            <solid android:color="@color/transparent" />
             <stroke
                 android:width="2dp"
                 android:color="@color/gray_10" />


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/526. Makes the story cover asset transparent so it looks right in dark mode:

![publish-icon-transparent-dark-mode-fix](https://user-images.githubusercontent.com/9613966/93432043-f04abc00-f8ff-11ea-84ef-785f5f1cefd0.png)

To test:
1. Enable dark mode
2. Create a new story
3. Press the 'next' button
4. Observe that the cover icon next to the story title looks good

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
