### PR TITLE
Stories: updated stories library

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -396,6 +396,11 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         viewModel.onStoryDiscarded()
     }
 
+    override fun onFrameRemove(storyIndex: StoryIndex, storyFrameIndex: Int) {
+        // no op
+        // TODO this will be implemented after the Story block support lands in develop
+    }
+
     private fun openPrepublishingBottomSheet() {
         val fragment = supportFragmentManager.findFragmentByTag(PrepublishingBottomSheetFragment.TAG)
         if (fragment == null) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2956,7 +2956,6 @@
     <string name="label_frame_errored">errored</string>
     <string name="label_text_alignment_button">Change text alignment</string>
     <string name="label_text_color_button">Change text color</string>
-    <string name="menu_delete_page">Delete slide</string>
     <string name="dialog_discard_page_title">Delete story slide?</string>
     <string name="dialog_discard_page_message">This slide will be removed from your story.</string>
     <string name="dialog_discard_errored_page_message">This slide has not been saved yet. If you delete this slide, you will lose any edits you have made.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2937,7 +2937,6 @@
     <string name="flip_button_alt">Flip camera</string>
     <string name="flash_button_alt">Flash</string>
     <string name="stickers_button_alt">Stickers</string>
-    <string name="more_button_alt">More</string>
     <string name="text_button_alt">Text</string>
     <string name="sound_button_alt">Sound</string>
     <string name="label_control_flip_camera">Flip</string>
@@ -2948,8 +2947,6 @@
     <string name="label_snackbar_loop_frame_saved">Saved to photos</string>
     <string name="label_snackbar_share">SHARE</string>
     <string name="label_share_to">Share to</string>
-    <string name="label_done">Done</string>
-    <string name="label_control_publish">Next</string>
     <string name="label_close_button">Close</string>
     <string name="label_saved_icon">Saved</string>
     <string name="label_retry_icon">Retry</string>


### PR DESCRIPTION
This PR just bumps the stories library so https://github.com/wordpress-mobile/WordPress-Android/pull/12973 and https://github.com/Automattic/stories-android/pull/540 can be brought up to date and get merged ASAP cc @planarvoid 

To test:
N/A just verify WPAndroid builds

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
