### PR TITLE
Fix continuous uploading notification on trashing queued post with media

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -127,6 +127,11 @@ class PostUploadNotifier {
     }
 
     private synchronized void startOrUpdateForegroundNotification(@Nullable PostImmutableModel post) {
+        boolean isTotalPostsAndMediaItemsCountZero = sNotificationData.mTotalPostItems == 0
+                                                     && sNotificationData.mTotalMediaItems == 0;
+        if (isTotalPostsAndMediaItemsCountZero) {
+            return;
+        }
         updateNotificationBuilder(post);
         if (sNotificationData.mNotificationId == 0) {
             sNotificationData.mNotificationId = (new Random()).nextInt();


### PR DESCRIPTION
Fixes #13428

### Findings

When a (queued) post with an (unsaved) image is trashed from the posts list, an attempt is made to remove this post info from the foreground notification. 

**Call trace**
[trashPost](https://github.com/wordpress-mobile/WordPress-Android/blob/a9eeed79f6d85fd3a3a55157ff9b2932248c00cc/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt#L267) -> [cancelQueuedPostUploadAndRelatedMedia](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java#L442) -> [removePostInfoFromForegroundNotification](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java#L140) -> [startOrUpdateForegroundNotification](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java#L129) -> [updateNotificationBuilder](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java#L100)

`updateNotificationBuilder` prepares a notification even when there are no post and media items to be uploaded resulting in a stuck notification.
(updateNotificationBuilder [else block](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java#L124-L125) is reached when `sNotificationData.mTotalMediaItems == 0` && `sNotificationData.mTotalPostItems == 0`)

**Video 1** https://cloudup.com/ipQRr0YVIdt
Queued post (with locally saved image) trashed: 00:37
Stuck notification: 00:43

While this notification is displaying and we upload media items to another post, notification remains in the stuck state even after image upload completes giving a _false impression that images are still uploading_.

**Video 2** https://cloudup.com/i7yUPPyc9Mr
Images uploaded in another post: 00:48 (verified in the media library:  01:06)
Stuck notification: 00:51

### Solution

When an attempt is made to start or update foreground notification, total count of the post and media items is now checked and if found to be zero, no changes (start or update) are made to the foreground notification.

### To test
(See video 1 for detailed steps)
1. Launch app
2. Edit a published post to upload an image (do not save the post) 
3. Delete the post from the posts list
4. Notice that continuous uploading notification is not displayed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
