### PR TITLE
Add timeout to save dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2038,6 +2038,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
             AccountModel account = mAccountStore.getAccount();
             // prompt user to verify e-mail before publishing
             if (!account.getEmailVerified()) {
+                mViewModel.hideSavingDialog();
                 String message = TextUtils.isEmpty(account.getEmail())
                         ? getString(R.string.editor_confirm_email_prompt_message)
                         : String.format(getString(R.string.editor_confirm_email_prompt_message_with_email),
@@ -2059,6 +2060,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 return;
             }
             if (!mPostUtils.isPublishable(mEditPostRepository.getPost())) {
+                mViewModel.hideSavingDialog();
                 // TODO we don't want to show "publish" message when the user clicked on eg. save
                 mEditPostRepository.updateStatusFromPostSnapshotWhenEditorOpened();
                 EditPostActivity.this.runOnUiThread(() -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1883,6 +1883,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     AppLog.e(T.EDITOR, s);
                 }
             });
+        } else if (mEditorFragment instanceof GutenbergEditorFragment) {
+            GutenbergEditorFragment gutenbergEditorFragment = (GutenbergEditorFragment) mEditorFragment;
+            gutenbergEditorFragment.setExternalLogger(e -> mCrashLogging.reportException(e));
         }
     }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -104,7 +104,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     private static final int UNSUPPORTED_BLOCK_REQUEST_CODE = 1001;
 
-    private static final int SAVE_DIALOG_TIMEOUT_DURATION = 15000;
+    private static final int SAVE_DIALOG_TIMEOUT_DURATION = 20000;
 
     private boolean mHtmlModeEnabled;
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergExternalLogger.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergExternalLogger.java
@@ -1,0 +1,5 @@
+package org.wordpress.android.editor.gutenberg;
+
+public interface GutenbergExternalLogger {
+    void reportException(Exception e);
+}

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/SaveDialogTimeoutException.kt
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/SaveDialogTimeoutException.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.editor.gutenberg
 
 class SaveDialogTimeoutException(timeoutDuration: Int) : Exception(timeoutMessage(timeoutDuration)) {
     companion object {
-        private fun timeoutMessage(timeoutDuration: Int) : String =
+        private fun timeoutMessage(timeoutDuration: Int): String =
                 "The Gutenberg editor's save dialog timeout fired after $timeoutDuration " +
                         "and automatically dismissed the dialog to ensure the user was not " +
                         "left with a blocking dialog. This indicates either that the local save " +

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/SaveDialogTimeoutException.kt
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/SaveDialogTimeoutException.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.editor.gutenberg
+
+class SaveDialogTimeoutException(timeoutDuration: Int) : Exception(timeoutMessage(timeoutDuration)) {
+    companion object {
+        private fun timeoutMessage(timeoutDuration: Int) : String =
+                "The Gutenberg editor's save dialog timeout fired after $timeoutDuration " +
+                        "and automatically dismissed the dialog to ensure the user was not " +
+                        "left with a blocking dialog. This indicates either that the local save " +
+                        "was slow or that we failed to properly dismiss the dialog."
+    }
+}


### PR DESCRIPTION
The save dialog when exiting the editor should always be dismissed, but it's a blocking dialog, so with this PR I want to make it so that if we don't dismiss it for some reason, the user isn't left with an unresponsive app (like what happened with https://github.com/wordpress-mobile/WordPress-Android/issues/13379).

I found that saving [a very long post](https://gist.github.com/mchowning/366c011db0ccfefaec703d0e4779525f) on my Pixel 1 took 10-16 seconds on release builds (debug builds took roughly twice as long 😱 ), so I set the timeout here for 20 seconds. I don't feel strongly about that number at all. If the timeout passes before the save is finished, the save dialog just gets dismissed and the user is able to use the editor until the save is finished, at which point the editor resumes whatever action was waiting on the save (probably exiting the editor).

I set this up so that if the timeout is used we send an event to Sentry. That way we can both (a) be able to get an idea if our timeout is too short, and (b) be able to see if there is a sudden spike in the usage of the timeout, which would indicate that we have a bug where we're failing to properly dismiss the save dialog. The exception that is thrown will look like [this in Sentry](https://sentry.io/share/issue/5487f9dec99746f0979f0e223f2c1ef9/) (ignore the fact that the timeout in the Sentry exception is different from the timeout in this PR--I was testing some different timeouts).

Note that I have included [@malinajirka 's fix for the blocking save dialog when previewing](https://github.com/wordpress-mobile/WordPress-Android/pull/13381) in order to facilitate testing this since that fix [has not been merged from the 16.1 release back to develop yet](https://github.com/wordpress-mobile/WordPress-Android/pull/13389).

### To test

Because it is helpful to trigger the save-on-exit behavior when testing this, and the save-on-exit causes a crash in Debug builds (the app is set up to crash if the save-on-exit is triggered because that is an indicator that there may be a problem with the autosave mechanism) I suggest creating a VanillaRelease build to test this PR. Alternatively, you could avoid that crash by creating a debug build with [the code that throws the save-on-exit exception](https://github.com/wordpress-mobile/WordPress-Android/blob/d05207745d0fc034b40af8aa8ff86edab22c39a2/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1781-L1784) commented out.

#### 1. Non-firing timeout causes no issues
1. Make a VanillaRelease build with this PR
2. Open a post
3. Make some changes to the post and quickly (before the 0.5 second autosave activates) preview the post  (if you open a saved post you'll encounter #12570, which means the first time you preview the post it will only save the post and not actually open the preview)
4. Observe the save dialog is presented and dismissed appropriately
5. Make some more changes and quickly exit the editor before the autosave activates.
6. Observe that the save dialog is presented and dismissed appropriately.
7. Reopen the post
8. Make some changes
9. Allow time for the autosave to finish
10. Exit the post
11. Observe the save dialog is presented and (quickly) dismissed.

#### 2. Firing timeout causes no issues
1. Create a VanillaRelease build where you set the timeout to be very short (maybe 500ms) so that it will fire every time.
2. Open a post (a longer one will help make sure you hit the timeout).
3. Make some changes
4. Quickly exit the post before the autosave kicks in
5. Observe the save dialog appears and is dismissed due to the timeout, after which you are left on the editor until the save finishes, at which point the editor closes.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
