### PR TITLE
Remove browser type from media picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -20,6 +20,7 @@ public class RequestCodes {
     public static final int STOCK_MEDIA_PICKER_MULTI_SELECT = 1201;
     public static final int STOCK_MEDIA_PICKER_SINGLE_SELECT = 1202;
     public static final int STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK = 1203;
+    public static final int STORIES_PHOTO_PICKER = 1204;
     public static final int SHOW_LOGIN_EPILOGUE_AND_RETURN = 1300;
     public static final int SHOW_SIGNUP_EPILOGUE_AND_RETURN = 1301;
     public static final int SMART_LOCK_SAVE = 1400;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -157,6 +157,7 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.util.config.ConsolidatedMediaPickerFeatureConfig
 import org.wordpress.android.util.getColorFromAttribute
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR
@@ -196,6 +197,7 @@ class MySiteFragment : Fragment(),
     @Inject lateinit var storiesTrackerHelper: StoriesTrackerHelper
     @Inject lateinit var mediaPickerLauncher: MediaPickerLauncher
     @Inject lateinit var storiesMediaPickerResultHandler: StoriesMediaPickerResultHandler
+    @Inject lateinit var consolidatedMediaPickerFeatureConfig: ConsolidatedMediaPickerFeatureConfig
     val selectedSite: SiteModel?
         get() {
             return (activity as? WPMainActivity)?.selectedSite
@@ -773,7 +775,12 @@ class MySiteFragment : Fragment(),
                 isDomainCreditAvailable = false
             }
             RequestCodes.PHOTO_PICKER -> if (resultCode == Activity.RESULT_OK && data != null) {
-                if (!storiesMediaPickerResultHandler.handleMediaPickerResultForStories(data, activity, selectedSite)) {
+                if (consolidatedMediaPickerFeatureConfig.isEnabled() ||
+                        !storiesMediaPickerResultHandler.handleMediaPickerResultForStories(
+                                data,
+                                activity,
+                                selectedSite
+                        )) {
                     if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_ID)) {
                         val mediaId = data.getLongExtra(MediaPickerConstants.EXTRA_MEDIA_ID, 0).toInt()
                         showSiteIconProgressBar(true)
@@ -812,6 +819,13 @@ class MySiteFragment : Fragment(),
                         }
                     }
                 }
