### PR TITLE
Reader Improvements: Move settings icon from following tab to reader app nav bar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -131,6 +131,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
                 }
                 uiHelpers.updateVisibility(tab_layout, uiState.tabLayoutVisible)
                 searchMenuItem?.isVisible = uiState.searchIconVisible
+                settingsMenuItem?.isVisible = uiState.settingsIconVisible
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -37,6 +37,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
     private lateinit var viewModel: ReaderViewModel
 
     private var searchMenuItem: MenuItem? = null
+    private var settingsMenuItem: MenuItem? = null
 
     private val viewPagerCallback = object : ViewPager2.OnPageChangeCallback() {
         override fun onPageSelected(position: Int) {
@@ -65,6 +66,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
     override fun onDestroyView() {
         super.onDestroyView()
         searchMenuItem = null
+        settingsMenuItem = null
     }
 
     override fun onResume() {
@@ -83,14 +85,25 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
             searchMenuItem = this
             this.isVisible = viewModel.uiState.value?.searchIconVisible ?: false
         }
+        menu.findItem(R.id.menu_settings).apply {
+            settingsMenuItem = this
+            this.isVisible = viewModel.uiState.value?.settingsIconVisible ?: false
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return if (item.itemId == R.id.menu_search) {
-            viewModel.onSearchActionClicked()
-            true
-        } else {
-            super.onOptionsItemSelected(item)
+        return when (item.itemId) {
+            R.id.menu_search -> {
+                viewModel.onSearchActionClicked()
+                true
+            }
+            R.id.menu_settings -> {
+                viewModel.onSettingsActionClicked()
+                true
+            }
+            else -> {
+                super.onOptionsItemSelected(item)
+            }
         }
     }
 
@@ -136,6 +149,12 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
         viewModel.showSearch.observe(viewLifecycleOwner, Observer { event ->
             event.getContentIfNotHandled()?.let {
                 ReaderActivityLauncher.showReaderSearch(context)
+            }
+        })
+
+        viewModel.showSettings.observe(viewLifecycleOwner, Observer { event ->
+            event.getContentIfNotHandled()?.let {
+                ReaderActivityLauncher.showReaderSubs(context)
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -172,7 +172,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
     private MenuItem mSearchMenuItem;
 
     private View mSubFilterComponent;
-    private ImageView mSettingsButton;
     private View mSubFiltersListButton;
     private TextView mSubFilterTitle;
     private View mRemoveFilterButton;
@@ -605,10 +604,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
     private void initSubFilterViews(ViewGroup rootView, LayoutInflater inflater) {
         mSubFilterComponent = inflater.inflate(R.layout.subfilter_component, rootView, false);
         ((ViewGroup) rootView.findViewById(R.id.sub_filter_component_container)).addView(mSubFilterComponent);
-        mSettingsButton = mSubFilterComponent.findViewById(R.id.filter_settings_button);
-        mSettingsButton.setOnClickListener(v -> {
-            showSettings();
-        });
 
         mSubFiltersListButton = mSubFilterComponent.findViewById(R.id.filter_selection);
         mSubFiltersListButton.setOnClickListener(v -> {
@@ -622,7 +617,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
             mSubFilterViewModel.setDefaultSubfilter();
         });
         mSubFilterComponent.setVisibility(isFollowingScreen() ? View.VISIBLE : View.GONE);
-        mSettingsButton.setVisibility(isFollowingScreen() && mAccountStore.hasAccessToken() ? View.VISIBLE : View.GONE);
 
         ElevationOverlayProvider elevationOverlayProvider = new ElevationOverlayProvider(mRecyclerView.getContext());
         float cardElevation = getResources().getDimension(R.dimen.card_elevation);
@@ -1119,12 +1113,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
         return rootView;
     }
 
-    private void showSettings() {
-        ReaderActivityLauncher.showReaderSubs(getActivity());
-    }
-
     /*
-     * adds a menu to the recycler's toolbar containing settings & search items - only called
+     * adds a menu to the recycler's toolbar containing search items - only called
      * for followed tags
      */
     private void setupRecyclerToolbar() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -17,7 +17,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
 import android.widget.AutoCompleteTextView;
-import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -7,7 +7,6 @@ import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.webkit.URLUtil;
 import android.widget.EditText;
-import android.widget.ImageButton;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -45,6 +44,7 @@ import org.wordpress.android.ui.reader.adapters.ReaderTagAdapter;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
+import org.wordpress.android.ui.reader.views.ReaderFollowButton;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.NetworkUtils;
@@ -66,7 +66,7 @@ import javax.inject.Inject;
 public class ReaderSubsActivity extends LocaleAwareActivity
         implements ReaderTagAdapter.TagDeletedListener {
     private EditText mEditAdd;
-    private ImageButton mBtnAdd;
+    private ReaderFollowButton mBtnAdd;
     private WPViewPager mViewPager;
     private SubsPageAdapter mPageAdapter;
 
@@ -136,7 +136,7 @@ public class ReaderSubsActivity extends LocaleAwareActivity
             }
         });
 
-        mBtnAdd = (ImageButton) findViewById(R.id.btn_add);
+        mBtnAdd = findViewById(R.id.btn_add);
         mBtnAdd.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -255,7 +255,7 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         if (result) {
-            followButton.setIsFollowedAnimated(isAskingToFollow);
+            followButton.setIsFollowed(isAskingToFollow);
             blog.isFollowing = isAskingToFollow;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -59,6 +59,9 @@ class ReaderViewModel @Inject constructor(
     private val _showSearch = MutableLiveData<Event<Unit>>()
     val showSearch: LiveData<Event<Unit>> = _showSearch
 
+    private val _showSettings = MutableLiveData<Event<Unit>>()
+    val showSettings: LiveData<Event<Unit>> = _showSettings
+
     private val _showReaderInterests = MutableLiveData<Event<Unit>>()
     val showReaderInterests: LiveData<Event<Unit>> = _showReaderInterests
 
@@ -82,7 +85,8 @@ class ReaderViewModel @Inject constructor(
                 _uiState.value = ContentUiState(
                         tagList.map { it.label },
                         tagList,
-                        searchIconVisible = isSearchSupported()
+                        searchIconVisible = isSearchSupported(),
+                        settingsIconVisible = isSettingsSupported()
                 )
                 if (!initialized) {
                     initialized = true
@@ -126,15 +130,18 @@ class ReaderViewModel @Inject constructor(
 
     sealed class ReaderUiState(
         open val searchIconVisible: Boolean,
+        open val settingsIconVisible: Boolean,
         val appBarExpanded: Boolean = false,
         val tabLayoutVisible: Boolean = false
     ) {
         data class ContentUiState(
             val tabTitles: List<String>,
             val readerTagList: ReaderTagList,
-            override val searchIconVisible: Boolean
+            override val searchIconVisible: Boolean,
+            override val settingsIconVisible: Boolean
         ) : ReaderUiState(
                 searchIconVisible = searchIconVisible,
+                settingsIconVisible = settingsIconVisible,
                 appBarExpanded = true,
                 tabLayoutVisible = true
         )
@@ -173,6 +180,14 @@ class ReaderViewModel @Inject constructor(
         }
     }
 
+    fun onSettingsActionClicked() {
+        if (isSettingsSupported()) {
+            _showSettings.value = Event(Unit)
+        } else if (BuildConfig.DEBUG) {
+            throw IllegalStateException("Settings should be hidden when isSettingsSupported returns false.")
+        }
+    }
+
     private fun ReaderTag.isDefaultSelectedTab(): Boolean = this.isDiscover
 
     @Subscribe(threadMode = MAIN)
@@ -193,6 +208,8 @@ class ReaderViewModel @Inject constructor(
     }
 
     private fun isSearchSupported() = accountStore.hasAccessToken()
+
+    private fun isSettingsSupported() = accountStore.hasAccessToken()
 
     private fun trackReaderTabShownIfNecessary(it: ReaderTag) {
         trackReaderTabJob?.cancel()

--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -60,19 +60,17 @@
             android:paddingEnd="@dimen/margin_medium"
             android:textAlignment="viewStart" />
 
-        <ImageButton
+        <org.wordpress.android.ui.reader.views.ReaderFollowButton
             android:id="@+id/btn_add"
+            style="@style/Reader.Follow.Button.Icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignTop="@+id/edit_add"
             android:layout_alignBottom="@+id/edit_add"
             android:layout_alignParentEnd="true"
-            android:background="?android:selectableItemBackground"
             android:contentDescription="@string/add"
-            android:paddingStart="@dimen/margin_extra_medium_large"
-            android:paddingEnd="@dimen/margin_extra_medium_large"
-            android:src="@drawable/ic_reader_follow_white_24dp"
-            app:tint="?attr/colorPrimary" />
+            android:layout_marginStart="@dimen/margin_extra_medium_large"
+            android:layout_marginEnd="@dimen/margin_extra_medium_large"/>
 
     </RelativeLayout>
 

--- a/WordPress/src/main/res/layout/reader_listitem_blog.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_blog.xml
@@ -4,7 +4,6 @@
     list item which shows a recommended or followed blog - see ReaderBlogAdapter
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -73,9 +72,10 @@
 
     <org.wordpress.android.ui.reader.views.ReaderFollowButton
         android:id="@+id/follow_button"
+        style="@style/Reader.Follow.Button.Icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="@dimen/margin_medium"
-        app:wpShowFollowButtonCaption="false" />
+        android:layout_marginStart="@dimen/margin_medium"
+        android:layout_marginEnd="@dimen/margin_medium"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/subfilter_component.xml
+++ b/WordPress/src/main/res/layout/subfilter_component.xml
@@ -61,27 +61,6 @@
         app:layout_constraintStart_toEndOf="@+id/selected_filter_name"
         app:layout_constraintEnd_toStartOf="@+id/guideline"/>
 
-    <View
-        android:id="@+id/view"
-        android:layout_width="@dimen/divider_size"
-        android:layout_height="match_parent"
-        android:layout_marginTop="@dimen/margin_medium"
-        android:layout_marginBottom="@dimen/margin_medium"
-        android:background="?android:attr/listDivider"
-        app:layout_constraintEnd_toStartOf="@+id/filter_settings_button" />
-
-    <ImageView
-        android:id="@+id/filter_settings_button"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:background="?selectableItemBackgroundBorderless"
-        android:contentDescription="@string/reader_menu_tags"
-        android:paddingEnd="@dimen/margin_extra_large"
-        android:paddingStart="@dimen/margin_extra_large"
-        android:src="@drawable/ic_cog_white_24dp"
-        app:tint="?attr/wpColorOnSurfaceMedium"
-        app:layout_constraintEnd_toEndOf="parent" />
-
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline"
         android:layout_width="wrap_content"

--- a/WordPress/src/main/res/menu/reader_home.xml
+++ b/WordPress/src/main/res/menu/reader_home.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/menu_settings"
+        android:icon="@drawable/ic_cog_white_24dp"
+        android:title="@string/reader_menu_tags"
+        android:visible="false"
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/menu_search"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -200,7 +200,7 @@
 
     <dimen name="reader_simple_post_image_width">72dp</dimen>
 
-    <dimen name="reader_subfilter_end_guideline_margin">58dp</dimen>
+    <dimen name="reader_subfilter_end_guideline_margin">16dp</dimen>
 
     <dimen name="reader_subfilter_url_margin_bottom">14dp</dimen>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -267,6 +267,51 @@ class ReaderViewModelTest {
     }
 
     @Test
+    fun `OnSettingsActionClicked emits showSettings event`() {
+        // Arrange
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        var event: Event<Unit>? = null
+        viewModel.showSettings.observeForever {
+            event = it
+        }
+        // Act
+        viewModel.onSettingsActionClicked()
+
+        // Assert
+        assertThat(event).isNotNull
+    }
+
+    @Test
+    fun `Settings menu is disabled for self-hosted login`() = testWithNonEmptyTags {
+        // Arrange
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        var state: ReaderUiState? = null
+        viewModel.uiState.observeForever {
+            state = it
+        }
+        // Act
+        triggerReaderTabContentDisplay()
+
+        // Assert
+        assertThat(state!!.settingsIconVisible).isFalse()
+    }
+
+    @Test
+    fun `Settings menu is enabled for dot com login`() = testWithNonEmptyTags {
+        // Arrange
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        var state: ReaderUiState? = null
+        viewModel.uiState.observeForever {
+            state = it
+        }
+        // Act
+        triggerReaderTabContentDisplay()
+
+        // Assert
+        assertThat(state!!.settingsIconVisible).isTrue()
+    }
+
+    @Test
     fun `Tab layout is visible when loaded tags are NOT empty`() = testWithNonEmptyTags {
         // Arrange
         val uiStates = mutableListOf<ReaderUiState>()


### PR DESCRIPTION
Project Issue: #12899
Task: #12882

This PR moves the settings icon to the app nav bar next to the search icon so it's a global action that can be accessed from any tab (following, discover, likes, saved).

Before | After
-------|------
![device-2020-10-17-170912](https://user-images.githubusercontent.com/1405144/96336219-bd7d1a80-109b-11eb-837c-0c4071253e73.png)|![device-2020-10-17-170510](https://user-images.githubusercontent.com/1405144/96336223-c372fb80-109b-11eb-995e-4f3962ef5576.png)



### To test

#### For dot com account login

1. Launch app
2. Login using dot com account
3. Go to Reader tab 
4. Notice that settings menu is visible on the app nav bar 
5. Click the menu 
6. Notice that "Manage Topics and Sites" screen is shown
7. Close "Manage Topics and Sites" 
8. Go to following tab 
9. Notice that settings icon is not visible on the filter bar

#### For self-hosted login

1. Launch app
2. Login using self-hosted site
3. Go to Reader tab 
4. Notice that settings menu is not visible on the app nav bar 

Note: For consistency also updated "Follow" button style on the "Manage Topics & Sites" screen accessed on "Settings" button click in 4d709ed.

![device-2020-10-19-111402](https://user-images.githubusercontent.com/1405144/96406083-55921580-11fc-11eb-9033-13b4cbf750a7.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
