### PR TITLE
Remove didSucceed check from ReaderDiscoverDataProvider

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProvider.kt
@@ -210,10 +210,8 @@ class ReaderDiscoverDataProvider @Inject constructor(
 
     @Subscribe(threadMode = BACKGROUND)
     fun onFollowedTagsChanged(event: FollowedTagsChanged) {
-        if (event.didSucceed()) {
-            launch {
-                refreshCards()
-            }
+        launch {
+            refreshCards()
         }
     }
 }


### PR DESCRIPTION
This PR fixes a bug discovered by @zwarm while reviewing https://github.com/wordpress-mobile/WordPress-Android/pull/13384. 


To test:
1. Start on discover tab - make sure there are some cards shown
2. Tap the gear icon & unfollow all existing tags
3. Type in a topic that doesn't exist like "fifififififififififi"
4. There is a toast with a message "unable to add this topic"
5. (The topic is added to the list - it is removed the next time you come back to that view, although it briefly flashes on the screen first)
6. Tap back to return to discover tab
7. Notice "No recent posts" empty view is shown (before this bug fix, cards from the cache were shown)


 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
