### PR TITLE
Fix infinite saving post dialog in editor 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1988,6 +1988,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
             AccountModel account = mAccountStore.getAccount();
             // prompt user to verify e-mail before publishing
             if (!account.getEmailVerified()) {
+                mViewModel.hideSavingDialog();
                 String message = TextUtils.isEmpty(account.getEmail())
                         ? getString(R.string.editor_confirm_email_prompt_message)
                         : String.format(getString(R.string.editor_confirm_email_prompt_message_with_email),
@@ -2009,6 +2010,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 return;
             }
             if (!mPostUtils.isPublishable(mEditPostRepository.getPost())) {
+                mViewModel.hideSavingDialog();
                 // TODO we don't want to show "publish" message when the user clicked on eg. save
                 mEditPostRepository.updateStatusFromPostSnapshotWhenEditorOpened();
                 EditPostActivity.this.runOnUiThread(() -> {


### PR DESCRIPTION
Fixes #13379 

This PR fixes two scenarios in which the user can end up with an infinite non-cancelable dialog in the editor.

Note: I think we should consider making the dialog cancelable. It's a fallback safe mechanism anyway - the autosave logic saves the post when needed.

To test:
1. Create a new empty post.
2. Tap PUBLISH in the toolbar.
3. Notice "Can't publish empty post Toast appears for a moment" snackbar message
4. Confirm that there is no infinite progress dialog

------------------------------
- prerequisite: Create a new account **on the web** and don't verify email address. (ping me and I can share my account with you)
1. Create a new post.
2. Optional: (Enter title)
3. Tap PUBLISH in the toolbar.
3. Notice "verify email" prompt shows up 
4. Dismiss it (by clicking outside of the dialog)
5. Notice the "Saving" progress dialog is not shown


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
