### PR TITLE
Refactor report post action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -95,6 +95,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEdito
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog;
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab;
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowNoSitesToReblog;
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReportPost;
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult;
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
@@ -139,7 +140,6 @@ import java.util.Stack;
 import javax.inject.Inject;
 
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.APP_REVIEWS_EVENT_INCREMENTED_BY_OPENING_READER_POST;
-import static org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_POST_REPORTED;
 import static org.wordpress.android.fluxc.generated.AccountActionBuilder.newUpdateSubscriptionNotificationPostAction;
 import static org.wordpress.android.ui.reader.ReaderActivityLauncher.OpenUrlType.INTERNAL;
 
@@ -441,6 +441,12 @@ public class ReaderPostListFragment extends ViewPagerFragment
                         ActivityLauncher.viewSavedPostsListInReader(getActivity());
                     } else if (navTarget instanceof ShowBookmarkedSavedOnlyLocallyDialog) {
                         showBookmarksSavedLocallyDialog((ShowBookmarkedSavedOnlyLocallyDialog) navTarget);
+                    } else if (navTarget instanceof ShowReportPost) {
+                        ShowReportPost data = (ShowReportPost) navTarget;
+                        ReaderActivityLauncher.openUrl(
+                            getContext(),
+                            ReaderUtils.getReportPostUrl(data.getUrl()),
+                            INTERNAL);
                     } else {
                         throw new IllegalStateException("Action not supported in ReaderPostListFragment " + navTarget);
                     }
@@ -2543,16 +2549,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
                 mViewModel.onReblogButtonClicked(post, isBookmarksList());
                 break;
             case REPORT_POST:
-                HashMap<String, Object> properties = new HashMap();
-                properties.put("blog_id", post.blogId);
-                properties.put("is_jetpack", post.isJetpack);
-                properties.put("post_id", post.postId);
-                AnalyticsTracker.track(READER_POST_REPORTED, properties);
-                ReaderActivityLauncher.openUrl(
-                        getContext(),
-                        ReaderUtils.getReportPostUrl(post.getUrl()),
-                        INTERNAL
-                );
+                mViewModel.onReportPostButtonClicked(post, isBookmarksList());
                 break;
             case BLOCK_SITE:
                 mViewModel.onBlockSiteButtonClicked(post, isBookmarksList());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostListViewModel.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMAR
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REBLOG
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REPORT_POST
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SITE_NOTIFICATIONS
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionsHandler
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
@@ -142,6 +143,12 @@ class ReaderPostListViewModel @Inject constructor(
     fun onLikeButtonClicked(post: ReaderPost, bookmarksList: Boolean) {
         launch(bgDispatcher) {
             readerPostCardActionsHandler.onAction(post, LIKE, bookmarksList)
+        }
+    }
+
+    fun onReportPostButtonClicked(post: ReaderPost, bookmarksList: Boolean) {
+        launch(bgDispatcher) {
+            readerPostCardActionsHandler.onAction(post, REPORT_POST, bookmarksList)
         }
     }
 


### PR DESCRIPTION
This PR refactors the legacy "Report this post" action to use the new `ReaderPostCardActionsHandler` logic.

To test:
1. Open the App
2. Navigate to reader "Following" tab
3. Tap on the overflow menu
4. Tap on the Report this Post option
5. An internal browser will open showing the abuse form for the post selected

I put the 15.9 milestone against this PR, but it can go in with 15.8 if it hasn't been created yet. 

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
