### PR TITLE
Issue/12767 instagram embed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.reader.views;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Color;
+import android.os.Handler;
+import android.os.Message;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
@@ -25,6 +27,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -189,6 +192,38 @@ public class ReaderWebView extends WPWebView {
         }
     }
 
+    /***
+     * isValidInstagramImageClick checks if this is an embedded instragram situation.
+     * If so, we want to ignore image click so that the iframe src gets handled
+     * The additional URL grab is an additional check for the instagram.com host
+     * @param hr - the HitTestResult
+     * @return true if is instagram or false otherwise
+     */
+    private boolean isValidInstagramImageClick(HitTestResult hr) {
+        if (!Objects.requireNonNull(hr.getExtra()).contains("cdninstagram")) {
+            return false;
+        }
+
+        // Referenced https://pacheco.dev/posts/android/webview-image-anchor/
+        if (hr.getType() == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE) {
+            Handler handler = new Handler();
+            Message message = handler.obtainMessage();
+
+            this.requestFocusNodeHref(message);
+            String url = message.getData().getString("url");
+            if (url == null) {
+                return false;
+            }
+
+            if (!UrlUtils.getHost(url).equalsIgnoreCase("www.instagram.com")) {
+                return false;
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     /*
      * detect when a link is tapped
      */
@@ -200,11 +235,15 @@ public class ReaderWebView extends WPWebView {
             if (hr != null) {
                 if (isValidClickedUrl(hr.getExtra())) {
                     if (UrlUtils.isImageUrl(hr.getExtra())) {
-                        return mUrlClickListener.onImageUrlClick(
-                                hr.getExtra(),
-                                this,
-                                (int) event.getX(),
-                                (int) event.getY());
+                        if (isValidInstagramImageClick(hr)) {
+                            return super.onTouchEvent(event);
+                        } else {
+                            return mUrlClickListener.onImageUrlClick(
+                                    hr.getExtra(),
+                                    this,
+                                    (int) event.getX(),
+                                    (int) event.getY());
+                        }
                     } else {
                         return mUrlClickListener.onUrlClick(hr.getExtra());
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -200,10 +199,6 @@ public class ReaderWebView extends WPWebView {
      * @return true if is instagram or false otherwise
      */
     private boolean isValidInstagramImageClick(HitTestResult hr) {
-        if (!Objects.requireNonNull(hr.getExtra()).contains("cdninstagram")) {
-            return false;
-        }
-
         // Referenced https://pacheco.dev/posts/android/webview-image-anchor/
         if (hr.getType() == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE) {
             Handler handler = new Handler();
@@ -215,7 +210,7 @@ public class ReaderWebView extends WPWebView {
                 return false;
             }
 
-            return UrlUtils.getHost(url).equalsIgnoreCase("www.instagram.com");
+            return url.contains("ig_embed");
         } else {
             return false;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -215,10 +215,7 @@ public class ReaderWebView extends WPWebView {
                 return false;
             }
 
-            if (!UrlUtils.getHost(url).equalsIgnoreCase("www.instagram.com")) {
-                return false;
-            }
-            return true;
+            return UrlUtils.getHost(url).equalsIgnoreCase("www.instagram.com");
         } else {
             return false;
         }


### PR DESCRIPTION
Fixes #12767 

This PR introduces custom logic for handling "instagram" image clicks within a iframe within a webview.

What happens is the onTouchEvent is captured and since it's a valid image url, we reroute the image click to our internal photo viewer. The correct behavior should not show the image, but let the webview handle the iframe src click. We do this by intercepting the instagram image click (verifying instagram) and then let the request continue with a `super.onTouchEvent(event)`.

My first attempt was to check for _cdninstagram_ in the image src and host _www.instagram.com_ as the url host, but after writing this synopsis I decided to go with a check for `ig_embed` instead. This _should_ protect us from instagram changing host or cdn naming. We are now relying on our backend to provide identification that this is an instagram embed. I am also open to suggestions, so fire away. Thanks.
 
To test:
1. Launch the App
2. Open the Reader tab and locate a post that contains an Instagram embed block
3. Tap on the post to open it and notice the Instagram post renders onscreen
4. Tap on the Instagram embed (either the picture or the surrounding instagram context)
5. Notice that the Instagram post is opened in a web view to allow the user to see the post on Instagram

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
