### PR TITLE
NPE in upload service

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -1055,17 +1055,16 @@ public class UploadService extends Service {
 
     private List<MediaModel> getRetriableStandaloneMedia(SiteModel selectedSite) {
         // get all retriable media ? To retry or not to retry, that is the question
-        List<MediaModel> failedMedia = new ArrayList<>();
         List<MediaModel> failedStandAloneMedia = new ArrayList<>();
         if (selectedSite != null) {
-            failedMedia = mMediaStore.getSiteMediaWithState(
+            List<MediaModel> failedMedia = mMediaStore.getSiteMediaWithState(
                     selectedSite, MediaUploadState.FAILED);
-        }
 
-        // only take into account those media items that do not belong to any Post
-        for (MediaModel media : failedMedia) {
-            if (media.getLocalPostId() == 0) {
-                failedStandAloneMedia.add(media);
+            // only take into account those media items that do not belong to any Post
+            for (MediaModel media : failedMedia) {
+                if (media.getLocalPostId() == 0) {
+                    failedStandAloneMedia.add(media);
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -1055,7 +1055,7 @@ public class UploadService extends Service {
 
     private List<MediaModel> getRetriableStandaloneMedia(SiteModel selectedSite) {
         // get all retriable media ? To retry or not to retry, that is the question
-        List<MediaModel> failedMedia = null;
+        List<MediaModel> failedMedia = new ArrayList<>();
         List<MediaModel> failedStandAloneMedia = new ArrayList<>();
         if (selectedSite != null) {
             failedMedia = mMediaStore.getSiteMediaWithState(


### PR DESCRIPTION
Fixes #12343

We were previously trying to iterate through a list which was null in certain cases (when the site was null). This fix prevents this behaviour by only iterating if the list is retrieved (and the site is not null).

To test:
- I don't know how to reproduce this

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
