### PR TITLE
Update material and swipeToRefresh versions

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -203,9 +203,9 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation "com.google.android.material:material:$materialVersion"
     implementation 'androidx.percentlayout:percentlayout:1.0.0'
-    implementation "androidx.preference:preference:$materialVersion"
+    implementation "androidx.preference:preference:$preferenceVersion"
     implementation "androidx.work:work-runtime:$androidxWorkVersion"
     implementation "androidx.work:work-runtime-ktx:$androidxWorkVersion"
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -205,6 +205,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation "com.google.android.material:material:$materialVersion"
     implementation 'androidx.percentlayout:percentlayout:1.0.0'
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:$swipeToRefresh"
     implementation "androidx.preference:preference:$preferenceVersion"
     implementation "androidx.work:work-runtime:$androidxWorkVersion"
     implementation "androidx.work:work-runtime-ktx:$androidxWorkVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,9 @@ ext {
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'
     constraintLayoutVersion = '1.1.3'
-    materialVersion = '1.1.0'
+    materialVersion = '1.2.1'
+    preferenceVersion = '1.1.0'
+    swipeToRefresh = '1.1.0'
     uCropVersion = '2.2.4'
     lifecycleVersion = '2.2.0'
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.0.0'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.2.1'
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'com.android.volley:volley:1.1.1'
     implementation 'org.wordpress:utils:1.25'

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'androidx.media:media:1.1.0'
     implementation 'androidx.legacy:legacy-support-v13:1.0.0'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation "com.google.android.material:material:1.2.1"
 
     implementation "androidx.core:core-ktx:$kotlin_ktx_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -27,7 +27,8 @@ repositories {
 dependencies {
     implementation 'org.apache.commons:commons-text:1.1'
     implementation 'com.android.volley:volley:1.1.1'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.2.1'
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'org.greenrobot:eventbus:3.0.0'
 


### PR DESCRIPTION
This PR updates Material design library to v1.2.1 and swipeToRefreshLayout to v1.1.0.

Related PRs:
- [gutenberg PR](https://github.com/WordPress/gutenberg/pull/26683)
- [stories PR](https://github.com/Automattic/stories-android/pull/600)
I believe we don't need to wait for these PRs and we can merge this PR.

Material:
WPAndroid was using v 1.2.0 through a transitive dependency (navigation-ui-ktx) for some time. The [changelist](https://github.com/material-components/material-components-android/releases/tag/1.2.1) between 1.2.0->1.2.1 is quite short.

SwipeToRefresh:
I also decided to explicitly declare "swipeRefreshLayout" as a dependency and updated it to v1.1.0.

To test:
Smoke test the app - editor, stories, reader, ...
Smoke test pull to refresh


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
