### PR TITLE
Alleviate time taken to populate media list in media picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -79,6 +79,7 @@ import org.wordpress.android.ui.people.PersonDetailFragment;
 import org.wordpress.android.ui.people.RoleChangeDialogFragment;
 import org.wordpress.android.ui.people.RoleSelectDialogFragment;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
+import org.wordpress.android.ui.photopicker.PhotoPickerAdapter;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment;
 import org.wordpress.android.ui.mediapicker.MediaPickerActivity;
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment;

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
@@ -14,7 +14,6 @@ import android.webkit.MimeTypeMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.utils.MediaUtils
 import org.wordpress.android.fluxc.utils.MimeTypes
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mediapicker.MediaSource.MediaLoadingResult
@@ -108,9 +107,7 @@ class DeviceListBuilder
                         getMimeType(uri),
                         dateModified
                 )
-                if (MediaUtils.isSupportedMimeType(context.contentResolver.getType(uri))) {
-                    result.add(item)
-                }
+                result.add(item)
             }
         } finally {
             SqlUtils.closeCursor(cursor)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/FileThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/FileThumbnailViewHolder.kt
@@ -13,6 +13,7 @@ class FileThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailViewU
     private val fileType: TextView = itemView.findViewById(R.id.media_item_filetype)
     private val fileName: TextView = itemView.findViewById(R.id.media_item_name)
     private val txtSelectionCount: TextView = itemView.findViewById(R.id.text_selection_count)
+    private val disabledView: View = itemView.findViewById(R.id.media_item_disabled_overlay)
 
     fun bind(item: MediaPickerUiItem.FileItem, animateSelection: Boolean, updateCount: Boolean) {
         val isSelected = item.isSelected
@@ -30,11 +31,13 @@ class FileThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailViewU
         mediaThumbnailViewUtils.setupFileImageView(
                 container,
                 imgThumbnail,
+                disabledView,
                 item.fileName,
                 item.isSelected,
                 item.clickAction,
                 item.toggleAction,
-                animateSelection
+                animateSelection,
+                item.mimeTypeNotSupported
         )
         fileType.text = item.fileExtension
         fileName.text = item.fileName

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerUiItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerUiItem.kt
@@ -12,6 +12,7 @@ sealed class MediaPickerUiItem(
 ) {
     data class PhotoItem(
         val uri: UriWrapper? = null,
+        val mimeTypeNotSupported: Boolean = false,
         val isSelected: Boolean = false,
         val selectedOrder: Int? = null,
         val showOrderCounter: Boolean = false,
@@ -21,6 +22,7 @@ sealed class MediaPickerUiItem(
 
     data class VideoItem(
         val uri: UriWrapper? = null,
+        val mimeTypeNotSupported: Boolean = false,
         val isSelected: Boolean = false,
         val selectedOrder: Int? = null,
         val showOrderCounter: Boolean = false,
@@ -30,6 +32,7 @@ sealed class MediaPickerUiItem(
 
     data class FileItem(
         val uri: UriWrapper? = null,
+        val mimeTypeNotSupported: Boolean = false,
         val fileName: String,
         val fileExtension: String? = null,
         val isSelected: Boolean = false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -151,6 +151,7 @@ class MediaPickerViewModel @Inject constructor(
                 when (it.type) {
                     IMAGE -> PhotoItem(
                             uri = it.uri,
+                            mimeTypeNotSupported = mediaUtilsWrapper.isSupportedMimeType(it.uri.uri),
                             isSelected = isSelected,
                             selectedOrder = selectedOrder,
                             showOrderCounter = showOrderCounter,
@@ -159,6 +160,7 @@ class MediaPickerViewModel @Inject constructor(
                     )
                     VIDEO -> VideoItem(
                             uri = it.uri,
+                            mimeTypeNotSupported = mediaUtilsWrapper.isSupportedMimeType(it.uri.uri),
                             isSelected = isSelected,
                             selectedOrder = selectedOrder,
                             showOrderCounter = showOrderCounter,
@@ -167,6 +169,7 @@ class MediaPickerViewModel @Inject constructor(
                     )
                     AUDIO, DOCUMENT -> FileItem(
                             uri = it.uri,
+                            mimeTypeNotSupported = mediaUtilsWrapper.isSupportedMimeType(it.uri.uri),
                             fileName = it.name ?: "",
                             fileExtension = fileExtension,
                             isSelected = isSelected,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaThumbnailViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaThumbnailViewUtils.kt
@@ -22,11 +22,13 @@ import java.util.Locale
 class MediaThumbnailViewUtils(val imageManager: ImageManager) {
     fun setupThumbnailImage(
         imgThumbnail: ImageView,
+        disabledView: View,
         url: String,
         isSelected: Boolean,
         clickAction: ClickAction,
         toggleAction: ToggleAction,
-        animateSelection: Boolean
+        animateSelection: Boolean,
+        mimeTypeNotSupported: Boolean
     ) {
         imageManager.cancelRequestAndClearImageView(imgThumbnail)
         imageManager.load(
@@ -35,30 +37,37 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
                 url,
                 FIT_CENTER
         )
-        addImageSelectedToAccessibilityFocusedEvent(imgThumbnail, isSelected)
-        imgThumbnail.setOnClickListener {
-            toggleAction.toggle()
-            PhotoPickerUtils.announceSelectedImageForAccessibility(
-                    imgThumbnail,
-                    isSelected
-            )
+        if (mimeTypeNotSupported) {
+            disabledView.visibility = View.VISIBLE
+        } else {
+            disabledView.visibility = View.GONE
+            addImageSelectedToAccessibilityFocusedEvent(imgThumbnail, isSelected)
+            imgThumbnail.setOnClickListener {
+                toggleAction.toggle()
+                PhotoPickerUtils.announceSelectedImageForAccessibility(
+                        imgThumbnail,
+                        isSelected
+                )
+            }
+            imgThumbnail.setOnLongClickListener {
+                clickAction.click()
+                true
+            }
+            imgThumbnail.redirectContextClickToLongPressListener()
+            displaySelection(animateSelection, isSelected, imgThumbnail)
         }
-        imgThumbnail.setOnLongClickListener {
-            clickAction.click()
-            true
-        }
-        imgThumbnail.redirectContextClickToLongPressListener()
-        displaySelection(animateSelection, isSelected, imgThumbnail)
     }
 
     fun setupFileImageView(
         container: View,
         imgThumbnail: ImageView,
+        disabledView: View,
         fileName: String,
         isSelected: Boolean,
         clickAction: ClickAction,
         toggleAction: ToggleAction,
-        animateSelection: Boolean
+        animateSelection: Boolean,
+        mimeTypeNotSupported: Boolean
     ) {
         imageManager.cancelRequestAndClearImageView(imgThumbnail)
 
@@ -69,20 +78,25 @@ class MediaThumbnailViewUtils(val imageManager: ImageManager) {
                 R.color.neutral_30
         )
 
-        addImageSelectedToAccessibilityFocusedEvent(imgThumbnail, isSelected)
-        container.setOnClickListener {
-            toggleAction.toggle()
-            PhotoPickerUtils.announceSelectedImageForAccessibility(
-                    imgThumbnail,
-                    isSelected
-            )
+        if (mimeTypeNotSupported) {
+            disabledView.visibility = View.VISIBLE
+        } else {
+            disabledView.visibility = View.GONE
+            addImageSelectedToAccessibilityFocusedEvent(imgThumbnail, isSelected)
+            container.setOnClickListener {
+                toggleAction.toggle()
+                PhotoPickerUtils.announceSelectedImageForAccessibility(
+                        imgThumbnail,
+                        isSelected
+                )
+            }
+            container.setOnLongClickListener {
+                clickAction.click()
+                true
+            }
+            container.redirectContextClickToLongPressListener()
+            displaySelection(animateSelection, isSelected, container)
         }
-        container.setOnLongClickListener {
-            clickAction.click()
-            true
-        }
-        container.redirectContextClickToLongPressListener()
-        displaySelection(animateSelection, isSelected, container)
     }
 
     private fun addImageSelectedToAccessibilityFocusedEvent(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/PhotoThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/PhotoThumbnailViewHolder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mediapicker
 
+import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
@@ -12,6 +13,7 @@ class PhotoThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailView
         ThumbnailViewHolder(parent, R.layout.media_picker_thumbnail_item) {
     private val imgThumbnail: ImageView = itemView.findViewById(R.id.image_thumbnail)
     private val txtSelectionCount: TextView = itemView.findViewById(R.id.text_selection_count)
+    private val disabledView: View = itemView.findViewById(R.id.media_item_disabled_overlay)
 
     fun bind(item: MediaPickerUiItem.PhotoItem, animateSelection: Boolean, updateCount: Boolean) {
         val isSelected = item.isSelected
@@ -28,11 +30,13 @@ class PhotoThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailView
         }
         mediaThumbnailViewUtils.setupThumbnailImage(
                 imgThumbnail,
+                disabledView,
                 item.uri.toString(),
                 item.isSelected,
                 item.clickAction,
                 item.toggleAction,
-                animateSelection
+                animateSelection,
+                item.mimeTypeNotSupported
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/VideoThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/VideoThumbnailViewHolder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mediapicker
 
+import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
@@ -17,6 +18,7 @@ class VideoThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailView
     private val imgThumbnail: ImageView = itemView.findViewById(id.image_thumbnail)
     private val txtSelectionCount: TextView = itemView.findViewById(id.text_selection_count)
     private val videoOverlay: ImageView = itemView.findViewById(id.image_video_overlay)
+    private val disabledView: View = itemView.findViewById(R.id.media_item_disabled_overlay)
 
     fun bind(item: MediaPickerUiItem.VideoItem, animateSelection: Boolean, updateCount: Boolean) {
         val isSelected = item.isSelected
@@ -33,11 +35,13 @@ class VideoThumbnailViewHolder(parent: ViewGroup, private val mediaThumbnailView
         }
         mediaThumbnailViewUtils.setupThumbnailImage(
                 imgThumbnail,
+                disabledView,
                 item.uri.toString(),
                 item.isSelected,
                 item.clickAction,
                 item.toggleAction,
-                animateSelection
+                animateSelection,
+                item.mimeTypeNotSupported
         )
         mediaThumbnailViewUtils.setupVideoOverlay(videoOverlay, item.clickAction)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/DeviceMediaListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/DeviceMediaListBuilder.kt
@@ -7,7 +7,6 @@ import android.provider.MediaStore.Images.Media
 import android.provider.MediaStore.Video
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.utils.MediaUtils
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.util.AppLog
@@ -71,9 +70,7 @@ class DeviceMediaListBuilder
                         UriWrapper(completeUri),
                         isVideo
                 )
-                if (MediaUtils.isSupportedMimeType(context.contentResolver.getType(completeUri))) {
-                    result.add(item)
-                }
+                result.add(item)
             }
         } finally {
             SqlUtils.closeCursor(cursor)

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.kt
@@ -8,11 +8,15 @@ import org.wordpress.android.ui.photopicker.PhotoPickerAdapterDiffCallback.Paylo
 import org.wordpress.android.ui.photopicker.PhotoPickerUiItem.PhotoItem
 import org.wordpress.android.ui.photopicker.PhotoPickerUiItem.Type
 import org.wordpress.android.ui.photopicker.PhotoPickerUiItem.VideoItem
+import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.image.ImageManager
 
 @Deprecated("This class is being refactored, if you implement any change, please also update " +
         "{@link org.wordpress.android.ui.mediapicker.MedaPickerAdapter}")
-class PhotoPickerAdapter internal constructor(private val imageManager: ImageManager) : Adapter<ThumbnailViewHolder>() {
+class PhotoPickerAdapter internal constructor(
+    private val imageManager: ImageManager,
+    private val mediaUtilsWrapper: MediaUtilsWrapper
+) : Adapter<ThumbnailViewHolder>() {
     private val thumbnailViewUtils = ThumbnailViewUtils(imageManager)
     private var mediaList = listOf<PhotoPickerUiItem>()
 
@@ -64,6 +68,9 @@ class PhotoPickerAdapter internal constructor(private val imageManager: ImageMan
                 updateCount = true
             }
         }
+        item.mimeTypeNotSupported = item.uri?.let {
+            mediaUtilsWrapper.isSupportedMimeType(it.uri)
+        } ?: false
         when (item) {
             is PhotoItem -> (holder as PhotoThumbnailViewHolder).bind(item, animateSelection, updateCount)
             is VideoItem -> (holder as VideoThumbnailViewHolder).bind(item, animateSelection, updateCount)

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.util.AniUtils.Duration.MEDIUM
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.POSTS
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.ViewWrapper
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.WPPermissionUtils
@@ -80,6 +81,7 @@ class PhotoPickerFragment : Fragment() {
     @Inject lateinit var tenorFeatureConfig: TenorFeatureConfig
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var mediaUtilsWrapper: MediaUtilsWrapper
     private lateinit var viewModel: PhotoPickerViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -226,7 +228,8 @@ class PhotoPickerFragment : Fragment() {
         if (uiModel is PhotoListUiModel.Data) {
             if (recycler.adapter == null) {
                 recycler.adapter = PhotoPickerAdapter(
-                        imageManager
+                        imageManager,
+                        mediaUtilsWrapper
                 )
             }
             val adapter = recycler.adapter as PhotoPickerAdapter

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerUiItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerUiItem.kt
@@ -10,6 +10,7 @@ sealed class PhotoPickerUiItem(
     val type: Type,
     open val id: Long,
     open val uri: UriWrapper? = null,
+    open var mimeTypeNotSupported: Boolean = false,
     open val isSelected: Boolean = false,
     open val selectedOrder: Int? = null,
     open val showOrderCounter: Boolean = false,
@@ -19,22 +20,26 @@ sealed class PhotoPickerUiItem(
     data class PhotoItem(
         override val id: Long,
         override val uri: UriWrapper? = null,
+        override var mimeTypeNotSupported: Boolean = false,
         override val isSelected: Boolean = false,
         override val selectedOrder: Int? = null,
         override val showOrderCounter: Boolean = false,
         override val toggleAction: ToggleAction,
         override val clickAction: ClickAction
-    ) : PhotoPickerUiItem(PHOTO, id, uri, isSelected, selectedOrder, showOrderCounter, toggleAction, clickAction)
+    ) : PhotoPickerUiItem(PHOTO, id, uri, mimeTypeNotSupported, isSelected, selectedOrder, showOrderCounter,
+            toggleAction, clickAction)
 
     data class VideoItem(
         override val id: Long,
         override val uri: UriWrapper? = null,
+        override var mimeTypeNotSupported: Boolean = false,
         override val isSelected: Boolean = false,
         override val selectedOrder: Int? = null,
         override val showOrderCounter: Boolean = false,
         override val toggleAction: ToggleAction,
         override val clickAction: ClickAction
-    ) : PhotoPickerUiItem(VIDEO, id, uri, isSelected, selectedOrder, showOrderCounter, toggleAction, clickAction)
+    ) : PhotoPickerUiItem(VIDEO, id, uri, mimeTypeNotSupported, isSelected, selectedOrder, showOrderCounter,
+            toggleAction, clickAction)
 
     data class ToggleAction(
         val id: Long,

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoThumbnailViewHolder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.photopicker
 
+import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
@@ -15,6 +16,7 @@ class PhotoThumbnailViewHolder(parent: ViewGroup, private val thumbnailViewUtils
         ThumbnailViewHolder(parent, R.layout.photo_picker_thumbnail) {
     private val imgThumbnail: ImageView = itemView.findViewById(R.id.image_thumbnail)
     private val txtSelectionCount: TextView = itemView.findViewById(R.id.text_selection_count)
+    private val disabledView: View = itemView.findViewById(R.id.media_item_disabled_overlay)
 
     fun bind(item: PhotoPickerUiItem.PhotoItem, animateSelection: Boolean, updateCount: Boolean) {
         val isSelected = item.isSelected
@@ -31,11 +33,13 @@ class PhotoThumbnailViewHolder(parent: ViewGroup, private val thumbnailViewUtils
         }
         thumbnailViewUtils.setupThumbnailImage(
                 imgThumbnail,
+                disabledView,
                 item.uri.toString(),
                 item.isSelected,
                 item.clickAction,
                 item.toggleAction,
-                animateSelection
+                animateSelection,
+                item.mimeTypeNotSupported
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/ThumbnailViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/ThumbnailViewUtils.kt
@@ -24,11 +24,13 @@ import java.util.Locale
 class ThumbnailViewUtils(val imageManager: ImageManager) {
     fun setupThumbnailImage(
         imgThumbnail: ImageView,
+        disabledView: View,
         url: String,
         isSelected: Boolean,
         clickAction: ClickAction,
         toggleAction: ToggleAction,
-        animateSelection: Boolean
+        animateSelection: Boolean,
+        mimeTypeNotSupported: Boolean
     ) {
         imageManager.cancelRequestAndClearImageView(imgThumbnail)
         imageManager.load(
@@ -37,20 +39,25 @@ class ThumbnailViewUtils(val imageManager: ImageManager) {
                 url,
                 FIT_CENTER
         )
-        addImageSelectedToAccessibilityFocusedEvent(imgThumbnail, isSelected)
-        imgThumbnail.setOnClickListener {
-            toggleAction.toggle()
-            PhotoPickerUtils.announceSelectedImageForAccessibility(
-                    imgThumbnail,
-                    isSelected
-            )
+        if (mimeTypeNotSupported) {
+            disabledView.visibility = View.VISIBLE
+        } else {
+            disabledView.visibility = View.GONE
+            addImageSelectedToAccessibilityFocusedEvent(imgThumbnail, isSelected)
+            imgThumbnail.setOnClickListener {
+                toggleAction.toggle()
+                PhotoPickerUtils.announceSelectedImageForAccessibility(
+                        imgThumbnail,
+                        isSelected
+                )
+            }
+            imgThumbnail.setOnLongClickListener {
+                clickAction.click()
+                true
+            }
+            imgThumbnail.redirectContextClickToLongPressListener()
+            displaySelection(animateSelection, isSelected, imgThumbnail)
         }
-        imgThumbnail.setOnLongClickListener {
-            clickAction.click()
-            true
-        }
-        imgThumbnail.redirectContextClickToLongPressListener()
-        displaySelection(animateSelection, isSelected, imgThumbnail)
     }
 
     private fun addImageSelectedToAccessibilityFocusedEvent(

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/VideoThumbnailViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/VideoThumbnailViewHolder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.photopicker
 
+import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
@@ -20,6 +21,7 @@ class VideoThumbnailViewHolder(parent: ViewGroup, private val thumbnailViewUtils
     private val imgThumbnail: ImageView = itemView.findViewById(id.image_thumbnail)
     private val txtSelectionCount: TextView = itemView.findViewById(id.text_selection_count)
     private val videoOverlay: ImageView = itemView.findViewById(id.image_video_overlay)
+    private val disabledView: View = itemView.findViewById(R.id.media_item_disabled_overlay)
 
     fun bind(item: PhotoPickerUiItem.VideoItem, animateSelection: Boolean, updateCount: Boolean) {
         val isSelected = item.isSelected
@@ -36,11 +38,13 @@ class VideoThumbnailViewHolder(parent: ViewGroup, private val thumbnailViewUtils
         }
         thumbnailViewUtils.setupThumbnailImage(
                 imgThumbnail,
+                disabledView,
                 item.uri.toString(),
                 item.isSelected,
                 item.clickAction,
                 item.toggleAction,
-                animateSelection
+                animateSelection,
+                item.mimeTypeNotSupported
         )
         thumbnailViewUtils.setupVideoOverlay(videoOverlay, item.clickAction)
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import dagger.Reusable
 import org.wordpress.android.editor.EditorMediaUtils
+import org.wordpress.android.fluxc.utils.MediaUtils.isSupportedMimeType
 import javax.inject.Inject
 
 /**
@@ -49,4 +50,6 @@ class MediaUtilsWrapper @Inject constructor(private val appContext: Context) {
     fun isLocalFile(uploadState: String): Boolean = MediaUtils.isLocalFile(uploadState)
 
     fun getExtensionForMimeType(mimeType: String?): String = MediaUtils.getExtensionForMimeType(mimeType)
+
+    fun isSupportedMimeType(uri: Uri): Boolean = isSupportedMimeType(appContext.contentResolver.getType(uri))
 }

--- a/WordPress/src/main/res/layout/media_picker_file_item.xml
+++ b/WordPress/src/main/res/layout/media_picker_file_item.xml
@@ -60,6 +60,14 @@
 
     </RelativeLayout>
 
+    <View
+        android:id="@+id/media_item_disabled_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:background="@color/black_translucent_40"
+        />
+
     <include layout="@layout/media_picker_selection_count" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/media_picker_thumbnail_item.xml
+++ b/WordPress/src/main/res/layout/media_picker_thumbnail_item.xml
@@ -37,4 +37,12 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
+    <View
+        android:id="@+id/media_item_disabled_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:background="@color/black_translucent_40"
+        />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
+++ b/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
@@ -53,4 +53,12 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
+    <View
+        android:id="@+id/media_item_disabled_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:background="@color/black_translucent_40"
+        />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #12996 

This PR intends to make the time taken by the filter more relaxed by moving the isSupportedMimeType call to the viewHolder bind() method, instead of running through the whole data set at first attempt.

Now instead of directly not showing items that we know are not supported, we paint a "disabled" overlay and remove / avoid setting any click listeners on such items.

To test:
1. open a post, add an image block, tap on ADD IMAGE
2. on the bottom sheet, tap Add media from device
3. observe the media gets populated quicker than before
4. observe the unsupported items have an overlay

Also note / side effect:
- scrolling is not smooth so, leaving this as a draft PR as of  now

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
