### PR TITLE
Catch IllegalArgumentException coming from Google Photos

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -182,6 +182,10 @@ public class MediaUtils {
                 result = cursor.getString(columnIndexDisplayName);
             }
             return result;
+        } catch (IllegalArgumentException exception) {
+            // This exception happens when Google Photos tries to retrieve latitude for videos even if it's not
+            // a requested column
+            return null;
         } finally {
             if (cursor != null) {
                 cursor.close();


### PR DESCRIPTION
Fixes #

There is a crash that sometimes happens when you're selecting an external video from Google Photos. When you see the stacktrace, you see that the crash is caused by the Google Photos requesting a column Latitude which is missing. However, in our code we're only requesting display name. This seems to be a bug in Google photos (see [this issue](https://stackoverflow.com/questions/61586124/illegalargumentexception-invalid-column-latitude)).
I think it's safe to catch this exception since it only happens when we're trying to figure out the file name when we copy a media file to local storage. There is a fallback to use timestamp instead and I think that works well in this case.

```
java.lang.IllegalArgumentException: Invalid column latitude
        at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:170)
        at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:140)
        at android.content.ContentProviderProxy.query(ContentProviderNative.java:423)
        at android.content.ContentResolver.query(ContentResolver.java:944)
        at android.content.ContentResolver.query(ContentResolver.java:880)
        at android.content.ContentResolver.query(ContentResolver.java:836)
        at org.wordpress.android.util.MediaUtils.getFilenameFromURI(MediaUtils.java:173)
        at org.wordpress.android.util.MediaUtils.downloadExternalMedia(MediaUtils.java:220)
        at org.wordpress.android.util.MediaUtilsWrapper.copyFileToAppStorage(MediaUtilsWrapper.kt:39)
        at org.wordpress.android.ui.posts.editor.media.CopyMediaToAppStorageUseCase.copyToAppStorage(CopyMediaToAppStorageUseCase.kt:46)
        at org.wordpress.android.ui.posts.editor.media.CopyMediaToAppStorageUseCase.access$copyToAppStorage(CopyMediaToAppStorageUseCase.kt:15)
        at org.wordpress.android.ui.posts.editor.media.CopyMediaToAppStorageUseCase$copyFilesToAppStorageIfNecessary$2.invokeSuspend(CopyMediaToAppStorageUseCase.kt:29)
        at org.wordpress.android.ui.posts.editor.media.CopyMediaToAppStorageUseCase$copyFilesToAppStorageIfNecessary$2.invoke(Unknown Source:10)
```

To test:
- I don't know how to reproduce this, it's happening with one video file in Google photos to me but it's not happening with the same file to someone else.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
