### PR TITLE
Additional tracking information of media upload errors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
@@ -53,6 +53,7 @@ class CreateSiteUseCase @Inject constructor(
                     languageWordPressId,
                     siteVisibility,
                     siteData.segmentId,
+                    null,
                     dryRun
             )
             continuation = cont

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -196,6 +196,9 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
 
         Map<String, Object> properties = new HashMap<>();
         properties.put("error_type", event.error.type.name());
+        properties.put("error_message", event.error.message);
+        properties.put("error_log", event.error.logMessage);
+        properties.put("error_status_code", event.error.statusCode);
         trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_ERROR, media, properties);
 
         completeUploadWithId(event.media.getId());

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '5685adcdb9fd5a858a413eab0e677156bf373e41'
+    fluxCVersion = '0ccf37b7e71aa6c4f027e2d973cc85e4a3f9627c'
 
 
     appCompatVersion = '1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ ext {
     androidxWorkVersion = "2.0.1"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.6.26-beta-3'
+    fluxCVersion = '5685adcdb9fd5a858a413eab0e677156bf373e41'
 
 
     appCompatVersion = '1.0.2'


### PR DESCRIPTION
FluxC PR - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1755

This PR adds 3 additional fields to the tracked media upload error. The purpose is to be able to analyze the various error types (right now we're only tracking the error type that's quite generic (one of the most common errors has literally "GENERIC_ERROR" type). Adding the message and the status code should help us find out if we're missing something during the upload. Let me know if it makes sense. 

To test:
- Simulate an error (for example turn off the data during media upload)
- Check an event is tracked in Logcat
- Check it has the new fields present

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
