### PR TITLE
Reviewing menus availability

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
@@ -42,9 +42,15 @@ class MediaPickerLauncher @Inject constructor(
         localPostId: Int
     ) {
         if (consolidatedMediaPickerFeatureConfig.isEnabled()) {
+            val availableDataSources = if (site != null && site.isUsingWpComRestApi) {
+                setOf(WP_LIBRARY, STOCK_LIBRARY, GIF_LIBRARY)
+            } else {
+                setOf(WP_LIBRARY, GIF_LIBRARY)
+            }
+
             val mediaPickerSetup = MediaPickerSetup(
                     primaryDataSource = DEVICE,
-                    availableDataSources = setOf(WP_LIBRARY, STOCK_LIBRARY, GIF_LIBRARY),
+                    availableDataSources = availableDataSources,
                     canMultiselect = false,
                     requiresStoragePermissions = true,
                     allowedTypes = setOf(IMAGE),
@@ -74,7 +80,7 @@ class MediaPickerLauncher @Inject constructor(
         if (consolidatedMediaPickerFeatureConfig.isEnabled()) {
             val mediaPickerSetup = MediaPickerSetup(
                     primaryDataSource = DEVICE,
-                    availableDataSources = setOf(WP_LIBRARY, GIF_LIBRARY),
+                    availableDataSources = setOf(WP_LIBRARY),
                     canMultiselect = false,
                     requiresStoragePermissions = true,
                     allowedTypes = setOf(IMAGE),


### PR DESCRIPTION
This PR is based on findings while final testing the #13131 

- Removing the stock menu for feature image when a site is pure self-hosted
- Removing Gif menu for site icon picker

## To test
### test 1
- Select a pure self-hosted site
- Go to post settings -> set featured image
- Check the picker opens and the stock library menu entry is not there
- Check the menu is available and it works for a .com or jp site

### test 2
- Go the My Site -> change site icon
- Check the picker opens and the select from tenor menu is not there

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
