### PR TITLE
Add legacy permission to enable media upload

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -60,6 +60,7 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:networkSecurityConfig="@xml/network_security_config"
+        android:requestLegacyExternalStorage="true"
         android:theme="@style/WordPress"
         tools:replace="allowBackup, icon,android:supportsRtl"
         android:supportsRtl="true"


### PR DESCRIPTION
This PR introduces a simple fox for a media upload problem we have with API 29 by enabling legacy access to external storage. This is a temporary solution which will only work until we target API 30. We'll do a proper solution outside of beta fix.

The testing steps are taken from this PR - #13063

To test (with a new device running API 28, 29 and 30):
- Go to Gutenberg editor
- Add image block
- Click on "Add Media"/"Choose from device"
- Select an item
- Confirm it
- Notice it gets uploaded correctly

To test (with a new device running API 28, 29 and 30):
- Go to Gutenberg editor
- Add image block
- Click on "Add Media"/"Take photo"
- Take a photo
- Notice it gets uploaded correctly

To test (with a new device running API 28, 29 and 30):
- Go to Gutenberg editor
- Add video block
- Click on "Add Media"/"Take video"
- Take a video
- Notice it gets uploaded correctly

To test (with a new device running API 28, 29 and 30):
- Go to Media library
- Click on "Take a photo"
- Take a photo
- Notice it gets uploaded correctly

To test (with a new device running API 28, 29 and 30):
- Go to Media library
- Click on "Take a video"
- Take a video
- Notice it gets uploaded correctly

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
