### PR TITLE
Fixes NullPointerException on synthetic notifications_list RecyclerView

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -69,7 +69,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
 
     private val showNewUnseenNotificationsRunnable = Runnable {
         if (isAdded) {
-            notifications_list.addOnScrollListener(mOnScrollListener)
+            notifications_list?.addOnScrollListener(mOnScrollListener)
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/12657

Description:
Adds safe call operator to prevent crash. 

*I was not able to reproduce this by posting notifications to the list.* From the crash reports it seems that synthetic notifications_list RecyclerView might be null in some corner case. The breadcrumbs indicate that the user has left the notifications screen before the `notifications update service` completes. My guess is that all this happen in the [1s of the `postDelayed` call](https://github.com/wordpress-mobile/WordPress-Android/blob/2ead79b7bf2e52f7dabec2edb6599b3d93c15abb/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt#L369). The side effect of the `mOnScrollListener` not being added (because the view is null) is that the `clearPendingNotificationsItemsOnUI` will not be called. In that case this call is irrelevant if the user has left the screen.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
