### PR TITLE
RI: Change copy "tags" to "topics" on the Reader screens

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1316,14 +1316,14 @@
     <string name="reader">Reader</string>
     <string name="reader_filter_cta">Filter</string>
     <string name="reader_filter_sites_title">Sites</string>
-    <string name="reader_filter_tags_title">Tags</string>
+    <string name="reader_filter_tags_title">Topics</string>
     <string name="reader_filter_main_title">Following</string>
     <string name="reader_filter_empty_sites_list">See the newest posts from sites you follow</string>
-    <string name="reader_filter_empty_tags_list">You can follow posts on a specific subject by adding a tag</string>
+    <string name="reader_filter_empty_tags_list">You can follow posts on a specific subject by adding a topic</string>
     <string name="reader_filter_self_hosted_empty_sites_list">Log in to WordPress.com to see the latest posts from sites you follow</string>
-    <string name="reader_filter_self_hosted_empty_tagss_list">Log in to WordPress.com to see the latest posts from tags you follow</string>
+    <string name="reader_filter_self_hosted_empty_tagss_list">Log in to WordPress.com to see the latest posts from topics you follow</string>
     <string name="reader_filter_empty_sites_action">Follow a site</string>
-    <string name="reader_filter_empty_tags_action">Add a tag</string>
+    <string name="reader_filter_empty_tags_action">Add a topic</string>
     <string name="reader_filter_self_hosted_empty_sites_tags_action">Log in to WordPress.com</string>
     <string name="reader_dot_separator" translatable="false">\u0020\u2022\u0020</string>
     <string name="reader_error_request_failed_title">There was a problem handling the request. Please try again later.</string>
@@ -1709,17 +1709,17 @@
     <string name="reader_title_post_detail">Reader Post</string>
     <string name="reader_title_post_detail_wpcom">WordPress.com Post</string>
     <string name="reader_title_related_post_detail">Related Post</string>
-    <string name="reader_title_subs">Manage Tags &amp; Sites</string>
+    <string name="reader_title_subs">Manage Topics &amp; Sites</string>
     <string name="reader_title_photo_viewer">%1$d of %2$d</string>
     <string name="reader_title_comments" translatable="false">@string/comments</string>
 
     <!-- view pager titles -->
-    <string name="reader_page_followed_tags">Followed tags</string>
+    <string name="reader_page_followed_tags">Followed topics</string>
     <string name="reader_page_followed_blogs">Followed sites</string>
     <string name="reader_page_recommended_blogs">Sites you may like</string>
 
     <!-- menu text -->
-    <string name="reader_menu_tags">Edit tags and sites</string>
+    <string name="reader_menu_tags">Edit topics and sites</string>
     <string name="reader_menu_block_blog">Block this site</string>
     <string name="reader_menu_report_post">Report this post</string>
 
@@ -1753,7 +1753,7 @@
     <!-- EditText hints -->
     <string name="reader_hint_comment_on_post">Reply to post…</string>
     <string name="reader_hint_comment_on_comment">Reply to comment…</string>
-    <string name="reader_hint_add_tag_or_url">Enter a URL or tag to follow</string>
+    <string name="reader_hint_add_tag_or_url">Enter a URL or topic to follow</string>
     <string name="reader_hint_post_search">Search WordPress</string>
     <string name="reader_hint_search_followed_sites">Search followed sites</string>
 
@@ -1804,10 +1804,10 @@
 
     <!-- toast messages -->
     <string name="reader_toast_err_comment_failed">Couldn\'t post your comment</string>
-    <string name="reader_toast_err_tag_exists">You already follow this tag</string>
-    <string name="reader_toast_err_tag_invalid">That isn\'t a valid tag</string>
-    <string name="reader_toast_err_add_tag">Unable to add this tag</string>
-    <string name="reader_toast_err_remove_tag">Unable to remove this tag</string>
+    <string name="reader_toast_err_tag_exists">You already follow this topic</string>
+    <string name="reader_toast_err_tag_invalid">That isn\'t a valid topic</string>
+    <string name="reader_toast_err_add_tag">Unable to add this topic</string>
+    <string name="reader_toast_err_remove_tag">Unable to remove this topic</string>
     <string name="reader_toast_err_share_intent">Unable to share</string>
     <string name="reader_toast_err_view_image">Unable to view image</string>
     <string name="reader_toast_err_get_blog_info">Unable to show this site</string>
@@ -1840,11 +1840,11 @@
     <string name="reader_empty_posts_no_connection" translatable="false">@string/no_network_title</string>
     <string name="reader_empty_posts_request_failed">Unable to retrieve posts</string>
     <string name="reader_self_hosted_select_filter">Use the filter button to find posts on specific subjects</string>
-    <string name="reader_empty_posts_in_tag">No posts with this tag</string>
+    <string name="reader_empty_posts_in_tag">No posts with this topic</string>
     <string name="reader_empty_posts_in_tag_updating">Fetching posts…</string>
     <string name="reader_empty_posts_in_custom_list">The sites in this list haven\'t posted anything recently</string>
-    <string name="reader_empty_followed_tags_subtitle">Add tags here to find posts about your favorite topics</string>
-    <string name="reader_empty_followed_tags_title">No followed tags</string>
+    <string name="reader_empty_followed_tags_subtitle">Add topics here to find posts about your favorite topics</string>
+    <string name="reader_empty_followed_tags_title">No followed topics</string>
     <string name="reader_empty_recommended_blogs">No recommended sites</string>
     <string name="reader_empty_followed_blogs_title">No followed sites</string>
     <string name="reader_empty_followed_blogs_search_title">No sites matching your search</string>


### PR DESCRIPTION
Project Issue: #12899
Task: #12883

This PR changes copy from "tags" to "topics" on the Reader screens.

|Manage Topics| Filter Topics | Discover | Filter Topics (self-hosted login)|
|-----|-----|----|-----|
|![manage topics](https://user-images.githubusercontent.com/1405144/96227348-9fd38680-0fb1-11eb-8590-cee9466d5dc3.png)|![filter-topics](https://user-images.githubusercontent.com/1405144/96227358-a3670d80-0fb1-11eb-9ac2-493945618f72.png)| ![device-2020-10-16-123018](https://user-images.githubusercontent.com/1405144/96227372-a82bc180-0fb1-11eb-8281-eeb8c6667b36.png)|![device-2020-10-16-123314](https://user-images.githubusercontent.com/1405144/96227387-ac57df00-0fb1-11eb-96c1-4e73c1344e1f.png)|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
