### PR TITLE
Add call to dismiss saving dialog when auto-saving from preview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3280,6 +3280,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     private PostModel handleRemoteAutoSave(boolean isError, PostModel post) {
         // We are in the process of remote previewing a post from the editor
         if (!isError && isUploadingPostForPreview()) {
+            mViewModel.hideSavingDialog();
             // We were uploading post for preview and we got no error:
             // update post status and preview it in the internal browser
             updateOnSuccessfulUpload();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -169,6 +169,10 @@ class StorePostViewModel
         _onFinish.postValue(Event(state))
     }
 
+    fun hideSavingDialog() {
+        _savingProgressDialogVisibility.postValue(Hidden)
+    }
+
     sealed class UpdateResult {
         object Error : UpdateResult()
         data class Success(val postTitleOrContentChanged: Boolean) : UpdateResult()


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/13320

Note that https://github.com/wordpress-mobile/WordPress-Android/issues/13320 was already fixed on WPAndroid develop by this PR: https://github.com/wordpress-mobile/WordPress-Android/pull/13217

This PR is targeting the release/16.1 branch in case we want to do a hotfix/betafix to fix the saving dialog stuck after preview screen issue https://github.com/wordpress-mobile/WordPress-Android/issues/13320 for 16.1. 

To test:

Steps from https://github.com/wordpress-mobile/WordPress-Android/issues/13320:
1. Go to My Site > Blog Posts > +.
1. Add a title and some content.
1. Tap the ellipsis menu (top right) > Preview.
1. Tap the arrow at top left to go back.

And:

1. Go to My Site > Blog Posts and open any pre-existing post or page.
1. Make any change to the post.
1. Tap the ellipsis menu (top right) > Preview.
1. Tap the arrow at top left to go back.

The issue should be fixed in this PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
