### PR TITLE
Gutenberg: UBE is enabled for all WPCom simple sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2167,8 +2167,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);
         Bundle themeBundle = (editorTheme != null) ? editorTheme.getThemeSupport().toBundle() : null;
 
-        boolean isUnsupportedBlockEditorEnabled = (mSite.isWPCom() || mIsJetpackSsoEnabled)
-                && "gutenberg".equals(mSite.getWebEditor());
+        boolean isUnsupportedBlockEditorEnabled =
+                mSite.isWPCom() || (mIsJetpackSsoEnabled && "gutenberg".equals(mSite.getWebEditor()));
 
         return new GutenbergPropsBuilder(
                 enableMentions,


### PR DESCRIPTION
This PR enables the Unsupported Block Editor for all WPCom simple sites.
For Jetpack sites we still check if the user has `gutenberg` enabled on web.

To test:
- On a WPCom simple site, open gutenberg with a post that contains an unsupported block.
- Tap on the unsupported block to open the Unsupported Block Editor.
- Check that Gutenberg loads on the WebView displaying the unsupported block.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
