### PR TITLE
Adding slides to story from photo.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
@@ -129,7 +129,8 @@ class MediaPickerLauncher @Inject constructor(
 
     fun showStoriesPhotoPickerForResult(
         activity: Activity,
-        site: SiteModel?
+        site: SiteModel?,
+        requestCode: Int = RequestCodes.STORIES_PHOTO_PICKER
     ) {
         val browserType = MediaBrowserType.WP_STORIES_MEDIA_PICKER
         if (consolidatedMediaPickerFeatureConfig.isEnabled()) {
@@ -138,7 +139,7 @@ class MediaPickerLauncher @Inject constructor(
                     buildLocalMediaPickerSetup(browserType),
                     site
             )
-            activity.startActivityForResult(intent, RequestCodes.STORIES_PHOTO_PICKER)
+            activity.startActivityForResult(intent, requestCode)
         } else {
             ActivityLauncher.showPhotoPickerForResult(activity, browserType, site, null)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -260,9 +260,13 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     }
 
     override fun showProvidedMediaPicker() {
+        // the ComposeLoopFrameActivity currently only knows about RequestCodes.PHOTO_PICKER and not about
+        // RequestCodes.STORIES_PHOTO_PICKER; as a temporary solution we are feeding the ComposeLoopFragmentActivity
+        // with the PHOTO_PICKER. We should add the STORIES_PHOTO_PICKER to the stories lib
         mediaPickerLauncher.showStoriesPhotoPickerForResult(
                 this,
-                site
+                site,
+                RequestCodes.PHOTO_PICKER
         )
     }
 


### PR DESCRIPTION
This PR is based on findings while final testing the #13131

When creating a story, first time you add a slide by taking a photo all works as expected but when adding additional slides from photo camera the camera is not opening up.

## To test
- Create a story
- Tap on photo FAB and notice the camera opens
- Take a photo and notice it is added as slide in the story composer
- Tap to add a new slide; the media picker is opened. Tap on the photo FAB
    - Behaviour before: camera does not open and you are back to the story composer; no slide is added
    - Behaviour after: the camera opens; take a photo and notice it is added as slide in the story composer

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
