### PR TITLE
Issue/13066 select category behavior

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/AddCategoryUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/AddCategoryUseCase.kt
@@ -1,31 +1,24 @@
 package org.wordpress.android.ui.posts
 
 import dagger.Reusable
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.TaxonomyActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.TermModel
 import org.wordpress.android.fluxc.store.TaxonomyStore
 import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload
-import org.wordpress.android.modules.IO_THREAD
 import javax.inject.Inject
-import javax.inject.Named
 
 @Reusable
 class AddCategoryUseCase @Inject constructor(
-    private val dispatcher: Dispatcher,
-    @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
+    private val dispatcher: Dispatcher
 ) {
-    suspend fun addCategory(categoryName: String, parentCategoryId: Long, siteModel: SiteModel) {
-        withContext(ioDispatcher) {
-            val newCategory = TermModel()
-            newCategory.taxonomy = TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
-            newCategory.name = categoryName
-            newCategory.parentRemoteId = parentCategoryId
-            val payload = RemoteTermPayload(newCategory, siteModel)
-            dispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(payload))
-        }
+    fun addCategory(categoryName: String, parentCategoryId: Long, siteModel: SiteModel) {
+        val newCategory = TermModel()
+        newCategory.taxonomy = TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
+        newCategory.name = categoryName
+        newCategory.parentRemoteId = parentCategoryId
+        val payload = RemoteTermPayload(newCategory, siteModel)
+        dispatcher.dispatch(TaxonomyActionBuilder.newPushTermAction(payload))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingActionClickedListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingActionClickedListener.kt
@@ -1,8 +1,9 @@
 package org.wordpress.android.ui.posts
 
+import android.os.Bundle
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType
 
 interface PrepublishingActionClickedListener {
-    fun onActionClicked(actionType: ActionType)
+    fun onActionClicked(actionType: ActionType, bundle: Bundle? = null)
     fun onSubmitButtonClicked(publishPost: PublishPost)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -24,12 +24,12 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import javax.inject.Inject
 
-class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_category_fragment),
-        PrepublishingBackPressedHandler {
+class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_category_fragment) {
     private var closeListener: PrepublishingScreenClosedListener? = null
 
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: PrepublishingAddCategoryViewModel
+    private lateinit var parentViewModel: PrepublishingViewModel
     @Inject lateinit var uiHelpers: UiHelpers
 
     var spinnerTouched: Boolean = false
@@ -134,6 +134,8 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
     private fun initViewModel() {
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(PrepublishingAddCategoryViewModel::class.java)
+        parentViewModel = ViewModelProviders.of(requireParentFragment(), viewModelFactory)
+                .get(PrepublishingViewModel::class.java)
 
         startObserving()
 
@@ -175,6 +177,12 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
             }
             updateSubmitButton(uiState.submitButtonUiState)
         })
+
+        parentViewModel.triggerOnDeviceBackPressed.observe(viewLifecycleOwner, Observer { event ->
+            event.getContentIfNotHandled()?.let {
+                closeListener?.onBackClicked(arguments)
+            }
+        })
     }
 
     private fun updateSubmitButton(submitButtonUiState: SubmitButtonUiState) {
@@ -193,10 +201,6 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
                 requireContext(), message,
                 SHORT
         )
