### PR TITLE
Update harmless libraries

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -231,7 +231,7 @@ dependencies {
     implementation 'org.wordpress:graphview:3.4.0'
     implementation 'org.wordpress:persistentedittext:1.0.2'
     implementation 'org.wordpress:emailchecker2:1.1.0'
-    implementation 'com.squareup.okio:okio:1.14.0'
+    implementation 'com.squareup.okio:okio:2.8.0'
     implementation 'org.apache.commons:commons-text:1.1'
     implementation 'com.airbnb.android:lottie:3.0.7'
     implementation 'com.facebook.shimmer:shimmer:0.4.0'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -253,7 +253,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$nhaarmanMockitoVersion"
     testImplementation "org.assertj:assertj-core:$assertJVersion"
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.1'
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
     testImplementation 'androidx.test:core:1.2.0'
 
     androidTestImplementation 'org.mockito:mockito-android:3.3.3'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -256,7 +256,7 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.1'
     testImplementation 'androidx.test:core:1.2.0'
 
-    androidTestImplementation 'org.mockito:mockito-android:2.27.0'
+    androidTestImplementation 'org.mockito:mockito-android:3.3.3'
     androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$nhaarmanMockitoVersion"
     androidTestImplementation 'com.squareup.okhttp:mockwebserver:2.7.5'
     androidTestImplementation 'com.squareup.okio:okio:1.14.0'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -259,7 +259,7 @@ dependencies {
     androidTestImplementation 'org.mockito:mockito-android:3.3.3'
     androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$nhaarmanMockitoVersion"
     androidTestImplementation 'com.squareup.okhttp:mockwebserver:2.7.5'
-    androidTestImplementation 'com.squareup.okio:okio:1.14.0'
+    androidTestImplementation 'com.squareup.okio:okio:2.8.0'
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion", {
         exclude group: 'com.android.support', module: 'support-annotations'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.21'
+    fluxCVersion = 'd0a87b4f9295739dca64b1edbc94fe2f3f54370c'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -139,13 +139,13 @@ ext {
     lifecycleVersion = '2.2.0'
 
     // testing
-    jUnitVersion = '4.12'
+    jUnitVersion = '4.13'
     androidxTestVersion = '1.1.0'
     androidxArchCoreVersion = '2.0.0'
     assertJVersion = '3.11.1'
     espressoVersion = '3.1.0'
-    mockitoCoreVersion = "2.28.2"
-    nhaarmanMockitoVersion = "2.1.0"
+    mockitoCoreVersion = "3.3.3"
+    nhaarmanMockitoVersion = "2.2.0"
 }
 
 // Onboarding and dev env setup tasks


### PR DESCRIPTION
This PR updates some of the libraries that felt safe to update. This is:
- test libraries
- updates FluxC to this PR - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1691/commits
- Okio - according to the changelog this should be a safe change

To test:
- Try to upload a new gravatar from the Me tab
- Smoke test the app (screens that touch the APIs)
- Check the tests are green

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
