### PR TITLE
Issue/13268 activity type filter screen skeleton

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterAdapter.kt
@@ -12,11 +12,11 @@ class ActivityLogTypeFilterAdapter(private val uiHelpers: UiHelpers) : Adapter<A
         return ActivityLogTypeFilterViewHolder(parent, uiHelpers)
     }
 
-    override fun getItemCount(): Int = items.size
-
     override fun onBindViewHolder(holder: ActivityLogTypeFilterViewHolder, position: Int) {
         holder.onBind(items[position])
     }
+
+    override fun getItemCount(): Int = items.size
 
     fun update(newItems: List<ItemUiState>) {
         items.clear()

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterAdapter.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.activitylog.list.filter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView.Adapter
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.ItemUiState
+import org.wordpress.android.ui.utils.UiHelpers
+
+class ActivityLogTypeFilterAdapter(private val uiHelpers: UiHelpers) : Adapter<ActivityLogTypeFilterViewHolder>() {
+    private val items = mutableListOf<ItemUiState>()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ActivityLogTypeFilterViewHolder {
+        return ActivityLogTypeFilterViewHolder(parent, uiHelpers)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: ActivityLogTypeFilterViewHolder, position: Int) {
+        holder.onBind(items[position])
+    }
+
+    fun update(newItems: List<ItemUiState>) {
+        items.clear()
+        items.addAll(newItems)
+        notifyDataSetChanged()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -51,13 +51,12 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
     }
 
     private fun initToolbar(view: View) {
-        val toolbar = view.findViewById(R.id.toolbar_main) as MaterialToolbar
-        toolbar.navigationIcon = ColorUtils.applyTintToDrawable(
-                toolbar.context, R.drawable.ic_close_white_24dp,
-                toolbar.context.getColorResIdFromAttribute(R.attr.colorOnSurface)
+        toolbar_main.navigationIcon = ColorUtils.applyTintToDrawable(
+                toolbar_main.context, R.drawable.ic_close_white_24dp,
+                toolbar_main.context.getColorResIdFromAttribute(R.attr.colorOnSurface)
         )
-        toolbar.setNavigationContentDescription(R.string.close_dialog_button_desc)
-        toolbar.setNavigationOnClickListener { dismiss() }
+        toolbar_main.setNavigationContentDescription(R.string.close_dialog_button_desc)
+        toolbar_main.setNavigationOnClickListener { dismiss() }
     }
 
     private fun initRecyclerView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -9,7 +9,10 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.MaterialToolbar
+import kotlinx.android.synthetic.main.site_creation_segments_screen.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.util.ColorUtils
@@ -36,6 +39,7 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.activity_log_type_filter_fragment, container, false)
         initToolbar(view)
+        initRecyclerView()
         return view
     }
 
@@ -52,5 +56,14 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
         )
         toolbar.setNavigationContentDescription(R.string.close_dialog_button_desc)
         toolbar.setNavigationOnClickListener { dismiss() }
+    }
+
+    private fun initRecyclerView() {
+        recycler_view.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+        initAdapter()
+    }
+
+    private fun initAdapter() {
+        // TODO malinjir init adapter
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -15,12 +15,14 @@ import com.google.android.material.appbar.MaterialToolbar
 import kotlinx.android.synthetic.main.site_creation_segments_screen.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ColorUtils
 import org.wordpress.android.util.getColorResIdFromAttribute
 import javax.inject.Inject
 
 class ActivityLogTypeFilterFragment : DialogFragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var uiHelpers: UiHelpers
 
     private lateinit var viewModel: ActivityLogTypeFilterViewModel
 
@@ -64,6 +66,6 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
     }
 
     private fun initAdapter() {
-        // TODO malinjir init adapter
+        recycler_view.adapter = ActivityLogTypeFilterAdapter(uiHelpers)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -39,14 +39,17 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val view = inflater.inflate(R.layout.activity_log_type_filter_fragment, container, false)
-        initToolbar(view)
-        initRecyclerView()
-        return view
+        return inflater.inflate(R.layout.activity_log_type_filter_fragment, container, false)
     }
 
     override fun getTheme(): Int {
         return R.style.WordPress_FullscreenDialog
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initToolbar(view)
+        initRecyclerView()
     }
 
     private fun initToolbar(view: View) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -26,6 +26,8 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
 
     private lateinit var viewModel: ActivityLogTypeFilterViewModel
 