-    }
-
-    override fun onBackPressed() {
-        closeListener?.onBackClicked(arguments)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.view.View
 import android.widget.AdapterView
 import androidx.fragment.app.Fragment
@@ -69,6 +70,7 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
 
     private fun initBackButton() {
         back_button.setOnClickListener {
+            Log.i(javaClass.simpleName, "***=> back button pressed")
             viewModel.onBackButtonClick()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.util.Log
 import android.view.View
 import android.widget.AdapterView
 import androidx.fragment.app.Fragment
@@ -25,7 +24,8 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import javax.inject.Inject
 
-class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_category_fragment) {
+class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_category_fragment),
+        PrepublishingBackPressedHandler {
     private var closeListener: PrepublishingScreenClosedListener? = null
 
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -70,7 +70,6 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
 
     private fun initBackButton() {
         back_button.setOnClickListener {
-            Log.i(javaClass.simpleName, "***=> back button pressed")
             viewModel.onBackButtonClick()
         }
     }
@@ -151,7 +150,12 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         })
 
         viewModel.navigateBack.observe(viewLifecycleOwner, Observer { bundle ->
-            closeListener?.onBackClicked(bundle)
+            val newBundle = Bundle()
+            newBundle.putAll(arguments)
+            bundle?.let {
+                newBundle.putAll(bundle)
+            }
+            closeListener?.onBackClicked(newBundle)
         })
 
         viewModel.toolbarTitleUiState.observe(viewLifecycleOwner, Observer { uiString ->
@@ -191,18 +195,26 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         )
     }
 
+    override fun onBackPressed() {
+        closeListener?.onBackClicked(arguments)
+    }
+
     companion object {
         const val TAG = "prepublishing_add_category_fragment_tag"
         const val NEEDS_REQUEST_LAYOUT = "prepublishing_add_category_fragment_needs_request_layout"
         @JvmStatic fun newInstance(
             site: SiteModel,
-            needsRequestLayout: Boolean
+            needsRequestLayout: Boolean,
+            bundle: Bundle? = null
         ): PrepublishingAddCategoryFragment {
-            val bundle = Bundle().apply {
+            val newBundle = Bundle().apply {
                 putSerializable(WordPress.SITE, site)
                 putBoolean(NEEDS_REQUEST_LAYOUT, needsRequestLayout)
             }
-            return PrepublishingAddCategoryFragment().apply { arguments = bundle }
+            bundle?.let {
+                newBundle.putAll(bundle)
+            }
+            return PrepublishingAddCategoryFragment().apply { arguments = newBundle }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBackPressedHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBackPressedHandler.kt
@@ -1,5 +1,0 @@
-package org.wordpress.android.ui.posts
-
-interface PrepublishingBackPressedHandler {
-    fun onBackPressed()
-}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBackPressedHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBackPressedHandler.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.ui.posts
+
+interface PrepublishingBackPressedHandler {
+    fun onBackPressed()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import kotlinx.android.synthetic.main.my_profile_activity.*
 import kotlinx.android.synthetic.main.post_prepublishing_bottom_sheet.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -82,7 +83,7 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                 if (event.action != KeyEvent.ACTION_DOWN) {
                     true
                 } else {
-                    onBackClicked()
+                    viewModel.onBackPressed()
                     true
                 }
             } else {
@@ -154,7 +155,15 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
             }
         })
 
-        val prepublishingScreenState = savedInstanceState?.getParcelable<PrepublishingScreen>(KEY_SCREEN_STATE)
+        viewModel.triggerOnBackPressedHandler.observe(this, Observer { event ->
+            event.getContentIfNotHandled()?.let {
+                triggerOnBackPressed(it)
+            }
+        })
+
+        val prepublishingScreenState = savedInstanceState?.getParcelable<PrepublishingScreen>(
+                KEY_SCREEN_STATE
+        )
         val site = arguments?.getSerializable(SITE) as SiteModel
 
         viewModel.start(site, prepublishingScreenState)
@@ -180,7 +189,7 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                     "arguments can't be null."
                 }
                 Pair(
-                    PrepublishingTagsFragment.newInstance(navigationTarget.site, isStoryPost),
+                        PrepublishingTagsFragment.newInstance(navigationTarget.site, isStoryPost),
                         PrepublishingTagsFragment.TAG
                 )
             }
@@ -192,7 +201,8 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                         PrepublishingCategoriesFragment.newInstance(
                                 navigationTarget.site,
                                 isStoryPost,
-                                navigationTarget.bundle),
+                                navigationTarget.bundle
+                        ),
                         PrepublishingCategoriesFragment.TAG
                 )
             }
@@ -201,7 +211,10 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                     "arguments can't be null."
                 }
                 Pair(
-                        PrepublishingAddCategoryFragment.newInstance(navigationTarget.site, isStoryPost),
+                        PrepublishingAddCategoryFragment.newInstance(
+                                navigationTarget.site,
+                                isStoryPost
+                        ),
                         PrepublishingAddCategoryFragment.TAG
                 )
             }
@@ -223,6 +236,15 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
             }
             fragmentTransaction.replace(R.id.prepublishing_content_fragment, fragment, tag)
             fragmentTransaction.commit()
