### PR TITLE
Login: Properly handle Simple, Atomic and Jetpack sites addresses

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -656,9 +656,8 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
     @Override
     public void gotWpcomSiteInfo(String siteAddress) {
-        LoginUsernamePasswordFragment loginUsernamePasswordFragment =
-                LoginUsernamePasswordFragment.newInstance(siteAddress, siteAddress, null, null, true);
-        slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
+        LoginEmailFragment loginEmailFragment = LoginEmailFragment.newInstance(false, false, true);
+        slideInFragment(loginEmailFragment, true, LoginEmailFragment.TAG);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -726,8 +726,8 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     }
 
     @Override
-    public void addGoogleLoginFragment() {
-        addGoogleFragment(LoginGoogleFragment.newInstance(mIsSignupFromLoginEnabled), LoginGoogleFragment.TAG);
+    public void addGoogleLoginFragment(boolean isSignupFromLoginEnabled) {
+        addGoogleFragment(LoginGoogleFragment.newInstance(isSignupFromLoginEnabled), LoginGoogleFragment.TAG);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -656,7 +656,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
     @Override
     public void gotWpcomSiteInfo(String siteAddress) {
-        LoginEmailFragment loginEmailFragment = LoginEmailFragment.newInstance(false, false, true);
+        LoginEmailFragment loginEmailFragment = LoginEmailFragment.newInstance(false, false, true, siteAddress);
         slideInFragment(loginEmailFragment, true, LoginEmailFragment.TAG);
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2403,7 +2403,7 @@
     <string name="login_text_otp">Text me a code instead</string>
     <string name="login_text_otp_another">Text me another code instead</string>
     <string name="requesting_otp">Requesting a verification code via SMS.</string>
-    <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address. Try the link below to log in using your site address.</string>
+    <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address.</string>
     <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
     <string name="login_magic_links_label">We\'ll email you a link that\'ll log you in instantly, no password needed.</string>
     <string name="login_magic_links_sent_label">Check your email on this device and tap the link in the email you received from WordPress.com.</string>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -382,7 +382,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             if (isAdded()) {
                 mOldSitesIDs = SiteUtils.getCurrentSiteIds(mSiteStore, false);
                 mIsSocialLogin = true;
-                mLoginListener.addGoogleLoginFragment();
+                mLoginListener.addGoogleLoginFragment(mIsSignupFromLoginEnabled);
             } else {
                 AppLog.e(T.NUX, "Google login could not be started.  LoginEmailFragment was not attached.");
                 showErrorDialog(getString(R.string.login_error_generic_start));

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -149,6 +149,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 break;
             case FULL:
             case WPCOM_LOGIN_ONLY:
+            case SELFHOSTED_ONLY:
                 if (!mShouldUseNewLayout) {
                     label.setText(R.string.enter_email_wordpress_com);
                 } else if (!TextUtils.isEmpty(mLoginSiteUrl)) {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.Html;
 import android.text.Spanned;
+import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.Patterns;
 import android.view.View;
@@ -112,11 +113,17 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
 
     public static LoginEmailFragment newInstance(boolean isSignupFromLoginEnabled, boolean isSiteLoginEnabled,
                                                  boolean shouldUseNewLayout) {
+        return newInstance(isSignupFromLoginEnabled, isSiteLoginEnabled, shouldUseNewLayout, null);
+    }
+
+    public static LoginEmailFragment newInstance(boolean isSignupFromLoginEnabled, boolean isSiteLoginEnabled,
+                                                 boolean shouldUseNewLayout, String url) {
         LoginEmailFragment fragment = new LoginEmailFragment();
         Bundle args = new Bundle();
         args.putBoolean(ARG_SIGNUP_FROM_LOGIN_ENABLED, isSignupFromLoginEnabled);
         args.putBoolean(ARG_SITE_LOGIN_ENABLED, isSiteLoginEnabled);
         args.putBoolean(ARG_SHOULD_USE_NEW_LAYOUT, shouldUseNewLayout);
+        args.putString(ARG_LOGIN_SITE_URL, url);
         fragment.setArguments(args);
         return fragment;
     }
@@ -142,10 +149,12 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 break;
             case FULL:
             case WPCOM_LOGIN_ONLY:
-                if (mShouldUseNewLayout) {
-                    label.setText(R.string.enter_email_to_continue_wordpress_com);
-                } else {
+                if (!mShouldUseNewLayout) {
                     label.setText(R.string.enter_email_wordpress_com);
+                } else if (!TextUtils.isEmpty(mLoginSiteUrl)) {
+                    label.setText(getString(R.string.enter_email_for_site, mLoginSiteUrl));
+                } else {
+                    label.setText(R.string.enter_email_to_continue_wordpress_com);
                 }
                 break;
             case WOO_LOGIN_MODE:

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginListener.java
@@ -29,7 +29,7 @@ public interface LoginListener {
     void loginViaSiteCredentials(String inputSiteAddress);
     void helpEmailScreen(String email);
     void helpSocialEmailScreen(String email);
-    void addGoogleLoginFragment();
+    void addGoogleLoginFragment(boolean isSignupFromLoginEnabled);
     void showHelpFindingConnectedEmail();
 
     // Login Request Magic Link callbacks

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -428,7 +428,8 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
     private boolean calculateHasJetpack(ConnectSiteInfoPayload siteInfo) {
         // Determining if jetpack is actually installed takes additional logic. This final
-        // calculated event property will make querying this event more straight-forward:
+        // calculated event property will make querying this event more straight-forward.
+        // Internal reference: p99K0U-1vO-p2#comment-3574
         boolean hasJetpack = false;
         if (siteInfo.isWPCom && siteInfo.hasJetpack) {
             // This is likely an atomic site.

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -396,25 +396,21 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
 
     private void handleConnectSiteInfoForWordPress(ConnectSiteInfoPayload siteInfo, boolean hasJetpack) {
         if (siteInfo.isWPCom || hasJetpack) {
-            // It's a WordPress.com or a valid Jetpack site
+            // It's a WordPress.com or a connected Jetpack site
             if (mLoginListener.getLoginMode() == LoginMode.SELFHOSTED_ONLY) {
                 // We're only interested in self-hosted sites
                 if (hasJetpack) {
                     // If Jetpack site, treat it as self-hosted and start the discovery process
                     // Note: This also includes Atomic sites
                     initiateDiscovery();
-                } else {
-                    // Not a self-hosted site
-                    showError(R.string.invalid_site_url_message); // TODO Update error message
-                    endProgressIfNeeded();
+                    return;
                 }
-            } else {
-                // It's a WordPress.com or a valid Jetpack site, so treat it as such
-                endProgressIfNeeded();
-                mLoginListener.gotWpcomSiteInfo(UrlUtils.removeScheme(siteInfo.url));
             }
+            // It's a WordPress.com or a connected Jetpack site, so treat it as such
+            endProgressIfNeeded();
+            mLoginListener.gotWpcomSiteInfo(UrlUtils.removeScheme(siteInfo.url));
         } else {
-            // Not a WordPress.com or a valid Jetpack site
+            // Not a WordPress.com or a connected Jetpack site
             if (mLoginListener.getLoginMode() == LoginMode.WPCOM_LOGIN_ONLY) {
                 // We're only interested in WordPress.com accounts
                 showError(R.string.enter_wpcom_or_jetpack_site);

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="login_text_otp">Text me a code instead</string>
     <string name="login_text_otp_another">Text me another code instead</string>
     <string name="requesting_otp">Requesting a verification code via SMS.</string>
-    <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address. Try the link below to log in using your site address.</string>
+    <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address.</string>
     <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
     <string name="login_magic_links_label">We\'ll email you a link that\'ll log you in instantly, no password needed.</string>
     <string name="login_site_credentials_magic_link_label">Almost there! We just need to verify your Jetpack connected email address &lt;b>%1$s&lt;/b></string>


### PR DESCRIPTION
Fixes #12957

This PR takes advantage of the endpoint used by #12940 to correctly detect Simple, Atomic and Jetpack sites on the login flow and then redirect the user to the Get Started screen, just like if they had tapped the "Continue with WordPress.com" button in the Prologue screen, where they will be able to enter an email address or continue with a Google account.

This new behavior is demonstrated in the video below:

![video-giffer](https://user-images.githubusercontent.com/830056/93514683-df00b000-f8fd-11ea-9c16-fff97ef9dbff.gif)

Notes:
- When a user is redirected to the Get Started from the site address flow **they won't be able to signup**, meaning an error will be shown if they try to continue with a non-existing account.
- Another smaller difference in the Get Started screen is that we're changing the main text label from "Enter your email address to log in or create a WordPress.com account." to "Log in with WordPress.com to connect to yoursiteaddress.com".
- If the user provides a site address that has Jetpack installed and/or active, but not connected to a WordPress.com account, then they will proceed to the Username/Password screen, where they'll be able to login to the site using their site credentials, just like before. In this case the site will behave just like a self-hosted one, and the user won't be able to access Stats and Notifications or to see other sites associated with the same WP.com account until they setup the Jetpack connection.

## To test

0. Clear app data.
1. On the Prologue screen, if the Smart Lock dialog appears, dismiss it.
1. Tap **Enter your site address**.
1. On the Site Address screen, enter either a Simple, Atomic or Jetpack site address.
1. Tap **Continue**.
1. Notice the Get Started screen.
1. Enter an email address associated with a WordPress.com account.
1. Tap **Continue**.
1. Complete the login flow normally.

Repeat for different types of sites and verify they all work as expected.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.