### PR TITLE
Integrate gutenberg-mobile release 1.38.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 * [**] Block Editor: Fix for a crash that can occur when long pressing selected images [https://github.com/wordpress-mobile/AztecEditor-Android/pull/924]
 * [***] Block Editor: Added expected double tap for focus behavior for text fields in accessibility mode [https://github.com/WordPress/gutenberg/pull/25384]
 * [*] Improved My Site layout on devices with big screens. [https://github.com/wordpress-mobile/WordPress-Android/pull/13026]
+* [***] Block Editor: Unsupported Block Editor: Fixed issue when cannot view or interact with the classic block on Jetpack sites [https://github.com/wordpress-mobile/gutenberg-mobile/issues/2695]
 
 15.8.1
 -----

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
@@ -24,7 +24,7 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
 
     public static final String ARG_USER_ID = "authenticated_user_id";
     public static final String ARG_BLOCK_ID = "block_id";
-    public static final String ARG_BLOCK_NAME = "block_name";
+    public static final String ARG_BLOCK_TITLE = "block_title";
     public static final String ARG_BLOCK_CONTENT = "block_content";
 
     private boolean mIsJetpackSsoEnabled;
@@ -73,9 +73,9 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
 
     @Override
     protected String getToolbarTitle() {
-        String blockName = getIntent().getExtras().getString(ARG_BLOCK_NAME);
-        if (blockName != null) {
-            return String.format(getString(R.string.menu_toolbar_title), blockName);
+        String blockTitle = getIntent().getExtras().getString(ARG_BLOCK_TITLE);
+        if (blockTitle != null) {
+            return String.format(getString(R.string.menu_toolbar_title), blockTitle);
         }
         return "";
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -304,7 +304,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                         openGutenbergWebViewActivity(
                                 unsupportedBlock.getContent(),
                                 unsupportedBlock.getId(),
-                                unsupportedBlock.getName()
+                                unsupportedBlock.getName(),
+                                unsupportedBlock.getTitle()
                         );
                     }
                 },
@@ -357,7 +358,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         return view;
     }
 
-    private void openGutenbergWebViewActivity(String content, String blockId, String blockName) {
+    private void openGutenbergWebViewActivity(String content, String blockId, String blockName, String blockTitle) {
         GutenbergWebViewAuthorizationData gutenbergWebViewAuthData =
                 getArguments().getParcelable(ARG_GUTENBERG_WEB_VIEW_AUTH_DATA);
 
@@ -367,7 +368,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
         Intent intent = new Intent(getActivity(), WPGutenbergWebViewActivity.class);
         intent.putExtra(WPGutenbergWebViewActivity.ARG_BLOCK_ID, blockId);
-        intent.putExtra(WPGutenbergWebViewActivity.ARG_BLOCK_NAME, blockName);
+        intent.putExtra(WPGutenbergWebViewActivity.ARG_BLOCK_TITLE, blockTitle);
         intent.putExtra(WPGutenbergWebViewActivity.ARG_BLOCK_CONTENT, content);
         intent.putExtra(WPGutenbergWebViewActivity.ARG_GUTENBERG_WEB_VIEW_AUTH_DATA, gutenbergWebViewAuthData);
 


### PR DESCRIPTION
## Description
This PR incorporates the 1.38.1 release of gutenberg-mobile.  
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2711

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.