### PR TITLE
Mobile Release v1.37.1

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
@@ -154,6 +154,7 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
     protected boolean isUrlOverridden(WebView view, String url) {
         if (mIsJetpackSsoEnabled) {
             if (!mIsJetpackSsoRedirected) {
+                mForegroundView.setVisibility(View.VISIBLE);
                 mIsJetpackSsoRedirected = true;
                 view.loadUrl(mUrlToLoad);
                 return true;
@@ -162,6 +163,9 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
             if (url.contains(mUrlToLoad)) {
                 mForegroundView.setVisibility(View.VISIBLE);
                 mIsRedirected = true;
+            }
+            else {
+                mForegroundView.setVisibility(View.INVISIBLE);
             }
 
             return false;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
@@ -163,8 +163,7 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
             if (url.contains(mUrlToLoad)) {
                 mForegroundView.setVisibility(View.VISIBLE);
                 mIsRedirected = true;
-            }
-            else {
+            } else {
                 mForegroundView.setVisibility(View.INVISIBLE);
             }
 


### PR DESCRIPTION
## Description
Release 1.37.1 of the react-native-editor and Gutenberg-Mobile.

For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2642

Extra PR after the release was cut:

- Remove the overlay from the Unsupported Block Editor web view, if Login with WordPress.com is requested. (https://github.com/wordpress-mobile/WordPress-Android/pull/12994)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->