### PR TITLE
Parcel marshaling issue with preview and edit

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
@@ -4,8 +4,8 @@ import android.net.Uri
 import android.os.Parcel
 import android.os.Parcelable
 import android.os.Parcelable.Creator
-import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.GifMediaIdentifier
+import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.LocalId
 import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.LocalUri
 import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.RemoteId
 import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.StockMediaIdentifier
@@ -22,6 +22,7 @@ data class MediaItem(
     enum class IdentifierType {
         LocalUri,
         RemoteId,
+        LocalId,
         StockMediaIdentifier,
         GifMediaIdentifier
     }
@@ -31,10 +32,11 @@ data class MediaItem(
 
         data class RemoteId(val value: Long) : Identifier(RemoteId)
 
+        data class LocalId(val value: Int) : Identifier(LocalId)
+
         data class StockMediaIdentifier(val url: String?, val name: String?, val title: String?) : Identifier(StockMediaIdentifier)
 
         data class GifMediaIdentifier(
-            val mediaModel: MediaModel?,
             val largeImageUri: UriWrapper,
             val title: String?
         ) : Identifier(GifMediaIdentifier)
@@ -48,13 +50,15 @@ data class MediaItem(
                 is RemoteId -> {
                     parcel.writeLong(this.value)
                 }
+                is LocalId -> {
+                    parcel.writeInt(this.value)
+                }
                 is StockMediaIdentifier -> {
                     parcel.writeString(this.url)
                     parcel.writeString(this.name)
                     parcel.writeString(this.title)
                 }
                 is GifMediaIdentifier -> {
-                    parcel.writeSerializable(this.mediaModel)
                     parcel.writeParcelable(this.largeImageUri.uri, flags)
                     parcel.writeString(this.title)
                 }
@@ -75,13 +79,14 @@ data class MediaItem(
                     RemoteId -> {
                         RemoteId(parcel.readLong())
                     }
+                    LocalId -> {
+                        LocalId(parcel.readInt())
+                    }
                     StockMediaIdentifier -> {
                         StockMediaIdentifier(parcel.readString(), parcel.readString(), parcel.readString())
                     }
                     GifMediaIdentifier -> {
-                        val model = parcel.readSerializable()
                         GifMediaIdentifier(
-                                model?.let { it as MediaModel },
                                 UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))),
                                 parcel.readString())
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
@@ -34,7 +34,11 @@ data class MediaItem(
 
         data class LocalId(val value: Int) : Identifier(LocalId)
 
-        data class StockMediaIdentifier(val url: String?, val name: String?, val title: String?) : Identifier(StockMediaIdentifier)
+        data class StockMediaIdentifier(
+            val url: String?,
+            val name: String?,
+            val title: String?
+        ) : Identifier(StockMediaIdentifier)
 
         data class GifMediaIdentifier(
             val largeImageUri: UriWrapper,
@@ -72,7 +76,7 @@ data class MediaItem(
         companion object CREATOR : Creator<Identifier> {
             override fun createFromParcel(parcel: Parcel): Identifier {
                 val type = IdentifierType.valueOf(requireNotNull(parcel.readString()))
-                return when(type) {
+                return when (type) {
                     LocalUri -> {
                         LocalUri(UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))))
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
@@ -73,32 +73,36 @@ data class MediaItem(
             return 0
         }
 
-        companion object CREATOR : Creator<Identifier> {
-            override fun createFromParcel(parcel: Parcel): Identifier {
-                val type = IdentifierType.valueOf(requireNotNull(parcel.readString()))
-                return when (type) {
-                    LocalUri -> {
-                        LocalUri(UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))))
-                    }
-                    RemoteId -> {
-                        RemoteId(parcel.readLong())
-                    }
-                    LocalId -> {
-                        LocalId(parcel.readInt())
-                    }
-                    StockMediaIdentifier -> {
-                        StockMediaIdentifier(parcel.readString(), parcel.readString(), parcel.readString())
-                    }
-                    GifMediaIdentifier -> {
-                        GifMediaIdentifier(
-                                UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))),
-                                parcel.readString())
+        companion object {
+            @JvmField
+            val CREATOR : Creator<Identifier> = object : Creator<Identifier> {
+                override fun createFromParcel(parcel: Parcel): Identifier {
+                    val type = IdentifierType.valueOf(requireNotNull(parcel.readString()))
+                    return when (type) {
+                        LocalUri -> {
+                            LocalUri(UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))))
+                        }
+                        RemoteId -> {
+                            RemoteId(parcel.readLong())
+                        }
+                        LocalId -> {
+                            LocalId(parcel.readInt())
+                        }
+                        StockMediaIdentifier -> {
+                            StockMediaIdentifier(parcel.readString(), parcel.readString(), parcel.readString())
+                        }
+                        GifMediaIdentifier -> {
+                            GifMediaIdentifier(
+                                    UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))),
+                                    parcel.readString()
+                            )
+                        }
                     }
                 }
-            }
 
