### PR TITLE
WP Stories : Prepublishing fragment container no longer cut off by nav bar in Android 10

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.posts
 
 import android.content.Context
 import android.content.DialogInterface
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.LayoutInflater
@@ -107,11 +109,26 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
             }
         }
         setupMinimumHeightForFragmentContainer()
+        addWindowInsetToFragmentContainer()
     }
 
     override fun onDismiss(dialog: DialogInterface) {
         analyticsTrackerWrapper.track(Stat.PREPUBLISHING_BOTTOM_SHEET_DISMISSED)
         super.onDismiss(dialog)
+    }
+
+    /**
+     * On Android 10, the bottom sheet is not above the window inset so that leads to the publish button being cut
+     * off. To fix this, we add the bottom inset as the margin bottom of the fragment container.
+     */
+    private fun addWindowInsetToFragmentContainer() {
+        if (VERSION.SDK_INT == VERSION_CODES.Q) {
+            activity?.window?.decorView?.rootWindowInsets?.systemWindowInsetBottom?.let { bottomInset ->
+                val param = prepublishing_content_fragment.layoutParams as ViewGroup.MarginLayoutParams
+                param.setMargins(0, 0, 0, bottomInset)
+                prepublishing_content_fragment.layoutParams = param
+            }
+        }
     }
 
     private fun setupMinimumHeightForFragmentContainer() {


### PR DESCRIPTION
Fixes # https://github.com/Automattic/stories-android/issues/537

## Findings

In Android 10, the bottom insets are not applied to the bottom sheet/fragment container. However, we are able to access the insets via `systemWindowInsetBottom` and dynamically adjust our layout so it sits on top of the navigation bar. 

## Solution
We get the `systemWindowInsetBottom` and we apply this as the `marginBottom` of our `fragmentContainer` so that the submit button no longer gets cut off.

**Note :** Within the attached [issue](https://github.com/Automattic/stories-android/issues/537) there is another keyboard bug where the story title focusing does not open the keyboard. 
That is when the keyboard is covering the view in its entirety. I think this solution might not be a fix for that specific issue and I will try to reproduce it in a clean branch and resolve it. Screenshot below. 

<kbd><img src="https://user-images.githubusercontent.com/1509205/98307533-ef471a00-1f93-11eb-97ad-23a630bff129.png" width="320"></kbd>




## Testing

### Android 10 

1. Create a story post on an Android 10/ API 29 device. 
2. Click Next. 
3. Observe that the publish button is no longer cut off.

Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/98307182-308afa00-1f93-11eb-9d34-2b9392fcee08.png" width="320"></kbd> |    <kbd><img src="https://user-images.githubusercontent.com/1509205/98307201-3bde2580-1f93-11eb-8c08-c76786675057.png" width="320"></kbd>

Before | After 
--------|-------
 <kbd><img src="https://user-images.githubusercontent.com/1509205/98307190-3385ea80-1f93-11eb-8a22-32879dae7a49.png" width="320"></kbd>   |    <kbd><img src="https://user-images.githubusercontent.com/1509205/98307208-3ed91600-1f93-11eb-8e6f-9679cf5af8cd.png" width="320"></kbd>
      
-----------------
### Other versions of Android 

1. Create a story post on an Android 10/ API 29 device. 
2. Click Next. 
3. Observe that the publish button is not cut off and the margin of the fragment container has not been changed.

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 