### PR TITLE
Remove the overlay from the Unsupported Block Editor web view, if Login with WordPress.com is requested.

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
@@ -154,6 +154,7 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
     protected boolean isUrlOverridden(WebView view, String url) {
         if (mIsJetpackSsoEnabled) {
             if (!mIsJetpackSsoRedirected) {
+                mForegroundView.setVisibility(View.VISIBLE);
                 mIsJetpackSsoRedirected = true;
                 view.loadUrl(mUrlToLoad);
                 return true;
@@ -162,6 +163,9 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
             if (url.contains(mUrlToLoad)) {
                 mForegroundView.setVisibility(View.VISIBLE);
                 mIsRedirected = true;
+            }
+            else {
+                mForegroundView.setVisibility(View.INVISIBLE);
             }
 
             return false;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
@@ -163,8 +163,7 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
             if (url.contains(mUrlToLoad)) {
                 mForegroundView.setVisibility(View.VISIBLE);
                 mIsRedirected = true;
-            }
-            else {
+            } else {
                 mForegroundView.setVisibility(View.INVISIBLE);
             }
 


### PR DESCRIPTION
This PR implements the changes to remove the overlay from the Unsupported Block Editor web view, if `Login with WordPress.com` is requested.

**To test:**
- On a Jetpack connected site, have a post with an unsupported block.
- On web, check that SSO is enabled under Settings -> Security. (`Allow users to log in to this site using WordPress.com accounts`)
- **Delete WPiOS from the device** and install it from this PR.
- Open the post with the unsupported block on the Jetpack connected site.
- Open the Unsupported Block Editor for the unsupported block.
- Check that the overlay disappear to show the `Login With WordPress.com` screen.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
