### PR TITLE
[Gutenberg] Update PostUtils for File block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -444,8 +444,8 @@ public class PostUtils {
     public static boolean isMediaInGutenbergPostBody(@NonNull String postContent,
                                             String localMediaId) {
         List<String> patterns = new ArrayList<>();
-        // Regex for Image and Video blocks
-        patterns.add("<!-- wp:(?:image|video){1} \\{[^\\}]*\"id\":%s([^\\d\\}][^\\}]*)*\\} -->");
+        // Regex for Image, Video, and File blocks
+        patterns.add("<!-- wp:(?:image|video|file){1} \\{[^\\}]*\"id\":%s([^\\d\\}][^\\}]*)*\\} -->");
         // Regex for Media&Text block
         patterns.add("<!-- wp:media-text \\{[^\\}]*\"mediaId\":%s([^\\d\\}][^\\}]*)*\\} -->");
         // Regex for Gallery block

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
@@ -124,6 +124,13 @@ class PostUtilsUnitTest {
     }
 
     @Test
+    fun `isMediaInGutenberg returns true when a File Block is found in the post content`() {
+        val mediaId = "999"
+        val postContent = "<!-- wp:file {\"id\":$mediaId} --> ...... <!-- /wp:file -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, mediaId)).isTrue()
+    }
+
+    @Test
     fun `isMediaInGutenberg returns false when an imageBlock with provided id is NOT found in the post content`() {
         val imgId = "123"
         val postContent = "<!-- wp:image {\"id\":$imgId} --> ...... <!-- /wp:image -->"
@@ -145,6 +152,13 @@ class PostUtilsUnitTest {
     }
 
     @Test
+    fun `isMediaInGutenberg returns false when a File Block with provided id is NOT found in the post content`() {
+        val mediaId = "123"
+        val postContent = "<!-- wp:file {\"id\":$mediaId} --> ...... <!-- /wp:file -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "999")).isFalse()
+    }
+
+    @Test
     fun `isMediaInGutenberg returns false for an imageBlock when only part of the id matches`() {
         val imgId = "12345"
         val postContent = "<!-- wp:image {\"id\":$imgId} --> ...... <!-- /wp:image -->"
@@ -162,6 +176,13 @@ class PostUtilsUnitTest {
     fun `isMediaInGutenberg returns false for a Media&Text when only part of the id matches`() {
         val imgId = "12345"
         val postContent = "<!-- wp:media-text {\"mediaId\":$imgId} --> ...... <!-- /wp:media-text -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "123")).isFalse()
+    }
+
+    @Test
+    fun `isMediaInGutenberg returns false for a File Block when only part of the id matches`() {
+        val mediaId = "12345"
+        val postContent = "<!-- wp:file {\"id\":$mediaId} --> ...... <!-- /wp:file -->"
         assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, "123")).isFalse()
     }
 
@@ -192,6 +213,14 @@ class PostUtilsUnitTest {
         val postContent = "<!-- wp:media-text {\"mediaId\":$imgId,\"sizeSlug\":\"large\"} -->" +
                 " ...... <!-- /wp:media-text -->"
         assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, imgId)).isTrue()
+    }
+
+    @Test
+    fun `isMediaInGutenberg works when a File Block tag has multiple attributes`() {
+        val mediaId = "999"
+        val href = "https://example.com/my.mp3"
+        val postContent = "<!-- wp:file {\"id\":$mediaId,\"href\":\"$href\"} --> ...... <!-- /wp:file -->"
+        assertThat(PostUtils.isMediaInGutenbergPostBody(postContent, mediaId)).isTrue()
     }
 
     @Test


### PR DESCRIPTION
This updates the regex and adds some tests for the `PostUtils.isMediaInGutenbergPostBody` method to add support for File Block.

To test:

Run the provided unit tests.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
