### PR TITLE
Simplify MediaPickerActivity.kt

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
@@ -28,7 +28,7 @@ data class MediaItem(
     }
 
     sealed class Identifier(val type: IdentifierType) : Parcelable {
-        data class LocalUri(val value: UriWrapper) : Identifier(LOCAL_URI)
+        data class LocalUri(val value: UriWrapper, val queued: Boolean = false) : Identifier(LOCAL_URI)
 
         data class RemoteId(val value: Long) : Identifier(REMOTE_ID)
 
@@ -50,6 +50,7 @@ data class MediaItem(
             when (this) {
                 is LocalUri -> {
                     parcel.writeParcelable(this.value.uri, flags)
+                    parcel.writeInt(if (this.queued) 1 else 0)
                 }
                 is RemoteId -> {
                     parcel.writeLong(this.value)
@@ -80,7 +81,10 @@ data class MediaItem(
                     val type = IdentifierType.valueOf(requireNotNull(parcel.readString()))
                     return when (type) {
                         LOCAL_URI -> {
-                            LocalUri(UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))))
+                            LocalUri(
+                                    UriWrapper(requireNotNull(parcel.readParcelable(Uri::class.java.classLoader))),
+                                    parcel.readInt() != 0
+                            )
                         }
                         REMOTE_ID -> {
                             RemoteId(parcel.readLong())

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -179,23 +179,25 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         data: Intent?
     ) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (resultCode != Activity.RESULT_OK || data == null) {
+        if (resultCode != Activity.RESULT_OK) {
             return
         }
         val intent: Intent? = when (requestCode) {
             MEDIA_LIBRARY -> {
-                val intent = Intent()
-                val uris = WPMediaUtils.retrieveMediaUris(data)
-                if (mediaPickerSetup.queueResults) {
-                    intent.putQueuedUris(uris)
-                } else {
-                    intent.putUris(uris)
+                data?.let {
+                    val intent = Intent()
+                    val uris = WPMediaUtils.retrieveMediaUris(data)
+                    if (mediaPickerSetup.queueResults) {
+                        intent.putQueuedUris(uris)
+                    } else {
+                        intent.putUris(uris)
+                    }
+                    intent.putExtra(
+                            EXTRA_MEDIA_SOURCE,
+                            ANDROID_PICKER.name
+                    )
+                    intent
                 }
-                intent.putExtra(
-                        EXTRA_MEDIA_SOURCE,
-                        ANDROID_PICKER.name
-                )
-                intent
             }
             TAKE_PHOTO -> {
                 try {
@@ -221,18 +223,20 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
                 }
             }
             IMAGE_EDITOR_EDIT_IMAGE -> {
-                val intent = Intent()
-                val uris = WPMediaUtils.retrieveImageEditorResult(data)
-                if (mediaPickerSetup.queueResults) {
-                    intent.putQueuedUris(uris)
-                } else {
-                    intent.putUris(uris)
+                data?.let {
+                    val intent = Intent()
+                    val uris = WPMediaUtils.retrieveImageEditorResult(data)
+                    if (mediaPickerSetup.queueResults) {
+                        intent.putQueuedUris(uris)
+                    } else {
+                        intent.putUris(uris)
+                    }
+                    intent.putExtra(
+                            EXTRA_MEDIA_SOURCE,
+                            APP_PICKER.name
+                    )
+                    intent
                 }
-                intent.putExtra(
-                        EXTRA_MEDIA_SOURCE,
-                        APP_PICKER.name
-                )
-                intent
             }
             else -> {
                 data

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.ui.RequestCodes.IMAGE_EDITOR_EDIT_IMAGE
 import org.wordpress.android.ui.RequestCodes.MEDIA_LIBRARY
 import org.wordpress.android.ui.RequestCodes.PHOTO_PICKER
 import org.wordpress.android.ui.RequestCodes.TAKE_PHOTO
@@ -24,6 +25,7 @@ import org.wordpress.android.ui.media.MediaBrowserActivity
 import org.wordpress.android.ui.mediapicker.MediaItem.Identifier
 import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.ANDROID_CAMERA
 import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.ANDROID_PICKER
+import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.APP_PICKER
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.Companion.newInstance
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerAction
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerAction.OpenCameraForPhotos
@@ -217,6 +219,20 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
                     AppLog.e(MEDIA, e)
                     null
                 }
+            }
+            IMAGE_EDITOR_EDIT_IMAGE -> {
+                val intent = Intent()
+                val uris = WPMediaUtils.retrieveImageEditorResult(data)
+                if (mediaPickerSetup.queueResults) {
+                    intent.putQueuedUris(uris)
+                } else {
+                    intent.putUris(uris)
+                }
+                intent.putExtra(
+                        EXTRA_MEDIA_SOURCE,
+                        APP_PICKER.name
+                )
+                intent
             }
             else -> {
                 data

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -183,7 +183,12 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         val intent: Intent? = when (requestCode) {
             MEDIA_LIBRARY -> {
                 val intent = Intent()
-                intent.putUris(WPMediaUtils.retrieveMediaUris(data))
+                val uris = WPMediaUtils.retrieveMediaUris(data)
+                if (mediaPickerSetup.queueResults) {
+                    intent.putQueuedUris(uris)
+                } else {
+                    intent.putUris(uris)
+                }
                 intent.putExtra(
                         EXTRA_MEDIA_SOURCE,
                         ANDROID_PICKER.name
@@ -197,7 +202,11 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
                         WPMediaUtils.scanMediaFile(this, it)
                         val f = File(it)
                         val capturedImageUri = listOf(Uri.fromFile(f))
-                        intent.putUris(capturedImageUri)
+                        if (mediaPickerSetup.queueResults) {
+                            intent.putQueuedUris(capturedImageUri)
+                        } else {
+                            intent.putUris(capturedImageUri)
+                        }
                         intent.putExtra(
                                 EXTRA_MEDIA_SOURCE,
                                 ANDROID_CAMERA.name
@@ -236,7 +245,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         this.putExtra(EXTRA_MEDIA_URIS, mediaUris.toStringArray())
     }
 
-    private fun Intent.doQueuedUrisSelected(
+    private fun Intent.putQueuedUris(
         mediaUris: List<Uri>
     ) {
         this.putExtra(EXTRA_MEDIA_QUEUED_URIS, mediaUris.toStringArray())
@@ -270,7 +279,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
             intent.putUris(chosenUris)
         }
         if (!queuedUris.isNullOrEmpty()) {
-            intent.doQueuedUrisSelected(queuedUris)
+            intent.putQueuedUris(queuedUris)
         }
         if (!chosenIds.isNullOrEmpty()) {
             intent.putMediaIds(chosenIds)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -15,26 +15,15 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.MediaStore
-import org.wordpress.android.imageeditor.preview.PreviewImageFragment
 import org.wordpress.android.ui.LocaleAwareActivity
-import org.wordpress.android.ui.RequestCodes.FILE_LIBRARY
-import org.wordpress.android.ui.RequestCodes.GIF_PICKER
-import org.wordpress.android.ui.RequestCodes.IMAGE_EDITOR_EDIT_IMAGE
 import org.wordpress.android.ui.RequestCodes.MEDIA_LIBRARY
-import org.wordpress.android.ui.RequestCodes.MULTI_SELECT_MEDIA_PICKER
-import org.wordpress.android.ui.RequestCodes.PICTURE_LIBRARY
-import org.wordpress.android.ui.RequestCodes.SINGLE_SELECT_MEDIA_PICKER
-import org.wordpress.android.ui.RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT
+import org.wordpress.android.ui.RequestCodes.PHOTO_PICKER
 import org.wordpress.android.ui.RequestCodes.TAKE_PHOTO
-import org.wordpress.android.ui.RequestCodes.VIDEO_LIBRARY
 import org.wordpress.android.ui.gif.GifPickerActivity
 import org.wordpress.android.ui.media.MediaBrowserActivity
 import org.wordpress.android.ui.mediapicker.MediaItem.Identifier
 import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.ANDROID_CAMERA
 import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.ANDROID_PICKER
-import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.APP_PICKER
-import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.STOCK_MEDIA_PICKER
-import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.WP_MEDIA_PICKER
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.Companion.newInstance
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerAction
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerAction.OpenCameraForPhotos
@@ -42,13 +31,14 @@ import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerActio
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerAction.OpenSystemPicker
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerAction.SwitchMediaPicker
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerListener
+import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.DEVICE
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.GIF_LIBRARY
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.STOCK_LIBRARY
 import org.wordpress.android.ui.mediapicker.MediaPickerSetup.DataSource.WP_LIBRARY
 import org.wordpress.android.ui.photopicker.MediaPickerConstants.EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED
 import org.wordpress.android.ui.photopicker.MediaPickerConstants.EXTRA_MEDIA_ID
-import org.wordpress.android.ui.photopicker.MediaPickerConstants.EXTRA_MEDIA_QUEUED
+import org.wordpress.android.ui.photopicker.MediaPickerConstants.EXTRA_MEDIA_QUEUED_URIS
 import org.wordpress.android.ui.photopicker.MediaPickerConstants.EXTRA_MEDIA_SOURCE
 import org.wordpress.android.ui.photopicker.MediaPickerConstants.EXTRA_MEDIA_URIS
 import org.wordpress.android.ui.photopicker.MediaPickerConstants.LOCAL_POST_ID
@@ -58,10 +48,8 @@ import org.wordpress.android.ui.posts.editor.ImageEditorTracker
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MEDIA
-import org.wordpress.android.util.ListUtils
 import org.wordpress.android.util.WPMediaUtils
 import java.io.File
-import java.util.ArrayList
 import javax.inject.Inject
 
 class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
@@ -97,6 +85,15 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
                     }
                 }
                 return null
+            }
+
+            fun fromDataSource(dataSource: DataSource): MediaPickerMediaSource {
+                return when (dataSource) {
+                    DEVICE -> APP_PICKER
+                    WP_LIBRARY -> WP_MEDIA_PICKER
+                    STOCK_LIBRARY -> STOCK_MEDIA_PICKER
+                    GIF_LIBRARY -> APP_PICKER
+                }
             }
         }
     }
@@ -180,60 +177,50 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         data: Intent?
     ) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (resultCode != Activity.RESULT_OK) {
+        if (resultCode != Activity.RESULT_OK || data == null) {
             return
         }
-        when (requestCode) {
-            PICTURE_LIBRARY, VIDEO_LIBRARY, MEDIA_LIBRARY, FILE_LIBRARY -> if (data != null) {
-                doMediaUrisSelected(WPMediaUtils.retrieveMediaUris(data), ANDROID_PICKER)
-            }
-            TAKE_PHOTO -> try {
-                mediaCapturePath!!.let {
-                    WPMediaUtils.scanMediaFile(this, it)
-                    val f = File(it)
-                    val capturedImageUri = listOf(
-                            Uri.fromFile(
-                                    f
-                            )
-                    )
-                    doMediaUrisSelected(capturedImageUri, ANDROID_CAMERA)
-                }
-            } catch (e: RuntimeException) {
-                AppLog.e(MEDIA, e)
-            }
-            MULTI_SELECT_MEDIA_PICKER -> if (data!!.hasExtra(
-                            MediaBrowserActivity.RESULT_IDS
-                    )) {
-                val ids = ListUtils.fromLongArray(
-                        data.getLongArrayExtra(
-                                MediaBrowserActivity.RESULT_IDS
-                        )
+        val intent: Intent? = when (requestCode) {
+            MEDIA_LIBRARY -> {
+                val intent = Intent()
+                intent.putUris(WPMediaUtils.retrieveMediaUris(data))
+                intent.putExtra(
+                        EXTRA_MEDIA_SOURCE,
+                        ANDROID_PICKER.name
                 )
-                doMediaIdsSelected(ids, WP_MEDIA_PICKER)
+                intent
             }
-            SINGLE_SELECT_MEDIA_PICKER -> if (data != null && data.hasExtra(EXTRA_MEDIA_ID)) {
-                val id = data.getLongExtra(EXTRA_MEDIA_ID, 0)
-                doMediaIdsSelected(listOf(id), WP_MEDIA_PICKER)
+            TAKE_PHOTO -> {
+                try {
+                    val intent = Intent()
+                    mediaCapturePath!!.let {
+                        WPMediaUtils.scanMediaFile(this, it)
+                        val f = File(it)
+                        val capturedImageUri = listOf(Uri.fromFile(f))
+                        intent.putUris(capturedImageUri)
+                        intent.putExtra(
+                                EXTRA_MEDIA_SOURCE,
+                                ANDROID_CAMERA.name
+                        )
+                    }
+                    intent
+                } catch (e: RuntimeException) {
+                    AppLog.e(MEDIA, e)
+                    null
+                }
             }
-            STOCK_MEDIA_PICKER_SINGLE_SELECT -> if (data != null && data.hasExtra(EXTRA_MEDIA_ID)) {
-                val mediaId = data.getLongExtra(EXTRA_MEDIA_ID, 0)
-                val ids = ArrayList<Long>()
-                ids.add(mediaId)
-                doMediaIdsSelected(ids, STOCK_MEDIA_PICKER)
+            else -> {
+                data
             }
-            GIF_PICKER -> if (data != null && data.hasExtra(GifPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS)) {
-                val localIds = data.getIntArrayExtra(GifPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS)
-                doMediaLocalIdsSelected(localIds?.toList(), APP_PICKER)
-            }
-            IMAGE_EDITOR_EDIT_IMAGE -> if (data != null && data.hasExtra(PreviewImageFragment.ARG_EDIT_IMAGE_DATA)) {
-                val uris = WPMediaUtils.retrieveImageEditorResult(data)
-                doMediaUrisSelected(uris, APP_PICKER)
-            }
+        }
+        intent?.let {
+            setResult(Activity.RESULT_OK, intent)
+            finish()
         }
     }
 
     private fun launchChooserWithContext(openSystemPicker: OpenSystemPicker, uiHelpers: UiHelpers) {
-        WPMediaUtils.launchChooserWithContext(this, openSystemPicker, uiHelpers)
+        WPMediaUtils.launchChooserWithContext(this, openSystemPicker, uiHelpers, MEDIA_LIBRARY)
     }
 
     private fun launchWPStoriesCamera() {
@@ -243,88 +230,61 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         finish()
     }
 
-    private fun doMediaUrisSelected(
-        mediaUris: List<Uri>,
-        source: MediaPickerMediaSource
+    private fun Intent.putUris(
+        mediaUris: List<Uri>
     ) {
-        // if user chose a featured image, we need to upload it and return the uploaded media object
-        if (mediaPickerSetup.queueResults) {
-            val intent = Intent()
-                    .putExtra(EXTRA_MEDIA_QUEUED, true)
-                    .putExtra(EXTRA_MEDIA_URIS, convertUrisListToStringArray(mediaUris))
-            setResult(Activity.RESULT_OK, intent)
-            finish()
-        } else {
-            val intent = Intent()
-                    .putExtra(EXTRA_MEDIA_URIS, convertUrisListToStringArray(mediaUris))
-                    .putExtra(
-                            EXTRA_MEDIA_SOURCE,
-                            source.name
-                    ) // set the browserType in the result, so caller can distinguish and handle things as needed
-            setResult(Activity.RESULT_OK, intent)
-            finish()
-        }
+        this.putExtra(EXTRA_MEDIA_URIS, mediaUris.toStringArray())
     }
 
-    private fun doMediaIdsSelected(
-        mediaIds: List<Long>?,
-        source: MediaPickerMediaSource
+    private fun Intent.doQueuedUrisSelected(
+        mediaUris: List<Uri>
     ) {
-        if (mediaIds != null && mediaIds.isNotEmpty()) {
-            if (mediaPickerSetup.canMultiselect) {
-                // TODO WPSTORIES add TRACKS (see how it's tracked below? maybe do along the same lines)
-                val data = Intent()
-                        .putExtra(
-                                MediaBrowserActivity.RESULT_IDS,
-                                ListUtils.toLongArray(mediaIds)
-                        )
-                        .putExtra(EXTRA_MEDIA_SOURCE, source.name)
-                setResult(Activity.RESULT_OK, data)
-                finish()
-            } else {
-                val data = Intent()
-                        .putExtra(EXTRA_MEDIA_ID, mediaIds[0])
-                        .putExtra(EXTRA_MEDIA_SOURCE, source.name)
-                setResult(Activity.RESULT_OK, data)
-                finish()
-            }
-        } else {
-            throw IllegalArgumentException("call to doMediaIdsSelected with null or empty mediaIds array")
-        }
+        this.putExtra(EXTRA_MEDIA_QUEUED_URIS, mediaUris.toStringArray())
     }
 
-    private fun doMediaLocalIdsSelected(
-        mediaLocalIds: List<Int>?,
-        source: MediaPickerMediaSource
+    private fun Intent.putMediaIds(
+        mediaIds: List<Long>
     ) {
-        if (mediaLocalIds != null && mediaLocalIds.isNotEmpty()) {
-            val data = Intent()
-                    .putExtra(
-                            GifPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS,
-                            ListUtils.toIntArray(mediaLocalIds)
-                    )
-                    .putExtra(EXTRA_MEDIA_SOURCE, source.name)
-            setResult(Activity.RESULT_OK, data)
-            finish()
-        } else {
-            throw IllegalArgumentException("call to doMediaLocalIdsSelected with null or empty mediaIds array")
-        }
+        this.putExtra(MediaBrowserActivity.RESULT_IDS, mediaIds.toLongArray())
+        this.putExtra(EXTRA_MEDIA_ID, mediaIds[0])
+    }
+
+    private fun Intent.putLocalIds(
+        mediaLocalIds: List<Int>
+    ) {
+        this.putExtra(
+                GifPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS,
+                mediaLocalIds.toIntArray()
+        )
     }
 
     override fun onItemsChosen(identifiers: List<Identifier>) {
-        val chosenUris = identifiers.mapNotNull { (it as? Identifier.LocalUri)?.value?.uri }
+        val chosenLocalUris = identifiers.mapNotNull { (it as? Identifier.LocalUri) }
+        val chosenUris = chosenLocalUris.filter { !it.queued }.map { it.value.uri }
+        val queuedUris = chosenLocalUris.filter { it.queued }.map { it.value.uri }
         val chosenIds = identifiers.mapNotNull { (it as? Identifier.RemoteId)?.value }
         val chosenLocalIds = identifiers.mapNotNull { (it as? Identifier.LocalId)?.value }
 
-        if (chosenUris.isNotEmpty()) {
-            doMediaUrisSelected(chosenUris, APP_PICKER)
+        val intent = Intent()
+        if (!chosenUris.isNullOrEmpty()) {
+            intent.putUris(chosenUris)
         }
-        if (chosenIds.isNotEmpty()) {
-            doMediaIdsSelected(chosenIds, APP_PICKER)
+        if (!queuedUris.isNullOrEmpty()) {
+            intent.doQueuedUrisSelected(queuedUris)
         }
-        if (chosenLocalIds.isNotEmpty()) {
-            doMediaLocalIdsSelected(chosenLocalIds, APP_PICKER)
+        if (!chosenIds.isNullOrEmpty()) {
+            intent.putMediaIds(chosenIds)
         }
+        if (!chosenLocalIds.isNullOrEmpty()) {
+            intent.putLocalIds(chosenLocalIds)
+        }
+        val source = MediaPickerMediaSource.fromDataSource(mediaPickerSetup.primaryDataSource)
+        intent.putExtra(
+                EXTRA_MEDIA_SOURCE,
+                source.name
+        )
+        setResult(Activity.RESULT_OK, intent)
+        finish()
     }
 
     override fun onIconClicked(action: MediaPickerAction) {
@@ -334,18 +294,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
             }
             is OpenCameraForWPStories -> launchWPStoriesCamera()
             is SwitchMediaPicker -> {
-                val intent = buildIntent(this, action.mediaPickerSetup, site, localPostId)
-                val requestCode = when (action.mediaPickerSetup.primaryDataSource) {
-                    WP_LIBRARY -> if (action.mediaPickerSetup.canMultiselect) {
-                        MULTI_SELECT_MEDIA_PICKER
-                    } else {
-                        SINGLE_SELECT_MEDIA_PICKER
-                    }
-                    DEVICE -> MEDIA_LIBRARY
-                    STOCK_LIBRARY -> STOCK_MEDIA_PICKER_SINGLE_SELECT
-                    GIF_LIBRARY -> GIF_PICKER
-                }
-                startActivityForResult(intent, requestCode)
+                startActivityForResult(buildIntent(this, action.mediaPickerSetup, site, localPostId), PHOTO_PICKER)
             }
             OpenCameraForPhotos -> {
                 WPMediaUtils.launchCamera(this, BuildConfig.APPLICATION_ID) { mediaCapturePath = it }
@@ -353,13 +302,7 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         }
     }
 
-    private fun convertUrisListToStringArray(uris: List<Uri>): Array<String?> {
-        val stringUris = arrayOfNulls<String>(uris.size)
-        for (i in uris.indices) {
-            stringUris[i] = uris[i].toString()
-        }
-        return stringUris
-    }
+    private fun List<Uri>.toStringArray() = this.map { it.toString() }.toTypedArray()
 
     companion object {
         private const val PICKER_FRAGMENT_TAG = "picker_fragment_tag"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -31,7 +31,6 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
-import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.media.MediaPreviewActivity
 import org.wordpress.android.ui.mediapicker.MediaItem.Identifier
 import org.wordpress.android.ui.mediapicker.MediaNavigationEvent.EditMedia
@@ -95,14 +94,13 @@ class MediaPickerFragment : Fragment() {
 
     enum class ChooserContext(
         val intentAction: String,
-        val requestCode: Int,
         val title: UiStringRes,
         val mediaTypeFilter: String
     ) {
-        PHOTO(ACTION_GET_CONTENT, RequestCodes.PICTURE_LIBRARY, UiStringRes(R.string.pick_photo), "image/*"),
-        VIDEO(ACTION_GET_CONTENT, RequestCodes.VIDEO_LIBRARY, UiStringRes(R.string.pick_video), "video/*"),
-        PHOTO_OR_VIDEO(ACTION_GET_CONTENT, RequestCodes.MEDIA_LIBRARY, UiStringRes(R.string.pick_media), "*/*"),
-        MEDIA_FILE(ACTION_OPEN_DOCUMENT, RequestCodes.FILE_LIBRARY, UiStringRes(R.string.pick_file), "*/*");
+        PHOTO(ACTION_GET_CONTENT, UiStringRes(R.string.pick_photo), "image/*"),
+        VIDEO(ACTION_GET_CONTENT, UiStringRes(R.string.pick_video), "video/*"),
+        PHOTO_OR_VIDEO(ACTION_GET_CONTENT, UiStringRes(R.string.pick_media), "*/*"),
+        MEDIA_FILE(ACTION_OPEN_DOCUMENT, UiStringRes(R.string.pick_file), "*/*");
     }
 
     sealed class MediaPickerAction {
@@ -177,7 +175,7 @@ class MediaPickerFragment : Fragment() {
      * parent activity must implement this listener
      */
     interface MediaPickerListener {
-        fun onItemsChosen(uriList: List<Identifier>)
+        fun onItemsChosen(identifiers: List<Identifier>)
         fun onIconClicked(action: MediaPickerAction)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/insert/DeviceListInsertUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/insert/DeviceListInsertUseCase.kt
@@ -27,7 +27,7 @@ class DeviceListInsertUseCase(
             if (failed) {
                 InsertModel.Error("Failed to fetch local media")
             } else {
-                InsertModel.Success(fetchedUris.map { LocalUri(UriWrapper(it)) })
+                InsertModel.Success(fetchedUris.map { LocalUri(UriWrapper(it), queueResults) })
             }
         } else {
             InsertModel.Success(localUris)

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerConstants.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerConstants.kt
@@ -2,8 +2,8 @@ package org.wordpress.android.ui.photopicker
 
 object MediaPickerConstants {
     const val EXTRA_MEDIA_URIS = "media_uris"
+    const val EXTRA_MEDIA_QUEUED_URIS = "queued_media_uris"
     const val EXTRA_MEDIA_ID = "media_id"
-    const val EXTRA_MEDIA_QUEUED = "media_queued"
     const val EXTRA_LAUNCH_WPSTORIES_CAMERA_REQUESTED = "launch_wpstories_camera_requested"
 
     // the enum name of the source will be returned as a string in EXTRA_MEDIA_SOURCE

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/MediaPickerLauncher.kt
@@ -87,7 +87,7 @@ class MediaPickerLauncher @Inject constructor(
                     cameraSetup = ENABLED,
                     systemPickerEnabled = true,
                     editingEnabled = true,
-                    queueResults = true,
+                    queueResults = false,
                     defaultSearchView = false,
                     title = R.string.photo_picker_title
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -304,8 +304,7 @@ public class PhotoPickerActivity extends LocaleAwareActivity
                                     // noop
                                     break;
                             }
-                            Intent intent = new Intent()
-                                    .putExtra(MediaPickerConstants.EXTRA_MEDIA_QUEUED, true);
+                            Intent intent = new Intent();
                             setResult(RESULT_OK, intent);
                             finish();
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2535,10 +2535,10 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_ID)) {
                         long mediaId = data.getLongExtra(MediaPickerConstants.EXTRA_MEDIA_ID, 0);
                         setFeaturedImageId(mediaId, true);
-                    } else if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_QUEUED)) {
+                    } else if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_QUEUED_URIS)) {
                         if (mConsolidatedMediaPickerFeatureConfig.isEnabled()) {
                             List<Uri> uris = convertStringArrayIntoUrisList(
-                                    data.getStringArrayExtra(MediaPickerConstants.EXTRA_MEDIA_URIS));
+                                    data.getStringArrayExtra(MediaPickerConstants.EXTRA_MEDIA_QUEUED_URIS));
                             int postId = getImmutablePost().getId();
                             mFeaturedImageHelper.trackFeaturedImageEvent(
                                     FeaturedImageHelper.TrackableEvent.IMAGE_PICKED,

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -249,10 +249,11 @@ public class WPMediaUtils {
     public static void launchChooserWithContext(
             Activity activity,
             OpenSystemPicker openSystemPicker,
-            UiHelpers uiHelpers
+            UiHelpers uiHelpers,
+            int requestCode
     ) {
         activity.startActivityForResult(prepareChooserIntent(activity, openSystemPicker, uiHelpers),
-                openSystemPicker.getChooserContext().getRequestCode());
+                requestCode);
     }
 
     private static Intent prepareVideoLibraryIntent(Context context, boolean multiSelect) {


### PR DESCRIPTION
I was investigating the complex way the media picker activity handles activity results and passes them back to the original caller and I think it could be much simplified. In most cases we can just pass full intent back to the caller without having to parse it. The exceptions are the system picker and the camera (where we have to load the selected/taken files). The calls to the other sources now don't need different request codes cause they are ignored anyway so all use the `PHOTO_PICKER` now. All the calls to the system picker now have one request code - `MEDIA_LIBRARY`. 

As an additional step I've decided to add all the results to the intent. This is a step that allows us in the future to have only one place that handles the result based on what identifiers it contains. Let me know what you think of this approach. Instead of a boolean flag with `queue_results` I've changed it to have a separate list of URIs that should be queued. 

To test:
- Test featured image picker other sources to check the redirecting works
- Test featured image default source to check the queueing works
- Take a photo with a camera in site icon picker 
- Check whatever you feel is necessary :-) 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
