### PR TITLE
Fixing app log appbar icon color

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -33,7 +33,6 @@ import static java.lang.String.format;
  * views the activity log (see utils/AppLog.java)
  */
 public class AppLogViewerActivity extends LocaleAwareActivity {
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -140,14 +141,8 @@ public class AppLogViewerActivity extends LocaleAwareActivity {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
-        // Copy to clipboard button
-        MenuItem item = menu.add(Menu.NONE, ID_COPY_TO_CLIPBOARD, Menu.NONE, R.string.copy_text);
-        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
-        item.setIcon(R.drawable.ic_copy_white_24dp);
-        // Share button
-        item = menu.add(Menu.NONE, ID_SHARE, Menu.NONE, R.string.reader_btn_share);
-        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
-        item.setIcon(R.drawable.ic_share_white_24dp);
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.app_log_viewer_menu, menu);
         return true;
     }
 
@@ -157,10 +152,10 @@ public class AppLogViewerActivity extends LocaleAwareActivity {
             case android.R.id.home:
                 finish();
                 return true;
-            case ID_SHARE:
+            case R.id.app_log_share:
                 shareAppLog();
                 return true;
-            case ID_COPY_TO_CLIPBOARD:
+            case R.id.app_log_copy_to_clipboard:
                 copyAppLogToClipboard();
                 return true;
             default:

--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -33,8 +33,6 @@ import static java.lang.String.format;
  * views the activity log (see utils/AppLog.java)
  */
 public class AppLogViewerActivity extends LocaleAwareActivity {
-    private static final int ID_SHARE = 1;
-    private static final int ID_COPY_TO_CLIPBOARD = 2;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/WordPress/src/main/res/menu/app_log_viewer_menu.xml
+++ b/WordPress/src/main/res/menu/app_log_viewer_menu.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/app_log_share"
+        android:icon="@drawable/ic_share_white_24dp"
+        android:title="@string/reader_btn_share"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/app_log_copy_to_clipboard"
+        android:icon="@drawable/ic_copy_white_24dp"
+        android:title="@string/copy_text"
+        app:showAsAction="ifRoom" />
+
+</menu>


### PR DESCRIPTION
Fixes #13067

This PR fixes the color of Application Log Appbar icons by inflating the menu from xml instead of creating it in code.

[![Image from Gyazo](https://i.gyazo.com/b028b2d51e6db9b428b3ad2f107aa3a3.png)](https://gyazo.com/b028b2d51e6db9b428b3ad2f107aa3a3)

[![Image from Gyazo](https://i.gyazo.com/b0cb655a5b500c2cc579bfe9a4fff35b.png)](https://gyazo.com/b0cb655a5b500c2cc579bfe9a4fff35b)

To test:
- Navigate to Application log activity from Help scren.
- Make sure the appbar icons for Share and Copy To Clipboard are visible in both light and dark mores.
- Make sure the correct tooltip appears when you long-press menu icons.
- Make sure the menu button performs the correct action (opening share dialog and copying logs into the clipboard).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
