### PR TITLE
Fix CI for release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -635,28 +635,28 @@ workflows:
           requires: [gutenberg-bundle-build]
       - promo-screenshots:
           requires: [raw-screenshots]
-#  Release Build:
-#    unless: << pipeline.parameters.translation_review_build >>
-#    jobs:
-#      - gutenberg-bundle-build:
-#          filters:
-#            branches:
-#              ignore: /.*/
-#            tags:
-#              only: /^\d+(\.\d+)*(-rc-\d)?$/
-#      - lint:
-#          requires:
-#            - gutenberg-bundle-build
-#          filters:
-#            branches:
-#              ignore: /.*/
-#            tags:
-#              only: /^\d+(\.\d+)*(-rc-\d)?$/
-#      - Release Build:
-#          requires:
-#            - lint 
-#          filters:
-#            branches:
-#              ignore: /.*/
-#            tags:
-#              only: /^\d+(\.\d+)*(-rc-\d)?$/
+  Release Build:
+    unless: << pipeline.parameters.translation_review_build >>
+    jobs:
+      - gutenberg-bundle-build:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+(\.\d+)*(-rc-\d)?$/
+      - lint:
+          requires:
+            - gutenberg-bundle-build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+(\.\d+)*(-rc-\d)?$/
+      - Release Build:
+          requires:
+            - lint 
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+(\.\d+)*(-rc-\d)?$/

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -54,9 +54,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "alpha-254"
+            versionName "alpha-255"
         }
-        versionCode 948
+        versionCode 950
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
@@ -93,9 +93,9 @@ android {
             dimension "buildType"
             // Only set the release version if one isn't provided
             if (!project.hasProperty("versionName")) {
-                versionName "16.1-rc-1"
+                versionName "16.1-rc-2"
             }
-            versionCode 947
+            versionCode 949
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "boolean", "TENOR_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -544,7 +544,7 @@ ENV["validate_translations"]="lintVanillaRelease"
     # Build
     Dir.chdir("..") do
       sh("mkdir -p #{build_dir}")
-      unless (is_ci) then 
+      unless is_ci
         # We pre-build the Gutenberg RN bundle on a different job on CI,  
         # so cleaning here breaks the build 
         UI.message("Cleaning branch...")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -544,9 +544,13 @@ ENV["validate_translations"]="lintVanillaRelease"
     # Build
     Dir.chdir("..") do
       sh("mkdir -p #{build_dir}")
-      UI.message("Cleaning branch...")
-      sh("echo \"Cleaning branch\" >> #{logfile_path}")
-      sh("./gradlew clean >> #{logfile_path} 2>&1")
+      unless (is_ci) then 
+        # We pre-build the Gutenberg RN bundle on a different job on CI,  
+        # so cleaning here breaks the build 
+        UI.message("Cleaning branch...")
+        sh("echo \"Cleaning branch\" >> #{logfile_path}")
+        sh("./gradlew clean >> #{logfile_path} 2>&1")
+      end 
       sh("mkdir -p #{build_dir}")
       UI.message("Running lint...")
       sh("echo \"Running lint...\" >> #{logfile_path}")


### PR DESCRIPTION
This PR restores builds on CI for WordPress Android which have been disabled in https://github.com/wordpress-mobile/WordPress-Android/pull/12928 because of some issues with Gutenberg. 

I investigated the issues and figured out that the issue was that on CI we need to split the build in different jobs, but the last job used to clean up the repository, deleting the Gutenberg artifact. For some reasons, the build doesn't fail when this happens 😅

This PR updates the `build_bundle` lane to skip the repository cleaning on CI (since CI uses a new container on every build, this should be safe)

To test:
Testing this isn't easy and testing on a test branch fouled us last time, probably because the patches we have to apply to make it work hid the issue. 
So, this time I'm trying a different strategy and I built the latest beta build of WPAndroid out of this branch, which is the release branch + only the changes needed to re-enable the CI build. 
This is far from ideal, but I haven't had a better idea (I'm open to suggestions here :-) ) 

The related CI job is here: https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/17982/workflows/d1ed9a17-a209-48c8-ba96-218ff981301b
and the artifacts are available on the alpha and beta channels.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
