### PR TITLE
Set submit button visibility

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -177,6 +177,9 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         with(submit_button) {
             isEnabled = submitButtonUiState.enabled
         }
+        with(uiHelpers) {
+            updateVisibility(submit_button, submitButtonUiState.visibility)
+        }
     }
 
     private fun loadCategories(categoryLevels: ArrayList<CategoryNode>) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryViewModel.kt
@@ -158,6 +158,7 @@ class PrepublishingAddCategoryViewModel @Inject constructor(
     )
 
     sealed class SubmitButtonUiState(
+        val visibility: Boolean = true,
         val enabled: Boolean = false
     ) {
         object SubmitButtonEnabledUiState : SubmitButtonUiState(

--- a/WordPress/src/main/res/layout/add_category.xml
+++ b/WordPress/src/main/res/layout/add_category.xml
@@ -58,6 +58,7 @@
             android:layout_marginTop="@dimen/margin_medium"
             android:layout_marginBottom="@dimen/margin_medium"
             android:enabled="false"
-            android:text="@string/prepublishing_nudges_add_category_button" />
+            android:text="@string/prepublishing_nudges_add_category_button"
+            android:visibility="gone"/>
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Part of #13066 

This PR fixes the visibility of the submit button on the Add Category bottom sheet. The value in the `add_category.xml` is now set to false and its visibility is managed by the `PrepublishingAddCategoryViewModel`.

To test:
- Launch the app
- Navigate to Posts and choose a post to edit
- Tap the Update button to launch the select categories view
- Tap the Add Category + symbol on the upper right of the tool bar
- Ensure that the Add Category is visible under the drop down list



PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
