### PR TITLE
Fix RTL support on interests you might like reader card

### DIFF
--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -124,13 +124,14 @@
     </style>
 
     <style name="ReaderTextView.Interests.ListItem.Text" parent="ReaderTextView">
-        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginBottom">@dimen/margin_large</item>
         <item name="android:layout_marginEnd">@dimen/margin_extra_large</item>
         <item name="android:layout_marginStart">@dimen/margin_extra_large</item>
         <item name="android:layout_marginTop">@dimen/margin_large</item>
         <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:textAlignment">viewStart</item>
     </style>
 
     <style name="ReaderTextView.Interests.Title" parent="ReaderTextView">


### PR DESCRIPTION
Fixes Right-to-Left support on Interests you might like card on discover screen.


| Before | After |
|-----|----|
| ![Screenshot_1600413432](https://user-images.githubusercontent.com/2261188/93568503-934b1680-f990-11ea-8cd0-3d182e0b0e31.png) | ![Screenshot_1600413690](https://user-images.githubusercontent.com/2261188/93568495-90502600-f990-11ea-9952-f7b1eff51a29.png) |


To test:
1. Open Reader - discover tab
2. Make sure the text on the "Interest you might like" card is aligned to left
3. Go to developer settings and check "Force RTL layout direction"
4. Open the app and notice the interests are now aligned to the right

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
