### PR TITLE
Use base 64 encoding to load map webview in stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapViewHolder.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 
 import android.annotation.SuppressLint
 import android.net.http.SslError
+import android.util.Base64
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.SslErrorHandler
@@ -119,7 +120,8 @@ class MapViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                 }
                 webView.settings.javaScriptEnabled = true
                 webView.settings.cacheMode = WebSettings.LOAD_NO_CACHE
-                webView.loadData(htmlPage, "text/html", "UTF-8")
+                val base64version: String = Base64.encodeToString(htmlPage.toByteArray(), Base64.DEFAULT)
+                webView.loadData(base64version, "text/html; charset=UTF-8", "base64")
             }
         }
     }


### PR DESCRIPTION
Fixes #13121

This fixes the invisible map introduced in 15.9. It was caused by the target SDK change to 29 where (for some reason) the `loadData` method on WebView started filtering out `#` symbol. I used solution proposed in https://stackoverflow.com/questions/58061708/webview-targeting-29-not-showing-content to convert the data to base 64 first before showing it to the user and it seems to fix the problem.

This PR doesn't fix the white map in dark mode issue. 

To test:
- Go to Stats/Years (to make sure you have some country views)
- Scroll to the "Country" block
- See that the map is visible

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
