### PR TITLE
Add maxlines and ellipse to site_name

### DIFF
--- a/WordPress/src/main/res/layout/prepublishing_home_header_list_item.xml
+++ b/WordPress/src/main/res/layout/prepublishing_home_header_list_item.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- ORIGINAL PPN HOME LAYOUT -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -55,6 +56,8 @@
         android:layout_marginStart="@dimen/margin_medium"
         android:textAlignment="viewStart"
         android:textAppearance="?attr/textAppearanceBody1"
+        android:maxLines="1"
+        android:ellipsize="end"
         app:layout_constraintBottom_toBottomOf="@id/site_icon_layout"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/site_icon_layout"

--- a/WordPress/src/main/res/layout/prepublishing_home_header_list_item.xml
+++ b/WordPress/src/main/res/layout/prepublishing_home_header_list_item.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- ORIGINAL PPN HOME LAYOUT -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"


### PR DESCRIPTION
This PR fixes the site name length on the Prepublishing Bottom Sheet header by adding maxLines and ellipsize to the site_name.

Before|After w/o spaces|After w/ spaces
---|---|---
<img width="480" src="https://user-images.githubusercontent.com/506707/97488635-df488e00-1934-11eb-8adb-7a649a10d8cb.png">|<img width="480" src="https://user-images.githubusercontent.com/506707/97488564-c9d36400-1934-11eb-8d10-97927c3f96f5.png">|<img width="480" src="https://user-images.githubusercontent.com/506707/97488568-cb049100-1934-11eb-9f05-e85301a2c886.png">

**To test:**
- Launch app
- Tap settings
- Change your site name to a long string (with or without spaces)
- Tap <- to save settings
- Tap posts
- Edit an existing post
- Tap Update to launch the Prepublishing Bottom Sheet
- Notice that the site name does not overtake the entire view

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
