### PR TITLE
Reader Improvements: Fix discover feed ptr scroll issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -100,6 +100,9 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
             when (it) {
                 is ContentUiState -> {
                     (recycler_view.adapter as ReaderDiscoverAdapter).update(it.cards)
+                    if (it.scrollToTop) {
+                        recycler_view.scrollToPosition(0)
+                    }
                 }
                 is ErrorUiState -> {
                     uiHelpers.setTextOrHide(error_title, it.titleResId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -88,6 +88,8 @@ class ReaderDiscoverViewModel @Inject constructor(
      */
     private var pendingReblogPost: ReaderPost? = null
 
+    private var swipeToRefreshTriggered = false
+
     /**
      * Don't recalculate the size after a device orientation change as it'd result in change of the url -> it wouldn't
      * use cached images.
@@ -131,8 +133,10 @@ class ReaderDiscoverViewModel @Inject constructor(
                             _uiState.value = ContentUiState(
                                     convertCardsToUiStates(posts),
                                     reloadProgressVisibility = false,
-                                    loadMoreProgressVisibility = false
+                                    loadMoreProgressVisibility = false,
+                                    scrollToTop = swipeToRefreshTriggered
                             )
+                            swipeToRefreshTriggered = false
                         }
                     }
                 }
@@ -380,6 +384,7 @@ class ReaderDiscoverViewModel @Inject constructor(
 
     fun swipeToRefresh() {
         analyticsTrackerWrapper.track(READER_PULL_TO_REFRESH)
+        swipeToRefreshTriggered = true
         launch {
             readerDiscoverDataProvider.refreshCards()
         }
@@ -402,7 +407,8 @@ class ReaderDiscoverViewModel @Inject constructor(
         val fullscreenProgressVisibility: Boolean = false,
         open val fullscreenErrorVisibility: Boolean = false,
         val swipeToRefreshEnabled: Boolean = false,
-        open val fullscreenEmptyVisibility: Boolean = false
+        open val fullscreenEmptyVisibility: Boolean = false,
+        open val scrollToTop: Boolean = false
     ) {
         open val reloadProgressVisibility: Boolean = false
         open val loadMoreProgressVisibility: Boolean = false
@@ -410,7 +416,8 @@ class ReaderDiscoverViewModel @Inject constructor(
         data class ContentUiState(
             val cards: List<ReaderCardUiState>,
             override val reloadProgressVisibility: Boolean,
-            override val loadMoreProgressVisibility: Boolean
+            override val loadMoreProgressVisibility: Boolean,
+            override val scrollToTop: Boolean
         ) : DiscoverUiState(contentVisiblity = true, swipeToRefreshEnabled = true)
 
         object LoadingUiState : DiscoverUiState(fullscreenProgressVisibility = true)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -462,6 +462,32 @@ class ReaderDiscoverViewModelTest {
     }
 
     @Test
+    fun `Scroll to top is triggered when discover feed is updated after swipe to refresh`() = test {
+        // Arrange
+        val uiStates = init().uiStates
+        // Act
+        viewModel.swipeToRefresh()
+        fakeDiscoverFeed.value = createDummyReaderCardsList()
+        // Assert
+        assertThat(uiStates.last().scrollToTop).isTrue()
+    }
+
+    @Test
+    fun `Scroll to top is not triggered when discover feed is updated after load more action`() = test {
+        // Arrange
+        val uiStates = init().uiStates
+        val closeToEndIndex = NUMBER_OF_ITEMS.toInt() - INITIATE_LOAD_MORE_OFFSET
+        init()
+        // Act
+        ((viewModel.uiState.value as ContentUiState).cards[closeToEndIndex] as ReaderPostUiState).let {
+            it.onItemRendered.invoke(it)
+        }
+        fakeDiscoverFeed.value = createDummyReaderCardsList()
+        // Assert
+        assertThat(uiStates.last().scrollToTop).isFalse()
+    }
+
+    @Test
     fun `OnEmptyActionClicked shows select interests screen`() = test {
         // Arrange
         init()
@@ -470,6 +496,7 @@ class ReaderDiscoverViewModelTest {
         // Assert
         verify(parentViewModel).onShowReaderInterests()
     }
+
     private fun init(autoUpdateFeed: Boolean = true): Observers {
         val uiStates = mutableListOf<DiscoverUiState>()
         viewModel.uiState.observeForever {


### PR DESCRIPTION
This PR fixes scroll position jumping issue after discover feed pull-to-refresh.

It overrides default `DiffUtil` behaviour that causes `RecyclerView` to not scroll to top if the refreshed list contains items that were present before. Related discussion [here](https://rb.gy/rh3sy2).

|Scroll Issue|
|-----------|
|![discover-scroll-position](https://user-images.githubusercontent.com/1405144/96563649-cd853c00-12df-11eb-8e52-1b2ba50e46a4.gif)|

**To test:**

1. Launch app
2. Goto Reader discover tab
3. Pull to refresh few times
4. Notice that feed always scrolls to the top

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
