### PR TITLE
Bump default LoginFlow's FluxC version

### DIFF
--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -64,7 +64,7 @@ dependencies {
             exclude group: "org.wordpress", module: "utils"
         }
     } else {
-        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1.5.1-beta-4") {
+        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1.6.22") {
             exclude group: "com.android.support"
             exclude group: "org.wordpress", module: "utils"
         }


### PR DESCRIPTION
This PR updates the default FluxC version used by the LoginFlow library to be the same one used by WPAndroid (`1.5.1-beta-4` → `1.6.22`). This shouldn't affect the behavior of WPAndroid as it was already using that version, but it should allow for the LoginFlow library to correctly build when being used independently from WPAndroid.

Currently, this is only affecting this LoginFlow PR: wordpress-mobile/WordPress-Login-Flow-Android/pull/45 — after this gets merged, I plan to add it into that PR so it can correctly build and pass CI tests.

To test:

Not much to test here, other than making sure I'm not missing anything.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.