### PR TITLE
Featured image not showing on http pure self-hosted sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 16.2
 -----
- 
+* [*] Posts List: fixed bug that prevented showing the Featured Image of a post for pure self-hosted sites [https://github.com/wordpress-mobile/WordPress-Android/pull/13323]
+
 16.1
 -----
 * [***] Block Editor: Adds new option to select from a variety of predefined page templates when creating a new page for a Gutenberg site.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
@@ -169,8 +169,7 @@ class FeaturedImageHelper @Inject constructor(
                 mediaUri,
                 maxDimen,
                 maxDimen,
-                !siteUtilsWrapper.isPhotonCapable(site),
-                site.isPrivateWPComAtomic
+                siteUtilsWrapper.getAccessibilityInfoFromSite(site)
         )
         return FeaturedImageData(FeaturedImageState.REMOTE_IMAGE_LOADING, photonUrl)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -70,9 +70,20 @@ public class ReaderUtils {
         final String unescapedUrl = StringEscapeUtils.unescapeHtml4(imageUrl);
 
         if (siteAccessibilityInfo.isPhotonCapable()) {
-            return PhotonUtils.getPhotonImageUrl(unescapedUrl, width, height, quality, siteAccessibilityInfo.getSiteVisibility() == SiteVisibility.PRIVATE_ATOMIC);
+            return PhotonUtils.getPhotonImageUrl(
+                    unescapedUrl,
+                    width,
+                    height,
+                    quality,
+                    siteAccessibilityInfo.getSiteVisibility() == SiteVisibility.PRIVATE_ATOMIC
+            );
         } else {
-            return getImageForDisplayWithoutPhoton(unescapedUrl, width, height, siteAccessibilityInfo.getSiteVisibility() == SiteVisibility.PRIVATE);
+            return getImageForDisplayWithoutPhoton(
+                    unescapedUrl,
+                    width,
+                    height,
+                    siteAccessibilityInfo.getSiteVisibility() == SiteVisibility.PRIVATE
+            );
         }
     }
 
@@ -81,7 +92,12 @@ public class ReaderUtils {
      * (i.e. a private post - images in private posts can't use photon
      * but these are usually wp images so they support the h= and w= query params)
      */
-    private static String getImageForDisplayWithoutPhoton(final String imageUrl, int width, int height, boolean forceHttps) {
+    private static String getImageForDisplayWithoutPhoton(
+            final String imageUrl,
+            int width,
+            int height,
+            boolean forceHttps
+    ) {
         if (TextUtils.isEmpty(imageUrl)) {
             return "";
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -49,17 +49,39 @@ public class ReaderUtils {
 
 
         if (isPrivate && !isPrivateAtomic) {
-            return getPrivateImageForDisplay(unescapedUrl, width, height);
+            return getImageForDisplayWithoutPhoton(unescapedUrl, width, height, true);
         } else {
             return PhotonUtils.getPhotonImageUrl(unescapedUrl, width, height, quality, isPrivateAtomic);
         }
     }
 
+    public static String getResizedImageUrl(final String imageUrl,
+                                            int width,
+                                            int height,
+                                            SiteAccessibilityInfo siteAccessibilityInfo) {
+        return getResizedImageUrl(imageUrl, width, height, siteAccessibilityInfo, PhotonUtils.Quality.MEDIUM);
+    }
+
+    public static String getResizedImageUrl(final String imageUrl,
+                                            int width,
+                                            int height,
+                                            SiteAccessibilityInfo siteAccessibilityInfo,
+                                            PhotonUtils.Quality quality) {
+        final String unescapedUrl = StringEscapeUtils.unescapeHtml4(imageUrl);
+
+        if (siteAccessibilityInfo.isPhotonCapable()) {
+            return PhotonUtils.getPhotonImageUrl(unescapedUrl, width, height, quality, siteAccessibilityInfo.getSiteVisibility() == SiteVisibility.PRIVATE_ATOMIC);
+        } else {
+            return getImageForDisplayWithoutPhoton(unescapedUrl, width, height, siteAccessibilityInfo.getSiteVisibility() == SiteVisibility.PRIVATE);
+        }
+    }
+
     /*
-     * use this to request a reduced size image from a private post - images in private posts can't
-     * use photon but these are usually wp images so they support the h= and w= query params
+     * use this to request a reduced size image from not photon capable sites
+     * (i.e. a private post - images in private posts can't use photon
+     * but these are usually wp images so they support the h= and w= query params)
      */
-    private static String getPrivateImageForDisplay(final String imageUrl, int width, int height) {
+    private static String getImageForDisplayWithoutPhoton(final String imageUrl, int width, int height, boolean forceHttps) {
         if (TextUtils.isEmpty(imageUrl)) {
             return "";
         }
@@ -74,8 +96,14 @@ public class ReaderUtils {
         } else {
             query = "";
         }
-        // remove the existing query string, add the new one, and make sure the url is https:
-        return UrlUtils.removeQuery(UrlUtils.makeHttps(imageUrl)) + query;
+
+        if (forceHttps) {
+            // remove the existing query string, add the new one, and make sure the url is https:
+            return UrlUtils.removeQuery(UrlUtils.makeHttps(imageUrl)) + query;
+        } else {
+            // remove the existing query string, add the new one
+            return UrlUtils.removeQuery(imageUrl) + query;
+        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
@@ -22,8 +22,12 @@ class ReaderUtilsWrapper @Inject constructor(
     fun getResizedImageUrl(imageUrl: String?, width: Int, height: Int, isPrivate: Boolean, isAtomic: Boolean): String? =
             ReaderUtils.getResizedImageUrl(imageUrl, width, height, isPrivate, isAtomic)
 
-    fun getResizedImageUrl(imageUrl: String?, width: Int, height: Int, siteAccessibilityInfo: SiteAccessibilityInfo): String? =
-            ReaderUtils.getResizedImageUrl(imageUrl, width, height, siteAccessibilityInfo)
+    fun getResizedImageUrl(
+        imageUrl: String?,
+        width: Int,
+        height: Int,
+        siteAccessibilityInfo: SiteAccessibilityInfo
+    ): String? = ReaderUtils.getResizedImageUrl(imageUrl, width, height, siteAccessibilityInfo)
 
     fun getTagFromTagName(tagName: String, tagType: ReaderTagType): ReaderTag =
             ReaderUtils.getTagFromTagName(tagName, tagType)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
@@ -22,6 +22,9 @@ class ReaderUtilsWrapper @Inject constructor(
     fun getResizedImageUrl(imageUrl: String?, width: Int, height: Int, isPrivate: Boolean, isAtomic: Boolean): String? =
             ReaderUtils.getResizedImageUrl(imageUrl, width, height, isPrivate, isAtomic)
 
+    fun getResizedImageUrl(imageUrl: String?, width: Int, height: Int, siteAccessibilityInfo: SiteAccessibilityInfo): String? =
+            ReaderUtils.getResizedImageUrl(imageUrl, width, height, siteAccessibilityInfo)
+
     fun getTagFromTagName(tagName: String, tagType: ReaderTagType): ReaderTag =
             ReaderUtils.getTagFromTagName(tagName, tagType)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/SiteAccessibilityInfo.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/SiteAccessibilityInfo.kt
@@ -1,0 +1,9 @@
+package org.wordpress.android.ui.reader.utils
+
+enum class SiteVisibility {
+    PRIVATE,
+    PRIVATE_ATOMIC,
+    PUBLIC
+}
+
+data class SiteAccessibilityInfo(val siteVisibility: SiteVisibility, val isPhotonCapable: Boolean)

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -5,6 +5,7 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -16,6 +17,8 @@ import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorForAllSi
 import org.wordpress.android.fluxc.store.SiteStore.DesignateMobileEditorPayload;
 import org.wordpress.android.ui.plans.PlansConstants;
 import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.ui.reader.utils.SiteAccessibilityInfo;
+import org.wordpress.android.ui.reader.utils.SiteVisibility;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
 import org.wordpress.android.util.helpers.Version;
@@ -244,6 +247,20 @@ public class SiteUtils {
     public static String getSiteIconUrl(SiteModel site, int size) {
         return PhotonUtils.getPhotonImageUrl(site.getIconUrl(), size, size, PhotonUtils.Quality.HIGH,
                 site.isPrivateWPComAtomic());
+    }
+
+    public static SiteAccessibilityInfo getAccessibilityInfoFromSite(@NotNull SiteModel site) {
+        SiteVisibility siteVisibility;
+
+        if (site.isPrivateWPComAtomic()) {
+            siteVisibility = SiteVisibility.PRIVATE_ATOMIC;
+        } else if (site.isPrivate()) {
+            siteVisibility = SiteVisibility.PRIVATE;
+        } else {
+            siteVisibility = SiteVisibility.PUBLIC;
+        }
+
+        return new SiteAccessibilityInfo(siteVisibility, isPhotonCapable(site));
     }
 
     public static ArrayList<Integer> getCurrentSiteIds(SiteStore siteStore, boolean selfhostedOnly) {

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.util
 
 import dagger.Reusable
+import org.jetbrains.annotations.NotNull
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.reader.utils.SiteAccessibilityInfo
 import javax.inject.Inject
 
 /**
@@ -14,4 +16,6 @@ import javax.inject.Inject
 @Reusable
 class SiteUtilsWrapper @Inject constructor() {
     fun isPhotonCapable(site: SiteModel): Boolean = SiteUtils.isPhotonCapable(site)
+    fun getAccessibilityInfoFromSite(site: SiteModel): SiteAccessibilityInfo
+            = SiteUtils.getAccessibilityInfoFromSite(site)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.util
 
 import dagger.Reusable
-import org.jetbrains.annotations.NotNull
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.reader.utils.SiteAccessibilityInfo
 import javax.inject.Inject
@@ -16,6 +15,6 @@ import javax.inject.Inject
 @Reusable
 class SiteUtilsWrapper @Inject constructor() {
     fun isPhotonCapable(site: SiteModel): Boolean = SiteUtils.isPhotonCapable(site)
-    fun getAccessibilityInfoFromSite(site: SiteModel): SiteAccessibilityInfo
-            = SiteUtils.getAccessibilityInfoFromSite(site)
+    fun getAccessibilityInfoFromSite(site: SiteModel): SiteAccessibilityInfo =
+            SiteUtils.getAccessibilityInfoFromSite(site)
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -395,8 +395,7 @@ class PostListViewModel @Inject constructor(
                     featuredImageUrl,
                     photonWidth,
                     photonHeight,
-                    !SiteUtils.isPhotonCapable(connector.site),
-                    connector.site.isPrivateWPComAtomic
+                    SiteUtils.getAccessibilityInfoFromSite(connector.site)
             )
 
     fun updateAuthorFilterIfNotSearch(authorFilterSelection: AuthorFilterSelection): Boolean {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
@@ -14,7 +14,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.junit.MockitoJUnitRunner

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.posts
 
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.argumentCaptor
@@ -29,6 +30,7 @@ import org.wordpress.android.fluxc.store.UploadStore
 import org.wordpress.android.ui.posts.FeaturedImageHelper.EnqueueFeaturedImageResult
 import org.wordpress.android.ui.posts.FeaturedImageHelper.FeaturedImageState
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.reader.utils.SiteAccessibilityInfo
 import org.wordpress.android.ui.uploads.UploadServiceFacade
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.SiteUtilsWrapper
@@ -43,12 +45,14 @@ class FeaturedImageHelperTest {
     private val readerUtilsWrapper: ReaderUtilsWrapper = mock()
     private val fluxCUtilsWrapper: FluxCUtilsWrapper = mock()
     private val siteUtilsWrapper: SiteUtilsWrapper = mock()
+    private val siteAccessibilityInfo: SiteAccessibilityInfo = mock()
     private val dispatcher: Dispatcher = mock()
 
     private lateinit var featuredImageHelper: FeaturedImageHelper
 
     @Before
     fun setUp() {
+        whenever(siteUtilsWrapper.getAccessibilityInfoFromSite(any())).thenReturn(siteAccessibilityInfo)
         featuredImageHelper = FeaturedImageHelper(
                 uploadStore,
                 mediaStore,
@@ -318,8 +322,7 @@ class FeaturedImageHelperTest {
                 eq("https://testing.com/url.jpg"),
                 anyInt(),
                 anyInt(),
-                anyBoolean(),
-                anyBoolean()
+                eq(siteAccessibilityInfo)
         )
     }
 
@@ -344,8 +347,7 @@ class FeaturedImageHelperTest {
                 "https://testing.com/thumbnail.jpg"),
                 anyInt(),
                 anyInt(),
-                anyBoolean(),
-                anyBoolean()
+                eq(siteAccessibilityInfo)
         )
     }
 


### PR DESCRIPTION
Fixes #9939

This PR fixes an issue with posts list not showing featured images for pure self-hosted sites on http (https worked well already). Basically we were overlapping the concept of being a site private with that of being photon capable. For a bit more context you can see this [comment](https://github.com/wordpress-mobile/WordPress-Android/issues/9939#issuecomment-598108469). I created a `SiteAccessibilityInfo` class an overload of the `getResizedImageUrl` function that tries to decouple site visibility from photon capability. I tried to evaluate it but not trivial to use it all over the places so for now I'm limiting this PR to the linked issue with posts.

## To test

### Pure self-hosted site on http
I can provide such a test site if needed
- Create a new post
- Add a block image and add an image
- Notice it can load in the block
- Set a featured image and publish the post
- Check you can see the feature image in the posts list
- Preview the post content (also on the web) and check the content is as expected and with the featured image showing up

### Regression checks
Check the above steps in the following scenarios both for Private and Public sites:
- WP.com
- Atomic
- Adding by site address (JP http/https, pure self-hosted http/https)
- Adding by WP.com user (JP http/https, pure self-hosted http/https)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
