### PR TITLE
Encode media filenames before upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '949a0579683e58bf93b7f0bf806a1cc3ac1f8e2c'
+    fluxCVersion = '1.6.22.1'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.22.1'
-    fluxCVersion = '1.6.22'
+    fluxCVersion = '949a0579683e58bf93b7f0bf806a1cc3ac1f8e2c'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'


### PR DESCRIPTION
Fixes #13194

Related FluxC PR - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1731

This PR updates FluxC version with the fix that encodes the filename with UTF-8 encoding before uploading.

To test:

Download in your device/emu this image
Create a post and add an image block
try to upload into the image block the downloaded image above
it works

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
