### PR TITLE
Fix crash with posts containing Story blocks: added safeguard by calling `find`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -53,7 +53,7 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor() {
 
         val localMediaId = mediaFile.id
         // now replace matching localMediaId with remoteMediaId in the mediaFileObjects, obtain the URLs and replace
-        storyBlockData?.mediaFiles?.filter { it.id == localMediaId }?.get(0)?.apply {
+        storyBlockData?.mediaFiles?.find { it.id == localMediaId }?.apply {
             id = mediaFile.mediaId.toInt()
             link = mediaFile.fileURL
             url = mediaFile.fileURL

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
@@ -4,8 +4,8 @@ package org.wordpress.android.ui.posts.mediauploadcompletionprocessors
 /* ktlint-disable string-template */
 object TestContent {
     const val siteUrl = "https://wordpress.org"
-    private const val localImageUrl = "file://Screenshot-1-1.png"
-    private const val localImageUrl2 = "file://Screenshot-1-2.png"
+    const val localImageUrl = "file://Screenshot-1-1.png"
+    const val localImageUrl2 = "file://Screenshot-1-2.png"
     const val remoteImageUrl = "https://onetwoonetwothisisjustatesthome.files.wordpress.com/2019/11/pexels-photo-1671668.jpg"
     const val remoteImageUrl2 = "https://onetwoonetwothisisjustatesthome.files.wordpress.com/2019/12/img_20191202_094944-19.jpg"
     private const val remoteImageUrlBlogLink = "http://onetwoonetwothisisjustatest.home.blog/pexels-photo-1671668/"
@@ -546,6 +546,15 @@ object TestContent {
 </figure>
 <!-- /wp:gallery -->
 """
+    const val storyMediaFileMimeTypeImage = "image/jpeg"
+    const val storyBlockWithLocalIdsAndUrls = """<!-- wp:jetpack/story {"mediaFiles":[{"alt":"","id":$localMediaId,"link":"$localImageUrl","type":"image","mime":"$storyMediaFileMimeTypeImage","caption":"","url":"$localImageUrl"},{"alt":"","id":$localMediaId2,"link":"$localImageUrl2","type":"image","mime":"$storyMediaFileMimeTypeImage","caption":"","url":"$localImageUrl2"}]} -->
+<div class="wp-story wp-block-jetpack-story"></div>
+<!-- /wp:jetpack/story -->"""
+    const val storyBlockWithFirstRemoteIdsAndUrlsReplaced = """<!-- wp:jetpack/story {"mediaFiles":[{"alt":"","id":$remoteMediaId,"link":"$remoteImageUrl","type":"image","mime":"$storyMediaFileMimeTypeImage","caption":"","url":"$remoteImageUrl"},{"alt":"","id":$localMediaId2,"link":"$localImageUrl2","type":"image","mime":"$storyMediaFileMimeTypeImage","caption":"","url":"$localImageUrl2"}]} -->
+<div class="wp-story wp-block-jetpack-story"></div>
+<!-- /wp:jetpack/story -->"""
+
+
     const val oldPostImage = paragraphBlock + oldImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val newPostImage = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val oldPostVideo = paragraphBlock + newImageBlock + oldVideoBlock + newMediaTextBlock + newGalleryBlock

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
@@ -554,7 +554,6 @@ object TestContent {
 <div class="wp-story wp-block-jetpack-story"></div>
 <!-- /wp:jetpack/story -->"""
 
-
     const val oldPostImage = paragraphBlock + oldImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val newPostImage = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val oldPostVideo = paragraphBlock + newImageBlock + oldVideoBlock + newMediaTextBlock + newGalleryBlock

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
@@ -1,0 +1,77 @@
+package org.wordpress.android.ui.stories
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.ui.posts.EditPostRepository
+import org.wordpress.android.ui.posts.mediauploadcompletionprocessors.TestContent
+import org.wordpress.android.util.helpers.MediaFile
+
+@RunWith(MockitoJUnitRunner::class)
+class SaveStoryGutenbergBlockUseCaseTest {
+    private lateinit var saveStoryGutenbergBlockUseCase: SaveStoryGutenbergBlockUseCase
+    @Mock lateinit var editPostRepository: EditPostRepository
+    @Mock lateinit var mediaFile: MediaFile
+    @Mock lateinit var mediaFile2: MediaFile
+    lateinit var postModel: PostModel
+
+    @Before
+    fun setUp() {
+        saveStoryGutenbergBlockUseCase = SaveStoryGutenbergBlockUseCase()
+    }
+
+    @Test
+    fun `replaceLocalMediaIdsWithRemoteMediaIdsInPost replaces local id and url for given mediaFile in Story block`() {
+        // arrange
+        whenever(mediaFile.id).thenReturn(TestContent.localMediaId.toInt())
+        whenever(mediaFile.mediaId).thenReturn(TestContent.remoteMediaId)
+        whenever(mediaFile.fileURL).thenReturn(TestContent.remoteImageUrl)
+        postModel = PostModel()
+        postModel.setContent(TestContent.storyBlockWithLocalIdsAndUrls)
+
+        // act
+        saveStoryGutenbergBlockUseCase.replaceLocalMediaIdsWithRemoteMediaIdsInPost(postModel, mediaFile)
+
+        // assert
+        Assertions.assertThat(postModel.content).isEqualTo(TestContent.storyBlockWithFirstRemoteIdsAndUrlsReplaced)
+    }
+
+    @Test
+    fun `buildJetpackStoryBlockInPost sets the Post content to a Story block with local ids and urls`() {
+        // arrange
+        postModel = PostModel()
+        whenever(editPostRepository.update<PostModel>(any())).then {
+            val action: (PostModel) -> Boolean = it.getArgument(0)
+            action(postModel)
+            null
+        }
+        whenever(editPostRepository.getPost()).thenReturn(postModel)
+
+
+        whenever(mediaFile.id).thenReturn(TestContent.localMediaId.toInt())
+        whenever(mediaFile.mediaId).thenReturn(TestContent.localMediaId)
+        whenever(mediaFile.fileURL).thenReturn(TestContent.localImageUrl)
+        whenever(mediaFile.mimeType).thenReturn(TestContent.storyMediaFileMimeTypeImage)
+
+        whenever(mediaFile2.id).thenReturn(TestContent.localMediaId2.toInt())
+        whenever(mediaFile2.mediaId).thenReturn(TestContent.localMediaId2)
+        whenever(mediaFile2.fileURL).thenReturn(TestContent.localImageUrl2)
+        whenever(mediaFile2.mimeType).thenReturn(TestContent.storyMediaFileMimeTypeImage)
+
+        val mediaFiles = HashMap<String, MediaFile>()
+        mediaFiles.put(TestContent.localMediaId, mediaFile)
+        mediaFiles.put(TestContent.localMediaId2, mediaFile2)
+
+        // act
+        saveStoryGutenbergBlockUseCase.buildJetpackStoryBlockInPost(editPostRepository, mediaFiles)
+
+        // assert
+        Assertions.assertThat(postModel.content).isEqualTo(TestContent.storyBlockWithLocalIdsAndUrls)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
@@ -53,7 +53,6 @@ class SaveStoryGutenbergBlockUseCaseTest {
         }
         whenever(editPostRepository.getPost()).thenReturn(postModel)
 
-
         whenever(mediaFile.id).thenReturn(TestContent.localMediaId.toInt())
         whenever(mediaFile.mediaId).thenReturn(TestContent.localMediaId)
         whenever(mediaFile.fileURL).thenReturn(TestContent.localImageUrl)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
@@ -51,15 +51,11 @@ class SaveStoryGutenbergBlockUseCaseTest {
             action(postModel)
             null
         }
-        whenever(editPostRepository.getPost()).thenReturn(postModel)
-
         whenever(mediaFile.id).thenReturn(TestContent.localMediaId.toInt())
-        whenever(mediaFile.mediaId).thenReturn(TestContent.localMediaId)
         whenever(mediaFile.fileURL).thenReturn(TestContent.localImageUrl)
         whenever(mediaFile.mimeType).thenReturn(TestContent.storyMediaFileMimeTypeImage)
 
         whenever(mediaFile2.id).thenReturn(TestContent.localMediaId2.toInt())
-        whenever(mediaFile2.mediaId).thenReturn(TestContent.localMediaId2)
         whenever(mediaFile2.fileURL).thenReturn(TestContent.localImageUrl2)
         whenever(mediaFile2.mimeType).thenReturn(TestContent.storyMediaFileMimeTypeImage)
 


### PR DESCRIPTION
This fixes a crash reported by @planarvoid on `develop` as follows

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{org.wordpress.android.beta/org.wordpress.android.ui.posts.EditPostActivity}: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3270)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3409)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
     Caused by: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.ArrayList.get(ArrayList.java:437)
        at org.wordpress.android.ui.stories.SaveStoryGutenbergBlockUseCase.replaceLocalMediaIdsWithRemoteMediaIdsInPost(SaveStoryGutenbergBlockUseCase.kt:56)
        at org.wordpress.android.ui.uploads.MediaUploadReadyProcessor.replaceMediaFileWithUrlInPost(MediaUploadReadyProcessor.java:26)
        at org.wordpress.android.ui.uploads.UploadService.updatePostWithMediaUrl(UploadService.java:611)
        at org.wordpress.android.ui.uploads.UploadService.updatePostWithCurrentlyCompletedUploads(UploadService.java:459)
        at org.wordpress.android.ui.posts.-$$Lambda$oKXGGak0_lNLvZhk4qsl8ml6C7w.invoke(Unknown Source:2)
        at org.wordpress.android.ui.posts.EditPostRepository.replace(EditPostRepository.kt:134)
        at org.wordpress.android.ui.posts.EditPostActivity.initializePostObject(EditPostActivity.java:841)
        at org.wordpress.android.ui.posts.EditPostActivity.onCreate(EditPostActivity.java:540)
```

The problem lies in the call to `.get(0)` on an empty list.
We're now using `find` instead of `filter`; also internally `find` returns a `firstOrNull` which is safe to work with the `?` operator.

To test:
- I haven't  found an easy way to reproduce, but I think this can happen during a window in which the media files have been uploaded but the Post has not yet been processed, and when the Post contains a Story and a new image block has been added. The current state on `develop` does not have support for multi-block posts with stories, and this'll change with the actual feature branch so, shouldn't happen in production

While at it, I also took the opportunity and added unit tests for the involved class.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
