### PR TITLE
Issue/13066 ppn categories

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/wrappers/CategoryNodeWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/wrappers/CategoryNodeWrapper.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.models.wrappers
+
+import dagger.Reusable
+import org.wordpress.android.fluxc.model.TermModel
+import org.wordpress.android.models.CategoryNode
+import java.util.ArrayList
+import javax.inject.Inject
+
+@Reusable
+class CategoryNodeWrapper @Inject constructor() {
+    fun createCategoryTreeFromList(categories: List<TermModel>): CategoryNode =
+            CategoryNode.createCategoryTreeFromList(categories)
+
+    fun getSortedListOfCategoriesFromRoot(node: CategoryNode): ArrayList<CategoryNode> =
+            CategoryNode.getSortedListOfCategoriesFromRoot(node)
+}

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -47,7 +47,6 @@ import org.wordpress.android.ui.history.HistoryDetailContainerFragment;
 import org.wordpress.android.ui.main.AddContentAdapter;
 import org.wordpress.android.ui.main.MainBottomSheetFragment;
 import org.wordpress.android.ui.main.MeFragment;
-import org.wordpress.android.ui.mlp.LayoutsAdapter;
 import org.wordpress.android.ui.main.MySiteFragment;
 import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.ui.main.SitePickerAdapter;
@@ -59,6 +58,9 @@ import org.wordpress.android.ui.media.MediaPreviewActivity;
 import org.wordpress.android.ui.media.MediaPreviewFragment;
 import org.wordpress.android.ui.media.MediaSettingsActivity;
 import org.wordpress.android.ui.media.services.MediaDeleteService;
+import org.wordpress.android.ui.mediapicker.MediaPickerActivity;
+import org.wordpress.android.ui.mediapicker.MediaPickerFragment;
+import org.wordpress.android.ui.mlp.LayoutsAdapter;
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment;
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity;
 import org.wordpress.android.ui.notifications.NotificationsDetailListFragment;
@@ -80,8 +82,6 @@ import org.wordpress.android.ui.people.RoleChangeDialogFragment;
 import org.wordpress.android.ui.people.RoleSelectDialogFragment;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment;
-import org.wordpress.android.ui.mediapicker.MediaPickerActivity;
-import org.wordpress.android.ui.mediapicker.MediaPickerFragment;
 import org.wordpress.android.ui.plans.PlanDetailsFragment;
 import org.wordpress.android.ui.plans.PlansActivity;
 import org.wordpress.android.ui.plans.PlansListAdapter;
@@ -101,7 +101,9 @@ import org.wordpress.android.ui.posts.PostNotificationScheduleTimeDialogFragment
 import org.wordpress.android.ui.posts.PostSettingsTagsFragment;
 import org.wordpress.android.ui.posts.PostTimePickerDialogFragment;
 import org.wordpress.android.ui.posts.PostsListActivity;
+import org.wordpress.android.ui.posts.PrepublishingAddCategoryFragment;
 import org.wordpress.android.ui.posts.PrepublishingBottomSheetFragment;
+import org.wordpress.android.ui.posts.PrepublishingCategoriesFragment;
 import org.wordpress.android.ui.posts.PrepublishingHomeAdapter;
 import org.wordpress.android.ui.posts.PrepublishingHomeFragment;
 import org.wordpress.android.ui.posts.PrepublishingTagsFragment;
@@ -583,6 +585,10 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(MediaPickerActivity object);
 
     void inject(MediaPickerFragment object);
