### PR TITLE
Rename prod deps gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,9 +206,9 @@ task applyCredentials(type:Exec, dependsOn:checkBundle) {
     }
 }
 
-tasks.register("prodDeps") {
+tasks.register("configureApply") {
     group = 'Onboarding'
-    description = 'Install dependencies for production builds'
+    description = 'Install dependencies for debug and production builds'
     dependsOn applyCredentials
     doLast {
         println("Done")


### PR DESCRIPTION
This PR renames the `prodDeps` Gradle task to something more suited and consistent. This task's name and description are both renamed to make sure that those are consistent with the iOS task and also descriptive enough so that developers can understand that it can also be used to configure debug builds.

The name `prodDeps` for this Gradle task is a bit confusing for developers since it might look like it can only be used for configuring production builds. However, this task can also be used for configuring debug builds by installing some extra dependencies. Also, the same task on iOS is called `configure_apply`, which doesn't help with consistency.

⚠️ When this PR gets merged with `develop` it is suggested that its corresponding [P2](https://androidp2.wordpress.com/2020/05/06/introducing-the-shared-android-debug-certificate-for-development/) instructions get updated with the new task name.

To test:
- Follow the instructions in this 

PR submission checklist:
- N/A