### PR TITLE
Add backup feature flag config

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -80,6 +80,7 @@ android {
         buildConfigField "boolean", "SCAN_AVAILABLE", "false"
         buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "true"
         buildConfigField "boolean", "MY_SITE_IMPROVEMENTS", "false"
+        buildConfigField "boolean", "BACKUP_AVAILABLE", "false"
     }
 
     // Gutenberg's dependency - react-native-video is using

--- a/WordPress/src/main/java/org/wordpress/android/util/BackupFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/BackupFeatureConfig.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.util
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.util.config.AppConfig
+import org.wordpress.android.util.config.FeatureConfig
+import javax.inject.Inject
+
+/**
+ * Configuration of the Jetpack Prepare Backup Download feature.
+ */
+@FeatureInDevelopment
+class BackupFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.BACKUP_AVAILABLE
+)


### PR DESCRIPTION
Part of #13329 

This PR add a local feature flag for the Jetpack Backup feature. This is the precursor step to using the feature flag during development. 

There is nothing to test in this PR.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
