### PR TITLE
Add PostMediaHandler.kt to add remote post ID to media on post uploaded

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostMediaHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostMediaHandler.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.ui.uploads
+
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.MediaActionBuilder
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
+import javax.inject.Inject
+
+class PostMediaHandler
+@Inject constructor(private val mediaStore: MediaStore, private val dispatcher: Dispatcher) {
+    fun updateMediaWithoutPostId(site: SiteModel, post: PostModel) {
+        if (post.remotePostId != 0L) {
+            val mediaForPost = mediaStore.getMediaForPost(post)
+            mediaForPost.filter { it.postId == 0L }.forEach { media ->
+                media.postId = post.remotePostId
+                dispatcher.dispatch(MediaActionBuilder.newPushMediaAction(MediaPayload(site, media)))
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -82,6 +82,7 @@ public class PostUploadHandler implements UploadHandler<PostModel>, OnAutoSavePo
     @Inject UiHelpers mUiHelpers;
     @Inject UploadActionUseCase mUploadActionUseCase;
     @Inject AutoSavePostIfNotDraftUseCase mAutoSavePostIfNotDraftUseCase;
+    @Inject PostMediaHandler mPostMediaHandler;
 
     PostUploadHandler(PostUploadNotifier postUploadNotifier) {
         ((WordPress) WordPress.getContext().getApplicationContext()).component().inject(this);
@@ -670,6 +671,7 @@ public class PostUploadHandler implements UploadHandler<PostModel>, OnAutoSavePo
             boolean isFirstTimePublish = sFirstPublishPosts.remove(event.post.getId());
             if (site != null) {
                 mPostUploadNotifier.updateNotificationSuccessForPost(event.post, site, isFirstTimePublish);
+                mPostMediaHandler.updateMediaWithoutPostId(site, event.post);
             } else {
                 AppLog.e(T.POSTS, "Cannot update notification success without a site");
             }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/PostMediaHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/PostMediaHandlerTest.kt
@@ -92,7 +92,6 @@ class PostMediaHandlerTest {
     @Test
     fun `does not emit when post remote ID is 0`() {
         // Arrange
-        whenever(mediaStore.getMediaForPost(post)).thenReturn(listOf(firstMediaItem))
         post.setRemotePostId(0L)
         firstMediaItem.postId = 0L
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/PostMediaHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/PostMediaHandlerTest.kt
@@ -1,0 +1,120 @@
+package org.wordpress.android.ui.uploads
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
+
+@RunWith(MockitoJUnitRunner::class)
+class PostMediaHandlerTest {
+    @Mock lateinit var mediaStore: MediaStore
+    @Mock lateinit var dispatcher: Dispatcher
+    private lateinit var postMediaHandler: PostMediaHandler
+    private val site = SiteModel()
+    private lateinit var post: PostModel
+    private lateinit var firstMediaItem: MediaModel
+    private lateinit var secondMediaItem: MediaModel
+    private val actions = mutableListOf<Action<MediaPayload>>()
+
+    @Before
+    fun setUp() {
+        postMediaHandler = PostMediaHandler(mediaStore, dispatcher)
+        post = PostModel()
+        firstMediaItem = MediaModel()
+        secondMediaItem = MediaModel()
+        actions.clear()
+        doAnswer {
+            actions.add(it.getArgument(0))
+        }.whenever(dispatcher).dispatch(any())
+    }
+
+    @Test
+    fun `emits media update action when media post ID is 0`() {
+        // Arrange
+        whenever(mediaStore.getMediaForPost(post)).thenReturn(listOf(firstMediaItem))
+        val updatedPostId = 1L
+        post.setRemotePostId(updatedPostId)
+        firstMediaItem.postId = 0L
+
+        // Act
+        postMediaHandler.updateMediaWithoutPostId(site, post)
+
+        // Assert
+        verify(dispatcher).dispatch(any())
+        assertThat(actions).hasSize(1)
+        val emittedAction = actions.last()
+        assertThat(emittedAction.payload.media.postId).isEqualTo(updatedPostId)
+        assertThat(emittedAction.payload.site).isEqualTo(site)
+    }
+
+    @Test
+    fun `emits media update action for multiple items`() {
+        // Arrange
+        whenever(mediaStore.getMediaForPost(post)).thenReturn(listOf(firstMediaItem, secondMediaItem))
+        val updatedPostId = 1L
+        post.setRemotePostId(updatedPostId)
+        firstMediaItem.postId = 0L
+        firstMediaItem.mediaId = 11L
+        secondMediaItem.postId = 0L
+        secondMediaItem.mediaId = 22L
+
+        // Act
+        postMediaHandler.updateMediaWithoutPostId(site, post)
+
+        // Assert
+        verify(dispatcher, times(2)).dispatch(any())
+        assertThat(actions).hasSize(2)
+        val firstAction = actions[0]
+        assertThat(firstAction.payload.media.mediaId).isEqualTo(firstMediaItem.mediaId)
+        assertThat(firstAction.payload.media.postId).isEqualTo(updatedPostId)
+        assertThat(firstAction.payload.site).isEqualTo(site)
+        val secondAction = actions[0]
+        assertThat(secondAction.payload.media.mediaId).isEqualTo(secondMediaItem.mediaId)
+        assertThat(secondAction.payload.media.postId).isEqualTo(updatedPostId)
+        assertThat(secondAction.payload.site).isEqualTo(site)
+    }
+
+    @Test
+    fun `does not emit when post remote ID is 0`() {
+        // Arrange
+        whenever(mediaStore.getMediaForPost(post)).thenReturn(listOf(firstMediaItem))
+        post.setRemotePostId(0L)
+        firstMediaItem.postId = 0L
+
+        // Act
+        postMediaHandler.updateMediaWithoutPostId(site, post)
+
+        // Assert
+        verifyZeroInteractions(dispatcher)
+    }
+
+    @Test
+    fun `does not update media when media remote ID is not 0`() {
+        // Arrange
+        whenever(mediaStore.getMediaForPost(post)).thenReturn(listOf(firstMediaItem))
+        val updatedPostId = 1L
+        post.setRemotePostId(updatedPostId)
+        firstMediaItem.postId = 2L
+
+        // Act
+        postMediaHandler.updateMediaWithoutPostId(site, post)
+
+        // Assert
+        verifyZeroInteractions(dispatcher)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/PostMediaHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/PostMediaHandlerTest.kt
@@ -83,7 +83,7 @@ class PostMediaHandlerTest {
         assertThat(firstAction.payload.media.mediaId).isEqualTo(firstMediaItem.mediaId)
         assertThat(firstAction.payload.media.postId).isEqualTo(updatedPostId)
         assertThat(firstAction.payload.site).isEqualTo(site)
-        val secondAction = actions[0]
+        val secondAction = actions[1]
         assertThat(secondAction.payload.media.mediaId).isEqualTo(secondMediaItem.mediaId)
         assertThat(secondAction.payload.media.postId).isEqualTo(updatedPostId)
         assertThat(secondAction.payload.site).isEqualTo(site)


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-Android/issues/5912

The previous functionality was caused by the fact that we don't have the post remote ID until it's saved for the first time. This means that once you create a new post and upload media, it gets uploaded without the post ID. Once you work with an already published post, this issue is not happening. This PR introduced a PostMediaHandler which is triggered on successful post upload and which updates the post ID for all the post media that don't have it set.

To test:
- Create a post in GB
- Add media
- Publish the post
- Go to wp-admin media library for your site
- Click on the media you added to the post
- Notice that the "Uploaded To ..." field is pointing to your new post

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
