### PR TITLE
Enable Stories in production

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 16.3
 -----
 * [*] Posts Settings: removed deprecated location setting [https://github.com/wordpress-mobile/WordPress-Android/pull/13404]
+* [***] Stories: New feature for WordPress.com and Jetpack sites: Use photos and videos to create engaging and tappable fullscreen slideshows. [https://github.com/wordpress-mobile/WordPress-Android/pull/13459]
 
 16.2
 -----

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -105,7 +105,7 @@ android {
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
             buildConfigField "boolean", "GUTENBERG_MENTIONS", "true"
             buildConfigField "boolean", "HOME_PAGE_PICKER", "false"
-            buildConfigField "boolean", "WP_STORIES_AVAILABLE", "false"
+            buildConfigField "boolean", "WP_STORIES_AVAILABLE", "true"
             buildConfigField "boolean", "ANY_FILE_UPLOAD", "false"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"
         }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.java
@@ -16,6 +16,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
+import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.longClickOn;
 
 public class MySitesPage {
@@ -49,6 +50,10 @@ public class MySitesPage {
 
     public void startNewPost() {
         clickOn(R.id.fab_button);
+        if (isElementDisplayed(R.id.design_bottom_sheet)) {
+            // If Stories are enabled, FAB opens a bottom sheet with options - select the 'Blog post' option
+            clickOn(onView(withText(R.string.my_site_bottom_sheet_add_post)));
+        }
     }
 
     public void gotoSiteSettings() {


### PR DESCRIPTION
Enables the Stories feature for all build configs, in preparation for entering public beta with `16.3`.

Note: #13426 is also a 'merge before release' PR for the Stories feature.

* Enables the feature flag for all build configs
* Fixes e2e tests (they would have broken on CI once `vanilla` builds included Stories)
* Adds release notes for Stories

### To test:
* Build a vanilla build of the app, check that you're able to create a Story (for WordPress.com sites and Jetpack sites running Jetpack 9.1 or later).
* Run the e2e tests (in vanilla, they'll pass whether Stories are enabled or not)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
