### PR TITLE
Init UiState for activity type filter screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterAdapter.kt
@@ -2,11 +2,11 @@ package org.wordpress.android.ui.activitylog.list.filter
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.Adapter
-import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.ItemUiState
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.ListItemUiState
 import org.wordpress.android.ui.utils.UiHelpers
 
 class ActivityLogTypeFilterAdapter(private val uiHelpers: UiHelpers) : Adapter<ActivityLogTypeFilterViewHolder>() {
-    private val items = mutableListOf<ItemUiState>()
+    private val items = mutableListOf<ListItemUiState>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ActivityLogTypeFilterViewHolder {
         return ActivityLogTypeFilterViewHolder(parent, uiHelpers)
@@ -18,7 +18,7 @@ class ActivityLogTypeFilterAdapter(private val uiHelpers: UiHelpers) : Adapter<A
         holder.onBind(items[position])
     }
 
-    fun update(newItems: List<ItemUiState>) {
+    fun update(newItems: List<ListItemUiState>) {
         items.clear()
         items.addAll(newItems)
         notifyDataSetChanged()

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewHolder.kt
@@ -4,7 +4,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
-import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.ItemUiState
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.ListItemUiState
 import org.wordpress.android.ui.utils.UiHelpers
 
 class ActivityLogTypeFilterViewHolder(
@@ -13,6 +13,6 @@ class ActivityLogTypeFilterViewHolder(
 ) : RecyclerView.ViewHolder(
         LayoutInflater.from(parent.context).inflate(R.layout.activity_log_type_filter_item, parent, false)
 ) {
-    fun onBind(uiState: ItemUiState) {
+    fun onBind(uiState: ListItemUiState) {
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -88,20 +88,20 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
     }
 
     sealed class UiState {
+        open val contentVisibility = false
         open val loadingVisibility = false
-        open val items: List<ListItemUiState>? = null
-        open val primaryAction: Action? = null
-        open val secondaryAction: Action? = null
 
         object FullscreenLoading : UiState() {
             override val loadingVisibility: Boolean = true
         }
 
         data class Content(
-            override val items: List<ListItemUiState>,
-            override val primaryAction: Action,
-            override val secondaryAction: Action
-        ) : UiState()
+            val items: List<ListItemUiState>,
+            val primaryAction: Action,
+            val secondaryAction: Action
+        ) : UiState() {
+            override val contentVisibility = true
+        }
 
         data class Action(val label: UiString) {
             var action: (() -> Unit)? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -17,6 +17,27 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
         isStarted = true
     }
 
+    sealed class UiState {
+        open val loadingVisibility = false
+        open val items: List<ListItemUiState>? = null
+        open val primaryAction: Action? = null
+        open val secondaryAction: Action? = null
+
+        object FullscreenLoading : UiState() {
+            override val loadingVisibility: Boolean = true
+        }
+
+        data class Content(
+            override val items: List<ListItemUiState>,
+            override val primaryAction: Action,
+            override val secondaryAction: Action
+        ) : UiState()
+
+        data class Action(val label: UiString) {
+            var action: (() -> Unit)? = null
+        }
+    }
+
     sealed class ListItemUiState {
         data class SectionHeader(
             val title: UiString

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import okhttp3.internal.immutableListOf
 import org.wordpress.android.R
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
@@ -40,7 +39,7 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
     private fun fetchAvailableActivityTypes() {
         launch {
             // TODO malinjir initiate the fetch
-            onActivityTypesFetched(immutableListOf(DummyActivityType, DummyActivityType, DummyActivityType))
+            onActivityTypesFetched(listOf(DummyActivityType, DummyActivityType, DummyActivityType))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -9,7 +9,6 @@ import org.wordpress.android.R
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.ListItemUiState.SectionHeader
-import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.UiState.Action
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.UiState.Content
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.UiState.FullscreenLoading
 import org.wordpress.android.ui.utils.UiString
@@ -99,9 +98,6 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
             override val contentVisibility = true
         }
 
-        data class Action(val label: UiString) {
-            var action: (() -> Unit)? = null
-        }
     }
 
     sealed class ListItemUiState {
@@ -113,6 +109,10 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
             val title: UiString,
             val checked: Boolean = false
         ) : ListItemUiState()
+    }
+
+    data class Action(val label: UiString) {
+        var action: (() -> Unit)? = null
     }
 
     object DummyActivityType

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.activitylog.list.filter
 
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -16,5 +17,14 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
         isStarted = true
     }
 
-    object ListItemUiState
+    sealed class ListItemUiState {
+        data class SectionHeader(
+            val title: UiString
+        ) : ListItemUiState()
+
+        data class ActivityType(
+            val title: UiString,
+            val checked: Boolean = false
+        ) : ListItemUiState()
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -9,6 +9,7 @@ import okhttp3.internal.immutableListOf
 import org.wordpress.android.R
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.ListItemUiState.SectionHeader
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.UiState.Action
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.UiState.Content
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.UiState.FullscreenLoading
@@ -49,13 +50,15 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
 
     private suspend fun buildContentUiState(activityTypes: List<DummyActivityType>): Content {
         return withContext(bgDispatcher) {
+            // TODO malinjir replace the hardcoded header title
+            val headerListItem = SectionHeader(UiStringText("Test"))
             // TODO malinjir replace "it.toString()" with activity type name
             val activityTypeListItems: List<ListItemUiState.ActivityType> = activityTypes
                     .map {
                         ListItemUiState.ActivityType(title = UiStringText(it.toString()))
                     }
             Content(
-                    activityTypeListItems,
+                    listOf(headerListItem) + activityTypeListItems,
                     primaryAction = Action(label = UiStringRes(R.string.activity_log_activity_type_filter_apply))
                             .apply { action = ::onApplyClicked },
                     secondaryAction = Action(label = UiStringRes(R.string.activity_log_activity_type_filter_clear))

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -53,9 +53,7 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
             val headerListItem = SectionHeader(UiStringText("Test"))
             // TODO malinjir replace "it.toString()" with activity type name
             val activityTypeListItems: List<ListItemUiState.ActivityType> = activityTypes
-                    .map {
-                        ListItemUiState.ActivityType(title = UiStringText(it.toString()))
-                    }
+                    .map { ListItemUiState.ActivityType(title = UiStringText(it.toString())) }
             Content(
                     listOf(headerListItem) + activityTypeListItems,
                     primaryAction = Action(label = UiStringRes(R.string.activity_log_activity_type_filter_apply))
@@ -72,19 +70,18 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
 
     private fun onClearClicked() {
         (_uiState.value as? Content)?.let { it ->
-            _uiState.value = it.copy(items = uncheckAllActivityTypeItems(it))
+            _uiState.value = it.copy(items = getAllActivityTypeItemsUnchecked(it.items))
         }
     }
 
-    private fun uncheckAllActivityTypeItems(it: Content): List<ListItemUiState> {
-        return it.items.map { item ->
-            if (item is ListItemUiState.ActivityType) {
-                item.copy(checked = false)
-            } else {
-                item
+    private fun getAllActivityTypeItemsUnchecked(listItemUiStates: List<ListItemUiState>): List<ListItemUiState> =
+            listItemUiStates.map { item ->
+                if (item is ListItemUiState.ActivityType) {
+                    item.copy(checked = false)
+                } else {
+                    item
+                }
             }
-        }
-    }
 
     sealed class UiState {
         open val contentVisibility = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -16,5 +16,5 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
         isStarted = true
     }
 
-    object ItemUiState
+    object ListItemUiState
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -97,7 +97,6 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
         ) : UiState() {
             override val contentVisibility = true
         }
-
     }
 
     sealed class ListItemUiState {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -56,10 +56,20 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
                     }
             Content(
                     activityTypeListItems,
-                    primaryAction = Action(label = UiStringRes(R.string.activity_log_activity_type_filter_apply)),
+                    primaryAction = Action(label = UiStringRes(R.string.activity_log_activity_type_filter_apply))
+                            .apply { action = ::onApplyClicked },
                     secondaryAction = Action(label = UiStringRes(R.string.activity_log_activity_type_filter_clear))
+                            .apply { action = ::onClearClicked }
             )
         }
+    }
+
+    private fun onApplyClicked() {
+        // TODO malinjir save and dismiss
+    }
+
+    private fun onClearClicked() {
+        // TODO malinjir uncheck all items
     }
 
     sealed class UiState {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -1,7 +1,10 @@
 package org.wordpress.android.ui.activitylog.list.filter
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.UiState.FullscreenLoading
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -12,9 +15,14 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
 ) : ScopedViewModel(mainDispatcher) {
     private var isStarted = false
 
+    private val _uiState = MutableLiveData<UiState>()
+    val uiState: LiveData<UiState> = _uiState
+
     fun start() {
         if (isStarted) return
         isStarted = true
+
+        _uiState.value = FullscreenLoading
     }
 
     sealed class UiState {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -69,7 +69,19 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
     }
 
     private fun onClearClicked() {
-        // TODO malinjir uncheck all items
+        (_uiState.value as? Content)?.let { it ->
+            _uiState.value = it.copy(items = uncheckAllActivityTypeItems(it))
+        }
+    }
+
+    private fun uncheckAllActivityTypeItems(it: Content): List<ListItemUiState> {
+        return it.items.map { item ->
+            if (item is ListItemUiState.ActivityType) {
+                item.copy(checked = false)
+            } else {
+                item
+            }
+        }
     }
 
     sealed class UiState {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1026,6 +1026,8 @@
     <string name="activity_log_rewind_site">Rewind Site</string>
     <string name="activity_log_rewind_dialog_message">Are you sure you want to rewind your site back to %1$s at %2$s? This will remove all content and options created or changed since then.</string>
     <string name="activity_log_limited_content_on_free_plan">Since you\'re on a free plan, you\'ll see limited events in your activity.</string>
+    <string name="activity_log_activity_type_filter_apply">Apply</string>
+    <string name="activity_log_activity_type_filter_clear">Clear</string>
 
     <!-- scan -->
     <string name="scan">Scan</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
@@ -30,8 +30,8 @@ class ActivityLogTypeFilterViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `section header gets added as first item in the list`() {
-        val uiStates = initObservers().uiStates
+    fun `section header gets added as first item in the list, when content shown`() {
+        initObservers()
 
         viewModel.start()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
@@ -35,7 +35,8 @@ class ActivityLogTypeFilterViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        assertThat((viewModel.uiState.value as Content).items[0]).isInstanceOf(ListItemUiState.SectionHeader::class.java)
+        assertThat((viewModel.uiState.value as Content).items[0])
+                .isInstanceOf(ListItemUiState.SectionHeader::class.java)
     }
 
     private fun initObservers(): Observers {

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
@@ -1,10 +1,15 @@
 package org.wordpress.android.ui.activitylog.list.filter
 
 import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.test
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.ListItemUiState
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.UiState
+import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.UiState.Content
 
 @InternalCoroutinesApi
 class ActivityLogTypeFilterViewModelTest : BaseUnitTest() {
@@ -12,11 +17,34 @@ class ActivityLogTypeFilterViewModelTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        viewModel = ActivityLogTypeFilterViewModel(TEST_DISPATCHER)
+        viewModel = ActivityLogTypeFilterViewModel(TEST_DISPATCHER, TEST_DISPATCHER)
     }
 
     @Test
-    fun `skeleton test`() {
-        // Skeleton test.
+    fun `fullscreen loading shown, when screen initialized`() = test {
+        val uiStates = initObservers().uiStates
+
+        viewModel.start()
+
+        assertThat(uiStates[0]).isInstanceOf(UiState.FullscreenLoading::class.java)
     }
+
+    @Test
+    fun `section header gets added as first item in the list`() {
+        val uiStates = initObservers().uiStates
+
+        viewModel.start()
+
+        assertThat((viewModel.uiState.value as Content).items[0]).isInstanceOf(ListItemUiState.SectionHeader::class.java)
+    }
+
+    private fun initObservers(): Observers {
+        val uiStates = mutableListOf<UiState>()
+        viewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
+        return Observers((uiStates))
+    }
+
+    private data class Observers(val uiStates: List<UiState>)
 }


### PR DESCRIPTION
Partially fixes #13268 

This PR initializes uistate for activity type filter screen and adds some basic logic. Since the endpoint for getting available activity types isn't implemented yet, it's just a dummy implementation.

Merge instructions:
1. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/13420 is merged
2. Remove "Not ready for merge" label
2. Merge this PR

To test:
Nothing to test, there is no UI yet.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
