### PR TITLE
CONTRIBUTING.md: Add information about our PR merge policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,14 @@ The core team monitors and reviews all pull requests. Depending on the changes, 
 
 We do our best to respond quickly to all pull requests. If you don't get a response from us after a week, feel free to reach out to us via Slack.
 
+Note: If you are part of the org and have the permissions on the repo, don't forget to assign yourself to the PR, and add the appropriate GitHub label and Milestone for the PR
+
+### PR merge policy
+
+* PRs require one reviewer to approve the PR before it can be merged to the base branch
+* We keep the PR git history when merging (merge via "merge commit")
+* The reviewer who approved the PR will merge it right after approval (without waiting for the PR author) if all checks are green.
+
 ### Development Practices
 
 Have look at the [Coding Style Guide](docs/coding-style.md) to learn how to format your code so it passes the convention and quality checks like the rest of the project. The [docs](docs/) contain all the development guides like [what a good pull request looks like](docs/pull-request-guidelines.md), and [how to use String and Drawable resources](docs/using-android-resources.md).


### PR DESCRIPTION
Similar addition to our contributing guidelines as https://github.com/wordpress-mobile/WordPress-iOS/pull/15170, but adapted to the Android workflow

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
