### PR TITLE
Set the prerelease flag on GitHub release drafts

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -681,7 +681,7 @@ ENV["HAS_ALPHA_VERSION"]="true"
   end
 
   private_lane :create_gh_release do | options |
-    set_prerelease_flag = options["prerelease"].nil? ? false : options["prerelease"]
+    set_prerelease_flag = options[:prerelease].nil? ? false : options[:prerelease]
     version = options[:version]
     apk_file_path = universal_apk_file_path(version)
     aab_file_path = bundle_file_path(version)


### PR DESCRIPTION
This PR fixes an issue where the `pre-release` flag is not set when creating drafts on GitHub. 

To test:
To test it properly, you should set up a beta release. Since the change is just about setting the prerelease flag, you can hack the code to test the change as follow:
1. Make the `create_gh_release` lane public.
2. Change line 689 to `version: version,`.
3. Change line 692 to `release_assets:""`
4. `bundle exec fastlane create_gh_release version:15.99 prerelease:true`. 15.99 can be every version you want.
5. Verify that the lane succeeds.
6. Verify that a release draft has been created on GitHub and that the prerelease flag is set. 
7. Discard the release draft on GitHub. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
