### PR TITLE
Cancel search when items are inserted to hide keyboard

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -453,6 +453,9 @@ class MediaPickerViewModel @Inject constructor(
                         progressDialogJob?.cancel()
                         job = null
                         _showProgressDialog.value = Hidden
+                        if (_searchExpanded.value == true) {
+                            _searchExpanded.value = false
+                        }
                         _onNavigate.value = Event(MediaNavigationEvent.InsertMedia(it.identifiers))
                     }
                 }


### PR DESCRIPTION
Fixes #13226 

This PR cancels search on insert which automatically hides the keyboard.

To test:
- Go to editor/post settings
- Click on "Choose featured image"
- Search for an item
- Insert a search result
- The keyboard gets hidden

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
