### PR TITLE
Login: Fix connected tests

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -15,9 +15,7 @@ import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_USERNAME;
-import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_SITE_ADDRESS;
-import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_USERNAME;
 
 @RunWith(AndroidJUnit4.class)
 public class LoginTests extends BaseTest {
@@ -42,7 +40,8 @@ public class LoginTests extends BaseTest {
     public void loginWithSiteAddress() {
         new LoginFlow().chooseEnterYourSiteAddress()
                        .enterSiteAddress(E2E_WP_COM_USER_SITE_ADDRESS)
-                       .enterUsernameAndPassword(E2E_WP_COM_USER_USERNAME, E2E_WP_COM_USER_PASSWORD)
+                       .enterEmailAddress()
+                       .enterPassword()
                        .confirmLogin();
     }
 


### PR DESCRIPTION
This PR fixes the connected tests that are currently failing in `develop` due to the changes introduced by #12978, which redirects users trying to login with a WP.com site address to the Get Started screen.

To test:

Run the connected tests on CI and make sure everything passes.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
