### PR TITLE
Test fixing screenshots build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,11 @@ commands:
         - run:
             name: Update memory setting
             command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false /" gradle.properties
+  update-gradle-memory-2:
+      steps:
+        - run:
+            name: Update memory setting
+            command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false /" gradle.properties
   npm-install:
     steps:
       - restore_cache:
@@ -368,7 +373,7 @@ jobs:
           cache_key_prefix: v1-raw-screenshots
       - android/restore-gradle-cache
       - copy-gradle-properties
-      - update-gradle-memory
+      - update-gradle-memory-2
       - restore-gutenberg-bundle-cache
       - run:
           name: Ensure assets folder exists

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
           name: Build
           environment:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
-          command: ./gradlew WordPress:assembleVanillaDebug --stacktrace
+          command: ./gradlew WordPress:assembleVanillaDebug WordPress:assembleVanillaDebugAndroidTest --stacktrace
       - run:
           name: Decrypt credentials
           command: openssl aes-256-cbc -md sha256 -d -in .circleci/.firebase.secrets.json.enc -out .circleci/.firebase.secrets.json -k "${FIREBASE_SECRETS_ENCRYPTION_KEY}"
@@ -393,6 +393,8 @@ jobs:
           command: ./gradlew WordPress:assembleVanillaDebug --stacktrace
       - run: 
           name: Build Tests
+          environment:
+            SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
           command: ./gradlew WordPress:assembleVanillaDebugAndroidTest --stacktrace
       - run:
           name: Decrypt credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,6 +391,9 @@ jobs:
           environment:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
           command: ./gradlew WordPress:assembleVanillaDebug --stacktrace
+      - run: 
+          name: Build Tests
+          command: ./gradlew WordPress:assembleVanillaDebugAndroidTest --stacktrace
       - run:
           name: Decrypt credentials
           command: openssl aes-256-cbc -md sha256 -d -in .circleci/.firebase.secrets.json.enc -out .circleci/.firebase.secrets.json -k "${FIREBASE_SECRETS_ENCRYPTION_KEY}"


### PR DESCRIPTION
This PR updates the raw-screenshot job on CI to fix an out of memory error during the build. 
This is a proof of concept rather than a finished solution. In particular, a cleaner solution for setting different memory sizes to JVM on different tasks should be implemented.

To test:

- Verify CI is green

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
