### PR TITLE
Exclude support-annotations dependency from zendesk to skip jetifier

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -327,6 +327,7 @@ dependencies {
 
     implementation (group: 'com.zendesk', name: 'support', version: '5.0.1') {
         exclude group: 'com.google.dagger'
+        exclude group: 'com.android.support', module: 'support-annotations'
     }
 
     implementation 'com.github.Tenor-Inc:tenor-android-core:0.5.1'


### PR DESCRIPTION
This PR excludes support-annotations from the Zendesk dependency. It's the only dependency in zendesk which requires Jetifier. I believe we can simply drop it since support-annotations is used just for code inspection.

To test:
1. Smoke test Zendesk in the app

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