+        }
+    }
+
+    private fun triggerOnBackPressed(screen: PrepublishingScreen) {
+        if (screen == CATEGORIES) {
+            val fragment = childFragmentManager.findFragmentByTag(PrepublishingCategoriesFragment.TAG)
+            if (fragment != null) {
+                (fragment as PrepublishingBackPressedHandler).onBackPressed()
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -212,7 +212,8 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                 Pair(
                         PrepublishingAddCategoryFragment.newInstance(
                                 navigationTarget.site,
-                                isStoryPost
+                                isStoryPost,
+                                navigationTarget.bundle
                         ),
                         PrepublishingAddCategoryFragment.TAG
                 )
@@ -244,6 +245,11 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
             if (fragment != null) {
                 (fragment as PrepublishingBackPressedHandler).onBackPressed()
             }
+        } else if (screen == ADD_CATEGORY) {
+            val fragment = childFragmentManager.findFragmentByTag(PrepublishingAddCategoryFragment.TAG)
+            if (fragment != null) {
+                (fragment as PrepublishingBackPressedHandler).onBackPressed()
+            }
         }
     }
 
@@ -256,8 +262,8 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
         viewModel.onBackClicked(bundle)
     }
 
-    override fun onActionClicked(actionType: ActionType) {
-        viewModel.onActionClicked(actionType)
+    override fun onActionClicked(actionType: ActionType, bundle: Bundle?) {
+        viewModel.onActionClicked(actionType, bundle)
     }
 
     override fun onSubmitButtonClicked(publishPost: PublishPost) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -82,7 +82,7 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                 if (event.action != KeyEvent.ACTION_DOWN) {
                     true
                 } else {
-                    viewModel.onBackPressed()
+                    viewModel.onDeviceBackPressed()
                     true
                 }
             } else {
@@ -151,12 +151,6 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
         viewModel.dismissKeyboard.observe(this, Observer { event ->
             event.applyIfNotHandled {
                 ActivityUtils.hideKeyboardForced(view)
-            }
-        })
-
-        viewModel.triggerOnBackPressedHandler.observe(this, Observer { event ->
-            event.getContentIfNotHandled()?.let {
-                triggerOnBackPressed(it)
             }
         })
 
@@ -236,20 +230,6 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
             }
             fragmentTransaction.replace(R.id.prepublishing_content_fragment, fragment, tag)
             fragmentTransaction.commit()
