### PR TITLE
Reader Improvements: Delete recommended blogs cache on refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTable.java
@@ -18,6 +18,7 @@ import org.wordpress.android.util.SqlUtils;
 import org.wordpress.android.util.UrlUtils;
 
 import java.util.Date;
+import java.util.List;
 
 /**
  * tbl_blog_info contains information about blogs viewed in the reader, and blogs the
@@ -361,6 +362,28 @@ public class ReaderBlogTable {
                         stmt.execute();
                     }
                 }
+                db.setTransactionSuccessful();
+            } catch (SQLException e) {
+                AppLog.e(AppLog.T.READER, e);
+            }
+        } finally {
+            SqlUtils.closeStatement(stmt);
+            db.endTransaction();
+        }
+    }
+
+    public static void deleteBlogsWithIds(final List<Long> blogIds) {
+        SQLiteDatabase db = ReaderDatabase.getWritableDb();
+        SQLiteStatement stmt = db.compileStatement(
+                "DELETE FROM tbl_blog_info"
+                + " WHERE blog_id IN ("
+                + TextUtils.join(",", blogIds)
+                + ")"
+        );
+        db.beginTransaction();
+        try {
+            try {
+                stmt.execute();
                 db.setTransactionSuccessful();
             } catch (SQLException e) {
                 AppLog.e(AppLog.T.READER, e);


### PR DESCRIPTION
Task #12834
Parent PR #13162

This PR deletes recommended blogs cache on pull to refresh similar to discover posts [here](https://github.com/wordpress-mobile/WordPress-Android/blob/9e59a46e33ea0fe7e79b7d5eaa96bfd8a7866fcc/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt#L216-L219).

### To test

1. Launch app
2. Go to Reader - Discover tab
3. Scroll to see recommended blogs section and note down their blog ids in the `tbl_blog_info` using DB explorer
4. Follow one of the recommended blogs. Note down its id.
5. Pull-to-refresh the discover feed
6. Notice that unfollowed recommended blog records with the noted blog ids are deleted from the DB
7. Notice that followed blog records with the noted blog id is not deleted from the DB

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
