### PR TITLE
Gutenberg/inject css on both page visible and page started and show correct title in web view

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
@@ -24,7 +24,7 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
 
     public static final String ARG_USER_ID = "authenticated_user_id";
     public static final String ARG_BLOCK_ID = "block_id";
-    public static final String ARG_BLOCK_NAME = "block_name";
+    public static final String ARG_BLOCK_TITLE = "block_title";
     public static final String ARG_BLOCK_CONTENT = "block_content";
 
     private boolean mIsJetpackSsoEnabled;
@@ -73,9 +73,9 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
 
     @Override
     protected String getToolbarTitle() {
-        String blockName = getIntent().getExtras().getString(ARG_BLOCK_NAME);
-        if (blockName != null) {
-            return String.format(getString(R.string.menu_toolbar_title), blockName);
+        String blockTitle = getIntent().getExtras().getString(ARG_BLOCK_TITLE);
+        if (blockTitle != null) {
+            return String.format(getString(R.string.menu_toolbar_title), blockTitle);
         }
         return "";
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -304,7 +304,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                         openGutenbergWebViewActivity(
                                 unsupportedBlock.getContent(),
                                 unsupportedBlock.getId(),
-                                unsupportedBlock.getName()
+                                unsupportedBlock.getName(),
+                                unsupportedBlock.getTitle()
                         );
                     }
                 },
@@ -357,7 +358,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         return view;
     }
 
-    private void openGutenbergWebViewActivity(String content, String blockId, String blockName) {
+    private void openGutenbergWebViewActivity(String content, String blockId, String blockName, String blockTitle) {
         GutenbergWebViewAuthorizationData gutenbergWebViewAuthData =
                 getArguments().getParcelable(ARG_GUTENBERG_WEB_VIEW_AUTH_DATA);
 
@@ -367,7 +368,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
         Intent intent = new Intent(getActivity(), WPGutenbergWebViewActivity.class);
         intent.putExtra(WPGutenbergWebViewActivity.ARG_BLOCK_ID, blockId);
-        intent.putExtra(WPGutenbergWebViewActivity.ARG_BLOCK_NAME, blockName);
+        intent.putExtra(WPGutenbergWebViewActivity.ARG_BLOCK_TITLE, blockTitle);
         intent.putExtra(WPGutenbergWebViewActivity.ARG_BLOCK_CONTENT, content);
         intent.putExtra(WPGutenbergWebViewActivity.ARG_GUTENBERG_WEB_VIEW_AUTH_DATA, gutenbergWebViewAuthData);
 


### PR DESCRIPTION
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/26071
Gutenberg mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2715

To test:

1. On the web, create a post with a classic block on a Jetpack site (we should use jurassic ninja to test the classic block on a jetpack site).
2. Save or publish the post.
3. In the app, open the post from the previous step in the block editor.
4. Tap on the classic block.
5. Tap on the classic block again.
6. Select the option to "Edit using the web editor."
7. Observe that classic block is presented and all HTML elements (navigation bar and other) are hidden.
8. Check that WebView has a good block title (e.g. 'Edit Classic block')

Screenshot:

![device-2020-10-13-143231](https://user-images.githubusercontent.com/28219092/95901206-fd24c900-0d60-11eb-92a5-10f5c2d69c91.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
