### PR TITLE
Prevents saving post locally in preview mode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -830,7 +830,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
             return null;
         }));
         mEditPostRepository.getPostChanged().observe(this, postEvent -> postEvent.applyIfNotHandled(post -> {
-            mViewModel.savePostToDb(mEditPostRepository, mSite);
+            if (!mIsPreview) {
+                mViewModel.savePostToDb(mEditPostRepository, mSite);
+            }
             return null;
         }));
     }


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2797

This clones https://github.com/wordpress-mobile/WordPress-Android/pull/13358 targeting 16.1 

## Description

This PR prevents saving post locally in preview mode

## To test:

Check https://github.com/wordpress-mobile/WordPress-Android/pull/13358

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
