### PR TITLE
Jetpack Mobile: Scan - Introduce feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -76,6 +76,7 @@ android {
         buildConfigField "boolean", "WP_STORIES_AVAILABLE", "true"
         buildConfigField "boolean", "ANY_FILE_UPLOAD", "true"
         buildConfigField "boolean", "CONSOLIDATED_MEDIA_PICKER", "false"
+        buildConfigField "boolean", "SCAN_AVAILABLE", "false"
         buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "true"
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -151,6 +151,7 @@ import org.wordpress.android.util.QuickStartUtils.Companion.getNextUncompletedQu
 import org.wordpress.android.util.QuickStartUtils.Companion.isQuickStartInProgress
 import org.wordpress.android.util.QuickStartUtils.Companion.removeQuickStartFocusPoint
 import org.wordpress.android.util.QuickStartUtils.Companion.stylizeQuickStartPrompt
+import org.wordpress.android.util.ScanFeatureConfig
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
@@ -162,6 +163,7 @@ import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR
 import org.wordpress.android.util.image.ImageType.USER
 import org.wordpress.android.util.requestEmailValidation
+import org.wordpress.android.util.setVisible
 import org.wordpress.android.widgets.WPDialogSnackbar
 import org.wordpress.android.widgets.WPSnackbar
 import java.io.File
@@ -197,6 +199,8 @@ class MySiteFragment : Fragment(),
     @Inject lateinit var mediaPickerLauncher: MediaPickerLauncher
     @Inject lateinit var storiesMediaPickerResultHandler: StoriesMediaPickerResultHandler
     @Inject lateinit var consolidatedMediaPickerFeatureConfig: ConsolidatedMediaPickerFeatureConfig
+    @Inject lateinit var scanFeatureConfig: ScanFeatureConfig
+
     val selectedSite: SiteModel?
         get() {
             return (activity as? WPMainActivity)?.selectedSite
@@ -232,6 +236,8 @@ class MySiteFragment : Fragment(),
         // Site details may have changed (e.g. via Settings and returning to this Fragment) so update the UI
         refreshSelectedSiteDetails(selectedSite)
         selectedSite?.let { site ->
+            updateScanMenuVisibility()
+
             val isNotAdmin = !site.hasCapabilityManageOptions
             val isSelfHostedWithoutJetpack = !SiteUtils.isAccessedViaWPComRest(
                     site
@@ -249,6 +255,10 @@ class MySiteFragment : Fragment(),
             showQuickStartDialogMigration()
         }
         showQuickStartNoticeIfNecessary()
+    }
+
+    private fun updateScanMenuVisibility() {
+        row_scan.setVisible(scanFeatureConfig.isEnabled())
     }
 
     private fun showQuickStartNoticeIfNecessary() {

--- a/WordPress/src/main/java/org/wordpress/android/util/ScanFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ScanFeatureConfig.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.util
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.util.config.AppConfig
+import org.wordpress.android.util.config.FeatureConfig
+import javax.inject.Inject
+
+/**
+ * Configuration of the Scan feature.
+ */
+@FeatureInDevelopment
+class ScanFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.SCAN_AVAILABLE
+)

--- a/WordPress/src/main/res/drawable/ic_scan_alt_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_scan_alt_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="22dp"
+    android:viewportWidth="18"
+    android:viewportHeight="22">
+  <path
+      android:pathData="M18,10C18,15.55 14.16,20.74 9,22C3.84,20.74 0,15.55 0,10V4L9,0L18,4V10ZM9,20C12.75,19 16,14.54 16,10.22V5.3L9,2.18V20Z"
+      android:fillColor="#50575E"/>
+</vector>

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -408,6 +408,24 @@
 
                     </LinearLayout>
 
+                    <!--Scan-->
+                    <LinearLayout
+                        android:id="@+id/row_scan"
+                        style="@style/MySiteListRowLayout">
+
+                        <ImageView
+                            android:id="@+id/my_site_scan_icon"
+                            style="@style/MySiteListRowIcon"
+                            android:importantForAccessibility="no"
+                            android:src="@drawable/ic_scan_alt_white_24dp" />
+
+                        <org.wordpress.android.widgets.WPTextView
+                            android:id="@+id/my_site_scan_text_view"
+                            style="@style/MySiteListRowTextView"
+                            android:text="@string/scan" />
+
+                    </LinearLayout>
+
                     <!--Plan-->
                     <LinearLayout
                         android:id="@+id/row_plan"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1026,6 +1026,9 @@
     <string name="activity_log_rewind_dialog_message">Are you sure you want to rewind your site back to %1$s at %2$s? This will remove all content and options created or changed since then.</string>
     <string name="activity_log_limited_content_on_free_plan">Since you\'re on a free plan, you\'ll see limited events in your activity.</string>
 
+    <!-- scan -->
+    <string name="scan">Scan</string>
+
     <!-- stats: labels for timeframes -->
     <string name="stats_timeframe_today">Today</string>
     <string name="stats_timeframe_yesterday">Yesterday</string>


### PR DESCRIPTION
#13326

This PR introduces a local feature flag for the Scan feature. When the feature flag is enabled a "Scan" menu is shown on the My Site tab (currently irrespective of the site plan).

#### To test

Prerequisite:  Ensure `ENABLE_FEATURE_CONFIGURATION` is enabled in the `build.gradle` for the build variant you're testing.

1. Launch app and go to My Site tab
2. Notice that "Scan" menu is hidden
3. Go to My Site -> Avatar icon in the toolbar -> App Settings -> Test feature configuration
4. Enable ScanFeatureConfig and click on "Restart app"
5. Go back to My Site  and notice "Scan" menu is shown

![device-2020-11-10-105404](https://user-images.githubusercontent.com/1405144/98631328-3130e100-2343-11eb-95ad-191653b35965.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