+
+    void inject(PrepublishingCategoriesFragment object);
+
+    void inject(PrepublishingAddCategoryFragment object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -11,6 +11,8 @@ import org.wordpress.android.ui.photopicker.PhotoPickerViewModel;
 import org.wordpress.android.ui.plans.PlansViewModel;
 import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel;
 import org.wordpress.android.ui.posts.PostListMainViewModel;
+import org.wordpress.android.ui.posts.PrepublishingAddCategoryViewModel;
+import org.wordpress.android.ui.posts.PrepublishingCategoriesViewModel;
 import org.wordpress.android.ui.posts.PrepublishingHomeViewModel;
 import org.wordpress.android.ui.posts.PrepublishingTagsViewModel;
 import org.wordpress.android.ui.posts.PrepublishingViewModel;
@@ -383,6 +385,16 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(ManualFeatureConfigViewModel.class)
     abstract ViewModel manualFeatureConfigViewModel(ManualFeatureConfigViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(PrepublishingCategoriesViewModel.class)
+    abstract ViewModel prepublishingCategoriesViewModel(PrepublishingCategoriesViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(PrepublishingAddCategoryViewModel.class)
+    abstract ViewModel prepublishingAddCategoryViewModel(PrepublishingAddCategoryViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/AddCategoryUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/AddCategoryUseCase.kt
@@ -1,0 +1,31 @@
+package org.wordpress.android.ui.posts
+
+import dagger.Reusable
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.TermModel
+import org.wordpress.android.fluxc.store.TaxonomyStore
+import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload
+import org.wordpress.android.modules.IO_THREAD
+import javax.inject.Inject
+import javax.inject.Named
+
+@Reusable
+class AddCategoryUseCase @Inject constructor(
+    private val dispatcher: Dispatcher,
+    @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
+) {
+    suspend fun addCategory(categoryName: String, parentCategoryId: Long, siteModel: SiteModel) {
+        withContext(ioDispatcher) {
+            val newCategory = TermModel()
+            newCategory.taxonomy = TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
+            newCategory.name = categoryName
+            newCategory.parentRemoteId = parentCategoryId
+            val payload = RemoteTermPayload(newCategory, siteModel)
+            dispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(payload))
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -529,7 +529,8 @@ public class EditPostSettingsFragment extends Fragment {
                     if (extras != null && extras.containsKey(KEY_SELECTED_CATEGORY_IDS)) {
                         @SuppressWarnings("unchecked")
                         List<Long> categoryList = (ArrayList<Long>) extras.getSerializable(KEY_SELECTED_CATEGORY_IDS);
-                        mAnalyticsTrackerWrapper.track(Stat.EDITOR_POST_CATEGORIES_ADDED);
+                        PostAnalyticsUtilsKt.trackPostSettings(
+                                mAnalyticsTrackerWrapper, Stat.EDITOR_POST_CATEGORIES_ADDED);
                         updateCategories(categoryList);
                     }
                     break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
@@ -1,0 +1,56 @@
+package org.wordpress.android.ui.posts
+
+import dagger.Reusable
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import org.apache.commons.text.StringEscapeUtils
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.TermModel
+import org.wordpress.android.fluxc.store.TaxonomyStore
+import org.wordpress.android.models.CategoryNode
+import org.wordpress.android.modules.IO_THREAD
+import javax.inject.Inject
+import javax.inject.Named
+
+@Reusable
+class GetCategoriesUseCase @Inject constructor(
+    private val taxonomyStore: TaxonomyStore,
+    private val dispatcher: Dispatcher,
+    @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
+) {
+    // todo: annmarie should these all be in suspendable functions?
+    fun getPostCategories(editPostRepository: EditPostRepository, siteModel: SiteModel): String? {
+        val post = editPostRepository.getPost() ?: return null
+        val categories: List<TermModel> = taxonomyStore.getCategoriesForPost(
+                post,
+                siteModel
+        )
+        return formatCategories(categories)
+    }
+
+    private fun formatCategories(categoryList: List<TermModel>): String? {
+        if (categoryList.isEmpty()) return null
+
+        val formattedCategories = categoryList.joinToString { it -> it.name }
+        return StringEscapeUtils.unescapeHtml4(formattedCategories)
+    }
+
+    fun getCategoryLevels(siteModel: SiteModel): ArrayList<CategoryNode> {
+        val rootCategory = CategoryNode.createCategoryTreeFromList(
+                getCategoriesForSite(siteModel)
+        )
+        return CategoryNode.getSortedListOfCategoriesFromRoot(rootCategory) ?: arrayListOf()
+    }
+
+    private fun getCategoriesForSite(siteModel: SiteModel): List<TermModel> {
+        return taxonomyStore.getCategoriesForSite(siteModel)
+    }
+
+    suspend fun fetchNewCategories(siteModel: SiteModel) {
+        withContext(ioDispatcher) {
+            dispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(siteModel))
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.model.TermModel
 import org.wordpress.android.fluxc.store.TaxonomyStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.models.CategoryNode
+import org.wordpress.android.models.wrappers.CategoryNodeWrapper
 import org.wordpress.android.util.AppLog.T.PREPUBLISHING_NUDGES
 import java.util.ArrayList
 import javax.inject.Inject
@@ -17,7 +18,8 @@ import javax.inject.Inject
 class GetCategoriesUseCase @Inject constructor(
     private val taxonomyStore: TaxonomyStore,
     private val dispatcher: Dispatcher,
-    private val appLogWrapper: AppLogWrapper
+    private val appLogWrapper: AppLogWrapper,
+    private val categoryNodeWrapper: CategoryNodeWrapper
 ) {
     fun getPostCategoriesString(
         editPostRepository: EditPostRepository,
@@ -39,10 +41,10 @@ class GetCategoriesUseCase @Inject constructor(
             editPostRepository.getPost()?.categoryIdList ?: listOf()
 
     fun getSiteCategories(siteModel: SiteModel): ArrayList<CategoryNode> {
-        val rootCategory = CategoryNode.createCategoryTreeFromList(
+        val rootCategory = categoryNodeWrapper.createCategoryTreeFromList(
                 getCategoriesForSite(siteModel)
         )
-        return CategoryNode.getSortedListOfCategoriesFromRoot(rootCategory) ?: arrayListOf()
+        return categoryNodeWrapper.getSortedListOfCategoriesFromRoot(rootCategory)
     }
 
     fun fetchSiteCategories(siteModel: SiteModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
@@ -7,20 +7,27 @@ import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.TermModel
 import org.wordpress.android.fluxc.store.TaxonomyStore
+import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.models.CategoryNode
+import org.wordpress.android.util.AppLog.T.PREPUBLISHING_NUDGES
 import java.util.ArrayList
 import javax.inject.Inject
 
 @Reusable
 class GetCategoriesUseCase @Inject constructor(
     private val taxonomyStore: TaxonomyStore,
-    private val dispatcher: Dispatcher
+    private val dispatcher: Dispatcher,
+    private val appLogWrapper: AppLogWrapper
 ) {
     fun getPostCategoriesString(
         editPostRepository: EditPostRepository,
         siteModel: SiteModel
     ): String? {
-        val post = editPostRepository.getPost() ?: return null
+        val post = editPostRepository.getPost()
+                if (post == null) {
+                    appLogWrapper.d(PREPUBLISHING_NUDGES, "Post is null in EditPostRepository")
+                    return null
+                }
         val categories: List<TermModel> = taxonomyStore.getCategoriesForPost(
                 post,
                 siteModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
@@ -22,11 +22,11 @@ class GetCategoriesUseCase @Inject constructor(
     fun getPostCategoriesString(
         editPostRepository: EditPostRepository,
         siteModel: SiteModel
-    ): String? {
+    ): String {
         val post = editPostRepository.getPost()
                 if (post == null) {
                     appLogWrapper.d(PREPUBLISHING_NUDGES, "Post is null in EditPostRepository")
-                    return null
+                    return ""
                 }
         val categories: List<TermModel> = taxonomyStore.getCategoriesForPost(
                 post,
@@ -49,8 +49,8 @@ class GetCategoriesUseCase @Inject constructor(
             dispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(siteModel))
     }
 
-    private fun formatCategories(categoryList: List<TermModel>): String? {
-        if (categoryList.isEmpty()) return null
+    private fun formatCategories(categoryList: List<TermModel>): String {
+        if (categoryList.isEmpty()) return ""
 
         val formattedCategories = categoryList.joinToString { it -> it.name }
         return StringEscapeUtils.unescapeHtml4(formattedCategories)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GetCategoriesUseCase.kt
@@ -1,8 +1,6 @@
 package org.wordpress.android.ui.posts
 
 import dagger.Reusable
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
 import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder
@@ -10,16 +8,13 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.TermModel
 import org.wordpress.android.fluxc.store.TaxonomyStore
 import org.wordpress.android.models.CategoryNode
-import org.wordpress.android.modules.IO_THREAD
 import java.util.ArrayList
 import javax.inject.Inject
-import javax.inject.Named
 
 @Reusable
 class GetCategoriesUseCase @Inject constructor(
     private val taxonomyStore: TaxonomyStore,
-    private val dispatcher: Dispatcher,
-    @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
+    private val dispatcher: Dispatcher
 ) {
     fun getPostCategoriesString(
         editPostRepository: EditPostRepository,
@@ -43,10 +38,8 @@ class GetCategoriesUseCase @Inject constructor(
         return CategoryNode.getSortedListOfCategoriesFromRoot(rootCategory) ?: arrayListOf()
     }
 
-    suspend fun fetchSiteCategories(siteModel: SiteModel) {
-        withContext(ioDispatcher) {
+    fun fetchSiteCategories(siteModel: SiteModel) {
             dispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(siteModel))
-        }
     }
 
     private fun formatCategories(categoryList: List<TermModel>): String? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/ParentCategorySpinnerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/ParentCategorySpinnerAdapter.java
@@ -79,4 +79,9 @@ public class ParentCategorySpinnerAdapter extends BaseAdapter implements Spinner
             this.mCategoryRowText = view.findViewById(R.id.categoryRowText);
         }
     }
+
+    public void updateItems(List<CategoryNode> categoryNodes) {
+        this.mObjects.addAll(categoryNodes);
+        notifyDataSetChanged();
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -137,7 +137,7 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         val siteModel = requireArguments().getSerializable(WordPress.SITE) as SiteModel
         val retainedSelectedCategoryPosition = savedInstanceState?.getInt(
                 SELECTED_PARENT_CATEGORY_POSITION)
-        viewModel.start(siteModel, !needsRequestLayout, retainedSelectedCategoryPosition )
+        viewModel.start(siteModel, !needsRequestLayout, retainedSelectedCategoryPosition)
     }
 
     private fun startObserving() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.posts
 
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -56,6 +57,7 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         initBackButton()
         initCloseButton()
         initInputText()
+       // initSpinner()
         initViewModel()
         super.onViewCreated(view, savedInstanceState)
     }
@@ -80,6 +82,19 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         category_name.requestFocus()
         ActivityUtils.showKeyboard(category_name)
     }
+
+// private fun initSpinner() {
+// todo: annmarie - get back to this after Android Studio is working again
+// parent_category.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+// override fun onNothingSelected(parent: AdapterView<*>?) {
+//  Log.i(javaClass.simpleName, "***=> implement nothing selected")
+//  }
+//
+// override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+// Log.i(javaClass.simpleName, "***=> implement item selected")
+// }
+// }
+// }
 
     private fun initViewModel() {
         viewModel = ViewModelProviders.of(this, viewModelFactory)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -1,0 +1,180 @@
+package org.wordpress.android.ui.posts
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.android.synthetic.main.add_category.*
+import kotlinx.android.synthetic.main.prepublishing_add_category_fragment.*
+import kotlinx.android.synthetic.main.prepublishing_toolbar.*
+import org.wordpress.android.R
+import org.wordpress.android.R.layout
+import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.models.CategoryNode
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.posts.PrepublishingAddCategoryViewModel.UiState.ContentUiState
+import org.wordpress.android.ui.posts.PrepublishingAddCategoryViewModel.UiState.InitialLoadUiState
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.ActivityUtils
+import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.ToastUtils.Duration.LONG
+import org.wordpress.android.widgets.WPSnackbar
+import javax.inject.Inject
+
+class PrepublishingAddCategoryFragment : Fragment(layout.prepublishing_add_category_fragment) {
+    private var closeListener: PrepublishingScreenClosedListener? = null
+
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: PrepublishingAddCategoryViewModel
+    @Inject lateinit var uiHelpers: UiHelpers
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (requireActivity().application as WordPress).component().inject(this)
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        closeListener = parentFragment as PrepublishingScreenClosedListener
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        closeListener = null
+    }
+
+    override fun onResume() {
+        val needsRequestLayout = requireArguments().getBoolean(NEEDS_REQUEST_LAYOUT)
+        if (needsRequestLayout) {
+            requireActivity().window.decorView.requestLayout()
+        }
+        super.onResume()
+    }
+
+    companion object {
+        const val TAG = "prepublishing_add_category_fragment_tag"
+        const val NEEDS_REQUEST_LAYOUT = "prepublishing_add_category_fragment_needs_request_layout"
+        @JvmStatic fun newInstance(
+            site: SiteModel,
+            needsRequestLayout: Boolean
+        ): PrepublishingAddCategoryFragment {
+            val bundle = Bundle().apply {
+                putSerializable(WordPress.SITE, site)
+                putBoolean(NEEDS_REQUEST_LAYOUT, needsRequestLayout)
+            }
+            return PrepublishingAddCategoryFragment().apply { arguments = bundle }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        initBackButton()
+        initCloseButton()
+        initInputText()
+        initViewModel()
+        super.onViewCreated(view, savedInstanceState)
+    }
+
+    private fun initBackButton() {
+        back_button.setOnClickListener {
+            viewModel.addCategory(
+                    category_name.text.toString(),
+                    (parent_category.selectedItem as CategoryNode)
+            )
+            viewModel.onBackButtonClicked()
+        }
+    }
+
+    private fun initCloseButton() {
+        close_button.setOnClickListener {
+            viewModel.onBackButtonClicked()
+        }
+    }
+
+    private fun initInputText() {
+        category_name.requestFocus()
+        ActivityUtils.showKeyboard(category_name)
+    }
+
+    private fun initViewModel() {
+        viewModel = ViewModelProviders.of(this, viewModelFactory)
+                .get(PrepublishingAddCategoryViewModel::class.java)
+        startObserving()
+    }
+
+    private fun startObserving() {
+        viewModel.dismissKeyboard.observe(viewLifecycleOwner, Observer { event ->
+            event?.applyIfNotHandled {
+                ActivityUtils.hideKeyboardForced(category_name)
+            }
+        })
+
+        viewModel.navigateBack.observe(viewLifecycleOwner, Observer { event ->
+            event?.applyIfNotHandled {
+                closeListener?.onBackClicked()
+            }
+        })
+
+        viewModel.toolbarTitleUiState.observe(viewLifecycleOwner, Observer { uiString ->
+            toolbar_title.text = uiHelpers.getTextOfUiString(requireContext(), uiString)
+        })
+
+        viewModel.snackbarEvents.observe(viewLifecycleOwner, Observer {
+            it?.applyIfNotHandled {
+                showToast()
+            }
+        })
+
+        viewModel.uiState.observe(viewLifecycleOwner, Observer { uiState ->
+                when (uiState) {
+                    is InitialLoadUiState -> {
+                    }
+                    is ContentUiState -> {
+                        loadCategories(uiState.categories)
+                    }
+                }
+            with(uiHelpers) {
+                updateVisibility(close_button, uiState.closeButtonVisible)
+            }
+        })
+
+        val needsRequestLayout = requireArguments().getBoolean(PrepublishingTagsFragment.NEEDS_REQUEST_LAYOUT)
+        val siteModel = requireArguments().getSerializable(WordPress.SITE) as SiteModel
+        viewModel.start(siteModel, !needsRequestLayout)
+    }
+
+    private fun loadCategories(categoryLevels: ArrayList<CategoryNode>) {
+        categoryLevels.add(
+                0, CategoryNode(
+                0, 0,
+                getString(R.string.top_level_category_name)
+        ))
+        val categoryAdapter = ParentCategorySpinnerAdapter(
+                activity,
+                layout.categories_row_parent,
+                categoryLevels
+        )
+        parent_category.adapter = categoryAdapter
+    }
+
+    private fun SnackbarMessageHolder.showToast() {
+        val message = uiHelpers.getTextOfUiString(requireContext(), this.message).toString()
+        ToastUtils.showToast(
+                requireContext(), message,
+                LONG
+        )
+    }
+
+    private fun SnackbarMessageHolder.showSnackBar() {
+        val snackBar = WPSnackbar.make(
+                add_category_content,
+                uiHelpers.getTextOfUiString(requireContext(), this.message),
+                Snackbar.LENGTH_LONG
+        )
+        snackBar.show()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.add_category.*
 import kotlinx.android.synthetic.main.prepublishing_toolbar.*
 import org.wordpress.android.R
-import org.wordpress.android.R.layout
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.CategoryNode
@@ -22,7 +21,7 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.LONG
 import javax.inject.Inject
 
-class PrepublishingAddCategoryFragment : Fragment(layout.prepublishing_add_category_fragment) {
+class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_category_fragment) {
     private var closeListener: PrepublishingScreenClosedListener? = null
 
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -149,7 +148,7 @@ class PrepublishingAddCategoryFragment : Fragment(layout.prepublishing_add_categ
         ))
         val categoryAdapter = ParentCategorySpinnerAdapter(
                 activity,
-                layout.categories_row_parent,
+                R.layout.categories_row_parent,
                 categoryLevels
         )
         parent_category.adapter = categoryAdapter

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -44,26 +44,12 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
     }
 
     override fun onResume() {
+        // Note: This supports the re-calculation and visibility of views when coming from stories.
         val needsRequestLayout = requireArguments().getBoolean(NEEDS_REQUEST_LAYOUT)
         if (needsRequestLayout) {
             requireActivity().window.decorView.requestLayout()
         }
         super.onResume()
-    }
-
-    companion object {
-        const val TAG = "prepublishing_add_category_fragment_tag"
-        const val NEEDS_REQUEST_LAYOUT = "prepublishing_add_category_fragment_needs_request_layout"
-        @JvmStatic fun newInstance(
-            site: SiteModel,
-            needsRequestLayout: Boolean
-        ): PrepublishingAddCategoryFragment {
-            val bundle = Bundle().apply {
-                putSerializable(WordPress.SITE, site)
-                putBoolean(NEEDS_REQUEST_LAYOUT, needsRequestLayout)
-            }
-            return PrepublishingAddCategoryFragment().apply { arguments = bundle }
-        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -160,5 +146,20 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
                 requireContext(), message,
                 LONG
         )
+    }
+
+    companion object {
+        const val TAG = "prepublishing_add_category_fragment_tag"
+        const val NEEDS_REQUEST_LAYOUT = "prepublishing_add_category_fragment_needs_request_layout"
+        @JvmStatic fun newInstance(
+            site: SiteModel,
+            needsRequestLayout: Boolean
+        ): PrepublishingAddCategoryFragment {
+            val bundle = Bundle().apply {
+                putSerializable(WordPress.SITE, site)
+                putBoolean(NEEDS_REQUEST_LAYOUT, needsRequestLayout)
+            }
+            return PrepublishingAddCategoryFragment().apply { arguments = bundle }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -7,9 +7,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
-import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.add_category.*
-import kotlinx.android.synthetic.main.prepublishing_add_category_fragment.*
 import kotlinx.android.synthetic.main.prepublishing_toolbar.*
 import org.wordpress.android.R
 import org.wordpress.android.R.layout
@@ -18,12 +16,10 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.CategoryNode
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.PrepublishingAddCategoryViewModel.UiState.ContentUiState
-import org.wordpress.android.ui.posts.PrepublishingAddCategoryViewModel.UiState.InitialLoadUiState
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.LONG
-import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 
 class PrepublishingAddCategoryFragment : Fragment(layout.prepublishing_add_category_fragment) {
@@ -131,8 +127,6 @@ class PrepublishingAddCategoryFragment : Fragment(layout.prepublishing_add_categ
 
         viewModel.uiState.observe(viewLifecycleOwner, Observer { uiState ->
                 when (uiState) {
-                    is InitialLoadUiState -> {
-                    }
                     is ContentUiState -> {
                         loadCategories(uiState.categories)
                     }
@@ -167,14 +161,5 @@ class PrepublishingAddCategoryFragment : Fragment(layout.prepublishing_add_categ
                 requireContext(), message,
                 LONG
         )
-    }
-
-    private fun SnackbarMessageHolder.showSnackBar() {
-        val snackBar = WPSnackbar.make(
-                add_category_content,
-                uiHelpers.getTextOfUiString(requireContext(), this.message),
-                Snackbar.LENGTH_LONG
-        )
-        snackBar.show()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import org.wordpress.android.R.string
+import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.CategoryNode
@@ -64,7 +64,7 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
     }
 
     private fun setToolbarTitleUiState() {
-        _toolbarTitleUiState.postValue(UiStringRes(string.prepublishing_nudges_toolbar_title_add_categories))
+        _toolbarTitleUiState.postValue(UiStringRes(R.string.prepublishing_nudges_toolbar_title_add_categories))
     }
 
     fun onBackButtonClicked() {
@@ -88,7 +88,7 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             _dismissKeyboard.postValue(Event(Unit))
             _snackbarEvents.postValue(
-                    Event(SnackbarMessageHolder(UiStringRes(string.no_network_message)))
+                    Event(SnackbarMessageHolder(UiStringRes(R.string.no_network_message)))
             )
             return
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
@@ -1,0 +1,128 @@
+package org.wordpress.android.ui.posts
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.wordpress.android.R.string
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.models.CategoryNode
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.posts.PrepublishingAddCategoryViewModel.UiState.ContentUiState
+import org.wordpress.android.ui.posts.PrepublishingAddCategoryViewModel.UiState.InitialLoadUiState
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+class PrepublishingAddCategoryViewModel @Inject constructor(
+    private val getCategoriesUseCase: GetCategoriesUseCase,
+    private val addCategoryUseCase: AddCategoryUseCase,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+) : ScopedViewModel(bgDispatcher) {
+    private var isStarted = false
+    private var closeKeyboard = true
+    private lateinit var siteModel: SiteModel
+    private var addCategoryJob: Job? = null
+
+    private val _navigateBack = MutableLiveData<Event<Unit>>()
+    val navigateBack: LiveData<Event<Unit>> = _navigateBack
+
+    private val _dismissKeyboard = MutableLiveData<Event<Unit>>()
+    val dismissKeyboard: LiveData<Event<Unit>> = _dismissKeyboard
+
+    private val _toolbarTitleUiState = MutableLiveData<UiString>()
+    val toolbarTitleUiState: LiveData<UiString> = _toolbarTitleUiState
+
+    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
+    private val _uiState: MutableLiveData<UiState> = MutableLiveData()
+    val uiState: LiveData<UiState> = _uiState
+
+    fun start(
+        siteModel: SiteModel,
+        closeKeyboard: Boolean = false
+    ) {
+        this.closeKeyboard = closeKeyboard
+        this.siteModel = siteModel
+
+        if (isStarted) return
+        isStarted = true
+
+        setToolbarTitleUiState()
+        loadCategories()
+    }
+
+    private fun setToolbarTitleUiState() {
+        _toolbarTitleUiState.postValue(UiStringRes(string.prepublishing_nudges_toolbar_title_add_categories))
+    }
+
+    fun onBackButtonClicked() {
+        if (closeKeyboard) {
+            _dismissKeyboard.postValue(Event(Unit))
+        }
+        _navigateBack.postValue(Event(Unit))
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        addCategoryJob?.cancel()
+    }
+
+    private fun loadCategories() {
+        updateUiState(InitialLoadUiState)
+        val newUiState = ContentUiState(categories = getCategoryLevels())
+        updateUiState(newUiState)
+    }
+
+    fun addCategory(categoryText: String, parentCategory: CategoryNode?) {
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+            _dismissKeyboard.postValue(Event(Unit))
+            _snackbarEvents.postValue(
+                    Event(SnackbarMessageHolder(UiStringRes(string.no_network_message)))
+            )
+            return
+        }
+
+        if (categoryText.isNotEmpty()) {
+            trackCategoryAddedEvent()
+            val parentCategoryId = parentCategory?.categoryId ?: 0
+            addCategoryJob?.cancel()
+            addCategoryJob = launch(bgDispatcher) {
+                addCategoryUseCase.addCategory(categoryText, parentCategoryId, siteModel)
+            }
+        }
+    }
+
+    private fun getCategoryLevels(): ArrayList<CategoryNode> =
+            getCategoriesUseCase.getCategoryLevels(siteModel)
+
+    private fun trackCategoryAddedEvent() {
+        analyticsTrackerWrapper.trackPrepublishingNudges(Stat.EDITOR_POST_CATEGORIES_ADDED)
+    }
+
+    private fun updateUiState(uiState: UiState) {
+        _uiState.value = uiState
+    }
+
+    sealed class UiState(
+        val closeButtonVisible: Boolean = true
+    ) {
+        object InitialLoadUiState : UiState()
+
+        data class ContentUiState(
+            val categories: ArrayList<CategoryNode>
+        ) : UiState()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.models.CategoryNode
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.PrepublishingAddCategoryViewModel.UiState.ContentUiState
-import org.wordpress.android.ui.posts.PrepublishingAddCategoryViewModel.UiState.InitialLoadUiState
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
@@ -81,7 +80,6 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
     }
 
     private fun loadCategories() {
-        updateUiState(InitialLoadUiState)
         val newUiState = ContentUiState(categories = getCategoryLevels())
         updateUiState(newUiState)
     }
@@ -106,7 +104,7 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
     }
 
     private fun getCategoryLevels(): ArrayList<CategoryNode> =
-            getCategoriesUseCase.getCategoryLevels(siteModel)
+            getCategoriesUseCase.getSiteCategories(siteModel)
 
     private fun trackCategoryAddedEvent() {
         analyticsTrackerWrapper.trackPrepublishingNudges(Stat.EDITOR_POST_CATEGORIES_ADDED)
@@ -119,8 +117,6 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
     sealed class UiState(
         val closeButtonVisible: Boolean = true
     ) {
-        object InitialLoadUiState : UiState()
-
         data class ContentUiState(
             val categories: ArrayList<CategoryNode>
         ) : UiState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -59,6 +60,10 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
         if (isStarted) return
         isStarted = true
 
+        init()
+    }
+
+    private fun init() {
         setToolbarTitleUiState()
         loadCategories()
     }
@@ -118,7 +123,8 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
         val closeButtonVisible: Boolean = true
     ) {
         data class ContentUiState(
-            val categories: ArrayList<CategoryNode>
+            val categories: ArrayList<CategoryNode>,
+            val selectedCategoryId: Long = 2
         ) : UiState()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.posts
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -34,6 +33,7 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
     private var closeKeyboard = true
     private lateinit var siteModel: SiteModel
     private var addCategoryJob: Job? = null
+    private var selectedParentCategoryPosition: Int? = null
 
     private val _navigateBack = MutableLiveData<Event<Unit>>()
     val navigateBack: LiveData<Event<Unit>> = _navigateBack
@@ -52,10 +52,12 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
 
     fun start(
         siteModel: SiteModel,
-        closeKeyboard: Boolean = false
+        closeKeyboard: Boolean = false,
+        selectedParentCategoryPosition: Int?
     ) {
         this.closeKeyboard = closeKeyboard
         this.siteModel = siteModel
+        this.selectedParentCategoryPosition = selectedParentCategoryPosition
 
         if (isStarted) return
         isStarted = true
@@ -65,7 +67,7 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
 
     private fun init() {
         setToolbarTitleUiState()
-        loadCategories()
+        initCategories()
     }
 
     private fun setToolbarTitleUiState() {
@@ -84,8 +86,11 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
         addCategoryJob?.cancel()
     }
 
-    private fun loadCategories() {
-        val newUiState = ContentUiState(categories = getCategoryLevels())
+    private fun initCategories() {
+        val newUiState = ContentUiState(
+                categories = getCategoryLevels(),
+                selectedParentCategoryPosition = 0
+        )
         updateUiState(newUiState)
     }
 
@@ -124,7 +129,15 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
     ) {
         data class ContentUiState(
             val categories: ArrayList<CategoryNode>,
-            val selectedCategoryId: Long = 2
+            val selectedParentCategoryPosition: Int
         ) : UiState()
+    }
+
+    fun parentCategorySelected(position: Int) {
+        _uiState.value?.let { state ->
+            if (state is ContentUiState) {
+                _uiState.value = state.copy(selectedParentCategoryPosition = position)
+            }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -210,10 +210,14 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
     private fun fadeInFragment(fragment: Fragment, tag: String) {
         childFragmentManager.let { fragmentManager ->
             val fragmentTransaction = fragmentManager.beginTransaction()
-            fragmentTransaction.addToBackStack(null).setCustomAnimations(
-                    R.anim.prepublishing_fragment_fade_in, R.anim.prepublishing_fragment_fade_out,
-                    R.anim.prepublishing_fragment_fade_in, R.anim.prepublishing_fragment_fade_out
-            )
+            fragmentManager.findFragmentById(R.id.prepublishing_content_fragment)?.run {
+                fragmentTransaction.addToBackStack(null).setCustomAnimations(
+                        R.anim.prepublishing_fragment_fade_in,
+                        R.anim.prepublishing_fragment_fade_out,
+                        R.anim.prepublishing_fragment_fade_in,
+                        R.anim.prepublishing_fragment_fade_out
+                )
+            }
             fragmentTransaction.replace(R.id.prepublishing_content_fragment, fragment, tag)
             fragmentTransaction.commit()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -22,6 +22,8 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.login.widgets.WPBottomSheetDialogFragment
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType
+import org.wordpress.android.ui.posts.PrepublishingScreen.ADD_CATEGORY
+import org.wordpress.android.ui.posts.PrepublishingScreen.CATEGORIES
 import org.wordpress.android.ui.posts.PrepublishingScreen.HOME
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetListener
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsFragment
@@ -182,18 +184,37 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                         PrepublishingTagsFragment.TAG
                 )
             }
+            CATEGORIES -> {
+                val isStoryPost = checkNotNull(arguments?.getBoolean(IS_STORY_POST)) {
+                    "arguments can't be null."
+                }
+                Pair(
+                        PrepublishingCategoriesFragment.newInstance(navigationTarget.site, isStoryPost),
+                        PrepublishingCategoriesFragment.TAG
+                )
+            }
+            ADD_CATEGORY -> {
+                val isStoryPost = checkNotNull(arguments?.getBoolean(IS_STORY_POST)) {
+                    "arguments can't be null."
+                }
+                Pair(
+                        PrepublishingAddCategoryFragment.newInstance(navigationTarget.site, isStoryPost),
+                        PrepublishingAddCategoryFragment.TAG
+                )
+            }
         }
 
         fadeInFragment(fragment, tag)
     }
 
+    // todo: annmarie - remove note enter, exit, enter, exit
     private fun fadeInFragment(fragment: Fragment, tag: String) {
         childFragmentManager.let { fragmentManager ->
             val fragmentTransaction = fragmentManager.beginTransaction()
             fragmentManager.findFragmentById(R.id.prepublishing_content_fragment)?.run {
                 fragmentTransaction.addToBackStack(null).setCustomAnimations(
-                        R.anim.prepublishing_fragment_fade_in, R.anim.prepublishing_fragment_fade_out,
-                        R.anim.prepublishing_fragment_fade_in, R.anim.prepublishing_fragment_fade_out
+                        R.anim.prepublishing_fragment_slide_in, R.anim.prepublishing_fragment_fade_out,
+                        R.anim.prepublishing_fragment_fade_in, R.anim.prepublishing_fragment_slide_out
                 )
             }
             fragmentTransaction.replace(R.id.prepublishing_content_fragment, fragment, tag)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -207,16 +207,13 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
         fadeInFragment(fragment, tag)
     }
 
-    // todo: annmarie - remove note enter, exit, enter, exit
     private fun fadeInFragment(fragment: Fragment, tag: String) {
         childFragmentManager.let { fragmentManager ->
             val fragmentTransaction = fragmentManager.beginTransaction()
-            fragmentManager.findFragmentById(R.id.prepublishing_content_fragment)?.run {
-                fragmentTransaction.addToBackStack(null).setCustomAnimations(
-                        R.anim.prepublishing_fragment_slide_in, R.anim.prepublishing_fragment_fade_out,
-                        R.anim.prepublishing_fragment_fade_in, R.anim.prepublishing_fragment_slide_out
-                )
-            }
+            fragmentTransaction.addToBackStack(null).setCustomAnimations(
+                    R.anim.prepublishing_fragment_fade_in, R.anim.prepublishing_fragment_fade_out,
+                    R.anim.prepublishing_fragment_fade_in, R.anim.prepublishing_fragment_fade_out
+            )
             fragmentTransaction.replace(R.id.prepublishing_content_fragment, fragment, tag)
             fragmentTransaction.commit()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesAdapter.kt
@@ -1,0 +1,108 @@
+package org.wordpress.android.ui.posts
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.prepublishing_categories_row.view.*
+import org.apache.commons.text.StringEscapeUtils
+import org.wordpress.android.R
+import org.wordpress.android.models.CategoryNode
+import org.wordpress.android.ui.posts.PrepublishingCategoriesAdapter.CategoriesViewHolder
+
+class PrepublishingCategoriesAdapter(
+    private val context: Context,
+    private val onCheckChangeListener: ((Long, Boolean) -> Unit)
+) : RecyclerView.Adapter<CategoriesViewHolder>() {
+    var categoryNodeList: List<CategoryNode> = ArrayList()
+        set(value) {
+            if (!isSameCategoryList(value)) {
+                field = value
+                notifyDataSetChanged()
+            }
+        }
+
+    // todo: annmarie - may not need this at all
+    private var selectedCategoryIds: HashSet<Long> = hashSetOf()
+
+    interface OnCategoryClickedListener {
+        fun onCategorySelected(categoryId: Long)
+        fun onCategoryUnselected(categoryId: Long)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CategoriesViewHolder {
+        val itemView = LayoutInflater.from(context)
+                .inflate(R.layout.prepublishing_categories_row, parent, false)
+        return CategoriesViewHolder(onCheckChangeListener, itemView)
+    }
+
+    override fun onBindViewHolder(viewHolder: CategoriesViewHolder, position: Int) {
+       viewHolder.bind(categoryNodeList[position])
+    }
+
+    init {
+        setHasStableIds(true)
+    }
+
+    fun setItemChecked(categoryId: Long) {
+        // todo: annmarie implement this
+    }
+
+    override fun getItemId(position: Int): Long {
+        return categoryNodeList[position].categoryId
+    }
+
+    override fun getItemCount(): Int {
+        return categoryNodeList.size
+    }
+
+    private fun isSameCategoryList(categoryList: List<CategoryNode>): Boolean {
+        if (categoryList.size != categoryNodeList.size) {
+            return false
+        }
+
+        categoryNodeList.forEach {
+            if (!containsNode(it)) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun containsNode(categoryNode: CategoryNode): Boolean {
+        categoryNodeList.forEach {
+            if (it.categoryId == categoryNode.categoryId) {
+                return true
+            }
+        }
+        return false
+    }
+
+    class CategoriesViewHolder(private val onCheckedChangeClickListener: ((Long, Boolean) -> Unit),
+        itemView: View) : RecyclerView.ViewHolder(itemView) {
+        fun bind(row: CategoryNode) = with(itemView) {
+
+            val verticalPadding: Int = prepublishing_category_text.resources.getDimensionPixelOffset(R.dimen.margin_large)
+            val horizontalPadding: Int = prepublishing_category_text.resources.getDimensionPixelOffset(R.dimen.margin_extra_large)
+
+            ViewCompat.setPaddingRelative(
+                    prepublishing_category_text,
+                    horizontalPadding * row.level,
+                    verticalPadding,
+                    horizontalPadding,
+                    verticalPadding
+            )
+
+            prepublishing_category_text.text = StringEscapeUtils.unescapeHtml4(
+                    row.name
+            )
+
+            prepublishing_category_check.isChecked = true
+            prepublishing_category_check.setOnCheckedChangeListener { buttonView, isChecked ->
+                onCheckedChangeClickListener.invoke(row.categoryId, isChecked)
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesAdapter.kt
@@ -16,7 +16,7 @@ class PrepublishingCategoriesAdapter(
     private val context: Context,
     private val onCheckChangeListener: ((Long, Boolean) -> Unit)
 ) : RecyclerView.Adapter<CategoriesViewHolder>() {
-    var categoryNodeList: List<CategoryNode> = ArrayList()
+    var categoryNodeList: List<CategoryNode> = arrayListOf()
         set(value) {
             if (!isSameCategoryList(value)) {
                 field = value
@@ -24,12 +24,11 @@ class PrepublishingCategoriesAdapter(
             }
         }
 
-    // todo: annmarie - may not need this at all
     private var selectedCategoryIds: HashSet<Long> = hashSetOf()
 
-    interface OnCategoryClickedListener {
-        fun onCategorySelected(categoryId: Long)
-        fun onCategoryUnselected(categoryId: Long)
+    fun set(categoryLevels: List<CategoryNode>, categoriesSelected: HashSet<Long>) {
+        selectedCategoryIds = categoriesSelected
+        categoryNodeList = categoryLevels
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CategoriesViewHolder {
@@ -39,15 +38,11 @@ class PrepublishingCategoriesAdapter(
     }
 
     override fun onBindViewHolder(viewHolder: CategoriesViewHolder, position: Int) {
-       viewHolder.bind(categoryNodeList[position])
+        viewHolder.bind(categoryNodeList[position], selectedCategoryIds)
     }
 
     init {
         setHasStableIds(true)
-    }
-
-    fun setItemChecked(categoryId: Long) {
-        // todo: annmarie implement this
     }
 
     override fun getItemId(position: Int): Long {
@@ -71,6 +66,10 @@ class PrepublishingCategoriesAdapter(
         return true
     }
 
+    private fun isSameSelectedList(selectedCategoryIdList: HashSet<Long>): Boolean {
+        return selectedCategoryIdList == selectedCategoryIds
+    }
+
     private fun containsNode(categoryNode: CategoryNode): Boolean {
         categoryNodeList.forEach {
             if (it.categoryId == categoryNode.categoryId) {
@@ -80,12 +79,17 @@ class PrepublishingCategoriesAdapter(
         return false
     }
 
-    class CategoriesViewHolder(private val onCheckedChangeClickListener: ((Long, Boolean) -> Unit),
-        itemView: View) : RecyclerView.ViewHolder(itemView) {
-        fun bind(row: CategoryNode) = with(itemView) {
-
-            val verticalPadding: Int = prepublishing_category_text.resources.getDimensionPixelOffset(R.dimen.margin_large)
-            val horizontalPadding: Int = prepublishing_category_text.resources.getDimensionPixelOffset(R.dimen.margin_extra_large)
+    class CategoriesViewHolder(
+        private val onCheckedChangeClickListener: ((Long, Boolean) -> Unit),
+        itemView: View
+    ) : RecyclerView.ViewHolder(itemView) {
+        fun bind(row: CategoryNode, selectedCategoryIds: HashSet<Long>) = with(itemView) {
+            val verticalPadding: Int = prepublishing_category_text.resources.getDimensionPixelOffset(
+                    R.dimen.margin_large
+            )
+            val horizontalPadding: Int = prepublishing_category_text.resources.getDimensionPixelOffset(
+                    R.dimen.margin_extra_large
+            )
 
             ViewCompat.setPaddingRelative(
                     prepublishing_category_text,
@@ -99,8 +103,12 @@ class PrepublishingCategoriesAdapter(
                     row.name
             )
 
-            prepublishing_category_check.isChecked = true
-            prepublishing_category_check.setOnCheckedChangeListener { buttonView, isChecked ->
+            prepublishing_category_check.isChecked = false
+            if (selectedCategoryIds.contains(row.categoryId)) {
+                prepublishing_category_check.isChecked = true
+            }
+
+            prepublishing_category_check.setOnCheckedChangeListener { _, isChecked ->
                 onCheckedChangeClickListener.invoke(row.categoryId, isChecked)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesAdapter.kt
@@ -84,6 +84,11 @@ class PrepublishingCategoriesAdapter(
         itemView: View
     ) : RecyclerView.ViewHolder(itemView) {
         fun bind(row: CategoryNode, selectedCategoryIds: HashSet<Long>) = with(itemView) {
+            itemView.isClickable = true
+
+            setOnClickListener {
+                prepublishing_category_check.isChecked = !prepublishing_category_check.isChecked
+            }
             val verticalPadding: Int = prepublishing_category_text.resources.getDimensionPixelOffset(
                     R.dimen.margin_large
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -72,26 +72,12 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
     }
 
     override fun onResume() {
+        // Note: This supports the re-calculation and visibility of views when coming from stories.
         val needsRequestLayout = requireArguments().getBoolean(NEEDS_REQUEST_LAYOUT)
         if (needsRequestLayout) {
             requireActivity().window.decorView.requestLayout()
         }
         super.onResume()
-    }
-
-    companion object {
-        const val TAG = "prepublishing_categories_fragment_tag"
-        const val NEEDS_REQUEST_LAYOUT = "prepublishing_categories_fragment_needs_request_layout"
-        @JvmStatic fun newInstance(
-            site: SiteModel,
-            needsRequestLayout: Boolean
-        ): PrepublishingCategoriesFragment {
-            val bundle = Bundle().apply {
-                putSerializable(WordPress.SITE, site)
-                putBoolean(NEEDS_REQUEST_LAYOUT, needsRequestLayout)
-            }
-            return PrepublishingCategoriesFragment().apply { arguments = bundle }
-        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -235,5 +221,20 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
     @Subscribe(threadMode = MAIN)
     fun onTermUploaded(event: OnTermUploaded) {
         viewModel.onNewSiteCategoryAddComplete(event)
+    }
+
+    companion object {
+        const val TAG = "prepublishing_categories_fragment_tag"
+        const val NEEDS_REQUEST_LAYOUT = "prepublishing_categories_fragment_needs_request_layout"
+        @JvmStatic fun newInstance(
+            site: SiteModel,
+            needsRequestLayout: Boolean
+        ): PrepublishingCategoriesFragment {
+            val bundle = Bundle().apply {
+                putSerializable(WordPress.SITE, site)
+                putBoolean(NEEDS_REQUEST_LAYOUT, needsRequestLayout)
+            }
+            return PrepublishingCategoriesFragment().apply { arguments = bundle }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -1,0 +1,321 @@
+package org.wordpress.android.ui.posts
+
+import android.content.Context
+import android.os.Bundle
+import android.util.Log
+import android.util.LongSparseArray
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.prepublishing_categories_fragment.*
+import kotlinx.android.synthetic.main.prepublishing_toolbar.*
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode.MAIN
+import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.TaxonomyAction.FETCH_CATEGORIES
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged
+import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded
+import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
+import org.wordpress.android.ui.posts.PrepublishingCategoriesAdapter.OnCategoryClickedListener
+import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType.ADD_CATEGORY
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.NetworkUtils
+import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.ToastUtils.Duration.LONG
+import org.wordpress.android.util.ToastUtils.Duration.SHORT
+import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
+import org.wordpress.android.util.helpers.ListScrollPositionManager
+import org.wordpress.android.util.helpers.SwipeToRefreshHelper
+import javax.inject.Inject
+
+class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categories_fragment),
+        OnCategoryClickedListener {
+    private var closeListener: PrepublishingScreenClosedListener? = null
+    private var actionListener: PrepublishingActionClickedListener? = null
+
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var viewModel: PrepublishingCategoriesViewModel
+    @Inject lateinit var uiHelpers: UiHelpers
+    @Inject lateinit var dispatcher: Dispatcher
+
+    private lateinit var listScrollPositionManager: ListScrollPositionManager
+    private val selectedCategories = hashSetOf<Long>()
+    private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
+    private val categoryRemoteIdsToListPositions = LongSparseArray<Int>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (requireActivity().application as WordPress).component().inject(this)
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        closeListener = parentFragment as PrepublishingScreenClosedListener
+        actionListener = parentFragment as PrepublishingActionClickedListener
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        closeListener = null
+        actionListener = null
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dispatcher.register(this)
+    }
+
+    override fun onStop() {
+        dispatcher.unregister(this)
+        super.onStop()
+    }
+
+    override fun onResume() {
+        val needsRequestLayout = requireArguments().getBoolean(NEEDS_REQUEST_LAYOUT)
+        if (needsRequestLayout) {
+            requireActivity().window.decorView.requestLayout()
+        }
+        super.onResume()
+    }
+
+    companion object {
+        const val TAG = "prepublishing_categories_fragment_tag"
+        const val NEEDS_REQUEST_LAYOUT = "prepublishing_categories_fragment_needs_request_layout"
+        @JvmStatic fun newInstance(
+            site: SiteModel,
+            needsRequestLayout: Boolean
+        ): PrepublishingCategoriesFragment {
+            val bundle = Bundle().apply {
+                putSerializable(WordPress.SITE, site)
+                putBoolean(NEEDS_REQUEST_LAYOUT, needsRequestLayout)
+            }
+            return PrepublishingCategoriesFragment().apply { arguments = bundle }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        initBackButton()
+        initAddCategoryButton()
+        initRecyclerView()
+        initSwipeToRefreshHelper()
+        initViewModel()
+        // todo: annmarie - these can go in the view model uiState
+        initSelectedCategories()
+        populateCategoryList()
+        super.onViewCreated(view, savedInstanceState)
+    }
+
+    private fun initBackButton() {
+        back_button.setOnClickListener {
+            // todo: annmarie make this a viewModel thing
+// todo: annmarie - this needs to be uncommented            updateSelectedCategoryList()
+// todo: annmarie - this needs to be uncommented            viewModel.updateCategories(ArrayList(selectedCategories))
+            viewModel.onBackButtonClicked()
+        }
+    }
+
+    private fun initAddCategoryButton() {
+        add_new_category.setOnClickListener {
+            viewModel.onAddNewCategoryClicked()
+        }
+    }
+
+    private fun initRecyclerView() {
+        recycler_view.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+        recycler_view.adapter = PrepublishingCategoriesAdapter(
+                onCheckChangeListener = { id, checked ->
+                    Log.i(javaClass.simpleName, "***=> I made it here $id and $checked")
+                }, context = requireContext()
+        )
+        recycler_view.addItemDecoration(
+                DividerItemDecoration(
+                        recycler_view.context,
+                        DividerItemDecoration.VERTICAL
+                )
+        )
+    }
+
+    private fun initSwipeToRefreshHelper() {
+        swipeToRefreshHelper = buildSwipeToRefreshHelper(ptr_layout,
+                SwipeToRefreshHelper.RefreshListener {
+                    if (!NetworkUtils.checkConnection(requireContext())) {
+                        swipeToRefreshHelper.isRefreshing = false
+                        return@RefreshListener
+                    }
+                    refreshCategories()
+                })
+    }
+
+    private fun initViewModel() {
+        viewModel = ViewModelProviders.of(this, viewModelFactory)
+                .get(PrepublishingCategoriesViewModel::class.java)
+        startObserving()
+    }
+
+    private fun startObserving() {
+        viewModel.navigateToHomeScreen.observe(viewLifecycleOwner, Observer { event ->
+            event?.applyIfNotHandled {
+                closeListener?.onBackClicked()
+            }
+        })
+
+        viewModel.navigateToAddCategoryScreen.observe(viewLifecycleOwner, Observer { event ->
+            event?.applyIfNotHandled {
+                actionListener?.onActionClicked(ADD_CATEGORY)
+            }
+        })
+
+        viewModel.toolbarTitleUiState.observe(viewLifecycleOwner, Observer { uiString ->
+            toolbar_title.text = uiHelpers.getTextOfUiString(requireContext(), uiString)
+        })
+
+//        viewModel.uiState.observe(viewLifecycleOwner, Observer { uiState ->
+//            when (uiState) {
+//                is InitialLoadUiState -> {
+//                }
+//                is ContentUiState -> {
+//
+//                }
+//            }
+//        })
+
+        val siteModel = requireArguments().getSerializable(WordPress.SITE) as SiteModel
+        viewModel.start(getEditPostRepository(), siteModel)
+    }
+
+    private fun initSelectedCategories() {
+        // this can go in the UiState
+        val post = getEditPostRepository().getPost()
+        if (post != null) {
+            selectedCategories.addAll(post.categoryIdList)
+        }
+    }
+
+    private fun refreshCategories() {
+        swipeToRefreshHelper.isRefreshing = true
+        listScrollPositionManager.saveScrollOffset()
+        updateSelectedCategoryList()
+        viewModel.fetchNewCategories()
+    }
+
+    // todo: annmarie - incomment this below and get it working
+    private fun updateSelectedCategoryList() {
+//        val selectedItems: SparseBooleanArray = recycler_view.adapter
+//        val categoryLevels = viewModel.getCategoryLevels()
+//        for (i in 0 until selectedItems.size()) {
+//            if (selectedItems.keyAt(i) >= categoryLevels.size) {
+//                continue
+//            }
+//            val categoryRemoteId: Long = categoryLevels[selectedItems.keyAt(i)]
+//                    .categoryId
+//            if (selectedItems[selectedItems.keyAt(i)]) {
+//                selectedCategories.add(categoryRemoteId)
+//            } else {
+//                selectedCategories.remove(categoryRemoteId)
+//            }
+//        }
+    }
+
+    private fun populateCategoryList() {
+        val categoryLevels = viewModel.getCategoryLevels()
+
+        for (i in categoryLevels.indices) {
+            categoryRemoteIdsToListPositions.put(categoryLevels[i].categoryId, i)
+        }
+
+        // todo: annmarie check for other stuff - like has adapater etc
+        (recycler_view.adapter as PrepublishingCategoriesAdapter).categoryNodeList = categoryLevels
+
+        // todo: annmarie make a method in the adapter for setting checked itmems
+        for (selectedCategory in selectedCategories) {
+            if (categoryRemoteIdsToListPositions.get(selectedCategory) != null) {
+                recycler_view.adapter.setItemChecked(
+                        categoryRemoteIdsToListPositions.get(selectedCategory),
+                        true
+                )
+            }
+        }
+//        // todo: annmarie - reset the scroll offset
+//        // listScrollPositionManager.restoreScrollOffset()
+    }
+
+    private fun getEditPostRepository(): EditPostRepository {
+        val editPostActivityHook = requireNotNull(getEditPostActivityHook()) {
+            "This is possibly null because it's " +
+                    "called during config changes."
+        }
+
+        return editPostActivityHook.editPostRepository
+    }
+
+    private fun getEditPostActivityHook(): EditPostActivityHook? {
+        val activity = activity ?: return null
+        return if (activity is EditPostActivityHook) {
+            activity
+        } else {
+            throw RuntimeException("$activity must implement EditPostActivityHook")
+        }
+    }
+
+    @Subscribe(threadMode = MAIN)
+    fun onTaxonomyChanged(event: OnTaxonomyChanged) {
+        when (event.causeOfChange) {
+            FETCH_CATEGORIES -> {
+                swipeToRefreshHelper.isRefreshing = false
+                if (event.isError) {
+                    if (isAdded) {
+                        ToastUtils.showToast(
+                                requireContext(), string.category_refresh_error,
+                                LONG
+                        )
+                    }
+                } else {
+                    populateCategoryList()
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = MAIN)
+    fun onTermUploaded(event: OnTermUploaded) {
+        // todo: annmarie - check that this is the visible fragment using FM
+        swipeToRefreshHelper.isRefreshing = false
+        if (event.isError) {
+            if (isAdded) {
+                ToastUtils.showToast(
+                        requireContext(),
+                        string.adding_cat_failed,
+                        LONG
+                )
+            }
+        } else {
+            selectedCategories.add(event.term.remoteTermId)
+            populateCategoryList()
+            if (isAdded) {
+                ToastUtils.showToast(
+                        requireContext(),
+                        string.adding_cat_success,
+                        SHORT
+                )
+            }
+        }
+    }
+
+    override fun onCategorySelected(categoryId: Long) {
+        Log.i(javaClass.simpleName, "***=> categorySelected $categoryId")
+    }
+
+    override fun onCategoryUnselected(categoryId: Long) {
+        Log.i(javaClass.simpleName, "***=> categoryUnselected $categoryId")
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -138,7 +138,7 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
 
         viewModel.snackbarEvents.observe(viewLifecycleOwner, Observer { event ->
             event?.applyIfNotHandled {
-                actionListener?.onActionClicked(ADD_CATEGORY)
+                showToast()
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
@@ -1,0 +1,106 @@
+package org.wordpress.android.ui.posts
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.models.CategoryNode
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+class PrepublishingCategoriesViewModel @Inject constructor(
+    private val getCategoriesUseCase: GetCategoriesUseCase,
+    private val updatePostCategoriesUseCase: UpdatePostCategoriesUseCase,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+) : ScopedViewModel(bgDispatcher) {
+    private var isStarted = false
+    private lateinit var editPostRepository: EditPostRepository
+    private lateinit var siteModel: SiteModel
+    private var updateCategoriesJob: Job? = null
+
+    private val _navigateToHomeScreen = MutableLiveData<Event<Unit>>()
+    val navigateToHomeScreen: LiveData<Event<Unit>> = _navigateToHomeScreen
+
+    private val _navigateToAddCategoryScreen = MutableLiveData<Event<Unit>>()
+    val navigateToAddCategoryScreen: LiveData<Event<Unit>> = _navigateToAddCategoryScreen
+
+    private val _toolbarTitleUiState = MutableLiveData<UiString>()
+    val toolbarTitleUiState: LiveData<UiString> = _toolbarTitleUiState
+
+    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
+    private val _uiState: MutableLiveData<UiState> = MutableLiveData()
+    val uiState: LiveData<UiState> = _uiState
+
+    fun start(editPostRepository: EditPostRepository, siteModel: SiteModel) {
+        this.editPostRepository = editPostRepository
+        this.siteModel = siteModel
+
+        if (isStarted) return
+        isStarted = true
+
+        setToolbarTitleUiState()
+    }
+
+    private fun setToolbarTitleUiState() {
+        _toolbarTitleUiState.postValue(UiStringRes(string.prepublishing_nudges_toolbar_title_categories))
+    }
+
+    fun onBackButtonClicked() {
+        _navigateToHomeScreen.postValue(Event(Unit))
+    }
+
+    fun onAddNewCategoryClicked() {
+        _navigateToAddCategoryScreen.postValue(Event(Unit))
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        updateCategoriesJob?.cancel()
+    }
+
+    fun getCategoryLevels(): ArrayList<CategoryNode> =
+            getCategoriesUseCase.getCategoryLevels(siteModel)
+
+    fun fetchNewCategories() = launch { getCategoriesUseCase.fetchNewCategories(siteModel) }
+
+    fun updateCategories(categoryList: List<Long>?) {
+        if (categoryList == null) {
+            return
+        }
+        updateCategoriesJob?.cancel()
+        updateCategoriesJob = launch(bgDispatcher) {
+            updatePostCategoriesUseCase.updateCategories(categoryList, editPostRepository)
+        }
+    }
+
+    private fun trackCategoriesChangedEvent() {
+        // todo: Annmarie add tracking
+        Log.d(javaClass.simpleName, "***=> trackCategoriesChangedEvent here")
+//        if (wereCategoriesChanged()) {
+//            analyticsTrackerWrapper.trackPrepublishingNudges(Stat.EDITOR_POST_TAGS_CHANGED)
+//        }
+    }
+
+    sealed class UiState(
+        open val selectedCategories: HashSet<Long> = hashSetOf()) {
+        data class InitialLoadUiState(
+            override val selectedCategories: HashSet<Long>) : UiState()
+
+        data class ContentUiState(
+            val categories: ArrayList<CategoryNode>
+        ) : UiState()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
@@ -174,9 +174,8 @@ class PrepublishingCategoriesViewModel @Inject constructor(
     private fun getSiteCategories() =
             getCategoriesUseCase.getSiteCategories(siteModel)
 
-    private fun fetchSiteCategories() = launch {
+    private fun fetchSiteCategories() =
         getCategoriesUseCase.fetchSiteCategories(siteModel)
-    }
 
     private fun getPostCategories() =
             getCategoriesUseCase.getPostCategories(editPostRepository, siteModel)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
@@ -118,7 +118,7 @@ class PrepublishingCategoriesViewModel @Inject constructor(
     fun removeSelectedCategory(categoryId: Long) {
         uiState.value.let { state ->
             if (state is ContentUiState) {
-                state.selectedCategoryIds.add(categoryId)
+                state.selectedCategoryIds.remove(categoryId)
                 _uiState.value = state.copy()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeItemUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeItemUiState.kt
@@ -62,6 +62,8 @@ sealed class PrepublishingHomeItemUiState {
 
     enum class ActionType(val textRes: UiStringRes) {
         PUBLISH(UiStringRes(R.string.prepublishing_nudges_publish_action)),
-        TAGS(UiStringRes(R.string.prepublishing_nudges_tags_action))
+        TAGS(UiStringRes(R.string.prepublishing_nudges_tags_action)),
+        CATEGORIES(UiStringRes(R.string.prepublishing_nudges_categories_action)),
+        ADD_CATEGORY(UiStringRes(R.string.prepublishing_nudges_categories_action))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
@@ -66,7 +66,11 @@ class PrepublishingHomeViewModel @Inject constructor(
         setupHomeUiState(editPostRepository, site, isStoryPost)
     }
 
-    private fun setupHomeUiState(editPostRepository: EditPostRepository, site: SiteModel, isStoryPost: Boolean) {
+    private fun setupHomeUiState(
+        editPostRepository: EditPostRepository,
+        site: SiteModel,
+        isStoryPost: Boolean
+    ) {
         val prepublishingHomeUiStateList = mutableListOf<PrepublishingHomeItemUiState>().apply {
             if (isStoryPost) {
                 _storyTitleUiState.postValue(StoryTitleUiState(
@@ -84,7 +88,13 @@ class PrepublishingHomeViewModel @Inject constructor(
                         HomeUiState(
                                 actionType = PUBLISH,
                                 actionResult = editPostRepository.getEditablePost()
-                                        ?.let { UiStringText(postSettingsUtils.getPublishDateLabel(it)) },
+                                        ?.let {
+                                            UiStringText(
+                                                    postSettingsUtils.getPublishDateLabel(
+                                                            it
+                                                    )
+                                            )
+                                        },
                                 actionClickable = true,
                                 onActionClicked = ::onActionClicked
                         )
@@ -94,7 +104,13 @@ class PrepublishingHomeViewModel @Inject constructor(
                         HomeUiState(
                                 actionType = PUBLISH,
                                 actionResult = editPostRepository.getEditablePost()
-                                        ?.let { UiStringText(postSettingsUtils.getPublishDateLabel(it)) },
+                                        ?.let {
+                                            UiStringText(
+                                                    postSettingsUtils.getPublishDateLabel(
+                                                            it
+                                                    )
+                                            )
+                                        },
                                 actionTypeColor = R.color.prepublishing_action_type_disabled_color,
                                 actionResultColor = R.color.prepublishing_action_result_disabled_color,
                                 actionClickable = false,
@@ -106,21 +122,39 @@ class PrepublishingHomeViewModel @Inject constructor(
             if (!editPostRepository.isPage) {
                 add(HomeUiState(
                         actionType = TAGS,
-                        actionResult = getPostTagsUseCase.getTags(editPostRepository)?.let { UiStringText(it) }
+                        actionResult = getPostTagsUseCase.getTags(editPostRepository)
+                                ?.let { UiStringText(it) }
                                 ?: run { UiStringRes(R.string.prepublishing_nudges_home_tags_not_set) },
                         actionClickable = true,
                         onActionClicked = ::onActionClicked
-                ))
+                )
+                )
 
-                add(HomeUiState(
-                        actionType = CATEGORIES,
-                        actionResult =
-                        getCategoriesUseCase.getPostCategoriesString(editPostRepository, site)?.let { UiStringText(it) }
-                                ?: run { UiStringRes(R.string.prepublishing_nudges_home_categories_not_set) },
-                        actionClickable = true,
-                        onActionClicked = ::onActionClicked
-                ))
+                val categoryString: String = getCategoriesUseCase.getPostCategoriesString(
+                        editPostRepository,
+                        site
+                )
+                if (categoryString.isNotEmpty())
+                    UiStringText(categoryString)
+            } else {
+                UiStringRes(R.string.prepublishing_nudges_home_categories_not_set)
             }
+
+            val categoriesString = getCategoriesUseCase.getPostCategoriesString(
+                    editPostRepository,
+                    site
+            )
+
+            add(HomeUiState(
+                    actionType = CATEGORIES,
+                    actionResult = if (categoriesString.isNotEmpty()) {
+                        UiStringText(categoriesString)
+                    } else {
+                        run { UiStringRes(R.string.prepublishing_nudges_home_categories_not_set) }
+                    },
+                    actionClickable = true,
+                    onActionClicked = ::onActionClicked
+            ))
 
             add(getButtonUiStateUseCase.getUiState(editPostRepository, site) { publishPost ->
                 analyticsTrackerWrapper.trackPrepublishingNudges(Stat.EDITOR_POST_PUBLISH_NOW_TAPPED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.posts
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
@@ -105,8 +104,6 @@ class PrepublishingHomeViewModel @Inject constructor(
             }
 
             if (!editPostRepository.isPage) {
-                // todo: annmarie remove the log line
-                Log.i(javaClass.simpleName, "***=> Going to reset the homeUIState and get dets")
                 add(HomeUiState(
                         actionType = TAGS,
                         actionResult = getPostTagsUseCase.getTags(editPostRepository)?.let { UiStringText(it) }
@@ -118,7 +115,7 @@ class PrepublishingHomeViewModel @Inject constructor(
                 add(HomeUiState(
                         actionType = CATEGORIES,
                         actionResult =
-                        getCategoriesUseCase.getPostCategories(editPostRepository, site)?.let { UiStringText(it) }
+                        getCategoriesUseCase.getPostCategoriesString(editPostRepository, site)?.let { UiStringText(it) }
                                 ?: run { UiStringRes(R.string.prepublishing_nudges_home_categories_not_set) },
                         actionClickable = true,
                         onActionClicked = ::onActionClicked

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -68,23 +68,20 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
     }
 
     private fun navigateToScreen(prepublishingScreen: PrepublishingScreen) {
-        // Note: given we know both the HOME and the TAGS screens have an EditText, we can ask to send the
+        // Note: given we know both the HOME, TAGS and ADD_CATEGORY screens have an EditText, we can ask to send the
         // dismissKeyboard signal only when we're not either in one of these nor navigating towards one of these.
         // At this point in code we only know where we want to navigate to, but it's ok since landing on any of these
         // two we'll want the keyboard to stay up if it was already up ;) (i.e. don't dismiss it).
         // For the case where this is not a story and hence there's no EditText in the HOME screen, we're ok too,
         // because there wouldn't have been a keyboard up anyway.
         if (prepublishingScreen == PUBLISH ||
-                prepublishingScreen == CATEGORIES ||
-                prepublishingScreen == ADD_CATEGORY) {
+            prepublishingScreen == CATEGORIES) {
             _dismissKeyboard.postValue(Event(Unit))
         }
         updateNavigationTarget(PrepublishingNavigationTarget(site, prepublishingScreen))
     }
 
     fun onBackClicked() {
-        // todo: annmarie - need to not go to HOME when click on the back of add category
-        // When tapping back from add_category, we need to go back to categories not home
         when {
             currentScreen == ADD_CATEGORY -> {
                 currentScreen = CATEGORIES

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/UpdatePostCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/UpdatePostCategoriesUseCase.kt
@@ -11,16 +11,4 @@ class UpdatePostCategoriesUseCase @Inject constructor() {
             true
         })
     }
-//        editPostRepository.updateAsync(
-//                { postModel: PostModel? ->
-//                    postModel?.setCategoryIdList(categoryList)
-//                    true
-//                },
-//                { _: PostImmutableModel?, result: UpdatePostResult? ->
-//                    result?.let {
-//                        Log.i(javaClass.simpleName, "***=> updatePostResult $it")
-//                    }
-//                    null
-//                })
-//    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/UpdatePostCategoriesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/UpdatePostCategoriesUseCase.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.posts
+
+import dagger.Reusable
+import javax.inject.Inject
+
+@Reusable
+class UpdatePostCategoriesUseCase @Inject constructor() {
+    fun updateCategories(categoryList: List<Long>, editPostRepository: EditPostRepository) {
+        editPostRepository.updateAsync({ postModel ->
+            postModel.setCategoryIdList(categoryList)
+            true
+        })
+    }
+//        editPostRepository.updateAsync(
+//                { postModel: PostModel? ->
+//                    postModel?.setCategoryIdList(categoryList)
+//                    true
+//                },
+//                { _: PostImmutableModel?, result: UpdatePostResult? ->
+//                    result?.let {
+//                        Log.i(javaClass.simpleName, "***=> updatePostResult $it")
+//                    }
+//                    null
+//                })
+//    }
+}

--- a/WordPress/src/main/res/anim/prepublishing_fragment_fade_in.xml
+++ b/WordPress/src/main/res/anim/prepublishing_fragment_fade_in.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android"
     android:fillAfter="true" >
-
     <alpha
+        android:duration="@android:integer/config_mediumAnimTime"
+        android:interpolator="@android:anim/decelerate_interpolator"
         android:fromAlpha="0"
-        android:toAlpha="1"
-        android:startOffset="200"
-        android:duration="200" />
+        android:toAlpha="1" />
+<!--<alpha-->
+<!--    android:fromAlpha="0"-->
+<!--    android:toAlpha="1"-->
+<!--    android:startOffset="200"-->
+<!--    android:duration="200" />-->
 </set>

--- a/WordPress/src/main/res/anim/prepublishing_fragment_fade_in.xml
+++ b/WordPress/src/main/res/anim/prepublishing_fragment_fade_in.xml
@@ -6,9 +6,4 @@
         android:interpolator="@android:anim/decelerate_interpolator"
         android:fromAlpha="0"
         android:toAlpha="1" />
-<!--<alpha-->
-<!--    android:fromAlpha="0"-->
-<!--    android:toAlpha="1"-->
-<!--    android:startOffset="200"-->
-<!--    android:duration="200" />-->
 </set>

--- a/WordPress/src/main/res/anim/prepublishing_fragment_fade_out.xml
+++ b/WordPress/src/main/res/anim/prepublishing_fragment_fade_out.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:fillAfter="true" >
-
+android:fillAfter="true" >
     <alpha
+        android:duration="@android:integer/config_mediumAnimTime"
+        android:interpolator="@android:anim/decelerate_interpolator"
         android:fromAlpha="1"
-        android:toAlpha="0"
-        android:startOffset="200"
-        android:duration="200" />
+        android:toAlpha="0" />
+<!--<alpha-->
+<!--    android:fromAlpha="0"-->
+<!--    android:toAlpha="1"-->
+<!--    android:startOffset="200"-->
+<!--    android:duration="200" />-->
 </set>

--- a/WordPress/src/main/res/anim/prepublishing_fragment_fade_out.xml
+++ b/WordPress/src/main/res/anim/prepublishing_fragment_fade_out.xml
@@ -6,9 +6,4 @@ android:fillAfter="true" >
         android:interpolator="@android:anim/decelerate_interpolator"
         android:fromAlpha="1"
         android:toAlpha="0" />
-<!--<alpha-->
-<!--    android:fromAlpha="0"-->
-<!--    android:toAlpha="1"-->
-<!--    android:startOffset="200"-->
-<!--    android:duration="200" />-->
 </set>

--- a/WordPress/src/main/res/anim/prepublishing_fragment_slide_in.xml
+++ b/WordPress/src/main/res/anim/prepublishing_fragment_slide_in.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_mediumAnimTime"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:fromXDelta="100%"
+    android:toXDelta="0%" />

--- a/WordPress/src/main/res/anim/prepublishing_fragment_slide_in.xml
+++ b/WordPress/src/main/res/anim/prepublishing_fragment_slide_in.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<translate xmlns:android="http://schemas.android.com/apk/res/android"
-    android:duration="@android:integer/config_mediumAnimTime"
-    android:interpolator="@android:anim/decelerate_interpolator"
-    android:fromXDelta="100%"
-    android:toXDelta="0%" />

--- a/WordPress/src/main/res/anim/prepublishing_fragment_slide_out.xml
+++ b/WordPress/src/main/res/anim/prepublishing_fragment_slide_out.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_mediumAnimTime"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:fromXDelta="0%"
+    android:toXDelta="100%" />

--- a/WordPress/src/main/res/anim/prepublishing_fragment_slide_out.xml
+++ b/WordPress/src/main/res/anim/prepublishing_fragment_slide_out.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<translate xmlns:android="http://schemas.android.com/apk/res/android"
-    android:duration="@android:integer/config_mediumAnimTime"
-    android:interpolator="@android:anim/decelerate_interpolator"
-    android:fromXDelta="0%"
-    android:toXDelta="100%" />

--- a/WordPress/src/main/res/layout/prepublishing_add_category_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_add_category_fragment.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:orientation="vertical"
+    android:id="@+id/add_category_content">
+
+    <include layout="@layout/prepublishing_toolbar" />
+
+    <include layout="@layout/add_category" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/relative_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        android:id="@+id/include_prepublishing_toolbar"
+        layout="@layout/prepublishing_toolbar" />
+
+    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+        android:id="@+id/ptr_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/add_new_category"
+        android:layout_below="@+id/include_prepublishing_toolbar">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:divider="?android:attr/listDivider"
+            android:dividerHeight="@dimen/divider_size" />
+
+    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/add_new_category"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_margin="@dimen/margin_large"
+        android:text="@string/prepublishing_nudges_toolbar_title_add_categories"
+        android:textAlignment="viewStart"
+        android:textAppearance="?attr/textAppearanceBody1"
+        android:padding="@dimen/margin_large"
+        android:textColor="?colorPrimary" />
+
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
@@ -5,24 +5,17 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:dividerHeight="@dimen/divider_size"
+        android:layout_above="@+id/add_new_category"
+        android:layout_below="@+id/include_prepublishing_toolbar"/>
+
     <include
         android:id="@+id/include_prepublishing_toolbar"
         layout="@layout/prepublishing_toolbar" />
-
-        <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
-            android:id="@+id/ptr_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_above="@+id/add_new_category"
-            android:layout_below="@+id/include_prepublishing_toolbar">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recycler_view"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:dividerHeight="@dimen/divider_size" />
-
-        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/add_new_category"

--- a/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"-->
+
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/relative_layout"
     android:layout_width="match_parent"
@@ -8,22 +9,20 @@
         android:id="@+id/include_prepublishing_toolbar"
         layout="@layout/prepublishing_toolbar" />
 
-    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
-        android:id="@+id/ptr_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/add_new_category"
-        android:layout_below="@+id/include_prepublishing_toolbar">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler_view"
+        <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+            android:id="@+id/ptr_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:clipToPadding="false"
-            android:divider="?android:attr/listDivider"
-            android:dividerHeight="@dimen/divider_size" />
+            android:layout_above="@+id/add_new_category"
+            android:layout_below="@+id/include_prepublishing_toolbar">
 
-    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:dividerHeight="@dimen/divider_size" />
+
+        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/add_new_category"
@@ -31,10 +30,10 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_margin="@dimen/margin_large"
+        android:padding="@dimen/margin_large"
         android:text="@string/prepublishing_nudges_toolbar_title_add_categories"
         android:textAlignment="viewStart"
         android:textAppearance="?attr/textAppearanceBody1"
-        android:padding="@dimen/margin_large"
         android:textColor="?colorPrimary" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
@@ -24,7 +24,7 @@
         android:layout_alignParentBottom="true"
         android:layout_margin="@dimen/margin_large"
         android:padding="@dimen/margin_large"
-        android:text="@string/prepublishing_nudges_toolbar_title_add_categories"
+        android:text="@string/prepublishing_nudges_add_category_action"
         android:textAlignment="viewStart"
         android:textAppearance="?attr/textAppearanceBody1"
         android:textColor="?colorPrimary" />

--- a/WordPress/src/main/res/layout/prepublishing_categories_row.xml
+++ b/WordPress/src/main/res/layout/prepublishing_categories_row.xml
@@ -11,6 +11,7 @@
             style="@style/MainBottomSheetRowTextView"
             android:gravity="start"
             android:layout_width="0dp"
+            android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/prepublishing_category_check"
             app:layout_constraintStart_toStartOf="parent"
@@ -21,19 +22,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/placeholder_spacer"
-            app:layout_constraintStart_toEndOf="@+id/prepublishing_category_text"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <View
-            android:id="@+id/placeholder_spacer"
-            android:layout_width="@dimen/margin_dialog"
-            android:layout_height="@dimen/margin_dialog"
-            android:contentDescription="@string/unknown"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/prepublishing_category_check"
+            app:layout_constraintStart_toEndOf="@+id/prepublishing_category_text"
             app:layout_constraintTop_toTopOf="parent"
-            android:visibility="gone"/>
+            app:layout_goneMarginEnd="@dimen/margin_dialog"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/prepublishing_categories_row.xml
+++ b/WordPress/src/main/res/layout/prepublishing_categories_row.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/prepublishing_category_row_layout"
+        style="@style/MainBottomSheetRowLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/prepublishing_category_text"
+            style="@style/MainBottomSheetRowTextView"
+            android:gravity="start"
+            android:layout_width="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/prepublishing_category_check"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <CheckBox
+            android:id="@+id/prepublishing_category_check"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/placeholder_spacer"
+            app:layout_constraintStart_toEndOf="@+id/prepublishing_category_text"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <View
+            android:id="@+id/placeholder_spacer"
+            android:layout_width="@dimen/margin_dialog"
+            android:layout_height="@dimen/margin_dialog"
+            android:contentDescription="@string/unknown"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/prepublishing_category_check"
+            app:layout_constraintTop_toTopOf="parent"
+            android:visibility="gone"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/prepublishing_toolbar.xml
+++ b/WordPress/src/main/res/layout/prepublishing_toolbar.xml
@@ -22,6 +22,26 @@
             android:contentDescription="@string/prepublishing_nudges_back_button"
             android:src="@drawable/ic_arrow_left_white_24dp"
             android:tint="@color/prepublishing_toolbar_icon_color" />
+
+    </RelativeLayout>
+    <RelativeLayout
+        android:id="@+id/close_button"
+        android:layout_width="@dimen/min_touch_target_sz"
+        android:layout_height="@dimen/min_touch_target_sz"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toRightOf="@id/toolbar_title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/bottom_sheet_handle"
+        android:visibility="gone">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/prepublishing_nudges_back_button"
+            android:src="@drawable/ic_close_white_24dp"
+            android:tint="@color/prepublishing_toolbar_icon_color"/>
     </RelativeLayout>
 
     <View

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2867,7 +2867,6 @@
     <string name="prepublishing_nudges_home_save_button">Save Now</string>
     <string name="prepublishing_nudges_home_update_button" translatable="false">@string/update_now</string>
     <string name="prepublishing_nudges_back_button">Back</string>
-    <string name="prepublishing_nudges_close_button">Close</string>
     <string name="prepublishing_nudges_toolbar_title_tags">Add Tags</string>
     <string name="prepublishing_nudges_toolbar_title_publish">Publish Date</string>
     <string name="prepublishing_tags_description">Tags help tell readers what a post is about.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2858,6 +2858,8 @@
     <!-- Prepublishing Nudges -->
     <string name="prepublishing_nudges_publish_action">Publish Date</string>
     <string name="prepublishing_nudges_tags_action">Tags</string>
+    <string name="prepublishing_nudges_categories_action">Categories</string>
+    <string name="prepublishing_nudges_add_category_action">Add New Category</string>
     <string name="prepublishing_nudges_home_header_publishing_to">Publishing to</string>
     <string name="prepublishing_nudges_home_publish_button" translatable="false">@string/publish_now</string>
     <string name="prepublishing_nudges_home_schedule_button">Schedule Now</string>
@@ -2865,11 +2867,15 @@
     <string name="prepublishing_nudges_home_save_button">Save Now</string>
     <string name="prepublishing_nudges_home_update_button" translatable="false">@string/update_now</string>
     <string name="prepublishing_nudges_back_button">Back</string>
+    <string name="prepublishing_nudges_close_button">Close</string>
     <string name="prepublishing_nudges_toolbar_title_tags">Add Tags</string>
     <string name="prepublishing_nudges_toolbar_title_publish">Publish Date</string>
     <string name="prepublishing_tags_description">Tags help tell readers what a post is about.</string>
     <string name="prepublishing_nudges_home_tags_not_set">Not set</string>
     <string name="prepublishing_nudges_story_title_hint">Give your story a title</string>
+    <string name="prepublishing_nudges_home_categories_not_set">Not set</string>
+    <string name="prepublishing_nudges_toolbar_title_categories">Categories</string>
+    <string name="prepublishing_nudges_toolbar_title_add_categories">Add New Category</string>
 
     <string name="content_description_logo">WordPress Logo</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
@@ -69,6 +69,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
         whenever(postSettingsUtils.getPublishDateLabel(any())).thenReturn((""))
         whenever(site.name).thenReturn("")
         whenever(storyRepositoryWrapper.getCurrentStoryThumbnailUrl()).thenReturn("")
+        whenever(getCategoriesUseCase.getPostCategoriesString(any(), any())).thenReturn("")
     }
 
     @Test
@@ -88,7 +89,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
     @Test
     fun `verify that page home actions are propagated to prepublishingHomeUiState once the viewModel is started`() {
         // arrange
-        val expectedActionsAmount = 1
+        val expectedActionsAmount = 2
         whenever(editPostRepository.isPage).thenReturn(true)
 
         // act

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
@@ -39,6 +39,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
     @Mock lateinit var getButtonUiStateUseCase: GetButtonUiStateUseCase
     @Mock lateinit var storyRepositoryWrapper: StoryRepositoryWrapper
     @Mock lateinit var updateStoryTitleUseCase: UpdateStoryPostTitleUseCase
+    @Mock lateinit var getCategoriesUseCase: GetCategoriesUseCase
     @Mock lateinit var site: SiteModel
 
     @InternalCoroutinesApi
@@ -51,6 +52,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
                 mock(),
                 storyRepositoryWrapper,
                 updateStoryTitleUseCase,
+                getCategoriesUseCase,
                 TEST_DISPATCHER
         )
         whenever(
@@ -72,7 +74,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
     @Test
     fun `verify that post home actions are propagated to prepublishingHomeUiState once the viewModel is started`() {
         // arrange
-        val expectedActionsAmount = 2
+        val expectedActionsAmount = 3
 
         // act
         viewModel.start(mock(), site, false)

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -60,7 +60,8 @@ public class AppLog {
         SUPPORT,
         SITE_CREATION,
         DOMAIN_REGISTRATION,
-        FEATURE_ANNOUNCEMENT
+        FEATURE_ANNOUNCEMENT,
+        PREPUBLISHING_NUDGES
     }
 
     public static final String TAG = "WordPress";


### PR DESCRIPTION
Part of #13066 

This PR adds support for
1. Selecting categories for a post
2. Adding a new category

This PR is labeled WIP/do not merge. I am looking for a review before moving forward with the open issues (see list below).

The meat of the PR can be found in:
`PrepublishingAddCategoryFragment` and `PrepublishingAddCategoryViewModel`
- This pair is responsible for the adding of a new category 

`PrepublishingCategoriesFragment and PrepublishingCategoriesViewModel`
- This pair is responsible for selecting/unselecting categories and for kicking off the Add Category action.

`PrepublishingBottomSheetFragment` (preexisting) is the traffic cop and handles adding/removing fragment transactions to the bottom sheet container. This was updated to handle the AddCategory and Categories fragments. Each of the individual actions in the bottom sheet are standalone fragments and the behavior is identical for all.

I was on the fence with regards to suspendable functions.
- They are used for update/add/fetch server calls in the `UpdatePostCategoriesUseCase`, `AddCategoryUseCase`, and `GetCategoriesUseCase`. I followed existing architecture for calls to TaxonomyStore and EditPostRepository. I am open to suggestions.

It’s a rather larger PR, but I broke it up by commits.
f8a263b => layout files, animation files, strings, `AppComponent`/`ViewModelModule`, plugging into existing architecture
740ce31 => Changes to `PrepublishingBottomSheetFragmentPrepublishingHomeViewModel`, `PrepublishingViewModel`
7c5012d => Add category related
3d28bb4 => Select category related

Home|Select|Add
---|---|---
<img width="480" src="https://user-images.githubusercontent.com/506707/96194465-6995f880-0f18-11eb-8959-d21eea29fd6f.png">|<img width="480" src="https://user-images.githubusercontent.com/506707/96194480-73b7f700-0f18-11eb-9202-25a09d2ba0a2.png">|<img width="480" src="https://user-images.githubusercontent.com/506707/96194499-7c103200-0f18-11eb-8825-2d9cca288bdf.png">

**This PR has open issues** and they are almost all related to BottomSheet behavior (scrolling the biggest one)
1. Showing a snackbar in a bottom sheet (using toast for now)
~~2. Recyclerview: scrolling within a bottom sheet (this also affects PTR)~~  ****Update**: Removed the PTR in commit cd27ec0 and scrolling works just fine. 
3. There is an existing [issue](https://github.com/wordpress-mobile/WordPress-Android/issues/12166) for the janky transitions between the bottom sheet fragments. I started on some new transition files and things were looking positive, but ultimately decided to push this issue off until all the bottom sheet scrolling issues are resolved.
4. There is a separate [issue](https://github.com/wordpress-mobile/WordPress-Android/issues/13149) for writing unit test 
I am open to any suggestions for solving the scrolling/recyclerview issues in a bottom sheet. 😉 

To test:
Prep
- Launch the app
- Select Blog posts
- Select Edit on a post
- From the edit post view, tap the UPDATE action to launch the bottom sheet

Categories are shown on the Categories row
- If the post has categories assigned, you will see them listed on the home view (figure 1 above). If not, you will see Not Set

Select Categories is shown when user taps on Categories
- Tap the categories row to launch the Select categories view (fig 2)

Add category is shown and user can save a new category
- Tap the Add New Category button on the bottom of the select categories view (fig 3)
- Enter a new category and tap the <- Back Arrow

Newly Added category is shown in the categories list
- Take note of the toast which will tell you if the action succeeded or failed. 
- Back on the select category view, the category you have added is visible and checked

Categories can be checked/unchecked 
- Select or unselect some categories

Categories are saved
- Tap the <- Back arrow to save your options
- The categories row on the home screen should reflect the selections you made

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
