### PR TITLE
Issue/13197 Google login NPE

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -865,14 +865,18 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     public void onGoogleEmailSelected(String email) {
         LoginEmailFragment loginEmailFragment =
                 (LoginEmailFragment) getSupportFragmentManager().findFragmentByTag(LoginEmailFragment.TAG);
-        loginEmailFragment.setGoogleEmail(email);
+        if (loginEmailFragment != null) {
+            loginEmailFragment.setGoogleEmail(email);
+        }
     }
 
     @Override
     public void onGoogleLoginFinished() {
         LoginEmailFragment loginEmailFragment =
                 (LoginEmailFragment) getSupportFragmentManager().findFragmentByTag(LoginEmailFragment.TAG);
-        loginEmailFragment.finishLogin();
+        if (loginEmailFragment != null) {
+            loginEmailFragment.finishLogin();
+        }
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/GoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/GoogleFragment.java
@@ -29,7 +29,7 @@ import javax.inject.Inject;
 
 import static android.app.Activity.RESULT_OK;
 
-public class GoogleFragment extends Fragment implements ConnectionCallbacks, OnConnectionFailedListener {
+public abstract class GoogleFragment extends Fragment implements ConnectionCallbacks, OnConnectionFailedListener {
     private static final String STATE_SHOULD_RESOLVE_ERROR = "STATE_SHOULD_RESOLVE_ERROR";
     private static final String STATE_FINISHED = "STATE_FINISHED";
     private static final String STATE_DISPLAY_NAME = "STATE_DISPLAY_NAME";
@@ -209,9 +209,7 @@ public class GoogleFragment extends Fragment implements ConnectionCallbacks, OnC
         }
     }
 
-    protected void startFlow() {
-        // Do nothing here.  This should be overridden by inheriting class.
-    }
+    protected abstract void startFlow();
 
     protected void finishFlow() {
         /* This flag might get lost when the finishFlow is called after the fragment's

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/GoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/GoogleFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.login;
 
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
@@ -54,6 +55,8 @@ public abstract class GoogleFragment extends Fragment implements ConnectionCallb
     protected String mGoogleEmail;
     protected String mIdToken;
     protected String mPhotoUrl;
+
+    protected ProgressDialog mProgressDialog;
 
     public static final String SERVICE_TYPE_GOOGLE = "google";
 
@@ -119,6 +122,7 @@ public abstract class GoogleFragment extends Fragment implements ConnectionCallb
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
+        mProgressDialog = ProgressDialog.show(getActivity(), null, getProgressDialogText(), true, false, null);
         mLoginListener = (LoginListener) context;
 
         try {
@@ -129,6 +133,12 @@ public abstract class GoogleFragment extends Fragment implements ConnectionCallb
         if (mFinished) {
             finishFlow();
         }
+    }
+
+    @Override
+    public void onDetach() {
+        dismissProgressDialog();
+        super.onDetach();
     }
 
     @Override
@@ -209,6 +219,8 @@ public abstract class GoogleFragment extends Fragment implements ConnectionCallb
         }
     }
 
+    protected abstract String getProgressDialogText();
+
     protected abstract void startFlow();
 
     protected void finishFlow() {
@@ -245,6 +257,12 @@ public abstract class GoogleFragment extends Fragment implements ConnectionCallb
 
                 mIsResolvingError = false;
                 break;
+        }
+    }
+
+    private void dismissProgressDialog() {
+        if (mProgressDialog != null && mProgressDialog.isShowing()) {
+            mProgressDialog.dismiss();
         }
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginGoogleFragment.java
@@ -52,6 +52,11 @@ public class LoginGoogleFragment extends GoogleFragment {
     }
 
     @Override
+    protected String getProgressDialogText() {
+        return getString(R.string.logging_in);
+    }
+
+    @Override
     protected void startFlow() {
         if (!mLoginRequested) {
             AppLog.d(T.MAIN, "GOOGLE LOGIN: startFlow");

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.login;
 
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -41,7 +40,6 @@ public class SignupGoogleFragment extends GoogleFragment {
     private static final String ARG_FORCE_SIGNUP_AT_START = "ARG_FORCE_SIGNUP_AT_START";
 
     private ArrayList<Integer> mOldSitesIds;
-    private ProgressDialog mProgressDialog;
     private boolean mSignupRequested;
     private boolean mForceSignupAtStart;
 
@@ -64,8 +62,6 @@ public class SignupGoogleFragment extends GoogleFragment {
     @Override
     public void onAttach(Context context) {
         AndroidSupportInjection.inject(this);
-        mProgressDialog = ProgressDialog.show(
-                getActivity(), null, getString(R.string.signup_with_google_progress), true, false, null);
         super.onAttach(context);
         Bundle args = getArguments();
         if (args != null) {
@@ -75,6 +71,11 @@ public class SignupGoogleFragment extends GoogleFragment {
             mPhotoUrl = args.getString(ARG_PHOTO_URL);
             mForceSignupAtStart = args.getBoolean(ARG_FORCE_SIGNUP_AT_START);
         }
+    }
+
+    @Override
+    protected String getProgressDialogText() {
+        return getString(R.string.signup_with_google_progress);
     }
 
     @Override public void onCreate(Bundle savedInstanceState) {
@@ -89,12 +90,6 @@ public class SignupGoogleFragment extends GoogleFragment {
         super.onSaveInstanceState(outState);
         outState.putIntegerArrayList(OLD_SITES_IDS, mOldSitesIds);
         outState.putBoolean(SIGN_UP_REQUESTED, mSignupRequested);
-    }
-
-    @Override
-    public void onDetach() {
-        dismissProgressDialog();
-        super.onDetach();
     }
 
     @Override
@@ -204,12 +199,6 @@ public class SignupGoogleFragment extends GoogleFragment {
                 }
 
                 break;
-        }
-    }
-
-    private void dismissProgressDialog() {
-        if (mProgressDialog != null && mProgressDialog.isShowing()) {
-            mProgressDialog.dismiss();
         }
     }
 


### PR DESCRIPTION
Fixes #13197

This PR basically introduces an intermediary progress dialog that prevents the user from accidently entering an inconsistent state between the time the `LoginGoogleFragment` finishes the login process and the `LoginEmailFragment` starts fetching user information, which eventually caused the app to crash (check the linked issue for additional context). 

This same progress dialog was already being used by `SignupGoogleFragment`, so it was just a matter of pulling it up to `GoogleFragment` and implementing it on `LoginGoogleFragment`.

I tried a few different solutions for this one, but eventually decided to go with a more pragmatic approach in order to keep the complexity under control and make it easier to test.

## To test:

1. On the Prologue screen, tap **Continue with WordPress.com**.
1. On the Get Started screen, tap **Continue with Google**.
1. On the Google Sign-In dialog, pick a Google account that is associated with a non-2FA WordPress.com account.
1. Notice that a progress dialog immediately appears.
1. Complete the login flow normally.

You should also try repeating the steps above with a slow network connection and try to reproduce the error described [here](https://github.com/wordpress-mobile/WordPress-Android/issues/13197#issuecomment-719050564).

👉 To use the Google Sign-In method, you might need to follow these instructions: paqN3M-9M-p2

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
