### PR TITLE
Fix importing media from external sources i.e. google photos

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -187,7 +187,8 @@ public class PhotoPickerActivity extends LocaleAwareActivity
             case RequestCodes.PICTURE_LIBRARY:
             case RequestCodes.VIDEO_LIBRARY:
                 if (data != null) {
-                    doMediaUrisSelected(WPMediaUtils.retrieveMediaUris(data), PhotoPickerMediaSource.ANDROID_PICKER);
+                    List<Uri> mediaUris = WPMediaUtils.retrieveMediaUris(data);
+                    getPickerFragment().urisSelectedFromSystemPicker(mediaUris);
                 }
                 break;
             case RequestCodes.TAKE_PHOTO:

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -325,8 +325,7 @@ class PhotoPickerFragment : Fragment() {
                             builder.setNegativeButton(
                                     R.string.cancel
                             ) { _, _ -> this.cancelAction() }
-                            builder.setOnCancelListener { this.cancelAction() }
-                            builder.setCancelable(true)
+                            builder.setCancelable(false)
                             progressDialog = builder.show()
                         }
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModel.kt
@@ -4,6 +4,8 @@ import android.Manifest.permission
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -21,6 +23,7 @@ import org.wordpress.android.ui.media.MediaBrowserType
 import org.wordpress.android.ui.media.MediaBrowserType.AZTEC_EDITOR_PICKER
 import org.wordpress.android.ui.media.MediaBrowserType.GRAVATAR_IMAGE_PICKER
 import org.wordpress.android.ui.media.MediaBrowserType.SITE_ICON_PICKER
+import org.wordpress.android.ui.mediapicker.MediaPickerViewModel.ProgressDialogUiModel
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerIcon
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerIcon.ANDROID_CAPTURE_PHOTO
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerIcon.ANDROID_CAPTURE_VIDEO
@@ -37,6 +40,7 @@ import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.BottomBarUiMode
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.BottomBarUiModel.BottomBar.MEDIA_SOURCE
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.BottomBarUiModel.BottomBar.NONE
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PopupMenuUiModel.PopupMenuItem
+import org.wordpress.android.ui.posts.editor.media.CopyMediaToAppStorageUseCase
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -58,8 +62,10 @@ import java.util.HashMap
 import javax.inject.Inject
 import javax.inject.Named
 
-@Deprecated("This class is being refactored, if you implement any change, please also update " +
-        "{@link org.wordpress.android.ui.mediapicker.MediaPickerViewModel}")
+@Deprecated(
+        "This class is being refactored, if you implement any change, please also update " +
+                "{@link org.wordpress.android.ui.mediapicker.MediaPickerViewModel}"
+)
 class PhotoPickerViewModel @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
