### PR TITLE
Reader Detail Updates (More menu)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -394,15 +394,21 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                             this.siteId,
                             this.feedId
                     )
+                    is ReaderNavigationEvents.SharePost -> ReaderActivityLauncher.sharePost(context, post)
+                    is ReaderNavigationEvents.OpenPost -> ReaderActivityLauncher.openPost(context, post)
+                    is ReaderNavigationEvents.ShowReportPost -> {
+                        ReaderActivityLauncher.openUrl(
+                                context,
+                                readerUtilsWrapper.getReportPostUrl(url),
+                                OpenUrlType.INTERNAL
+                        )
+                    }
                     is ReaderNavigationEvents.ShowReaderComments,
                     is ReaderNavigationEvents.ShowNoSitesToReblog,
                     is ReaderNavigationEvents.ShowSitePickerForResult,
                     is ReaderNavigationEvents.OpenEditorForReblog,
                     is ReaderNavigationEvents.ShowBookmarkedTab,
-                    is ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog,
-                    is ReaderNavigationEvents.SharePost,
-                    is ReaderNavigationEvents.OpenPost,
-                    is ReaderNavigationEvents.ShowReportPost -> { // TODO: Handle nav events
+                    is ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog -> { // TODO: Handle nav events
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -214,6 +214,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             val menu: Menu = toolbar.menu
             val menuBrowse: MenuItem? = menu.findItem(R.id.menu_browse)
             val menuShare: MenuItem? = menu.findItem(R.id.menu_share)
+            val menuMore: MenuItem? = menu.findItem(R.id.menu_more)
 
             val collapsingToolbarHeight = collapsingToolbarLayout.height
             val isCollapsed = (collapsingToolbarHeight + verticalOffset) <=
@@ -234,6 +235,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
             menuBrowse?.icon?.colorFilter = colorFilter
             menuShare?.icon?.colorFilter = colorFilter
+            menuMore?.icon?.colorFilter = colorFilter
         }
     }
 
