### PR TITLE
Login: Add null check for LoginBaseDiscoveryListener to prevent crash

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseDiscoveryFragment.java
@@ -26,7 +26,8 @@ public abstract class LoginBaseDiscoveryFragment extends LoginBaseFormFragment<L
     }
 
     void initiateDiscovery() {
-        if (!NetworkUtils.checkConnection(getActivity())) {
+        if (mLoginBaseDiscoveryListener == null || !NetworkUtils.checkConnection(getActivity())) {
+            // Fragment was detached or there's no active network connection
             return;
         }
 


### PR DESCRIPTION
Fixes #13418

I haven't been able to reproduce this, but according to the logs in the linked issue it seems that `LoginBaseDiscoveryFragment::initiateDiscovery` is being called from `LoginSiteAddressFragment::onFetchedConnectSiteInfo` after that fragment has already been detached, which causes `LoginBaseDiscoveryListener` to be null. So I believe introducing this null check should be enough to prevent the crash.

Note: I will merge the changes back into `wordpress-mobile/WordPress-Login-Flow-Android` after this is merged.

To test:

Nothing specific to test here, but feel free to go through the site address flow and verifying nothing looks off.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
