### PR TITLE
Add a test to create the 'My site' screenshot

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -82,7 +82,7 @@ public class WPScreenshotTest extends BaseTest {
 
         waitForElementToBeDisplayedWithoutFailure(R.id.row_blog_posts);
 
-        takeScreenshot("4-screenshot-my-site");
+        takeScreenshot("4-keep-tabs-on-your-site");
     }
 
     private void editBlogPost() {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -65,6 +65,7 @@ public class WPScreenshotTest extends BaseTest {
         idleFor(1000);
         takeScreenshot("1-build-and-manage-your-website");
 
+        navigateMySite();
         editBlogPost();
         manageMedia();
         navigateNotifications();
@@ -73,6 +74,15 @@ public class WPScreenshotTest extends BaseTest {
         // Turn Demo Mode off on the emulator when we're done
         mDemoModeEnabler.disable();
         logoutIfNecessary();
+    }
+
+    private void navigateMySite() {
+        // Click on the "Sites" tab and take a screenshot
+        clickOn(R.id.nav_sites);
+
+        waitForElementToBeDisplayedWithoutFailure(R.id.row_blog_posts);
+
+        takeScreenshot("4-screenshot-my-site");
     }
 
     private void editBlogPost() {


### PR DESCRIPTION
Adds a UI Test to create a screenshot for the Play Store with heading "Keep tabs on your site" showing the "My site" screen according to the design.

![android-phone-1](https://user-images.githubusercontent.com/1119271/93654970-e5665900-f9dd-11ea-8a6d-37bafb4f6b35.png)

### Challenges

* Running screenshot tests against `develop` is currently failing with the following error. I asked for help fixing the tests earlier but have been unable to get them unstuck.

`java.lang.NullPointerException: Attempt to invoke virtual method 'boolean androidx.recyclerview.widget.RecyclerView.isComputingLayout()' on a null object reference`

### What was tried?

* Tried commenting out `PostsListPage.java:20` with `scrollToTopOfRecyclerView()` because the tests appear to be failing when attempting to scroll in either the block editor or the posts list page—the tests still failed so that must be used elsewhere.
* Tried adding a breakpoint to `PostsListPage.java:25` to try to see if that's where the failure happens and `pager.getChildAt(pager.getCurrentItem()).findViewById(R.id.recycler_view);` fails as expected but `pager.getChildAt(pager.getCurrentItem());` works and I'm not sure why it wouldn't be able to find `recycler_view` in this context.

### Notes

* For the sake of the project (and speed), we decided I should go ahead and commit and _then_ get some help figuring out how to fix the broken tests before moving forward. 
* In this first iteration, the "Create a post or page" bubble that shows up when you first install and open the app is showing on the My Site screen but it's not in the design. I can add it, but it also seems fine (and simpler) to leave it in and I'm wondering what people think about whether to remove it.

Example with the "Create a post or page" bubble|Example without it
---|---
<img src="https://user-images.githubusercontent.com/1119271/93655001-134b9d80-f9de-11ea-8dc5-516ba4720395.png" width="200" alt="Screenshot_20200918-181539">|<img src="https://user-images.githubusercontent.com/1119271/93655007-1cd50580-f9de-11ea-8b9a-e7d3af7952b8.png" width="200" alt="Screenshot_20200918-181553">

To test:

1. Apply these changes to the 15.6 tag.
1. Select `WPScreensotTest` as the run configuration.
1. Run the test and confirm it passes.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
