### PR TITLE
Load media library without storage permissions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -354,7 +354,7 @@ class MediaPickerViewModel @Inject constructor(
                     _domainModel.value = domainModel
                 }
             }
-            if (permissionsHandler.hasStoragePermission()) {
+            if (!mediaPickerSetup.requiresStoragePermissions || permissionsHandler.hasStoragePermission()) {
                 launch(bgDispatcher) {
                     loadActions.send(LoadAction.Start())
                 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
@@ -646,7 +646,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `does not start loading without storage permissions`() = test{
+    fun `does not start loading without storage permissions`() = test {
         setupViewModel(
                 listOf(firstItem),
                 singleSelectMediaPickerSetup.copy(requiresStoragePermissions = true),
@@ -657,7 +657,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `starts loading with storage permissions`() = test{
+    fun `starts loading with storage permissions`() = test {
         setupViewModel(
                 listOf(firstItem),
                 singleSelectMediaPickerSetup.copy(requiresStoragePermissions = true),
@@ -668,7 +668,7 @@ class MediaPickerViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `starts loading when storage permissions not necessary`() = test{
+    fun `starts loading when storage permissions not necessary`() = test {
         setupViewModel(
                 listOf(firstItem),
                 singleSelectMediaPickerSetup.copy(requiresStoragePermissions = false),


### PR DESCRIPTION
We've implemented a fix to not start loading data when the app doesn't have the storage permissions (this was crashing on one testing Samsung tablet). However, this didn't count with the use cases that don't require storage permissions. That's why when you have a fresh install of the app, the WP media library is not populated.

To test:
- Start with a freshly installed app
- Add a new post in GB editor
- Add an image block
- Click on "Add Image" 
- Click on "WordPress Media Library"
- Notice the images are populated

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
