### PR TITLE
[Modal Layout Picker] Prevents layout preview from creating a duplicate page

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -860,7 +860,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
             return null;
         }));
         mEditPostRepository.getPostChanged().observe(this, postEvent -> postEvent.applyIfNotHandled(post -> {
-            mViewModel.savePostToDb(mEditPostRepository, mSite);
+            if (!mIsPreview) {
+                mViewModel.savePostToDb(mEditPostRepository, mSite);
+            }
             return null;
         }));
     }


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2797

Relates with: https://github.com/wordpress-mobile/WordPress-Android/pull/13022

## Description

This PR prevents saving post locally in preview mode

## To test:

### Preview and Create Page
1. Go to My Site > Site Pages > + and select any layout.
1. Tap Preview at bottom left.
1. Tap the Create page button.
1. Make some changes to the title and content.
1. Tap the back arrow at top left.
1. Verify that no duplicate post is created in drafts

### Preview only
1. Go to My Site > Site Pages > + and select any layout.
1. Tap Preview at bottom left.
1. Tap the back arrow at top left.
1. Verify that no local post is created in drafts

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
