### PR TITLE
Issue/13066 add category behavior

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -148,10 +148,8 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
             }
         })
 
-        viewModel.navigateBack.observe(viewLifecycleOwner, Observer { event ->
-            event?.applyIfNotHandled {
-                closeListener?.onBackClicked()
-            }
+        viewModel.navigateBack.observe(viewLifecycleOwner, Observer { bundle ->
+            closeListener?.onBackClicked(bundle)
         })
 
         viewModel.toolbarTitleUiState.observe(viewLifecycleOwner, Observer { uiString ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -189,7 +189,10 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                     "arguments can't be null."
                 }
                 Pair(
-                        PrepublishingCategoriesFragment.newInstance(navigationTarget.site, isStoryPost),
+                        PrepublishingCategoriesFragment.newInstance(
+                                navigationTarget.site,
+                                isStoryPost,
+                                navigationTarget.bundle),
                         PrepublishingCategoriesFragment.TAG
                 )
             }
@@ -228,8 +231,8 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
         viewModel.writeToBundle(outState)
     }
 
-    override fun onBackClicked() {
-        viewModel.onBackClicked()
+    override fun onBackClicked(bundle: Bundle?) {
+        viewModel.onBackClicked(bundle)
     }
 
     override fun onActionClicked(actionType: ActionType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import javax.inject.Inject
 
-// todo: annmarie - show progress on back button & lock dismiss
 class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categories_fragment) {
     private var closeListener: PrepublishingScreenClosedListener? = null
     private var actionListener: PrepublishingActionClickedListener? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import javax.inject.Inject
 
+// todo: annmarie - show progress on back button & lock dismiss
 class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categories_fragment) {
     private var closeListener: PrepublishingScreenClosedListener? = null
     private var actionListener: PrepublishingActionClickedListener? = null
@@ -54,6 +55,7 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
         if (needsRequestLayout) {
             requireActivity().window.decorView.requestLayout()
         }
+
         super.onResume()
     }
 
@@ -123,11 +125,15 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
             )
             with(uiHelpers) {
                 updateVisibility(add_action_button, it.addCategoryActionButtonVisibility)
+                updateVisibility(progress_loading, it.progressVisibility)
+                updateVisibility(recycler_view, it.categoryListVisibility)
             }
         })
 
         val siteModel = requireArguments().getSerializable(WordPress.SITE) as SiteModel
