### PR TITLE
Copy media from system picker before they are passed down

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -24,7 +24,6 @@ import org.wordpress.android.ui.gif.GifPickerActivity
 import org.wordpress.android.ui.media.MediaBrowserActivity
 import org.wordpress.android.ui.mediapicker.MediaItem.Identifier
 import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.ANDROID_CAMERA
-import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.ANDROID_PICKER
 import org.wordpress.android.ui.mediapicker.MediaPickerActivity.MediaPickerMediaSource.APP_PICKER
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.Companion.newInstance
 import org.wordpress.android.ui.mediapicker.MediaPickerFragment.MediaPickerAction
@@ -185,18 +184,9 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         val intent: Intent? = when (requestCode) {
             MEDIA_LIBRARY -> {
                 data?.let {
-                    val intent = Intent()
                     val uris = WPMediaUtils.retrieveMediaUris(data)
-                    if (mediaPickerSetup.queueResults) {
-                        intent.putQueuedUris(uris)
-                    } else {
-                        intent.putUris(uris)
-                    }
-                    intent.putExtra(
-                            EXTRA_MEDIA_SOURCE,
-                            ANDROID_PICKER.name
-                    )
-                    intent
+                    pickerFragment?.urisSelectedFromSystemPicker(uris)
+                    return
                 }
             }
             TAKE_PHOTO -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -4,6 +4,7 @@ import android.Manifest.permission
 import android.app.Activity
 import android.content.Intent.ACTION_GET_CONTENT
 import android.content.Intent.ACTION_OPEN_DOCUMENT
+import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
 import android.text.Html
@@ -68,6 +69,7 @@ import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarItem.Action
 import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
+import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPLinkMovementMethod
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.WPPermissionUtils
@@ -382,6 +384,10 @@ class MediaPickerFragment : Fragment() {
             }
         }
         return true
+    }
+
+    fun urisSelectedFromSystemPicker(uris: List<Uri>) {
+        viewModel.urisSelectedFromSystemPicker(uris.map { UriWrapper(it) })
     }
 
     private fun initializeSearchView(actionMenuItem: MenuItem) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -74,6 +74,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.MediaUtilsWrapper
+import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.distinct
 import org.wordpress.android.util.merge
@@ -416,6 +417,10 @@ class MediaPickerViewModel @Inject constructor(
 
     fun performInsertAction() {
         val ids = selectedIdentifiers()
+        insertIdentifiers(ids)
+    }
+
+    private fun insertIdentifiers(ids: List<Identifier>) {
         var job: Job? = null
         job = launch {
             var progressDialogJob: Job? = null
@@ -633,6 +638,10 @@ class MediaPickerViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         searchJob?.cancel()
+    }
+
+    fun urisSelectedFromSystemPicker(uris: List<UriWrapper>) {
+        insertIdentifiers(uris.map { LocalUri(it) })
     }
 
     data class MediaPickerUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -354,8 +354,10 @@ class MediaPickerViewModel @Inject constructor(
                     _domainModel.value = domainModel
                 }
             }
-            launch(bgDispatcher) {
-                loadActions.send(LoadAction.Start())
+            if (permissionsHandler.hasStoragePermission()) {
+                launch(bgDispatcher) {
+                    loadActions.send(LoadAction.Start())
+                }
             }
         }
         if (mediaPickerSetup.defaultSearchView) {


### PR DESCRIPTION
Fixes Automattic/stories-android#585

When we use the system picker to select media from Google photos, the media has to be handled in the same context (the activity that requested them has to be alive). This PR handles this problem in the new media picker by taking the result of the system picker and passing it through the insert use case to copy the selected file to the app local storage.

To test:
- Turn on ConsolidatedMediaPicker flag in App Settings/Test feature configuration
- Follow steps in the following PR - https://github.com/wordpress-mobile/WordPress-Android/pull/13352

To test:
- Go to an existing post
- Go to post settings
- Click on "Choose featured image"
- Click on "System picker" icon in the Toolbar
- Select an image from a system picker
- The media gets selected and uploaded correctly
- Repeat the same steps not using System picker

To test:
- Go to a post in GB
- Add an image block
- Click on "Add Media"
- Click on "System picker" icon in the toolbar
- Select an item
- The item gets correctly added to a block
- Repeat with a video block and a video item

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
