### PR TITLE
[Modal Layout Picker] Disables picker when the block editor is not enabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -438,7 +438,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     handleNewPostAction(PagePostCreationSourcesDetail.POST_FROM_MY_SITE);
                     break;
                 case CREATE_NEW_PAGE:
-                    if (mModalLayoutPickerFeatureConfig.isEnabled()) {
+                    if (mModalLayoutPickerFeatureConfig.isEnabled() && mMLPViewModel.canShowModalLayoutPicker()) {
                         mMLPViewModel.createPageFlowTriggered();
                     } else {
                         handleNewPageAction("", "", null,

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -347,7 +347,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         })
 
         viewModel.createNewPage.observe(viewLifecycleOwner, Observer {
-            if (modalLayoutPickerFeatureConfig.isEnabled()) {
+            if (modalLayoutPickerFeatureConfig.isEnabled() && mlpViewModel.canShowModalLayoutPicker()) {
                 mlpViewModel.createPageFlowTriggered()
             } else {
                 createNewPage()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.mlp.SupportedBlocksProvider
 import org.wordpress.android.ui.mlp.ThumbDimensionProvider
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -177,6 +178,17 @@ class ModalLayoutPickerViewModel @Inject constructor(
             }
             loadLayouts()
         }
+    }
+
+    /**
+     * Checks if the Modal Layout Picker can be shown
+     * at this point the only requirement is to have the block editor enabled
+     * @return true if the Modal Layout Picker can be shown
+     */
+    fun canShowModalLayoutPicker(): Boolean {
+        val siteId = appPrefsWrapper.getSelectedSite()
+        val site = siteStore.getSiteByLocalId(siteId)
+        return SiteUtils.isBlockEditorDefaultForNewPost(site)
     }
 
     /**

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.ui.mlp.ThumbDimensionProvider
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
+import org.wordpress.android.util.SiteUtils.GB_EDITOR_NAME
 import org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel.PageRequest.Blank
 import org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel.PageRequest.Preview
 import org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel.PageRequest.Create
@@ -101,7 +102,7 @@ class ModalLayoutPickerViewModelTest {
     private fun <T> mockFetchingSelectedSite(isError: Boolean = false, block: suspend CoroutineScope.() -> T) {
         coroutineScope.runBlockingTest {
             val siteId = 1
-            val site = SiteModel()
+            val site = SiteModel().apply { mobileEditor = GB_EDITOR_NAME }
             whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
             whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(site)
             whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(site)


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2447

## Description
Disables picker when the block editor is not enabled

## To test:
Layout Picker should show [when creating a new page from *My Site* or *Site Pages* the *Modal Layout Picker* appears](https://github.com/wordpress-mobile/WordPress-Android/pull/12482).

### Block editor Enabled
1. From the *My site* page scroll down and select **Settings**
1. **Enable** the **Use Block Editor** option (or confirm that is is enabled)
1. Create a new page for a Gutenberg site. 
     - **Expect** to see the Modal Layout Picker. 

### Block editor Disabled
1. From the *My site* page scroll down and select **Settings**
1. **Disable** the **Use Block Editor** option
1. Create a new page for a Gutenberg site. 
     - **Expect** to see the Editor.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
