### PR TITLE
Update photo view version

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -227,7 +227,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-auth:18.1.0'
     implementation 'com.google.android.gms:play-services-places:17.0.0'
     implementation 'com.android.installreferrer:installreferrer:1.0'
-    implementation 'com.github.chrisbanes.photoview:library:1.2.4'
+    implementation 'com.github.chrisbanes:PhotoView:2.3.0'
     implementation 'org.greenrobot:eventbus:3.1.1'
     implementation ('com.automattic:rest:1.0.8') {
         exclude group: 'com.mcxiaoke.volley'

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -9,7 +9,6 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 import android.widget.ImageView.ScaleType;
 import android.widget.MediaController;
 import android.widget.TextView;
@@ -18,6 +17,9 @@ import android.widget.VideoView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
+import com.github.chrisbanes.photoview.PhotoView;
+import com.github.chrisbanes.photoview.PhotoViewAttacher;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -37,8 +39,6 @@ import org.wordpress.android.util.image.ImageManager.RequestListener;
 import org.wordpress.android.util.image.ImageType;
 
 import javax.inject.Inject;
-
-import uk.co.senab.photoview.PhotoViewAttacher;
 
 public class MediaPreviewFragment extends Fragment implements MediaController.MediaPlayerControl {
     public static final String TAG = "media_preview_fragment";
@@ -65,7 +65,7 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
 
     private SiteModel mSite;
 
-    private ImageView mImageView;
+    private PhotoView mImageView;
     private VideoView mVideoView;
     private ViewGroup mVideoFrame;
     private ViewGroup mAudioFrame;
@@ -300,10 +300,7 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
                     @Override
                     public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
                         if (isAdded()) {
-                            // assign the photo attacher to enable pinch/zoom - must come before
-                            // setImageBitmap
-                            // for it to be correctly resized upon loading
-                            PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
+                            PhotoViewAttacher attacher = mImageView.getAttacher();
                             attacher.setOnViewTapListener((view, x, y) -> {
                                 if (mMediaTapListener != null) {
                                     mMediaTapListener.onMediaTapped();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
@@ -5,7 +5,6 @@ import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 import android.widget.ImageView.ScaleType;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
@@ -14,6 +13,9 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.github.chrisbanes.photoview.PhotoView;
+import com.github.chrisbanes.photoview.PhotoViewAttacher;
+
 import org.wordpress.android.R;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
@@ -21,8 +23,6 @@ import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageManager.RequestListener;
 import org.wordpress.android.util.image.ImageType;
-
-import uk.co.senab.photoview.PhotoViewAttacher;
 
 /**
  * used by ReaderPhotoViewerActivity to show full-width images - based on Volley's ImageView
@@ -37,7 +37,7 @@ public class ReaderPhotoView extends RelativeLayout {
     private String mLoResImageUrl;
     private String mHiResImageUrl;
 
-    private final ImageView mImageView;
+    private final PhotoView mImageView;
     private final ProgressBar mProgress;
     private final TextView mTxtError;
     private boolean mIsInitialLayout = true;
@@ -134,25 +134,19 @@ public class ReaderPhotoView extends RelativeLayout {
         hideProgress();
         hideError();
         // attach the pinch/zoom handler
-        setAttacher();
+        setupOnTapListeners();
     }
 
-    private void setAttacher() {
-        PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
-        attacher.setOnPhotoTapListener(new PhotoViewAttacher.OnPhotoTapListener() {
-            @Override
-            public void onPhotoTap(View view, float v, float v2) {
-                if (mPhotoViewListener != null) {
-                    mPhotoViewListener.onTapPhotoView();
-                }
+    private void setupOnTapListeners() {
+        PhotoViewAttacher attacher = mImageView.getAttacher();
+        attacher.setOnPhotoTapListener((view, v, v2) -> {
+            if (mPhotoViewListener != null) {
+                mPhotoViewListener.onTapPhotoView();
             }
         });
-        attacher.setOnViewTapListener(new PhotoViewAttacher.OnViewTapListener() {
-            @Override
-            public void onViewTap(View view, float v, float v2) {
-                if (mPhotoViewListener != null) {
-                    mPhotoViewListener.onTapPhotoView();
-                }
+        attacher.setOnViewTapListener((view, v, v2) -> {
+            if (mPhotoViewListener != null) {
+                mPhotoViewListener.onTapPhotoView();
             }
         });
     }

--- a/WordPress/src/main/res/layout/media_preview_fragment.xml
+++ b/WordPress/src/main/res/layout/media_preview_fragment.xml
@@ -58,7 +58,7 @@
 
     </RelativeLayout>
 
-    <ImageView
+    <com.github.chrisbanes.photoview.PhotoView
         android:id="@+id/image_preview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/WordPress/src/main/res/layout/reader_photo_view.xml
+++ b/WordPress/src/main/res/layout/reader_photo_view.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ImageView
+    <com.github.chrisbanes.photoview.PhotoView
         android:id="@+id/image_photo"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
Updates PhotoView library version from 1.2.4 to 2.3.0. We need to update from 1.2.4 so we can disable jetifier in the future.

Before this change we'd manually attach PhotoViewAttacher to an ImageView. This approach isn't supported anymore, so I replaced ImageViews with PhotoView which seems to work just fine.

There shouldn't be any user facing changes.

To test:
1. Open Reader
2. Open a post with a photo
3. Click on the photo and make sure the fullscreen image loads correctly and that you can "pinch zoom"
------------
1. Open My Site
2. Open Media Library
3. Open media detail
4. Click on the image
5. make sure the fullscreen image loads correctly and that you can "pinch zoom"

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
