### PR TITLE
Refactor to make variable more in line with it's meaning.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -220,10 +220,10 @@ class MediaPickerViewModel @Inject constructor(
                 }
             }
         }
-        val onlyImagesSelected = items?.any { it.type != IMAGE && selectedIds.contains(it.identifier) } ?: false
+        val onlyImagesSelected = items?.none { it.type != IMAGE && selectedIds.contains(it.identifier) } ?: true
         return ActionModeUiModel.Visible(
                 title,
-                showEditAction = mediaPickerSetup.editingEnabled && !onlyImagesSelected
+                showEditAction = mediaPickerSetup.editingEnabled && onlyImagesSelected
         )
     }
 


### PR DESCRIPTION
While reviewing another PR we noticed that the `onlyImagesSelected` was used as if it was a sort of `notOnlyImagesSelected`, so we decided to improve it.

### To test

Unit test should pass; moreover the behaviour should not have changed (it was correct even before), so:
- Open Media > + > Choose from Device
- In the media picker try to select only images and check the edit icon is shown
- Try to select other kind of files (and also images together with those other kind of files) and check the Edit icon is hidden
- Smoke test

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
