### PR TITLE
Fix/2692 unsupported block editor cannot save changes

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -154,6 +154,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
         if (getGutenbergContainerFragment() == null) {
             GutenbergPropsBuilder gutenbergPropsBuilder = getArguments().getParcelable(ARG_GUTENBERG_PROPS_BUILDER);
+            mLatestGutenbergPropsBuilder = gutenbergPropsBuilder;
 
             FragmentManager fragmentManager = getChildFragmentManager();
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -114,7 +114,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     private boolean mIsJetpackSsoEnabled;
 
     private boolean mEditorDidMount;
-    private GutenbergPropsBuilder mLatestGutenbergPropsBuilder;
+    private GutenbergPropsBuilder mCurrentGutenbergPropsBuilder;
 
     private ProgressDialog mSavingContentProgressDialog;
 
@@ -154,7 +154,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
         if (getGutenbergContainerFragment() == null) {
             GutenbergPropsBuilder gutenbergPropsBuilder = getArguments().getParcelable(ARG_GUTENBERG_PROPS_BUILDER);
-            mLatestGutenbergPropsBuilder = gutenbergPropsBuilder;
+            mCurrentGutenbergPropsBuilder = gutenbergPropsBuilder;
 
             FragmentManager fragmentManager = getChildFragmentManager();
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
@@ -398,7 +398,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 String content = data.getStringExtra(WPGutenbergWebViewActivity.ARG_BLOCK_CONTENT);
                 getGutenbergContainerFragment().replaceUnsupportedBlock(content, blockId);
                 // We need to send latest capabilities as JS side clears them
-                getGutenbergContainerFragment().updateCapabilities(mLatestGutenbergPropsBuilder);
+                getGutenbergContainerFragment().updateCapabilities(mCurrentGutenbergPropsBuilder);
                 trackWebViewClosed("save");
             } else {
                 trackWebViewClosed("dismiss");
@@ -691,7 +691,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     public void updateCapabilities(boolean isJetpackSsoEnabled, GutenbergPropsBuilder gutenbergPropsBuilder) {
         mIsJetpackSsoEnabled = isJetpackSsoEnabled;
-        mLatestGutenbergPropsBuilder = gutenbergPropsBuilder;
+        mCurrentGutenbergPropsBuilder = gutenbergPropsBuilder;
         getGutenbergContainerFragment().updateCapabilities(gutenbergPropsBuilder);
     }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2692

To test:

1. On the web, add any block not yet supported in Gutenberg Mobile (i.e. Business Hours, Contact Form, YouTube Embed).
2. Save or publish changes.
3. On the app, open the post created in step 1.
4. Tap the unsupported block.
5. Tap the unsupported block again.
6. Tap the "Edit using web editor" option.
7. Try making any change to the block.
8. Tap the checkmark button at the top right.
9. You should return to Blog Post
10. Open Unsupported block again on web or mobile
11. You should see the latest changes

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
