### PR TITLE
Reader Details Updates (Update header view from vm)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -99,14 +99,13 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.ReaderPostDetailsUiState
 import org.wordpress.android.ui.reader.views.ReaderIconCountView
-import org.wordpress.android.ui.reader.views.ReaderPostDetailHeaderView
 import org.wordpress.android.ui.reader.views.ReaderPostDetailsHeaderViewUiStateBuilder
 import org.wordpress.android.ui.reader.views.ReaderWebView
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderCustomViewListener
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewPageFinishedListener
 import org.wordpress.android.ui.reader.views.ReaderWebView.ReaderWebViewUrlClickListener
-import org.wordpress.android.ui.reader.views.uistates.ReaderPostDetailsHeaderViewUiState.ReaderPostDetailsHeaderUiState
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AppLog
@@ -361,11 +360,11 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
     private fun initViewModel() {
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReaderPostDetailViewModel::class.java)
-        viewModel.headerUiState.observe(
-            viewLifecycleOwner,
-            Observer<ReaderPostDetailsHeaderUiState> { state ->
-                header_view.updatePost(state)
-            }
+        viewModel.uiState.observe(
+                viewLifecycleOwner,
+                Observer<ReaderPostDetailsUiState> { state ->
+                    header_view.updatePost(state.headerUiState)
+                }
         )
 
         viewModel.snackbarEvents.observe(viewLifecycleOwner, Observer {
@@ -1230,7 +1229,6 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             readerWebView.setIsPrivatePost(post!!.isPrivate)
             readerWebView.setBlogSchemeIsHttps(UrlUtils.isHttps(post!!.blogUrl))
 
-            val headerView = view!!.findViewById<ReaderPostDetailHeaderView>(R.id.header_view)
             if (!canShowFooter()) {
                 layoutFooter.visibility = View.GONE
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -106,4 +106,9 @@ class ReaderPostDetailViewModel @Inject constructor(
             readerPostCardActionsHandler.handleHeaderClicked(blogId, postId)
         }
     }
+
+    override fun onCleared() {
+        super.onCleared()
+        readerPostCardActionsHandler.onCleared()
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderTagType.FOLLOWED
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType
@@ -36,6 +37,9 @@ class ReaderPostDetailViewModel @Inject constructor(
     private val _navigationEvents = MediatorLiveData<Event<ReaderNavigationEvents>>()
     val navigationEvents: LiveData<Event<ReaderNavigationEvents>> = _navigationEvents
 
+    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
     private var isStarted = false
 
     fun start() {
@@ -59,12 +63,24 @@ class ReaderPostDetailViewModel @Inject constructor(
                 _headerUiState.value = createPostDetailsHeaderUiState(it)
             }
         }
+
+        _snackbarEvents.addSource(readerPostCardActionsHandler.snackbarEvents) { event ->
+            _snackbarEvents.value = event
+        }
+
+        _navigationEvents.addSource(readerPostCardActionsHandler.navigationEvents) { event ->
+            _navigationEvents.value = event
+        }
     }
 
     fun onButtonClicked(post: ReaderPost, type: ReaderPostCardActionType) {
         launch {
             readerPostCardActionsHandler.onAction(post, type, isBookmarkList = false)
         }
+    }
+
+    fun onShowPost(post: ReaderPost) {
+        _headerUiState.value = createPostDetailsHeaderUiState(post)
     }
 
     private fun createPostDetailsHeaderUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -1,14 +1,41 @@
 package org.wordpress.android.ui.reader.viewmodels
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
+import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.models.ReaderTagType.FOLLOWED
+import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionsHandler
+import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.reader.views.ReaderPostDetailsHeaderViewUiStateBuilder
+import org.wordpress.android.ui.reader.views.uistates.ReaderPostDetailsHeaderViewUiState.ReaderPostDetailsHeaderUiState
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
 class ReaderPostDetailViewModel @Inject constructor(
-    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
+    private val readerPostCardActionsHandler: ReaderPostCardActionsHandler,
+    private val postDetailsHeaderViewUiStateBuilder: ReaderPostDetailsHeaderViewUiStateBuilder,
+    private val readerUtilsWrapper: ReaderUtilsWrapper,
+    private val readerPostTableWrapper: ReaderPostTableWrapper,
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
+    @Named(BG_THREAD) private val ioDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {
+    private val _headerUiState = MediatorLiveData<ReaderPostDetailsHeaderUiState>()
+    val headerUiState: LiveData<ReaderPostDetailsHeaderUiState> = _headerUiState
+
+    private val _navigationEvents = MediatorLiveData<Event<ReaderNavigationEvents>>()
+    val navigationEvents: LiveData<Event<ReaderNavigationEvents>> = _navigationEvents
+
     private var isStarted = false
 
     fun start() {
@@ -16,5 +43,51 @@ class ReaderPostDetailViewModel @Inject constructor(
             return
         }
         isStarted = true
+
+        init()
+    }
+
+    private fun init() {
+        _headerUiState.addSource(readerPostCardActionsHandler.followStatusUpdated) { data ->
+            val post = readerPostTableWrapper.getBlogPost(
+                    data.blogId,
+                    (_headerUiState.value as ReaderPostDetailsHeaderUiState).blogSectionUiState.postId,
+                    true
+            )
+            post?.let {
+                it.isFollowedByCurrentUser = data.following
+                _headerUiState.value = createPostDetailsHeaderUiState(it)
+            }
+        }
+    }
+
+    fun onButtonClicked(post: ReaderPost, type: ReaderPostCardActionType) {
+        launch {
+            readerPostCardActionsHandler.onAction(post, type, isBookmarkList = false)
+        }
+    }
+
+    private fun createPostDetailsHeaderUiState(
+        post: ReaderPost
+    ): ReaderPostDetailsHeaderUiState {
+        return postDetailsHeaderViewUiStateBuilder.mapPostToUiState(
+                post,
+                this@ReaderPostDetailViewModel::onBlogSectionClicked,
+                { onButtonClicked(post, FOLLOW) },
+                this@ReaderPostDetailViewModel::onTagItemClicked
+        )
+    }
+
+    private fun onTagItemClicked(tagSlug: String) {
+        launch(ioDispatcher) {
+            val readerTag = readerUtilsWrapper.getTagFromTagName(tagSlug, FOLLOWED)
+            _navigationEvents.postValue(Event(ShowPostsByTag(readerTag)))
+        }
+    }
+
+    private fun onBlogSectionClicked(postId: Long, blogId: Long) {
+        launch {
+            readerPostCardActionsHandler.handleHeaderClicked(blogId, postId)
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailsHeaderViewUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailsHeaderViewUiStateBuilder.kt
@@ -23,7 +23,7 @@ class ReaderPostDetailsHeaderViewUiStateBuilder @Inject constructor(
 ) {
     fun mapPostToUiState(
         post: ReaderPost,
-        onBlogSectionClicked: (Long?, Long?) -> Unit,
+        onBlogSectionClicked: (Long, Long) -> Unit,
         onFollowClicked: () -> Unit,
         onTagItemClicked: (String) -> Unit
     ): ReaderPostDetailsHeaderUiState {
@@ -45,7 +45,7 @@ class ReaderPostDetailsHeaderViewUiStateBuilder @Inject constructor(
 
     private fun buildBlogSectionUiState(
         post: ReaderPost,
-        onBlogSectionClicked: (Long?, Long?) -> Unit
+        onBlogSectionClicked: (Long, Long) -> Unit
     ): ReaderBlogSectionUiState {
         return postUiStateBuilder.mapPostToBlogSectionUiState(
             post,

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -7,8 +7,13 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionsHandler
+import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.reader.views.ReaderPostDetailsHeaderViewUiStateBuilder
 
 @InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -18,9 +23,21 @@ class ReaderPostDetailViewModelTest {
 
     private lateinit var viewModel: ReaderPostDetailViewModel
 
+    @Mock private lateinit var readerPostCardActionsHandler: ReaderPostCardActionsHandler
+    @Mock private lateinit var readerUtilsWrapper: ReaderUtilsWrapper
+    @Mock private lateinit var postDetailsHeaderViewUiStateBuilder: ReaderPostDetailsHeaderViewUiStateBuilder
+    @Mock private lateinit var readerPostTableWrapper: ReaderPostTableWrapper
+
     @Before
     fun setUp() {
-        viewModel = ReaderPostDetailViewModel(TEST_DISPATCHER)
+        viewModel = ReaderPostDetailViewModel(
+                readerPostCardActionsHandler,
+                postDetailsHeaderViewUiStateBuilder,
+                readerUtilsWrapper,
+                readerPostTableWrapper,
+                TEST_DISPATCHER,
+                TEST_DISPATCHER
+        )
     }
 
     @Test


### PR DESCRIPTION
Task: #12900
Parent PR #13114

This PR 
- Updates reader post details header view using the VM
- Removes now unused follow action from the  reader post details fragment 

To Test:
- Click a Reader post
- Verify that click action for Follow, Blog Preview and Tag (inside expandable tags view) work as before

**Merge instructions**

1. Make sure #13116 is merged
2. Change branch to "issue/12900-rip3-detail-updates-main"
3. Remove "Not Ready for Merge"
4. Merge this PR

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
