### PR TITLE
[Home Page Picker] Mark Theme Selection as Completed as part of the Site Creation Flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -14,6 +14,8 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.store.QuickStartStore
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHOOSE_THEME
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
@@ -35,6 +37,7 @@ import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState.S
 import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState.SiteCreationStep.FAILURE
 import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState.SiteCreationStep.IDLE
 import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState.SiteCreationStep.SUCCESS
+import org.wordpress.android.ui.sitecreation.theme.defaultTemplateSlug
 import org.wordpress.android.ui.sitecreation.usecases.isWordPressComSubDomain
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -62,6 +65,7 @@ private val loadingTexts = listOf(
 class SitePreviewViewModel @Inject constructor(
     private val dispatcher: Dispatcher,
     private val siteStore: SiteStore,
+    private val quickStartStore: QuickStartStore,
     private val fetchWpComSiteUseCase: FetchWpComSiteUseCase,
     private val networkUtils: NetworkUtilsWrapper,
     private val urlUtils: UrlUtilsWrapper,
@@ -216,6 +220,8 @@ class SitePreviewViewModel @Inject constructor(
                 val siteBySiteId = requireNotNull(siteStore.getSiteBySiteId(remoteSiteId)) {
                     "Site successfully fetched but has not been found in the local db."
                 }
+                val userHasSelectedDesign = siteCreationState.siteDesign != defaultTemplateSlug
+                quickStartStore.setDoneTask(siteBySiteId.id.toLong(), CHOOSE_THEME, userHasSelectedDesign)
                 CreateSiteState.SiteCreationCompleted(siteBySiteId.id)
             } else {
                 SiteNotInLocalDb(remoteSiteId)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -17,6 +17,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
@@ -60,6 +61,7 @@ class SitePreviewViewModelTest {
 
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var siteStore: SiteStore
+    @Mock private lateinit var quickStartStore: QuickStartStore
     @Mock private lateinit var fetchWpComUseCase: FetchWpComSiteUseCase
     @Mock private lateinit var networkUtils: NetworkUtilsWrapper
     @Mock private lateinit var urlUtils: UrlUtilsWrapper
@@ -80,6 +82,7 @@ class SitePreviewViewModelTest {
         viewModel = SitePreviewViewModel(
                 dispatcher,
                 siteStore,
+                quickStartStore,
                 fetchWpComUseCase,
                 networkUtils,
                 urlUtils,


### PR DESCRIPTION
With the release of the home page picker https://github.com/wordpress-mobile/WordPress-Android/pull/13409
We make users pick a theme during site creation. We thus need to mark the theme selection step as completed in the quick start tour screen.

## To test:

## Choose a theme
- Create a site
- Pick a theme
- Take the tour
- Notice "Choose a theme" is marked as completed

## Skip site creation
- Create a site
- Select `Skip` on Choose a Design
- Take the tour
- Notice "Choose a theme" is in the checklist

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
