### PR TITLE
Update Prologue Third

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginProloguePageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginProloguePageFragment.kt
@@ -1,10 +1,12 @@
 package org.wordpress.android.ui.accounts.login
 
 import android.os.Bundle
+import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
+import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
@@ -83,6 +85,16 @@ class LoginProloguePageFragment : Fragment() {
                         editText.isPressed = true
                         editText.setSelection(editText.length())
                     }
+                }
+
+                // format text from HTML to show bold on third prologue screen
+                if (promoLayoutId == R.layout.login_prologue_third) {
+                    view.findViewById<TextView>(R.id.text_one).text = Html.fromHtml(getString(
+                            R.string.login_prologue_third_subtitle_one))
+                    view.findViewById<TextView>(R.id.text_two).text = Html.fromHtml(getString(
+                            R.string.login_prologue_third_subtitle_two))
+                    view.findViewById<TextView>(R.id.text_three).text = Html.fromHtml(getString(
+                            R.string.login_prologue_third_subtitle_three))
                 }
             }
         }

--- a/WordPress/src/main/res/layout/login_prologue_third.xml
+++ b/WordPress/src/main/res/layout/login_prologue_third.xml
@@ -31,6 +31,7 @@
                 android:src="@drawable/login_prologue_third_asset_one" />
 
             <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/text_one"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
@@ -68,6 +69,7 @@
                 android:src="@drawable/login_prologue_third_asset_two" />
 
             <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/text_two"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
@@ -105,6 +107,7 @@
                 android:src="@drawable/login_prologue_third_asset_three" />
 
             <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/text_three"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2403,7 +2403,7 @@
     <string name="log_in">Log In</string>
     <string name="login_prologue_title_first">Welcome to the world\’s most popular website builder.</string>
     <string name="login_prologue_title_second">With the powerful editor you can post on the go.</string>
-    <string name="login_prologue_title_third">See comments and notification in real time.</string>
+    <string name="login_prologue_title_third">See comments and notifications in real time.</string>
     <string name="login_prologue_title_fourth">Watch your audience grow with in-depth analytics.</string>
     <string name="login_prologue_title_fifth">Follow your favorite sites and discover new reads.</string>
     <string name="login_prologue_second_subtitle_one">Getting Inspired</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2408,9 +2408,9 @@
     <string name="login_prologue_title_fifth">Follow your favorite sites and discover new reads.</string>
     <string name="login_prologue_second_subtitle_one">Getting Inspired</string>
     <string name="login_prologue_second_subtitle_two">I am so inspired by photographer Cameron Karsten\’s work. I will be trying these techniques on my next</string>
-    <string name="login_prologue_third_subtitle_one"><b>Madison Ruiz</b> liked your post</string>
-    <string name="login_prologue_third_subtitle_two">You received <b>50 likes</b> on your site today</string>
-    <string name="login_prologue_third_subtitle_three"><b>Johan Brandt</b> responded to your post</string>
+    <string name="login_prologue_third_subtitle_one">&lt;b&gt;Madison Ruiz&lt;/b&gt; liked your post</string>
+    <string name="login_prologue_third_subtitle_two">You received &lt;b&gt;50 likes&lt;/b&gt; on your site today</string>
+    <string name="login_prologue_third_subtitle_three">&lt;b&gt;Johan Brandt&lt;/b&gt; responded to your post</string>
     <string name="login_prologue_fifth_subtitle_one">Pamela Nguyen</string>
     <string name="login_prologue_fifth_subtitle_two">Web News</string>
     <string name="login_prologue_fifth_subtitle_three">Rock n\' Roll Weekly</string>


### PR DESCRIPTION
### Fix
Update the string resources used for the third page of the prologue screen from HTML tags to HTML entities in order to avoid missing text in strings sent to translators.  Also, the title of the third page of the prologue screen was updated from "See comments and notification in real time." to "See comments and notifications in real time." to correct a typographical error.  These changes should have no visual change to the third page of the prologue screen other than the typographical error update.  See the screenshot below for illustration.

![wordpress_android_prologue_third](https://user-images.githubusercontent.com/3827611/98065854-a87de680-1e12-11eb-86fe-9bf48521c15b.png)

### Test
1. Clear app data.
2. Notice prologue screen is shown.
3. Swipe to third page of prologue screen.
4. Notice third page appears as **_After_** screenshot above.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

#### Checklist
- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
