### PR TITLE
Introduce skeleton activity type filter screen in Activity Log

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -32,6 +32,7 @@ import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailFragment;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListFragment;
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterFragment;
 import org.wordpress.android.ui.comments.CommentAdapter;
 import org.wordpress.android.ui.comments.CommentDetailFragment;
 import org.wordpress.android.ui.comments.CommentsActivity;
@@ -598,6 +599,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PrepublishingCategoriesFragment object);
 
     void inject(PrepublishingAddCategoryFragment object);
+
+    void inject(ActivityLogTypeFilterFragment object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel;
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel;
 import org.wordpress.android.ui.domains.DomainRegistrationMainViewModel;
 import org.wordpress.android.ui.main.MeViewModel;
 import org.wordpress.android.ui.mediapicker.MediaPickerViewModel;
@@ -412,7 +413,11 @@ abstract class ViewModelModule {
     @Binds
     @IntoMap
     @ViewModelKey(PrepublishingAddCategoryViewModel.class)
-    abstract ViewModel prepublishingAddCategoryViewModel(PrepublishingAddCategoryViewModel viewModel);
+    abstract ViewModel prepublishingAddCategoryViewModel(PrepublishingAddCategoryViewModel viewModel);@Binds
+
+    @IntoMap
+    @ViewModelKey(ActivityLogTypeFilterViewModel.class)
+    abstract ViewModel activityLogTypeFilterViewModel(ActivityLogTypeFilterViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -413,8 +413,9 @@ abstract class ViewModelModule {
     @Binds
     @IntoMap
     @ViewModelKey(PrepublishingAddCategoryViewModel.class)
-    abstract ViewModel prepublishingAddCategoryViewModel(PrepublishingAddCategoryViewModel viewModel);@Binds
+    abstract ViewModel prepublishingAddCategoryViewModel(PrepublishingAddCategoryViewModel viewModel);
 
+    @Binds
     @IntoMap
     @ViewModelKey(ActivityLogTypeFilterViewModel.class)
     abstract ViewModel activityLogTypeFilterViewModel(ActivityLogTypeFilterViewModel viewModel);

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterFragment
 import org.wordpress.android.ui.posts.BasicFragmentDialog
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.NetworkUtils
@@ -27,6 +28,8 @@ import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.Activity
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.LOADING_MORE
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
+
+private const val DATE_PICKER_TAG = "activity_log_type_filter_tag"
 
 class ActivityLogListFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -73,6 +76,8 @@ class ActivityLogListFragment : Fragment() {
             }
         })
 
+        activity_type_filter.setOnClickListener { viewModel.onActivityTypeFilterClicked() }
+
         setupObservers()
 
         viewModel.start(site)
@@ -98,6 +103,11 @@ class ActivityLogListFragment : Fragment() {
 
         viewModel.filtersVisibility.observe(viewLifecycleOwner, Observer { visibility ->
             uiHelpers.updateVisibility(date_range_picker, visibility)
+            uiHelpers.updateVisibility(activity_type_filter, visibility)
+        })
+
+        viewModel.showActivityTypeFilter.observe(viewLifecycleOwner, Observer { _ ->
+            showActivityTypeFilter()
         })
 
         viewModel.showItemDetail.observe(viewLifecycleOwner, Observer {
@@ -134,6 +144,10 @@ class ActivityLogListFragment : Fragment() {
                     getString(R.string.cancel))
             dialog.show(requireFragmentManager(), it)
         }
+    }
+
+    private fun showActivityTypeFilter() {
+        ActivityLogTypeFilterFragment().show(parentFragmentManager, DATE_PICKER_TAG)
     }
 
     private fun refreshProgressBars(eventListStatus: ActivityLogViewModel.ActivityLogListStatus?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -106,8 +106,8 @@ class ActivityLogListFragment : Fragment() {
             uiHelpers.updateVisibility(activity_type_filter, visibility)
         })
 
-        viewModel.showActivityTypeFilter.observe(viewLifecycleOwner, Observer { _ ->
-            showActivityTypeFilter()
+        viewModel.showActivityTypeFilterDialog.observe(viewLifecycleOwner, Observer { _ ->
+            showActivityTypeFilterDialog()
         })
 
         viewModel.showItemDetail.observe(viewLifecycleOwner, Observer {
@@ -146,7 +146,7 @@ class ActivityLogListFragment : Fragment() {
         }
     }
 
-    private fun showActivityTypeFilter() {
+    private fun showActivityTypeFilterDialog() {
         ActivityLogTypeFilterFragment().show(parentFragmentManager, DATE_PICKER_TAG)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -29,7 +29,7 @@ import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.Activity
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 
-private const val DATE_PICKER_TAG = "activity_log_type_filter_tag"
+private const val ACTIVITY_TYPE_FILTER_TAG = "activity_log_type_filter_tag"
 
 class ActivityLogListFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -147,7 +147,7 @@ class ActivityLogListFragment : Fragment() {
     }
 
     private fun showActivityTypeFilterDialog() {
-        ActivityLogTypeFilterFragment().show(parentFragmentManager, DATE_PICKER_TAG)
+        ActivityLogTypeFilterFragment().show(parentFragmentManager, ACTIVITY_TYPE_FILTER_TAG)
     }
 
     private fun refreshProgressBars(eventListStatus: ActivityLogViewModel.ActivityLogListStatus?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -96,7 +96,7 @@ class ActivityLogListFragment : Fragment() {
             refreshProgressBars(listStatus)
         })
 
-        viewModel.dateRangePickerVisibility.observe(viewLifecycleOwner, Observer { visibility ->
+        viewModel.filtersVisibility.observe(viewLifecycleOwner, Observer { visibility ->
             uiHelpers.updateVisibility(date_range_picker, visibility)
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -1,13 +1,20 @@
 package org.wordpress.android.ui.activitylog.list.filter
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import org.wordpress.android.R.layout
+import org.wordpress.android.WordPress
 
 class ActivityLogTypeFilterFragment : DialogFragment() {
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(layout.activity_log_type_filter_fragment, container, false)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -1,18 +1,33 @@
 package org.wordpress.android.ui.activitylog.list.filter
 
+import android.app.Dialog
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
 import org.wordpress.android.R.layout
 import org.wordpress.android.WordPress
+import javax.inject.Inject
 
 class ActivityLogTypeFilterFragment : DialogFragment() {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+
+    private lateinit var viewModel: ActivityLogTypeFilterViewModel
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         (requireActivity().applicationContext as WordPress).component().inject(this)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+        viewModel = ViewModelProviders.of(this, viewModelFactory)
+                .get(ActivityLogTypeFilterViewModel::class.java)
+        return dialog
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.ui.activitylog.list.filter
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import org.wordpress.android.R.layout
+
+class ActivityLogTypeFilterFragment : DialogFragment() {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(layout.activity_log_type_filter_fragment, container, false)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui.activitylog.list.filter
+
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+class ActivityLogTypeFilterViewModel @Inject constructor(
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
+) : ScopedViewModel(mainDispatcher) {
+    private var isStarted = false
+
+    fun start() {
+        if (isStarted) return
+        isStarted = true
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -63,6 +63,10 @@ class ActivityLogViewModel @Inject constructor(
     val showRewindDialog: LiveData<ActivityLogListItem>
         get() = _showRewindDialog
 
+    private val _showActivityTypeFilter = SingleLiveEvent<Unit>()
+    val showActivityTypeFilter: LiveData<Unit>
+        get() = _showActivityTypeFilter
+
     private val _moveToTop = SingleLiveEvent<Unit>()
     val moveToTop: SingleLiveEvent<Unit>
         get() = _moveToTop
@@ -149,6 +153,10 @@ class ActivityLogViewModel @Inject constructor(
         if (item is Event) {
             _showRewindDialog.value = item
         }
+    }
+
+    fun onActivityTypeFilterClicked() {
+        _showActivityTypeFilter.value = Unit
     }
 
     fun onRewindConfirmed(rewindId: String) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -55,9 +55,9 @@ class ActivityLogViewModel @Inject constructor(
     val eventListStatus: LiveData<ActivityLogListStatus>
         get() = _eventListStatus
 
-    private val _dateRangePickerVisibility = MutableLiveData<Boolean>()
-    val dateRangePickerVisibility: LiveData<Boolean>
-        get() = _dateRangePickerVisibility
+    private val _filtersVisibility = MutableLiveData<Boolean>()
+    val filtersVisibility: LiveData<Boolean>
+        get() = _filtersVisibility
 
     private val _showRewindDialog = SingleLiveEvent<ActivityLogListItem>()
     val showRewindDialog: LiveData<ActivityLogListItem>
@@ -122,7 +122,7 @@ class ActivityLogViewModel @Inject constructor(
         reloadEvents(done = true)
         requestEventsUpdate(false)
 
-        _dateRangePickerVisibility.value = activityLogFiltersFeatureConfig.isEnabled()
+        _filtersVisibility.value = activityLogFiltersFeatureConfig.isEnabled()
 
         isStarted = true
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -63,9 +63,9 @@ class ActivityLogViewModel @Inject constructor(
     val showRewindDialog: LiveData<ActivityLogListItem>
         get() = _showRewindDialog
 
-    private val _showActivityTypeFilter = SingleLiveEvent<Unit>()
-    val showActivityTypeFilter: LiveData<Unit>
-        get() = _showActivityTypeFilter
+    private val _showActivityTypeFilterDialog = SingleLiveEvent<Unit>()
+    val showActivityTypeFilterDialog: LiveData<Unit>
+        get() = _showActivityTypeFilterDialog
 
     private val _moveToTop = SingleLiveEvent<Unit>()
     val moveToTop: SingleLiveEvent<Unit>
@@ -156,7 +156,7 @@ class ActivityLogViewModel @Inject constructor(
     }
 
     fun onActivityTypeFilterClicked() {
-        _showActivityTypeFilter.value = Unit
+        _showActivityTypeFilterDialog.value = Unit
     }
 
     fun onRewindConfirmed(rewindId: String) {

--- a/WordPress/src/main/res/layout/activity_log_list_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_fragment.xml
@@ -13,6 +13,15 @@
         android:text="Date Range - hardcoded"
         tools:ignore="HardcodedText" />
 
+    <com.google.android.material.chip.Chip
+        android:id="@+id/activity_type_filter"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toEndOf="@id/date_range_picker"
+        android:visibility="gone"
+        android:text="Activity type - hardcoded"
+        tools:ignore="HardcodedText" />
+
     <org.wordpress.android.ui.ActionableEmptyView
         android:id="@+id/actionable_empty_view"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="Just Test!"
+        tools:ignore="HardcodedText" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.ui.activitylog.list.filter
+
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
+
+@InternalCoroutinesApi
+class ActivityLogTypeFilterViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: ActivityLogTypeFilterViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = ActivityLogTypeFilterViewModel(TEST_DISPATCHER)
+    }
+
+    @Test
+    fun `skeleton test`() {
+        // Skeleton test.
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -327,7 +327,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun dateRangePickerIsNotVisibleWhenFiltersFeatureFlagIsDisabled() = runBlocking {
+    fun filtersAreNotVisibleWhenFiltersFeatureFlagIsDisabled() = runBlocking {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(false)
 
         viewModel.start(site)
@@ -336,12 +336,19 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun dateRangePickerIsVisibleWhenFiltersFeatureFlagIsEnabled() = runBlocking {
+    fun filtersAreVisibleWhenFiltersFeatureFlagIsEnabled() = runBlocking {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
 
         viewModel.start(site)
 
         assertEquals(true, viewModel.filtersVisibility.value)
+    }
+
+    @Test
+    fun onActivityTypeFilterClickShowsActivityTypeFilter() {
+        viewModel.onActivityTypeFilterClicked()
+
+        assertEquals(Unit, viewModel.showActivityTypeFilterDialog.value)
     }
 
     private suspend fun assertFetchEvents(canLoadMore: Boolean = false) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -332,7 +332,7 @@ class ActivityLogViewModelTest {
 
         viewModel.start(site)
 
-        assertEquals(false, viewModel.dateRangePickerVisibility.value)
+        assertEquals(false, viewModel.filtersVisibility.value)
     }
 
     @Test
@@ -341,7 +341,7 @@ class ActivityLogViewModelTest {
 
         viewModel.start(site)
 
-        assertEquals(true, viewModel.dateRangePickerVisibility.value)
+        assertEquals(true, viewModel.filtersVisibility.value)
     }
 
     private suspend fun assertFetchEvents(canLoadMore: Boolean = false) {


### PR DESCRIPTION
Partially fixes #13268 

This PR introduces a skeleton activity type filter screen. Only a dummy ui is used just to showcase that the dialog is shown on button click.

Big part of this PR was written during a pair programming session with @ParaskP7. Thanks 🙇 

To test:
1. My Site -> Avatar icon in the toolbar -> App Settings -> Test feature configuration -> **enable** "ActivityLogFiltersFeatureConfig" and restart the app
2. My Site -> Activity Log
3. Notice the "Activity Type" chip is shown
4. Click on the chip and notice a dialog is shown (it's not fullscreen yet)
5. Rotate your device and make sure the dialog survives the rotation
6. My Site -> Avatar icon in the toolbar -> App Settings -> Test feature configuration -> **disable** "ActivityLogFiltersFeatureConfig" and restart the app 
7. My Site -> Activity Log
8. Make sure the "Activity Type" chip is hidden

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
