### PR TITLE
Reader Detail Updates (Comments entry view)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -44,6 +44,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.elevation.ElevationOverlayProvider
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.reader_fragment_post_detail.*
+import kotlinx.android.synthetic.main.reader_include_post_detail_comments_entry.*
 import kotlinx.android.synthetic.main.reader_include_post_detail_footer.*
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
@@ -100,6 +101,7 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.CommentsEntryUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.ReaderPostDetailsUiState
 import org.wordpress.android.ui.reader.views.ReaderIconCountView
 import org.wordpress.android.ui.reader.views.ReaderPostDetailsHeaderViewUiStateBuilder
@@ -375,6 +377,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                     updateActionButton(state.postId, state.blogId, state.actions.reblogAction, reblog)
                     updateActionButton(state.postId, state.blogId, state.actions.commentsAction, count_comments)
                     updateActionButton(state.postId, state.blogId, state.actions.bookmarkAction, bookmark)
+
+                    updateCommentsEntryView(state.postId, state.blogId, state.commentsEntrySection)
                 }
         )
 
@@ -442,6 +446,13 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         view.isSelected = state.isSelected
         view.contentDescription = state.contentDescription?.let { uiHelpers.getTextOfUiString(view.context, it) }
         view.setOnClickListener { state.onClicked?.invoke(postId, blogId, state.type) }
+    }
+
+    private fun updateCommentsEntryView(postId: Long, blogId: Long, state: CommentsEntryUiState) {
+        layout_post_detail_comments_entry.setVisible(state.isVisible)
+        comments_label.text = uiHelpers.getTextOfUiString(comments_label.context, state.labelText)
+        comments_action.text = uiHelpers.getTextOfUiString(comments_action.context, state.actionText)
+        comments_action.setOnClickListener { state.onClicked?.invoke(postId, blogId, state.type) }
     }
 
     private fun showBookmarkSavedLocallyDialog(bookmarkDialog: ShowBookmarkedSavedOnlyLocallyDialog) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -483,14 +483,14 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         moreMenu?.let {
             state.moreMenuItems?.let {
                 if (moreMenuPopup == null) {
-                    createAndShowMoreMenu(it, moreMenu)
+                    createMoreMenuPopup(it, moreMenu)
                 }
                 moreMenuPopup?.show()
             } ?: moreMenuPopup?.dismiss()
         }
     }
 
