### PR TITLE
Enable consolidated media picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/ConsolidatedMediaPickerFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ConsolidatedMediaPickerFeatureConfig.kt
@@ -1,15 +1,21 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.ConsolidatedMediaPickerFeatureConfig.Companion.CONSOLIDATED_MEDIA_PICKER_REMOTE_FIELD
 import javax.inject.Inject
 
 /**
  * Configuration of the Consolidated media picker
  */
-@FeatureInDevelopment
+@Feature(CONSOLIDATED_MEDIA_PICKER_REMOTE_FIELD, true)
 class ConsolidatedMediaPickerFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.CONSOLIDATED_MEDIA_PICKER
-)
+        BuildConfig.CONSOLIDATED_MEDIA_PICKER,
+        CONSOLIDATED_MEDIA_PICKER_REMOTE_FIELD
+) {
+    companion object {
+        const val CONSOLIDATED_MEDIA_PICKER_REMOTE_FIELD = "consolidated_media_picker_enabled"
+    }
+}


### PR DESCRIPTION
This PR turns the feature flag for consolidated media picker ON and makes it possible to control it remotely (turn it off when necessary).

To test:
- Install the app
- Make sure you haven't manually overriden the flag 
- Check that the new media picker is used everywhere except stories (where we still use the old picker)

Let's do a smoke test of the media picker as part of this PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
