### PR TITLE
Issue/13196 fix not initialised featured imageview 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -88,6 +88,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
     private ViewPager.OnPageChangeListener mOnPageChangeListener;
     private NotificationDetailFragmentAdapter mAdapter;
     private AppBarLayout mAppBarLayout;
+    private Toolbar mToolbar;
 
     @Override
     public void onBackPressed() {
@@ -109,8 +110,8 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
 
         setContentView(R.layout.notifications_detail_activity);
 
-        Toolbar toolbar = findViewById(R.id.toolbar_main);
-        setSupportActionBar(toolbar);
+        mToolbar = findViewById(R.id.toolbar_main);
+        setSupportActionBar(mToolbar);
 
         mAppBarLayout = findViewById(R.id.appbar_main);
 
@@ -213,6 +214,10 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
 
                 @Override
                 public void onPageSelected(int position) {
+                    Fragment fragment = mAdapter.getItem(mViewPager.getCurrentItem());
+                    boolean hideToolbar = (fragment instanceof ReaderPostDetailFragment);
+                    showHideToolbar(hideToolbar);
+
                     AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_SWIPE_PAGE_CHANGED);
                     // change the action bar title for the current note
                     Note currentNote = mAdapter.getNoteAtPosition(position);
@@ -229,6 +234,18 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
             };
         }
         mViewPager.addOnPageChangeListener(mOnPageChangeListener);
+    }
+
+    public void showHideToolbar(boolean hide) {
+        if (getSupportActionBar() != null) {
+            if (hide) {
+                getSupportActionBar().hide();
+            } else {
+                setSupportActionBar(mToolbar);
+                getSupportActionBar().show();
+            }
+            getSupportActionBar().setDisplayShowTitleEnabled(!hide);
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -297,33 +297,26 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         appBar = view.findViewById(R.id.appbar_with_collapsing_toolbar_layout)
         toolBar = appBar.findViewById(R.id.toolbar_main)
 
-        if (activity is ReaderPostPagerActivity) {
-            toolBar.setVisible(true)
-            appBar.addOnOffsetChangedListener(appBarLayoutOffsetChangedListener)
+        toolBar.setVisible(true)
+        appBar.addOnOffsetChangedListener(appBarLayoutOffsetChangedListener)
 
-            (activity as AppCompatActivity).setSupportActionBar(toolBar)
-            (activity as AppCompatActivity).supportActionBar?.setDisplayShowTitleEnabled(false)
-
-            // Fixes collapsing toolbar layout being obscured by the status bar when drawn behind it
-            ViewCompat.setOnApplyWindowInsetsListener(appBar) { v: View, insets: WindowInsetsCompat ->
-                val insetTop = insets.systemWindowInsetTop
-                if (insetTop > 0) {
-                    toolBar.setPadding(0, insetTop, 0, 0)
-                }
-                insets.consumeSystemWindowInsets()
+        // Fixes collapsing toolbar layout being obscured by the status bar when drawn behind it
+        ViewCompat.setOnApplyWindowInsetsListener(appBar) { v: View, insets: WindowInsetsCompat ->
+            val insetTop = insets.systemWindowInsetTop
+            if (insetTop > 0) {
+                toolBar.setPadding(0, insetTop, 0, 0)
             }
-
-            // Fixes viewpager not displaying menu items for first fragment
-            toolBar.inflateMenu(R.menu.reader_detail)
-
-            toolBar.setNavigationIcon(R.drawable.ic_arrow_back_white_24dp)
-            toolBar.setNavigationOnClickListener { requireActivity().onBackPressed() }
-
-            featuredImageView = appBar.findViewById(R.id.featured_image)
-            featuredImageView.setOnClickListener { showFullScreen() }
-        } else {
-            toolBar.setVisible(false)
+            insets.consumeSystemWindowInsets()
         }
+
+        // Fixes viewpager not displaying menu items for first fragment
+        toolBar.inflateMenu(R.menu.reader_detail)
+
+        toolBar.setNavigationIcon(R.drawable.ic_arrow_back_white_24dp)
+        toolBar.setNavigationOnClickListener { requireActivity().onBackPressed() }
+
+        featuredImageView = appBar.findViewById(R.id.featured_image)
+        featuredImageView.setOnClickListener { showFullScreen() }
 
         layoutFooter = view.findViewById(R.id.layout_post_detail_footer)
 
@@ -357,6 +350,23 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         showPost()
 
         return view
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (isVisible) {
+            replaceActivityToolbarWithCollapsingToolbar()
+        }
+    }
+
+    private fun replaceActivityToolbarWithCollapsingToolbar() {
+        val activity = activity as? AppCompatActivity
+        activity?.supportActionBar?.hide()
+
+        toolBar.setVisible(true)
+        activity?.setSupportActionBar(toolBar)
+
+        activity?.supportActionBar?.setDisplayShowTitleEnabled(false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
Fixes #13196

`ReaderPostDetailFragment` applies a parallax effect on scroll on the featured image by using a collapsing toolbar within the fragment. This PR fixes linked issue that occurs when this fragment is accessed from the notification tab `NotificationsDetailActivity` which also has its toolbar. It hides activity's toolbar and shows fragment's toolbar to display collapsing featured image view. 

### To test

Prerequisite: Two wp.com accounts

- Launch app and login using wp.com account (Account A)
- Go to Reader tab and follow another wp.com account's (Account B) site using AppBar -> Settings -> "Manage Topics and Sites" 
- Ensure new post notifications are enabled for this followed site  in the notifications settings
- Publish a new post containing featured image on the followed site using Account B on a web browser
- Go to notifications tab in the app - pull-to-refresh if needed
- Click on the new post
- Notice that post is opened properly with the featured image 
- Notice that (horizontal) swipe gesture on the post works and other notification posts are shown properly

![featured image](https://user-images.githubusercontent.com/1405144/96832384-4ad5bb80-145c-11eb-908c-c7979c4890a4.gif)

**Merge Instructions**

Targeting `release/16.0` otherwise users will not be able to open featured image posts using above path properly.

cc @loremattei, @AliSoftware 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
