### PR TITLE
Fixes site creation domain text color in dark mode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -45,7 +45,6 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AutoForeground.ServiceEventConnection
 import org.wordpress.android.util.ErrorManagedWebViewClient.ErrorManagedWebViewClientListener
 import org.wordpress.android.util.URLFilteredWebViewClient
-import org.wordpress.android.util.getColorFromAttribute
 import javax.inject.Inject
 
 private const val ARG_DATA = "arg_site_creation_data"
@@ -279,7 +278,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
         )
         spannableTitle.setSpan(
-                ForegroundColorSpan(context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)),
+                ForegroundColorSpan(ContextCompat.getColor(context, R.color.neutral_40)),
                 domainSpan.first,
                 domainSpan.second,
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/WordPress-Android/issues/12829

## Description
Fixes site creation domain text color in dark mode

## To test:

1. Set your device in dark mode
1. Start the site creation flow (e.g. *Choose site > Add button*)
1. Select the *Create WordPress.com site* option
1. Create a site
1. Verify that the full domain is visible in the preview screen

## Screenshots

|Normal|Dark|
|---|---|
|![device-2020-11-24-142820](https://user-images.githubusercontent.com/304044/100094706-180b5280-2e62-11eb-96a5-30e9d17b25bf.png)|![device-2020-11-24-142757](https://user-images.githubusercontent.com/304044/100094749-29545f00-2e62-11eb-97fd-3b4e5e8e8d57.png)|


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
