### PR TITLE
Fix configuration for Connected Tests and Screenshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,14 @@ commands:
           name: Setup gradle.properties
           command: cp gradle.properties-example gradle.properties && cp libs/utils/WordPressUtils/gradle.properties-example libs/utils/WordPressUtils/gradle.properties
   update-gradle-memory:
+      parameters:
+        jvmargs:
+          type: string
+          default: "Xmx2048m"
       steps:
         - run:
             name: Update memory setting
-            command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false /" gradle.properties
+            command: sed -i "s/org.gradle.jvmargs=.*/org.gradle.jvmargs=-<< parameters.jvmargs >> -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false /" gradle.properties
   npm-install:
     steps:
       - restore_cache:
@@ -320,7 +324,8 @@ jobs:
       - checkout-submodules
       - android/restore-gradle-cache
       - copy-gradle-properties
-      - update-gradle-memory
+      - update-gradle-memory:
+          jvmargs: "Xmx1024m"
       - restore-gutenberg-bundle-cache
       - run:
           name: Ensure assets folder exists
@@ -331,7 +336,12 @@ jobs:
           name: Build
           environment:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
-          command: ./gradlew WordPress:assembleVanillaDebug WordPress:assembleVanillaDebugAndroidTest --stacktrace
+          command: ./gradlew WordPress:assembleVanillaDebug --stacktrace
+      - run:
+          name: Build Tests
+          environment:
+            SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
+          command: ./gradlew WordPress:assembleVanillaDebugAndroidTest --stacktrace
       - run:
           name: Decrypt credentials
           command: openssl aes-256-cbc -md sha256 -d -in .circleci/.firebase.secrets.json.enc -out .circleci/.firebase.secrets.json -k "${FIREBASE_SECRETS_ENCRYPTION_KEY}"
@@ -368,7 +378,8 @@ jobs:
           cache_key_prefix: v1-raw-screenshots
       - android/restore-gradle-cache
       - copy-gradle-properties
-      - update-gradle-memory
+      - update-gradle-memory:
+          jvmargs: "Xmx1024m"
       - restore-gutenberg-bundle-cache
       - run:
           name: Ensure assets folder exists
@@ -385,7 +396,12 @@ jobs:
           name: Build
           environment:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
-          command: ./gradlew WordPress:assembleVanillaDebug WordPress:assembleVanillaDebugAndroidTest --stacktrace
+          command: ./gradlew WordPress:assembleVanillaDebug --stacktrace
+      - run:
+          name: Build Tests
+          environment:
+            SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
+          command: ./gradlew WordPress:assembleVanillaDebugAndroidTest --stacktrace
       - run:
           name: Decrypt credentials
           command: openssl aes-256-cbc -md sha256 -d -in .circleci/.firebase.secrets.json.enc -out .circleci/.firebase.secrets.json -k "${FIREBASE_SECRETS_ENCRYPTION_KEY}"


### PR DESCRIPTION
This PR attempts a fix for an issue where some tasks run out of memory:

- it updates the memory configuration to leave more free memory to spawned tasks.
- it splits some critical jobs in smaller parts.

To test:
- Make sure CI is green

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
