### PR TITLE
Login: Enable signup when adding a WordPress.com account from the Me screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -149,10 +149,12 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
             switch (getLoginMode()) {
                 case FULL:
                     mUnifiedLoginTracker.setSource(Source.DEFAULT);
+                    mIsSignupFromLoginEnabled = true;
                     loginFromPrologue();
                     break;
                 case WPCOM_LOGIN_ONLY:
                     mUnifiedLoginTracker.setSource(Source.ADD_WORDPRESS_COM_ACCOUNT);
+                    mIsSignupFromLoginEnabled = true;
                     if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
                         checkSmartLockPasswordAndStartLogin();
                     } else {
@@ -164,8 +166,8 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                     showFragment(new LoginSiteAddressFragment(), LoginSiteAddressFragment.TAG);
                     break;
                 case JETPACK_STATS:
-                    mIsSignupFromLoginEnabled = true;
                     mUnifiedLoginTracker.setSource(Source.JETPACK);
+                    mIsSignupFromLoginEnabled = true;
                     checkSmartLockPasswordAndStartLogin();
                     break;
                 case WPCOM_LOGIN_DEEPLINK:
@@ -201,7 +203,6 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     }
 
     private void loginFromPrologue() {
-        mIsSignupFromLoginEnabled = true;
         showFragment(new LoginPrologueFragment(), LoginPrologueFragment.TAG);
         if (BuildConfig.UNIFIED_LOGIN_AVAILABLE) {
             mIsSmartLockTriggeredFromPrologue = true;


### PR DESCRIPTION
This PR fixes an issue that prevented users from signing up after they had logged in with a self-hosted site and tried to add a WordPress.com account from the Me screen.

## To test

**Email**

1. Log in with a self-hosted site.
1. Go to the Me screen.
1. Tap **Log in to WordPress.com**.
1. On the Get Started screen, enter an email address that **is not** associated with a WordPress.com account.
1. Tap **Continue**.
1. Notice the Sign-Up Confirmation screen.

**Google Sign-In**

1. Log in with a self-hosted site.
1. Go to the Me screen.
1. Tap **Log in to WordPress.com**.
1. On the Get Started screen, tap **Continue with Google**.
1. On the Google Sign-In dialog, pick a Google account that **is not** associated with a WordPress.com account.
1. Notice the Sign-Up Confirmation screen.

👉 To use the Google Sign-In method, you might need to follow these instructions: paqN3M-9M-p2

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.