### PR TITLE
Update utils bintray publish instructions

### DIFF
--- a/libs/utils/.circleci/config.yml
+++ b/libs/utils/.circleci/config.yml
@@ -3,6 +3,13 @@ version: 2.1
 orbs:
   android: wordpress-mobile/android@0.0.22
 
+commands:
+  copy-gradle-properties:
+    steps:
+      - run:
+          name: Setup gradle.properties
+          command: cp gradle.properties-example gradle.properties
+
 jobs:
   Lint:
     executor: 
@@ -10,6 +17,7 @@ jobs:
       api-version: "27"
     steps:
       - checkout
+      - copy-gradle-properties
       - android/restore-gradle-cache
       - run:
           name: Lint & Checkstyle
@@ -22,6 +30,7 @@ jobs:
       api-version: "27"
     steps:
       - checkout
+      - copy-gradle-properties
       - android/restore-gradle-cache
       - run:
           name: Build

--- a/libs/utils/README.md
+++ b/libs/utils/README.md
@@ -24,7 +24,8 @@ $ ./gradlew assemble test publishToMavenLocal
 When a new version is ready to be published to the remote repository, use the following command to publish it to Bintray:
 
 ```shell
-$ ./gradlew clean build bintrayUpload -PbintrayUser=FIXME -PbintrayKey=FIXME
+$ ./gradlew clean build
+$ ./gradlew bintrayUpload -PbintrayUser=FIXME -PbintrayKey=FIXME
 ```
 
 ## Apps and libraries using WordPress-Utils-Android:

--- a/libs/utils/README.md
+++ b/libs/utils/README.md
@@ -24,7 +24,7 @@ $ ./gradlew assemble test publishToMavenLocal
 When a new version is ready to be published to the remote repository, use the following command to publish it to Bintray:
 
 ```shell
-$ ./gradlew clean build bintrayPublish -PbintrayUser=FIXME -PbintrayKey=FIXME
+$ ./gradlew clean build bintrayUpload -PbintrayUser=FIXME -PbintrayKey=FIXME
 ```
 
 ## Apps and libraries using WordPress-Utils-Android:

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -91,6 +91,7 @@ bintray {
     user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
     key = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.getenv('BINTRAY_KEY')
     publications = ['UtilsPublication']
+    publish = true
     pkg {
         repo = 'maven'
         name = 'utils'


### PR DESCRIPTION
This PR updates Bintray publish instructions for libs/utils. The `bintrayPublish` command didn't work for me, so I updated the build file to auto publish for `bintrayUpload` command. I also added the gradle properties copy step to CircleCI, since it'll be necessary for Gradle 6 upgrade when these changes are moved to https://github.com/wordpress-mobile/WordPress-Utils-Android.

**To test:**
If CircleCI is green, that should be good enough.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
