### PR TITLE
Reader: Fix deeplink activity disable/enable

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -459,6 +459,10 @@
             android:label="@string/reader_title_deeplink"
             android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="adjustResize" >
+        </activity>
+        <activity-alias
+            android:name=".WPComPostReaderActivity"
+            android:targetActivity=".ui.reader.ReaderPostPagerActivity">
             <intent-filter>
                 <data
                     android:host="wordpress.com"
@@ -513,7 +517,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
             </intent-filter>
-        </activity>
+        </activity-alias>
         <activity
             android:name=".ui.reader.ReaderCommentListActivity"
             android:label="@string/reader_title_comments"

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -115,6 +115,7 @@ import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.UploadWorker;
 import org.wordpress.android.util.UploadWorkerKt;
 import org.wordpress.android.util.VolleyUtils;
+import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.config.AppConfig;
 import org.wordpress.android.util.image.ImageManager;
@@ -928,6 +929,9 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
             properties.putAll(mReaderTracker.getAnalyticsData());
 
             mReaderTracker.onAppGoesToBackground();
+
+            // Ensure that the deeplinking activity is re-enabled.
+            WPActivityUtils.enableReaderDeeplinks(getContext());
 
             AnalyticsTracker.track(AnalyticsTracker.Stat.APPLICATION_CLOSED, properties);
             AnalyticsTracker.endSession(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -68,7 +68,6 @@ import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
 import org.wordpress.android.ui.prefs.MyProfileActivity;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsActivity;
 import org.wordpress.android.ui.publicize.PublicizeListActivity;
-import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
 import org.wordpress.android.ui.sitecreation.SiteCreationActivity;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
 import org.wordpress.android.ui.stats.StatsConstants;
@@ -1087,8 +1086,9 @@ public class ActivityLauncher {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
         try {
-            // disable deeplinking activity so to not catch WP URLs
-            WPActivityUtils.disableComponent(context, ReaderPostPagerActivity.class);
+            // Disable deeplinking activity so to not catch WP URLs.
+            // We'll re-enable them later - see callers of WPActivityUtils#enableReaderDeeplinks.
+            WPActivityUtils.disableReaderDeeplinks(context);
 
             context.startActivity(intent);
         } catch (ActivityNotFoundException e) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1106,9 +1106,6 @@ public class ActivityLauncher {
                 Intent chooser = Intent.createChooser(intent, context.getString(R.string.error_please_choose_browser));
                 context.startActivity(chooser);
             }
-        } finally {
-            // re-enable deeplinking
-            WPActivityUtils.enableComponent(context, ReaderPostPagerActivity.class);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -102,7 +102,6 @@ import org.wordpress.android.ui.prefs.AppSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsFragment;
 import org.wordpress.android.ui.quickstart.QuickStartEvent;
 import org.wordpress.android.ui.reader.ReaderFragment;
-import org.wordpress.android.ui.reader.ReaderPostPagerActivity;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.ui.reader.tracker.ReaderTracker;
@@ -328,7 +327,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         }
 
         // ensure the deep linking activity is enabled. It may have been disabled elsewhere and failed to get re-enabled
-        WPActivityUtils.enableComponent(this, ReaderPostPagerActivity.class);
+        WPActivityUtils.enableReaderDeeplinks(this);
 
         // monitor whether we're not the default app
         trackDefaultApp();
@@ -776,7 +775,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         // ensure the deep linking activity is enabled. We might be returning from the external-browser
         // viewing of a post
-        WPActivityUtils.enableComponent(this, ReaderPostPagerActivity.class);
+        WPActivityUtils.enableReaderDeeplinks(this);
 
         // We need to track the current item on the screen when this activity is resumed.
         // Ex: Notifications -> notifications detail -> back to notifications

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -26,6 +26,8 @@ import org.wordpress.android.util.AppLog.T;
 import java.util.List;
 
 public class WPActivityUtils {
+    public static final String READER_DEEPLINK_ACTIVITY_ALIAS = "org.wordpress.android.WPComPostReaderActivity";
+
     // Hack! PreferenceScreens don't show the toolbar, so we'll manually add one
     // See: http://stackoverflow.com/a/27455363/309558
 
@@ -151,15 +153,15 @@ public class WPActivityUtils {
         context.startActivity(intent);
     }
 
-    public static void disableComponent(Context context, Class<?> klass) {
+    public static void disableReaderDeeplinks(Context context) {
         PackageManager pm = context.getPackageManager();
-        pm.setComponentEnabledSetting(new ComponentName(context, klass),
+        pm.setComponentEnabledSetting(new ComponentName(context, READER_DEEPLINK_ACTIVITY_ALIAS),
                 PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
     }
 
-    public static void enableComponent(Context context, Class<?> klass) {
+    public static void enableReaderDeeplinks(Context context) {
         PackageManager pm = context.getPackageManager();
-        pm.setComponentEnabledSetting(new ComponentName(context, klass),
+        pm.setComponentEnabledSetting(new ComponentName(context, READER_DEEPLINK_ACTIVITY_ALIAS),
                 PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP);
     }
 }


### PR DESCRIPTION
Fixes #13010. Adjusts the way we disable/re-enable the Reader deeplink activity when opening an external URL so that it works correctly on all devices.

Relies on #13002 since that's where the issue was noticed, but I didn't want to bury this deep change in an apparently unrelated PR. That one should be mergable independent of this fix.

The first step to address the issue was to remove the re-enabling logic from [this `finally` block](https://github.com/wordpress-mobile/WordPress-Android/compare/feature/stories-reader-detail...issue/13010-fix-reader-deeplink-registration?expand=1#diff-cb472478231b297b0399fbbe2bde9f32L1111), which it seems is too soon for some devices, and we end up with the deeplink activity being re-enabled before the intent is handled and appearing when it was supposed to be removed. (My best guess is that this has been happening for a while and we just didn't notice, and/or that perhaps behavior changed in recent Android API levels so that `startActivity` unblocks the main thread earlier than before.)

However, this introduced a different issue: as soon as the chooser menu was shown, the app would close. This is because the `pm.setComponentEnabledSetting()` with `COMPONENT_ENABLED_STATE_DISABLED` call causes the system to close the activity in question (`ReaderPostPagerActivity`) in some cases. If the external URL was opened from the reader detail view, that's actually the current activity, and the app closes.

```
I/WindowManager:   Force finishing activity ActivityRecord{ea34428 u0 org.wordpress.android.beta/org.wordpress.android.ui.reader.ReaderPostPagerActivity t28021}
I/WindowManager:   Force finishing activity ActivityRecord{fadbc24 u0 org.wordpress.android.beta/org.wordpress.android.ui.main.WPMainActivity t28021}
```

You may be able to confirm this by checking out fb58104.

To address this, I moved the `intent-filter` rules for `ReaderPostPagerActivity` to an [activity-alias](https://developer.android.com/guide/topics/manifest/activity-alias-element). That way we enable/disable the alias activity for deeplinking instead, and the system never tries to force finish the real `ReaderPostPagerActivity`.

Finally, I also added a new call to re-enable deeplinking, when the app is backgrounded (we already do this when `WPMainActivity` is created or resumed). This should replace the work the `finally` block was doing, ensuring that deeplinks are re-enabled as the user leaves the app. This way links visited outside the app can still be picked up by the WordPress app and open the Reader, as before.

### To test:

Note that if you have multiple different builds of the WordPress app installed, the other builds will always show - that's expected and not something a regular user will experience.

1. Visit an external link from the Reader (the globe icon in the action bar in detail view works, but also check a Story block on WordPress.com).
2. Confirm that there is either no chooser screen (if you only have one browser installed), or that if there is a chooser the WordPress app isn't an option
3. Dismiss the chooser, visit another link, confirm the same behavior
4. Choose to open a link in the browser
5. Without returning to the app, visit a blog post link on a WordPress.com site
6. Confirm that the chooser appears, allowing you to open the post in the Reader

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.