### PR TITLE
Hide saving dialog on saving finished before preview

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,18 @@ jobs:
     steps:
       - git/shallow-checkout
       - restore-gutenberg-bundle-cache
+      - run:
+          name: Abort If JS Bundle Exists
+          command: |
+            if [ -f "libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/build/assets/index.android.bundle" ]; then
+              echo "Gutenberg-Mobile bundle already in cache, no need to create a new one."
+              circleci-agent step halt
+            else
+              echo "Gutenberg-Mobile bundle not found in cache. Proceeding to generate new bundle"
+            fi
       - checkout-submodules
+      - npm-install
+      - npm-bundle-android
       - run:
           name: Ensure assets folder exists
           command: mkdir -p libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/build/assets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,18 +85,7 @@ jobs:
     steps:
       - git/shallow-checkout
       - restore-gutenberg-bundle-cache
-      - run:
-          name: Abort If JS Bundle Exists
-          command: |
-            if [ -f "libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/build/assets/index.android.bundle" ]; then
-              echo "Gutenberg-Mobile bundle already in cache, no need to create a new one."
-              circleci-agent step halt
-            else
-              echo "Gutenberg-Mobile bundle not found in cache. Proceeding to generate new bundle"
-            fi
       - checkout-submodules
-      - npm-install
-      - npm-bundle-android
       - run:
           name: Ensure assets folder exists
           command: mkdir -p libs/gutenberg-mobile/gutenberg/packages/react-native-bridge/android/build/assets

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3268,9 +3268,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     @Nullable
     private PostModel handleRemoteAutoSave(boolean isError, PostModel post) {
+        mViewModel.hideSavingDialog();
         // We are in the process of remote previewing a post from the editor
         if (!isError && isUploadingPostForPreview()) {
-            mViewModel.hideSavingDialog();
             // We were uploading post for preview and we got no error:
             // update post status and preview it in the internal browser
             updateOnSuccessfulUpload();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3270,6 +3270,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     private PostModel handleRemoteAutoSave(boolean isError, PostModel post) {
         // We are in the process of remote previewing a post from the editor
         if (!isError && isUploadingPostForPreview()) {
+            mViewModel.hideSavingDialog();
             // We were uploading post for preview and we got no error:
             // update post status and preview it in the internal browser
             updateOnSuccessfulUpload();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -169,6 +169,10 @@ class StorePostViewModel
         _onFinish.postValue(Event(state))
     }
 
+    fun hideSavingDialog() {
+        _savingProgressDialogVisibility.postValue(Hidden)
+    }
+
     sealed class UpdateResult {
         object Error : UpdateResult()
         data class Success(val postTitleOrContentChanged: Boolean) : UpdateResult()


### PR DESCRIPTION
Fixes #13320

Copy changes from https://github.com/wordpress-mobile/WordPress-Android/pull/13331 to a hotfix

To test:

1. Go to My Site > Blog Posts and open any pre-existing post or page.
2. Make any change to the post.
3. Tap the ellipsis menu (top right) > Preview
4. Notice the saving dialog pops up for a short time
5. Notice the preview is opened
6. Tap the arrow at top left to go back.
7. Notice the dialog is hidden

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