-        }
-    }
-
-    private fun triggerOnBackPressed(screen: PrepublishingScreen) {
-        if (screen == CATEGORIES) {
-            val fragment = childFragmentManager.findFragmentByTag(PrepublishingCategoriesFragment.TAG)
-            if (fragment != null) {
-                (fragment as PrepublishingBackPressedHandler).onBackPressed()
-            }
-        } else if (screen == ADD_CATEGORY) {
-            val fragment = childFragmentManager.findFragmentByTag(PrepublishingAddCategoryFragment.TAG)
-            if (fragment != null) {
-                (fragment as PrepublishingBackPressedHandler).onBackPressed()
-            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import kotlinx.android.synthetic.main.my_profile_activity.*
 import kotlinx.android.synthetic.main.post_prepublishing_bottom_sheet.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -23,7 +23,8 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import javax.inject.Inject
 
-class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categories_fragment) {
+class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categories_fragment),
+    PrepublishingBackPressedHandler {
     private var closeListener: PrepublishingScreenClosedListener? = null
     private var actionListener: PrepublishingActionClickedListener? = null
 
@@ -54,7 +55,6 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
         if (needsRequestLayout) {
             requireActivity().window.decorView.requestLayout()
         }
-
         super.onResume()
     }
 
@@ -79,7 +79,11 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
     }
 
     private fun initRecyclerView() {
-        recycler_view.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+        recycler_view.layoutManager = LinearLayoutManager(
+                context,
+                RecyclerView.VERTICAL,
+                false
+        )
         recycler_view.adapter = PrepublishingCategoriesAdapter(uiHelpers)
         recycler_view.addItemDecoration(
                 DividerItemDecoration(
@@ -102,11 +106,13 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
             }
         })
 
-        viewModel.navigateToAddCategoryScreen.observe(viewLifecycleOwner, Observer { event ->
-            event?.applyIfNotHandled {
-                actionListener?.onActionClicked(ADD_CATEGORY)
-            }
-        })
+        viewModel.navigateToAddCategoryScreen.observe(
+                viewLifecycleOwner,
+                Observer { event ->
+                    event?.applyIfNotHandled {
+                        actionListener?.onActionClicked(ADD_CATEGORY)
+                    }
+                })
 
         viewModel.toolbarTitleUiState.observe(viewLifecycleOwner, Observer { uiString ->
             toolbar_title.text = uiHelpers.getTextOfUiString(requireContext(), uiString)
@@ -180,5 +186,9 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
 
             return PrepublishingCategoriesFragment().apply { arguments = newBundle }
         }
+    }
+
+    override fun onBackPressed() {
+        viewModel.onBackButtonClick()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.posts
 
 import androidx.annotation.DimenRes
+import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -262,5 +263,11 @@ class PrepublishingCategoriesViewModel @Inject constructor(
         val checked: Boolean = false,
         @DimenRes val verticalPaddingResId: Int = R.dimen.margin_large,
         @DimenRes val horizontalPaddingResId: Int = R.dimen.margin_extra_large
+    )
+
+    data class ToolbarUiState(
+        val addCategoryButtonEnabled: Boolean = true,
+        val backButtonEnabled: Boolean = true,
+        @StringRes val title: Int = string.prepublishing_nudges_toolbar_title_categories
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -43,8 +43,8 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
     private val _triggerOnSubmitButtonClickedListener = MutableLiveData<Event<PublishPost>>()
     val triggerOnSubmitButtonClickedListener: LiveData<Event<PublishPost>> = _triggerOnSubmitButtonClickedListener
 
-    private val _triggerOnBackPressedHandler = MutableLiveData<Event<PrepublishingScreen>>()
-    val triggerOnBackPressedHandler: LiveData<Event<PrepublishingScreen>> = _triggerOnBackPressedHandler
+    private val _triggerOnDeviceBackPressed = MutableLiveData<Event<PrepublishingScreen>>()
+    val triggerOnDeviceBackPressed: LiveData<Event<PrepublishingScreen>> = _triggerOnDeviceBackPressed
 
     init {
         dispatcher.register(this)
@@ -87,10 +87,10 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
 
     // Send this back out to the current screen and so it can determine if it needs to save
     // any data before accepting a backPress - in our case, the only view that needs this today
-    // is the Categories selection
-    fun onBackPressed() {
+    // is the Categories selection & AddCategory
+    fun onDeviceBackPressed() {
         if (currentScreen == CATEGORIES || currentScreen == ADD_CATEGORY) {
-            _triggerOnBackPressedHandler.value = Event(currentScreen as PrepublishingScreen)
+            _triggerOnDeviceBackPressed.value = Event(currentScreen as PrepublishingScreen)
         } else {
             onBackClicked()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -43,6 +43,9 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
     private val _triggerOnSubmitButtonClickedListener = MutableLiveData<Event<PublishPost>>()
     val triggerOnSubmitButtonClickedListener: LiveData<Event<PublishPost>> = _triggerOnSubmitButtonClickedListener
 
+    private val _triggerOnBackPressedHandler = MutableLiveData<Event<PrepublishingScreen>>()
+    val triggerOnBackPressedHandler: LiveData<Event<PrepublishingScreen>> = _triggerOnBackPressedHandler
+
     init {
         dispatcher.register(this)
     }
@@ -80,6 +83,17 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
             _dismissKeyboard.postValue(Event(Unit))
         }
         updateNavigationTarget(PrepublishingNavigationTarget(site, prepublishingScreen, bundle))
+    }
+
+    // Send this back out to the current screen and so it can determine if it needs to save
+    // any data before accepting a backPress - in our case, the only view that needs this today
+    // is the Categories selection
+    fun onBackPressed() {
+        if (currentScreen == CATEGORIES) {
+            _triggerOnBackPressedHandler.value = Event(currentScreen as PrepublishingScreen)
+        } else {
+            onBackClicked()
+        }
     }
 
     fun onBackClicked(bundle: Bundle? = null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -79,7 +79,7 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
         // For the case where this is not a story and hence there's no EditText in the HOME screen, we're ok too,
         // because there wouldn't have been a keyboard up anyway.
         if (prepublishingScreen == PUBLISH ||
-            prepublishingScreen == CATEGORIES) {
+                prepublishingScreen == CATEGORIES) {
             _dismissKeyboard.postValue(Event(Unit))
         }
         updateNavigationTarget(PrepublishingNavigationTarget(site, prepublishingScreen, bundle))
@@ -89,7 +89,7 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
     // any data before accepting a backPress - in our case, the only view that needs this today
     // is the Categories selection
     fun onBackPressed() {
-        if (currentScreen == CATEGORIES) {
+        if (currentScreen == CATEGORIES || currentScreen == ADD_CATEGORY) {
             _triggerOnBackPressedHandler.value = Event(currentScreen as PrepublishingScreen)
         } else {
             onBackClicked()
@@ -124,10 +124,10 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
         outState.putParcelable(KEY_SCREEN_STATE, currentScreen)
     }
 
-    fun onActionClicked(actionType: ActionType) {
+    fun onActionClicked(actionType: ActionType, bundle: Bundle?) {
         val screen = PrepublishingScreen.valueOf(actionType.name)
         currentScreen = screen
-        navigateToScreen(screen)
+        navigateToScreen(screen, bundle)
     }
 
     fun onSubmitButtonClicked(publishPost: PublishPost) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -124,7 +124,7 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
         outState.putParcelable(KEY_SCREEN_STATE, currentScreen)
     }
 
-    fun onActionClicked(actionType: ActionType, bundle: Bundle?) {
+    fun onActionClicked(actionType: ActionType, bundle: Bundle? = null) {
         val screen = PrepublishingScreen.valueOf(actionType.name)
         currentScreen = screen
         navigateToScreen(screen, bundle)

--- a/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
@@ -1,28 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/relative_layout"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler_view"
+    <RelativeLayout
+        android:id="@+id/relative_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:dividerHeight="@dimen/divider_size"
-        android:layout_below="@+id/include_prepublishing_toolbar"/>
+        android:layout_height="wrap_content">
 
-    <ProgressBar
-        android:id="@+id/progress_loading"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_medium"
-        android:layout_marginStart="@dimen/margin_extra_large"
-        android:layout_below="@+id/include_prepublishing_toolbar" />
+        <ProgressBar
+            android:id="@+id/progress_loading"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/include_prepublishing_toolbar"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:layout_marginStart="@dimen/margin_extra_large" />
 
-    <include
-        android:id="@+id/include_prepublishing_toolbar"
-        layout="@layout/prepublishing_toolbar" />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:focusableInTouchMode="true"
+            android:layout_below="@+id/include_prepublishing_toolbar"
+            android:dividerHeight="@dimen/divider_size" />
 
-</RelativeLayout>
+        <include
+            android:id="@+id/include_prepublishing_toolbar"
+            layout="@layout/prepublishing_toolbar" />
+
+    </RelativeLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_categories_fragment.xml
@@ -19,7 +19,7 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recycler_view"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:focusableInTouchMode="true"
             android:layout_below="@+id/include_prepublishing_toolbar"
             android:dividerHeight="@dimen/divider_size" />


### PR DESCRIPTION
Part of #13066 

This PR addresses some wonkiness within the category selection behavior. The PPN bottomsheet architecture is to always replace fragments instead of reusing them. Since the fragment is always reinstantiated we do not have access to data, as even the VM is restarted, which was causing the selected/not selected issues when moving to/from select/add. Rewriting that fragment behavior sits outside of the scope of this PR and is on track for my next hack week project.

To support keeping category selection alive, the data is passed along in a bundle to the `PrepublishingAddCategoryFragment` fragment and then the `PrepublishingAddCategoryFragment` passes that same bundle back to the `PrepublishingCategoriesFragment`. Which is then sent along when the new fragment instance is created.

This PR also adds a liveData observer to intercept the device backbutton press. It it observed from  `PrepublishingCategoriesFragment` & `PrepublishingAddCategoryFragment` , so they can save data/package up the bundle before requesting a back navigation.

`PrepublishingActionClickedListener.onActionClicked` & `PrepublishingScreenClosedListener.onBackClick` have been modified to both accept a `(bundle: Bundle?)`

The category selection view now has a progress spinner. The spinner is shown upon return from Add Category while the save is taking place. It is also shown on toolbar or device back button tap while the categories selected are updated in the post. This prevents the Home view from showing out-of-date categories.

**Merge Instructions**
Note: This PR will be merged into a feature branch
Make sure #13219  has been merged 
Remove the Not Ready For Merge label
Merge as normal

**To test:**
- Launch the app
- Select Blog posts
- Select Edit on a post
- From the edit post view, tap the UPDATE action to launch the bottom sheet
- Categories are shown on the Categories row

If the post has categories assigned, you will see them listed on the home view. If not, you will see Not Set or Uncategorized
Select Categories is shown when user taps on Categories

- Tap the categories row to launch the Select categories view 
- Select/unselect a few categories - but note which ones 
- Tap the Add New Category button "+" on the title bar
- Enter a new category and tap "Add Category Button" 
Note: A new category is NOT saved on back press - the explicit tap on the action button is needed

- Back on the select category view, the category you have added is visible and checked
- Take note of the toast which will tell you if the action succeeded or failed.
- The categories you unselected/selected will be shown properly
- Tap the <- Back arrow or the device back button to save your options
- The categories row on the home screen should reflect the selections you made

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
