### PR TITLE
Issue/13066 ppn add category button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
@@ -133,6 +133,7 @@ class PrepublishingCategoriesViewModel @Inject constructor(
         _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringRes(message))))
 
         if (!event.isError) {
+            analyticsTrackerWrapper.trackPrepublishingNudges(Stat.EDITOR_POST_CATEGORIES_ADDED)
             val categoryLevels = getSiteCategories()
             val selectedCategoryIds = (uiState.value as? ContentUiState)?.selectedCategoryIds
                     ?: hashSetOf()

--- a/WordPress/src/main/res/layout/add_category.xml
+++ b/WordPress/src/main/res/layout/add_category.xml
@@ -45,5 +45,19 @@
             android:layout_height="wrap_content"
             app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
             tools:listitem="@layout/wp_simple_list_item_1" />
+
+        <!-- Submit button -->
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/submit_button"
+            style="@style/WordPress.PrepubPrimaryButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_medium"
+            android:layout_marginEnd="@dimen/margin_medium"
+            android:layout_marginTop="@dimen/margin_medium"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:enabled="false"
+            android:text="@string/prepublishing_nudges_add_category_button" />
     </LinearLayout>
 </ScrollView>

--- a/WordPress/src/main/res/layout/prepublishing_toolbar.xml
+++ b/WordPress/src/main/res/layout/prepublishing_toolbar.xml
@@ -24,25 +24,6 @@
             android:tint="@color/prepublishing_toolbar_icon_color" />
 
     </RelativeLayout>
-    <RelativeLayout
-        android:id="@+id/close_button"
-        android:layout_width="@dimen/min_touch_target_sz"
-        android:layout_height="@dimen/min_touch_target_sz"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toRightOf="@id/toolbar_title"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/bottom_sheet_handle"
-        android:visibility="gone">
-
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/prepublishing_nudges_back_button"
-            android:src="@drawable/ic_close_white_24dp"
-            android:tint="@color/prepublishing_toolbar_icon_color"/>
-    </RelativeLayout>
 
     <View
         android:id="@+id/bottom_sheet_handle"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2875,6 +2875,7 @@
     <string name="prepublishing_nudges_home_categories_not_set">Not set</string>
     <string name="prepublishing_nudges_toolbar_title_categories">Categories</string>
     <string name="prepublishing_nudges_toolbar_title_add_categories">Add New Category</string>
+    <string name="prepublishing_nudges_add_category_button">Add Category</string>
 
     <string name="content_description_logo">WordPress Logo</string>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1333,4 +1333,8 @@
         <item name="android:textAppearance">?attr/textAppearanceBody2</item>
     </style>
 
+    <style name="WordPress.PrepubPrimaryButton" parent="WordPress.Button.Primary">
+        <item name="android:textAllCaps">true</item>
+        <item name="android:textStyle">bold</item>
+    </style>
 </resources>


### PR DESCRIPTION
Part of #13066 

This PR removes the Close "X" click button on the Add Category toolbar and replaces it with a Submit button. The `PrepublishingAddCategoryViewModel` and `PrepublishingAddCategoryFragment` have been refactored based on PR comments in #13150 

***Merge Instructions***
- Note: This PR will be merged into a feature branch
- Make sure #13150 has been merged
- Remove the Not Ready For Merge label
- Merge as normal

Before|After
---|---
<img width="480" src="https://user-images.githubusercontent.com/506707/96194499-7c103200-0f18-11eb-8825-2d9cca288bdf.png">|<img width="480" src="https://user-images.githubusercontent.com/506707/96375007-5bc4bb00-1144-11eb-9e65-2abcc8930a4b.png">

To test:

- Launch the app
- Select Blog posts
- Select Edit on a post
- From the edit post view, tap the UPDATE action to launch the bottom sheet
- From the select categories view, tap the Add New Category link on the bottom of the select categories view 
- Enter a new category and tap the submit button
- Newly Added category is shown in the categories list

Take note of the toast which will tell you if the action succeeded or failed.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
