### PR TITLE
Refactor jetpack security settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -74,7 +74,6 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.plans.PlansConstants;
-import org.wordpress.android.ui.posts.JetpackSecuritySettingsActivity;
 import org.wordpress.android.ui.prefs.EditTextPreferenceWithValidation.ValidationType;
 import org.wordpress.android.ui.prefs.SiteSettingsFormatDialog.FormatType;
 import org.wordpress.android.ui.prefs.homepage.HomepageSettingsDialog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -70,6 +70,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.DeleteSiteError;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.support.ZendeskHelper;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity.Origin;
 import org.wordpress.android.ui.plans.PlansConstants;
@@ -496,7 +497,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
             return setupMorePreferenceScreen();
         } else if (preference == mJpSecuritySettings) {
-            setupJetpackSecurityScreen();
+            ActivityLauncher.viewJetpackSecuritySettings(getActivity(), mSite);
         } else if (preference == mSiteAcceleratorSettings) {
             setupSiteAcceleratorScreen();
         } else if (preference == mSiteAcceleratorSettingsNested) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -823,7 +823,6 @@
     <string name="site_settings_list_editor_input_hint">Enter a word or phrase</string>
     <string name="site_settings_hold_for_moderation_description">When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be held in the moderation queue. You can enter partial words, so \"press\" will match \"WordPress.\"</string>
     <string name="site_settings_blacklist_description">When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam. You can enter partial words, so \"press\" will match \"WordPress.\"</string>
-    <string name="site_settings_jetpack_whitelist_description">You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1–12.12.12.100</string>
 
     <!-- Dialogs -->
     <string name="site_settings_discussion_title" translatable="false">@string/discussion</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -466,77 +466,11 @@
         android:key="@string/pref_key_jetpack_settings"
         android:title="@string/jetpack_site_settings_category_title">
 
-        <PreferenceScreen
+        <Preference
             android:id="@+id/jetpack_security_settings_screen"
             android:key="@string/pref_key_jetpack_security_screen"
-            android:title="@string/jetpack_security_setting_title">
+            android:title="@string/jetpack_security_setting_title" />
 
-            <org.wordpress.android.ui.prefs.WPSwitchPreference
-                android:id="@+id/pref_monitor_uptime"
-                android:key="@string/pref_key_jetpack_monitor_uptime"
-                android:title="@string/jetpack_monitor_uptime_title" />
-
-            <org.wordpress.android.ui.prefs.WPSwitchPreference
-                android:id="@+id/pref_jetpack_send_email_notifications"
-                android:dependency="@string/pref_key_jetpack_monitor_uptime"
-                android:key="@string/pref_key_jetpack_send_email_notifications"
-                android:title="@string/jetpack_send_email_notifications_title" />
-
-            <org.wordpress.android.ui.prefs.WPSwitchPreference
-                android:id="@+id/pref_jetpack_send_wp_notifications"
-                android:dependency="@string/pref_key_jetpack_monitor_uptime"
-                android:key="@string/pref_key_jetpack_send_wp_notifications"
-                android:title="@string/jetpack_send_wp_notifications_title" />
-
-            <PreferenceCategory
-                android:id="@+id/pref_category_jetpack_brute_force"
-                android:title="@string/jetpack_prevent_brute_force_category_title">
-
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_prevent_brute_force"
-                    android:key="@string/pref_key_jetpack_prevent_brute_force"
-                    android:title="@string/jetpack_prevent_brute_force_title" />
-
-                <org.wordpress.android.ui.prefs.WPPreference
-                    android:id="@+id/pref_brute_force_whitelist"
-                    android:dependency="@string/pref_key_jetpack_prevent_brute_force"
-                    android:key="@string/pref_key_jetpack_brute_force_whitelist"
-                    android:title="@string/jetpack_brute_force_whitelist_title" />
-
-            </PreferenceCategory>
-
-            <PreferenceCategory
-                android:id="@+id/pref_category_jetpack_wpcom_sign_in"
-                android:title="@string/jetpack_wpcom_sign_in_category_title">
-
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_allow_wpcom_sign_in"
-                    android:key="@string/pref_key_jetpack_allow_wpcom_sign_in"
-                    android:title="@string/jetpack_allow_wpcom_sign_in_title" />
-
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_jetpack_match_wpcom_email"
-                    android:dependency="@string/pref_key_jetpack_allow_wpcom_sign_in"
-                    android:key="@string/pref_key_jetpack_match_via_email"
-                    android:title="@string/jetpack_match_wpcom_via_email_title" />
-
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_jetpack_require_two_factor"
-                    android:dependency="@string/pref_key_jetpack_allow_wpcom_sign_in"
-                    android:key="@string/pref_key_jetpack_require_two_factor"
-                    android:title="@string/jetpack_require_two_factor_title" />
-
-                <org.wordpress.android.ui.prefs.LearnMorePreference
-                    android:id="@+id/pref_jetpack_learn_more"
-                    android:key="@string/pref_key_jetpack_learn_more"
-                    android:title="@string/site_settings_learn_more_header"
-                    app:layout="@layout/learn_more_pref_old"
-                    app:openInDialog="true"
-                    app:url="https://jetpack.com/support/sso/"
-                    app:useCustomJsFormatting="false" />
-
-            </PreferenceCategory>
-        </PreferenceScreen>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
We currently have two copies of the Jetpack Security Settings. This makes the code hard to maintain and very error prone since we always need to make sure to update both places. This PR tries to solve this issue by removing all business code related to Jetpack Security settings from the Site Settings fragment. We simply redirect the user to the JetpackSecuritySettingsActivity when they click on "Security" row.

This PR is currently blocked by [this issue](https://github.com/wordpress-mobile/WordPress-Android/issues/13407). Since "whitelisted IPs" button doesn't work in the JetpackSecuritySettingsActivity. Introducing the changes in this PR would break this feature in the whole app. We'll need to wait until the issue is fixed before we merge this PR.


To test - select a jetpack site in the app
1. My Site
2. Site Settings
3. Click on "Security" row in the "Jetpack" section at the bottom
4. Notice the Jetpack security settings screen is shown
5. Edit some settings and leave the screen
6. Open the app on a different device are check on the web that the setting got successfully updated

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
