### PR TITLE
Stories: prevent gif files from being added as background for new Story slides

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -725,7 +725,7 @@ public class ActivityLauncher {
             return;
         }
 
-        Intent intent = new Intent(activity, StoryComposerActivity.class);
+            Intent intent = new Intent(activity, StoryComposerActivity.class);
         intent.putExtra(WordPress.SITE, site);
         intent.putExtra(MediaPickerConstants.EXTRA_MEDIA_URIS, mediaUris);
         intent.putExtra(AnalyticsUtils.EXTRA_CREATION_SOURCE_DETAIL, source);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2906,7 +2906,7 @@
     <string name="dialog_edit_story_unavailable_message">Unable to load media for this story. Check your internet connection and try again in a moment.</string>
     <string name="dialog_edit_story_unrecoverable_title">Can\'t edit Story</string>
     <string name="dialog_edit_story_unrecoverable_message">We couldn\'t find the media for this story on the site.</string>
-    <string name="dialog_edit_story_unsupported_format_title">Unsupported format</string>
+    <string name="dialog_edit_story_unsupported_format_title">GIF files not supported</string>
     <string name="dialog_edit_story_unsupported_format_message">Stories don\'t support GIF files at the moment; one or more slides have not been added to your Story. Please choose a static image or video background instead.</string>
     <string name="capture_button_alt">Capture</string>
     <string name="flip_button_alt">Flip camera</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2906,6 +2906,8 @@
     <string name="dialog_edit_story_unavailable_message">Unable to load media for this story. Check your internet connection and try again in a moment.</string>
     <string name="dialog_edit_story_unrecoverable_title">Can\'t edit Story</string>
     <string name="dialog_edit_story_unrecoverable_message">We couldn\'t find the media for this story on the site.</string>
+    <string name="dialog_edit_story_unsupported_format_title">Unsupported format</string>
+    <string name="dialog_edit_story_unsupported_format_message">Stories don\'t support GIF files at the moment; one or more slides have not been added to your Story. Please choose a static image or video background instead.</string>
     <string name="capture_button_alt">Capture</string>
     <string name="flip_button_alt">Flip camera</string>
     <string name="flash_button_alt">Flash</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2907,7 +2907,7 @@
     <string name="dialog_edit_story_unrecoverable_title">Can\'t edit Story</string>
     <string name="dialog_edit_story_unrecoverable_message">We couldn\'t find the media for this story on the site.</string>
     <string name="dialog_edit_story_unsupported_format_title">GIF files not supported</string>
-    <string name="dialog_edit_story_unsupported_format_message">Stories don\'t support GIF files at the moment; one or more slides have not been added to your Story. Please choose a static image or video background instead.</string>
+    <string name="dialog_edit_story_unsupported_format_message">One or more slides have not been added to your Story because Stories don\'t support GIF files at the moment. Please choose a static image or video background instead.</string>
     <string name="capture_button_alt">Capture</string>
     <string name="flip_button_alt">Flip camera</string>
     <string name="flash_button_alt">Flash</string>


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/592: the issue describes vido, but it's actually a gif file what the root cause of the problem was.

When a gif file is attempted to be used as a background for a Story slide, this PR shows this dialog:

<img width="394" alt="Screen Shot 2020-11-04 at 08 37 36" src="https://user-images.githubusercontent.com/6597771/98107271-09d8a080-1e79-11eb-90f5-8ca4f9c60377.png">

(notet: open to suggestions about wording there)

To test:
First of all, make sure to add a gif file to your site's media library using tenor. Go to the media section of the app, press the + button, then select tenor as a source.

CASE A: create a story with 1 slide (gif)
1. create a new story by tapping on the WPAndroid app's main screen FAB -> Story
2. when the picker appears, select the W icon on the right bottom of the screen
3. select the gif file only and tap the ✔️ on the navigation bar
4. observe the story composer appears and then the dialog shows up indicating it's not possible to add gif files as a slide background for now

CASE B: create a story using 1 gif and 1 (or more) normal image / video
1. create a new story by tapping on the WPAndroid app's main screen FAB -> Story
2. when the picker appears, select the W icon on the right bottom of the screen
3. select the gif file and a few other supported files (images / videos) and tap the ✔️ on the navigation bar
4. observe the story composer appears and then the dialog shows up indicating it's not possible to add gif files as a slide background for now, but the Story with the valid slides is kept for you to continue creating
![nogif](https://user-images.githubusercontent.com/6597771/98105206-5f5f7e00-1e76-11eb-96c9-6f25af1d5709.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
