### PR TITLE
Issue/12934 add header to p2 postcard to show author

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -25,7 +25,7 @@ import java.util.Locale;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 143;
+    private static final int DB_VERSION = 144;
     private static final int DB_LAST_VERSION_WITHOUT_MIGRATION_SCRIPT = 136; // do not change this value
 
     /*
@@ -102,6 +102,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      * 141 - added tbl_posts.tags
      * 142 - remove followed tags from tbl_tags
      * 143 - drop tbl_recommended_blogs
+     * 141 - added tbl_posts.is_wpforteams_site
      */
 
     /*
@@ -209,6 +210,9 @@ public class ReaderDatabase extends SQLiteOpenHelper {
                 currentVersion++;
             case 142:
                 db.execSQL("DROP TABLE IF EXISTS tbl_recommended_blogs;");
+                currentVersion++;
+            case 143:
+                db.execSQL("ALTER TABLE tbl_posts ADD is_wpforteams_site BOOLEAN;");
                 currentVersion++;
         }
         if (currentVersion != newVersion) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -102,7 +102,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      * 141 - added tbl_posts.tags
      * 142 - remove followed tags from tbl_tags
      * 143 - drop tbl_recommended_blogs
-     * 141 - added tbl_posts.is_wpforteams_site
+     * 144 - added tbl_posts.is_wpforteams_site
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -87,7 +87,8 @@ public class ReaderPostTable {
             + "use_excerpt," // 45
             + "is_bookmarked," // 46
             + "is_private_atomic," // 47
-            + "tags"; // 48
+            + "tags," // 48
+            + "is_wpforteams_site"; // 49
 
     // used when querying multiple rows and skipping text column
     private static final String COLUMN_NAMES_NO_TEXT =
@@ -137,7 +138,8 @@ public class ReaderPostTable {
             + "use_excerpt," // 44
             + "is_bookmarked," // 45
             + "is_private_atomic," // 46
-            + "tags"; // 47
+            + "tags," // 47
+            + "is_wpforteams_site"; // 48
 
     protected static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE tbl_posts ("
@@ -189,6 +191,7 @@ public class ReaderPostTable {
                    + " is_bookmarked INTEGER DEFAULT 0,"
                    + " is_private_atomic INTEGER DEFAULT 0,"
                    + " tags TEXT,"
+                   + " is_wpforteams_site INTEGER DEFAULT 0,"
                    + " PRIMARY KEY (pseudo_id, tag_name, tag_type)"
                    + ")");
 
@@ -831,7 +834,7 @@ public class ReaderPostTable {
                 + COLUMN_NAMES
                 + ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,"
                 + "?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36,?37,?38,?39,?40,?41,?42,?43,?44, ?45, ?46, ?47,"
-                + "?48)");
+                + "?48,?49)");
 
         db.beginTransaction();
         try {
@@ -892,6 +895,7 @@ public class ReaderPostTable {
                 stmtPosts.bindLong(46, SqlUtils.boolToSql(post.isBookmarked));
                 stmtPosts.bindLong(47, SqlUtils.boolToSql(post.isPrivateAtomic));
                 stmtPosts.bindString(48, ReaderUtils.getCommaSeparatedTagSlugs(post.getTags()));
+                stmtPosts.bindLong(49, SqlUtils.boolToSql(post.isWpForTeams));
                 stmtPosts.execute();
             }
 
@@ -1144,6 +1148,8 @@ public class ReaderPostTable {
         if (commaSeparatedTags != null) {
             post.setTags(ReaderUtils.getTagsFromCommaSeparatedSlugs(commaSeparatedTags));
         }
+
+        post.isWpForTeams = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_wpforteams_site")));
 
         return post;
     }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -65,6 +65,7 @@ public class ReaderPost {
     public boolean isPrivateAtomic;
     public boolean isVideoPress;
     public boolean isJetpack;
+    public boolean isWpForTeams;
     public boolean useExcerpt;
 
     private String mAttachmentsJson;
@@ -168,6 +169,11 @@ public class ReaderPost {
             }
             // TODO: as of 29-Sept-2014, this is broken - endpoint returns false when it should be true
             post.isJetpack = JSONUtils.getBool(jsonSite, "jetpack");
+
+            JSONObject jsonSiteOptions = JSONUtils.getJSONChild(jsonSite, "options");
+            if (jsonSiteOptions != null) {
+                post.isWpForTeams = JSONUtils.getBool(jsonSiteOptions, "is_wpforteams_site");
+            }
         }
 
         // "discover" posts

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -326,7 +326,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
             UiStringText(post.authorName)
         }
 
-        return UiStringResWithParams(R.string.reader_author_with_blog_name, listOf(authorName, UiStringText("Very Very Very Very Long and Complicated Blog Name")))
+        return UiStringResWithParams(R.string.reader_author_with_blog_name, listOf(authorName, blogName))
     }
 
     private fun buildAvatarOrBlavatarUrl(post: ReaderPost) =

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -216,14 +216,14 @@ class ReaderPostUiStateBuilder @Inject constructor(
         post: ReaderPost,
         onBlogSectionClicked: (Long, Long) -> Unit,
         postListType: ReaderPostListType? = null,
-        showP2SpecificLayout: Boolean = false,
+        showP2SpecificLayout: Boolean = false
     ) = buildBlogSectionUiState(post, onBlogSectionClicked, postListType, showP2SpecificLayout)
 
     private fun buildBlogSectionUiState(
         post: ReaderPost,
         onBlogSectionClicked: (Long, Long) -> Unit,
         postListType: ReaderPostListType?,
-        showP2SpecificLayout: Boolean = false,
+        showP2SpecificLayout: Boolean = false
     ): ReaderBlogSectionUiState {
         return ReaderBlogSectionUiState(
                 postId = post.postId,
@@ -326,7 +326,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
             UiStringText(post.authorName)
         }
 
-        return UiStringResWithParams(R.string.reader_author_with_blog_name, listOf(authorName, blogName))
+        return UiStringResWithParams(R.string.reader_author_with_blog_name, listOf(authorName, UiStringText("Very Very Very Very Long and Complicated Blog Name")))
     }
 
     private fun buildAvatarOrBlavatarUrl(post: ReaderPost) =

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -216,23 +216,23 @@ class ReaderPostUiStateBuilder @Inject constructor(
         post: ReaderPost,
         onBlogSectionClicked: (Long, Long) -> Unit,
         postListType: ReaderPostListType? = null,
-        showP2SpecificLayout: Boolean = false
-    ) = buildBlogSectionUiState(post, onBlogSectionClicked, postListType, showP2SpecificLayout)
+        isP2Post: Boolean = false
+    ) = buildBlogSectionUiState(post, onBlogSectionClicked, postListType, isP2Post)
 
     private fun buildBlogSectionUiState(
         post: ReaderPost,
         onBlogSectionClicked: (Long, Long) -> Unit,
         postListType: ReaderPostListType?,
-        showP2SpecificLayout: Boolean = false
+        isP2Post: Boolean = false
     ): ReaderBlogSectionUiState {
         return ReaderBlogSectionUiState(
                 postId = post.postId,
                 blogId = post.blogId,
-                blogName = buildBlogName(post, showP2SpecificLayout),
+                blogName = buildBlogName(post, isP2Post),
                 blogUrl = buildBlogUrl(post),
                 dateLine = buildDateLine(post),
                 avatarOrBlavatarUrl = buildAvatarOrBlavatarUrl(post),
-                isAuthorAvatarVisible = showP2SpecificLayout,
+                isAuthorAvatarVisible = isP2Post,
                 authorAvatarUrl = gravatarUtilsWrapper.fixGravatarUrlWithResource(
                         post.postAvatar,
                         R.dimen.avatar_sz_medium
@@ -312,11 +312,11 @@ class ReaderPostUiStateBuilder @Inject constructor(
     private fun buildExcerpt(post: ReaderPost) =
             post.takeIf { post.cardType != PHOTO && post.hasExcerpt() }?.excerpt
 
-    private fun buildBlogName(post: ReaderPost, showP2SpecificLayout: Boolean = false): UiString {
+    private fun buildBlogName(post: ReaderPost, isP2Post: Boolean = false): UiString {
         val blogName = post.takeIf { it.hasBlogName() }?.blogName?.let { UiStringText(it) }
                 ?: UiStringRes(R.string.untitled_in_parentheses)
 
-        if (!showP2SpecificLayout) {
+        if (!isP2Post) {
             return blogName
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -22,7 +22,6 @@ import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils.VideoThumbnailUrlListener
 import org.wordpress.android.ui.reader.views.ReaderIconCountView
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.expandTouchTargetArea
 import org.wordpress.android.util.getDrawableResIdFromAttribute
 import org.wordpress.android.util.image.ImageManager
@@ -138,13 +137,11 @@ class ReaderPostViewHolder(
             )
         }
 
-        uiHelpers.updateVisibility(
-                p2_author_avatar, state.blogSection.avatarOrBlavatarUrl != null && state.blogSection.isAuthorAvatarVisible
-        )
-        if (state.blogSection.isAuthorAvatarVisible && state.blogSection.authorAvatarUrl != null) {
-            imageManager.loadIntoCircle(p2_author_avatar, BLAVATAR_CIRCULAR, state.blogSection.authorAvatarUrl)
+        uiHelpers.updateVisibility(authors_avatar, state.blogSection.isAuthorAvatarVisible)
+        if (state.blogSection.authorAvatarUrl == null) {
+            imageManager.cancelRequestAndClearImageView(authors_avatar)
         } else {
-            imageManager.cancelRequestAndClearImageView(p2_author_avatar)
+            imageManager.loadIntoCircle(authors_avatar, BLAVATAR_CIRCULAR, state.blogSection.authorAvatarUrl)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -137,11 +137,13 @@ class ReaderPostViewHolder(
             )
         }
 
-        uiHelpers.updateVisibility(authors_avatar, state.blogSection.isAuthorAvatarVisible)
-        if (state.blogSection.authorAvatarUrl == null) {
+        val canShowAuthorsAvatar = state.blogSection.authorAvatarUrl != null && state.blogSection.isAuthorAvatarVisible
+        uiHelpers.updateVisibility(authors_avatar, canShowAuthorsAvatar)
+
+        if (!canShowAuthorsAvatar) {
             imageManager.cancelRequestAndClearImageView(authors_avatar)
         } else {
-            imageManager.loadIntoCircle(authors_avatar, BLAVATAR_CIRCULAR, state.blogSection.authorAvatarUrl)
+            imageManager.loadIntoCircle(authors_avatar, BLAVATAR_CIRCULAR, state.blogSection.authorAvatarUrl!!)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils.VideoThumbnailUrlListener
 import org.wordpress.android.ui.reader.views.ReaderIconCountView
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.expandTouchTargetArea
 import org.wordpress.android.util.getDrawableResIdFromAttribute
 import org.wordpress.android.util.image.ImageManager
@@ -135,6 +136,15 @@ class ReaderPostViewHolder(
                     image_avatar_or_blavatar,
                     BLAVATAR_CIRCULAR, state.blogSection.avatarOrBlavatarUrl
             )
+        }
+
+        uiHelpers.updateVisibility(
+                p2_author_avatar, state.blogSection.avatarOrBlavatarUrl != null && state.blogSection.isAuthorAvatarVisible
+        )
+        if (state.blogSection.isAuthorAvatarVisible && state.blogSection.authorAvatarUrl != null) {
+            imageManager.loadIntoCircle(p2_author_avatar, BLAVATAR_CIRCULAR, state.blogSection.authorAvatarUrl)
+        } else {
+            imageManager.cancelRequestAndClearImageView(p2_author_avatar)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.kt
@@ -78,6 +78,7 @@ class ReaderPostDetailHeaderView @JvmOverloads constructor(
 
     private fun updateBlavatar(state: ReaderBlogSectionUiState) {
         uiHelpers.updateVisibility(image_avatar_or_blavatar, state.avatarOrBlavatarUrl != null)
+        uiHelpers.updateVisibility(p2_author_avatar, state.isAuthorAvatarVisible)
         if (state.avatarOrBlavatarUrl == null) {
             imageManager.cancelRequestAndClearImageView(image_avatar_or_blavatar)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.kt
@@ -78,7 +78,7 @@ class ReaderPostDetailHeaderView @JvmOverloads constructor(
 
     private fun updateBlavatar(state: ReaderBlogSectionUiState) {
         uiHelpers.updateVisibility(image_avatar_or_blavatar, state.avatarOrBlavatarUrl != null)
-        uiHelpers.updateVisibility(p2_author_avatar, state.isAuthorAvatarVisible)
+        uiHelpers.updateVisibility(authors_avatar, state.isAuthorAvatarVisible)
         if (state.avatarOrBlavatarUrl == null) {
             imageManager.cancelRequestAndClearImageView(image_avatar_or_blavatar)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.kt
@@ -78,7 +78,6 @@ class ReaderPostDetailHeaderView @JvmOverloads constructor(
 
     private fun updateBlavatar(state: ReaderBlogSectionUiState) {
         uiHelpers.updateVisibility(image_avatar_or_blavatar, state.avatarOrBlavatarUrl != null)
-        uiHelpers.updateVisibility(authors_avatar, state.isAuthorAvatarVisible)
         if (state.avatarOrBlavatarUrl == null) {
             imageManager.cancelRequestAndClearImageView(image_avatar_or_blavatar)
         } else {
@@ -87,6 +86,8 @@ class ReaderPostDetailHeaderView @JvmOverloads constructor(
                     BLAVATAR_CIRCULAR, state.avatarOrBlavatarUrl
             )
         }
+        // we don't show the p2 style of header in post details yet
+        uiHelpers.updateVisibility(authors_avatar, state.isAuthorAvatarVisible)
     }
 
     private fun updateFollowButton(followButtonUiState: FollowButtonUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/uistates/ReaderBlogSectionUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/uistates/ReaderBlogSectionUiState.kt
@@ -10,6 +10,8 @@ data class ReaderBlogSectionUiState(
     val blogName: UiString,
     val blogUrl: String?,
     val avatarOrBlavatarUrl: String?,
+    val authorAvatarUrl: String?,
+    val isAuthorAvatarVisible: Boolean,
     val blogSectionClickData: ReaderBlogSectionClickData?
 ) {
     data class ReaderBlogSectionClickData(

--- a/WordPress/src/main/res/drawable/bg_oval_stroke_p2_author_1dp.xml
+++ b/WordPress/src/main/res/drawable/bg_oval_stroke_p2_author_1dp.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <stroke
+        android:width="1dp"
+        android:color="@color/p2_author_bg_stroke"/>
+</shape>

--- a/WordPress/src/main/res/layout/reader_blog_section_view.xml
+++ b/WordPress/src/main/res/layout/reader_blog_section_view.xml
@@ -5,17 +5,33 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
-    <ImageView
-        android:id="@+id/image_avatar_or_blavatar"
-        style="@style/ReaderImageView.Avatar"
-        android:importantForAccessibility="no"
-        android:background="@drawable/bg_oval_stroke_placeholder_1dp"
-        android:padding="@dimen/reader_image_avatar_or_blavatar_border_width"
+
+    <FrameLayout
         android:layout_marginEnd="@dimen/margin_medium"
-        app:layout_constraintStart_toStartOf="parent"
+        android:id="@+id/author_and_site_imagery_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         app:layout_constraintEnd_toStartOf="@id/text_author_and_blog_name"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:ignore="RtlSymmetry" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/image_avatar_or_blavatar"
+            style="@style/ReaderImageView.Avatar"
+            android:background="@drawable/bg_oval_stroke_placeholder_1dp"
+            android:importantForAccessibility="no"
+            android:padding="@dimen/reader_image_avatar_or_blavatar_border_width"
+            tools:ignore="RtlSymmetry" />
+
+        <ImageView
+            android:id="@+id/p2_author_avatar"
+            style="@style/ReaderImageView.Avatar"
+            android:layout_marginStart="20dp"
+            android:background="@drawable/bg_oval_stroke_placeholder_1dp"
+            android:importantForAccessibility="no"
+            android:padding="@dimen/reader_image_avatar_or_blavatar_border_width"
+            tools:ignore="RtlSymmetry" />
+    </FrameLayout>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_author_and_blog_name"
@@ -25,7 +41,7 @@
         android:layout_marginTop="@dimen/margin_small"
         android:layout_marginEnd="@dimen/margin_medium"
         android:includeFontPadding="false"
-        app:layout_constraintStart_toEndOf="@id/image_avatar_or_blavatar"
+        app:layout_constraintStart_toEndOf="@id/author_and_site_imagery_container"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="text_blog_nametext_blog_name text_blog_name" />

--- a/WordPress/src/main/res/layout/reader_blog_section_view.xml
+++ b/WordPress/src/main/res/layout/reader_blog_section_view.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <FrameLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_marginEnd="@dimen/margin_medium"
         android:id="@+id/author_and_site_imagery_container"
         android:layout_width="wrap_content"
@@ -21,17 +21,29 @@
             android:background="@drawable/bg_oval_stroke_placeholder_1dp"
             android:importantForAccessibility="no"
             android:padding="@dimen/reader_image_avatar_or_blavatar_border_width"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             tools:ignore="RtlSymmetry" />
+
+        <ViewStub
+            android:id="@+id/dynamic_center_point"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="@+id/image_avatar_or_blavatar"
+            app:layout_constraintLeft_toLeftOf="@+id/image_avatar_or_blavatar"
+            app:layout_constraintRight_toRightOf="@+id/image_avatar_or_blavatar"
+            app:layout_constraintTop_toTopOf="@+id/image_avatar_or_blavatar" />
 
         <ImageView
             android:id="@+id/authors_avatar"
             style="@style/ReaderImageView.Avatar"
-            android:layout_marginStart="20dp"
-            android:background="@drawable/bg_oval_stroke_placeholder_1dp"
+            android:background="@drawable/bg_oval_stroke_p2_author_1dp"
             android:importantForAccessibility="no"
             android:padding="@dimen/reader_image_avatar_or_blavatar_border_width"
+            app:layout_constraintStart_toEndOf="@+id/dynamic_center_point"
+            app:layout_constraintTop_toTopOf="parent"
             tools:ignore="RtlSymmetry" />
-    </FrameLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/text_author_and_blog_name"

--- a/WordPress/src/main/res/layout/reader_blog_section_view.xml
+++ b/WordPress/src/main/res/layout/reader_blog_section_view.xml
@@ -24,7 +24,7 @@
             tools:ignore="RtlSymmetry" />
 
         <ImageView
-            android:id="@+id/p2_author_avatar"
+            android:id="@+id/authors_avatar"
             style="@style/ReaderImageView.Avatar"
             android:layout_marginStart="20dp"
             android:background="@drawable/bg_oval_stroke_placeholder_1dp"

--- a/WordPress/src/main/res/layout/reader_cardview_xpost.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_xpost.xml
@@ -14,18 +14,6 @@
         android:padding="@dimen/reader_card_content_padding">
 
         <ImageView
-            android:id="@+id/image_avatar"
-            style="@style/ReaderImageView.Avatar.ExtraSmall"
-            android:layout_marginStart="@dimen/reader_xpost_avatar_margin_start"
-            android:background="@drawable/bg_oval_stroke_placeholder_1dp"
-            android:importantForAccessibility="no"
-            android:padding="@dimen/reader_image_avatar_or_blavatar_border_width"
-            android:src="@drawable/bg_rectangle_placeholder_user_32dp"
-            app:layout_constraintBottom_toBottomOf="@+id/text_subtitle"
-            app:layout_constraintStart_toStartOf="@id/image_blavatar"
-            app:layout_constraintTop_toTopOf="@+id/text_subtitle" />
-
-        <ImageView
             android:id="@+id/image_blavatar"
             style="@style/ReaderImageView.Avatar.ExtraSmall"
             android:background="@drawable/bg_oval_stroke_placeholder_1dp"
@@ -35,6 +23,18 @@
             app:layout_constraintBottom_toBottomOf="@+id/image_avatar"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@+id/image_avatar" />
+
+        <ImageView
+            android:id="@+id/image_avatar"
+            style="@style/ReaderImageView.Avatar.ExtraSmall"
+            android:layout_marginStart="@dimen/reader_xpost_avatar_margin_start"
+            android:background="@drawable/bg_oval_stroke_p2_author_1dp"
+            android:importantForAccessibility="no"
+            android:padding="@dimen/reader_image_avatar_or_blavatar_border_width"
+            android:src="@drawable/bg_rectangle_placeholder_user_32dp"
+            app:layout_constraintBottom_toBottomOf="@+id/text_subtitle"
+            app:layout_constraintStart_toStartOf="@id/image_blavatar"
+            app:layout_constraintTop_toTopOf="@+id/text_subtitle" />
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/text_subtitle"

--- a/WordPress/src/main/res/values-ldrtl/strings.xml
+++ b/WordPress/src/main/res/values-ldrtl/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="reader_author_with_blog_name" translatable="false">%2$s ◂ %1$s</string>
+
+</resources>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -19,6 +19,7 @@
 
     <!-- Switch to attribute after dropping support for api 21-23 -->
     <color name="placeholder">#1AFFFFFF</color>
+    <color name="p2_author_bg_stroke">#1E1E1E</color>
 
     <!-- Stats -->
 

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -16,6 +16,7 @@
 
     <!-- Switch to attribute after dropping support for api 21-23 -->
     <color name="placeholder">#1A000000</color>
+    <color name="p2_author_bg_stroke">#FFF</color>
 
     <!-- Stats -->
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1342,6 +1342,7 @@
     <string name="reader_discover_no_posts_subtitle">Try following more topics to broaden the search</string>
     <string name="reader_discover_empty_button_text">Get Started</string>
     <string name="reader_discover_no_posts_button_text">Follow topics</string>
+    <string name="reader_author_with_blog_name" translatable="false">%s ▸ %s</string>
 
     <!-- editor -->
     <string name="editor_post_saved_online">Post saved online</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1342,7 +1342,7 @@
     <string name="reader_discover_no_posts_subtitle">Try following more topics to broaden the search</string>
     <string name="reader_discover_empty_button_text">Get Started</string>
     <string name="reader_discover_no_posts_button_text">Follow topics</string>
-    <string name="reader_author_with_blog_name" translatable="false">%s ▸ %s</string>
+    <string name="reader_author_with_blog_name" translatable="false">%1$s ▸ %2$s</string>
 
     <!-- editor -->
     <string name="editor_post_saved_online">Post saved online</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -656,7 +656,15 @@ class ReaderDiscoverViewModelTest {
                 postId = post.postId,
                 blogId = post.blogId,
                 blogSection = ReaderBlogSectionUiState(
-                        post.postId, post.blogId, "", mock(), "", "", ReaderBlogSectionClickData(postHeaderClicked, 0)
+                        post.postId,
+                        post.blogId,
+                        "",
+                        mock(),
+                        "",
+                        "",
+                        "",
+                        false,
+                        ReaderBlogSectionClickData(postHeaderClicked, 0)
                 ),
                 tagItems = listOf(TagUiState("", "", false, onTagClicked)),
                 excerpt = "",

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -531,18 +531,20 @@ class ReaderPostUiStateBuilderTest {
                 authorName = "John Smith"
         )
         // Act
-        val postWithFirstNameUiState = mapPostToUiState(postWithFirstName)
-        val postWithoutFirstNameUiState = mapPostToUiState(postWithoutFirstName)
+        val firstNameUiState = mapPostToUiState(postWithFirstName)
+        val fullNameUiState = mapPostToUiState(postWithoutFirstName)
         // Assert
-        assertThat((postWithFirstNameUiState.blogSection.blogName as UiStringResWithParams).stringRes).isEqualTo(R.string.reader_author_with_blog_name)
-        assertThat((postWithFirstNameUiState.blogSection.blogName as UiStringResWithParams).params.size).isEqualTo(2)
-        assertThat(((postWithFirstNameUiState.blogSection.blogName as UiStringResWithParams).params[0] as UiStringText).text).isEqualTo("John")
-        assertThat(((postWithFirstNameUiState.blogSection.blogName as UiStringResWithParams).params[1] as UiStringText).text).isEqualTo("Fancy Blog")
+        val firstNameBlog = firstNameUiState.blogSection.blogName as UiStringResWithParams
+        assertThat(firstNameBlog.stringRes).isEqualTo(R.string.reader_author_with_blog_name)
+        assertThat(firstNameBlog.params.size).isEqualTo(2)
+        assertThat((firstNameBlog.params[0] as UiStringText).text).isEqualTo("John")
+        assertThat((firstNameBlog.params[1] as UiStringText).text).isEqualTo("Fancy Blog")
 
-        assertThat((postWithoutFirstNameUiState.blogSection.blogName as UiStringResWithParams).stringRes).isEqualTo(R.string.reader_author_with_blog_name)
-        assertThat((postWithoutFirstNameUiState.blogSection.blogName as UiStringResWithParams).params.size).isEqualTo(2)
-        assertThat(((postWithoutFirstNameUiState.blogSection.blogName as UiStringResWithParams).params[0] as UiStringText).text).isEqualTo("John Smith")
-        assertThat(((postWithoutFirstNameUiState.blogSection.blogName as UiStringResWithParams).params[1] as UiStringText).text).isEqualTo("Fancy Blog")
+        val fullNameBlog = fullNameUiState.blogSection.blogName as UiStringResWithParams
+        assertThat(fullNameBlog.stringRes).isEqualTo(R.string.reader_author_with_blog_name)
+        assertThat(fullNameBlog.params.size).isEqualTo(2)
+        assertThat((fullNameBlog.params[0] as UiStringText).text).isEqualTo("John Smith")
+        assertThat((fullNameBlog.params[1] as UiStringText).text).isEqualTo("Fancy Blog")
     }
     // endregion
 
@@ -943,7 +945,7 @@ class ReaderPostUiStateBuilderTest {
         isp2Post: Boolean = false,
         blogName: String = "",
         authorFirstName: String = "",
-        authorName: String = "",
+        authorName: String = ""
     ): ReaderPost {
         val post = spy(ReaderPost().apply {
             this.blogUrl = blogUrl

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -327,6 +327,8 @@ class ReaderPostDetailViewModelTest {
                             blogName = mock(),
                             blogUrl = "",
                             avatarOrBlavatarUrl = "",
+                            authorAvatarUrl = "",
+                            isAuthorAvatarVisible = false,
                             blogSectionClickData = ReaderBlogSectionClickData(onBlogSectionClicked, 0)
                         ),
                         FollowButtonUiState(


### PR DESCRIPTION
Fixes #12934

This PR modifies a header of the P2 reader posts to show the author's avatar alongside the blog avatar and show the author's name alongside the blog's name.
Where the p2 has not blavatar only the author's avatar will be shown (or no avatar at all if neither are available).

| Before | After Dark | After Light |
|--------|--------|--------|
| [![Image from Gyazo](https://i.gyazo.com/56a9ffafa4d9717bf3e3ddf067a9c898.png)](https://gyazo.com/56a9ffafa4d9717bf3e3ddf067a9c898) |[![Image from Gyazo](https://i.gyazo.com/900e6c9adc83c6cabfcb90d3f9c91e8a.png)](https://gyazo.com/900e6c9adc83c6cabfcb90d3f9c91e8a)|[![Image from Gyazo](https://i.gyazo.com/f8e2694a58729421cb121badf7b5d55f.png)](https://gyazo.com/f8e2694a58729421cb121badf7b5d55f)|

To test:
- To test DB migration install this branch over any previous version (eg. develop). Older posts already stored in DB without P2 flag will not show P2 specific layout.
- Make sure you follow a p2 site.
- Navigate to the reader and check that the p2 site's postcard header show's author's avatar next to the blog avatar.
- Make sure that the author's name is shown next to the blog name.
- Make sure those changes are not visible on non-p2 posts or in post details (including details of P2 post).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
