### PR TITLE
Adding analytics to follow unfollow comments feature.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCase.kt
@@ -179,7 +179,10 @@ class ReaderCommentsFollowUseCase @Inject constructor(
         return this
     }
 
-    private fun MutableMap<String, Any?>.addFollowActionResult(result: AnalyticsFollowCommentsActionResult, errorMessage: String? = null): MutableMap<String, Any?> {
+    private fun MutableMap<String, Any?>.addFollowActionResult(
+        result: AnalyticsFollowCommentsActionResult,
+        errorMessage: String? = null
+    ): MutableMap<String, Any?> {
         this[FOLLOW_COMMENT_ACTION_RESULT] = result.actionResult
         errorMessage?.also {
             this[FOLLOW_COMMENT_ACTION_ERROR] = errorMessage

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCase.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.Anal
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsAction.UNFOLLOW_COMMENTS
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsActionResult.ERROR
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsActionResult.SUCCEEDED
-import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsGenericErrors.NO_NETWORK
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsGenericError.NO_NETWORK
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.UserNotAuthenticated
 import org.wordpress.android.ui.reader.utils.PostSubscribersApiCallsProvider
 import org.wordpress.android.ui.reader.utils.PostSubscribersApiCallsProvider.PostSubscribersCallResult
@@ -88,7 +88,7 @@ class ReaderCommentsFollowUseCase @Inject constructor(
 
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             emit(FollowCommentsState.Failure(blogId, postId, UiStringRes(R.string.error_network_connection)))
-            properties.addFollowActionResult(ERROR, NO_NETWORK.actionError)
+            properties.addFollowActionResult(ERROR, NO_NETWORK.errorMessage)
         } else {
             val status: PostSubscribersCallResult = suspendCoroutine { continuation ->
                 if (subscribe) {
@@ -166,7 +166,7 @@ class ReaderCommentsFollowUseCase @Inject constructor(
         ERROR("error")
     }
 
-    private enum class AnalyticsFollowCommentsGenericErrors(val actionError: String) {
+    private enum class AnalyticsFollowCommentsGenericError(val errorMessage: String) {
         NO_NETWORK("no_network")
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCase.kt
@@ -3,7 +3,14 @@ package org.wordpress.android.ui.reader.usecases
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsAction.FOLLOW_COMMENTS
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsAction.UNFOLLOW_COMMENTS
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsActionResult.ERROR
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsActionResult.SUCCEEDED
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.AnalyticsFollowCommentsGenericErrors.NO_NETWORK
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.UserNotAuthenticated
 import org.wordpress.android.ui.reader.utils.PostSubscribersApiCallsProvider
 import org.wordpress.android.ui.reader.utils.PostSubscribersApiCallsProvider.PostSubscribersCallResult
@@ -13,14 +20,21 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import javax.inject.Inject
 import kotlin.coroutines.suspendCoroutine
 
 class ReaderCommentsFollowUseCase @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val postSubscribersApiCallsProvider: PostSubscribersApiCallsProvider,
-    private val accountStore: AccountStore
+    private val accountStore: AccountStore,
+    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper,
+    private val readerPostTableWrapper: ReaderPostTableWrapper
 ) {
+    private val FOLLOW_COMMENT_ACTION = "follow_action"
+    private val FOLLOW_COMMENT_ACTION_RESULT = "follow_action_result"
+    private val FOLLOW_COMMENT_ACTION_ERROR = "follow_action_error"
+
     suspend fun getMySubscriptionToPost(blogId: Long, postId: Long, isInit: Boolean) = flow {
         if (!accountStore.hasAccessToken()) {
             emit(UserNotAuthenticated)
@@ -66,10 +80,15 @@ class ReaderCommentsFollowUseCase @Inject constructor(
         postId: Long,
         subscribe: Boolean
     ): Flow<FollowCommentsState> = flow {
+        val properties = mutableMapOf<String, Any?>()
+
+        properties.addFollowAction(subscribe)
+
         emit(FollowCommentsState.Loading)
 
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             emit(FollowCommentsState.Failure(blogId, postId, UiStringRes(R.string.error_network_connection)))
+            properties.addFollowActionResult(ERROR, NO_NETWORK.actionError)
         } else {
             val status: PostSubscribersCallResult = suspendCoroutine { continuation ->
                 if (subscribe) {
@@ -95,12 +114,24 @@ class ReaderCommentsFollowUseCase @Inject constructor(
                                     )
                             )
                     )
+                    properties.addFollowActionResult(SUCCEEDED)
                 }
                 is Failure -> {
                     emit(FollowCommentsState.Failure(blogId, postId, UiStringText(status.error)))
+                    properties.addFollowActionResult(ERROR, status.error)
                 }
             }
         }
+
+        val post = readerPostTableWrapper.getBlogPost(blogId, postId, true)
+
+        analyticsUtilsWrapper.trackFollowCommentsWithReaderPostDetails(
+                Stat.COMMENT_FOLLOW_CONVERSATION,
+                blogId,
+                postId,
+                post,
+                properties
+        )
     }
 
     sealed class FollowCommentsState {
@@ -123,5 +154,36 @@ class ReaderCommentsFollowUseCase @Inject constructor(
         object FollowCommentsNotAllowed : FollowCommentsState()
 
         object UserNotAuthenticated : FollowCommentsState()
+    }
+
+    private enum class AnalyticsFollowCommentsAction(val action: String) {
+        FOLLOW_COMMENTS("followed"),
+        UNFOLLOW_COMMENTS("unfollowed")
+    }
+
+    private enum class AnalyticsFollowCommentsActionResult(val actionResult: String) {
+        SUCCEEDED("succeeded"),
+        ERROR("error")
+    }
+
+    private enum class AnalyticsFollowCommentsGenericErrors(val actionError: String) {
+        NO_NETWORK("no_network")
+    }
+
+    private fun MutableMap<String, Any?>.addFollowAction(subscribe: Boolean): MutableMap<String, Any?> {
+        this[FOLLOW_COMMENT_ACTION] = if (subscribe) {
+            FOLLOW_COMMENTS.action
+        } else {
+            UNFOLLOW_COMMENTS.action
+        }
+        return this
+    }
+
+    private fun MutableMap<String, Any?>.addFollowActionResult(result: AnalyticsFollowCommentsActionResult, errorMessage: String? = null): MutableMap<String, Any?> {
+        this[FOLLOW_COMMENT_ACTION_RESULT] = result.actionResult
+        errorMessage?.also {
+            this[FOLLOW_COMMENT_ACTION_ERROR] = errorMessage
+        }
+        return this
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -725,4 +725,28 @@ public class AnalyticsUtils {
 
         AnalyticsUtils.trackWithReaderPostDetails(stat, post, properties);
     }
+
+    public static void trackFollowCommentsWithReaderPostDetails(
+            AnalyticsTracker.Stat stat,
+            long blogId,
+            long postId,
+            ReaderPost post,
+            Map<String, Object> properties
+    ) {
+        if (post != null) {
+            AnalyticsUtils.trackWithReaderPostDetails(stat, post, properties);
+        } else {
+            AppLog.w(AppLog.T.READER, "The passed post obj is null."
+                                     + " Tracking analytics without post details info");
+            // let's log basic info
+            if (properties == null) {
+                properties = new HashMap<>();
+            }
+
+            properties.put(BLOG_ID_KEY, blogId);
+            properties.put(POST_ID_KEY, postId);
+
+            AnalyticsTracker.track(stat, properties);
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
@@ -29,4 +29,12 @@ class AnalyticsUtilsWrapper @Inject constructor(private val appContext: Context)
 
     fun trackWithReaderPostDetails(stat: AnalyticsTracker.Stat, post: ReaderPost) =
             AnalyticsUtils.trackWithReaderPostDetails(stat, post)
+
+    fun trackFollowCommentsWithReaderPostDetails(
+        stat: AnalyticsTracker.Stat,
+        blogId: Long,
+        postId: Long,
+        post: ReaderPost?,
+        properties: Map<String, Any?>?
+    ) = AnalyticsUtils.trackFollowCommentsWithReaderPostDetails(stat, blogId, postId, post, properties)
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -709,6 +709,7 @@ public final class AnalyticsTracker {
         COMMENT_QUICK_ACTION_APPROVED,
         COMMENT_QUICK_ACTION_LIKED,
         COMMENT_QUICK_ACTION_REPLIED_TO,
+        COMMENT_FOLLOW_CONVERSATION
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1929,6 +1929,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "comment_viewed";
             case COMMENT_DELETED:
                 return "comment_deleted";
+            case COMMENT_FOLLOW_CONVERSATION:
+                return "comment_follow_conversation";
         }
         return null;
     }


### PR DESCRIPTION
This is part of #12602 

It is a follow up to #13473 and it adds analytics to the follow/unfollow comments feature.

Event added is `comment_follow_conversation` and properties are:

- follow_action: (followed|unfollowed)
- follow_action_result: (succeeded|error)
- follow_action_error: error message only present when `follow_action_result` is `error`

The tracking tries to log info with reader post details (below an example):

```
🔵 Tracked: comment_follow_conversation, Properties: {"follow_action":"followed","follow_action_result":"succeeded","blog_id":185464053,"post_id":2,"feed_id":110225253,"feed_item_id":0,"is_jetpack":false,"site_type":"p2"}
🔵 Tracked: comment_follow_conversation, Properties: {"follow_action":"unfollowed","follow_action_result":"error","follow_action_error":"Error fetching subscription status for post","blog_id":185464053,"post_id":2,"feed_id":110225253,"feed_item_id":0,"is_jetpack":false,"site_type":"p2"}
```

If it's not possible to recover the ReaderPost from the local cache, then a basic set of information is logged (like below example):

```
🔵 Tracked: comment_follow_conversation, Properties: {"follow_action":"followed","follow_action_result":"succeeded","blog_id":185464053,"post_id":2}
🔵 Tracked: comment_follow_conversation, Properties: {"follow_action":"unfollowed","follow_action_result":"error","follow_action_error":"Error fetching subscription status for post","blog_id":185464053,"post_id":2}
```

### To test
- Activate the tracking
- Use the logcat with a `comment_follow_conversation` filter
- From the Reader Comments screen toggle the Follow conversation button and check the tracking in logcat are consistent with the toggled state
- Try to toggle with Airplane mode on and check you get an error tracking


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
