### PR TITLE
Fix SQLiteException: no such table: tbl_discover_cards

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt
@@ -21,14 +21,9 @@ object ReaderDiscoverCardsTable {
         db.execSQL("DROP TABLE IF EXISTS tbl_discover_cards")
     }
 
-    fun reset() {
-        reset(getWritableDb())
-    }
-
-    fun reset(db: SQLiteDatabase) {
-        AppLog.i(AppLog.T.READER, "resetting ReaderDiscoverCardsTable")
-        dropTables(db)
-        createTable(db)
+    fun clear() {
+        AppLog.i(AppLog.T.READER, "clearing ReaderDiscoverCardsTable")
+        getWritableDb().delete(DISCOVER_CARDS_TABLE, null, null)
     }
 
     private fun getReadableDb(): SQLiteDatabase {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -214,7 +214,7 @@ class ReaderDiscoverLogic(
     }
 
     private fun clearCache() {
-        ReaderDiscoverCardsTable.reset()
+        ReaderDiscoverCardsTable.clear()
         ReaderPostTable.deletePostsWithTag(ReaderTag.createDiscoverPostCardsTag())
     }
 }


### PR DESCRIPTION
Fixes #13016

I was not able to reproduce this exception but [Sentry logs](https://sentry.io/share/issue/8901c9353bff433c8b1e56a1996420ab/) point to [this part of code ](https://github.com/wordpress-mobile/WordPress-Android/blob/37a0156978a793eef4252265d8b1ae159e98254b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDiscoverCardsTable.kt#L30-L31) where we drop and recreate discover cards table while refreshing discover feed.

<img width="400" alt="Screenshot 2020-10-07 at 12 56 17 PM" src="https://user-images.githubusercontent.com/1405144/95315494-2f8d7c80-08b0-11eb-86a0-e091592b889d.png">

It seems there's some kind of a race condition while trying to drop/create/select from the same table.
This PR deletes records from the table instead of recreating it which serves the same purpose and hopefully fixes this issue. 

**Merge Instructions**

Targeting release/15.9 as discussed on Slack.

cc @loremattei 


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
