### PR TITLE
Update out-dated checkstyle ide configuration instructions

### DIFF
--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -25,7 +25,7 @@ You can install the CheckStyle-IDEA plugin in Android Studio here:
 
 Once installed, you can configure the plugin here:
 
-`Android Studio > Preferences... > Other Settings > Checkstyle`
+`Android Studio > Preferences... > Tools > Checkstyle`
 
 From there, add and enable the custom configuration file, located at [config/checkstyle.xml](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/config/checkstyle.xml).
 


### PR DESCRIPTION
This PR updates the out-dated checkstyle IDE configuration instructions.

⚠️ Note that this exact change most probably needs to happen on all the Android related repos that mention the exact same `CheckStyle` related configuration instructions (like [WordPress-FluxC-Android](https://github.com/wordpress-mobile/WordPress-FluxC-Android)). A quick search within `WordPress Mobile` on all the `android` related repos revealed that the only repo that contains this very same steps of instructions is `FluxC`. As such, it shouldn't be much as an update. However, and so that we avoid this kind of change in the future I would also suggest to remove these specific two lines from the `CheckStyle` instructions since they are too specific. Most developers are aware of `Android Studio` and how to search for a configuration, there is no need to explicitly guide them to it, especially when `Preferences` is continuously evolving its inner structure.

To test:
- N/A

PR submission checklist:
- N/A