### PR TITLE
Enable follow unfollow button in comments reader.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Posts Settings: removed deprecated location setting [https://github.com/wordpress-mobile/WordPress-Android/pull/13404]
 * [***] Stories: New feature for WordPress.com and Jetpack sites: Use photos and videos to create engaging and tappable fullscreen slideshows. [https://github.com/wordpress-mobile/WordPress-Android/pull/13459]
+* [**] Reader: introduced a Follow/Unfollow button in comments screen to follow a post conversation and get notified by e-mail. Not supported for self-hosted sites not Jetpack connected. [https://github.com/wordpress-mobile/WordPress-Android/pull/13473]
 
 16.2
 -----

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -124,7 +124,6 @@ android {
             buildConfigField "boolean", "HOME_PAGE_PICKER", "true"
             // Enable this for testing consolidated media picker
             // buildConfigField "boolean", "CONSOLIDATED_MEDIA_PICKER", "true"
-            buildConfigField "boolean", "FOLLOW_UNFOLLOW_COMMENTS", "true"
         }
 
         jalapeno { // Pre-Alpha version, used for PR builds, can be installed along release, alpha, beta, dev versions

--- a/WordPress/src/main/java/org/wordpress/android/util/config/FollowUnfollowCommentsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/FollowUnfollowCommentsFeatureConfig.kt
@@ -1,15 +1,21 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.FollowUnfollowCommentsFeatureConfig.Companion.FOLLOW_UNFOLLOW_COMMENTS_REMOTE_FIELD
 import javax.inject.Inject
 
 /**
  * Configuration of the Follow Unfollow Comments
  */
-@FeatureInDevelopment
+@Feature(FOLLOW_UNFOLLOW_COMMENTS_REMOTE_FIELD, true)
 class FollowUnfollowCommentsFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.FOLLOW_UNFOLLOW_COMMENTS
-)
+        BuildConfig.FOLLOW_UNFOLLOW_COMMENTS,
+        FOLLOW_UNFOLLOW_COMMENTS_REMOTE_FIELD
+) {
+    companion object {
+        const val FOLLOW_UNFOLLOW_COMMENTS_REMOTE_FIELD = "follow_unfollow_comments_enabled"
+    }
+}


### PR DESCRIPTION
This PR enables the Follow/Unfollow button in Reader comments screen and makes it remotely controlled.

### To test
- Install the app
- Make sure you haven't manually overridden the flag
- Check that the Follow/Unfollow button is available in Reader comments screen (some more context/info in the #13473 PR description)
- Smoke test the feature following the #13473 instructions (and whatever steps you can think of additionally :) )

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
