### PR TITLE
Issue/13417 fix site creation restoration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -28,6 +28,7 @@ import javax.inject.Inject
 
 const val TAG_WARNING_DIALOG = "back_pressed_warning_dialog"
 const val KEY_CURRENT_STEP = "key_current_step"
+const val KEY_SITE_CREATION_COMPLETED = "key_site_creation_completed"
 const val KEY_SITE_CREATION_STATE = "key_site_creation_state"
 
 @Parcelize
@@ -76,6 +77,7 @@ class SiteCreationMainVM @Inject constructor(
             tracker.trackSiteCreationAccessed()
             siteCreationState = SiteCreationState()
         } else {
+            siteCreationCompleted = savedInstanceState.getBoolean(KEY_SITE_CREATION_COMPLETED, false)
             siteCreationState = requireNotNull(savedInstanceState.getParcelable(KEY_SITE_CREATION_STATE))
             val currentStepIndex = savedInstanceState.getInt(KEY_CURRENT_STEP)
             wizardManager.setCurrentStepIndex(currentStepIndex)
@@ -88,6 +90,7 @@ class SiteCreationMainVM @Inject constructor(
     }
 
     fun writeToBundle(outState: Bundle) {
+        outState.putBoolean(KEY_SITE_CREATION_COMPLETED, siteCreationCompleted)
         outState.putInt(KEY_CURRENT_STEP, wizardManager.currentStep)
         outState.putParcelable(KEY_SITE_CREATION_STATE, siteCreationState)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -32,7 +32,6 @@ import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.sitecreation.SiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.SiteCreationState
 import org.wordpress.android.ui.sitecreation.misc.OnHelpClickedListener
-import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewData
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewContentUiState
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewFullscreenErrorUiState

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.sitecreation.SiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.SiteCreationState
 import org.wordpress.android.ui.sitecreation.misc.OnHelpClickedListener
+import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.CreateSiteState
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewData
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewContentUiState
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewFullscreenErrorUiState
@@ -78,6 +79,11 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
     override fun onResume() {
         super.onResume()
         serviceEventConnection = ServiceEventConnection(context, SiteCreationService::class.java, viewModel)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        viewModel.writeToBundle(outState)
     }
 
     override fun onPause() {
@@ -152,8 +158,6 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
                 (requireActivity() as SitePreviewScreenListener).onSitePreviewScreenDismissed(createSiteState)
             }
         })
-
-        viewModel.start(requireArguments()[ARG_DATA] as SiteCreationState)
     }
 
     private fun initRetryButton() {
@@ -290,6 +294,8 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
         super.onActivityCreated(savedInstanceState)
 
         (requireActivity() as AppCompatActivity).supportActionBar?.hide()
+
+        viewModel.start(requireArguments()[ARG_DATA] as SiteCreationState, savedInstanceState)
     }
 
     override fun onWebViewPageLoaded() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -1,7 +1,10 @@
 package org.wordpress.android.ui.sitecreation.previews
 
+import android.os.Bundle
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.notNull
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.CoroutineScope
@@ -60,6 +63,7 @@ class SitePreviewViewModelTest {
 
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var siteStore: SiteStore
+    @Mock private lateinit var bundle: Bundle
     @Mock private lateinit var fetchWpComUseCase: FetchWpComSiteUseCase
     @Mock private lateinit var networkUtils: NetworkUtilsWrapper
     @Mock private lateinit var urlUtils: UrlUtilsWrapper
@@ -267,8 +271,68 @@ class SitePreviewViewModelTest {
         assertThat(getCreateSiteState()).isEqualTo(SiteNotInLocalDb(REMOTE_SITE_ID))
     }
 
-    private fun initViewModel() {
-        viewModel.start(SITE_CREATION_STATE)
+    @Test
+    fun `CreateSiteState is saved into bundle`() {
+        initViewModel(null)
+
+        viewModel.writeToBundle(bundle)
+
+        verify(bundle).putParcelable(eq(KEY_CREATE_SITE_STATE), notNull())
+    }
+
+    @Test
+    fun `show fullscreen progress when restoring from SiteNotCreated state`() = testWithSuccessResponse {
+        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
+        initViewModel(bundle)
+
+        assertThat(viewModel.uiState.value).isInstanceOf(SitePreviewFullscreenProgressUiState::class.java)
+    }
+
+    @Test
+    fun `service started when restoring from SiteNotCreated state`() {
+        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
+        initViewModel(bundle)
+
+        assertThat(viewModel.startCreateSiteService.value).isNotNull
+    }
+
+    @Test
+    fun `show fullscreen progress when restoring from SiteNotInLocalDb state`() = testWithSuccessResponse {
+        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
+        initViewModel(bundle)
+
+        assertThat(viewModel.uiState.value).isInstanceOf(SitePreviewFullscreenProgressUiState::class.java)
+    }
+
+    @Test
+    fun `start pre-loading WebView when restoring from SiteNotInLocalDb state`() = testWithSuccessResponse {
+        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
+                .thenReturn(SiteNotInLocalDb(REMOTE_SITE_ID))
+        initViewModel(bundle)
+
+        assertThat(viewModel.uiState.value).isInstanceOf(SitePreviewFullscreenProgressUiState::class.java)
+    }
+
+    @Test
+    fun `fetch newly created SiteModel when restoring from SiteNotInLocalDb state`() = testWithSuccessResponse {
+        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
+                .thenReturn(SiteNotInLocalDb(REMOTE_SITE_ID))
+        initViewModel(bundle)
+
+        verify(fetchWpComUseCase).fetchSiteWithRetry(REMOTE_SITE_ID)
+    }
+
+    @Test
+    fun `start pre-loading WebView when restoring from SiteCreationCompleted state`() {
+        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
+                .thenReturn(SiteCreationCompleted(LOCAL_SITE_ID))
+        initViewModel(bundle)
+
+        assertThat(viewModel.preloadPreview.value).isEqualTo(URL)
+    }
+
+    private fun initViewModel(savedState: Bundle? = null) {
+        viewModel.start(SITE_CREATION_STATE, savedState)
     }
 
     private fun createServiceFailureState(): SiteCreationServiceState {


### PR DESCRIPTION
Fixes #13417 

Note: I think it'd be good if this PR was reviewed by 2 devs, since it touches a vital flow.

I've looked into #13417 more deeply and I noticed a few interesting things:
1. There is a note that the device is low on memory almost in all the stack-traces in Sentry
2. The app crashes within 2 seconds after it's re-opened
3. The app crashes when the site gets created on the server before the app is closed/killed

I was able to reproduce the crash
1. Go to developer settings
2. Turn on "Don't keep activities"
3. Set background process limit to 0
4. Open the app
5. Go through the SiteCreation flow
6. When you are on the final preview screen, switch to a different app
7. Switch back to WPAndroid and notice the app crashes (you won't see ANR or a crash dialog since it crashes in background. However you should see the crash in LogCat + you can notice that the Preview screen is not shown after the crash) 

I realized we don't handle state restoration in the SiteCreationPreviewFragment + VM. This PR fixes this issue.

Few notes about the existing logic to help you better understand the code:
1. SiteCreationPreview fragment is responsible for the following
    - starting a Service which communicates with the server and takes care of the actual site creation
    - listening to changes in the service and showing a corresponding state on the UI  -> Progress/Error/Content(preview)
    - when the service completes, the fragment keeps showing the progress screen and starts preloading the site url into a webview -> when the webview finishes loading the site url, it shows the content


To test:
1. Verify the above steps work after the changes
- test anything else you can think of


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
