### PR TITLE
Quick Start: Show missing indicator dot on the Add Page floating action button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -186,6 +186,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         }
 
         newPageButton.setOnClickListener {
+            QuickStartUtils.removeQuickStartFocusPoint(fab_container)
             viewModel.onNewPageButtonTapped()
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -577,6 +577,14 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
 
         if (quickStartEvent?.task == QuickStartTask.CREATE_NEW_PAGE) {
             view?.post {
+                val marginOffset = resources.getDimensionPixelOffset(R.dimen.margin_extra_large)
+                QuickStartUtils.addQuickStartFocusPointAboveTheView(
+                        fab_container,
+                        newPageButton,
+                        -marginOffset,
+                        -marginOffset
+                )
+
                 val title = QuickStartUtils.stylizeQuickStartPrompt(
                         requireActivity(),
                         R.string.quick_start_dialog_create_new_page_message_short_pages,

--- a/WordPress/src/main/res/layout/pages_fragment.xml
+++ b/WordPress/src/main/res/layout/pages_fragment.xml
@@ -9,7 +9,8 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/coordinatorLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:clipChildren="false">
 
         <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
             android:id="@+id/pullToRefresh"
@@ -89,17 +90,26 @@
 
         </com.google.android.material.appbar.AppBarLayout>
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/newPageButton"
+        <FrameLayout
+            android:id="@+id/fab_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end|bottom"
             android:layout_marginBottom="@dimen/fab_margin"
             android:layout_marginEnd="@dimen/fab_margin"
-            android:contentDescription="@string/fab_create_desc"
-            android:src="@drawable/ic_create_white_24dp"
-            android:visibility="gone"
-            app:borderWidth="0dp" />
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            app:layout_dodgeInsetEdges="bottom">
+
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/newPageButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/fab_create_desc"
+                android:src="@drawable/ic_create_white_24dp"
+                android:visibility="gone"
+                app:borderWidth="0dp" />
+        </FrameLayout>
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 


### PR DESCRIPTION
Fixes #13221

To test:

1. Log out and sign up as a new user and create a new site.
1. Select "Yes, Help Me" when prompted for help getting started.
1. Go to Next Steps > Customize Your Site > Create a new page.
1. Tap Pages.
1. Verify that the pulsing dot on the "Add Page" FAB (floating action bar) is shown.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
