### PR TITLE
Add validation for translations

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,6 +41,7 @@ ENV[GHHELPER_REPO="wordpress-mobile/WordPress-Android"]
 ENV["PROJECT_ROOT_FOLDER"]="./"
 ENV["PROJECT_NAME"]="WordPress"
 ENV["HAS_ALPHA_VERSION"]="true"
+ENV["validate_translations"]="lintVanillaRelease"
 
 ########################################################################
 # Release Lanes


### PR DESCRIPTION
This PR brings back validation for translations to the `finalize_release` lane. 
For some reasons we lost it over the time on WPAndroid. We were still doing validation before building the final release build, but I think that having validation before tagging the release is better, especially now that tags triggers release builds on CI.

To test:
1. Create a new branch out of this one. 
2. Comment everything in the `finalize_release` line, other than these three lines: 
```
    configure_apply(force: is_ci)
    hotfix = android_current_branch_is_hotfix
    android_update_metadata(options) unless hotfix
```
3. Run `bundle exec fastlane finalize_release`
4. Verify that the linter runs (many translations for the `login_promo_title_37_percent` strings are currently broken, so you may get a failure during this phase, which is good)


Note: I'm targeting the release branch because it's something that will be useful for the next release. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