-    private fun createAndShowMoreMenu(actions: List<SecondaryAction>, v: View) {
+    private fun createMoreMenuPopup(actions: List<SecondaryAction>, v: View) {
         // TODO: ashiagr Add Tracks
         moreMenuPopup = ListPopupWindow(v.context)
         moreMenuPopup?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailUiStateBuilder.kt
@@ -1,20 +1,27 @@
 package org.wordpress.android.ui.reader.viewmodels
 
 import dagger.Reusable
+import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.ui.reader.discover.ReaderPostActions
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType
 import org.wordpress.android.ui.reader.discover.ReaderPostUiStateBuilder
+import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.CommentsEntryUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.ReaderPostDetailsUiState
 import org.wordpress.android.ui.reader.views.ReaderPostDetailsHeaderViewUiStateBuilder
 import org.wordpress.android.ui.reader.views.uistates.ReaderPostDetailsHeaderViewUiState.ReaderPostDetailsHeaderUiState
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import javax.inject.Inject
 
 @Reusable
 class ReaderPostDetailUiStateBuilder @Inject constructor(
     private val postDetailsHeaderViewUiStateBuilder: ReaderPostDetailsHeaderViewUiStateBuilder,
-    private val postUiStateBuilder: ReaderPostUiStateBuilder
+    private val postUiStateBuilder: ReaderPostUiStateBuilder,
+    private val accountStore: AccountStore
 ) {
     fun mapPostToUiState(
         post: ReaderPost,
@@ -37,6 +44,7 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
                 ),
                 moreMenuItems = moreMenuItems,
                 actions = buildPostActions(post, onButtonClicked),
+                commentsEntrySection = buildCommentsEntryUiState(post, onButtonClicked),
                 onMoreButtonClicked = onMoreButtonClicked,
                 onMoreDismissed = onMoreDismissed
         )
@@ -61,5 +69,29 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
         onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ): ReaderPostActions {
         return postUiStateBuilder.mapPostToActions(post, onButtonClicked)
+    }
+
+    private fun buildCommentsEntryUiState(
+        post: ReaderPost,
+        onAddCommentsClicked: (Long, Long, ReaderPostCardActionType) -> Unit
+    ): CommentsEntryUiState {
+        val showCommentsEntry = when {
+            post.isDiscoverPost -> false
+            !accountStore.hasAccessToken() -> post.numReplies > 0
+            else -> post.isWP && (post.isCommentsOpen || post.numReplies > 0)
+        }
+
+        val labelText = UiStringResWithParams(
+                string.reader_no_of_comments,
+                listOf(UiStringText(post.numReplies.toString()))
+        )
+        val actionText = UiStringRes(string.reader_add_comments)
+
+        return CommentsEntryUiState(
+            isVisible = showCommentsEntry,
+            labelText = labelText,
+            actionText = actionText,
+            onClicked = onAddCommentsClicked
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.reader.discover.ReaderPostMoreButtonUiStateBuild
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.views.uistates.ReaderPostDetailsHeaderViewUiState.ReaderPostDetailsHeaderUiState
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.viewmodel.Event
@@ -218,8 +219,17 @@ class ReaderPostDetailViewModel @Inject constructor(
         val headerUiState: ReaderPostDetailsHeaderUiState,
         val moreMenuItems: List<SecondaryAction>? = null,
         val actions: ReaderPostActions,
+        val commentsEntrySection: CommentsEntryUiState,
         val onMoreButtonClicked: (ReaderPostDetailsUiState) -> Unit,
         val onMoreDismissed: (ReaderPostDetailsUiState) -> Unit
+    )
+
+    data class CommentsEntryUiState(
+        val isVisible: Boolean,
+        val labelText: UiString,
+        val actionText: UiString,
+        val onClicked: ((Long, Long, ReaderPostCardActionType) -> Unit)? = null,
+        val type: ReaderPostCardActionType = ReaderPostCardActionType.COMMENTS
     )
 
     override fun onCleared() {

--- a/WordPress/src/main/res/color/primary_selector.xml
+++ b/WordPress/src/main/res/color/primary_selector.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:alpha="@dimen/material_emphasis_medium" android:color="?attr/colorPrimary" android:state_pressed="true" />
+    <item android:color="?attr/colorPrimary" />
+
+</selector>

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -46,15 +46,23 @@
                         android:layout_below="@+id/header_view"
                         android:layout_centerHorizontal="true"
                         android:layout_marginEnd="@dimen/reader_detail_margin"
-                        android:layout_marginStart="@dimen/reader_detail_margin"
-                        android:layout_marginBottom="@dimen/margin_extra_large"
-                        />
+                        android:layout_marginStart="@dimen/reader_detail_margin" />
+
+                    <include
+                        layout="@layout/reader_include_post_detail_comments_entry"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@id/layout_post_detail_content"
+                        android:layout_alignParentBottom="@id/layout_post_detail_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:layout_marginEnd="@dimen/reader_detail_margin"
+                        android:layout_marginStart="@dimen/reader_detail_margin" />
 
                     <View
                         android:id="@+id/footer_spacer"
                         android:layout_width="match_parent"
                         android:layout_height="@dimen/toolbar_height"
-                        android:layout_below="@id/layout_post_detail_content" />
+                        android:layout_below="@id/layout_post_detail_comments_entry" />
 
                 </RelativeLayout>
 

--- a/WordPress/src/main/res/layout/reader_include_post_detail_comments_entry.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_comments_entry.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout_post_detail_comments_entry"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/comments_label"
+        style="@style/ReaderTextView.MetaHeader"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:textAllCaps="false"
+        android:gravity="center_vertical|start"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/comments_action"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:text="53 Comments"/>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/comments_action"
+        style="@style/ReaderTextView.MetaHeader"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true"
+        android:paddingTop="@dimen/margin_extra_medium_large"
+        android:paddingBottom="@dimen/margin_extra_medium_large"
+        android:textColor="@color/primary_selector"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:text="Add comment"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1724,7 +1724,6 @@
     <string name="reader_btn_select_few_interests">Select a few to continue</string>
     <string name="reader_btn_done">Done</string>
 
-
     <!-- accessibility content desciptions -->
     <string name="reader_btn_remove_filter_content_description">Remove the current filter</string>
     <string name="reader_btn_select_filter_content_description">Select a Site or Tag to filter posts</string>
@@ -1761,6 +1760,8 @@
     <string name="reader_label_discover_follow_tags">Discover and follow tags you love</string>
     <string name="reader_label_choose_your_interests">Choose your interests</string>
     <string name="reader_view_comments">View comments</string>
+    <string name="reader_no_of_comments">%s Comments</string>
+    <string name="reader_add_comments">Add comment</string>
     <string name="reader_welcome_banner">Welcome to Reader. Discover millions of blogs at your fingertips.</string>
 
     <string name="reader_excerpt_link">Visit %s for more</string>


### PR DESCRIPTION
Task: #12900

This PR adds comments entry view at the bottom of reader details view as per [Figma design](https://www.figma.com/file/yG8ieha0yESnr8wCtplr29/Post-Detail-View?node-id=13%3A30).

Light mode | Dark mode
------------|------------
![device-2020-10-15-142117](https://user-images.githubusercontent.com/1405144/96100857-7142a680-0ef2-11eb-8ae4-24666aa94767.png)|![device-2020-10-15-142149](https://user-images.githubusercontent.com/1405144/96100865-743d9700-0ef2-11eb-8a82-ed4371d8045c.png)

**To test**

1. Open a reader post which allows adding comments 
2. Click "Add comment"
3. Verify that Comments screen is opened

Note: Grey border on the top and bottom are not added because of the margin on the sides. iOS mockup also do not include those borders, let me know if it is not ok. 

**Merge instructions**

1. Make sure #13128 are merged
2. Change branch to "issue/12900-rip3-detail-updates-main"
3. Remove "Not Ready for Merge"
4. Merge this PR

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
