### PR TITLE
Prepublishing bottom sheet : fixed an issue where the keyboard overlays fragment container

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/KeyboardResizeViewUtil.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/KeyboardResizeViewUtil.java
@@ -35,30 +35,32 @@ public class KeyboardResizeViewUtil {
     ViewTreeObserver.OnGlobalLayoutListener mOnGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
         @Override
         public void onGlobalLayout() {
-            Rect r = new Rect();
-            // r will be populated with the coordinates of your view that area still visible.
-            mDecorView.getWindowVisibleDisplayFrame(r);
+            mContentView.post(() -> {
+                Rect r = new Rect();
+                // r will be populated with the coordinates of your view that area still visible.
+                mDecorView.getWindowVisibleDisplayFrame(r);
 
-            // get screen height and calculate the difference with the useable area from the r
-            int height = mDecorView.getContext().getResources().getDisplayMetrics().heightPixels;
-            int diff = height - r.bottom;
+                // get screen height and calculate the difference with the useable area from the r
+                int height = mDecorView.getContext().getResources().getDisplayMetrics().heightPixels;
+                int diff = height - r.bottom;
 
-            // if it could be a keyboard add the padding to the view
-            if (diff != 0) {
-                // if the use-able screen height differs from the total screen height we assume that it shows a
-                // keyboard now
-                // check if the padding is 0 (if yes set the padding for the keyboard)
-                if (mContentView.getPaddingBottom() != diff) {
-                    // set the padding of the contentView for the keyboard
-                    mContentView.setPadding(0, 0, 0, diff);
+                // if it could be a keyboard add the padding to the view
+                if (diff != 0) {
+                    // if the use-able screen height differs from the total screen height we assume that it shows a
+                    // keyboard now
+                    // check if the padding is 0 (if yes set the padding for the keyboard)
+                    if (mContentView.getPaddingBottom() != diff) {
+                        // set the padding of the contentView for the keyboard
+                        mContentView.setPadding(0, 0, 0, diff);
+                    }
+                } else {
+                    // check if the padding is != 0 (if yes reset the padding)
+                    if (mContentView.getPaddingBottom() != 0) {
+                        // reset the padding of the contentView
+                        mContentView.setPadding(0, 0, 0, 0);
+                    }
                 }
-            } else {
-                // check if the padding is != 0 (if yes reset the padding)
-                if (mContentView.getPaddingBottom() != 0) {
-                    // reset the padding of the contentView
-                    mContentView.setPadding(0, 0, 0, 0);
-                }
-            }
+            });
         }
     };
 }


### PR DESCRIPTION
Fixes #13299 

## Findings
The `KeyboardResizeViewUtil` is a layout hack used to add padding to a container layout's padding-bottom since we can't use the `adjustResize` of `android:windowSoftInputMode ` because the `StoryComposerActivity` is full screen. It seems the issue arises when the `OnGlobalLayoutListener` within the `KeyboardResizeViewUtil` is called and the `contentView` is not ready as yet hence the padding is not set.
 
## Solution

I thought of this solution because the property of a view not being set and reflected is a common occurrence when the main thread is handling a lot of work and these properties are modified before the view is properly attached to the window. So my solution is to utilize the `contentView.post` method so that we can queue the padding changes being applied on the `contentView`'s message loop, so once the view gets attached to the window, the padding will go into effect. 

## Testing
1. Create a new story post. 
2. Press the Next button multiple times after closing the bottom sheet and it will never overlap the content.

Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/98314661-77cdb680-1fa4-11eb-8a22-c1b812d9257c.gif" width="320"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/1509205/98314559-3b9a5600-1fa4-11eb-8283-42fd840d6dd3.gif" width="320"></kbd>

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 