### PR TITLE
Setup new My Site fragment behind a feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -78,6 +78,7 @@ android {
         buildConfigField "boolean", "CONSOLIDATED_MEDIA_PICKER", "false"
         buildConfigField "boolean", "ACTIVITY_LOG_FILTERS", "false"
         buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "true"
+        buildConfigField "boolean", "MY_SITE_IMPROVEMENTS", "false"
     }
 
     // Gutenberg's dependency - react-native-video is using

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ImprovedMySiteFragment.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.ui.main
+
+import androidx.fragment.app.Fragment
+
+class ImprovedMySiteFragment : Fragment() {
+    companion object {
+        fun newInstance(): ImprovedMySiteFragment {
+            return ImprovedMySiteFragment()
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1087,6 +1087,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
             case RequestCodes.STORIES_PHOTO_PICKER:
             case RequestCodes.PHOTO_PICKER:
                 Fragment fragment = mBottomNav.getActiveFragment();
+                // TODO move this logic directly to the fragment
                 if (fragment instanceof MySiteFragment) {
                     fragment.onActivityResult(requestCode, resultCode, data);
                 }
@@ -1148,6 +1149,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (fragment instanceof MySiteFragment) {
             return (MySiteFragment) fragment;
         }
+
+        // TODO consider the new my site fragment
         return null;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -126,6 +126,7 @@ import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.service.InstallationReferrerServiceStarter;
 import org.wordpress.android.util.config.ModalLayoutPickerFeatureConfig;
+import org.wordpress.android.util.config.MySiteImprovementsFeatureConfig;
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel;
 import org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel;
 import org.wordpress.android.widgets.AppRatingDialog;
@@ -210,6 +211,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Inject ModalLayoutPickerFeatureConfig mModalLayoutPickerFeatureConfig;
     @Inject ReaderTracker mReaderTracker;
     @Inject MediaPickerLauncher mMediaPickerLauncher;
+    @Inject MySiteImprovementsFeatureConfig mMySiteImprovementsFeatureConfig;
 
     /*
      * fragments implement this if their contents can be scrolled, called when user
@@ -237,7 +239,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         mBottomNav = findViewById(R.id.bottom_navigation);
 
-        mBottomNav.init(getSupportFragmentManager(), this);
+        mBottomNav.init(getSupportFragmentManager(), this, mMySiteImprovementsFeatureConfig.isEnabled());
 
         mConnectionBar = findViewById(R.id.connection_bar);
         mConnectionBar.setOnClickListener(v -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.main.WPMainActivity.OnScrollToTopListener
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType.MY_SITE
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType.NOTIFS
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType.READER
+import org.wordpress.android.ui.mysite.ImprovedMySiteFragment
 import org.wordpress.android.ui.notifications.NotificationsListFragment
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.reader.ReaderFragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -67,11 +67,11 @@ class WPMainNavigationView @JvmOverloads constructor(
         fun onNewPostButtonClicked()
     }
 
-    fun init(fm: FragmentManager, listener: OnPageListener) {
+    fun init(fm: FragmentManager, listener: OnPageListener, showNewMySiteFragment: Boolean) {
         fragmentManager = fm
         pageListener = listener
 
-        navAdapter = NavAdapter()
+        navAdapter = NavAdapter(showNewMySiteFragment)
         assignNavigationListeners(true)
         disableShiftMode()
 
@@ -278,10 +278,14 @@ class WPMainNavigationView @JvmOverloads constructor(
         return position in 0 until numPages()
     }
 
-    private inner class NavAdapter {
+    private inner class NavAdapter(val showNewMySiteFragment: Boolean) {
         private fun createFragment(pageType: PageType): Fragment {
             val fragment = when (pageType) {
-                MY_SITE -> MySiteFragment.newInstance()
+                MY_SITE -> if (showNewMySiteFragment) {
+                    ImprovedMySiteFragment.newInstance()
+                } else {
+                    MySiteFragment.newInstance()
+                }
                 READER -> ReaderFragment()
                 NOTIFS -> NotificationsListFragment.newInstance()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.main
+package org.wordpress.android.ui.mysite
 
 import androidx.fragment.app.Fragment
 

--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteImprovementsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteImprovementsFeatureConfig.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration of the my site infrastructure improvements
+ */
+@FeatureInDevelopment
+class MySiteImprovementsFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.MY_SITE_IMPROVEMENTS
+)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/13339

This PR adds a new empty fragment that's opened instead of `MySiteFragment` when the flag is turned on. The fragment doesn't do anything. I've added 2 TODOs to the WPMainActivity so that we don't miss usage of the current fragment.

To test:
- Open the app
- Check that My Site is not broken (if it opens, it works)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
