### PR TITLE
Encode media filename before upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.24-beta-2'
+    fluxCVersion = 'f221b78fd54f4fa0b8f3614aa62a2841cf062c81'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-Android/issues/13194

Related FluxC PR - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1729

This PR updates FluxC version with the fix that encodes the filename with UTF-8 encoding before uploading. 

To test:
- Download in your device/emu this [image](http://93.46.113.64/wp-content/uploads/2020/10/IMG_%D9%A0%D9%A6%D9%A1%D9%A0%D9%A2%D9%A0%D9%A2%D9%A0_%D9%A1%D9%A0%D9%A1%D9%A7%D9%A5%D9%A0_650_x_650_pixel.jpg)
- Create a post and add an image block
- try to upload into the image block the downloaded image above
- it works

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
