### PR TITLE
Provide different error message when input is empty

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
@@ -81,7 +81,8 @@ class SuggestionActivity : LocaleAwareActivity() {
             setOnKeyListener { _, keyCode, event ->
                 if (event.action == KeyEvent.ACTION_UP) {
                     if (keyCode == KeyEvent.KEYCODE_ENTER) {
-                        return@setOnKeyListener exitIfOnlyOneMatchingUser()
+                        exitIfOnlyOneMatchingUser()
+                        return@setOnKeyListener true
                     }
                 }
                 false
@@ -90,6 +91,7 @@ class SuggestionActivity : LocaleAwareActivity() {
             setOnEditorActionListener { _, actionId, _ ->
                 if (actionId == EditorInfo.IME_ACTION_DONE) {
                     exitIfOnlyOneMatchingUser()
+                    true
                 } else {
                     false
                 }
@@ -167,18 +169,16 @@ class SuggestionActivity : LocaleAwareActivity() {
         })
     }
 
-    private fun exitIfOnlyOneMatchingUser(): Boolean {
-        return when (val finishAttempt = viewModel.onAttemptToFinish(
+    private fun exitIfOnlyOneMatchingUser() {
+        when (val finishAttempt = viewModel.onAttemptToFinish(
                 suggestionAdapter?.filteredSuggestions,
                 autocompleteText.text.toString()
         )) {
             is OnlyOneAvailable -> {
                 finishWithValue(finishAttempt.onlySelectedValue)
-                true
             }
             is NotExactlyOneAvailable -> {
                 ToastUtils.showToast(this@SuggestionActivity, finishAttempt.errorMessage)
-                false
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionViewModel.kt
@@ -91,11 +91,18 @@ class SuggestionViewModel @Inject constructor(
         return if (onlyDisplayedSuggestion != null) {
             OnlyOneAvailable(onlyDisplayedSuggestion.value)
         } else {
-            val message = resourceProvider.getString(
-                    R.string.suggestion_invalid,
-                    currentUserInput,
-                    suggestionTypeString
-            )
+            // Provide different message depending on whether the user has tried to "submit" a suggestion
+            // based on no filter text versus tried to submit a suggestion based on text that just doesn't
+            // match a single suggestion.
+            val message = if (currentUserInput == suggestionPrefix.toString()) {
+                resourceProvider.getString(R.string.suggestion_selection_needed)
+            } else {
+                resourceProvider.getString(
+                        R.string.suggestion_invalid,
+                        currentUserInput,
+                        suggestionTypeString
+                )
+            }
             NotExactlyOneAvailable(message)
         }
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2321,6 +2321,7 @@
     <string name="tap_to_try_again">Tap to try again!</string>
     <string name="add_media_progress">Adding media</string>
     <string name="suggestion_invalid">"%s is not a valid %s"</string>
+    <string name="suggestion_selection_needed">"Please type to filter the list of suggestions."</string>
     <string name="suggestion_none">"No %s suggestions available."</string>
     <string name="suggestion_no_matching">"No matching %s."</string>
     <string name="suggestion_no_connection">"No internet connection.\nSuggestions are unavailable."</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/suggestion/SuggestionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/suggestion/SuggestionViewModelTest.kt
@@ -166,6 +166,21 @@ class SuggestionViewModelTest {
     }
 
     @Test
+    fun `onAttemptToFinish no filter text from user`() {
+        initViewModel(XPosts)
+        val emptyUserInput = "+"
+        val expectedMesage = "expected_message"
+        whenever(mockResourceProvider.getString(R.string.suggestion_selection_needed))
+                .thenReturn(expectedMesage)
+
+        val listWithMoreThanOne = listOf<Suggestion>(mock(), mock())
+        val actual = viewModel.onAttemptToFinish(listWithMoreThanOne, emptyUserInput)
+
+        val expected = NotExactlyOneAvailable(expectedMesage)
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `onAttemptToFinish multiple displayed suggestions`() {
         initViewModel()
         val userInput = "user_input"


### PR DESCRIPTION
Previously, if a user tried to "submit" from the suggestions UI when they had typed nothing in the suggestions field a toast would appear with the message "+ is not a valid crosspost", which struck me as a bit confusing. The message makes sense when the user has typed something: "+something is not a valid crosspost", so this PR just adds a different message ("Please type to filter the list of suggestions.") to be used when the suggestions filter is empty.

This PR relies on the changes in the `xposts_suggestions` branch, so I'm targeting that branch. I just wanted to extract these changes out so it would be easy to review them independently before adding them to the `xposts_suggestions` branch.

### To Test

This behavior should be the same for both xposting and @-mentions

1. Open a site that is capable of suggestions
2. Open the suggestions UI
3. Without typing anything, tap the Enter/Checkmark key on the on-screen keyboard
4. Observe a toast is presented with the text: "Please type to filter the list of suggestions"
5. Add some text to filter the list of suggestions so that there are either 0 or more than 1 suggestions (i.e., anything but a single matching suggestion)
6. Tap the Enter/Checkmark key on the on-screen keyboard
7. Observe a toast is presented informing that the entered text is not a valid suggestion
8. Update the text so it matches exactly 1 suggestion
9. Tap the Enter/Checkmark key on the on-screen keyboard
10. Observe the suggestion is added to the post.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
