### PR TITLE
Check if site is not null in onSiteChanged in SiteSettingsFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1966,7 +1966,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
-        if (!event.isError()) {
+        if (!event.isError() && mSite != null) {
             mSite = mSiteStore.getSiteByLocalId(mSite.getId());
             updateHomepageSummary();
         }


### PR DESCRIPTION
Fixes #13045 

The site shouldn't be null if the fragment is properly initialized. However, it seems that this doesn't always happen. I'm following the approach that's used in the rest of the fragment where we always check whether the site is present when we want to access it.

To test:
- I don't know how to reproduce this but the fix should be clear enough

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
