### PR TITLE
Add translation download to new_beta_release

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -167,6 +167,7 @@ ENV["validate_translations"]="lintVanillaRelease"
   lane :new_beta_release do | options |
     android_betabuild_prechecks(options)
     send_strings_for_translation()
+    android_update_metadata(options)
     android_bump_version_beta()
     android_tag_build()
   end


### PR DESCRIPTION
This PR adds a step to download the translations to the `new_beta_release` lane. This way, we can start to test available translations a little bit earlier in the release process. 

To Test:
Testing is a bit hack-y. 
- Checkout a new branch out of this one. 
- Comment out the `android_betabuild_prechecks` line. This is important because otherwise you'll push stuff to the current release branch.
- Comment out the `android_tag_build` step, otherwise you'll push tags to GitHub.
- Commit the new `Fastfile` to your test branch. 
- Run `bundle exec fastlane new_beta_release`.
- Verify that the translations are downloaded and the lint phase run. Note that some translations are currently broken, so this step will likely fail :-) 
- Delete your local test branch.
- Delete your test branch from GitHub (it has been probably automatically pushed). 


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
