### PR TITLE
Reader: Support Stories in detail view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager
 import android.content.res.Resources
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.os.AsyncTask
 import android.os.Bundle
 import android.text.Html
@@ -1537,6 +1538,11 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private fun shouldOpenExternal(url: String): Boolean {
         // open YouTube videos in external app so they launch the YouTube player
         if (ReaderVideoUtils.isYouTubeVideoLink(url)) {
+            return true
+        }
+
+        // Open Stories links in external browser so they have more fullscreen play real estate
+        if (Uri.parse(url).queryParameterNames.any { it.contains("wp-story") }) {
             return true
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -379,9 +379,11 @@ public class ReaderPostRenderer {
               .append(" p, div" + (renderAsTiledGallery ? ":not(." + galleryOnlyClass + ")" : "")
                       + ", li { line-height: 1.6em; font-size: 100%; }")
               .append(" h1, h2, h3 { line-height: 1.6em; }")
-              // counteract pre-defined height/width styles, expect for the tiled-gallery divs when rendering as
-              // tiled gallery as those will be handled with the .tiled-gallery rules bellow.
-              .append(" p, div" + (renderAsTiledGallery ? ":not(.tiled-gallery.*)" : "")
+              // Counteract pre-defined height/width styles, expect for:
+              // 1. Story blocks, which set their own mobile-friendly size we shouldn't override.
+              // 2. The tiled-gallery divs when rendering as tiled gallery, as those will be handled
+              // with the .tiled-gallery rules below.
+              .append(" p, div:not(.wp-story-container.*)" + (renderAsTiledGallery ? ":not(.tiled-gallery.*)" : "")
                       + ", dl, table { width: auto !important; height: auto !important; }")
               // make sure long strings don't force the user to scroll horizontally
               .append(" body, p, div, a { word-wrap: break-word; }")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -124,9 +124,11 @@ public class ReaderPostRenderer {
         ReaderHtmlUtils.HtmlScannerListener imageListener = new ReaderHtmlUtils.HtmlScannerListener() {
             @Override
             public void onTagFound(String imageTag, String imageUrl) {
-                if (!imageUrl.contains("wpcom-smileys")) {
-                    replaceImageTag(imageTag, imageUrl);
+                // Exceptions which should keep their original tag attributes
+                if (imageUrl.contains("wpcom-smileys") || imageTag.contains("wp-story")) {
+                    return;
                 }
+                replaceImageTag(imageTag, imageUrl);
             }
         };
         String content = mRenderBuilder.toString();


### PR DESCRIPTION
Tweaks the Reader to support the Story block in detail view:

![device-2020-09-22-122031](https://user-images.githubusercontent.com/9613966/93841318-2b693880-fcce-11ea-88e4-8d0d4a0aaa51.png)

The bulk of the work for this has been done in the shared CSS file in Calypso and already deployed: https://github.com/Automattic/wp-calypso/pull/45397

Extra changes that were needed for WPAndroid:
* The in-app custom CSS forces auto height/width for divs, which breaks with the Story markup. Stories already have set, mobile-friendly width/height params, so I [excluded Stories from the rule](https://github.com/wordpress-mobile/WordPress-Android/compare/feature/stories-reader-detail?expand=1#diff-01ae2d5b004de5f0cdafb0f21217c146R388).
* I [excluded Stories from the img tag re-building](https://github.com/wordpress-mobile/WordPress-Android/compare/feature/stories-reader-detail?expand=1#diff-01ae2d5b004de5f0cdafb0f21217c146R128) we do, as it strips class attributes important for the CSS. Again, we can just rely on the attributes provided by the Story markup.
* Tapping on a story directly [opens the external browser](https://github.com/wordpress-mobile/WordPress-Android/compare/feature/stories-reader-detail?expand=1#diff-0ce39e7d0d99df91b63bcf95cdeb14caR1545) instead of the in-app web viewer. This is because the in-app web viewer has a lot of navigational chrome and doesn't provide as a good a 'full-screen' experience as the browser does.

iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14965

### To test:

1. Proxy WP.com on your device (because the Story block is currently a beta block and poorly supported by the API)
2. Clear device data to make sure you get a fresh copy of the `reader-mobile.css` and aren't hit by the 5-day cache
3. Follow a site or two with Stories (DM me for some samples)
4. Check that opening a story in Reader detail shows a properly formatted story, like the screenshot above
5. Check that tapping the story opens it in the browser, and it automatically plays once the page loads

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
