### PR TITLE
Add FLAG_UPDATE_CURRENT flag to notification pending intent

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -496,9 +496,7 @@ public class ActivityLauncher {
             ToastUtils.showToast(context, R.string.posts_cannot_be_started, ToastUtils.Duration.SHORT);
             return;
         }
-        Intent intent = new Intent(context, PostsListActivity.class);
-        intent.putExtra(WordPress.SITE, site);
-        context.startActivity(intent);
+        context.startActivity(PostsListActivity.buildIntent(context, site));
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_POSTS, site);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.posts
 
 import android.app.Activity
 import android.app.ProgressDialog
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.HapticFeedbackConstants
@@ -150,8 +151,10 @@ class PostsListActivity : LocaleAwareActivity(),
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
         setContentView(R.layout.post_list_activity)
-
         site = if (savedInstanceState == null) {
+            checkNotNull(intent.getSerializableExtra(WordPress.SITE) as? SiteModel) {
+                "SiteModel cannot be null, check the PendingIntent starting PostsListActivity"
+            }
             intent.getSerializableExtra(WordPress.SITE) as SiteModel
         } else {
             restorePreviousSearch = true
@@ -609,5 +612,14 @@ class PostsListActivity : LocaleAwareActivity(),
     override fun onScrollableViewInitialized(containerId: Int) {
         appbar_main.setLiftOnScrollTargetViewIdAndRequestLayout(containerId)
         appbar_main.setTag(R.id.posts_non_search_recycler_view_id_tag_key, containerId)
+    }
+
+    companion object {
+        @JvmStatic
+        fun buildIntent(context: Context, site: SiteModel): Intent {
+            val intent = Intent(context, PostsListActivity::class.java)
+            intent.putExtra(WordPress.SITE, site)
+            return intent
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -155,7 +155,6 @@ class PostsListActivity : LocaleAwareActivity(),
             checkNotNull(intent.getSerializableExtra(WordPress.SITE) as? SiteModel) {
                 "SiteModel cannot be null, check the PendingIntent starting PostsListActivity"
             }
-            intent.getSerializableExtra(WordPress.SITE) as SiteModel
         } else {
             restorePreviousSearch = true
             savedInstanceState.getSerializable(WordPress.SITE) as SiteModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -349,9 +349,12 @@ class PostUploadNotifier {
         Intent notificationIntent = getNotificationIntent(post, site);
         notificationIntent.putExtra(ARG_NOTIFICATION_TYPE, notificationType);
 
-        PendingIntent pendingIntentPost = PendingIntent.getActivity(mContext,
-                                                                    (int) notificationId,
-                                                                    notificationIntent, PendingIntent.FLAG_ONE_SHOT);
+        PendingIntent pendingIntentPost = PendingIntent.getActivity(
+                mContext,
+                (int) notificationId,
+                notificationIntent,
+                PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_UPDATE_CURRENT
+        );
         notificationBuilder.setContentIntent(pendingIntentPost);
 
         // Share intent - started if the user tap the share link button - only if the link exist
@@ -498,9 +501,12 @@ class PostUploadNotifier {
         NotificationType notificationType = NotificationType.POST_UPLOAD_ERROR;
         notificationIntent.putExtra(ARG_NOTIFICATION_TYPE, notificationType);
 
-        PendingIntent pendingIntent = PendingIntent.getActivity(mContext,
-                                                                (int) notificationId,
-                                                                notificationIntent, PendingIntent.FLAG_ONE_SHOT);
+        PendingIntent pendingIntent = PendingIntent.getActivity(
+                mContext,
+                (int) notificationId,
+                notificationIntent,
+                PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_UPDATE_CURRENT
+        );
 
         notificationBuilder.setSmallIcon(android.R.drawable.stat_notify_error);
 
@@ -543,14 +549,14 @@ class PostUploadNotifier {
         if (post.isPage()) {
             notificationIntent = new Intent(mContext, PagesActivity.class);
             notificationIntent.putExtra(EXTRA_PAGE_REMOTE_ID_KEY, post.getRemotePostId());
+            notificationIntent.putExtra(WordPress.SITE, site);
         } else {
-            notificationIntent = new Intent(mContext, PostsListActivity.class);
+            notificationIntent = PostsListActivity.buildIntent(mContext, site);
             notificationIntent.putExtra(PostsListActivityKt.EXTRA_TARGET_POST_LOCAL_ID, post.getId());
         }
 
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        notificationIntent.putExtra(WordPress.SITE, site);
         return notificationIntent;
     }
 


### PR DESCRIPTION
Fixes #8363

It seems that this issue happens because the pending intent sometimes doesn't pass the extras. It seems that the system (because of efficiency) reuses the previous pending intent without the extras ([the issue](https://stackoverflow.com/questions/18037991/pendingintent-does-not-send-intent-extras)). 

The suggested fix seems to be to use the `PendingIntent.FLAG_UPDATE_CURRENT` flag when creating the pending intent. 

The second fix in this PR is a proper error message when the `SiteModel` is null in the `PostsListActivity`

To test:
- I don't know how to reproduce this issue

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
