### PR TITLE
Guard for null kotlin synthetic during orientation change

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 16.4
 -----
+* [*] My Site: Fixes crash on rotation while editing site title [https://github.com/wordpress-mobile/WordPress-Android/pull/13505]
  
 16.3
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -1585,7 +1585,7 @@ class MySiteFragment : Fragment(),
     }
 
     override fun onTextInputDialogDismissed(callbackId: Int) {
-        if (callbackId == site_info_container.title.id) {
+        if (callbackId == site_info_container?.title?.id) {
             showQuickStartNoticeIfNecessary()
             updateQuickStartContainer()
         }


### PR DESCRIPTION
Fixes #12550

It seems that `site_info_container` kotlin synthetic is `null` during an orientation change event. When the dialog is dismissed, the id of this resource is used to match against the callbackId set during instantiation of the dialog fragment. This PR adds a guard to that check. When the `site_info_container` is `null`, I beleive skipping `showQuickStartNoticeIfNecessary` and `updateQuickStartContainer` should be ok, since the fragment handles these via its own lifecycle methods.

To test:

* Log in and go to "My Site" tab
* Tap site title to open text input dialog
* Rotate phone

Expect the app not to crash, and the dialog to remain open, populated with the same text content from before the orientation change.


### Screen recordings

Before fix | After fix
-|-
![issue-12550-orientation-change-crash](https://user-images.githubusercontent.com/8507675/100710250-2bd32d80-33fb-11eb-9168-5ac0e67f87c8.gif)|![issue-12550-orientation-change-no-crash](https://user-images.githubusercontent.com/8507675/100709648-37722480-33fa-11eb-9b05-6832ef65abfa.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
