### PR TITLE
Update shimmer effect library to 0.5.0

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -238,7 +238,7 @@ dependencies {
     implementation 'com.squareup.okio:okio:2.8.0'
     implementation 'org.apache.commons:commons-text:1.1'
     implementation 'com.airbnb.android:lottie:3.0.7'
-    implementation 'com.facebook.shimmer:shimmer:0.4.0'
+    implementation 'com.facebook.shimmer:shimmer:0.5.0'
 
     implementation ("com.github.yalantis:ucrop:$uCropVersion") {
         exclude group: 'com.squareup.okhttp3'


### PR DESCRIPTION
This PR updates Shimmer Effect library from 0.4.0 to 0.5.0. We need to update it so we can drop jetifier in the future.

There shouldn't be any user facing changes.

To test:
1. Slow down internet connection on your emulator
2. Open My Site
3. Create a new page
4. Make sure the shimmer effect works on the skeleton view
5. Go back
6. Open post list
7. Make sure the shimmer effect works on the row skeleton views (you might need to clear app data if you have all posts in cache)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
