### PR TITLE
Issue/13046 fix collapsing toolbar text and icon color

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -267,15 +267,12 @@ public class MediaSettingsActivity extends LocaleAwareActivity
         AppBarLayout appBarLayout = findViewById(R.id.app_bar_layout);
         collapsingToolbar.setCollapsedTitleTextColor(
                 AppCompatResources.getColorStateList(this,
-                        ContextExtensionsKt.getColorResIdFromAttribute(this, R.attr.colorOnPrimarySurface)));
+                        ContextExtensionsKt.getColorResIdFromAttribute(this, R.attr.colorOnSurface)));
 
         ElevationOverlayProvider elevationOverlayProvider = new ElevationOverlayProvider(this);
 
         float appbarElevation = getResources().getDimension(R.dimen.appbar_elevation);
-        int elevatedColor = elevationOverlayProvider
-                .compositeOverlayIfNeeded(ContextExtensionsKt.getColorFromAttribute(this, R.attr.wpColorAppBar),
-                        appbarElevation);
-
+        int elevatedColor = elevationOverlayProvider.compositeOverlayWithThemeSurfaceColorIfNeeded(appbarElevation);
         collapsingToolbar.setContentScrimColor(elevatedColor);
 
         appBarLayout.addOnOffsetChangedListener(new AppBarLayout.OnOffsetChangedListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -272,7 +272,9 @@ public class MediaSettingsActivity extends LocaleAwareActivity
         ElevationOverlayProvider elevationOverlayProvider = new ElevationOverlayProvider(this);
 
         float appbarElevation = getResources().getDimension(R.dimen.appbar_elevation);
-        int elevatedColor = elevationOverlayProvider.compositeOverlayWithThemeSurfaceColorIfNeeded(appbarElevation);
+        int elevatedColor = elevationOverlayProvider
+                .compositeOverlayIfNeeded(ContextExtensionsKt.getColorFromAttribute(this, R.attr.wpColorAppBar),
+                        appbarElevation);
         collapsingToolbar.setContentScrimColor(elevatedColor);
 
         appBarLayout.addOnOffsetChangedListener(new AppBarLayout.OnOffsetChangedListener() {

--- a/WordPress/src/main/res/drawable/collapsing_toolbar_gradient_scrim.xml
+++ b/WordPress/src/main/res/drawable/collapsing_toolbar_gradient_scrim.xml
@@ -3,7 +3,7 @@
     <gradient
         android:angle="90"
         android:centerY="75%"
-        android:endColor="@color/black_translucent_50"
+        android:endColor="@color/collapsing_toolbar_custom_scrim_color"
         android:startColor="@android:color/transparent"
         android:type="linear"/>
 </shape>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -44,7 +44,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="top"
-                    android:background="@drawable/media_settings_gradient_scrim"
+                    app:srcCompat="@drawable/collapsing_toolbar_gradient_scrim"
                     android:contentDescription="@null"
                     tools:layout_height="74dp" />
 

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -18,7 +18,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fitsSystemWindows="false"
-            app:contentScrim="?attr/wpColorAppBar"
             app:expandedTitleMarginEnd="64dp"
             app:expandedTitleMarginStart="48dp"
             app:layout_scrollFlags="scroll|exitUntilCollapsed">

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -65,7 +65,8 @@
                 android:layout_height="?attr/actionBarSize"
                 android:background="@null"
                 android:elevation="0dp"
-                app:layout_collapseMode="pin" />
+                app:layout_collapseMode="pin"
+                app:theme="@style/WordPress.ActionBar" />
 
         </com.google.android.material.appbar.CollapsingToolbarLayout>
 

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -11,8 +11,7 @@
         android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="false"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+        android:fitsSystemWindows="false">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsing_toolbar"
@@ -40,7 +39,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="top"
-                    android:background="@drawable/media_settings_gradient_scrim"
+                    android:background="@drawable/collapsing_toolbar_gradient_scrim"
                     android:contentDescription="@null"
                     tools:layout_height="74dp" />
             </FrameLayout>
@@ -51,6 +50,7 @@
                 android:layout_height="?attr/actionBarSize"
                 android:background="@null"
                 app:layout_collapseMode="pin"
+                app:theme="@style/WordPress.ActionBar"
                 app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
         </com.google.android.material.appbar.CollapsingToolbarLayout>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -68,4 +68,7 @@
     <color name="prepublishing_action_type_disabled_color">@color/gray_50</color>
     <color name="prepublishing_action_result_disabled_color">@color/gray_50</color>
 
+    <!-- Collapsing Toolbar Custom Scrim Color -->
+    <color name="collapsing_toolbar_custom_scrim_color">@color/black_translucent_50</color>
+
 </resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -336,6 +336,6 @@
     <color name="reader_welcome_card_text">@color/blue_70</color>
 
     <!-- Collapsing Toolbar Custom Scrim Color -->
-    <color name="collapsing_toolbar_custom_scrim_color">@color/white_translucent_60</color>
+    <color name="collapsing_toolbar_custom_scrim_color">@color/white_translucent_50</color>
 
 </resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -334,4 +334,8 @@
     <!--Reader Welcome Card -->
     <color name="reader_welcome_card_background">@color/primary_emphasis_lowest</color>
     <color name="reader_welcome_card_text">@color/blue_70</color>
+
+    <!-- Collapsing Toolbar Custom Scrim Color -->
+    <color name="collapsing_toolbar_custom_scrim_color">@color/white_translucent_60</color>
+
 </resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -308,6 +308,7 @@
     <color name="grey_lighten_30_translucent_50">#80e9eff3</color> <!-- Use for old Stats.  Will be removed soon. -->
     <color name="white_translucent_20">#33ffffff</color>
     <color name="white_translucent_40">#66ffffff</color>
+    <color name="white_translucent_50">#80ffffff</color>
     <color name="white_translucent_65">#a6ffffff</color>
 
     <!-- Reader -->

--- a/libs/login/WordPressLoginFlow/src/main/res/values/colors.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/colors.xml
@@ -88,7 +88,6 @@
     <color name="grey_lighten_20_translucent_50">#80c8d7e1</color>
     <color name="grey_lighten_30_translucent_50">#80e9eff3</color>
     <color name="white_translucent_40">#66ffffff</color>
-    <color name="white_translucent_50">#80ffffff</color>
     <color name="white_translucent_60">#99ffffff</color>
     <color name="white_translucent_65">#a6ffffff</color>
 

--- a/libs/login/WordPressLoginFlow/src/main/res/values/colors.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/colors.xml
@@ -88,6 +88,7 @@
     <color name="grey_lighten_20_translucent_50">#80c8d7e1</color>
     <color name="grey_lighten_30_translucent_50">#80e9eff3</color>
     <color name="white_translucent_40">#66ffffff</color>
+    <color name="white_translucent_50">#80ffffff</color>
     <color name="white_translucent_60">#99ffffff</color>
     <color name="white_translucent_65">#a6ffffff</color>
 


### PR DESCRIPTION
Fixes #13046

This PR fixes the title and custom scrim color used with the collapsing toolbar in Media Details and Plugin Detail activities.

[![Image from Gyazo](https://i.gyazo.com/523e9f7c90b50f524e31626ae3afae22.png)](https://gyazo.com/523e9f7c90b50f524e31626ae3afae22)

[![Image from Gyazo](https://i.gyazo.com/a1279ab75d64039f247bc2c5865d285e.png)](https://gyazo.com/a1279ab75d64039f247bc2c5865d285e)

[![Image from Gyazo](https://i.gyazo.com/aa61d434111f9b9721a58e78efe542d7.png)](https://gyazo.com/aa61d434111f9b9721a58e78efe542d7)

To test (in both light and dark modes):
- Check the Media Settings and make sure icons are visible when the top image is fully expanded (default state). Do the same with the Plugin Details screen. 
- Check the Media Settings and make sure the title is visible when the toolbar is fully collapsed (scroll down all the way). 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
