### PR TITLE
Login: Update behavior when logging in with a Jetpack site so it defaults to using site credentials instead of WP.com credentials

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 15.9
 -----
+
+15.8.1
+-----
+* [***] Login: Fixed an issue where some users would be prevented to login with a Jetpack site address.
  
 15.8
 -----

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -372,7 +372,7 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
             if (mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE) {
                 handleConnectSiteInfoForWoo(event.info, hasJetpack);
             } else {
-                handleConnectSiteInfoForWordPress(event.info, hasJetpack);
+                handleConnectSiteInfoForWordPress(event.info);
             }
         }
     }
@@ -394,23 +394,21 @@ public class LoginSiteAddressFragment extends LoginBaseDiscoveryFragment impleme
         }
     }
 
-    private void handleConnectSiteInfoForWordPress(ConnectSiteInfoPayload siteInfo, boolean hasJetpack) {
-        if (siteInfo.isWPCom || hasJetpack) {
-            // It's a WordPress.com or a connected Jetpack site
+    private void handleConnectSiteInfoForWordPress(ConnectSiteInfoPayload siteInfo) {
+        if (siteInfo.isWPCom) {
+            // It's a Simple or Atomic site
             if (mLoginListener.getLoginMode() == LoginMode.SELFHOSTED_ONLY) {
                 // We're only interested in self-hosted sites
-                if (hasJetpack) {
-                    // If Jetpack site, treat it as self-hosted and start the discovery process
-                    // Note: This also includes Atomic sites
+                if (siteInfo.hasJetpack) {
+                    // This is an Atomic site, so treat it as self-hosted and start the discovery process
                     initiateDiscovery();
                     return;
                 }
             }
-            // It's a WordPress.com or a connected Jetpack site, so treat it as such
             endProgressIfNeeded();
             mLoginListener.gotWpcomSiteInfo(UrlUtils.removeScheme(siteInfo.url));
         } else {
-            // Not a WordPress.com or a connected Jetpack site
+            // It's a Jetpack or self-hosted site
             if (mLoginListener.getLoginMode() == LoginMode.WPCOM_LOGIN_ONLY) {
                 // We're only interested in WordPress.com accounts
                 showError(R.string.enter_wpcom_or_jetpack_site);


### PR DESCRIPTION
Fixes #13064

This PR partially reverts the changes made by #12978 in order to redirect a user logging in with a Jetpack site address to the Username/Password screen instead of the Get Started screen, so they can complete the flow using their site credentials instead of their WP.com credentials. 

The new behavior is consistent with what we currently have on WPiOS.

To test:

0. Clear app data.
1. On the Prologue screen, if the Smart Lock dialog appears, dismiss it.
1. Tap **Enter your site address**.
1. On the Site Address screen, enter a Jetpack site address.
1. Tap **Continue**.
1. Notice the Username/Password screen.
1. Enter the username and password associated with the site*.
1. Tap **Continue**.
1. Complete the login flow normally.

\* These are the site credentials, which are used to login to `wp-admin` on the web.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
