### PR TITLE
Removed the `contentResolver.getMimeType - isSupportedMimeType() `  check for populating the picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
@@ -14,7 +14,6 @@ import android.webkit.MimeTypeMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.utils.MediaUtils
 import org.wordpress.android.fluxc.utils.MimeTypes
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mediapicker.MediaSource.MediaLoadingResult
@@ -108,9 +107,7 @@ class DeviceListBuilder
                         getMimeType(uri),
                         dateModified
                 )
-                if (MediaUtils.isSupportedMimeType(context.contentResolver.getType(uri))) {
-                    result.add(item)
-                }
+                result.add(item)
             }
         } finally {
             SqlUtils.closeCursor(cursor)

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/DeviceMediaListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/DeviceMediaListBuilder.kt
@@ -7,7 +7,6 @@ import android.provider.MediaStore.Images.Media
 import android.provider.MediaStore.Video
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.utils.MediaUtils
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.util.AppLog
@@ -71,9 +70,7 @@ class DeviceMediaListBuilder
                         UriWrapper(completeUri),
                         isVideo
                 )
-                if (MediaUtils.isSupportedMimeType(context.contentResolver.getType(completeUri))) {
-                    result.add(item)
-                }
+                result.add(item)
             }
         } finally {
             SqlUtils.closeCursor(cursor)


### PR DESCRIPTION

Fixes #12996 

After discussion and attempting an alternative solution in #13034, this PR effectively unmakes the change introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/12824 with which we wanted to offer users only those media item types that were supported on their WP sites.

To test:
1. create a GB post, add an image block
2. tap on Add Image
3. on the bottom sheet, choose "Choose from device"
4. observe the picker shows up and loads image thumbnails without issues

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
