### PR TITLE
Media and text from WP lib picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSource.kt
@@ -121,7 +121,7 @@ class MediaLibraryDataSource(
     }
 
     private fun List<MediaModel>.toMediaItems(mediaType: MediaType): List<MediaItem> {
-        return this.map { mediaModel ->
+        return this.filter { it.url != null }.map { mediaModel ->
             MediaItem(
                     RemoteId(mediaModel.mediaId),
                     mediaModel.url,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2671,7 +2671,17 @@ public class EditPostActivity extends LocaleAwareActivity implements
         // TODO move this to EditorMedia
         ArrayList<Long> ids = ListUtils.fromLongArray(data.getLongArrayExtra(MediaBrowserActivity.RESULT_IDS));
         if (ids == null || ids.size() == 0) {
-            return;
+            if (mConsolidatedMediaPickerFeatureConfig.isEnabled()) {
+                if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_ID)) {
+                    long mediaId = data.getLongExtra(MediaPickerConstants.EXTRA_MEDIA_ID, 0);
+                    ids = new ArrayList<>();
+                    ids.add(mediaId);
+                } else {
+                    return;
+                }
+            } else {
+                return;
+            }
         }
 
         boolean allAreImages = true;


### PR DESCRIPTION
This PR is based on findings while final testing the #13131

- Checking the expected extra when picking from wp media lib for media and text block
- Filtering media with null url when picking from wp media lib seems correct when picking an image/video. This condition can happen for example when a gif upload doesn't complete correctly (in this case the upload is done in 2 phases, phase 1 creates a scaffolding entry in the fluxc MediaModel table, phase 2 completes the upload and populate the table entry).

## To test
### Media & Text block from WP lib 
- Go to GB editor and add a Media&Text block -> Add image or video
- Select Choose from media library
- Select an image/video
- Check the image/video uploads correctly in the GB block

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
