### PR TITLE
Stories: Onboarding screen tweaks

### DIFF
--- a/WordPress/src/main/res/layout/stories_intro_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/stories_intro_dialog_fragment.xml
@@ -38,6 +38,7 @@
                 android:textAppearance="?attr/textAppearanceBody2"
                 android:textSize="18sp"
                 android:textColor="?attr/wpColorOnSurfaceMedium"
+                android:lineSpacingMultiplier="1.2"
                 android:text="@string/stories_intro_main_subtitle" />
 
             <LinearLayout
@@ -101,9 +102,11 @@
                 android:id="@+id/feature_subtitle_first"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small"
                 android:layout_marginBottom="@dimen/margin_extra_medium_large"
                 android:textAppearance="?attr/textAppearanceBody2"
                 android:textColor="?attr/wpColorOnSurfaceMedium"
+                android:lineSpacingMultiplier="1.2"
                 android:text="@string/stories_intro_description_first" />
 
             <com.google.android.material.textview.MaterialTextView
@@ -117,9 +120,11 @@
                 android:id="@+id/feature_subtitle_second"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small"
                 android:layout_marginBottom="@dimen/margin_extra_medium_large"
                 android:textAppearance="?attr/textAppearanceBody2"
                 android:textColor="?attr/wpColorOnSurfaceMedium"
+                android:lineSpacingMultiplier="1.2"
                 android:text="@string/stories_intro_description_second" />
 
         </LinearLayout>

--- a/WordPress/src/main/res/layout/stories_intro_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/stories_intro_dialog_fragment.xml
@@ -41,55 +41,40 @@
                 android:lineSpacingMultiplier="1.2"
                 android:text="@string/stories_intro_main_subtitle" />
 
-            <LinearLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/story_images"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
                 android:layout_marginBottom="@dimen/margin_extra_medium_large"
-                android:weightSum="2"
-                android:orientation="horizontal"
+                android:layout_gravity="start"
                 android:baselineAligned="false">
 
-                <LinearLayout
-                    android:layout_width="0dp"
+                <ImageView
+                    android:id="@+id/story_image_first"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:orientation="vertical"
-                    android:layout_weight="1">
+                    android:src="@drawable/stories_intro_cover_1"
+                    android:background="@color/transparent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toStartOf="@+id/story_image_second"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    android:scaleType="fitCenter"
+                    android:contentDescription="@string/stories_intro_image_caption_first" />
 
-                    <ImageView
-                        android:id="@+id/story_image_first"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:src="@drawable/stories_intro_cover_1"
-                        android:background="@color/transparent"
-                        android:layout_gravity="center"
-                        android:scaleType="fitCenter"
-                        android:contentDescription="@string/stories_intro_image_caption_first" />
-
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="0dp"
+                <ImageView
+                    android:id="@+id/story_image_second"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:orientation="vertical"
-                    android:layout_weight="1">
+                    android:src="@drawable/stories_intro_cover_2"
+                    android:background="@color/transparent"
+                    app:layout_constraintStart_toEndOf="@+id/story_image_first"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    android:layout_marginStart="@dimen/margin_extra_extra_medium_large"
+                    android:scaleType="fitCenter"
+                    android:contentDescription="@string/stories_intro_image_caption_second"/>
 
-                    <ImageView
-                        android:id="@+id/story_image_second"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:src="@drawable/stories_intro_cover_2"
-                        android:layout_gravity="center"
-                        android:background="@color/transparent"
-                        android:scaleType="fitCenter"
-                        android:contentDescription="@string/stories_intro_image_caption_second"/>
-
-                </LinearLayout>
-
-            </LinearLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/feature_title_first"

--- a/WordPress/src/main/res/layout/stories_intro_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/stories_intro_dialog_fragment.xml
@@ -67,15 +67,6 @@
                         android:scaleType="fitCenter"
                         android:contentDescription="@string/stories_intro_image_caption_first" />
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/image_caption_first"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center"
-                        android:textAppearance="?attr/textAppearanceBody2"
-                        android:textColor="?attr/wpColorOnSurfaceMedium"
-                        android:text="@string/stories_intro_image_caption_first" />
-
                 </LinearLayout>
 
                 <LinearLayout
@@ -95,14 +86,6 @@
                         android:scaleType="fitCenter"
                         android:contentDescription="@string/stories_intro_image_caption_second"/>
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/image_caption_second"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center"
-                        android:textAppearance="?attr/textAppearanceBody2"
-                        android:textColor="?attr/wpColorOnSurfaceMedium"
-                        android:text="@string/stories_intro_image_caption_second" />
                 </LinearLayout>
 
             </LinearLayout>


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/575, making some visual tweaks to the stories intro screen introduced in #13141:

* Left aligned images
* Roughly same padding between images as before
* Extra space under headlines
* Increased line spacing in detail text

<img width="238" alt="Screen Shot 2020-10-21 at 10 16 17 AM" src="https://user-images.githubusercontent.com/9613966/96661313-bcdbd100-1386-11eb-9e2e-e36fe80a7714.png">
<img width="369" alt="Screen Shot 2020-10-21 at 10 16 29 AM" src="https://user-images.githubusercontent.com/9613966/96661315-be0cfe00-1386-11eb-91c9-ccaaf155fd9b.png">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
