### PR TITLE
issue/13195 updated parent class of nested webview.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/NestedWebView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/NestedWebView.kt
@@ -5,7 +5,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.MotionEvent
-import android.webkit.WebView
 import androidx.core.view.MotionEventCompat
 import androidx.core.view.NestedScrollingChild3
 import androidx.core.view.NestedScrollingChildHelper

--- a/WordPress/src/main/java/org/wordpress/android/widgets/NestedWebView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/NestedWebView.kt
@@ -10,6 +10,7 @@ import androidx.core.view.MotionEventCompat
 import androidx.core.view.NestedScrollingChild3
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat
+import org.wordpress.android.ui.WPWebView
 
 /**
  * To make WebView work with AppBar in Coordinator layout we need to put into a NestedScrollView
@@ -24,7 +25,7 @@ class NestedWebView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = attr.webViewStyle
-) : WebView(context, attrs, defStyleAttr), NestedScrollingChild3 {
+) : WPWebView(context, attrs, defStyleAttr), NestedScrollingChild3 {
     private var lastY = 0
     private val scrollOffset = IntArray(2)
     private val scrollConsumed = IntArray(2)


### PR DESCRIPTION
Fixes #13195

There is a known webview related crash on devices with API 21 and 22, and it surfaced when we implemented NestedWebView in our app. We already had a fix, so I just had to add it to NestedWebView.

To test:
- On a device with API 21 or 22 preview your site from the My Site screen and notice that the app does not crash.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
