### PR TITLE
Issue/13066 prevent null name crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
@@ -1,12 +1,10 @@
 package org.wordpress.android.ui.posts
 
 import android.os.Bundle
-import android.util.Log
 import androidx.annotation.DimenRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import com.wordpress.stories.util.LOG_TAG
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -207,7 +205,10 @@ class PrepublishingCategoriesViewModel @Inject constructor(
                     .toMutableList()
             selectedIds.add(event.term.remoteTermId)
             val categoryLevels = getSiteCategories()
-            val recreatedListItemUiState = buildListOfCategoriesItemUiState(categoryLevels, selectedIds)
+            val recreatedListItemUiState = buildListOfCategoriesItemUiState(
+                    categoryLevels,
+                    selectedIds
+            )
             _uiState.value = uiState.value?.copy(
                     categoriesListItemUiState = recreatedListItemUiState, progressVisibility = false
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewModel.kt
@@ -1,10 +1,12 @@
 package org.wordpress.android.ui.posts
 
 import android.os.Bundle
+import android.util.Log
 import androidx.annotation.DimenRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
+import com.wordpress.stories.util.LOG_TAG
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -187,14 +189,17 @@ class PrepublishingCategoriesViewModel @Inject constructor(
     }
 
     fun onTermUploadedComplete(event: OnTermUploaded) {
-        val message = if (event.isError) {
+        // Sometimes the API will return a success response with a null name which we will
+        // treat as an error because without a name, there is no category
+        val isError = event.isError || event.term?.name == null
+        val message = if (isError) {
             string.adding_cat_failed
         } else {
             string.adding_cat_success
         }
         _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringRes(message))))
 
-        if (!event.isError) {
+        if (!isError) {
             val currentState = uiState.value as UiState
             val selectedIds = currentState.categoriesListItemUiState.toMutableList()
                     .filter { x -> x.checked }


### PR DESCRIPTION
Fixes #13230 

This PR treats a success response with a null name as an error. A message is shown to the user and the app doesn't try to reload.

**To test:**
Since this happens intermittently, I suggest verifying existing Add Category functionality works as expected

- Launch the app
- Select Blog posts
- Select Edit on a post
- From the edit post view, tap the UPDATE action to launch the bottom sheet
- Categories are shown on the Categories row
- If the post has categories assigned, you will see them listed on the home view. If not, you will see Not Set or Uncategorized
- Select Categories is shown when user taps on Categories
- Tap the categories row to launch the Select categories view
- Tap the Add New Category button "+" on the title bar
- Enter a new category and tap "Add Category Button"(Note: A new category is NOT saved on back press - the explicit tap on the action button is needed)
- Back on the select category view, the category you have added is visible and checked. An success message was shown
- Tap the Add New Category button "+" on the title bar
- Enter a new category - use a name that is already on the list - and tap "Add Category Button"
- Back on the select category view, the category you have added is not visible and an error message was shown

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