-        viewModel.start(getEditPostRepository(), siteModel)
+        val addCategoryRequest: PrepublishingAddCategoryRequest? =
+                arguments?.getSerializable(ADD_CATEGORY_REQUEST) as? PrepublishingAddCategoryRequest
+        viewModel.start(getEditPostRepository(), siteModel, addCategoryRequest)
     }
 
     private fun getEditPostRepository(): EditPostRepository {
@@ -159,15 +165,21 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
     companion object {
         const val TAG = "prepublishing_categories_fragment_tag"
         const val NEEDS_REQUEST_LAYOUT = "prepublishing_categories_fragment_needs_request_layout"
+        const val ADD_CATEGORY_REQUEST = "prepublishing_add_category_request"
         @JvmStatic fun newInstance(
             site: SiteModel,
-            needsRequestLayout: Boolean
+            needsRequestLayout: Boolean,
+            bundle: Bundle? = null
         ): PrepublishingCategoriesFragment {
-            val bundle = Bundle().apply {
+            val newBundle = Bundle().apply {
                 putSerializable(WordPress.SITE, site)
                 putBoolean(NEEDS_REQUEST_LAYOUT, needsRequestLayout)
             }
-            return PrepublishingCategoriesFragment().apply { arguments = bundle }
+            bundle?.let {
+                newBundle.putAll(bundle)
+            }
+
+            return PrepublishingCategoriesFragment().apply { arguments = newBundle }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
@@ -222,7 +222,6 @@ class PrepublishingCategoriesViewModel @Inject constructor(
             val categoryLevels = getSiteCategories()
             val selectedCategoryIds = getSelectedIds().toMutableList()
             selectedCategoryIds.add(event.term.remoteTermId)
-            // todo: annmarie fix this as a copy to hold on to previous selected
             _uiState.value = UiState(
                     categoriesListItemUiState = createListItemUiState(
                             categoryLevels,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
@@ -32,6 +32,7 @@ import javax.inject.Named
 
 class PrepublishingCategoriesViewModel @Inject constructor(
     private val getCategoriesUseCase: GetCategoriesUseCase,
+    private val addCategoryUseCase: AddCategoryUseCase,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val dispatcher: Dispatcher,
@@ -41,6 +42,7 @@ class PrepublishingCategoriesViewModel @Inject constructor(
     private lateinit var editPostRepository: EditPostRepository
     private lateinit var siteModel: SiteModel
     private var updateCategoriesJob: Job? = null
+    private var addCategoryJob: Job? = null
 
     private val _navigateToHomeScreen = MutableLiveData<Event<Unit>>()
     val navigateToHomeScreen: LiveData<Event<Unit>> = _navigateToHomeScreen
@@ -61,18 +63,29 @@ class PrepublishingCategoriesViewModel @Inject constructor(
         dispatcher.register(this)
     }
 
-    fun start(editPostRepository: EditPostRepository, siteModel: SiteModel) {
+    fun start(
+        editPostRepository: EditPostRepository,
+        siteModel: SiteModel,
+        addCategoryRequest: PrepublishingAddCategoryRequest? = null
+    ) {
         this.editPostRepository = editPostRepository
         this.siteModel = siteModel
 
         if (isStarted) return
         isStarted = true
 
-        init()
+        init(addCategoryRequest)
     }
 
-    private fun init() {
+    private fun init(addCategoryRequest: PrepublishingAddCategoryRequest?) {
         setToolbarTitleUiState()
+
+        addCategoryRequest?.let {
+            addCategoryJob?.cancel()
+            addCategoryJob = launch(bgDispatcher) {
+                addCategoryUseCase.addCategory(it.categoryText, it.categoryParentId, siteModel)
+            }
+        }
 
         val siteCategories = getSiteCategories()
         val postCategories = getPostCategories()
@@ -80,7 +93,7 @@ class PrepublishingCategoriesViewModel @Inject constructor(
                 categoriesListItemUiState = createListItemUiState(
                         siteCategories = siteCategories,
                         selectedCategoryIds = postCategories
-                )
+                ), progressVisibility = addCategoryRequest != null
         )
     }
 
@@ -203,11 +216,13 @@ class PrepublishingCategoriesViewModel @Inject constructor(
             string.adding_cat_success
         }
         _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringRes(message))))
+        _uiState.value = uiState.value?.copy(progressVisibility = false)
 
         if (!event.isError) {
             val categoryLevels = getSiteCategories()
             val selectedCategoryIds = getSelectedIds().toMutableList()
             selectedCategoryIds.add(event.term.remoteTermId)
+            // todo: annmarie fix this as a copy to hold on to previous selected
             _uiState.value = UiState(
                     categoriesListItemUiState = createListItemUiState(
                             categoryLevels,
@@ -236,7 +251,9 @@ class PrepublishingCategoriesViewModel @Inject constructor(
 
     data class UiState(
         val addCategoryActionButtonVisibility: Boolean = true,
-        val categoriesListItemUiState: List<PrepublishingCategoriesListItemUiState> = listOf()
+        val categoriesListItemUiState: List<PrepublishingCategoriesListItemUiState> = listOf(),
+        val categoryListVisibility: Boolean = true,
+        val progressVisibility: Boolean = false
     )
 
     data class PrepublishingCategoriesListItemUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingScreenClosedListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingScreenClosedListener.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.posts
 
+import android.os.Bundle
+
 interface PrepublishingScreenClosedListener {
-    fun onBackClicked()
+    fun onBackClicked(bundle: Bundle? = null)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.posts.PrepublishingScreen.PUBLISH
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.viewmodel.Event
+import java.io.Serializable
 import javax.inject.Inject
 
 const val KEY_SCREEN_STATE = "key_screen_state"
@@ -67,7 +68,7 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
         fetchTags()
     }
 
-    private fun navigateToScreen(prepublishingScreen: PrepublishingScreen) {
+    private fun navigateToScreen(prepublishingScreen: PrepublishingScreen, bundle: Bundle? = null) {
         // Note: given we know both the HOME, TAGS and ADD_CATEGORY screens have an EditText, we can ask to send the
         // dismissKeyboard signal only when we're not either in one of these nor navigating towards one of these.
         // At this point in code we only know where we want to navigate to, but it's ok since landing on any of these
@@ -78,14 +79,14 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
             prepublishingScreen == CATEGORIES) {
             _dismissKeyboard.postValue(Event(Unit))
         }
-        updateNavigationTarget(PrepublishingNavigationTarget(site, prepublishingScreen))
+        updateNavigationTarget(PrepublishingNavigationTarget(site, prepublishingScreen, bundle))
     }
 
-    fun onBackClicked() {
+    fun onBackClicked(bundle: Bundle? = null) {
         when {
             currentScreen == ADD_CATEGORY -> {
                 currentScreen = CATEGORIES
-                navigateToScreen(currentScreen as PrepublishingScreen)
+                navigateToScreen(currentScreen as PrepublishingScreen, bundle)
             }
             currentScreen != HOME -> {
                 currentScreen = HOME
@@ -150,5 +151,11 @@ enum class PrepublishingScreen : Parcelable {
 
 data class PrepublishingNavigationTarget(
     val site: SiteModel,
-    val targetScreen: PrepublishingScreen
+    val targetScreen: PrepublishingScreen,
+    val bundle: Bundle? = null
 )
+
+data class PrepublishingAddCategoryRequest(
+    val categoryText: String,
+    val categoryParentId: Long
+) : Serializable

--- a/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?><!--    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"-->
+<?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/relative_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -11,6 +12,14 @@
         android:layout_height="wrap_content"
         android:dividerHeight="@dimen/divider_size"
         android:layout_below="@+id/include_prepublishing_toolbar"/>
+
+    <ProgressBar
+        android:id="@+id/progress_loading"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_medium"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_below="@+id/include_prepublishing_toolbar" />
 
     <include
         android:id="@+id/include_prepublishing_toolbar"


### PR DESCRIPTION
Part of #13066

This PR changes the submit behavior in Add Category. The "add category" request will no longer take place in `PrepublishingAddCategoryFragment`. The logic has been moved to `PrepublishingCategoriesFragment`, so that we can better control the action. The extra request is passed along as a `Bundle?` to the `PrepublishingScreenClosedListener.onBackClicked()`. Using a bundle keeps it generic so that it can be used for any current or future additions to the PPN bottom sheet family.

This PR also introduces a progress spinner to the select categories view. This keeps the user informed that an action is taking place and the list is in the progress of being updated. This aligns the feature more closely with how the EditPostSettings architecture works (which is the action is passed to the previous fragment/activity for submittal).

To test:

- Launch the app
- Navigate to Posts and choose a post to edit
- Tap the Update button to launch the select categories view
- Tap the Add Category + symbol on the upper right of the tool bar
- Enter a new category (with or without a parent - I'd try both)
- Tap the Add Category button
- Notice that you are taken back to the select categories view and the progress indicator is visible.

To test:

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
