### PR TITLE
Fix duplicate media upload issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -205,15 +205,18 @@ public class UploadService extends Service {
             // if this media belongs to some post, register such Post
             registerPostModelsForMedia(mediaList, intent.getBooleanExtra(KEY_SHOULD_RETRY, false));
 
-            ArrayList<MediaModel> toBeUploadedMediaList = new ArrayList<>(mediaList);
+            ArrayList<MediaModel> toBeUploadedMediaList = new ArrayList<>();
             for (MediaModel media : mediaList) {
-                // Reload media and if already uploaded, remove it from the media list to be uploaded
                 MediaModel localMedia = mMediaStore.getMediaWithLocalId(media.getId());
-                if (localMedia != null
-                    && MediaUploadState.fromString(localMedia.getUploadState()) == MediaUploadState.UPLOADED) {
-                    toBeUploadedMediaList.remove(media);
-                    continue;
+                boolean notUploadedYet = localMedia != null
+                                         && MediaUploadState.fromString(localMedia.getUploadState())
+                                            != MediaUploadState.UPLOADED;
+                if (notUploadedYet) {
+                    toBeUploadedMediaList.add(localMedia);
                 }
+            }
+
+            for (MediaModel media : toBeUploadedMediaList) {
                 mMediaUploadHandler.upload(media);
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -205,10 +205,21 @@ public class UploadService extends Service {
             // if this media belongs to some post, register such Post
             registerPostModelsForMedia(mediaList, intent.getBooleanExtra(KEY_SHOULD_RETRY, false));
 
+            ArrayList<MediaModel> toBeUploadedMediaList = new ArrayList<>(mediaList);
             for (MediaModel media : mediaList) {
+                // Reload media and if already uploaded, remove it from the media list to be uploaded
+                MediaModel localMedia = mMediaStore.getMediaWithLocalId(media.getId());
+                if (localMedia != null
+                    && MediaUploadState.fromString(localMedia.getUploadState()) == MediaUploadState.UPLOADED) {
+                    toBeUploadedMediaList.remove(media);
+                    continue;
+                }
                 mMediaUploadHandler.upload(media);
             }
-            mPostUploadNotifier.addMediaInfoToForegroundNotification(mediaList);
+
+            if (!toBeUploadedMediaList.isEmpty()) {
+                mPostUploadNotifier.addMediaInfoToForegroundNotification(toBeUploadedMediaList);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #11722

This PR removes media in `MediaUploadState.UPLOADED` state from the list of (to be uploaded) media received in the `UploadService` on app restart.

#### Findings

When a media is uploaded for a post and the app is restarted, sometimes `UploadService` receives an intent that contains the original media in the `MediaUploadState.QUEUED` state. The app start re-uploading it as it is still not in the `MediaUploadState.UPLOADED` state.
This results in duplicate media in the site's Media section while the post still contains only the original image. 

https://cloudup.com/i05aJ0_x9nd

|Timestamp | Description |
|------------|-------------|
|`00:19 - 00:23` | Image is uploaded  |
|`00:23 - 00:27` | App is killed  |
|`00:32 - 00:36` | App starts re-uploading the image on relaunch |
|`00:51` | Media section displays duplicate images |

#### Solution

Media received in the `UploadService` intent is now reloaded from the DB to check the latest upload status and if found in the `MediaUploadState.UPLOADED` state, it is removed from the (to be uploaded) media list.

#### To test

- Launch the app
- Upload an image on a post using the Gutenberg editor
- After upload completes, wait for few seconds and kill the app
- Restart the app 
- Notice that uploading arrow is not shown in the status bar
- Go to media browser for the site
- Notice that it contains no unneeded duplicate images 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
