### PR TITLE
Fix NPE crash when reponse doesn't contains settings object

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPComSiteSettings.java
@@ -653,6 +653,10 @@ class WPComSiteSettings extends SiteSettingsInterface {
     private void deserializeWpComRestResponse(SiteModel site, JSONObject response) {
         if (site == null || response == null) return;
         JSONObject settingsObject = response.optJSONObject("settings");
+        if (settingsObject == null) {
+            AppLog.w(AppLog.T.API, "Error: Settings response doesn't contain settings object");
+            return;
+        }
 
         mRemoteSettings.username = site.getUsername();
         mRemoteSettings.password = site.getPassword();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPComSiteSettings.java
@@ -654,7 +654,7 @@ class WPComSiteSettings extends SiteSettingsInterface {
         if (site == null || response == null) return;
         JSONObject settingsObject = response.optJSONObject("settings");
         if (settingsObject == null) {
-            AppLog.w(AppLog.T.API, "Error: Settings response doesn't contain settings object");
+            AppLog.e(AppLog.T.API, "Error: Settings response doesn't contain settings object");
             return;
         }
 


### PR DESCRIPTION
Fixes #12552 

This PR fixes a NPE crash when the response JSON doesn't contain the "Settings" object. I think logging this state and just returning in this case is a good enough solution (as we do the same thing in other cases as well). Let me know what you think

To test:
- I don't know how to reproduce this issue. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
