### PR TITLE
Selected site repository

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -81,6 +81,7 @@ import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment;
+import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
@@ -186,7 +187,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
     private boolean mIsMagicLinkLogin;
     private boolean mIsMagicLinkSignup;
 
-    private SiteModel mSelectedSite;
     private WPMainActivityViewModel mViewModel;
     private ModalLayoutPickerViewModel mMLPViewModel;
     private FloatingActionButton mFloatingActionButton;
@@ -212,6 +212,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Inject ReaderTracker mReaderTracker;
     @Inject MediaPickerLauncher mMediaPickerLauncher;
     @Inject MySiteImprovementsFeatureConfig mMySiteImprovementsFeatureConfig;
+    @Inject SelectedSiteRepository mSelectedSiteRepository;
 
     /*
      * fragments implement this if their contents can be scrolled, called when user
@@ -488,16 +489,16 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     getMySiteFragment().requestNextStepOfActiveQuickStartTask(false);
                 }
             }
-            mViewModel.onFabClicked(mSelectedSite, shouldShowPublishPostQuickStartTask);
+            mViewModel.onFabClicked(mSelectedSiteRepository.getSelectedSite(), shouldShowPublishPostQuickStartTask);
         });
 
         mFloatingActionButton.setOnLongClickListener(v -> {
             if (v.isHapticFeedbackEnabled()) {
                 v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
             }
-            mViewModel.onFabLongPressed(mSelectedSite);
+            mViewModel.onFabLongPressed(mSelectedSiteRepository.getSelectedSite());
 
-            int messageId = mViewModel.getCreateContentMessageId(mSelectedSite);
+            int messageId = mViewModel.getCreateContentMessageId(mSelectedSiteRepository.getSelectedSite());
 
             Toast.makeText(v.getContext(), messageId, Toast.LENGTH_SHORT).show();
             return true;
@@ -506,7 +507,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         ViewUtilsKt.redirectContextClickToLongPressListener(mFloatingActionButton);
 
         mFabTooltip.setOnClickListener(v -> {
-            mViewModel.onTooltipTapped(mSelectedSite);
+            mViewModel.onTooltipTapped(mSelectedSiteRepository.getSelectedSite());
         });
 
         mViewModel.isBottomSheetShowing().observe(this, event -> {
@@ -565,7 +566,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         // initialized with the most restrictive rights case. This is OK and will be frequently checked
         // to normalize the UI state whenever mSelectedSite changes.
         // It also means that the ViewModel must accept a nullable SiteModel.
-        mViewModel.start(mSelectedSite);
+        mViewModel.start(mSelectedSiteRepository.getSelectedSite());
     }
 
     private @Nullable String getAuthToken() {
@@ -605,22 +606,22 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     }
                     break;
                 case ARG_EDITOR:
-                    if (mSelectedSite == null) {
+                    if (!mSelectedSiteRepository.hasSelectedSite()) {
                         initSelectedSite();
                     }
                     onNewPostButtonClicked();
                     break;
                 case ARG_STATS:
-                    if (mSelectedSite == null) {
+                    if (!mSelectedSiteRepository.hasSelectedSite()) {
                         initSelectedSite();
                     }
-                    ActivityLauncher.viewBlogStats(this, mSelectedSite);
+                    ActivityLauncher.viewBlogStats(this, mSelectedSiteRepository.getSelectedSite());
                     break;
                 case ARG_PAGES:
-                    if (mSelectedSite == null) {
+                    if (!mSelectedSiteRepository.hasSelectedSite()) {
                         initSelectedSite();
                     }
-                    ActivityLauncher.viewCurrentBlogPages(this, mSelectedSite);
+                    ActivityLauncher.viewCurrentBlogPages(this, mSelectedSiteRepository.getSelectedSite());
                     break;
             }
         } else {
@@ -807,8 +808,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
         ProfilingUtils.dump();
         ProfilingUtils.stop();
 
-        mViewModel.onResume(mSelectedSite,
-                mSelectedSite != null && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE);
+        mViewModel.onResume(mSelectedSiteRepository.getSelectedSite(),
+                mSelectedSiteRepository.hasSelectedSite() && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE);
 
         mFirstResume = false;
     }
@@ -875,7 +876,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         mViewModel.onPageChanged(
                 mSiteStore.hasSite() && pageType == PageType.MY_SITE,
-                mSelectedSite);
+                mSelectedSiteRepository.getSelectedSite());
     }
 
     // user tapped the new post button in the bottom navbar
@@ -921,7 +922,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
             // TODO: evaluate to include the QuickStart logic like in the handleNewPostAction
             if (AppPrefs.shouldShowStoriesIntro()) {
                 StoriesIntroDialogFragment.newInstance(site)
-                        .show(getSupportFragmentManager(), StoriesIntroDialogFragment.TAG);
+                                          .show(getSupportFragmentManager(), StoriesIntroDialogFragment.TAG);
             } else {
                 mMediaPickerLauncher.showStoriesPhotoPickerForResultAndTrack(this, site);
             }
@@ -977,7 +978,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (mSelectedSite == null) {
+        if (!mSelectedSiteRepository.hasSelectedSite()) {
             initSelectedSite();
         }
         switch (requestCode) {
@@ -1168,8 +1169,10 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
         if (event.isError()) {
-            if (mSelectedSite != null && event.error.type == AuthenticationErrorType.INVALID_TOKEN) {
-                AuthenticationDialogUtils.showAuthErrorView(this, mSiteStore, mSelectedSite);
+            if (mSelectedSiteRepository.hasSelectedSite()
+                && event.error.type == AuthenticationErrorType.INVALID_TOKEN) {
+                AuthenticationDialogUtils
+                        .showAuthErrorView(this, mSiteStore, mSelectedSiteRepository.getSelectedSite());
             }
 
             return;
@@ -1184,7 +1187,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     AppPrefs.setShouldTrackMagicLinkSignup(true);
                     mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
                     if (mJetpackConnectSource != null) {
-                        ActivityLauncher.continueJetpackConnect(this, mJetpackConnectSource, mSelectedSite);
+                        ActivityLauncher.continueJetpackConnect(this, mJetpackConnectSource,
+                                mSelectedSiteRepository.getSelectedSite());
                     } else {
                         ActivityLauncher.showSignupEpilogue(this, null, null, null, null, true);
                     }
@@ -1192,7 +1196,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     mLoginAnalyticsListener.trackLoginMagicLinkSucceeded();
 
                     if (mJetpackConnectSource != null) {
-                        ActivityLauncher.continueJetpackConnect(this, mJetpackConnectSource, mSelectedSite);
+                        ActivityLauncher.continueJetpackConnect(this, mJetpackConnectSource,
+                                mSelectedSiteRepository.getSelectedSite());
                     } else {
                         ActivityLauncher.showLoginEpilogue(this, true,
                                 getIntent().getIntegerArrayListExtra(ARG_OLD_SITES_IDS));
@@ -1286,7 +1291,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
      * @return null if there is no site or if there is no selected site
      */
     public @Nullable SiteModel getSelectedSite() {
-        return mSelectedSite;
+        return mSelectedSiteRepository.getSelectedSite();
     }
 
     public void setSelectedSite(int localSiteId) {
@@ -1294,7 +1299,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     }
 
     public void setSelectedSite(@Nullable SiteModel selectedSite) {
-        mSelectedSite = selectedSite;
+        mSelectedSiteRepository.updateSite(selectedSite);
         if (selectedSite == null) {
             AppPrefs.setSelectedSite(-1);
             return;
@@ -1318,9 +1323,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         if (siteLocalId != -1) {
             // Site previously selected, use it
-            mSelectedSite = mSiteStore.getSiteByLocalId(siteLocalId);
+            mSelectedSiteRepository.updateSite(mSiteStore.getSiteByLocalId(siteLocalId));
             // If saved site exist, then return, else (site has been removed?) try to select another site
-            if (mSelectedSite != null) {
+            if (mSelectedSiteRepository.hasSelectedSite()) {
                 return;
             }
         }
@@ -1407,10 +1412,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         SiteModel site = mSiteStore.getSiteByLocalId(getSelectedSite().getId());
         if (site != null) {
-            mSelectedSite = site;
-        }
-        if (getMySiteFragment() != null) {
-            getMySiteFragment().onSiteChanged(site);
+            mSelectedSiteRepository.updateSite(site);
         }
     }
 
@@ -1462,10 +1464,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         SiteModel site = mSiteStore.getSiteByLocalId(getSelectedSite().getId());
         if (site != null) {
-            mSelectedSite = site;
-        }
-        if (getMySiteFragment() != null) {
-            getMySiteFragment().onSiteChanged(site);
+            mSelectedSiteRepository.updateSite(site);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -21,6 +21,9 @@ class SelectedSiteRepository
     val selectedSiteChange = _selectedSiteChange as LiveData<SiteModel>
     val showSiteIconProgressBar = _showSiteIconProgressBar as LiveData<Boolean>
     fun updateSite(selectedSite: SiteModel?) {
+        if (getSelectedSite()?.iconUrl != selectedSite?.iconUrl) {
+            _showSiteIconProgressBar.value = false
+        }
         _selectedSiteChange.value = selectedSite
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -1,0 +1,82 @@
+package org.wordpress.android.ui.mysite
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SelectedSiteRepository
+@Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val siteSettingsInterfaceFactory: SiteSettingsInterfaceWrapper.Factory
+) {
+    private var siteSettings: SiteSettingsInterfaceWrapper? = null
+    private val _selectedSiteChange = MutableLiveData<SiteModel>()
+    private val _showSiteIconProgressBar = MutableLiveData<Boolean>()
+    val selectedSiteChange = _selectedSiteChange as LiveData<SiteModel>
+    val showSiteIconProgressBar = _showSiteIconProgressBar as LiveData<Boolean>
+    fun updateSite(selectedSite: SiteModel?) {
+        _selectedSiteChange.value = selectedSite
+    }
+
+    fun updateSiteIconMediaId(mediaId: Int, showProgressBar: Boolean) {
+        siteSettings?.let {
+            _showSiteIconProgressBar.postValue(showProgressBar)
+            it.setSiteIconMediaId(mediaId)
+            it.saveSettings()
+        }
+    }
+
+    fun showSiteIconProgressBar(progressBarVisible: Boolean) {
+        _showSiteIconProgressBar.postValue(progressBarVisible)
+    }
+
+    fun updateTitle(title: String) {
+        siteSettings?.let {
+            getSelectedSite()?.name = title
+            dispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(getSelectedSite()))
+            it.title = title
+            it.saveSettings()
+        }
+    }
+
+    fun clear() {
+        siteSettings?.clear()
+    }
+
+    fun hasSelectedSite() = _selectedSiteChange.value != null
+
+    fun getSelectedSite() = _selectedSiteChange.value
+
+    fun updateSiteSettingsIfNecessary() {
+        // If the selected site is null, we can't update its site settings
+        val selectedSite = getSelectedSite() ?: return
+        if (siteSettings != null && siteSettings!!.localSiteId != selectedSite.id) {
+            // The site has changed, we can't use the previous site settings, force a refresh
+            siteSettings?.clear()
+            siteSettings = null
+        }
+        if (siteSettings == null) {
+            fun onError(error: Exception?) {
+                _showSiteIconProgressBar.postValue(false)
+            }
+            siteSettings = siteSettingsInterfaceFactory.build(
+                    selectedSite,
+                    onSaveError = ::onError,
+                    onFetchError = ::onError,
+                    onSettingsSaved = {
+                        getSelectedSite()?.let { site ->
+                            dispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(site))
+                        }
+                    }
+            )
+
+            siteSettings?.init(true)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -1060,12 +1060,14 @@ public abstract class SiteSettingsInterface {
             String quotaAvailableSentence;
             if (mSite.getPlanId() == PlansConstants.BUSINESS_PLAN_ID) {
                 String usedSpace = FormatUtils.formatFileSize(mSite.getSpaceUsed(), units);
-                quotaAvailableSentence = String.format(mResourceProvider.getString(R.string.site_settings_quota_space_unlimited),
-                        usedSpace);
+                quotaAvailableSentence =
+                        String.format(mResourceProvider.getString(R.string.site_settings_quota_space_unlimited),
+                                usedSpace);
             } else {
                 String spaceAllowed = FormatUtils.formatFileSize(mSite.getSpaceAllowed(), units);
-                quotaAvailableSentence = String.format(mResourceProvider.getString(R.string.site_settings_quota_space_value),
-                        percentage, spaceAllowed);
+                quotaAvailableSentence =
+                        String.format(mResourceProvider.getString(R.string.site_settings_quota_space_value),
+                                percentage, spaceAllowed);
             }
             setQuotaDiskSpace(quotaAvailableSentence);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -36,6 +36,7 @@ import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.viewmodel.ResourceProvider;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -165,7 +166,6 @@ public abstract class SiteSettingsInterface {
      */
     protected abstract void fetchRemoteData();
 
-    protected Context mContext;
     protected final SiteModel mSite;
     protected final SiteSettingsListener mListener;
     protected final SiteSettingsModel mSettings;
@@ -177,11 +177,11 @@ public abstract class SiteSettingsInterface {
     @Inject SiteStore mSiteStore;
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
+    @Inject ResourceProvider mResourceProvider;
 
     protected SiteSettingsInterface(Context host, SiteModel site, SiteSettingsListener listener) {
         ((WordPress) host.getApplicationContext()).component().inject(this);
         mDispatcher.register(this);
-        mContext = host;
         mSite = site;
         mListener = listener;
         mSettings = new SiteSettingsModel();
@@ -199,7 +199,6 @@ public abstract class SiteSettingsInterface {
 
     public void clear() {
         mDispatcher.unregister(this);
-        mContext = null;
     }
 
     public void saveSettings() {
@@ -231,15 +230,13 @@ public abstract class SiteSettingsInterface {
     }
 
     public @NonNull String getPrivacyDescription() {
-        if (mContext != null) {
-            switch (getPrivacy()) {
-                case -1:
-                    return mContext.getString(R.string.site_settings_privacy_private_summary);
-                case 0:
-                    return mContext.getString(R.string.site_settings_privacy_hidden_summary);
-                case 1:
-                    return mContext.getString(R.string.site_settings_privacy_public_summary);
-            }
+        switch (getPrivacy()) {
+            case -1:
+                return mResourceProvider.getString(R.string.site_settings_privacy_private_summary);
+            case 0:
+                return mResourceProvider.getString(R.string.site_settings_privacy_hidden_summary);
+            case 1:
+                return mResourceProvider.getString(R.string.site_settings_privacy_public_summary);
         }
         return "";
     }
@@ -258,8 +255,8 @@ public abstract class SiteSettingsInterface {
 
     public @NonNull Map<String, String> getFormats() {
         mSettings.postFormats = new HashMap<>();
-        String[] postFormatDisplayNames = mContext.getResources().getStringArray(R.array.post_format_display_names);
-        String[] postFormatKeys = mContext.getResources().getStringArray(R.array.post_format_keys);
+        String[] postFormatDisplayNames = mResourceProvider.getStringArray(R.array.post_format_display_names);
+        String[] postFormatKeys = mResourceProvider.getStringArray(R.array.post_format_keys);
         // Add standard post format (only for .com)
         mSettings.postFormats.put(STANDARD_POST_FORMAT_KEY, STANDARD_POST_FORMAT);
         // Add default post formats
@@ -337,10 +334,7 @@ public abstract class SiteSettingsInterface {
     }
 
     public @NonNull String getRelatedPostsDescription() {
-        if (mContext == null) {
-            return "";
-        }
-        String desc = mContext.getString(getShowRelatedPosts() ? R.string.on : R.string.off);
+        String desc = mResourceProvider.getString(getShowRelatedPosts() ? R.string.on : R.string.off);
         return StringUtils.capitalize(desc);
     }
 
@@ -377,16 +371,12 @@ public abstract class SiteSettingsInterface {
     }
 
     public @NonNull String getCloseAfterDescriptionForPeriod(int period) {
-        if (mContext == null) {
-            return "";
-        }
-
         if (!getShouldCloseAfter()) {
-            return mContext.getString(R.string.never);
+            return mResourceProvider.getString(R.string.never);
         }
 
-        return StringUtils.getQuantityString(mContext, R.string.never, R.string.days_quantity_one,
-                                             R.string.days_quantity_other, period);
+        return mResourceProvider.getQuantityString(R.string.never, R.string.days_quantity_one,
+                R.string.days_quantity_other, period);
     }
 
     public int getCommentSorting() {
@@ -394,18 +384,14 @@ public abstract class SiteSettingsInterface {
     }
 
     public @NonNull String getSortingDescription() {
-        if (mContext == null) {
-            return "";
-        }
-
         int order = getCommentSorting();
         switch (order) {
             case SiteSettingsInterface.ASCENDING_SORT:
-                return mContext.getString(R.string.oldest_first);
+                return mResourceProvider.getString(R.string.oldest_first);
             case SiteSettingsInterface.DESCENDING_SORT:
-                return mContext.getString(R.string.newest_first);
+                return mResourceProvider.getString(R.string.newest_first);
             default:
-                return mContext.getString(R.string.unknown);
+                return mResourceProvider.getString(R.string.unknown);
         }
     }
 
@@ -426,14 +412,14 @@ public abstract class SiteSettingsInterface {
     }
 
     public @NonNull String getThreadingDescriptionForLevel(int level) {
-        if (mContext == null) {
+        if (mResourceProvider == null) {
             return "";
         }
 
         if (level <= 1) {
-            return mContext.getString(R.string.none);
+            return mResourceProvider.getString(R.string.none);
         }
-        return String.format(mContext.getString(R.string.site_settings_threading_summary), level);
+        return String.format(mResourceProvider.getString(R.string.site_settings_threading_summary), level);
     }
 
     public boolean getShouldPageComments() {
@@ -449,17 +435,13 @@ public abstract class SiteSettingsInterface {
     }
 
     public @NonNull String getPagingDescription() {
-        if (mContext == null) {
-            return "";
-        }
-
         if (!getShouldPageComments()) {
-            return mContext.getString(R.string.disabled);
+            return mResourceProvider.getString(R.string.disabled);
         }
 
         int count = getPagingCountForDescription();
-        return StringUtils.getQuantityString(mContext, R.string.none, R.string.site_settings_paging_summary_one,
-                                             R.string.site_settings_paging_summary_other, count);
+        return mResourceProvider.getQuantityString(R.string.none, R.string.site_settings_paging_summary_one,
+                R.string.site_settings_paging_summary_other, count);
     }
 
     public boolean getManualApproval() {
@@ -554,13 +536,13 @@ public abstract class SiteSettingsInterface {
     }
 
     public @NonNull String getKeysDescription(int count) {
-        if (mContext == null) {
+        if (mResourceProvider == null) {
             return "";
         }
 
-        return StringUtils.getQuantityString(mContext, R.string.site_settings_list_editor_no_items_text,
-                                             R.string.site_settings_list_editor_summary_one,
-                                             R.string.site_settings_list_editor_summary_other, count);
+        return mResourceProvider.getQuantityString(R.string.site_settings_list_editor_no_items_text,
+                R.string.site_settings_list_editor_summary_one,
+                R.string.site_settings_list_editor_summary_other, count);
     }
 
     public String getStartOfWeek() {
@@ -1069,20 +1051,20 @@ public abstract class SiteSettingsInterface {
         // Quota information always comes from the main site table
         if (mSite.hasDiskSpaceQuotaInformation()) {
             String percentage = FormatUtils.formatPercentage(mSite.getSpacePercentUsed() / 100);
-            final String[] units = new String[] {mContext.getString(R.string.file_size_in_bytes),
-                    mContext.getString(R.string.file_size_in_kilobytes),
-                    mContext.getString(R.string.file_size_in_megabytes),
-                    mContext.getString(R.string.file_size_in_gigabytes),
-                    mContext.getString(R.string.file_size_in_terabytes) };
+            final String[] units = new String[]{mResourceProvider.getString(R.string.file_size_in_bytes),
+                    mResourceProvider.getString(R.string.file_size_in_kilobytes),
+                    mResourceProvider.getString(R.string.file_size_in_megabytes),
+                    mResourceProvider.getString(R.string.file_size_in_gigabytes),
+                    mResourceProvider.getString(R.string.file_size_in_terabytes)};
 
             String quotaAvailableSentence;
             if (mSite.getPlanId() == PlansConstants.BUSINESS_PLAN_ID) {
                 String usedSpace = FormatUtils.formatFileSize(mSite.getSpaceUsed(), units);
-                quotaAvailableSentence = String.format(mContext.getString(R.string.site_settings_quota_space_unlimited),
+                quotaAvailableSentence = String.format(mResourceProvider.getString(R.string.site_settings_quota_space_unlimited),
                         usedSpace);
             } else {
                 String spaceAllowed = FormatUtils.formatFileSize(mSite.getSpaceAllowed(), units);
-                quotaAvailableSentence = String.format(mContext.getString(R.string.site_settings_quota_space_value),
+                quotaAvailableSentence = String.format(mResourceProvider.getString(R.string.site_settings_quota_space_value),
                         percentage, spaceAllowed);
             }
             setQuotaDiskSpace(quotaAvailableSentence);
@@ -1103,7 +1085,7 @@ public abstract class SiteSettingsInterface {
      * Notifies listener that credentials have been validated or are incorrect.
      */
     private void notifyCredentialsVerifiedOnUiThread(final Exception error) {
-        if (mContext == null || mListener == null) {
+        if (mResourceProvider == null || mListener == null) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterfaceWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterfaceWrapper.kt
@@ -1,0 +1,70 @@
+package org.wordpress.android.ui.prefs
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.viewmodel.ContextProvider
+import javax.inject.Inject
+
+class SiteSettingsInterfaceWrapper(private val siteSettingsInterface: SiteSettingsInterface) {
+    val localSiteId: Int
+        get() = siteSettingsInterface.localSiteId
+
+    var title: String
+        get() = siteSettingsInterface.title
+        set(value) {
+            siteSettingsInterface.title = value
+        }
+
+    fun setSiteIconMediaId(mediaId: Int) = siteSettingsInterface.setSiteIconMediaId(mediaId)
+
+    fun saveSettings() = siteSettingsInterface.saveSettings()
+    fun clear() {
+        siteSettingsInterface.clear()
+    }
+
+    fun init(fetchRemote: Boolean) {
+        siteSettingsInterface.init(fetchRemote)
+    }
+
+    class Factory
+    @Inject constructor(private val contextProvider: ContextProvider) {
+        fun build(
+            site: SiteModel,
+            onSaveError: ((error: Exception?) -> Unit)? = null,
+            onFetchError: ((error: Exception?) -> Unit)? = null,
+            onSettingsUpdated: (() -> Unit)? = null,
+            onSettingsSaved: (() -> Unit)? = null,
+            onCredentialsValidated: ((error: Exception?) -> Unit)? = null
+        ): SiteSettingsInterfaceWrapper? {
+            val siteSettingsInterface = SiteSettingsInterface.getInterface(
+                    contextProvider.getContext(),
+                    site,
+                    object : SiteSettingsInterface.SiteSettingsListener {
+                        override fun onSaveError(error: Exception?) {
+                            onSaveError?.invoke(error)
+                        }
+
+                        override fun onFetchError(error: Exception?) {
+                            onFetchError?.invoke(error)
+                        }
+
+                        override fun onSettingsUpdated() {
+                            onSettingsUpdated?.invoke()
+                        }
+
+                        override fun onSettingsSaved() {
+                            onSettingsSaved?.invoke()
+                        }
+
+                        override fun onCredentialsValidated(error: Exception?) {
+                            onCredentialsValidated?.invoke(error)
+                        }
+
+                    })
+            return siteSettingsInterface?.let {
+                SiteSettingsInterfaceWrapper(
+                        it
+                )
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterfaceWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterfaceWrapper.kt
@@ -58,7 +58,6 @@ class SiteSettingsInterfaceWrapper(private val siteSettingsInterface: SiteSettin
                         override fun onCredentialsValidated(error: Exception?) {
                             onCredentialsValidated?.invoke(error)
                         }
-
                     })
             return siteSettingsInterface?.let {
                 SiteSettingsInterfaceWrapper(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
@@ -15,6 +15,8 @@ class ResourceProvider @Inject constructor(private val contextProvider: ContextP
         return contextProvider.getContext().getString(resourceId, *formatArgs)
     }
 
+    fun getStringArray(id: Int): Array<String> = contextProvider.getContext().resources.getStringArray(id)
+
     fun getColor(@ColorRes resourceId: Int): Int {
         return ContextCompat.getColor(contextProvider.getContext(), resourceId)
     }
@@ -27,5 +29,23 @@ class ResourceProvider @Inject constructor(private val contextProvider: ContextP
     fun getDimension(@DimenRes dimen: Int): Float {
         val resources = contextProvider.getContext().resources
         return resources.getDimension(dimen)
+    }
+
+    /**
+     * Formats the string for the given quantity, using the given arguments.
+     * We need this because our translation platform doesn't support Android plurals.
+     *
+     * @param zero The desired string identifier to get when quantity is exactly 0
+     * @param one The desired string identifier to get when quantity is exactly 1
+     * @param other The desired string identifier to get when quantity is not (0 or 1)
+     * @param quantity The number used to get the correct string
+     */
+    fun getQuantityString(@StringRes zero: Int, @StringRes one: Int, @StringRes other: Int, quantity: Int): String? {
+        if (quantity == 0) {
+            return contextProvider.getContext().getString(zero)
+        }
+        return if (quantity == 1) {
+            contextProvider.getContext().getString(one)
+        } else String.format(contextProvider.getContext().getString(other), quantity)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
@@ -127,6 +127,33 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
     }
 
     @Test
+    fun `updateSite hides progress bar if icon has changed`() {
+        siteModel.iconUrl = "originalIcon.jpg"
+        initializeSiteAndSiteSettings()
+        val updatedSite = SiteModel()
+        updatedSite.iconUrl = "updatedIcon.jpg"
+        selectedSiteRepository.showSiteIconProgressBar(true)
+
+        selectedSiteRepository.updateSite(updatedSite)
+
+        assertThat(siteIconProgressBarVisible).isFalse()
+    }
+
+    @Test
+    fun `updateSite does not hide progress bar if icon has not changed`() {
+        val iconName = "originalIcon.jpg"
+        siteModel.iconUrl = iconName
+        initializeSiteAndSiteSettings()
+        val updatedSite = SiteModel()
+        updatedSite.iconUrl = iconName
+        selectedSiteRepository.showSiteIconProgressBar(true)
+
+        selectedSiteRepository.updateSite(updatedSite)
+
+        assertThat(siteIconProgressBarVisible).isTrue()
+    }
+
+    @Test
     fun `site settings onSaveError hides icon progress bar`() {
         initializeSiteAndSiteSettings()
         selectedSiteRepository.showSiteIconProgressBar(true)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
@@ -1,0 +1,187 @@
+package org.wordpress.android.ui.mysite
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.isNull
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.SiteAction
+import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
+
+class SelectedSiteRepositoryTest : BaseUnitTest() {
+    @Mock lateinit var dispatcher: Dispatcher
+    @Mock lateinit var siteSettingsInterfaceFactory: SiteSettingsInterfaceWrapper.Factory
+    @Mock lateinit var siteSettingsInterfaceWrapper: SiteSettingsInterfaceWrapper
+    private lateinit var siteModel: SiteModel
+    private var siteIconProgressBarVisible: Boolean = false
+    private var selectedSite: SiteModel? = null
+    private lateinit var actions: MutableList<Action<*>>
+    private lateinit var selectedSiteRepository: SelectedSiteRepository
+    private var onSaveError: ((error: Exception?) -> Unit)? = null
+    private var onFetchError: ((error: Exception?) -> Unit)? = null
+    private var onSettingsSaved: (() -> Unit)? = null
+    private val selectedSiteId = 1
+
+    @Before
+    fun setUp() {
+        selectedSiteRepository = SelectedSiteRepository(dispatcher, siteSettingsInterfaceFactory)
+        selectedSiteRepository.showSiteIconProgressBar.observeForever { siteIconProgressBarVisible = it == true }
+        selectedSiteRepository.selectedSiteChange.observeForever { selectedSite = it }
+        siteModel = SiteModel()
+        siteModel.id = selectedSiteId
+        whenever(siteSettingsInterfaceWrapper.localSiteId).thenReturn(selectedSiteId)
+        doAnswer {
+            actions.add(it.getArgument(0))
+        }.whenever(dispatcher).dispatch(any())
+        actions = mutableListOf()
+    }
+
+    @Test
+    fun `icon update updates site settings and shows progress bar when selected site is initialized`() {
+        initializeSiteAndSiteSettings()
+        val mediaId = 5
+
+        selectedSiteRepository.updateSiteIconMediaId(mediaId, true)
+
+        assertThat(siteIconProgressBarVisible).isTrue()
+        val inOrder = inOrder(siteSettingsInterfaceWrapper)
+        inOrder.verify(siteSettingsInterfaceWrapper).setSiteIconMediaId(mediaId)
+        inOrder.verify(siteSettingsInterfaceWrapper).saveSettings()
+    }
+
+    @Test
+    fun `icon update updates site settings and does not show progress bar when parameter is false`() {
+        initializeSiteAndSiteSettings()
+        val mediaId = 5
+
+        selectedSiteRepository.updateSiteIconMediaId(mediaId, false)
+
+        assertThat(siteIconProgressBarVisible).isFalse()
+        val inOrder = inOrder(siteSettingsInterfaceWrapper)
+        inOrder.verify(siteSettingsInterfaceWrapper).setSiteIconMediaId(mediaId)
+        inOrder.verify(siteSettingsInterfaceWrapper).saveSettings()
+    }
+
+    @Test
+    fun `icon update does not show progress bar when site not initialized`() {
+        val mediaId = 5
+
+        selectedSiteRepository.updateSiteIconMediaId(mediaId, true)
+
+        assertThat(siteIconProgressBarVisible).isFalse()
+        verifyZeroInteractions(siteSettingsInterfaceWrapper)
+    }
+
+    @Test
+    fun `showSiteIconProgressBar(true) shows progress bar`() {
+        selectedSiteRepository.showSiteIconProgressBar(true)
+
+        assertThat(siteIconProgressBarVisible).isTrue()
+    }
+
+    @Test
+    fun `showSiteIconProgressBar(false) hides progress bar`() {
+        selectedSiteRepository.showSiteIconProgressBar(false)
+
+        assertThat(siteIconProgressBarVisible).isFalse()
+    }
+
+    @Test
+    fun `title update changes site name, settings title and dispatches change`() {
+        initializeSiteAndSiteSettings()
+        siteModel.name = "original title"
+        val updatedTitle = "updated title"
+
+        selectedSiteRepository.updateTitle(updatedTitle)
+
+        assertThat(siteModel.name).isEqualTo(updatedTitle)
+        verify(dispatcher).dispatch(any())
+        assertThat(actions.last().payload).isEqualTo(siteModel)
+        assertThat(actions.last().type).isEqualTo(SiteAction.UPDATE_SITE)
+
+        val inOrder = inOrder(siteSettingsInterfaceWrapper)
+        inOrder.verify(siteSettingsInterfaceWrapper).title = updatedTitle
+        inOrder.verify(siteSettingsInterfaceWrapper).saveSettings()
+    }
+
+    @Test
+    fun `updateSite updates site`() {
+        assertThat(selectedSiteRepository.hasSelectedSite()).isFalse()
+        assertThat(selectedSiteRepository.getSelectedSite()).isNull()
+
+        selectedSiteRepository.updateSite(siteModel)
+
+        assertThat(selectedSiteRepository.hasSelectedSite()).isTrue()
+        assertThat(selectedSiteRepository.getSelectedSite()).isEqualTo(siteModel)
+    }
+
+    @Test
+    fun `site settings onSaveError hides icon progress bar`() {
+        initializeSiteAndSiteSettings()
+        selectedSiteRepository.showSiteIconProgressBar(true)
+        assertThat(siteIconProgressBarVisible).isTrue()
+
+        onSaveError!!.invoke(Exception("testing"))
+
+        assertThat(siteIconProgressBarVisible).isFalse()
+    }
+
+    @Test
+    fun `site settings onFetchError hides icon progress bar`() {
+        initializeSiteAndSiteSettings()
+        selectedSiteRepository.showSiteIconProgressBar(true)
+        assertThat(siteIconProgressBarVisible).isTrue()
+
+        onFetchError!!.invoke(Exception("testing"))
+
+        assertThat(siteIconProgressBarVisible).isFalse()
+    }
+
+    @Test
+    fun `site settings onSettingsSaved emits fetch site event`() {
+        initializeSiteAndSiteSettings()
+
+        onSettingsSaved!!.invoke()
+
+        assertThat(actions.last().type).isEqualTo(SiteAction.FETCH_SITE)
+        assertThat(actions.last().payload).isEqualTo(siteModel)
+    }
+
+    @Test
+    fun `clears previous site settings when selected site has different ID`() {
+        val firstSiteId = 1
+        val updatedSiteId = 2
+        whenever(siteSettingsInterfaceWrapper.localSiteId).thenReturn(firstSiteId)
+        initializeSiteAndSiteSettings()
+        siteModel.id = updatedSiteId
+
+        selectedSiteRepository.updateSiteSettingsIfNecessary()
+
+        verify(siteSettingsInterfaceWrapper).clear()
+    }
+
+    private fun initializeSiteAndSiteSettings() {
+        selectedSiteRepository.updateSite(siteModel)
+        doAnswer {
+            onSaveError = it.getArgument(1)
+            onFetchError = it.getArgument(2)
+            onSettingsSaved = it.getArgument(4)
+            siteSettingsInterfaceWrapper
+        }.whenever(siteSettingsInterfaceFactory).build(any(), any(), any(), isNull(), any(), isNull())
+
+        selectedSiteRepository.updateSiteSettingsIfNecessary()
+        verify(siteSettingsInterfaceWrapper).init(true)
+        verify(siteSettingsInterfaceFactory).build(eq(siteModel), any(), any(), isNull(), any(), isNull())
+    }
+}


### PR DESCRIPTION
In order to implement the new my site fragment I need to pull out the selected site and the selected site settings logic into a separate class. The main reason behind this change is that right now we're relying on the callback from the top activity and it makes the code entangled. Hopefully with this change we'd be able to make the selected site logic separate from the rest of the code and hopefully move as much logic from the main activity as possible.

The functionality should be the same as it was before. The only piece of logic that might be a little bit fragile is the logic around the site icon progress bar. 

To test:
- Set site icon with an icon from your device
- Notice the progress bar
- The icon gets set
- Set site icon from WP media library
- The new icon is visible
- Change site title
- Change settings
- Switch sites
- Everything behaves as you'd expect

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
