### PR TITLE
Update Prologue's site button label

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2543,7 +2543,7 @@
     <string name="signup_confirmation_title">Signup confirmation</string>
 
     <string name="continue_with_wpcom">Continue with WordPress.com</string>
-    <string name="enter_your_site_address">Enter your site address</string>
+    <string name="enter_your_site_address">Enter your existing site address</string>
 
     <string name="username_changer_action">Save</string>
     <string name="username_changer_dismiss_button_positive">Discard</string>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -92,7 +92,7 @@
     <string name="signup_with_google_button">Sign Up with Google</string>
     <string name="signup_with_google_progress">Signing up with Google&#8230;</string>
     <string name="continue_with_wpcom">Continue with WordPress.com</string>
-    <string name="enter_your_site_address">Enter your site address</string>
+    <string name="enter_your_site_address">Enter your existing site address</string>
 
     <string name="google_error_timeout">Google took too long to respond. You may need to wait until you have a stronger internet connection.</string>
 


### PR DESCRIPTION
This PR updates the label of the Prologue's "Enter your site address" button to "Enter your existing site address". More details about this change here: p4a5px-2Ez-p2#comment-11440

|Before|After|
|----|----|
|![Before](https://user-images.githubusercontent.com/830056/97723396-81d64d80-1aaa-11eb-8271-60d1a00ce6c6.png)|![After](https://user-images.githubusercontent.com/830056/97723435-8a2e8880-1aaa-11eb-967a-f3693118286a.png)|

To test: 

Verify that the button text is always visible on different screen sizes and orientations.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.