### PR TITLE
Add from wp media lib for stories.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -143,8 +143,10 @@ class MediaPickerViewModel @Inject constructor(
     private fun buildBrowseMenuUiModel(softAskRequest: SoftAskRequest?, searchExpanded: Boolean?): BrowseMenuUiModel {
         val isSoftAskRequestVisible = softAskRequest?.show ?: false
         val isSearchExpanded = searchExpanded ?: false
-        val showSystemPicker = mediaPickerSetup.systemPickerEnabled && !isSoftAskRequestVisible && !isSearchExpanded
-        return if (showSystemPicker || mediaPickerSetup.availableDataSources.isNotEmpty()) {
+        val showActions = !isSoftAskRequestVisible && !isSearchExpanded
+        val showSystemPicker = mediaPickerSetup.systemPickerEnabled && showActions
+
+        return if (showActions && (showSystemPicker || mediaPickerSetup.availableDataSources.isNotEmpty())) {
             val actions = mutableSetOf<BrowseAction>()
             if (showSystemPicker) {
                 actions.add(SYSTEM_PICKER)

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
@@ -302,7 +302,7 @@ class MediaPickerLauncher @Inject constructor(
         }
         return MediaPickerSetup(
                 primaryDataSource = DEVICE,
-                availableDataSources = setOf(),
+                availableDataSources = if (browserType.isWPStoriesPicker) setOf(WP_LIBRARY) else setOf(),
                 canMultiselect = browserType.canMultiselect(),
                 requiresStoragePermissions = true,
                 allowedTypes = allowedTypes,


### PR DESCRIPTION
Fixes #13229 

This PR:
- Adds the possibility to add from WP Media library for stories.
- Avoids showing actions when search is expanded or we are asking for permissions.

## To test

### test 1
- Create a new story
- In the picker that opens notice you can add from WP media picker; tap on WP media picker icon and add from there
- Smock test the picker and stories scenario

### test 2
- Create a new story
- In the picker that opens notice you can add from WP media picker
- Tap on search icon and notice both system picker and WP media picker icons are not visible with search expanded
- Make the same check in changing site icon scenario.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
