### PR TITLE
Fix post previews show black nav bar after user visits Unsupport Block Editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 * [***] Block Editor: Full-width and wide alignment support for Video, Latest-posts, Gallery, Media & text, and Pullquote block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/2605]
 * [***] Block Editor: Fix unsupported block bottom sheet is triggered when device is rotated. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/2710]
 * [***] Block Editor: Unsupported Block Editor: Fixed issue when cannot view or interact with the classic block on Jetpack site. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/2709]
-* [***] Block Editor: Post previews show black nav bar after user visits Unsupported Block Editor [https://github.com/wordpress-mobile/WordPress-Android/issues/13133]
+* [***] Block Editor: Fix post previews show black nav bar after user visits Unsupported Block Editor [https://github.com/wordpress-mobile/WordPress-Android/issues/13133]
 
 15.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [***] Block Editor: Full-width and wide alignment support for Video, Latest-posts, Gallery, Media & text, and Pullquote block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/2605]
 * [***] Block Editor: Fix unsupported block bottom sheet is triggered when device is rotated. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/2710]
 * [***] Block Editor: Unsupported Block Editor: Fixed issue when cannot view or interact with the classic block on Jetpack site. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/2709]
+* [***] Block Editor: Post previews show black nav bar after user visits Unsupported Block Editor [https://github.com/wordpress-mobile/WordPress-Android/issues/13133]
 
 15.9
 -----

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
@@ -12,7 +12,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergWebViewActivity;
 
-import java.io.UnsupportedEncodingException;;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.List;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.View;
+import android.webkit.CookieManager;
 import android.webkit.WebView;
 
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData;
@@ -11,7 +12,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergWebViewActivity;
 
-import java.io.UnsupportedEncodingException;
+import java.io.UnsupportedEncodingException;;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.List;
@@ -144,7 +145,8 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
         return Arrays.asList(file);
     }
 
-    @Override protected List<String> getOnPageLoadExternalSources() {
+    @Override
+    protected List<String> getOnPageLoadExternalSources() {
         long userId = getIntent().getExtras().getLong(ARG_USER_ID, 0);
         String file = getFileContentFromAssets("unsupported-block-editor/extra-localstorage-entries.js")
                 .replace("%@", Long.toString(userId));
@@ -173,7 +175,15 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
         }
     }
 
-    @Override public long getUserId() {
+    @Override
+    public long getUserId() {
         return mUserId;
+    }
+
+    @Override
+    protected void onDestroy() {
+        CookieManager cookieManager = CookieManager.getInstance();
+        cookieManager.removeAllCookies((success) -> AppLog.e(AppLog.T.EDITOR, "Cookies removed " + success));
+        super.onDestroy();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/13133

To test:

1. Open a post containing an unsupported block (e.g. an Audio block at the time of writing)
2. Tap the (?) option to open the Unsupported Block Editor (UBE)
3. Once the UBE is open, close it
4. Close the post and tap the View button on the post list screen to preview the post
5. Notice the black navbar is not presented at the top of the preview

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
