### PR TITLE
Full screen width search in media picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -347,6 +347,7 @@ class MediaPickerFragment : Fragment() {
 
             if (uiState.searchUiModel is SearchUiModel.Expanded && !searchMenuItem.isActionViewExpanded) {
                 searchMenuItem.expandActionView()
+                searchView.maxWidth = Integer.MAX_VALUE;
                 searchView.setQuery(uiState.searchUiModel.filter, true)
                 searchView.setOnCloseListener { !uiState.searchUiModel.closeable }
             } else if (uiState.searchUiModel is SearchUiModel.Collapsed && searchMenuItem.isActionViewExpanded) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -347,7 +347,7 @@ class MediaPickerFragment : Fragment() {
 
             if (uiState.searchUiModel is SearchUiModel.Expanded && !searchMenuItem.isActionViewExpanded) {
                 searchMenuItem.expandActionView()
-                searchView.maxWidth = Integer.MAX_VALUE;
+                searchView.maxWidth = Integer.MAX_VALUE
                 searchView.setQuery(uiState.searchUiModel.filter, true)
                 searchView.setOnCloseListener { !uiState.searchUiModel.closeable }
             } else if (uiState.searchUiModel is SearchUiModel.Collapsed && searchMenuItem.isActionViewExpanded) {


### PR DESCRIPTION
Fixes #13225 

This PR makes the search view occupy full width of the screen in landscape. This follows approach in the other parts of the app.

To test:
- Turn on Consolidated media picker feature
- Go to Media library/Choose from device (or any other source)
- Click on "Search" icon
- Rotate your device
- Type in search query
- Notice the 'x' icon is in the top right corner

![Screenshot_1603715915](https://user-images.githubusercontent.com/1079756/97173347-b1c2df80-1790-11eb-8924-1742077e52b5.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
