### PR TITLE
Open local previews for atomic sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -879,12 +879,13 @@ public class ActivityLauncher {
                     shareSubject,
                     true,
                     startPreviewForResult);
-        } else if (site.isWPComAtomic() && !site.isPrivateWPComAtomic()) {
+        } else if (remotePreviewType == RemotePreviewType.REMOTE_PREVIEW_WITH_REMOTE_AUTO_SAVE && site.isWPComAtomic()
+                   && !site.isPrivateWPComAtomic()) {
             openAtomicBlogPostPreview(
-                            context,
-                            url,
-                            site.getLoginUrl(),
-                            site.getFrameNonce());
+                    context,
+                    url,
+                    site.getLoginUrl(),
+                    site.getFrameNonce());
         } else if (site.isJetpackConnected() && site.isUsingWpComRestApi()) {
             WPWebViewActivity
                     .openJetpackBlogPostPreview(

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -87,6 +87,8 @@ import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -99,6 +101,7 @@ import static org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_ARTIC
 import static org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_ACCESS_ERROR;
 import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG_EDIT_IMAGE_DATA;
 import static org.wordpress.android.login.LoginMode.WPCOM_LOGIN_ONLY;
+import static org.wordpress.android.ui.WPWebViewActivity.ENCODING_UTF8;
 import static org.wordpress.android.ui.media.MediaBrowserActivity.ARG_BROWSER_TYPE;
 import static org.wordpress.android.ui.pages.PagesActivityKt.EXTRA_PAGE_REMOTE_ID_KEY;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_ID_KEY;
@@ -876,6 +879,12 @@ public class ActivityLauncher {
                     shareSubject,
                     true,
                     startPreviewForResult);
+        } else if (site.isWPComAtomic() && !site.isPrivateWPComAtomic()) {
+            openAtomicBlogPostPreview(
+                            context,
+                            url,
+                            site.getLoginUrl(),
+                            site.getFrameNonce());
         } else if (site.isJetpackConnected() && site.isUsingWpComRestApi()) {
             WPWebViewActivity
                     .openJetpackBlogPostPreview(
@@ -902,6 +911,18 @@ public class ActivityLauncher {
                     true,
                     true,
                     startPreviewForResult);
+        }
+    }
+
+    private static void openAtomicBlogPostPreview(Context context, String url, String authenticationUrl,
+                                                 String frameNonce) {
+        try {
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            intent.setData(Uri.parse(authenticationUrl + "?redirect_to=" + URLEncoder
+                    .encode(url + "&frame-nonce=" + UrlUtils.urlEncode(frameNonce), ENCODING_UTF8)));
+            context.startActivity(intent);
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3280,6 +3280,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     private PostModel handleRemoteAutoSave(boolean isError, PostModel post) {
         // We are in the process of remote previewing a post from the editor
         if (!isError && isUploadingPostForPreview()) {
+            mViewModel.hideSavingDialog();
             // We were uploading post for preview and we got no error:
             // update post status and preview it in the internal browser
             updateOnSuccessfulUpload();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelper.kt
@@ -93,17 +93,6 @@ class RemotePreviewLogicHelper @Inject constructor(
                     helperFunctions.notifyEmptyPost()
                     return PreviewLogicOperationResult.CANNOT_REMOTE_AUTO_SAVE_EMPTY_POST
                 }
-                // TODO: remove the following Jetpack exception when the API bug for Jetpack sites is fixed
-                // and previewing auto-saves are working. More informations about this on the following ticket:
-                // https://github.com/Automattic/wp-calypso/issues/20265
-                if (site.isJetpackConnected) {
-                    activityLauncherWrapper.showActionableEmptyView(
-                            activity,
-                            WPWebViewUsageCategory.REMOTE_PREVIEW_NOT_AVAILABLE,
-                            post.title
-                    )
-                    return PreviewLogicOperationResult.PREVIEW_NOT_AVAILABLE
-                }
                 helperFunctions.startUploading(true, post)
                 PreviewLogicOperationResult.GENERATING_PREVIEW
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -169,6 +169,10 @@ class StorePostViewModel
         _onFinish.postValue(Event(state))
     }
 
+    fun hideSavingDialog() {
+        _savingProgressDialogVisibility.postValue(Hidden)
+    }
+
     sealed class UpdateResult {
         object Error : UpdateResult()
         data class Success(val postTitleOrContentChanged: Boolean) : UpdateResult()

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelperTest.kt
@@ -236,47 +236,6 @@ class RemotePreviewLogicHelperTest {
     }
 
     @Test
-    fun `preview not available for Jetpack sites on published post with modification`() {
-        // Given
-        doReturn(true).whenever(site).isJetpackConnected
-        doReturn(true).whenever(post).isLocallyChanged
-
-        // When
-        val result = remotePreviewLogicHelper.runPostPreviewLogic(activity, site, post, mock())
-
-        // Then
-        assertThat(result).isEqualTo(RemotePreviewLogicHelper.PreviewLogicOperationResult.PREVIEW_NOT_AVAILABLE)
-        verify(activityLauncherWrapper, times(1)).showActionableEmptyView(
-                activity,
-                WPWebViewUsageCategory.REMOTE_PREVIEW_NOT_AVAILABLE,
-                post.title
-        )
-    }
-
-    /**
-     * Preview for Jetpack sites is temporarily disabled due to a server side bug.
-     * https://github.com/Automattic/wp-calypso/issues/20265
-     */
-    @Test
-    fun `preview not available for Jetpack sites on a post with modification`() {
-        // Given
-        // next stub not used (made lenient) in case we update future logic.
-        lenient().doReturn(true).whenever(site).isJetpackConnected
-        doReturn(true).whenever(post).isLocallyChanged
-
-        // When
-        val result = remotePreviewLogicHelper.runPostPreviewLogic(activity, site, post, helperFunctions)
-
-        // Then
-        assertThat(result).isEqualTo(RemotePreviewLogicHelper.PreviewLogicOperationResult.PREVIEW_NOT_AVAILABLE)
-        verify(activityLauncherWrapper, times(1)).showActionableEmptyView(
-                activity,
-                WPWebViewUsageCategory.REMOTE_PREVIEW_NOT_AVAILABLE,
-                post.title
-        )
-    }
-
-    @Test
     fun `preview available for Jetpack sites on a post post without modification`() {
         // Given
         // next stub not used (made lenient) in case we update future logic


### PR DESCRIPTION
Fixes #13093

This is a tricky issue. First I tried using the WPWebViewActivity but there was a lot of redirecting happening and I always ended up having the `wp-admin` site opened in the browser (outside of the web view). In the end I've tried using the browser for this very specific usecase and it works. It's a bit inconsistent but I think that's enough for this edge case. 

Since it's an Atomic site, we can't do any of the authentication we normally do - Auth token only works on wp.com sites, we don't have username and password. We need to let the user login in the browser. They only have to do it once. It's not super convenient but it's better than what's happening now. I'm open to suggestions for improvements!

To test:
- Go to an Atomic site with a plugin installed (so you can be sure it's fully transformed)
- Go to an existing post
- Make a change 
- Click on Menu/Preview
- Notice the browser is opened
- Log in to your site in the browser
- The post is opened and your local changes are visible
- Go back to the app
- Open another post
- Make local changes
- Click on Menu/Preview
- Notice the post with changes is opened in the browser
- Notice no login was necessary 
- Test with a post without changes to check it's opened in the in-app WebView activity

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
