### PR TITLE
Fix importing media from external sources i.e. google photos

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
@@ -13,8 +13,9 @@ class CopyMediaToAppStorageUseCase @Inject constructor(
 ) {
     /*
    * Some media providers (eg. Google Photos) give us a limited access to media files just so we can copy them and then
-   * they revoke the access. Copying these files must be performed on the UI thread, otherwise the access might be
-   * revoked before the action completes. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
+   * they revoke the access. Copying these files must be performed within the context (Activity) that requested the
+   * files, otherwise the access might be revoked before the action completes.
+   * See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
    */
     fun copyFilesToAppStorageIfNecessary(uriList: List<Uri>): CopyMediaResult {
             uriList

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
@@ -22,7 +22,7 @@ class CopyMediaToAppStorageUseCase @Inject constructor(
                     .map { mediaUri ->
                         if (!mediaUtilsWrapper.isInMediaStore(mediaUri) &&
                                 // don't copy existing local files
-                                !mediaUri.toString().startsWith("file://") ) {
+                                !mediaUri.toString().startsWith("file://")) {
                             copyToAppStorage(mediaUri)
                         } else {
                             mediaUri

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
@@ -22,7 +22,7 @@ class CopyMediaToAppStorageUseCase @Inject constructor(
                     .map { mediaUri ->
                         if (!mediaUtilsWrapper.isInMediaStore(mediaUri) &&
                                 // don't copy existing local files
-                                !mediaUri.toString().startsWith("file://")) {
+                                !mediaUtilsWrapper.isFile(mediaUri)) {
                             copyToAppStorage(mediaUri)
                         } else {
                             mediaUri

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
@@ -2,19 +2,14 @@ package org.wordpress.android.ui.posts.editor.media
 
 import android.net.Uri
 import dagger.Reusable
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
-import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.UTILS
 import org.wordpress.android.util.MediaUtilsWrapper
 import javax.inject.Inject
-import javax.inject.Named
 
 @Reusable
 class CopyMediaToAppStorageUseCase @Inject constructor(
-    private val mediaUtilsWrapper: MediaUtilsWrapper,
-    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
+    private val mediaUtilsWrapper: MediaUtilsWrapper
 ) {
     /*
    * Some media providers (eg. Google Photos) give us a limited access to media files just so we can copy them and then

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
@@ -73,7 +73,8 @@ class StoryEditorMedia @Inject constructor(
     }
 
     fun addNewMediaItemsToEditorAsync(uriList: List<Uri>, freshlyTaken: Boolean) {
-        _uiState.value = if (uriList.size > 1 || uriList.any { !mediaUtilsWrapper.isInMediaStore(it) }) {
+        _uiState.value = if (uriList.size > 1
+                || uriList.any { !mediaUtilsWrapper.isInMediaStore(it) && !mediaUtilsWrapper.isFile(it) }) {
             AddingMultipleMediaToStory
         } else {
             AddingSingleMediaToStory

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryEditorMedia.kt
@@ -73,19 +73,19 @@ class StoryEditorMedia @Inject constructor(
     }
 
     fun addNewMediaItemsToEditorAsync(uriList: List<Uri>, freshlyTaken: Boolean) {
-        _uiState.value = if (uriList.size > 1
-                || uriList.any { !mediaUtilsWrapper.isInMediaStore(it) && !mediaUtilsWrapper.isFile(it) }) {
+        _uiState.value = if (uriList.size > 1 ||
+                uriList.any { !mediaUtilsWrapper.isInMediaStore(it) && !mediaUtilsWrapper.isFile(it) }) {
             AddingMultipleMediaToStory
         } else {
             AddingSingleMediaToStory
         }
         launch {
             val allMediaSucceed = withContext(bgDispatcher) {
-                 return@withContext addLocalMediaToPostUseCase.addNewMediaToEditorAsync(
-                        uriList,
-                        site,
-                        freshlyTaken,
-                        editorMediaListener,
+                return@withContext addLocalMediaToPostUseCase.addNewMediaToEditorAsync(
+                    uriList,
+                    site,
+                    freshlyTaken,
+                    editorMediaListener,
                         false // don't start upload for StoryComposer, that'll be all started
                                                 // when finished composing
                 )

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -35,6 +35,9 @@ class MediaUtilsWrapper @Inject constructor(private val appContext: Context) {
     fun isInMediaStore(mediaUri: Uri?): Boolean =
             MediaUtils.isInMediaStore(mediaUri)
 
+    fun isFile(mediaUri: Uri?): Boolean =
+            MediaUtils.isFile(mediaUri)
+
     fun copyFileToAppStorage(imageUri: Uri): Uri? =
             MediaUtils.downloadExternalMedia(appContext, imageUri)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCaseTest.kt
@@ -114,7 +114,6 @@ class CopyMediaToAppStorageUseCaseTest : BaseUnitTest() {
         ) =
                 mock<MediaUtilsWrapper> {
                     on { isInMediaStore(any()) }.thenReturn(resultForIsInMediaStore)
-                    on { isFile(any()) }.thenReturn(resultForIsFile)
                     on { copyFileToAppStorage(any()) }.thenReturn(mock())
                     resultForCopiedFileUri?.let {
                         on { copyFileToAppStorage(resultForCopiedFileUri.first) }.thenReturn(

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCaseTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -169,6 +169,10 @@ public class MediaUtils {
         return mediaUri != null && mediaUri.toString().startsWith("content://media/");
     }
 
+    public static boolean isFile(Uri mediaUri) {
+        return mediaUri != null && mediaUri.toString().startsWith("file://");
+    }
+
     public static @Nullable String getFilenameFromURI(Context context, Uri uri) {
         Cursor cursor = context.getContentResolver().query(uri, new String[]{OpenableColumns.DISPLAY_NAME},
                 null, null, null);


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/585

There was a misconception that we needed to run the copy process of the files URI[ in the UI thread ](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt#L20-L22) given the permissions for the passed Uris were temporary. Actually, the valid lifespan of these Uris is only for as long as [the context in which these were requested lasts](https://github.com/wordpress-mobile/WordPress-Android/pull/12670), so it's not really about the UI thread but rather about keeping the same context in which things were requested.
It makes sense since performing heavy operations such as i/o in the UI thread is counterintuitive.

This PR then removes the pre-existing code that made this operation run in the UI thread, and also performs the copy in the PhotoPickerActivity where it initially triggers the `startActivityForResult` to call the native picker, so the processing can be performed in this context.

While this was made apparent while testing Stories, I was able to observe the problem happening on Gutenberg and Aztec (although less frequently) as well.

To test:
On a handset where you have Google Photos installed and are logged in to:
1. start a new Story
2. when the media picker shows up, tap on the left-bottom button
3. then select `Select videos from device`
4. when the native picker appears, tap on the hamburger menu icon
5. look for Google Photos
6. choose a video that is long enough that would otherwise fail as per the reported issue.
7. verify the `Adding media...`  progress dialog appears on the PhotoPickerActivity and does not hang the UI, while the files are getting copied locally, and the app doesn't crash
8. verify the video gets finally added to the Story in the Story creator.

9. Repeat the same with an already created Story (i,e, add another slide to the Story you just created, and verify the same steps still work)



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