@@ -68,7 +74,8 @@ class PhotoPickerViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val permissionsHandler: PermissionsHandler,
     private val tenorFeatureConfig: TenorFeatureConfig,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val copyMediaToAppStorageUseCase: CopyMediaToAppStorageUseCase
 ) : ScopedViewModel(mainDispatcher) {
     private val _navigateToPreview = MutableLiveData<Event<UriWrapper>>()
     private val _onInsert = MutableLiveData<Event<List<UriWrapper>>>()
@@ -78,6 +85,7 @@ class PhotoPickerViewModel @Inject constructor(
     private val _onIconClicked = MutableLiveData<Event<IconClickEvent>>()
     private val _onPermissionsRequested = MutableLiveData<Event<PermissionsRequested>>()
     private val _softAskRequest = MutableLiveData<SoftAskRequest>()
+    private val _showProgressDialog = MutableLiveData<ProgressDialogUiModel>()
 
     val onNavigateToPreview: LiveData<Event<UriWrapper>> = _navigateToPreview
     val onInsert: LiveData<Event<List<UriWrapper>>> = _onInsert
@@ -91,8 +99,9 @@ class PhotoPickerViewModel @Inject constructor(
     val uiState: LiveData<PhotoPickerUiState> = merge(
             _photoPickerItems.distinct(),
             _selectedIds.distinct(),
-            _softAskRequest
-    ) { photoPickerItems, selectedIds, softAskRequest ->
+            _softAskRequest,
+            _showProgressDialog
+    ) { photoPickerItems, selectedIds, softAskRequest, progressDialogModel ->
         PhotoPickerUiState(
                 buildPhotoPickerUiModel(photoPickerItems, selectedIds),
                 buildBottomBar(
@@ -104,7 +113,8 @@ class PhotoPickerViewModel @Inject constructor(
                 FabUiModel(browserType.isWPStoriesPicker && selectedIds.isNullOrEmpty()) {
                     clickIcon(WP_STORIES_CAPTURE)
                 },
-                buildActionModeUiModel(selectedIds)
+                buildActionModeUiModel(selectedIds),
+                progressDialogModel ?: ProgressDialogUiModel.Hidden
         )
     }
 
@@ -440,10 +450,12 @@ class PhotoPickerViewModel @Inject constructor(
         if (softAskRequest != null && softAskRequest.show) {
             val appName = "<strong>${resourceProvider.getString(R.string.app_name)}</strong>"
             val label = if (softAskRequest.isAlwaysDenied) {
-                val permissionName = ("<strong>${WPPermissionUtils.getPermissionName(
-                        resourceProvider,
-                        permission.WRITE_EXTERNAL_STORAGE
-                )}</strong>")
+                val permissionName = ("<strong>${
+                    WPPermissionUtils.getPermissionName(
+                            resourceProvider,
+                            permission.WRITE_EXTERNAL_STORAGE
+                    )
+                }</strong>")
                 String.format(
                         resourceProvider.getString(R.string.photo_picker_soft_ask_permissions_denied), appName,
                         permissionName
@@ -465,12 +477,26 @@ class PhotoPickerViewModel @Inject constructor(
         }
     }
 
+    fun urisSelectedFromSystemPicker(uris: List<UriWrapper>) {
+        launch {
+            _showProgressDialog.value = ProgressDialogUiModel.Visible(R.string.uploading_title) {
+                cancel()
+            }
+            val localUris = copyMediaToAppStorageUseCase.copyFilesToAppStorageIfNecessary(uris.map { it.uri })
+            _showProgressDialog.value = ProgressDialogUiModel.Hidden
+            if (isActive) {
+                _onInsert.value = Event(localUris.permanentlyAccessibleUris.map { UriWrapper(it) })
+            }
+        }
+    }
+
     data class PhotoPickerUiState(
         val photoListUiModel: PhotoListUiModel,
         val bottomBarUiModel: BottomBarUiModel,
         val softAskViewUiModel: SoftAskViewUiModel,
         val fabUiModel: FabUiModel,
-        val actionModeUiModel: ActionModeUiModel
+        val actionModeUiModel: ActionModeUiModel,
+        val progressDialogUiModel: ProgressDialogUiModel
     )
 
     sealed class PhotoListUiModel {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModel.kt
@@ -480,10 +480,11 @@ class PhotoPickerViewModel @Inject constructor(
     fun urisSelectedFromSystemPicker(uris: List<UriWrapper>) {
         launch {
             _showProgressDialog.value = ProgressDialogUiModel.Visible(R.string.uploading_title) {
+                _showProgressDialog.postValue(ProgressDialogUiModel.Hidden)
                 cancel()
             }
             val localUris = copyMediaToAppStorageUseCase.copyFilesToAppStorageIfNecessary(uris.map { it.uri })
-            _showProgressDialog.value = ProgressDialogUiModel.Hidden
+            _showProgressDialog.postValue(ProgressDialogUiModel.Hidden)
             if (isActive) {
                 _onInsert.value = Event(localUris.permanentlyAccessibleUris.map { UriWrapper(it) })
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import dagger.Reusable
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.UTILS
 import org.wordpress.android.util.MediaUtilsWrapper
@@ -14,7 +14,7 @@ import javax.inject.Named
 @Reusable
 class CopyMediaToAppStorageUseCase @Inject constructor(
     private val mediaUtilsWrapper: MediaUtilsWrapper,
-    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
     /*
    * Some media providers (eg. Google Photos) give us a limited access to media files just so we can copy them and then
@@ -22,7 +22,7 @@ class CopyMediaToAppStorageUseCase @Inject constructor(
    * revoked before the action completes. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
    */
     suspend fun copyFilesToAppStorageIfNecessary(uriList: List<Uri>): CopyMediaResult {
-        return withContext(mainDispatcher) {
+        return withContext(bgDispatcher) {
             uriList
                     .map { mediaUri ->
                         if (!mediaUtilsWrapper.isInMediaStore(mediaUri)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
@@ -28,7 +28,9 @@ class CopyMediaToAppStorageUseCase @Inject constructor(
         return withContext(bgDispatcher) {
             uriList
                     .map { mediaUri ->
-                        if (!mediaUtilsWrapper.isInMediaStore(mediaUri)) {
+                        if (!mediaUtilsWrapper.isInMediaStore(mediaUri) &&
+                                // don't copy existing local files
+                                !mediaUtilsWrapper.isFile(mediaUri)) {
                             copyToAppStorage(mediaUri)
                         } else {
                             mediaUri

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt
@@ -20,6 +20,9 @@ class CopyMediaToAppStorageUseCase @Inject constructor(
    * Some media providers (eg. Google Photos) give us a limited access to media files just so we can copy them and then
    * they revoke the access. Copying these files must be performed on the UI thread, otherwise the access might be
    * revoked before the action completes. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
+   * they revoke the access. Copying these files must be performed within the context (Activity) that requested the
+   * files, otherwise the access might be revoked before the action completes.
+   * See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
    */
     suspend fun copyFilesToAppStorageIfNecessary(uriList: List<Uri>): CopyMediaResult {
         return withContext(bgDispatcher) {

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -49,4 +49,6 @@ class MediaUtilsWrapper @Inject constructor(private val appContext: Context) {
     fun isLocalFile(uploadState: String): Boolean = MediaUtils.isLocalFile(uploadState)
 
     fun getExtensionForMimeType(mimeType: String?): String = MediaUtils.getExtensionForMimeType(mimeType)
+
+    fun isFile(mediaUri: Uri): Boolean = MediaUtils.isFile(mediaUri)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModelTest.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.BottomBarUiMode
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PhotoListUiModel
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PhotoPickerUiState
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.SoftAskViewUiModel
+import org.wordpress.android.ui.posts.editor.media.CopyMediaToAppStorageUseCase
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -48,6 +49,7 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
     @Mock lateinit var tenorFeatureConfig: TenorFeatureConfig
     @Mock lateinit var context: Context
     @Mock lateinit var resourceProvider: ResourceProvider
+    @Mock lateinit var copyMediaToAppStorageUseCase: CopyMediaToAppStorageUseCase
     private lateinit var viewModel: PhotoPickerViewModel
     private var uiStates = mutableListOf<PhotoPickerUiState>()
     private var navigateEvents = mutableListOf<Event<UriWrapper>>()
@@ -68,7 +70,8 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
                 analyticsTrackerWrapper,
                 permissionsHandler,
                 tenorFeatureConfig,
-                resourceProvider
+                resourceProvider,
+                copyMediaToAppStorageUseCase
         )
         uiStates.clear()
         firstItem = PhotoPickerItem(1, uriWrapper1, false)

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCaseTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.android.test
 import org.wordpress.android.util.MediaUtilsWrapper
 
 @RunWith(MockitoJUnitRunner::class)
-@UseExperimental(InternalCoroutinesApi::class)
+@InternalCoroutinesApi
 class CopyMediaToAppStorageUseCaseTest : BaseUnitTest() {
     @Test
     fun `do NOT copy files which are present in media store`() = test {
@@ -88,6 +88,7 @@ class CopyMediaToAppStorageUseCaseTest : BaseUnitTest() {
     }
 
     private companion object Fixtures {
+        @InternalCoroutinesApi
         fun createCopyMediaToAppStorageUseCase(mediaUtilsWrapper: MediaUtilsWrapper = createMediaUtilsWrapper()) =
                 CopyMediaToAppStorageUseCase(mediaUtilsWrapper, TEST_DISPATCHER)
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -169,6 +169,10 @@ public class MediaUtils {
         return mediaUri != null && mediaUri.toString().startsWith("content://media/");
     }
 
+    public static boolean isFile(Uri mediaUri) {
+        return mediaUri != null && mediaUri.toString().startsWith("file://");
+    }
+
     public static @Nullable String getFilenameFromURI(Context context, Uri uri) {
         Cursor cursor = context.getContentResolver().query(uri, new String[]{OpenableColumns.DISPLAY_NAME},
                 null, null, null);


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/585

I'm copying the description from [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13352): 

There was a misconception that we needed to run the copy process of the files URI[ in the UI thread ](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/CopyMediaToAppStorageUseCase.kt#L20-L22) given the permissions for the passed Uris were temporary. Actually, the valid lifespan of these Uris is only for as long as [the context in which these were requested lasts](https://github.com/wordpress-mobile/WordPress-Android/pull/12670), so it's not really about the UI thread but rather about keeping the same context in which things were requested.
It makes sense since performing heavy operations such as i/o in the UI thread is counterintuitive.

I've moved the logic to ViewModel in this PR and it seems to work well.

To test:
On a handset where you have Google Photos installed and are logged in to:
1. start a new Story
2. when the media picker shows up, tap on the left-bottom button
3. then select `Select videos from device`
4. when the native picker appears, tap on the hamburger menu icon
5. look for Google Photos
6. choose a video that is long enough that would otherwise fail as per the reported issue.
7. verify the `Adding media...`  progress dialog appears on the PhotoPickerActivity and does not hang the UI, while the files are getting copied locally, and the app doesn't crash
8. verify the video gets finally added to the Story in the Story creator.

9. Repeat the same with an already created Story (i,e, add another slide to the Story you just created, and verify the same steps still work)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
