### PR TITLE
[Home Page Picker] Adds Loading Skeleton Animation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.appbar.AppBarLayout
 import kotlinx.android.synthetic.main.home_page_picker_bottom_toolbar.*
 import kotlinx.android.synthetic.main.home_page_picker_fragment.*
+import kotlinx.android.synthetic.main.home_page_picker_loading_skeleton.*
 import kotlinx.android.synthetic.main.home_page_picker_titlebar.*
 import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
 import kotlinx.android.synthetic.main.modal_layout_picker_title_row.*
@@ -48,7 +49,14 @@ class HomePagePickerFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.home_page_picker_fragment, container, false)
+        val view = inflater.inflate(R.layout.home_page_picker_fragment, container, false)
+        val skeletonCardView = view.findViewById<View>(R.id.skeletonCardView)
+        skeletonCardView.minimumHeight = thumbDimensionProvider.height
+        skeletonCardView.minimumWidth = thumbDimensionProvider.width
+        (skeletonCardView.layoutParams as? ViewGroup.MarginLayoutParams)?.let {
+            it.marginStart = thumbDimensionProvider.calculatedStartMargin
+        }
+        return view
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/ThumbDimensionProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/ThumbDimensionProvider.kt
@@ -51,6 +51,13 @@ class ThumbDimensionProvider @Inject constructor(
     val height: Int
         get() = (width / ratio).toInt()
 
+    /**
+     * The start margin can be calculated by dividing the space remaining after placing the thumbnails by two
+     */
+    val calculatedStartMargin: Int
+        get() = (displayUtilsWrapper.getDisplayPixelWidth() -
+                ((columns * width) + ((columns - 1) * getPixels(dimen.hpp_card_padding)))) / 2
+
     val scale: Double = 1.0
 
     private fun getPixels(@DimenRes id: Int) = contextProvider.getContext().resources.getDimensionPixelSize(id)

--- a/WordPress/src/main/res/layout/home_page_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_fragment.xml
@@ -55,11 +55,11 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <ProgressBar
-        android:id="@+id/loadingIndicator"
-        android:layout_width="wrap_content"
+    <include
+        layout="@layout/home_page_picker_loading_skeleton"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/layoutsRecyclerView"
@@ -69,6 +69,7 @@
         android:layout_gravity="center|top"
         android:paddingStart="@dimen/hpp_card_padding"
         android:paddingEnd="0dp"
+        android:paddingBottom="@dimen/toolbar_height"
         android:background="?attr/categoriesBackground"
         android:clipToPadding="false"
         android:descendantFocusability="beforeDescendants"

--- a/WordPress/src/main/res/layout/home_page_picker_loading_skeleton.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_loading_skeleton.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.facebook.shimmer.ShimmerFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/loadingIndicator"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/margin_medium"
+    android:background="?attr/categoriesBackground"
+    app:shimmer_base_alpha="@dimen/skeleton_shimmer_base_alpha"
+    app:shimmer_highlight_alpha="@dimen/skeleton_shimmer_highlight_alpha">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/skeletonCardView"
+        style="@style/LayoutCardView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/mlp_layout_card_margin_start"
+        android:layout_marginTop="@dimen/margin_medium"
+        app:cardBackgroundColor="?attr/categoriesButtonBackground">
+
+    </com.google.android.material.card.MaterialCardView>
+
+</com.facebook.shimmer.ShimmerFrameLayout>


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2718

## Description

This PR adds an animated skeleton view while the layouts are loading

*Internal design reference: pb3aDo-xN*

## To test:

<details>
<summary><strong>To disable or enable the development version of Home Page Picker</strong></summary>

- Open the app from the build that allows FeatureFlags such as a PR build or a local development build
    - By default, the modal layout picker is enabled only in development builds.
    - From the site page:
        - Click on your Gravatar.
        - Click on App Settings.
        - Click on Test feature configuration.
        - Toggle "HomePagePickerFeatureConfig" to enable or disable the picker
        - Restart the App
</details>

1. Start the site creation flow (e.g. *Choose site > Add button*)
1. Select the *Create WordPress.com site* option
1. Wait for the data to load
1. Expect to see as skeleton view while the data are loading

## Screenshot

|Animation|Dark mode|
|---|---|
|![ani](https://user-images.githubusercontent.com/304044/98112908-8be1bd00-1eab-11eb-8743-ed2a6c548db2.gif)|![device-2020-11-04-142754](https://user-images.githubusercontent.com/304044/98112902-8ab09000-1eab-11eb-82a2-bf6ac1ede357.png)|

|Landscape|
|---|
|![device-2020-11-04-142715](https://user-images.githubusercontent.com/304044/98112897-88e6cc80-1eab-11eb-873a-9e8f2334ac40.png)|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
