### PR TITLE
Stories: Update minimum supported Jetpack version

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -30,8 +30,7 @@ public class SiteUtils {
     public static final String GB_EDITOR_NAME = "gutenberg";
     public static final String AZTEC_EDITOR_NAME = "aztec";
     public static final String WP_STORIES_CREATOR_NAME = "wp_stories_creator";
-    // TODO Update to the first version with the story block as a production and not a beta block
-    public static final String WP_STORIES_JETPACK_VERSION = "8.8";
+    public static final String WP_STORIES_JETPACK_VERSION = "9.1";
     private static final int GB_ROLLOUT_PERCENTAGE_PHASE_1 = 100;
     private static final int GB_ROLLOUT_PERCENTAGE_PHASE_2 = 100;
 


### PR DESCRIPTION
9.1 is the first Jetpack release with the Story block as a production block (and not a beta block), so it will be the earliest version we support when we lift the feature flag and ship to users on WPAndroid. (See https://github.com/Automattic/jetpack/pull/17536.)

### To test:

* In the app, select a site running Jetpack 9.1
* Confirm that the stories option appears from the My Site and post list FABs
* Switch to a site running a Jetpack with version earlier than 9.1
* Confirm that you're unable to access the stories option from the FABs.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
