### PR TITLE
Fixes snackbar crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.android.synthetic.main.main_activity.*
 import kotlinx.android.synthetic.main.reader_discover_fragment_layout.*
 import kotlinx.android.synthetic.main.reader_fullscreen_empty_with_action.*
 import kotlinx.android.synthetic.main.reader_fullscreen_error_with_retry.*
@@ -187,17 +188,19 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
     }
 
     private fun SnackbarMessageHolder.showSnackbar() {
-        val snackbar = WPSnackbar.make(
-                constraint_layout,
-                uiHelpers.getTextOfUiString(requireContext(), this.message),
-                Snackbar.LENGTH_LONG
-        )
-        if (this.buttonTitle != null) {
-            snackbar.setAction(uiHelpers.getTextOfUiString(requireContext(), this.buttonTitle)) {
-                this.buttonAction.invoke()
+        activity?.findViewById<View>(R.id.coordinator)?.let { coordinator ->
+            val snackbar = WPSnackbar.make(
+                    coordinator,
+                    uiHelpers.getTextOfUiString(requireContext(), this.message),
+                    Snackbar.LENGTH_LONG
+            )
+            if (this.buttonTitle != null) {
+                snackbar.setAction(uiHelpers.getTextOfUiString(requireContext(), this.buttonTitle)) {
+                    this.buttonAction.invoke()
+                }
             }
+            snackbar.show()
         }
-        snackbar.show()
     }
 
     private fun PreLoadPostContent.addWebViewCachingFragment() {


### PR DESCRIPTION
Fixes #13251

I wasn't able to reproduce the crash. However, I decided to copy the behavior from ReaderPostListFragment where we show snackbars on the parent's coordinator layout -> when the layout is not found, the snackbar isn't shown.

To test:
1. Open Discover tab
2. Click on Bookmark icon
3. Dismiss the dialog if it's shown
4. Click on another bookmark icon
5. Notice a snackbar is shown

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
