### PR TITLE
Allows https redirection in webview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/URLFilteredWebViewClient.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/URLFilteredWebViewClient.java
@@ -43,6 +43,12 @@ public class URLFilteredWebViewClient extends ErrorManagedWebViewClient {
         return mAllowedURLs.size() == 0;
     }
 
+    private boolean isHttpUrlAllowed(String url) {
+        return mAllowedURLs.contains(url.replace("https://", "http://"))
+               || mAllowedURLs.contains(StringUtils.removeTrailingSlash(url)
+                                                   .replace("https://", "http://"));
+    }
+
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
         // Found a bug on some pages where there is an incorrect
@@ -52,6 +58,7 @@ public class URLFilteredWebViewClient extends ErrorManagedWebViewClient {
         }
 
         if (isAllURLsAllowed() || mAllowedURLs.contains(url)
+            || isHttpUrlAllowed(url) // Allow https redirection
             // If a url is allowed without the trailing `/`, it should be allowed with it as well
             || mAllowedURLs.contains(StringUtils.removeTrailingSlash(url))) {
             boolean isComingFromLoginUrl =


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/WordPress-Android/issues/13468

## Description
Allows https redirection in webview (but not the opposite since it may raise security concerns)

## To test:

1. Set your device in dark mode
1. Start the site creation flow (e.g. *Choose site > Add button*)
1. Select the *Create WordPress.com site* option
1. Select a design that that allows `.blog` subdomains like `Cassel`
1. On the Choose a Domain screen search for and select a domain that includes `buisness.blog`
1. Create your site
1. Verify that the preview is loading

## Screenshots

<image width="360" src="https://user-images.githubusercontent.com/304044/100112570-0a60c780-2e78-11eb-8c11-534057af9a83.png"/>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.