+    override fun getTheme(): Int = R.style.WordPress_FullscreenDialog
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         (requireActivity().applicationContext as WordPress).component().inject(this)
@@ -40,10 +42,6 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.activity_log_type_filter_fragment, container, false)
-    }
-
-    override fun getTheme(): Int {
-        return R.style.WordPress_FullscreenDialog
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -9,8 +9,11 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
+import com.google.android.material.appbar.MaterialToolbar
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.util.ColorUtils
+import org.wordpress.android.util.getColorResIdFromAttribute
 import javax.inject.Inject
 
 class ActivityLogTypeFilterFragment : DialogFragment() {
@@ -31,10 +34,23 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.activity_log_type_filter_fragment, container, false)
+        val view = inflater.inflate(R.layout.activity_log_type_filter_fragment, container, false)
+        initToolbar(view)
+        return view
     }
 
     override fun getTheme(): Int {
         return R.style.WordPress_FullscreenDialog
+    }
+
+    private fun initToolbar(view: View) {
+        val toolbar = view.findViewById(R.id.toolbar_main) as MaterialToolbar
+        toolbar.title = "Ahoj"
+        toolbar.navigationIcon = ColorUtils.applyTintToDrawable(
+                toolbar.context, R.drawable.ic_close_white_24dp,
+                toolbar.context.getColorResIdFromAttribute(R.attr.colorOnSurface)
+        )
+        toolbar.setNavigationContentDescription(R.string.close_dialog_button_desc)
+        toolbar.setNavigationOnClickListener { dismiss() }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -54,7 +54,6 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
 
     private fun initToolbar(view: View) {
         val toolbar = view.findViewById(R.id.toolbar_main) as MaterialToolbar
-        toolbar.title = "Ahoj"
         toolbar.navigationIcon = ColorUtils.applyTintToDrawable(
                 toolbar.context, R.drawable.ic_close_white_24dp,
                 toolbar.context.getColorResIdFromAttribute(R.attr.colorOnSurface)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -9,7 +9,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
-import org.wordpress.android.R.layout
+import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import javax.inject.Inject
 
@@ -31,6 +31,10 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(layout.activity_log_type_filter_fragment, container, false)
+        return inflater.inflate(R.layout.activity_log_type_filter_fragment, container, false)
+    }
+
+    override fun getTheme(): Int {
+        return R.style.WordPress_FullscreenDialog
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.MaterialToolbar
-import kotlinx.android.synthetic.main.site_creation_segments_screen.*
+import kotlinx.android.synthetic.main.activity_log_type_filter_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.utils.UiHelpers

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.appbar.MaterialToolbar
 import kotlinx.android.synthetic.main.activity_log_type_filter_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewHolder.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui.activitylog.list.filter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import org.wordpress.android.R
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.ItemUiState
+import org.wordpress.android.ui.utils.UiHelpers
+
+class ActivityLogTypeFilterViewHolder(
+    parent: ViewGroup,
+    private val uiHelpers: UiHelpers
+) : RecyclerView.ViewHolder(
+        LayoutInflater.from(parent.context).inflate(R.layout.activity_log_type_filter_item, parent, false)
+) {
+    fun onBind(uiState: ItemUiState) {
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -15,4 +15,6 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
         if (isStarted) return
         isStarted = true
     }
+
+    object ItemUiState
 }

--- a/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
@@ -6,6 +6,12 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/toolbar_height" />
+
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"
         style="@style/WordPress.AppBarLayout"
@@ -20,11 +26,5 @@
             android:layout_height="wrap_content" />
 
     </com.google.android.material.appbar.AppBarLayout>
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="@dimen/toolbar_height" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
@@ -1,13 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.google.android.material.textview.MaterialTextView
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        style="@style/WordPress.AppBarLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="Just Test!"
-        tools:ignore="HardcodedText" />
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@+id/recycler_view">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            style="@style/WordPress.ToolBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
@@ -21,4 +21,10 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/toolbar_height" />
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/activity_log_type_filter_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_type_filter_item.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/activity_log_type_filter_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_type_filter_item.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1225,6 +1225,10 @@
         <item name="android:windowAnimationStyle">@style/FullScreenDialogFragmentAnimation</item>
     </style>
 
+    <style name="WordPress.FullscreenDialog">
+        <item name="android:windowIsFloating">false</item>
+    </style>
+
     <!-- Overload of Aztec theme -->
     <style name="FormatBarButton">
         <item name="android:minWidth">@dimen/format_bar_height</item>


### PR DESCRIPTION
Partially fixes #13268 

This PR updates Activity type filter screen
- makes the fragment fullscreen
- inits a toolbar
- inits adapter and view holder skeletons

Note: The adapter doesn't contain any data so the screen is completely empty (except of the "X" button)

To test - make sure the ActivityLogFilters feature flag is on in App settings
1. My site -> Activity Log
2. Click on "Activity Type" chip
3. Notice a fullscreen fragment with "X" is shown

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
