### PR TITLE
Default to (Untitled) on the reader post card when blogName is empty

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -20,7 +20,7 @@ sealed class ReaderCardUiState {
         val blogId: Long,
         val dateLine: String,
         val title: UiString?,
-        val blogName: String?,
+        val blogName: UiString?,
         val excerpt: String?, // mTxtText
         val blogUrl: String?,
         val tagItems: List<TagUiState>,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -20,7 +20,7 @@ sealed class ReaderCardUiState {
         val blogId: Long,
         val dateLine: String,
         val title: UiString?,
-        val blogName: UiString?,
+        val blogName: UiString,
         val excerpt: String?, // mTxtText
         val blogUrl: String?,
         val tagItems: List<TagUiState>,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -240,7 +240,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private fun buildExcerpt(post: ReaderPost) =
             post.takeIf { post.cardType != PHOTO && post.hasExcerpt() }?.excerpt
 
-    private fun buildBlogName(post: ReaderPost) = post.takeIf { it.hasBlogName() }?.blogName
+    private fun buildBlogName(post: ReaderPost) = post.takeIf { it.hasBlogName() }?.blogName?.let { UiStringText(it) }
+            ?: UiStringRes(R.string.untitled_in_parentheses)
 
     private fun buildAvatarOrBlavatarUrl(post: ReaderPost) =
             post.takeIf { it.hasBlogImageUrl() }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -55,6 +55,7 @@ import org.wordpress.android.ui.reader.repository.ReaderDiscoverDataProvider
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FIRST_PAGE
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_MORE
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -497,7 +498,7 @@ class ReaderDiscoverViewModelTest {
                 tagItems = listOf(TagUiState("", "", false, onTagClicked)),
                 dateLine = "",
                 avatarOrBlavatarUrl = "",
-                blogName = "",
+                blogName = mock(),
                 excerpt = "",
                 title = mock(),
                 photoFrameVisibility = false,

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -55,7 +55,6 @@ import org.wordpress.android.ui.reader.repository.ReaderDiscoverDataProvider
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_FIRST_PAGE
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_MORE
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
-import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -489,13 +489,13 @@ class ReaderPostUiStateBuilderTest {
     }
 
     @Test
-    fun `blogName is not displayed the post doesn't have a blog name`() = test {
+    fun `default blog name is displayed when the post doesn't have a blog name`() = test {
         // Arrange
         val post = createPost(hasBlogName = false)
         // Act
         val uiState = mapPostToUiState(post)
         // Assert
-        assertThat(uiState.blogName).isNull()
+        assertThat((uiState.blogName as UiStringRes).stringRes).isEqualTo(R.string.untitled_in_parentheses)
     }
     // endregion
 


### PR DESCRIPTION
Fixes blank site title issue reported in https://github.com/wordpress-mobile/WordPress-Android/pull/13042#pullrequestreview-502998546

#### To test

- Go to Reader
- Find a post with empty site title
- Verify that header positioning is not broken and blog name defaults to (Untitled)

![image](https://user-images.githubusercontent.com/1405144/95294150-66549a00-0892-11eb-8f8b-a92e0d42cfd3.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
