### PR TITLE
Feature/add android complete codefreeze

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org" do
-  gem 'fastlane', "~> 2.158"
+  gem 'fastlane', "~> 2"
   gem 'nokogiri'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,5 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: dd4dd1b1af753f7369f08715343d031be09a2c27
-  tag: 0.9.14
+PATH
+  remote: ../release-toolkit
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.9.14)
       activesupport (~> 4)
@@ -30,22 +28,22 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     atomos (0.1.3)
     aws-eventstream (1.1.0)
-    aws-partitions (1.366.0)
-    aws-sdk-core (3.105.0)
+    aws-partitions (1.385.0)
+    aws-sdk-core (3.109.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.37.0)
-      aws-sdk-core (~> 3, >= 3.99.0)
+    aws-sdk-kms (1.39.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.79.1)
-      aws-sdk-core (~> 3, >= 3.104.3)
+    aws-sdk-s3 (1.83.1)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    babosa (1.0.3)
+    babosa (1.0.4)
     bigdecimal (1.4.4)
     chroma (0.2.0)
     claide (1.0.3)
@@ -62,7 +60,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
     emoji_regex (3.0.0)
-    excon (0.76.0)
+    excon (0.78.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.7)
@@ -71,7 +69,7 @@ GEM
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     fastimage (2.2.0)
-    fastlane (2.158.0)
+    fastlane (2.164.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       aws-sdk-s3 (~> 1.0)
@@ -121,17 +119,17 @@ GEM
     google-cloud-core (1.5.0)
       google-cloud-env (~> 1.0)
       google-cloud-errors (~> 1.0)
-    google-cloud-env (1.3.3)
+    google-cloud-env (1.4.0)
       faraday (>= 0.17.3, < 2.0)
     google-cloud-errors (1.0.1)
-    google-cloud-storage (1.28.0)
+    google-cloud-storage (1.29.1)
       addressable (~> 2.5)
       digest-crc (~> 0.4)
       google-api-client (~> 0.33)
       google-cloud-core (~> 1.2)
       googleauth (~> 0.9)
       mini_mime (~> 1.0)
-    googleauth (0.13.1)
+    googleauth (0.14.0)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -161,10 +159,10 @@ GEM
     naturally (2.2.0)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    octokit (4.18.0)
+    octokit (4.19.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.13)
+    oj (3.10.15)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)
@@ -215,7 +213,7 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     word_wrap (1.0.0)
-    xcodeproj (1.18.0)
+    xcodeproj (1.19.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -230,7 +228,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (~> 2.158)!
+  fastlane (~> 2)!
   fastlane-plugin-wpmreleasetoolkit!
   nokogiri!
   rmagick (~> 4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: ../release-toolkit
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit
+  revision: a53b7c23e372e87d56ee340f1504a8788b9bd21d
+  ref: a53b7c2
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.9.14)
       activesupport (~> 4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: a53b7c23e372e87d56ee340f1504a8788b9bd21d
-  ref: a53b7c2
+  revision: 3dcfb7f1231d6da70861b0632a6265dcecc1e761
+  tag: 0.10.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.14)
+    fastlane-plugin-wpmreleasetoolkit (0.10.0)
       activesupport (~> 4)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -85,6 +85,24 @@ ENV["validate_translations"]="lintVanillaRelease"
     get_prs_list(repository:GHHELPER_REPO, start_tag:"release/#{old_version}", report_path:"#{File.expand_path('~')}/wpandroid_prs_list_#{old_version}_#{new_version}.txt")
   end
 
+  #####################################################################################
+  # complete_code_freeze
+  # -----------------------------------------------------------------------------------
+  # This lane executes the initial steps planned on code freeze
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane complete_code_freeze [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane complete_code_freeze
+  # bundle exec fastlane complete_code_freeze skip_confirm:true
+  #####################################################################################
+  desc "Creates a new release branch from the current develop"
+  lane :complete_code_freeze do | options |
+    android_completecodefreeze_prechecks(options)
+    android_tag_build()
+  end
+
 #####################################################################################
 # update_appstore_strings
 # -----------------------------------------------------------------------------------

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: 'a53b7c2'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.10.0'
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.14'
-gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../wordpress-mobile/release-toolkit'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: 'a53b7c2'
+

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.14'
-
+#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.14'
+gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../wordpress-mobile/release-toolkit'


### PR DESCRIPTION
This PR adds the `complete_code_freeze` lane to this project. 
At this point, the Android lane only runs the usual prechecks (make sure git repo is clean, make sure a release branch is checked out, confirm the version with the user) and pushes the tags. 

Related `release-toolkit` PR: https://github.com/wordpress-mobile/release-toolkit/pull/169

To test:
- Checkout a new `release/test` branch from this one and push it. 
- Update the version in `build.gradle` for both the beta and the alpha, and commit. 
- Run `bundle exec fastlane complete_code_freeze`.
- Verify that the lane finishes without errors and that the tags related to your new version have been pushed.

**Clean up:**
- Remove the test tags from GitHub.
- Remove the test tags from your local repository. 
- Delete the test branch from GitHub.
- Delete the test branch from your local repository.


_Note:_ After review and approval, before merging this PR, I'll release a new version of `release-toolkit` and update the reference to the released version,

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