@@ -362,10 +364,10 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private fun initViewModel() {
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReaderPostDetailViewModel::class.java)
         viewModel.headerUiState.observe(
-            viewLifecycleOwner,
-            Observer<ReaderPostDetailsHeaderUiState> { state ->
-                header_view.updatePost(state)
-            }
+                viewLifecycleOwner,
+                Observer<ReaderPostDetailsHeaderUiState> { state ->
+                    header_view.updatePost(state)
+                }
         )
 
         viewModel.snackbarEvents.observe(viewLifecycleOwner, Observer {
@@ -466,6 +468,11 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             R.id.menu_share -> {
                 AnalyticsTracker.track(SHARED_ITEM)
                 sharePage()
+                return true
+            }
+            R.id.menu_more -> {
+                // TODO: Handle more menu
+
                 return true
             }
             else -> return super.onOptionsItemSelected(item)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -495,7 +495,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         when (item.itemId) {
             R.id.menu_browse -> {
                 if (hasPost()) {
-                    ReaderActivityLauncher.openUrl(activity, post!!.url, OpenUrlType.EXTERNAL)
+                    ReaderActivityLauncher.openPost(context, post)
                 } else if (interceptedUri != null) {
                     AnalyticsUtils.trackWithInterceptedUri(
                             DEEP_LINKED_FALLBACK,
@@ -508,7 +508,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             }
             R.id.menu_share -> {
                 AnalyticsTracker.track(SHARED_ITEM)
-                sharePage()
+                ReaderActivityLauncher.sharePost(context, post)
                 return true
             }
             else -> return super.onOptionsItemSelected(item)
@@ -725,28 +725,6 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                     READER_ARTICLE_DETAIL_UNLIKED,
                     post
             )
-        }
-    }
-
-    /**
-     * display the standard Android share chooser to share this post
-     */
-    private fun sharePage() {
-        val post = this.post
-        if (!isAdded || post == null) {
-            return
-        }
-
-        val url = if (post.hasShortUrl()) post.shortUrl else post.url
-
-        val intent = Intent(Intent.ACTION_SEND)
-        intent.type = "text/plain"
-        intent.putExtra(Intent.EXTRA_TEXT, url)
-        intent.putExtra(Intent.EXTRA_SUBJECT, post.title)
-        try {
-            startActivity(Intent.createChooser(intent, getString(R.string.share_link)))
-        } catch (ex: android.content.ActivityNotFoundException) {
-            ToastUtils.showToast(activity, R.string.reader_toast_err_share_intent)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -50,7 +50,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
                     SecondaryAction(
                             type = FOLLOW,
                             label = UiStringRes(R.string.reader_btn_unfollow),
-                            labelColor = R.attr.wpColorSuccess,
+                            labelColor = R.attr.wpColorOnSurfaceMedium,
                             iconRes = R.drawable.ic_reader_following_white_24dp,
                             isSelected = true,
                             onClicked = onButtonClicked
@@ -64,7 +64,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
                             SecondaryAction(
                                     type = SITE_NOTIFICATIONS,
                                     label = UiStringRes(R.string.reader_btn_notifications_off),
-                                    labelColor = R.attr.wpColorSuccess,
+                                    labelColor = R.attr.wpColorOnSurfaceMedium,
                                     iconRes = R.drawable.ic_bell_white_24dp,
                                     isSelected = true,
                                     onClicked = onButtonClicked
@@ -89,7 +89,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
                     SecondaryAction(
                             type = FOLLOW,
                             label = UiStringRes(R.string.reader_btn_follow),
-                            labelColor = R.attr.colorPrimary,
+                            labelColor = R.attr.colorSecondary,
                             iconRes = R.drawable.ic_reader_follow_white_24dp,
                             isSelected = false,
                             onClicked = onButtonClicked
@@ -112,7 +112,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
                         type = VISIT_SITE,
                         label = UiStringRes(R.string.reader_label_visit),
                         labelColor = R.attr.colorOnSurface,
-                        iconRes = R.drawable.ic_external_white_24dp,
+                        iconRes = R.drawable.ic_globe_white_24dp,
                         iconColor = R.attr.wpColorOnSurfaceMedium,
                         onClicked = onButtonClicked
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -79,26 +79,35 @@ class ReaderPostDetailViewModel @Inject constructor(
         }
     }
 
-    private fun onMoreButtonClicked(uiState: ReaderPostDetailsUiState) {
-        changeMoreMenuVisibility(uiState, true)
+    fun onMoreButtonClicked() {
+        changeMoreMenuVisibility(true)
     }
 
-    private fun onMoreMenuDismissed(uiState: ReaderPostDetailsUiState) {
-        changeMoreMenuVisibility(uiState, false)
+    fun onMoreMenuDismissed() {
+        changeMoreMenuVisibility(false)
     }
 
-    private fun changeMoreMenuVisibility(currentUiState: ReaderPostDetailsUiState, show: Boolean) {
-        launch {
-            findPost(currentUiState.postId, currentUiState.blogId)?.let { post ->
+    fun onMoreMenuItemClicked(type: ReaderPostCardActionType) {
+        val currentUiState = uiState.value
+        currentUiState?.let {
+            onButtonClicked(currentUiState.postId, currentUiState.blogId, type)
+        }
+        changeMoreMenuVisibility(false)
+    }
+
+    private fun changeMoreMenuVisibility(show: Boolean) {
+        val currentUiState = uiState.value
+        currentUiState?.let {
+            findPost(it.postId, it.blogId)?.let { post ->
                 val moreMenuItems = if (show) {
-                    readerPostMoreButtonUiStateBuilder.buildMoreMenuItems(
+                    readerPostMoreButtonUiStateBuilder.buildMoreMenuItemsBlocking(
                             post, TAG_FOLLOWED, this@ReaderPostDetailViewModel::onButtonClicked
                     )
                 } else {
                     null
                 }
 
-                _uiState.value = currentUiState.copy(moreMenuItems = moreMenuItems)
+                _uiState.value = it.copy(moreMenuItems = moreMenuItems)
             }
         }
     }
@@ -121,9 +130,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         return ReaderPostDetailsUiState(
                 postId = post.postId,
                 blogId = post.blogId,
-                headerUiState = createPostDetailsHeaderUiState(post),
-                onMoreButtonClicked = this@ReaderPostDetailViewModel::onMoreButtonClicked,
-                onMoreDismissed = this@ReaderPostDetailViewModel::onMoreMenuDismissed
+                headerUiState = createPostDetailsHeaderUiState(post)
         )
     }
 
@@ -163,9 +170,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         val postId: Long,
         val blogId: Long,
         val headerUiState: ReaderPostDetailsHeaderUiState,
-        val moreMenuItems: List<SecondaryAction>? = null,
-        val onMoreButtonClicked: (ReaderPostDetailsUiState) -> Unit,
-        val onMoreDismissed: (ReaderPostDetailsUiState) -> Unit
+        val moreMenuItems: List<SecondaryAction>? = null
     )
 
     override fun onCleared() {

--- a/WordPress/src/main/res/menu/reader_detail.xml
+++ b/WordPress/src/main/res/menu/reader_detail.xml
@@ -14,4 +14,10 @@
         android:title="@string/share_action"
         app:showAsAction="always" />
 
+    <item
+        android:id="@+id/menu_more"
+        android:icon="@drawable/ic_ellipsis_vertical_white_24dp"
+        android:title="@string/more"
+        app:showAsAction="always" />
+
 </menu>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilderTest.kt
@@ -176,7 +176,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
     }
 
     @Test
-    fun `follow action label color is primary(blue)`() = test {
+    fun `follow action label color is secondary(pink)`() = test {
         // Arrange
         val post = init(isFollowed = false)
         // Act
@@ -184,12 +184,12 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.FOLLOW &&
-                    it.labelColor == R.attr.colorPrimary
+                    it.labelColor == R.attr.colorSecondary
         }).isNotNull
     }
 
     @Test
-    fun `unfollow action label color is success(green)`() = test {
+    fun `unfollow action label color is OnSurfaceMedium(grey)`() = test {
         // Arrange
         val post = init(isFollowed = true)
         // Act
@@ -197,7 +197,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.FOLLOW &&
-                    it.labelColor == R.attr.wpColorSuccess
+                    it.labelColor == R.attr.wpColorOnSurfaceMedium
         }).isNotNull
     }
 
@@ -215,7 +215,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
     }
 
     @Test
-    fun `site notifications action label color is success(green) when notifications enabled`() = test {
+    fun `site notifications action label color is OnSurfaceMedium(grey) when notifications enabled`() = test {
         // Arrange
         val post = init(isFollowed = true, isNotificationsEnabled = true)
         // Act
@@ -223,7 +223,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.SITE_NOTIFICATIONS &&
-                    it.labelColor == R.attr.wpColorSuccess
+                    it.labelColor == R.attr.wpColorOnSurfaceMedium
         }).isNotNull
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -12,6 +12,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionsHandler
+import org.wordpress.android.ui.reader.discover.ReaderPostMoreButtonUiStateBuilder
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.views.ReaderPostDetailsHeaderViewUiStateBuilder
 
@@ -27,6 +28,7 @@ class ReaderPostDetailViewModelTest {
     @Mock private lateinit var readerUtilsWrapper: ReaderUtilsWrapper
     @Mock private lateinit var postDetailsHeaderViewUiStateBuilder: ReaderPostDetailsHeaderViewUiStateBuilder
     @Mock private lateinit var readerPostTableWrapper: ReaderPostTableWrapper
+    @Mock private lateinit var menuUiStateBuilder: ReaderPostMoreButtonUiStateBuilder
 
     @Before
     fun setUp() {
@@ -35,6 +37,7 @@ class ReaderPostDetailViewModelTest {
                 postDetailsHeaderViewUiStateBuilder,
                 readerUtilsWrapper,
                 readerPostTableWrapper,
+                menuUiStateBuilder,
                 TEST_DISPATCHER,
                 TEST_DISPATCHER
         )


### PR DESCRIPTION
Task: #12900

This PR adds more menu on the reader post details screen.

Child PRs:
#13116 Introduces VM
#13117 Updates post details header view using the VM

**To Test**

1. Click a reader post
2. Verify that click action on menu items behave correctly
3. Verify that globe menu action opens the post inside the app

![more_menu](https://user-images.githubusercontent.com/1405144/95860145-4420b780-0d7d-11eb-9a3f-bc16affc74a1.gif)

**Merge instructions**

1. Make sure #13116, #13117 are merged
2. Change branch to "issue/12900-rip3-detail-updates-main"
3. Remove "Not Ready for Merge"
4. Merge this PR

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
