### PR TITLE
Fixed about activity color

### DIFF
--- a/WordPress/src/main/res/layout/about_activity.xml
+++ b/WordPress/src/main/res/layout/about_activity.xml
@@ -4,7 +4,7 @@
     android:id="@+id/main_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/wpColorAppBar"
+    android:background="?attr/colorPrimarySurface"
     android:fillViewport="true">
 
     <com.google.android.material.appbar.AppBarLayout
@@ -12,7 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fitsSystemWindows="true"
-        android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+        android:background="?attr/colorPrimarySurface"
         app:elevation="0dp">
 
         <com.google.android.material.appbar.MaterialToolbar

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -155,7 +155,12 @@
 
     <style name="WordPress.NoActionBar.DarkNavbar" parent="WordPress.NoActionBar">
         <item name="android:windowLightNavigationBar">false</item>
-        <item name="android:navigationBarColor">?attr/wpColorAppBar</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:statusBarColor">?attr/colorPrimarySurface</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="toolbarNavigationButtonStyle">
+            @style/Widget.AppCompat.Toolbar.Button.Navigation
+        </item>
     </style>
 
     <style name="WordPress.FloatingActionButton" parent="Widget.MaterialComponents.FloatingActionButton">


### PR DESCRIPTION
This PR fixes the colors at About activity. 

About screen used appbar colors, and since they changed in a recent update, it became unusable (see the first image).


[![Image from Gyazo](https://i.gyazo.com/ad75c161b4724810cbde62e33d6fd2ad.png)](https://gyazo.com/ad75c161b4724810cbde62e33d6fd2ad)

To test:
- Navigate to About activity (tap "WordPress for Android" in App Settings)
- Make sure the screen looks like on the screenshots in both light and dark modes.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
