### PR TITLE
Wrap verse block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -396,9 +396,9 @@ public class ReaderPostRenderer {
               .append(" p { margin-top: ").append(mResourceVars.mMarginMediumPx).append("px;")
               .append(" margin-bottom: ").append(mResourceVars.mMarginMediumPx).append("px; }")
               .append(" p:first-child { margin-top: 0px; }")
-              // add background color, fontsize and padding to pre blocks, and add overflow scrolling
-              // so user can scroll the block if it's wider than the display
-              .append(" pre { overflow-x: scroll;")
+              // add background color, fontsize and padding to pre blocks, and wrap the text
+              // so the user can see full block.
+              .append(" pre { word-wrap: break-word; white-space: pre-wrap; ")
               .append(" background-color: var(--color-neutral-20);")
               .append(" padding: ").append(mResourceVars.mMarginMediumPx).append("px; ")
               .append(" line-height: 1.2em; font-size: 14px; }")


### PR DESCRIPTION
Fixes #13037 

The PR adds styles to the `<pre>` tag which wraps the _verse_ block text so that all is readable. This functionality matches iOS and the mobile preview of calypso.

Before | After
---|---
<img src="https://user-images.githubusercontent.com/506707/94686391-c4183d80-02f8-11eb-9382-4ad010dfe49b.png" width="200" alt="Screenshot">|<img src="https://user-images.githubusercontent.com/506707/94686453-d98d6780-02f8-11eb-88c3-1d53a9b24dfc.png" width="200" alt="Screenshot">

To test:
1. Launch the app
2. Tap Reader
3. Navigate to a post with a verse block
4. Notice that the verse block is wrapped and all the text is readable.

PR submission checklist:


- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
