### PR TITLE
Login: Add test case for the passwordless login flow

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_USERNAME;
+import static org.wordpress.android.BuildConfig.E2E_WP_COM_PASSWORDLESS_USER_EMAIL;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_SITE_ADDRESS;
@@ -35,6 +36,14 @@ public class LoginTests extends BaseTest {
         new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword(E2E_WP_COM_USER_PASSWORD)
+                       .confirmLogin();
+    }
+
+    @Test
+    public void loginWithPasswordlessAccount() {
+        new LoginFlow().chooseContinueWithWpCom()
+                       .enterEmailAddress(E2E_WP_COM_PASSWORDLESS_USER_EMAIL)
+                       .openMagicLink(mMagicLinkActivityTestRule)
                        .confirmLogin();
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -16,6 +16,7 @@ import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_USERNAME;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
+import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_SITE_ADDRESS;
 
 @RunWith(AndroidJUnit4.class)
@@ -33,7 +34,7 @@ public class LoginTests extends BaseTest {
     public void loginWithEmailPassword() {
         new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
-                       .enterPassword()
+                       .enterPassword(E2E_WP_COM_USER_PASSWORD)
                        .confirmLogin();
     }
 
@@ -42,7 +43,7 @@ public class LoginTests extends BaseTest {
         new LoginFlow().chooseEnterYourSiteAddress()
                        .enterSiteAddress(E2E_WP_COM_USER_SITE_ADDRESS)
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
-                       .enterPassword()
+                       .enterPassword(E2E_WP_COM_USER_PASSWORD)
                        .confirmLogin();
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.java
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_USERNAME;
+import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_SITE_ADDRESS;
 
 @RunWith(AndroidJUnit4.class)
@@ -31,7 +32,7 @@ public class LoginTests extends BaseTest {
     @Test
     public void loginWithEmailPassword() {
         new LoginFlow().chooseContinueWithWpCom()
-                       .enterEmailAddress()
+                       .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword()
                        .confirmLogin();
     }
@@ -40,7 +41,7 @@ public class LoginTests extends BaseTest {
     public void loginWithSiteAddress() {
         new LoginFlow().chooseEnterYourSiteAddress()
                        .enterSiteAddress(E2E_WP_COM_USER_SITE_ADDRESS)
-                       .enterEmailAddress()
+                       .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword()
                        .confirmLogin();
     }
@@ -48,7 +49,7 @@ public class LoginTests extends BaseTest {
     @Test
     public void loginWithMagicLink() {
         new LoginFlow().chooseContinueWithWpCom()
-                       .enterEmailAddress()
+                       .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .chooseMagicLink()
                        .openMagicLink(mMagicLinkActivityTestRule)
                        .confirmLogin();

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -41,13 +41,6 @@ public class LoginFlow {
         return this;
     }
 
-    public LoginFlow choosePassword() {
-        // Magic Link Request or Magic Link Sent Screen – Choose "Or type your password"
-        // See LoginMagicLinkRequestFragment or LoginMagicLinkSentFragment
-        clickOn(R.id.login_enter_password);
-        return this;
-    }
-
     public LoginFlow enterPassword() {
         // Password Screen – Fill it in and click "Continue"
         // See LoginEmailPasswordFragment

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -17,7 +17,6 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.CoreMatchers.allOf;
-import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_USERNAME;
 import static org.wordpress.android.support.WPSupportUtils.atLeastOneElementWithIdIsDisplayed;
@@ -33,10 +32,10 @@ public class LoginFlow {
         return this;
     }
 
-    public LoginFlow enterEmailAddress() {
+    public LoginFlow enterEmailAddress(String emailAddress) {
         // Email Address Screen – Fill it in and click "Continue"
         // See LoginEmailFragment
-        populateTextField(R.id.input, E2E_WP_COM_USER_EMAIL);
+        populateTextField(R.id.input, emailAddress);
         clickOn(R.id.login_continue_button);
         return this;
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.java
@@ -40,10 +40,10 @@ public class LoginFlow {
         return this;
     }
 
-    public LoginFlow enterPassword() {
+    public LoginFlow enterPassword(String password) {
         // Password Screen – Fill it in and click "Continue"
         // See LoginEmailPasswordFragment
-        populateTextField(R.id.input, E2E_WP_COM_USER_PASSWORD);
+        populateTextField(R.id.input, password);
         clickOn(R.id.primary_button);
         return this;
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -38,6 +38,7 @@ import java.util.TimeZone;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
+import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
 import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 
 public class BaseTest {
@@ -99,7 +100,7 @@ public class BaseTest {
         logoutIfNecessary();
         new LoginFlow().chooseContinueWithWpCom()
                        .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
-                       .enterPassword()
+                       .enterPassword(E2E_WP_COM_USER_PASSWORD)
                        .confirmLogin();
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -37,6 +37,7 @@ import java.util.TimeZone;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRESS;
+import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
 import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 
 public class BaseTest {
@@ -97,7 +98,7 @@ public class BaseTest {
     protected void wpLogin() {
         logoutIfNecessary();
         new LoginFlow().chooseContinueWithWpCom()
-                       .enterEmailAddress()
+                       .enterEmailAddress(E2E_WP_COM_USER_EMAIL)
                        .enterPassword()
                        .confirmLogin();
     }

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -41,6 +41,7 @@ wp.e2e.wp_com_user.email=e2eflowtestingmobile@example.com
 wp.e2e.wp_com_user.password=mocked_password
 wp.e2e.wp_com_user.site_address=e2eflowtestingmobile.wordpress.com
 wp.e2e.wp_com_user.username=e2eflowtestingmobile
+wp.e2e.wp_com_passwordless_user.email=e2eflowtestingmobile+passwordless@example.com
 wp.e2e.self_hosted_user.username=e2eflowtestingmobile
 wp.e2e.self_hosted_user.password=mocked_password
 wp.e2e.self_hosted_user.site_address=127.0.0.1:8080

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/auth-options_passwordless_user.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/auth/auth-options_passwordless_user.json
@@ -1,0 +1,17 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPattern": "/rest/v1.1/users/e2eflowtestingmobile\\+passwordless@example.com/auth-options.*"
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "passwordless": true,
+            "email_verified": true
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}


### PR DESCRIPTION
This PR complements the changes introduced in #12893 by adding a test case for the passwordless login flow.

To test:

Run the connected tests on CI and make sure everything passes.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
