### PR TITLE
Merge hotfix 15.9.2 into trunk

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 16.0
 -----
+
+15.9.2
+-----
+* [*] Block Editor: Fix for a crash that can occur when activity is null [https://github.com/wordpress-mobile/WordPress-Android/issues/13248]
  
 15.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 15.9.2
 -----
-* [*] Block Editor: Fix for a crash that can occur when activity is null [https://github.com/wordpress-mobile/WordPress-Android/issues/13248]
+* [*] Block Editor: Fix for a crash that can occur when activity is null during capabilities update[https://github.com/wordpress-mobile/WordPress-Android/issues/13248]
  
 15.9
 -----

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -92,9 +92,9 @@ android {
             dimension "buildType"
             // Only set the release version if one isn't provided
             if (!project.hasProperty("versionName")) {
-                versionName "15.9.1"
+                versionName "15.9.2"
             }
-            versionCode 938
+            versionCode 15.9.2
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "boolean", "TENOR_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -56,7 +56,7 @@ android {
         } else {
             versionName "alpha-249"
         }
-        versionCode 934
+        versionCode 943
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
@@ -94,7 +94,7 @@ android {
             if (!project.hasProperty("versionName")) {
                 versionName "15.9.2"
             }
-            versionCode 15.9.2
+            versionCode 943
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "boolean", "TENOR_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.editor.gutenberg;
 
+import android.app.Activity;
 import android.os.Bundle;
 import android.view.ViewGroup;
 
@@ -214,8 +215,9 @@ public class GutenbergContainerFragment extends Fragment {
     public void updateCapabilities(GutenbergPropsBuilder gutenbergPropsBuilder) {
         // We want to make sure that activity isn't null
         // as it can make this crash to happen: https://github.com/wordpress-mobile/WordPress-Android/issues/13248
-        if (getActivity() != null) {
-            GutenbergProps gutenbergProps = gutenbergPropsBuilder.build(getActivity(), mHtmlModeEnabled);
+        final Activity activity = getActivity();
+        if (activity != null) {
+            GutenbergProps gutenbergProps = gutenbergPropsBuilder.build(activity, mHtmlModeEnabled);
             mWPAndroidGlueCode.updateCapabilities(gutenbergProps);
         }
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -212,7 +212,11 @@ public class GutenbergContainerFragment extends Fragment {
     }
 
     public void updateCapabilities(GutenbergPropsBuilder gutenbergPropsBuilder) {
-        GutenbergProps gutenbergProps = gutenbergPropsBuilder.build(getActivity(), mHtmlModeEnabled);
-        mWPAndroidGlueCode.updateCapabilities(gutenbergProps);
+        // We want to make sure that activity isn't null
+        // as it can make this crash to happen: https://github.com/wordpress-mobile/WordPress-Android/issues/13248
+        if (getActivity() != null) {
+            GutenbergProps gutenbergProps = gutenbergPropsBuilder.build(getActivity(), mHtmlModeEnabled);
+            mWPAndroidGlueCode.updateCapabilities(gutenbergProps);
+        }
     }
 }


### PR DESCRIPTION
I bumped the `versionCode` value to make sure it's clear that `versionCode` 943 belonged to 15.9.2 and has nothing to do with the current version.

I'm not 100% sure that's appropriate... Maybe I should have bumped `versionName`, too, shipping a new RC for 16.0?

Let me know and I'll update if necessary.
Thanks :smile: