### PR TITLE
Update WordPress Utils to 1.30.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.androidx_work_version = "2.0.1"
     ext.buildGutenbergMobileJSBundle = 1
-    ext.wordPressUtilsVersion = '1.30'
+    ext.wordPressUtilsVersion = '1.30.1'
 
     repositories {
         google()


### PR DESCRIPTION
This is a test to make sure the binary built with https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/48 works.