-            override fun newArray(size: Int): Array<Identifier?> {
-                return arrayOfNulls(size)
+                override fun newArray(size: Int): Array<Identifier?> {
+                    return arrayOfNulls(size)
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
@@ -1,9 +1,14 @@
 package org.wordpress.android.ui.mediapicker
 
+import android.net.Uri
+import android.os.Parcel
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.RawValue
+import android.os.Parcelable.Creator
 import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.GifMediaIdentifier
+import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.LocalUri
+import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.RemoteId
+import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.StockMediaIdentifier
 import org.wordpress.android.util.UriWrapper
 
 data class MediaItem(
@@ -14,21 +19,78 @@ data class MediaItem(
     val mimeType: String? = null,
     val dataModified: Long
 ) {
-    sealed class Identifier : Parcelable {
-        @Parcelize
-        data class LocalUri(val value: @RawValue UriWrapper) : Identifier()
+    enum class IdentifierType {
+        LocalUri,
+        RemoteId,
+        StockMediaIdentifier,
+        GifMediaIdentifier
+    }
 
-        @Parcelize
-        data class RemoteId(val value: Long) : Identifier()
+    sealed class Identifier(val type: IdentifierType) : Parcelable {
+        data class LocalUri(val value: UriWrapper) : Identifier(LocalUri)
 
-        @Parcelize
-        data class StockMediaIdentifier(val url: String?, val name: String?, val title: String?) : Identifier()
+        data class RemoteId(val value: Long) : Identifier(RemoteId)
 
-        @Parcelize
+        data class StockMediaIdentifier(val url: String?, val name: String?, val title: String?) : Identifier(StockMediaIdentifier)
+
         data class GifMediaIdentifier(
             val mediaModel: MediaModel?,
-            val largeImageUri: @RawValue UriWrapper,
+            val largeImageUri: UriWrapper,
             val title: String?
-        ) : Identifier()
+        ) : Identifier(GifMediaIdentifier)
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeString(this.type.name)
+            when (this) {
+                is LocalUri -> {
+                    parcel.writeParcelable(this.value.uri, flags)
+                }
+                is RemoteId -> {
+                    parcel.writeLong(this.value)
+                }
+                is StockMediaIdentifier -> {
+                    parcel.writeString(this.url)
+                    parcel.writeString(this.name)
+                    parcel.writeString(this.title)
+                }
+                is GifMediaIdentifier -> {
+                    parcel.writeSerializable(this.mediaModel)
+                    parcel.writeParcelable(this.largeImageUri.uri, flags)
+                    parcel.writeString(this.title)
+                }
+            }
+        }
+
+        override fun describeContents(): Int {
+            return 0
+        }
+
+        companion object CREATOR : Creator<Identifier> {
+            override fun createFromParcel(parcel: Parcel): Identifier {
+                val type = IdentifierType.valueOf(requireNotNull(parcel.readString()))
+                return when(type) {
+                    LocalUri -> {
+                        LocalUri(UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))))
+                    }
+                    RemoteId -> {
+                        RemoteId(parcel.readLong())
+                    }
+                    StockMediaIdentifier -> {
+                        StockMediaIdentifier(parcel.readString(), parcel.readString(), parcel.readString())
+                    }
+                    GifMediaIdentifier -> {
+                        val model = parcel.readSerializable()
+                        GifMediaIdentifier(
+                                model?.let { it as MediaModel },
+                                UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))),
+                                parcel.readString())
+                    }
+                }
+            }
+
+            override fun newArray(size: Int): Array<Identifier?> {
+                return arrayOfNulls(size)
+            }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
@@ -75,7 +75,7 @@ data class MediaItem(
 
         companion object {
             @JvmField
-            val CREATOR : Creator<Identifier> = object : Creator<Identifier> {
+            val CREATOR: Creator<Identifier> = object : Creator<Identifier> {
                 override fun createFromParcel(parcel: Parcel): Identifier {
                     val type = IdentifierType.valueOf(requireNotNull(parcel.readString()))
                     return when (type) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
@@ -4,11 +4,11 @@ import android.net.Uri
 import android.os.Parcel
 import android.os.Parcelable
 import android.os.Parcelable.Creator
-import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.GifMediaIdentifier
-import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.LocalId
-import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.LocalUri
-import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.RemoteId
-import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.StockMediaIdentifier
+import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.GIF_MEDIA_IDENTIFIER
+import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.LOCAL_ID
+import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.LOCAL_URI
+import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.REMOTE_ID
+import org.wordpress.android.ui.mediapicker.MediaItem.IdentifierType.STOCK_MEDIA_IDENTIFIER
 import org.wordpress.android.util.UriWrapper
 
 data class MediaItem(
@@ -20,30 +20,30 @@ data class MediaItem(
     val dataModified: Long
 ) {
     enum class IdentifierType {
-        LocalUri,
-        RemoteId,
-        LocalId,
-        StockMediaIdentifier,
-        GifMediaIdentifier
+        LOCAL_URI,
+        REMOTE_ID,
+        LOCAL_ID,
+        STOCK_MEDIA_IDENTIFIER,
+        GIF_MEDIA_IDENTIFIER
     }
 
     sealed class Identifier(val type: IdentifierType) : Parcelable {
-        data class LocalUri(val value: UriWrapper) : Identifier(LocalUri)
+        data class LocalUri(val value: UriWrapper) : Identifier(LOCAL_URI)
 
-        data class RemoteId(val value: Long) : Identifier(RemoteId)
+        data class RemoteId(val value: Long) : Identifier(REMOTE_ID)
 
-        data class LocalId(val value: Int) : Identifier(LocalId)
+        data class LocalId(val value: Int) : Identifier(LOCAL_ID)
 
         data class StockMediaIdentifier(
             val url: String?,
             val name: String?,
             val title: String?
-        ) : Identifier(StockMediaIdentifier)
+        ) : Identifier(STOCK_MEDIA_IDENTIFIER)
 
         data class GifMediaIdentifier(
             val largeImageUri: UriWrapper,
             val title: String?
-        ) : Identifier(GifMediaIdentifier)
+        ) : Identifier(GIF_MEDIA_IDENTIFIER)
 
         override fun writeToParcel(parcel: Parcel, flags: Int) {
             parcel.writeString(this.type.name)
@@ -79,19 +79,19 @@ data class MediaItem(
                 override fun createFromParcel(parcel: Parcel): Identifier {
                     val type = IdentifierType.valueOf(requireNotNull(parcel.readString()))
                     return when (type) {
-                        LocalUri -> {
+                        LOCAL_URI -> {
                             LocalUri(UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))))
                         }
-                        RemoteId -> {
+                        REMOTE_ID -> {
                             RemoteId(parcel.readLong())
                         }
-                        LocalId -> {
+                        LOCAL_ID -> {
                             LocalId(parcel.readInt())
                         }
-                        StockMediaIdentifier -> {
+                        STOCK_MEDIA_IDENTIFIER -> {
                             StockMediaIdentifier(parcel.readString(), parcel.readString(), parcel.readString())
                         }
-                        GifMediaIdentifier -> {
+                        GIF_MEDIA_IDENTIFIER -> {
                             GifMediaIdentifier(
                                     UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))),
                                     parcel.readString()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -296,7 +296,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
     override fun onItemsChosen(identifiers: List<Identifier>) {
         val chosenUris = identifiers.mapNotNull { (it as? Identifier.LocalUri)?.value?.uri }
         val chosenIds = identifiers.mapNotNull { (it as? Identifier.RemoteId)?.value }
-        val chosenLocalIds = identifiers.mapNotNull { (it as? Identifier.LocalId)?.value}
+        val chosenLocalIds = identifiers.mapNotNull { (it as? Identifier.LocalId)?.value }
 
         if (chosenUris.isNotEmpty()) {
             doMediaUrisSelected(chosenUris, APP_PICKER)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -296,7 +296,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
     override fun onItemsChosen(identifiers: List<Identifier>) {
         val chosenUris = identifiers.mapNotNull { (it as? Identifier.LocalUri)?.value?.uri }
         val chosenIds = identifiers.mapNotNull { (it as? Identifier.RemoteId)?.value }
-        val chosenLocalIds = identifiers.mapNotNull { (it as? Identifier.GifMediaIdentifier)?.mediaModel?.id }
+        val chosenLocalIds = identifiers.mapNotNull { (it as? Identifier.LocalId)?.value}
 
         if (chosenUris.isNotEmpty()) {
             doMediaUrisSelected(chosenUris, APP_PICKER)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/insert/GifMediaInsertUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/insert/GifMediaInsertUseCase.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.yield
@@ -18,6 +19,7 @@ import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.ui.mediapicker.MediaItem.Identifier
 import org.wordpress.android.ui.mediapicker.MediaItem.Identifier.GifMediaIdentifier
+import org.wordpress.android.ui.mediapicker.MediaItem.Identifier.LocalId
 import org.wordpress.android.ui.mediapicker.insert.MediaInsertHandler.InsertModel
 import org.wordpress.android.util.FluxCUtils
 import org.wordpress.android.util.WPMediaUtils
@@ -42,9 +44,9 @@ class GifMediaInsertUseCase(
                         (identifier as? GifMediaIdentifier)?.let {
                             fetchAndSaveAsync(this, it, site)
                         }
-                    }.map { it.await() }
+                    }
 
-                    InsertModel.Success(mediaIdentifiers)
+                    InsertModel.Success(mediaIdentifiers.awaitAll())
                 } catch (e: CancellationException) {
                     InsertModel.Success(listOf<GifMediaIdentifier>())
                 } catch (e: Exception) {
@@ -58,7 +60,7 @@ class GifMediaInsertUseCase(
         scope: CoroutineScope,
         gifIdentifier: GifMediaIdentifier,
         site: SiteModel
-    ): Deferred<GifMediaIdentifier> = scope.async(ioDispatcher) {
+    ): Deferred<LocalId> = scope.async(ioDispatcher) {
         return@async gifIdentifier.largeImageUri.let { mediaUri ->
             // No need to log the Exception here. The underlying method that is used, [MediaUtils.downloadExternalMedia]
             // already logs any errors.
@@ -75,7 +77,7 @@ class GifMediaInsertUseCase(
             mediaModel.title = gifIdentifier.title
             dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel))
 
-            gifIdentifier.copy(mediaModel = mediaModel)
+            LocalId(mediaModel.id)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/GifMediaDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/GifMediaDataSource.kt
@@ -115,7 +115,6 @@ class GifMediaDataSource
 
     private fun Result.toMediaItem() = MediaItem(
             identifier = GifMediaIdentifier(
-                    null,
                     UriWrapper(Uri.parse(urlFromCollectionFormat(MediaCollectionFormat.GIF))),
                     title
             ),


### PR DESCRIPTION
Fixes #13132 

The issue is related to parceling of UriWrapper; since UriWrapper is widely used I tried to play simple and used a more classic approach explicitly implementing the `Parcelable` interface on the sealed class (maybe a bit old school but should do the job 😄  ). Since the changed code was related to the [comment here](https://github.com/wordpress-mobile/WordPress-Android/pull/13104#discussion_r503851806) I tried to address that here simplifying `GifMediaIdentifier` and introducing `LocalId`. Hope I interpreted your intention in that comment correctly 🙇 

## To test
We are talking about the Wasabi flavor with the `CONSOLIDATED_MEDIA_PICKER` flag on

- trigger the long press preview on all the sources and check it works as expected
- trigger the edit action in the device picker (selecting one or more images) and check you can edit images and insert them in the media library or GB image block(s)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
