### PR TITLE
Bugs in media on api 29

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/DeviceListBuilder.kt
@@ -120,7 +120,7 @@ class DeviceListBuilder
     private suspend fun addDownloads(): List<MediaItem> = withContext(bgDispatcher) {
         val storagePublicDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
         return@withContext storagePublicDirectory.listFiles()
-                .mapNotNull { file ->
+                ?.mapNotNull { file ->
                     val uri = parse(file.toURI().toString())
                     val mimeType = getMimeType(uri)
                     if (mimeType != null && mimeTypes.isSupportedApplicationType(mimeType)) {
@@ -135,7 +135,7 @@ class DeviceListBuilder
                     } else {
                         null
                     }
-                }
+                } ?: listOf()
     }
 
     private fun getMimeType(uri: Uri): String? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -189,6 +189,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPMediaUtils;
+import org.wordpress.android.util.WPMediaUtils.LaunchCameraCallback;
 import org.wordpress.android.util.WPPermissionUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper;
@@ -2190,6 +2191,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     public static final String NEW_MEDIA_POST = "NEW_MEDIA_POST";
     public static final String NEW_MEDIA_POST_EXTRA_IDS = "NEW_MEDIA_POST_EXTRA_IDS";
     private String mMediaCapturePath = "";
+    private Uri mMediaUri;
 
     private String getUploadErrorHtml(String mediaId, String path) {
         return String.format(Locale.US,
@@ -2289,7 +2291,15 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     private void launchCamera() {
         WPMediaUtils.launchCamera(this, BuildConfig.APPLICATION_ID,
-                mediaCapturePath -> mMediaCapturePath = mediaCapturePath);
+                new LaunchCameraCallback() {
+                    @Override public void onMediaCapturePathReady(String mediaCapturePath) {
+                        mMediaCapturePath = mediaCapturePath;
+                    }
+
+                    @Override public void onMediaUriReady(Uri mediaUri) {
+                        mMediaUri = mediaUri;
+                    }
+                });
     }
 
     protected void setPostContentFromShareAction() {
@@ -2550,17 +2560,21 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     private void addLastTakenPicture() {
         try {
-            // TODO why do we scan the file twice? Also how come it can result in OOM?
-            WPMediaUtils.scanMediaFile(this, mMediaCapturePath);
-            File f = new File(mMediaCapturePath);
-            Uri capturedImageUri = Uri.fromFile(f);
-            if (capturedImageUri != null) {
-                mEditorMedia.addNewMediaToEditorAsync(capturedImageUri, true);
-                final Intent scanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-                scanIntent.setData(capturedImageUri);
-                sendBroadcast(scanIntent);
+            if (mMediaCapturePath != null && !mMediaCapturePath.isEmpty()) {
+                // TODO why do we scan the file twice? Also how come it can result in OOM?
+                WPMediaUtils.scanMediaFile(this, mMediaCapturePath);
+                File f = new File(mMediaCapturePath);
+                Uri capturedImageUri = Uri.fromFile(f);
+                if (capturedImageUri != null) {
+                    mEditorMedia.addNewMediaToEditorAsync(capturedImageUri, true);
+                    final Intent scanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+                    scanIntent.setData(capturedImageUri);
+                    sendBroadcast(scanIntent);
+                } else {
+                    ToastUtils.showToast(this, R.string.gallery_error, Duration.SHORT);
+                }
             } else {
-                ToastUtils.showToast(this, R.string.gallery_error, Duration.SHORT);
+                mEditorMedia.addNewMediaToEditorAsync(mMediaUri, true);
             }
         } catch (RuntimeException | OutOfMemoryError e) {
             AppLog.e(T.EDITOR, e);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCase.kt
@@ -51,7 +51,7 @@ class AddLocalMediaToPostUseCase @Inject constructor(
         doUploadAfterAdding: Boolean = true
     ): Boolean {
         // Copy files to apps storage to make sure they are permanently accessible.
-        val copyFilesResult: CopyMediaResult = copyMediaToAppStorageUseCase.copyFilesToAppStorageIfNecessary(uriList)
+        val copyFilesResult: CopyMediaResult = copyMediaToAppStorageUseCase.copyFilesToAppStorage(uriList)
 
         // Optimize and rotate the media
         val optimizeMediaResult: OptimizeMediaResult = optimizeMediaUseCase

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
@@ -20,17 +20,13 @@ class CopyMediaToAppStorageUseCase @Inject constructor(
    * Some media providers (eg. Google Photos) give us a limited access to media files just so we can copy them and then
    * they revoke the access. Copying these files must be performed on the UI thread, otherwise the access might be
    * revoked before the action completes. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
+   *
+   * From API 29 we need to download also the files from the media store
    */
     suspend fun copyFilesToAppStorageIfNecessary(uriList: List<Uri>): CopyMediaResult {
         return withContext(mainDispatcher) {
             uriList
-                    .map { mediaUri ->
-                        if (!mediaUtilsWrapper.isInMediaStore(mediaUri)) {
-                            copyToAppStorage(mediaUri)
-                        } else {
-                            mediaUri
-                        }
-                    }
+                    .map { mediaUri -> copyToAppStorage(mediaUri) }
                     .toList()
                     .let {
                         CopyMediaResult(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
@@ -23,7 +23,7 @@ class CopyMediaToAppStorageUseCase @Inject constructor(
    *
    * From API 29 we need to download also the files from the media store
    */
-    suspend fun copyFilesToAppStorageIfNecessary(uriList: List<Uri>): CopyMediaResult {
+    suspend fun copyFilesToAppStorage(uriList: List<Uri>): CopyMediaResult {
         return withContext(mainDispatcher) {
             uriList
                     .map { mediaUri -> copyToAppStorage(mediaUri) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
@@ -27,7 +27,6 @@ class CopyMediaToAppStorageUseCase @Inject constructor(
         return withContext(mainDispatcher) {
             uriList
                     .map { mediaUri -> copyToAppStorage(mediaUri) }
-                    .toList()
                     .let {
                         CopyMediaResult(
                                 permanentlyAccessibleUris = it.filterNotNull(),

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -369,7 +369,6 @@ public class WPMediaUtils {
             values.put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg");
 
             values.put(MediaStore.Images.Media.RELATIVE_PATH, "DCIM/Camera");
-            //values.put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/playground");
 
             fileUri = context.getContentResolver().insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values);
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCaseTest.kt
@@ -220,7 +220,7 @@ class AddLocalMediaToPostUseCaseTest : BaseUnitTest() {
         ).addNewMediaToEditorAsync(localUris, siteModel, FRESHLY_TAKEN, mock())
 
         // Assert
-        inOrder.verify(copyMediaToAppStorageUseCase).copyFilesToAppStorageIfNecessary(localUris)
+        inOrder.verify(copyMediaToAppStorageUseCase).copyFilesToAppStorage(localUris)
         inOrder.verify(optimizeMediaUseCase).optimizeMediaIfSupportedAsync(any(), any(), any())
         inOrder.verify(getMediaModelUseCase)
                 .createMediaModelFromUri(eq(LOCAL_SITE_ID), any<List<Uri>>())
@@ -284,7 +284,7 @@ class AddLocalMediaToPostUseCaseTest : BaseUnitTest() {
 
         fun createCopyMediaToAppStorageUseCase(copyMediaResult: CopyMediaResult = createCopyMediaResult()) =
                 mock<CopyMediaToAppStorageUseCase> {
-                    onBlocking { copyFilesToAppStorageIfNecessary(any()) }.thenReturn(
+                    onBlocking { copyFilesToAppStorage(any()) }.thenReturn(
                             copyMediaResult
                     )
                 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCaseTest.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.posts.editor.media
 import android.net.Uri
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -16,29 +15,14 @@ import org.wordpress.android.test
 import org.wordpress.android.util.MediaUtilsWrapper
 
 @RunWith(MockitoJUnitRunner::class)
-@UseExperimental(InternalCoroutinesApi::class)
+@InternalCoroutinesApi
 class CopyMediaToAppStorageUseCaseTest : BaseUnitTest() {
     @Test
-    fun `do NOT copy files which are present in media store`() = test {
-        // Arrange
-        val uris = listOf<Uri>(mock())
-        val mediaUtilsWrapper = createMediaUtilsWrapper(resultForIsInMediaStore = true)
-        // Act
-        val result = createCopyMediaToAppStorageUseCase(mediaUtilsWrapper = mediaUtilsWrapper)
-                .copyFilesToAppStorageIfNecessary(uris)
-
-        // Assert
-        verify(mediaUtilsWrapper, never()).copyFileToAppStorage(any())
-        assertThat(result.permanentlyAccessibleUris[0]).isEqualTo(uris[0])
-    }
-
-    @Test
-    fun `copy only files which are NOT present in media store`() = test {
+    fun `copy all files`() = test {
         // Arrange
         val expectedCopiedFileUri = mock<Uri>()
         val uris = listOf<Uri>(mock())
         val mediaUtilsWrapper = createMediaUtilsWrapper(
-                resultForIsInMediaStore = false,
                 resultForCopiedFileUri = (uris[0] to expectedCopiedFileUri)
         )
         // Act
@@ -88,15 +72,14 @@ class CopyMediaToAppStorageUseCaseTest : BaseUnitTest() {
     }
 
     private companion object Fixtures {
+        @InternalCoroutinesApi
         fun createCopyMediaToAppStorageUseCase(mediaUtilsWrapper: MediaUtilsWrapper = createMediaUtilsWrapper()) =
                 CopyMediaToAppStorageUseCase(mediaUtilsWrapper, TEST_DISPATCHER)
 
         fun createMediaUtilsWrapper(
-            resultForIsInMediaStore: Boolean = false,
             resultForCopiedFileUri: Pair<Uri, Uri?>? = null
         ) =
                 mock<MediaUtilsWrapper> {
-                    on { isInMediaStore(any()) }.thenReturn(resultForIsInMediaStore)
                     on { copyFileToAppStorage(any()) }.thenReturn(mock())
                     resultForCopiedFileUri?.let {
                         on { copyFileToAppStorage(resultForCopiedFileUri.first) }.thenReturn(

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCaseTest.kt
@@ -27,7 +27,7 @@ class CopyMediaToAppStorageUseCaseTest : BaseUnitTest() {
         )
         // Act
         val result = createCopyMediaToAppStorageUseCase(mediaUtilsWrapper = mediaUtilsWrapper)
-                .copyFilesToAppStorageIfNecessary(uris)
+                .copyFilesToAppStorage(uris)
 
         // Assert
         verify(mediaUtilsWrapper).copyFileToAppStorage(uris[0])
@@ -41,7 +41,7 @@ class CopyMediaToAppStorageUseCaseTest : BaseUnitTest() {
         val mediaUtilsWrapper = createMediaUtilsWrapper(resultForCopiedFileUri = (uris[0] to null))
         // Act
         val result = createCopyMediaToAppStorageUseCase(mediaUtilsWrapper = mediaUtilsWrapper)
-                .copyFilesToAppStorageIfNecessary(uris)
+                .copyFilesToAppStorage(uris)
 
         // Assert
         assertThat(result.permanentlyAccessibleUris.size).isEqualTo(uris.size - 1)
@@ -54,7 +54,7 @@ class CopyMediaToAppStorageUseCaseTest : BaseUnitTest() {
         val mediaUtilsWrapper = createMediaUtilsWrapper(resultForCopiedFileUri = (uris[1] to null))
         // Act
         val result = createCopyMediaToAppStorageUseCase(mediaUtilsWrapper = mediaUtilsWrapper)
-                .copyFilesToAppStorageIfNecessary(uris)
+                .copyFilesToAppStorage(uris)
 
         // Assert
         assertThat(result.copyingSomeMediaFailed).isTrue()
@@ -66,7 +66,7 @@ class CopyMediaToAppStorageUseCaseTest : BaseUnitTest() {
         val uris = listOf<Uri>(mock(), mock(), mock())
         // Act
         val result = createCopyMediaToAppStorageUseCase()
-                .copyFilesToAppStorageIfNecessary(uris)
+                .copyFilesToAppStorage(uris)
         // Assert
         assertThat(result.copyingSomeMediaFailed).isFalse()
     }


### PR DESCRIPTION
This PR introduces fixes necessary on devices with API 29. To test the failure make sure you download a fresh emulator with API 29, for some reason the bugs were not happening to me on an older device. The problem is that we can no longer access media file URIs from the device supplied from the media store (we have to copy them to the app memory) and we can no longer access media from camera as we used to (we also need to copy them into the app memory). The `File` interface no longer works with API 29. 

Since there is quite a lot of code in this fix, I recommend being careful. The changes are not super straightforward. 

The testing steps are taken from this PR - https://github.com/wordpress-mobile/WordPress-Android/pull/13063

To test (with a new device running API 28, 29 and 30):

Go to Gutenberg editor
Add image block
Click on "Add Media"/"Choose from device"
Select an item
Confirm it
Notice it gets uploaded correctly
To test (with a new device running API 28, 29 and 30):

Go to Gutenberg editor
Add image block
Click on "Add Media"/"Take photo"
Take a photo
Notice it gets uploaded correctly
To test (with a new device running API 28, 29 and 30):

Go to Gutenberg editor
Add video block
Click on "Add Media"/"Take video"
Take a video
Notice it gets uploaded correctly
To test (with a new device running API 28, 29 and 30):

Go to Media library
Click on "Take a photo"
Take a photo
Notice it gets uploaded correctly
To test (with a new device running API 28, 29 and 30):

Go to Media library
Click on "Take a video"
Take a video
Notice it gets uploaded correctly

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