+            }
+            RequestCodes.STORIES_PHOTO_PICKER -> if (resultCode == Activity.RESULT_OK && data != null) {
+                storiesMediaPickerResultHandler.handleMediaPickerResultForStories(
+                        data,
+                        activity,
+                        selectedSite
+                )
             }
             UCrop.REQUEST_CROP -> if (resultCode == Activity.RESULT_OK) {
                 AnalyticsTracker.track(MY_SITE_ICON_CROPPED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -20,6 +20,7 @@ import androidx.appcompat.widget.TooltipCompat
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.snackbar.Snackbar
 import com.wordpress.stories.compose.frame.FrameSaveNotifier.Companion.buildSnackbarErrorMessage
 import com.wordpress.stories.compose.frame.FrameSaveNotifier.Companion.getNotificationIdForError
 import com.wordpress.stories.compose.frame.StorySaveEvents.Companion.allErrorsInResult
@@ -27,7 +28,6 @@ import com.wordpress.stories.compose.frame.StorySaveEvents.StorySaveProcessStart
 import com.wordpress.stories.compose.frame.StorySaveEvents.StorySaveResult
 import com.wordpress.stories.compose.story.StoryRepository.getStoryAtIndex
 import com.wordpress.stories.util.KEY_STORY_SAVE_RESULT
-import com.google.android.material.snackbar.Snackbar
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity
@@ -37,8 +37,8 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.R.attr
+import org.wordpress.android.R.string
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
@@ -125,7 +125,7 @@ import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts.Companion.getPromptDetailsForTask
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts.Companion.isTargetingBottomNavBar
 import org.wordpress.android.ui.quickstart.QuickStartNoticeDetails
-import org.wordpress.android.ui.stories.StoriesMediaPickerResultHandler.Companion.handleMediaPickerResultForStories
+import org.wordpress.android.ui.stories.StoriesMediaPickerResultHandler
 import org.wordpress.android.ui.stories.StoriesTrackerHelper
 import org.wordpress.android.ui.stories.StoryComposerActivity
 import org.wordpress.android.ui.themes.ThemeBrowserActivity
@@ -195,6 +195,7 @@ class MySiteFragment : Fragment(),
     @Inject lateinit var meGravatarLoader: MeGravatarLoader
     @Inject lateinit var storiesTrackerHelper: StoriesTrackerHelper
     @Inject lateinit var mediaPickerLauncher: MediaPickerLauncher
+    @Inject lateinit var storiesMediaPickerResultHandler: StoriesMediaPickerResultHandler
     val selectedSite: SiteModel?
         get() {
             return (activity as? WPMainActivity)?.selectedSite
@@ -772,7 +773,7 @@ class MySiteFragment : Fragment(),
                 isDomainCreditAvailable = false
             }
             RequestCodes.PHOTO_PICKER -> if (resultCode == Activity.RESULT_OK && data != null) {
-                if (!handleMediaPickerResultForStories(data, activity, selectedSite)) {
+                if (!storiesMediaPickerResultHandler.handleMediaPickerResultForStories(data, activity, selectedSite)) {
                     if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_ID)) {
                         val mediaId = data.getLongExtra(MediaPickerConstants.EXTRA_MEDIA_ID, 0).toInt()
                         showSiteIconProgressBar(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -80,7 +80,6 @@ import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
-import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
@@ -916,11 +915,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (site != null) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.MEDIA_PICKER_OPEN_FOR_STORIES);
             // TODO: evaluate to include the QuickStart logic like in the handleNewPostAction
-            mMediaPickerLauncher.showPhotoPickerForResult(
+            mMediaPickerLauncher.showStoriesPhotoPickerForResult(
                     this,
-                    MediaBrowserType.WP_STORIES_MEDIA_PICKER,
-                    site,
-                    null // this is not required, only used for featured image in normal Posts
+                    site
             );
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1078,6 +1078,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     getNotificationsListFragment().onActivityResult(requestCode, resultCode, data);
                 }
                 break;
+            case RequestCodes.STORIES_PHOTO_PICKER:
             case RequestCodes.PHOTO_PICKER:
                 Fragment fragment = mBottomNav.getActiveFragment();
                 if (fragment instanceof MySiteFragment) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -27,8 +27,6 @@ import org.wordpress.android.ui.RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT
 import org.wordpress.android.ui.RequestCodes.TAKE_PHOTO
 import org.wordpress.android.ui.RequestCodes.VIDEO_LIBRARY
 import org.wordpress.android.ui.media.MediaBrowserActivity
-import org.wordpress.android.ui.media.MediaBrowserType
-import org.wordpress.android.ui.media.MediaBrowserType.FEATURED_IMAGE_PICKER
 import org.wordpress.android.ui.mediapicker.MediaItem.Identifier
 import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.ANDROID_CAMERA
 import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.ANDROID_PICKER
@@ -65,7 +63,6 @@ import javax.inject.Inject
 class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
     private var mediaCapturePath: String? = null
     private lateinit var mediaPickerSetup: MediaPickerSetup
-    private lateinit var browserType: MediaBrowserType
 
     // note that the site isn't required and may be null
     private var site: SiteModel? = null
@@ -112,12 +109,10 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
             actionBar.setDisplayShowTitleEnabled(true)
         }
         if (savedInstanceState == null) {
-            browserType = intent.getSerializableExtra(MediaBrowserActivity.ARG_BROWSER_TYPE) as MediaBrowserType
             mediaPickerSetup = MediaPickerSetup.fromIntent(intent)
             site = intent.getSerializableExtra(WordPress.SITE) as? SiteModel
             localPostId = intent.getIntExtra(LOCAL_POST_ID, EMPTY_LOCAL_POST_ID)
         } else {
-            browserType = savedInstanceState.getSerializable(MediaBrowserActivity.ARG_BROWSER_TYPE) as MediaBrowserType
             mediaPickerSetup = MediaPickerSetup.fromBundle(savedInstanceState)
             site = savedInstanceState.getSerializable(WordPress.SITE) as? SiteModel
             localPostId = savedInstanceState.getInt(LOCAL_POST_ID, EMPTY_LOCAL_POST_ID)
@@ -151,7 +146,6 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putSerializable(MediaBrowserActivity.ARG_BROWSER_TYPE, browserType)
         mediaPickerSetup.toBundle(outState)
         outState.putInt(LOCAL_POST_ID, localPostId)
         if (site != null) {
@@ -240,7 +234,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         source: MediaPickerMediaSource
     ) {
         // if user chose a featured image, we need to upload it and return the uploaded media object
-        if (browserType == FEATURED_IMAGE_PICKER) {
+        if (mediaPickerSetup.queueResults) {
             val mediaUri = mediaUris[0]
             val mimeType = contentResolver.getType(mediaUri)
             featuredImageHelper.trackFeaturedImageEvent(
@@ -281,7 +275,6 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
                             EXTRA_MEDIA_SOURCE,
                             source.name
                     ) // set the browserType in the result, so caller can distinguish and handle things as needed
-                    .putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, browserType)
             setResult(Activity.RESULT_OK, intent)
             finish()
         }
@@ -292,25 +285,17 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         source: MediaPickerMediaSource
     ) {
         if (mediaIds != null && mediaIds.isNotEmpty()) {
-            if (browserType.canMultiselect()) {
+            if (mediaPickerSetup.canMultiselect) {
                 // TODO WPSTORIES add TRACKS (see how it's tracked below? maybe do along the same lines)
                 val data = Intent()
                         .putExtra(
                                 MediaBrowserActivity.RESULT_IDS,
                                 ListUtils.toLongArray(mediaIds)
                         )
-                        .putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, browserType)
                         .putExtra(EXTRA_MEDIA_SOURCE, source.name)
                 setResult(Activity.RESULT_OK, data)
                 finish()
             } else {
-                // if user chose a featured image, track image picked event
-                if (browserType == FEATURED_IMAGE_PICKER) {
-                    featuredImageHelper.trackFeaturedImageEvent(
-                            IMAGE_PICKED,
-                            localPostId
-                    )
-                }
                 val data = Intent()
                         .putExtra(EXTRA_MEDIA_ID, mediaIds[0])
                         .putExtra(EXTRA_MEDIA_SOURCE, source.name)
@@ -356,13 +341,11 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
 
         fun buildIntent(
             context: Context,
-            browserType: MediaBrowserType,
             mediaPickerSetup: MediaPickerSetup,
             site: SiteModel? = null,
             localPostId: Int? = null
         ): Intent {
             val intent = Intent(context, MediaPickerActivity::class.java)
-            intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, browserType)
             mediaPickerSetup.toIntent(intent)
             if (site != null) {
                 intent.putExtra(WordPress.SITE, site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerSetup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerSetup.kt
@@ -13,6 +13,7 @@ data class MediaPickerSetup(
     val cameraEnabled: Boolean,
     val systemPickerEnabled: Boolean,
     val editingEnabled: Boolean,
+    val queueResults: Boolean,
     @StringRes val title: Int
 ) {
     enum class DataSource {
@@ -27,6 +28,7 @@ data class MediaPickerSetup(
         bundle.putBoolean(KEY_CAMERA_ENABLED, cameraEnabled)
         bundle.putBoolean(KEY_SYSTEM_PICKER_ENABLED, systemPickerEnabled)
         bundle.putBoolean(KEY_EDITING_ENABLED, editingEnabled)
+        bundle.putBoolean(KEY_QUEUE_RESULTS, queueResults)
         bundle.putInt(KEY_TITLE, title)
     }
 
@@ -38,6 +40,7 @@ data class MediaPickerSetup(
         intent.putExtra(KEY_CAMERA_ENABLED, cameraEnabled)
         intent.putExtra(KEY_SYSTEM_PICKER_ENABLED, systemPickerEnabled)
         intent.putExtra(KEY_EDITING_ENABLED, editingEnabled)
+        intent.putExtra(KEY_QUEUE_RESULTS, queueResults)
         intent.putExtra(KEY_TITLE, title)
     }
 
@@ -49,6 +52,7 @@ data class MediaPickerSetup(
         private const val KEY_CAMERA_ENABLED = "key_camera_enabled"
         private const val KEY_SYSTEM_PICKER_ENABLED = "key_system_picker_enabled"
         private const val KEY_EDITING_ENABLED = "key_editing_enabled"
+        private const val KEY_QUEUE_RESULTS = "key_queue_results"
         private const val KEY_TITLE = "key_title"
 
         fun fromBundle(bundle: Bundle): MediaPickerSetup {
@@ -63,6 +67,7 @@ data class MediaPickerSetup(
             val requiresStoragePermissions = bundle.getBoolean(KEY_REQUIRES_STORAGE_PERMISSIONS)
             val systemPickerEnabled = bundle.getBoolean(KEY_SYSTEM_PICKER_ENABLED)
             val editingEnabled = bundle.getBoolean(KEY_EDITING_ENABLED)
+            val queueResults = bundle.getBoolean(KEY_QUEUE_RESULTS)
             val title = bundle.getInt(KEY_TITLE)
             return MediaPickerSetup(
                     dataSource,
@@ -72,6 +77,7 @@ data class MediaPickerSetup(
                     cameraAllowed,
                     systemPickerEnabled,
                     editingEnabled,
+                    queueResults,
                     title
             )
         }
@@ -88,6 +94,7 @@ data class MediaPickerSetup(
             val requiresStoragePermissions = intent.getBooleanExtra(KEY_REQUIRES_STORAGE_PERMISSIONS, false)
             val systemPickerEnabled = intent.getBooleanExtra(KEY_SYSTEM_PICKER_ENABLED, false)
             val editingEnabled = intent.getBooleanExtra(KEY_SYSTEM_PICKER_ENABLED, false)
+            val queueResults = intent.getBooleanExtra(KEY_QUEUE_RESULTS, false)
             val title = intent.getIntExtra(KEY_TITLE, R.string.photo_picker_photo_or_video_title)
             return MediaPickerSetup(
                     dataSource,
@@ -97,6 +104,7 @@ data class MediaPickerSetup(
                     cameraAllowed,
                     systemPickerEnabled,
                     editingEnabled,
+                    queueResults,
                     title
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
@@ -45,6 +45,23 @@ class MediaPickerLauncher
         }
     }
 
+    fun showStoriesPhotoPickerForResult(
+        activity: Activity,
+        site: SiteModel?
+    ) {
+        val browserType = MediaBrowserType.WP_STORIES_MEDIA_PICKER
+        if (consolidatedMediaPickerFeatureConfig.isEnabled()) {
+            val intent = MediaPickerActivity.buildIntent(
+                    activity,
+                    buildLocalMediaPickerSetup(browserType),
+                    site
+            )
+            activity.startActivityForResult(intent, RequestCodes.STORIES_PHOTO_PICKER)
+        } else {
+            ActivityLauncher.showPhotoPickerForResult(activity, browserType, site, null)
+        }
+    }
+
     fun showPhotoPickerForResult(
         fragment: Fragment,
         browserType: MediaBrowserType,

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.media.MediaBrowserActivity
 import org.wordpress.android.ui.media.MediaBrowserType
-import org.wordpress.android.ui.media.MediaBrowserType.BROWSER
+import org.wordpress.android.ui.media.MediaBrowserType.FEATURED_IMAGE_PICKER
 import org.wordpress.android.ui.media.MediaBrowserType.GRAVATAR_IMAGE_PICKER
 import org.wordpress.android.ui.mediapicker.MediaPickerActivity
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup
@@ -35,7 +35,6 @@ class MediaPickerLauncher
         if (consolidatedMediaPickerFeatureConfig.isEnabled()) {
             val intent = MediaPickerActivity.buildIntent(
                     activity,
-                    browserType,
                     buildLocalMediaPickerSetup(browserType),
                     site,
                     localPostId
@@ -55,7 +54,6 @@ class MediaPickerLauncher
         if (consolidatedMediaPickerFeatureConfig.isEnabled()) {
             val intent = MediaPickerActivity.buildIntent(
                     fragment.requireContext(),
-                    browserType,
                     buildLocalMediaPickerSetup(browserType),
                     site,
                     localPostId
@@ -70,7 +68,6 @@ class MediaPickerLauncher
         val intent = if (consolidatedMediaPickerFeatureConfig.isEnabled()) {
             MediaPickerActivity.buildIntent(
                     fragment.requireContext(),
-                    GRAVATAR_IMAGE_PICKER,
                     buildLocalMediaPickerSetup(GRAVATAR_IMAGE_PICKER)
             )
         } else {
@@ -92,11 +89,11 @@ class MediaPickerLauncher
                     cameraEnabled = false,
                     systemPickerEnabled = true,
                     editingEnabled = true,
+                    queueResults = false,
                     title = R.string.photo_picker_choose_file
             )
             val intent = MediaPickerActivity.buildIntent(
                     activity,
-                    BROWSER,
                     mediaPickerSetup
             )
             activity.startActivityForResult(
@@ -112,7 +109,6 @@ class MediaPickerLauncher
         if (consolidatedMediaPickerFeatureConfig.isEnabled()) {
             val intent = MediaPickerActivity.buildIntent(
                     activity,
-                    browserType,
                     buildWPMediaLibraryPickerSetup(browserType),
                     site
             )
@@ -150,6 +146,7 @@ class MediaPickerLauncher
                 cameraEnabled = browserType.isWPStoriesPicker,
                 systemPickerEnabled = true,
                 editingEnabled = browserType.isImagePicker,
+                queueResults = browserType == FEATURED_IMAGE_PICKER,
                 title = title
         )
     }
@@ -170,6 +167,7 @@ class MediaPickerLauncher
                 cameraEnabled = browserType.isWPStoriesPicker,
                 systemPickerEnabled = false,
                 editingEnabled = false,
+                queueResults = false,
                 title = R.string.wp_media_title
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2391,6 +2391,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 case RequestCodes.MULTI_SELECT_MEDIA_PICKER:
                 case RequestCodes.SINGLE_SELECT_MEDIA_PICKER:
                 case RequestCodes.PHOTO_PICKER:
+                case RequestCodes.STORIES_PHOTO_PICKER:
                 case RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT:
                 case RequestCodes.MEDIA_LIBRARY:
                 case RequestCodes.PICTURE_LIBRARY:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1571,7 +1571,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     FluxCUtils.mediaFileFromMediaModel(media));
         } else if (media != null && media.getMarkedLocallyAsFeatured() && media.getLocalPostId() == mEditPostRepository
                 .getId()) {
-            setFeaturedImageId(media.getMediaId());
+            setFeaturedImageId(media.getMediaId(), false);
         }
     }
 
@@ -2341,9 +2341,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
         }
     }
 
-    private void setFeaturedImageId(final long mediaId) {
+    private void setFeaturedImageId(final long mediaId, final boolean imagePicked) {
         if (mEditPostSettingsFragment != null) {
-            mEditPostSettingsFragment.updateFeaturedImage(mediaId);
+            mEditPostSettingsFragment.updateFeaturedImage(mediaId, imagePicked);
         }
     }
 
@@ -2421,7 +2421,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     // user chose a featured image
                     if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_ID)) {
                         long mediaId = data.getLongExtra(MediaPickerConstants.EXTRA_MEDIA_ID, 0);
-                        setFeaturedImageId(mediaId);
+                        setFeaturedImageId(mediaId, true);
                     } else if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_QUEUED)) {
                         if (mEditPostSettingsFragment != null) {
                             mEditPostSettingsFragment.refreshViews();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -82,6 +82,7 @@ import org.wordpress.android.util.GeocoderUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper;
+import org.wordpress.android.util.config.ConsolidatedMediaPickerFeatureConfig;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageManager.RequestListener;
 import org.wordpress.android.util.image.ImageType;
@@ -158,6 +159,7 @@ public class EditPostSettingsFragment extends Fragment {
     @Inject AnalyticsTrackerWrapper mAnalyticsTrackerWrapper;
     @Inject UpdatePostStatusUseCase mUpdatePostStatusUseCase;
     @Inject MediaPickerLauncher mMediaPickerLauncher;
+    @Inject ConsolidatedMediaPickerFeatureConfig mConsolidatedMediaPickerFeatureConfig;
 
     @Inject ViewModelProvider.Factory mViewModelFactory;
     private EditPostPublishSettingsViewModel mPublishedViewModel;
@@ -991,7 +993,7 @@ public class EditPostSettingsFragment extends Fragment {
     // Featured Image Helpers
 
     public void updateFeaturedImage(long featuredImageId, boolean imagePicked) {
-        if (isAdded() && imagePicked) {
+        if (isAdded() && imagePicked && mConsolidatedMediaPickerFeatureConfig.isEnabled()) {
             int postId = getEditPostRepository().getId();
             mFeaturedImageHelper.trackFeaturedImageEvent(
                     TrackableEvent.IMAGE_PICKED,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -991,6 +991,13 @@ public class EditPostSettingsFragment extends Fragment {
     // Featured Image Helpers
 
     public void updateFeaturedImage(long featuredImageId) {
+        if (isAdded() && featuredImageId != 0) {
+            int postId = getEditPostRepository().getId();
+            mFeaturedImageHelper.trackFeaturedImageEvent(
+                    TrackableEvent.IMAGE_PICKED,
+                    postId
+            );
+        }
         EditPostRepository postRepository = getEditPostRepository();
         if (postRepository == null) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -990,8 +990,8 @@ public class EditPostSettingsFragment extends Fragment {
 
     // Featured Image Helpers
 
-    public void updateFeaturedImage(long featuredImageId) {
-        if (isAdded() && featuredImageId != 0) {
+    public void updateFeaturedImage(long featuredImageId, boolean imagePicked) {
+        if (isAdded() && imagePicked) {
             int postId = getEditPostRepository().getId();
             mFeaturedImageHelper.trackFeaturedImageEvent(
                     TrackableEvent.IMAGE_PICKED,
@@ -1014,7 +1014,7 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     private void clearFeaturedImage() {
-        updateFeaturedImage(0);
+        updateFeaturedImage(0, false);
     }
 
     private void updateFeaturedImageView(PostImmutableModel postModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -6,7 +6,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.push.NativeNotificationsUtils
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.POST_FROM_POSTS_LIST
-import org.wordpress.android.ui.media.MediaBrowserType.WP_STORIES_MEDIA_PICKER
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
 import org.wordpress.android.ui.uploads.UploadService
@@ -53,11 +52,9 @@ fun handlePostListAction(
             ActivityLauncher.addNewPostForResult(activity, action.site, action.isPromo, POST_FROM_POSTS_LIST)
         }
         is PostListAction.NewStoryPost -> {
-            mediaPickerLauncher.showPhotoPickerForResult(
+            mediaPickerLauncher.showStoriesPhotoPickerForResult(
                     activity,
-                    WP_STORIES_MEDIA_PICKER,
-                    action.site,
-                    null // this is not required, only used for featured image in normal Posts
+                    action.site
             )
         }
         is PostListAction.PreviewPost -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -59,6 +59,7 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarSequencer
+import org.wordpress.android.util.config.ConsolidatedMediaPickerFeatureConfig
 import org.wordpress.android.util.redirectContextClickToLongPressListener
 import org.wordpress.android.util.setLiftOnScrollTargetViewIdAndRequestLayout
 import org.wordpress.android.viewmodel.posts.PostListCreateMenuViewModel
@@ -88,6 +89,8 @@ class PostsListActivity : LocaleAwareActivity(),
     @Inject internal lateinit var systemNotificationTracker: SystemNotificationsTracker
     @Inject internal lateinit var editPostRepository: EditPostRepository
     @Inject internal lateinit var mediaPickerLauncher: MediaPickerLauncher
+    @Inject internal lateinit var storiesMediaPickerResultHandler: StoriesMediaPickerResultHandler
+    @Inject internal lateinit var consolidatedMediaPickerFeatureConfig: ConsolidatedMediaPickerFeatureConfig
 
     private lateinit var site: SiteModel
 
@@ -442,8 +445,16 @@ class PostsListActivity : LocaleAwareActivity(),
             viewModel.handleEditPostResult(data)
         } else if (requestCode == RequestCodes.REMOTE_PREVIEW_POST) {
             viewModel.handleRemotePreviewClosing()
-        } else if (requestCode == RequestCodes.PHOTO_PICKER && resultCode == Activity.RESULT_OK && data != null) {
-            StoriesMediaPickerResultHandler.handleMediaPickerResultForStories(data, this, site)
+        } else if (!consolidatedMediaPickerFeatureConfig.isEnabled() &&
+                requestCode == RequestCodes.PHOTO_PICKER &&
+                resultCode == Activity.RESULT_OK &&
+                data != null) {
+            storiesMediaPickerResultHandler.handleMediaPickerResultForStories(data, this, site)
+        } else if (consolidatedMediaPickerFeatureConfig.isEnabled() &&
+                requestCode == RequestCodes.STORIES_PHOTO_PICKER &&
+                resultCode == Activity.RESULT_OK &&
+                data != null) {
+            storiesMediaPickerResultHandler.handleMediaPickerResultForStories(data, this, site)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
@@ -6,7 +6,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
 import org.wordpress.android.ui.media.MediaBrowserActivity
-import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.UTILS
@@ -26,7 +25,7 @@ class StoriesMediaPickerResultHandler {
                         PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
                 )
                 return true
-            } else if (isWPStoriesMediaBrowserTypeResult(data)) {
+            } else {
                 if (data.hasExtra(MediaBrowserActivity.RESULT_IDS)) {
                     ActivityLauncher.addNewStoryWithMediaIdsForResult(
                             activity,
@@ -56,14 +55,6 @@ class StoriesMediaPickerResultHandler {
                     )
                     return true
                 }
-            }
-            return false
-        }
-
-        private fun isWPStoriesMediaBrowserTypeResult(data: Intent): Boolean {
-            if (data.hasExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)) {
-                val browserType = data.getSerializableExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)
-                return (browserType as MediaBrowserType).isWPStoriesPicker
             }
             return false
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
@@ -6,57 +6,67 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
 import org.wordpress.android.ui.media.MediaBrowserActivity
+import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.UTILS
+import org.wordpress.android.util.config.ConsolidatedMediaPickerFeatureConfig
+import javax.inject.Inject
 
-class StoriesMediaPickerResultHandler {
-    companion object {
-        /* return true if MediaPickerResult was handled */
-        fun handleMediaPickerResultForStories(
-            data: Intent,
-            activity: Activity?,
-            selectedSite: SiteModel?
-        ): Boolean {
-            if (data.getBooleanExtra(MediaPickerConstants.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED, false)) {
-                ActivityLauncher.addNewStoryForResult(
+class StoriesMediaPickerResultHandler
+@Inject constructor(private val consolidatedMediaPickerFeatureConfig: ConsolidatedMediaPickerFeatureConfig) {
+    /* return true if MediaPickerResult was handled */
+    fun handleMediaPickerResultForStories(
+        data: Intent,
+        activity: Activity?,
+        selectedSite: SiteModel?
+    ): Boolean {
+        if (data.getBooleanExtra(MediaPickerConstants.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED, false)) {
+            ActivityLauncher.addNewStoryForResult(
+                    activity,
+                    selectedSite,
+                    PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
+            )
+            return true
+        } else if (consolidatedMediaPickerFeatureConfig.isEnabled() || isWPStoriesMediaBrowserTypeResult(data)) {
+            if (data.hasExtra(MediaBrowserActivity.RESULT_IDS)) {
+                ActivityLauncher.addNewStoryWithMediaIdsForResult(
                         activity,
                         selectedSite,
-                        PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
+                        PagePostCreationSourcesDetail.STORY_FROM_MY_SITE,
+                        data.getLongArrayExtra(
+                                MediaBrowserActivity.RESULT_IDS
+                        )
                 )
                 return true
             } else {
-                if (data.hasExtra(MediaBrowserActivity.RESULT_IDS)) {
-                    ActivityLauncher.addNewStoryWithMediaIdsForResult(
-                            activity,
-                            selectedSite,
-                            PagePostCreationSourcesDetail.STORY_FROM_MY_SITE,
-                            data.getLongArrayExtra(
-                                    MediaBrowserActivity.RESULT_IDS
-                            )
+                val mediaUriStringsArray = data.getStringArrayExtra(
+                        MediaPickerConstants.EXTRA_MEDIA_URIS
+                )
+                if (mediaUriStringsArray.isNullOrEmpty()) {
+                    AppLog.e(
+                            UTILS,
+                            "Can't resolve picked or captured image"
                     )
-                    return true
-                } else {
-                    val mediaUriStringsArray = data.getStringArrayExtra(
-                            MediaPickerConstants.EXTRA_MEDIA_URIS
-                    )
-                    if (mediaUriStringsArray.isNullOrEmpty()) {
-                        AppLog.e(
-                                UTILS,
-                                "Can't resolve picked or captured image"
-                        )
-                        return false
-                    }
-                    ActivityLauncher.addNewStoryWithMediaUrisForResult(
-                            activity,
-                            selectedSite,
-                            PagePostCreationSourcesDetail.STORY_FROM_MY_SITE,
-                            mediaUriStringsArray
-                    )
-                    return true
+                    return false
                 }
+                ActivityLauncher.addNewStoryWithMediaUrisForResult(
+                        activity,
+                        selectedSite,
+                        PagePostCreationSourcesDetail.STORY_FROM_MY_SITE,
+                        mediaUriStringsArray
+                )
+                return true
             }
-            return false
         }
+        return false
+    }
+
+    private fun isWPStoriesMediaBrowserTypeResult(data: Intent): Boolean {
+        if (data.hasExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)) {
+            val browserType = data.getSerializableExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)
+            return (browserType as MediaBrowserType).isWPStoriesPicker
+        }
+        return false
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -210,7 +210,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                 RequestCodes.MULTI_SELECT_MEDIA_PICKER, RequestCodes.SINGLE_SELECT_MEDIA_PICKER -> {
                     handleMediaPickerIntentData(it)
                 }
-                RequestCodes.PHOTO_PICKER -> {
+                RequestCodes.PHOTO_PICKER, RequestCodes.STORIES_PHOTO_PICKER -> {
                     if (it.hasExtra(MediaPickerConstants.EXTRA_MEDIA_URIS)) {
                         val uriList: List<Uri> = convertStringArrayIntoUrisList(
                                 it.getStringArrayExtra(MediaPickerConstants.EXTRA_MEDIA_URIS)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -35,7 +35,6 @@ import org.wordpress.android.push.NotificationsProcessingService
 import org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.media.MediaBrowserActivity
-import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
@@ -260,11 +259,9 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     }
 
     override fun showProvidedMediaPicker() {
-        mediaPickerLauncher.showPhotoPickerForResult(
+        mediaPickerLauncher.showStoriesPhotoPickerForResult(
                 this,
-                MediaBrowserType.WP_STORIES_MEDIA_PICKER,
-                site,
-                null // this is not required, only used for featured image in normal Posts
+                site
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
@@ -217,6 +217,67 @@ fun <S, T, U, V, W> merge(
 }
 
 /**
+ * Merges five LiveData sources using a given function. The function returns an object of a new type.
+ * @param sourceA first source
+ * @param sourceB second source
+ * @param sourceC third source
+ * @param sourceD fourth source
+ * @param sourceE fifth source
+ * @return new data source
+ */
+fun <S, T, U, V, W, X> merge(
+    sourceA: LiveData<S>,
+    sourceB: LiveData<T>,
+    sourceC: LiveData<U>,
+    sourceD: LiveData<V>,
+    sourceE: LiveData<W>,
+    distinct: Boolean = false,
+    merger: (S?, T?, U?, V?, W?) -> X?
+): LiveData<X> {
+    data class FiveItemContainer(
+        val first: S? = null,
+        val second: T? = null,
+        val third: U? = null,
+        val fourth: V? = null,
+        val fifth: W? = null
+    )
+
+    val mediator = MediatorLiveData<FiveItemContainer>()
+    mediator.value = FiveItemContainer()
+    mediator.addSource(sourceA) {
+        val container = mediator.value
+        if (container?.first != it || !distinct) {
+            mediator.value = container?.copy(first = it)
+        }
+    }
+    mediator.addSource(sourceB) {
+        val container = mediator.value
+        if (container?.second != it || !distinct) {
+            mediator.value = container?.copy(second = it)
+        }
+    }
+    mediator.addSource(sourceC) {
+        val container = mediator.value
+        if (container?.third != it || !distinct) {
+            mediator.value = container?.copy(third = it)
+        }
+    }
+    mediator.addSource(sourceD) {
+        val container = mediator.value
+        if (container?.fourth != it || !distinct) {
+            mediator.value = container?.copy(fourth = it)
+        }
+    }
+    mediator.addSource(sourceE) {
+        val container = mediator.value
+        if (container?.fifth != it || !distinct) {
+            mediator.value = container?.copy(fifth = it)
+        }
+    }
+    return mediator.map { (first, second, third, fourth, fifth) -> merger(first, second, third, fourth, fifth) }
+}
+
+/**
  * Combines all the LiveData values in the given Map into one LiveData with the map of values.
  * @param sources is a map of all the live data sources in a map by a given key
  * @return one livedata instance that combines all the values into one map

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaLoaderFactoryTest.kt
@@ -41,6 +41,7 @@ class MediaLoaderFactoryTest {
                 cameraEnabled = false,
                 systemPickerEnabled = true,
                 editingEnabled = true,
+                queueResults = false,
                 title = R.string.wp_media_title
         )
         val mediaLoader = mediaLoaderFactory.build(mediaPickerSetup, site)
@@ -64,6 +65,7 @@ class MediaLoaderFactoryTest {
                 cameraEnabled = false,
                 systemPickerEnabled = false,
                 editingEnabled = false,
+                queueResults = false,
                 title = R.string.wp_media_title
         )
         whenever(mediaLibraryDataSourceFactory.build(site)).thenReturn(mediaLibraryDataSource)
@@ -90,6 +92,7 @@ class MediaLoaderFactoryTest {
                             cameraEnabled = false,
                             systemPickerEnabled = true,
                             editingEnabled = true,
+                            queueResults = false,
                             title = R.string.wp_media_title
                     ),
                     site
@@ -104,6 +107,7 @@ class MediaLoaderFactoryTest {
                             cameraEnabled = false,
                             systemPickerEnabled = true,
                             editingEnabled = true,
+                            queueResults = false,
                             title = R.string.wp_media_title
                     ),
                     site

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
@@ -705,6 +705,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
             cameraEnabled = cameraAllowed,
             systemPickerEnabled = true,
             editingEnabled = editingEnabled,
+            queueResults = false,
             title = R.string.wp_media_title
     )
 

--- a/WordPress/src/test/java/org/wordpress/android/util/LiveDataUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/LiveDataUtilsTest.kt
@@ -114,6 +114,37 @@ class LiveDataUtilsTest : BaseUnitTest() {
     }
 
     @Test
+    fun `merge merges 5 sources with function`() = test {
+        val sourceA = MutableLiveData<Int>()
+        val sourceB = MutableLiveData<String>()
+        val sourceC = MutableLiveData<Boolean>()
+        val sourceD = MutableLiveData<Double>()
+        val sourceE = MutableLiveData<Float>()
+
+        val mergedSources = merge(sourceA, sourceB, sourceC, sourceD, sourceE) { i, s, b, d, f ->
+            "$s: $i: $b: $d: $f"
+        }
+        mergedSources.observeForever { }
+
+        assertThat(mergedSources.value).isEqualTo("null: null: null: null: null")
+        val firstValue = 1
+        val secondValue = "value"
+        val thirdValue = true
+        val fourthValue = 2.4
+        val fifthValue = 2F
+        sourceA.value = firstValue
+        assertThat(mergedSources.value).isEqualTo("null: $firstValue: null: null: null")
+        sourceB.value = secondValue
+        assertThat(mergedSources.value).isEqualTo("$secondValue: $firstValue: null: null: null")
+        sourceC.value = thirdValue
+        assertThat(mergedSources.value).isEqualTo("$secondValue: $firstValue: $thirdValue: null: null")
+        sourceD.value = fourthValue
+        assertThat(mergedSources.value).isEqualTo("$secondValue: $firstValue: $thirdValue: $fourthValue: null")
+        sourceE.value = fifthValue
+        assertThat(mergedSources.value).isEqualTo("$secondValue: $firstValue: $thirdValue: $fourthValue: $fifthValue")
+    }
+
+    @Test
     fun `combineMap combines sources in a map`() {
         val sourceA = MutableLiveData<Int>()
         val sourceB = MutableLiveData<Int>()


### PR DESCRIPTION
This PR removes the browser type from the MediaPickerActivity. There are 2 tricky places where it was still used and I hope I fixed them correctly.

I've moved this part:
```
if (browserType == FEATURED_IMAGE_PICKER) {
                    featuredImageHelper.trackFeaturedImageEvent(
                            IMAGE_PICKED,
                            localPostId
                    )
                }
```
to the place where the results are processed in the `EditPostSettingsFragment`. I've tested it and I think it's tracking the upload correctly.

I've removed the `isWPStoriesMediaBrowserTypeResult(data))` from the stories handler. As far as I can tell it wasn't necessary. I've checked all the usage and I don't think there is any branch we're skipping or missing if the check failed (I don't think it could've failed, it was just a precaution). Let me know if it makes any sense. 

I've squeezed in `LiveDataUtils` update into this PR because it will be necessary for the stock media data source. I hope that's fine. 

To test:
- Set the ConsolidatedMediaPickerConfig to `true` in the App settings
- Check the featured image upload
- Check that an event like this `WordPress-STATS: 🔵 Tracked: featured_image_picked_post_settings, Properties: {"post_id":2}` is tracked correctly when the image is picked (before the upload finishes)
- Check that you can pick media for stories

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
