### PR TITLE
Reader Detail Updates (Post Header UI Polishing)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1578,7 +1578,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                 ReaderBlogActions.followBlogById(post.blogId, isAskingToFollow, listener)
             }
             if (result) {
-                followButton.setIsFollowedAnimated(isAskingToFollow)
+                followButton.setIsFollowed(isAskingToFollow)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
@@ -31,11 +31,9 @@ class ReaderFollowButton @JvmOverloads constructor(
     private fun initView(context: Context, attrs: AttributeSet?) {
         // default to showing caption, then read the value from passed attributes
         showCaption = true
-        if (attrs != null) {
+        attrs?.let {
             val array = context.theme.obtainStyledAttributes(attrs, R.styleable.ReaderFollowButton, 0, 0)
-            array?.let {
-                showCaption = array.getBoolean(R.styleable.ReaderFollowButton_wpShowFollowButtonCaption, true)
-            }
+            showCaption = array.getBoolean(R.styleable.ReaderFollowButton_wpShowFollowButtonCaption, true)
         }
         if (!showCaption) {
             hideCaptionAndEnlargeIcon(context)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
@@ -45,6 +45,8 @@ class ReaderFollowButton @JvmOverloads constructor(
     private fun hideCaptionAndEnlargeIcon(context: Context) {
         text = null
         iconSize = context.resources.getDimensionPixelSize(R.dimen.reader_follow_icon_no_caption)
+        iconPadding = context.resources.getDimensionPixelSize(R.dimen.reader_follow_icon_padding_no_caption)
+        iconGravity = ICON_GRAVITY_TEXT_START
     }
 
     private fun updateFollowTextAndIcon() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.kt
@@ -45,6 +45,9 @@ class ReaderPostDetailHeaderView @JvmOverloads constructor(
 
         uiHelpers.setTextOrHide(text_author, uiState.authorName)
         text_by.setVisible(uiState.authorName != null)
+
+        uiHelpers.updateVisibility(post_detail_dot_separator, uiState.dotSeparatorVisibility)
+        uiHelpers.setTextOrHide(post_detail_text_dateline, uiState.dateLine)
     }
 
     private fun updateBlogSection(
@@ -54,10 +57,6 @@ class ReaderPostDetailHeaderView @JvmOverloads constructor(
 
         uiHelpers.setTextOrHide(text_author_and_blog_name, blogSectionUiState.blogName)
         uiHelpers.setTextOrHide(text_blog_url, blogSectionUiState.blogUrl)
-        uiHelpers.updateVisibility(dot_separator, blogSectionUiState.dotSeparatorVisibility)
-        uiHelpers.setTextOrHide(text_dateline, blogSectionUiState.dateLine)
-
-        dot_separator.setVisible(blogSectionUiState.dotSeparatorVisibility)
 
         layout_blog_section.setBackgroundResource(
                 layout_blog_section.context.getDrawableResIdFromAttribute(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailsHeaderViewUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailsHeaderViewUiStateBuilder.kt
@@ -11,13 +11,15 @@ import org.wordpress.android.ui.reader.views.uistates.ReaderBlogSectionUiState
 import org.wordpress.android.ui.reader.views.uistates.ReaderPostDetailsHeaderViewUiState.ReaderPostDetailsHeaderUiState
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.DateTimeUtilsWrapper
 import javax.inject.Inject
 
 @Reusable
 class ReaderPostDetailsHeaderViewUiStateBuilder @Inject constructor(
     private val accountStore: AccountStore,
     private val postUiStateBuilder: ReaderPostUiStateBuilder,
-    private val readerPostTagsUiStateBuilder: ReaderPostTagsUiStateBuilder
+    private val readerPostTagsUiStateBuilder: ReaderPostTagsUiStateBuilder,
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper
 ) {
     fun mapPostToUiState(
         post: ReaderPost,
@@ -36,7 +38,8 @@ class ReaderPostDetailsHeaderViewUiStateBuilder @Inject constructor(
                 tagItems = buildTagItems(post, onTagItemClicked),
                 tagItemsVisibility = buildTagItemsVisibility(post),
                 blogSectionUiState = buildBlogSectionUiState(post, onBlogSectionClicked),
-                followButtonUiState = buildFollowButtonUiState(onFollowClicked, post, hasAccessToken)
+                followButtonUiState = buildFollowButtonUiState(onFollowClicked, post, hasAccessToken),
+                dateLine = buildDateLine(post)
         )
     }
 
@@ -67,4 +70,7 @@ class ReaderPostDetailsHeaderViewUiStateBuilder @Inject constructor(
             readerPostTagsUiStateBuilder.mapPostTagsToTagUiStates(post, onClicked)
 
     private fun buildTagItemsVisibility(post: ReaderPost) = post.tags.isNotEmpty()
+
+    private fun buildDateLine(post: ReaderPost) =
+            dateTimeUtilsWrapper.javaDateToTimeSpan(post.getDisplayDate(dateTimeUtilsWrapper))
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/uistates/ReaderPostDetailsHeaderViewUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/uistates/ReaderPostDetailsHeaderViewUiState.kt
@@ -10,6 +10,9 @@ sealed class ReaderPostDetailsHeaderViewUiState {
         val tagItems: List<TagUiState>,
         val tagItemsVisibility: Boolean,
         val blogSectionUiState: ReaderBlogSectionUiState,
-        val followButtonUiState: FollowButtonUiState
-    ) : ReaderPostDetailsHeaderViewUiState()
+        val followButtonUiState: FollowButtonUiState,
+        val dateLine: String
+    ) : ReaderPostDetailsHeaderViewUiState() {
+        val dotSeparatorVisibility: Boolean = authorName != null
+    }
 }

--- a/WordPress/src/main/res/color/secondary_gray_20_selector.xml
+++ b/WordPress/src/main/res/color/secondary_gray_20_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/gray_20" android:state_selected="true" />
+    <item android:color="?attr/colorSecondary" />
+</selector>

--- a/WordPress/src/main/res/layout/reader_blog_section_view.xml
+++ b/WordPress/src/main/res/layout/reader_blog_section_view.xml
@@ -19,7 +19,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_author_and_blog_name"
-        style="@style/ReaderTextView.Site.Title"
+        style="@style/ReaderTextView.Label.Medium"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_small"
@@ -59,6 +59,7 @@
         android:includeFontPadding="false"
         android:text="@string/reader_dot_separator"
         android:textAlignment="viewStart"
+        android:visibility="gone"
         app:layout_constraintStart_toEndOf="@id/text_blog_url"
         app:layout_constraintEnd_toStartOf="@id/text_dateline"
         app:layout_constraintTop_toBottomOf="@id/text_author_and_blog_name"

--- a/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
@@ -58,9 +58,9 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_by"
+        style="@style/ReaderTextView.Label.Medium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        style="@style/ReaderTextView.Site.Title"
         android:layout_marginTop="@dimen/margin_extra_large"
         android:text="@string/reader_post_details_header_by_author_name"
         android:includeFontPadding="false"
@@ -71,7 +71,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_author"
-        style="@style/ReaderTextView.Site.Title"
+        style="@style/ReaderTextView.Label.Medium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_extra_large"
@@ -80,5 +80,38 @@
         app:layout_constraintStart_toEndOf="@id/text_by"
         app:layout_constraintTop_toBottomOf="@id/layout_blog_section"
         tools:text="text_author"/>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/post_detail_dot_separator"
+        style="@style/ReaderTextView.Label.Medium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:includeFontPadding="false"
+        android:textAppearance="?attr/textAppearanceCaption"
+        android:textColor="?attr/colorOnSurface"
+        android:text="@string/reader_dot_separator"
+        android:textAlignment="viewStart"
+        app:layout_constraintStart_toEndOf="@id/text_author"
+        app:layout_constraintTop_toTopOf="@id/text_author"
+        app:layout_constraintBottom_toBottomOf="@id/text_author"
+        app:layout_constrainedWidth="true"
+        tools:text="@string/reader_dot_separator" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/post_detail_text_dateline"
+        style="@style/ReaderTextView.Label.Medium"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_marginBottom="@dimen/margin_small"
+        android:layout_marginEnd="@dimen/margin_medium"
+        android:includeFontPadding="false"
+        android:fontFamily="sans-serif"
+        android:maxLines="1"
+        app:layout_constraintStart_toEndOf="@id/post_detail_dot_separator"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_blog_section"
+        app:layout_constrainedWidth="true"
+        tools:text="text_dateline" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
@@ -45,6 +45,17 @@
         app:layout_constraintEnd_toStartOf="@id/header_follow_button"
         app:layout_constraintTop_toBottomOf="@id/text_title" />
 
+    <org.wordpress.android.ui.reader.views.ReaderFollowButton
+        android:id="@+id/header_follow_button"
+        style="@style/Reader.Follow.Button.PostDetail"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/layout_blog_section"
+        app:layout_constraintBottom_toBottomOf="@id/layout_blog_section"
+        tools:visibility="visible" />
+
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_by"
         android:layout_width="wrap_content"
@@ -69,17 +80,5 @@
         app:layout_constraintStart_toEndOf="@id/text_by"
         app:layout_constraintTop_toBottomOf="@id/layout_blog_section"
         tools:text="text_author"/>
-
-    <org.wordpress.android.ui.reader.views.ReaderFollowButton
-        android:id="@+id/header_follow_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:layout_marginTop="@dimen/margin_extra_large"
-        android:layout_marginStart="@dimen/margin_extra_large"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/text_title"
-        app:wpShowFollowButtonCaption="false"
-        tools:visibility="visible"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
@@ -49,9 +49,11 @@
         android:id="@+id/text_by"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        style="@style/ReaderTextView.Site.Title"
         android:layout_marginTop="@dimen/margin_extra_large"
         android:text="@string/reader_post_details_header_by"
         android:includeFontPadding="false"
+        android:fontFamily="sans-serif"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/layout_blog_section"
         tools:text="By"/>

--- a/WordPress/src/main/res/layout/reader_simple_post_view.xml
+++ b/WordPress/src/main/res/layout/reader_simple_post_view.xml
@@ -29,14 +29,14 @@
 
         <org.wordpress.android.ui.reader.views.ReaderFollowButton
             android:id="@+id/simple_post_follow_button"
+            style="@style/Reader.Follow.Button.Icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
             android:layout_marginStart="@dimen/margin_medium"
             android:contentDescription="@string/reader_btn_follow"
-            android:padding="@dimen/reader_follow_button_padding"
-            app:wpShowFollowButtonCaption="false" />
+            android:padding="@dimen/reader_follow_button_padding" />
 
         <ImageView
             android:id="@+id/image_avatar"

--- a/WordPress/src/main/res/values-w600dp/reader_styles.xml
+++ b/WordPress/src/main/res/values-w600dp/reader_styles.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <style name="Reader.Follow.Button.PostDetail" parent="Reader.Follow.Button.New"/>
+</resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -191,6 +191,7 @@
     <dimen name="reader_follow_icon">16dp</dimen>
     <dimen name="reader_follow_icon_no_caption">24dp</dimen>
     <dimen name="reader_follow_button_padding">@dimen/margin_small</dimen>
+    <dimen name="reader_follow_icon_padding_no_caption">@dimen/margin_none</dimen>
 
     <dimen name="reader_featured_image_height_default">220dp</dimen>
     <dimen name="reader_featured_image_height_tablet">280dp</dimen>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -63,7 +63,9 @@
     <style name="ReaderTextView.Post.Title.Detail" parent="ReaderTextView.Post.Title">
         <item name="android:textAppearance">?attr/textAppearanceHeadline6</item>
         <item name="android:maxLines">5</item>
-        <item name="textColor">?attr/textColor</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:fontFamily">serif</item>
+        <item name="android:lineSpacingMultiplier">1.2</item>
         <item name="android:includeFontPadding">false</item>
     </style>
 
@@ -175,7 +177,6 @@
         <item name="textColor">?attr/colorOnSurface</item>
         <item name="android:gravity">start</item>
         <item name="android:fontFamily">serif</item>
-        <item name="android:textStyle">bold</item>-->
     </style>
 
     <style name="ReaderTextView.Site.Header.Caption" parent="ReaderTextView">

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -40,7 +40,7 @@
         <item name="textColor">?attr/textColor</item>
     </style>
 
-    <style name="ReaderTextView.Site.Title" parent="ReaderTextView">
+    <style name="ReaderTextView.Label.Medium" parent="ReaderTextView">
         <item name="android:textAlignment">viewStart</item>
         <item name="android:textAppearance">?attr/textAppearanceBody2</item>
         <item name="android:fontFamily">sans-serif-medium</item>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -253,6 +253,15 @@
         <item name="android:minWidth">@dimen/min_touch_target_sz</item>
     </style>
 
+    <style name="Reader.Follow.Button.PostDetail" parent="Reader.Follow.Button.Icon"/>
+
+    <style name="Reader.Follow.Button.Icon" parent="Reader.Follow.Button">
+        <item name="iconTint">@color/secondary_gray_20_selector</item>
+        <item name="android:minWidth">@dimen/min_touch_target_sz</item>
+        <item name="android:minHeight">@dimen/min_touch_target_sz</item>
+        <item name="wpShowFollowButtonCaption">false</item>
+    </style>
+
     <style name="Reader.Button.Error" parent="WordPress.Button.Primary">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -257,8 +257,8 @@
 
     <style name="Reader.Follow.Button.Icon" parent="Reader.Follow.Button">
         <item name="iconTint">@color/secondary_gray_20_selector</item>
-        <item name="android:minWidth">@dimen/min_touch_target_sz</item>
         <item name="android:minHeight">@dimen/min_touch_target_sz</item>
+        <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
         <item name="wpShowFollowButtonCaption">false</item>
     </style>
 


### PR DESCRIPTION
Task: #12900

This PR polishes post header UI, particularly

- Applies new follow button style
- Updates post title style

Looking for design review for UI updates so far (except for the backlog items in #12900 )

**Mobile**

| Light Mode Following | Light Mode Follow | Dark Mode Following | Dark Mode Follow |
|-----|-----|-----|-----|
|![device-2020-10-06-125504](https://user-images.githubusercontent.com/1405144/95172869-8d996180-07d5-11eb-87b9-1f6ec75795a4.png)|![device-2020-10-06-125513](https://user-images.githubusercontent.com/1405144/95172889-92f6ac00-07d5-11eb-944c-a3318321ce5e.png)|![device-2020-10-06-125548](https://user-images.githubusercontent.com/1405144/95172912-9a1dba00-07d5-11eb-8442-8c8d8083ddd2.png)|![device-2020-10-06-125602](https://user-images.githubusercontent.com/1405144/95172927-9ee26e00-07d5-11eb-8567-31fabc7a40fc.png)|

**Mobile Landscape**
| Following | Follow | 
|-----|-----|
|![device-2020-10-06-125418](https://user-images.githubusercontent.com/1405144/95205147-9a807a00-0802-11eb-96bc-587bf4f5b7cf.png)| ![device-2020-10-06-125449](https://user-images.githubusercontent.com/1405144/95205159-9eac9780-0802-11eb-896b-2915097e1878.png)

**Tablet Light Mode** 

| Following | Follow | 
|-----|-----|
|![device-2020-10-06-125831](https://user-images.githubusercontent.com/1405144/95203213-0ca38f80-0800-11eb-8142-8c9e235c65ca.png)| ![device-2020-10-06-125848](https://user-images.githubusercontent.com/1405144/95203220-1200da00-0800-11eb-8d14-e7af6ffb14f4.png)|

**Tablet Dark Mode** 

| Following | Follow |
|-----|-----|
|![device-2020-10-06-130145](https://user-images.githubusercontent.com/1405144/95203268-25ac4080-0800-11eb-884c-aa4ca64958aa.png)| ![device-2020-10-06-130153](https://user-images.githubusercontent.com/1405144/95203285-29d85e00-0800-11eb-8953-a85731c8122c.png)|






PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
