### PR TITLE
Implement click logic on site items

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -24,16 +24,34 @@ import kotlinx.android.synthetic.main.new_my_site_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.R.attr
 import org.wordpress.android.WordPress
+import org.wordpress.android.login.LoginMode.JETPACK_STATS
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.TextInputDialogFragment
+import org.wordpress.android.ui.accounts.LoginActivity
 import org.wordpress.android.ui.main.WPMainActivity
 import org.wordpress.android.ui.main.utils.MeGravatarLoader
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.ConnectJetpackForStats
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenActivityLog
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenAdmin
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenComments
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenCropActivity
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenMeScreen
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenMedia
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenMediaPicker
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPages
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPeople
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPlan
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPlugins
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPosts
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenScan
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSharing
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSite
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSitePicker
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSiteSettings
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenStats
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenThemes
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.StartWPComLoginForJetpackStats
 import org.wordpress.android.ui.mysite.SiteIconUploadViewModel.ItemUploadedModel
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
@@ -185,6 +203,45 @@ class ImprovedMySiteFragment : Fragment(),
                     }
                     is OpenCropActivity -> {
                         startCropActivity(action.imageUri)
+                    }
+                    is OpenActivityLog ->
+                        ActivityLauncher.viewActivityLogList(
+                                activity,
+                                action.site
+                        )
+                    is OpenScan -> TODO()
+                    is OpenPlan -> ActivityLauncher.viewBlogPlans(activity, action.site)
+                    is OpenPosts -> ActivityLauncher.viewCurrentBlogPosts(requireActivity(), action.site)
+                    is OpenPages -> ActivityLauncher.viewCurrentBlogPages(requireActivity(), action.site)
+                    is OpenAdmin -> ActivityLauncher.viewBlogAdmin(
+                            activity,
+                            action.site
+                    )
+                    is OpenPeople -> ActivityLauncher.viewCurrentBlogPeople(
+                            activity,
+                            action.site
+                    )
+                    is OpenSharing -> ActivityLauncher.viewBlogSharing(activity, action.site)
+                    is OpenSiteSettings -> ActivityLauncher.viewBlogSettingsForResult(
+                            activity,
+                            action.site
+                    )
+                    is OpenThemes -> ActivityLauncher.viewCurrentBlogThemes(activity, action.site)
+                    is OpenPlugins -> ActivityLauncher.viewPluginBrowser(
+                            activity,
+                            action.site
+                    )
+                    is OpenMedia -> ActivityLauncher.viewCurrentBlogMedia(activity, action.site)
+                    is OpenComments -> ActivityLauncher.viewCurrentBlogComments(
+                            activity,
+                            action.site
+                    )
+                    is OpenStats -> ActivityLauncher.viewBlogStats(activity, action.site)
+                    is ConnectJetpackForStats -> ActivityLauncher.viewConnectJetpackForStats(activity, action.site)
+                    StartWPComLoginForJetpackStats -> {
+                        val loginIntent = Intent(activity, LoginActivity::class.java)
+                        JETPACK_STATS.putInto(loginIntent)
+                        startActivityForResult(loginIntent, RequestCodes.DO_LOGIN)
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ListItemAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ListItemAction.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.ui.mysite
+
+enum class ListItemAction {
+    ACTIVITY_LOG,
+    SCAN,
+    PLAN,
+    POSTS,
+    PAGES,
+    ADMIN,
+    PEOPLE,
+    SHARING,
+    SITE_SETTINGS,
+    THEMES,
+    PLUGINS,
+    STATS,
+    MEDIA,
+    COMMENTS,
+    VIEW_SITE
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteListItemViewHolder.kt
@@ -19,5 +19,6 @@ class MySiteListItemViewHolder(parent: ViewGroup, private val uiHelpers: UiHelpe
         uiHelpers.setImageOrHide(secondaryIcon, item.secondaryIcon)
         uiHelpers.setTextOrHide(primaryText, item.primaryText)
         uiHelpers.setTextOrHide(secondaryText, item.secondaryText)
+        itemView.setOnClickListener { item.onClick.click() }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -136,7 +136,7 @@ class MySiteViewModel
 
     private fun onItemClick(action: ListItemAction) {
         selectedSiteRepository.getSelectedSite()?.let { site ->
-            val navigationAction = when(action) {
+            val navigationAction = when (action) {
                 ACTIVITY_LOG -> OpenActivityLog(site)
                 SCAN -> OpenScan(site)
                 PLAN -> OpenPlan(site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -18,11 +18,42 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.mysite.ListItemAction.ACTIVITY_LOG
+import org.wordpress.android.ui.mysite.ListItemAction.ADMIN
+import org.wordpress.android.ui.mysite.ListItemAction.COMMENTS
+import org.wordpress.android.ui.mysite.ListItemAction.MEDIA
+import org.wordpress.android.ui.mysite.ListItemAction.PAGES
+import org.wordpress.android.ui.mysite.ListItemAction.PEOPLE
+import org.wordpress.android.ui.mysite.ListItemAction.PLAN
+import org.wordpress.android.ui.mysite.ListItemAction.PLUGINS
+import org.wordpress.android.ui.mysite.ListItemAction.POSTS
+import org.wordpress.android.ui.mysite.ListItemAction.SCAN
+import org.wordpress.android.ui.mysite.ListItemAction.SHARING
+import org.wordpress.android.ui.mysite.ListItemAction.SITE_SETTINGS
+import org.wordpress.android.ui.mysite.ListItemAction.STATS
+import org.wordpress.android.ui.mysite.ListItemAction.THEMES
+import org.wordpress.android.ui.mysite.ListItemAction.VIEW_SITE
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.ConnectJetpackForStats
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenActivityLog
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenAdmin
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenComments
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenCropActivity
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenMeScreen
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenMedia
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenMediaPicker
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPages
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPeople
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPlan
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPlugins
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPosts
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenScan
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSharing
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSite
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSitePicker
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSiteSettings
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenStats
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenThemes
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.StartWPComLoginForJetpackStats
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ChangeSiteIconDialogModel
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
@@ -32,7 +63,6 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Dismissed
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Negative
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Positive
-import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.MediaUtilsWrapper
@@ -84,20 +114,53 @@ class MySiteViewModel
     ) { currentAvatarUrl, site, showSiteIconProgressBar ->
         val items = if (site != null) {
             val siteItems = mutableListOf<MySiteItem>()
-            siteItems.add(siteInfoBlockBuilder.buildSiteInfoBlock(
-                    site,
-                    showSiteIconProgressBar ?: false,
-                    this::titleClick,
-                    this::iconClick,
-                    this::urlClick,
-                    this::switchSiteClick
-            ))
-            siteItems.addAll(siteItemsBuilder.buildSiteItems(site, ListItemInteraction.create {  }))
+            siteItems.add(
+                    siteInfoBlockBuilder.buildSiteInfoBlock(
+                            site,
+                            showSiteIconProgressBar ?: false,
+                            this::titleClick,
+                            this::iconClick,
+                            this::urlClick,
+                            this::switchSiteClick
+                    )
+            )
+            siteItems.addAll(siteItemsBuilder.buildSiteItems(site, this::onItemClick))
             siteItems
         } else {
             listOf()
         }
         UiModel(currentAvatarUrl.orEmpty(), items)
+    }
+
+    private fun onItemClick(action: ListItemAction) {
+        selectedSiteRepository.getSelectedSite()?.let { site ->
+            val navigationAction = when(action) {
+                ACTIVITY_LOG -> OpenActivityLog(site)
+                SCAN -> OpenScan(site)
+                PLAN -> OpenPlan(site)
+                POSTS -> OpenPosts(site)
+                PAGES -> OpenPages(site)
+                ADMIN -> OpenAdmin(site)
+                PEOPLE -> OpenPeople(site)
+                SHARING -> OpenSharing(site)
+                SITE_SETTINGS -> OpenSiteSettings(site)
+                THEMES -> OpenThemes(site)
+                PLUGINS -> OpenPlugins(site)
+                STATS -> if (!accountStore.hasAccessToken() && site.isJetpackConnected) {
+                    // If the user is not connected to WordPress.com, ask him to connect first.
+                    StartWPComLoginForJetpackStats
+                } else if (site.isWPCom || site.isJetpackInstalled && site
+                                .isJetpackConnected) {
+                    OpenStats(site)
+                } else {
+                    ConnectJetpackForStats(site)
+                }
+                MEDIA -> OpenMedia(site)
+                COMMENTS -> OpenComments(site)
+                VIEW_SITE -> OpenSite(site)
+            }
+            _onNavigation.postValue(Event(navigationAction))
+        } ?: _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.site_cannot_be_loaded))))
     }
 
     private fun titleClick(selectedSite: SiteModel) {
@@ -279,6 +342,22 @@ class MySiteViewModel
         data class OpenSitePicker(val site: SiteModel) : NavigationAction()
         data class OpenMediaPicker(val site: SiteModel) : NavigationAction()
         data class OpenCropActivity(val imageUri: UriWrapper) : NavigationAction()
+        data class OpenActivityLog(val site: SiteModel) : NavigationAction()
+        data class OpenScan(val site: SiteModel) : NavigationAction()
+        data class OpenPlan(val site: SiteModel) : NavigationAction()
+        data class OpenPosts(val site: SiteModel) : NavigationAction()
+        data class OpenPages(val site: SiteModel) : NavigationAction()
+        data class OpenAdmin(val site: SiteModel) : NavigationAction()
+        data class OpenPeople(val site: SiteModel) : NavigationAction()
+        data class OpenSharing(val site: SiteModel) : NavigationAction()
+        data class OpenSiteSettings(val site: SiteModel) : NavigationAction()
+        data class OpenThemes(val site: SiteModel) : NavigationAction()
+        data class OpenPlugins(val site: SiteModel) : NavigationAction()
+        data class OpenMedia(val site: SiteModel) : NavigationAction()
+        data class OpenComments(val site: SiteModel) : NavigationAction()
+        object StartWPComLoginForJetpackStats : NavigationAction()
+        data class OpenStats(val site: SiteModel) : NavigationAction()
+        data class ConnectJetpackForStats(val site: SiteModel) : NavigationAction()
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteItemsBuilder.kt
@@ -13,7 +13,7 @@ class SiteItemsBuilder
     private val siteCategoryItemBuilder: SiteCategoryItemBuilder,
     private val siteListItemBuilder: SiteListItemBuilder
 ) {
-    fun buildSiteItems(site: SiteModel, onClick: ListItemInteraction): List<MySiteItem> {
+    fun buildSiteItems(site: SiteModel, onClick: (ListItemAction) -> Unit): List<MySiteItem> {
         val siteItems = mutableListOf<MySiteItem>()
         siteItems.addItemIfNotNull(siteListItemBuilder.buildPlanItemIfAvailable(site, onClick))
         siteItems.addItemIfNotNull(siteCategoryItemBuilder.buildJetpackCategoryIfAvailable(site))
@@ -21,7 +21,7 @@ class SiteItemsBuilder
                 ListItem(
                         R.drawable.ic_stats_alt_white_24dp,
                         UiStringRes(R.string.stats),
-                        onClick = onClick
+                        onClick = ListItemInteraction.create(ListItemAction.STATS, onClick)
                 )
         )
         siteItems.addItemIfNotNull(siteListItemBuilder.buildActivityLogItemIfAvailable(site, onClick))
@@ -32,21 +32,21 @@ class SiteItemsBuilder
                 ListItem(
                         R.drawable.ic_posts_white_24dp,
                         UiStringRes(R.string.my_site_btn_blog_posts),
-                        onClick = onClick
+                        onClick = ListItemInteraction.create(ListItemAction.POSTS, onClick)
                 )
         )
         siteItems.add(
                 ListItem(
                         R.drawable.ic_media_white_24dp,
                         UiStringRes(R.string.media),
-                        onClick = onClick
+                        onClick = ListItemInteraction.create(ListItemAction.MEDIA, onClick)
                 )
         )
         siteItems.add(
                 ListItem(
                         R.drawable.ic_comment_white_24dp,
                         UiStringRes(R.string.my_site_btn_comments),
-                        onClick = onClick
+                        onClick = ListItemInteraction.create(ListItemAction.COMMENTS, onClick)
                 )
         )
         siteItems.addItemIfNotNull(siteCategoryItemBuilder.buildLookAndFeelHeaderIfAvailable(site))
@@ -62,7 +62,7 @@ class SiteItemsBuilder
                         R.drawable.ic_globe_white_24dp,
                         UiStringRes(R.string.my_site_btn_view_site),
                         secondaryIcon = R.drawable.ic_external_white_24dp,
-                        onClick = onClick
+                        onClick = ListItemInteraction.create(ListItemAction.VIEW_SITE, onClick)
                 )
         )
         siteItems.addItemIfNotNull(siteListItemBuilder.buildAdminItemIfAvailable(site, onClick))

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
@@ -26,7 +26,7 @@ class SiteListItemBuilder
     private val scanFeatureConfig: ScanFeatureConfig,
     private val themeBrowserUtils: ThemeBrowserUtils
 ) {
-    fun buildActivityLogItemIfAvailable(site: SiteModel, onClick: ListItemInteraction): ListItem? {
+    fun buildActivityLogItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         val isWpComOrJetpack = siteUtilsWrapper.isAccessedViaWPComRest(
                 site
         ) || site.isJetpackConnected
@@ -34,22 +34,22 @@ class SiteListItemBuilder
             ListItem(
                     R.drawable.ic_history_alt_white_24dp,
                     UiStringRes(R.string.activity),
-                    onClick = onClick
+                    onClick = ListItemInteraction.create(ListItemAction.ACTIVITY_LOG, onClick)
             )
         } else null
     }
 
-    fun buildScanItemIfAvailable(onClick: ListItemInteraction): ListItem? {
+    fun buildScanItemIfAvailable(onClick: (ListItemAction) -> Unit): ListItem? {
         return if (scanFeatureConfig.isEnabled()) {
             ListItem(
                     R.drawable.ic_scan_alt_white_24dp,
                     UiStringRes(R.string.scan),
-                    onClick = onClick
+                    onClick = ListItemInteraction.create(ListItemAction.SCAN, onClick)
             )
         } else null
     }
 
-    fun buildPlanItemIfAvailable(site: SiteModel, onClick: ListItemInteraction): ListItem? {
+    fun buildPlanItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         val planShortName = site.planShortName
         return if (!TextUtils.isEmpty(planShortName) &&
                 site.hasCapabilityManageOptions &&
@@ -59,68 +59,68 @@ class SiteListItemBuilder
                     R.drawable.ic_plans_white_24dp,
                     UiStringRes(R.string.plan),
                     secondaryText = UiStringText(planShortName),
-                    onClick = onClick
+                    onClick = ListItemInteraction.create(ListItemAction.PLAN, onClick)
             )
         } else null
     }
 
-    fun buildPagesItemIfAvailable(site: SiteModel, onClick: ListItemInteraction): ListItem? {
+    fun buildPagesItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (site.isSelfHostedAdmin || site.hasCapabilityEditPages) {
             ListItem(
                     R.drawable.ic_pages_white_24dp,
                     UiStringRes(R.string.my_site_btn_site_pages),
-                    onClick = onClick
+                    onClick = ListItemInteraction.create(ListItemAction.PAGES, onClick)
             )
         } else null
     }
 
-    fun buildAdminItemIfAvailable(site: SiteModel, onClick: ListItemInteraction): ListItem? {
+    fun buildAdminItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (shouldShowWPAdmin(site)) {
             ListItem(
                     R.drawable.ic_my_sites_white_24dp,
                     UiStringRes(R.string.my_site_btn_view_admin),
                     secondaryIcon = R.drawable.ic_external_white_24dp,
-                    onClick = onClick
+                    onClick = ListItemInteraction.create(ListItemAction.ADMIN, onClick)
             )
         } else null
     }
 
-    fun buildPeopleItemIfAvailable(site: SiteModel, onClick: ListItemInteraction): ListItem? {
+    fun buildPeopleItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (site.hasCapabilityListUsers) {
             ListItem(
                     R.drawable.ic_user_white_24dp,
                     UiStringRes(R.string.people),
-                    onClick = onClick
+                    onClick = ListItemInteraction.create(ListItemAction.PEOPLE, onClick)
             )
         } else null
     }
 
-    fun buildPluginItemIfAvailable(site: SiteModel, onClick: ListItemInteraction): ListItem? {
+    fun buildPluginItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (pluginUtilsWrapper.isPluginFeatureAvailable(site)) {
             ListItem(
                     R.drawable.ic_plugins_white_24dp,
                     UiStringRes(R.string.my_site_btn_plugins),
-                    onClick = onClick
+                    onClick = ListItemInteraction.create(ListItemAction.PLUGINS, onClick)
             )
         } else null
     }
 
-    fun buildShareItemIfAvailable(site: SiteModel, onClick: ListItemInteraction): ListItem? {
+    fun buildShareItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (siteUtilsWrapper.isAccessedViaWPComRest(site)) {
             ListItem(
                     R.drawable.ic_share_white_24dp,
                     UiStringRes(R.string.my_site_btn_sharing),
-                    onClick = onClick
+                    onClick = ListItemInteraction.create(ListItemAction.SHARING, onClick)
             )
         } else null
     }
 
-    fun buildSiteSettingsItemIfAvailable(site: SiteModel, onClick: ListItemInteraction): ListItem? {
+    fun buildSiteSettingsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (site.hasCapabilityManageOptions || !siteUtilsWrapper.isAccessedViaWPComRest(site)) {
             ListItem(
                     R.drawable.ic_cog_white_24dp,
                     UiStringRes(R.string.my_site_btn_site_settings),
-                    onClick = onClick
+                    onClick = ListItemInteraction.create(ListItemAction.SITE_SETTINGS, onClick)
             )
         } else null
     }
@@ -139,12 +139,12 @@ class SiteListItemBuilder
         }
     }
 
-    fun buildThemesItemIfAvailable(site: SiteModel, onClick: ListItemInteraction): MySiteItem? {
+    fun buildThemesItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): MySiteItem? {
         return if (themeBrowserUtils.isAccessible(site)) {
             ListItem(
                     R.drawable.ic_themes_white_24dp,
                     UiStringRes(R.string.themes),
-                    onClick = onClick
+                    onClick = ListItemInteraction.create(ListItemAction.THEMES, onClick)
             )
         } else null
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -19,12 +19,41 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.mysite.ListItemAction.ACTIVITY_LOG
+import org.wordpress.android.ui.mysite.ListItemAction.ADMIN
+import org.wordpress.android.ui.mysite.ListItemAction.COMMENTS
+import org.wordpress.android.ui.mysite.ListItemAction.MEDIA
+import org.wordpress.android.ui.mysite.ListItemAction.PAGES
+import org.wordpress.android.ui.mysite.ListItemAction.PLAN
+import org.wordpress.android.ui.mysite.ListItemAction.PLUGINS
+import org.wordpress.android.ui.mysite.ListItemAction.POSTS
+import org.wordpress.android.ui.mysite.ListItemAction.SCAN
+import org.wordpress.android.ui.mysite.ListItemAction.SHARING
+import org.wordpress.android.ui.mysite.ListItemAction.SITE_SETTINGS
+import org.wordpress.android.ui.mysite.ListItemAction.STATS
+import org.wordpress.android.ui.mysite.ListItemAction.THEMES
+import org.wordpress.android.ui.mysite.ListItemAction.VIEW_SITE
 import org.wordpress.android.ui.mysite.MySiteItem.SiteInfoBlock
 import org.wordpress.android.ui.mysite.MySiteItem.SiteInfoBlock.IconState
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.ConnectJetpackForStats
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenActivityLog
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenAdmin
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenComments
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenMeScreen
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenMedia
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPages
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPlan
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPlugins
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenPosts
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenScan
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSharing
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSite
 import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSitePicker
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenSiteSettings
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenStats
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.OpenThemes
+import org.wordpress.android.ui.mysite.MySiteViewModel.NavigationAction.StartWPComLoginForJetpackStats
 import org.wordpress.android.ui.mysite.MySiteViewModel.TextInputDialogModel
 import org.wordpress.android.ui.mysite.MySiteViewModel.UiModel
 import org.wordpress.android.ui.mysite.MySiteViewModelTest.SiteInfoBlockAction.ICON_CLICK
@@ -372,6 +401,139 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(navigationActions).containsOnly(OpenMeScreen)
     }
 
+    @Test
+    fun `activity item click emits OpenActivity navigation event`() {
+        invokeItemClickAction(ACTIVITY_LOG)
+
+        assertThat(navigationActions).containsExactly(OpenActivityLog(site))
+    }
+
+    @Test
+    fun `scan item click emits OpenScan navigation event`() {
+        invokeItemClickAction(SCAN)
+
+        assertThat(navigationActions).containsExactly(OpenScan(site))
+    }
+
+    @Test
+    fun `plan item click emits OpenPlan navigation event`() {
+        invokeItemClickAction(PLAN)
+
+        assertThat(navigationActions).containsExactly(OpenPlan(site))
+    }
+
+    @Test
+    fun `posts item click emits OpenPosts navigation event`() {
+        invokeItemClickAction(POSTS)
+
+        assertThat(navigationActions).containsExactly(OpenPosts(site))
+    }
+
+    @Test
+    fun `pages item click emits OpenPages navigation event`() {
+        invokeItemClickAction(PAGES)
+
+        assertThat(navigationActions).containsExactly(OpenPages(site))
+    }
+
+    @Test
+    fun `admin item click emits OpenAdmin navigation event`() {
+        invokeItemClickAction(ADMIN)
+
+        assertThat(navigationActions).containsExactly(OpenAdmin(site))
+    }
+
+    @Test
+    fun `sharing item click emits OpenSharing navigation event`() {
+        invokeItemClickAction(SHARING)
+
+        assertThat(navigationActions).containsExactly(OpenSharing(site))
+    }
+
+    @Test
+    fun `site settings item click emits OpenSiteSettings navigation event`() {
+        invokeItemClickAction(SITE_SETTINGS)
+
+        assertThat(navigationActions).containsExactly(OpenSiteSettings(site))
+    }
+
+    @Test
+    fun `themes item click emits OpenThemes navigation event`() {
+        invokeItemClickAction(THEMES)
+
+        assertThat(navigationActions).containsExactly(OpenThemes(site))
+    }
+
+    @Test
+    fun `plugins item click emits OpenPlugins navigation event`() {
+        invokeItemClickAction(PLUGINS)
+
+        assertThat(navigationActions).containsExactly(OpenPlugins(site))
+    }
+
+    @Test
+    fun `media item click emits OpenMedia navigation event`() {
+        invokeItemClickAction(MEDIA)
+
+        assertThat(navigationActions).containsExactly(OpenMedia(site))
+    }
+
+    @Test
+    fun `comments item click emits OpenMedia navigation event`() {
+        invokeItemClickAction(COMMENTS)
+
+        assertThat(navigationActions).containsExactly(OpenComments(site))
+    }
+
+    @Test
+    fun `view site item click emits OpenSite navigation event`() {
+        invokeItemClickAction(VIEW_SITE)
+
+        assertThat(navigationActions).containsExactly(OpenSite(site))
+    }
+
+    @Test
+    fun `stats item click emits OpenStats navigation event if site is WPCom and has access token`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        site.setIsWPCom(true)
+
+        invokeItemClickAction(STATS)
+
+        assertThat(navigationActions).containsExactly(OpenStats(site))
+    }
+
+    @Test
+    fun `stats item click emits OpenStats navigation event if site is Jetpack and has access token`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        site.setIsJetpackConnected(true)
+        site.setIsJetpackInstalled(true)
+
+        invokeItemClickAction(STATS)
+
+        assertThat(navigationActions).containsExactly(OpenStats(site))
+    }
+
+    @Test
+    fun `stats item click emits StartWPComLoginForJetpackStats if site is Jetpack and doesn't have access token`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        site.setIsJetpackConnected(true)
+
+        invokeItemClickAction(STATS)
+
+        assertThat(navigationActions).containsExactly(StartWPComLoginForJetpackStats)
+    }
+
+    @Test
+    fun `stats item click emits ConnectJetpackForStats if neither Jetpack, nor WPCom and no access token`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        site.setIsJetpackConnected(false)
+        site.setIsWPCom(false)
+
+        invokeItemClickAction(STATS)
+
+        assertThat(navigationActions).containsExactly(ConnectJetpackForStats(site))
+    }
+
     private fun setupAccount(account: AccountModel?) = whenever(accountStore.account).thenReturn(account)
 
     private fun buildAccountWithAvatarUrl(avatarUrl: String?) = AccountModel().apply { this.avatarUrl = avatarUrl }
@@ -393,6 +555,20 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         assertThat(clickAction).isNotNull()
         clickAction!!.invoke(site)
+    }
+
+    private fun invokeItemClickAction(action: ListItemAction) {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        var clickAction: ((ListItemAction) -> Unit)? = null
+        doAnswer {
+            clickAction = it.getArgument(1)
+            listOf<MySiteItem>()
+        }.whenever(siteItemsBuilder).buildSiteItems(eq(site), any())
+
+        onSiteChange.postValue(site)
+
+        assertThat(clickAction).isNotNull()
+        clickAction!!.invoke(action)
     }
 
     private enum class SiteInfoBlockAction {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemFixtures.kt
@@ -1,95 +1,100 @@
 package org.wordpress.android.ui.mysite
 
-import org.wordpress.android.R.drawable
-import org.wordpress.android.R.string
+import org.wordpress.android.R
 import org.wordpress.android.ui.mysite.MySiteItem.CategoryHeader
 import org.wordpress.android.ui.mysite.MySiteItem.ListItem
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 
-val onClick = ListItemInteraction.create { }
-val jetpackHeader = CategoryHeader(
-        UiStringRes(string.my_site_header_jetpack)
+val SITE_ITEM_ACTION: (ListItemAction) -> Unit = {}
+val JETPACK_HEADER = CategoryHeader(
+        UiStringRes(R.string.my_site_header_jetpack)
 )
-val publishHeader = CategoryHeader(UiStringRes(string.my_site_header_publish))
-val lookAndFeelHeader = CategoryHeader(
-        UiStringRes(string.my_site_header_look_and_feel)
+val PUBLISH_HEADER = CategoryHeader(UiStringRes(R.string.my_site_header_publish))
+val LOOK_AND_FEEL_HEADER = CategoryHeader(
+        UiStringRes(R.string.my_site_header_look_and_feel)
 )
-val configurationHeader = CategoryHeader(
-        UiStringRes(string.my_site_header_configuration)
+val CONFIGURATION_HEADER = CategoryHeader(
+        UiStringRes(R.string.my_site_header_configuration)
 )
-val externalHeader = CategoryHeader(UiStringRes(string.my_site_header_external))
-val planItem = ListItem(
-        drawable.ic_plans_white_24dp,
-        UiStringRes(string.plan),
-        secondaryText = UiStringText("plan"),
-        onClick = onClick
+val EXTERNAL_HEADER = CategoryHeader(UiStringRes(R.string.my_site_header_external))
+val PLAN_NAME = "plan_name"
+val PLAN_ITEM = ListItem(
+        R.drawable.ic_plans_white_24dp,
+        UiStringRes(R.string.plan),
+        secondaryText = UiStringText(PLAN_NAME),
+        onClick = ListItemInteraction.create(ListItemAction.PLAN, SITE_ITEM_ACTION)
 )
-val activityItem = ListItem(
-        drawable.ic_history_alt_white_24dp,
-        UiStringRes(string.activity),
-        onClick = onClick
+val STATS_ITEM = ListItem(
+        R.drawable.ic_stats_alt_white_24dp,
+        UiStringRes(R.string.stats),
+        onClick = ListItemInteraction.create(ListItemAction.STATS, SITE_ITEM_ACTION)
 )
-val scanItem = ListItem(
-        drawable.ic_scan_alt_white_24dp,
-        UiStringRes(string.scan),
-        onClick = onClick
+val ACTIVITY_ITEM = ListItem(
+        R.drawable.ic_history_alt_white_24dp,
+        UiStringRes(R.string.activity),
+        onClick = ListItemInteraction.create(ListItemAction.ACTIVITY_LOG, SITE_ITEM_ACTION)
 )
-val pagesItem = ListItem(
-        drawable.ic_pages_white_24dp,
-        UiStringRes(string.my_site_btn_site_pages),
-        onClick = onClick
+val SCAN_ITEM = ListItem(
+        R.drawable.ic_scan_alt_white_24dp,
+        UiStringRes(R.string.scan),
+        onClick = ListItemInteraction.create(ListItemAction.SCAN, SITE_ITEM_ACTION)
 )
-val postsItem = ListItem(
-        drawable.ic_posts_white_24dp,
-        UiStringRes(string.my_site_btn_blog_posts),
-        onClick = onClick
+val PAGES_ITEM = ListItem(
+        R.drawable.ic_pages_white_24dp,
+        UiStringRes(R.string.my_site_btn_site_pages),
+        onClick = ListItemInteraction.create(ListItemAction.PAGES, SITE_ITEM_ACTION)
 )
-val mediaItem = ListItem(
-        drawable.ic_media_white_24dp,
-        UiStringRes(string.media),
-        onClick = onClick
+val POSTS_ITEM = ListItem(
+        R.drawable.ic_posts_white_24dp,
+        UiStringRes(R.string.my_site_btn_blog_posts),
+        onClick = ListItemInteraction.create(ListItemAction.POSTS, SITE_ITEM_ACTION)
 )
-val commentsItem = ListItem(
-        drawable.ic_comment_white_24dp,
-        UiStringRes(string.my_site_btn_comments),
-        onClick = onClick
+val MEDIA_ITEM = ListItem(
+        R.drawable.ic_media_white_24dp,
+        UiStringRes(R.string.media),
+        onClick = ListItemInteraction.create(ListItemAction.MEDIA, SITE_ITEM_ACTION)
 )
-val adminItem = ListItem(
-        drawable.ic_my_sites_white_24dp,
-        UiStringRes(string.my_site_btn_view_admin),
-        secondaryIcon = drawable.ic_external_white_24dp,
-        onClick = onClick
+val COMMENTS_ITEM = ListItem(
+        R.drawable.ic_comment_white_24dp,
+        UiStringRes(R.string.my_site_btn_comments),
+        onClick = ListItemInteraction.create(ListItemAction.COMMENTS, SITE_ITEM_ACTION)
 )
-val peopleItem = ListItem(
-        drawable.ic_user_white_24dp,
-        UiStringRes(string.people),
-        onClick = onClick
+val ADMIN_ITEM = ListItem(
+        R.drawable.ic_my_sites_white_24dp,
+        UiStringRes(R.string.my_site_btn_view_admin),
+        secondaryIcon = R.drawable.ic_external_white_24dp,
+        onClick = ListItemInteraction.create(ListItemAction.ADMIN, SITE_ITEM_ACTION)
 )
-val pluginsItem = ListItem(
-        drawable.ic_plugins_white_24dp,
-        UiStringRes(string.my_site_btn_plugins),
-        onClick = onClick
+val PEOPLE_ITEM = ListItem(
+        R.drawable.ic_user_white_24dp,
+        UiStringRes(R.string.people),
+        onClick = ListItemInteraction.create(ListItemAction.PEOPLE, SITE_ITEM_ACTION)
 )
-val sharingItem = ListItem(
-        drawable.ic_share_white_24dp,
-        UiStringRes(string.my_site_btn_sharing),
-        onClick = onClick
+val PLUGINS_ITEM = ListItem(
+        R.drawable.ic_plugins_white_24dp,
+        UiStringRes(R.string.my_site_btn_plugins),
+        onClick = ListItemInteraction.create(ListItemAction.PLUGINS, SITE_ITEM_ACTION)
 )
-val siteSettingsItem = ListItem(
-        drawable.ic_cog_white_24dp,
-        UiStringRes(string.my_site_btn_site_settings),
-        onClick = onClick
+val SHARING_ITEM = ListItem(
+        R.drawable.ic_share_white_24dp,
+        UiStringRes(R.string.my_site_btn_sharing),
+        onClick = ListItemInteraction.create(ListItemAction.SHARING, SITE_ITEM_ACTION)
 )
-val themesItem = ListItem(
-        drawable.ic_themes_white_24dp,
-        UiStringRes(string.themes),
-        onClick = onClick
+val SITE_SETTINGS_ITEM = ListItem(
+        R.drawable.ic_cog_white_24dp,
+        UiStringRes(R.string.my_site_btn_site_settings),
+        onClick = ListItemInteraction.create(ListItemAction.SITE_SETTINGS, SITE_ITEM_ACTION)
 )
-val viewSiteItem = ListItem(
-        drawable.ic_globe_white_24dp,
-        UiStringRes(string.my_site_btn_view_site),
-        secondaryIcon = drawable.ic_external_white_24dp,
-        onClick = onClick
+val THEMES_ITEM = ListItem(
+        R.drawable.ic_themes_white_24dp,
+        UiStringRes(R.string.themes),
+        onClick = ListItemInteraction.create(ListItemAction.THEMES, SITE_ITEM_ACTION)
+)
+val VIEW_SITE_ITEM = ListItem(
+        R.drawable.ic_globe_white_24dp,
+        UiStringRes(R.string.my_site_btn_view_site),
+        secondaryIcon = R.drawable.ic_external_white_24dp,
+        onClick = ListItemInteraction.create(ListItemAction.VIEW_SITE, SITE_ITEM_ACTION)
 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemsBuilderTest.kt
@@ -7,17 +7,13 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.mysite.MySiteItem.ListItem
-import org.wordpress.android.ui.utils.UiString.UiStringRes
 
 @RunWith(MockitoJUnitRunner::class)
 class SiteItemsBuilderTest {
     @Mock lateinit var siteCategoryItemBuilder: SiteCategoryItemBuilder
     @Mock lateinit var siteListItemBuilder: SiteListItemBuilder
     @Mock lateinit var siteModel: SiteModel
-    private val statsItem = ListItem(R.drawable.ic_stats_alt_white_24dp, UiStringRes(R.string.stats), onClick = onClick)
     private lateinit var siteItemsBuilder: SiteItemsBuilder
 
     @Before
@@ -29,21 +25,21 @@ class SiteItemsBuilderTest {
     fun `always adds stats, publish, posts, media, comment, external and view site items`() {
         setupHeaders(addJetpackHeader = false, addLookAndFeelHeader = false, addConfigurationHeader = false)
 
-        val buildSiteItems = siteItemsBuilder.buildSiteItems(siteModel, onClick)
+        val buildSiteItems = siteItemsBuilder.buildSiteItems(siteModel, SITE_ITEM_ACTION)
 
         assertThat(buildSiteItems).containsExactly(
-                statsItem,
-                publishHeader,
-                postsItem,
-                mediaItem,
-                commentsItem,
-                externalHeader,
-                viewSiteItem
+                STATS_ITEM,
+                PUBLISH_HEADER,
+                POSTS_ITEM,
+                MEDIA_ITEM,
+                COMMENTS_ITEM,
+                EXTERNAL_HEADER,
+                VIEW_SITE_ITEM
         )
     }
 
     @Test
-    fun `always all the items in the correct order`() {
+    fun `adds all the items in the correct order`() {
         setupHeaders(
                 addJetpackHeader = true,
                 addLookAndFeelHeader = true,
@@ -60,29 +56,29 @@ class SiteItemsBuilderTest {
                 addScanItem = true
         )
 
-        val buildSiteItems = siteItemsBuilder.buildSiteItems(siteModel, onClick)
+        val buildSiteItems = siteItemsBuilder.buildSiteItems(siteModel, SITE_ITEM_ACTION)
 
         assertThat(buildSiteItems).containsExactly(
-                planItem,
-                jetpackHeader,
-                statsItem,
-                activityItem,
-                scanItem,
-                publishHeader,
-                pagesItem,
-                postsItem,
-                mediaItem,
-                commentsItem,
-                lookAndFeelHeader,
-                themesItem,
-                configurationHeader,
-                peopleItem,
-                pluginsItem,
-                sharingItem,
-                siteSettingsItem,
-                externalHeader,
-                viewSiteItem,
-                adminItem
+                PLAN_ITEM,
+                JETPACK_HEADER,
+                STATS_ITEM,
+                ACTIVITY_ITEM,
+                SCAN_ITEM,
+                PUBLISH_HEADER,
+                PAGES_ITEM,
+                POSTS_ITEM,
+                MEDIA_ITEM,
+                COMMENTS_ITEM,
+                LOOK_AND_FEEL_HEADER,
+                THEMES_ITEM,
+                CONFIGURATION_HEADER,
+                PEOPLE_ITEM,
+                PLUGINS_ITEM,
+                SHARING_ITEM,
+                SITE_SETTINGS_ITEM,
+                EXTERNAL_HEADER,
+                VIEW_SITE_ITEM,
+                ADMIN_ITEM
         )
     }
 
@@ -103,67 +99,67 @@ class SiteItemsBuilderTest {
     ) {
         if (addJetpackHeader) {
             whenever(siteCategoryItemBuilder.buildJetpackCategoryIfAvailable(siteModel)).thenReturn(
-                    jetpackHeader
+                    JETPACK_HEADER
             )
         }
         if (addLookAndFeelHeader) {
             whenever(siteCategoryItemBuilder.buildLookAndFeelHeaderIfAvailable(siteModel)).thenReturn(
-                    lookAndFeelHeader
+                    LOOK_AND_FEEL_HEADER
             )
         }
         if (addConfigurationHeader) {
             whenever(siteCategoryItemBuilder.buildConfigurationHeaderIfAvailable(siteModel)).thenReturn(
-                    configurationHeader
+                    CONFIGURATION_HEADER
             )
         }
         if (addPlanItem) {
-            whenever(siteListItemBuilder.buildPlanItemIfAvailable(siteModel, onClick)).thenReturn(
-                    planItem
+            whenever(siteListItemBuilder.buildPlanItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                    PLAN_ITEM
             )
         }
         if (addActivityLogItem) {
-            whenever(siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, onClick)).thenReturn(
-                    activityItem
+            whenever(siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                    ACTIVITY_ITEM
             )
         }
         if (addScanItem) {
-            whenever(siteListItemBuilder.buildScanItemIfAvailable(onClick)).thenReturn(
-                    scanItem
+            whenever(siteListItemBuilder.buildScanItemIfAvailable(SITE_ITEM_ACTION)).thenReturn(
+                    SCAN_ITEM
             )
         }
         if (addPagesItem) {
-            whenever(siteListItemBuilder.buildPagesItemIfAvailable(siteModel, onClick)).thenReturn(
-                    pagesItem
+            whenever(siteListItemBuilder.buildPagesItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                    PAGES_ITEM
             )
         }
         if (addAdminItem) {
-            whenever(siteListItemBuilder.buildAdminItemIfAvailable(siteModel, onClick)).thenReturn(
-                    adminItem
+            whenever(siteListItemBuilder.buildAdminItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                    ADMIN_ITEM
             )
         }
         if (addPeopleItem) {
-            whenever(siteListItemBuilder.buildPeopleItemIfAvailable(siteModel, onClick)).thenReturn(
-                    peopleItem
+            whenever(siteListItemBuilder.buildPeopleItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                    PEOPLE_ITEM
             )
         }
         if (addPluginItem) {
-            whenever(siteListItemBuilder.buildPluginItemIfAvailable(siteModel, onClick)).thenReturn(
-                    pluginsItem
+            whenever(siteListItemBuilder.buildPluginItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                    PLUGINS_ITEM
             )
         }
         if (addShareItem) {
-            whenever(siteListItemBuilder.buildShareItemIfAvailable(siteModel, onClick)).thenReturn(
-                    sharingItem
+            whenever(siteListItemBuilder.buildShareItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                    SHARING_ITEM
             )
         }
         if (addSiteSettingsItem) {
-            whenever(siteListItemBuilder.buildSiteSettingsItemIfAvailable(siteModel, onClick)).thenReturn(
-                    siteSettingsItem
+            whenever(siteListItemBuilder.buildSiteSettingsItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                    SITE_SETTINGS_ITEM
             )
         }
         if (addThemesItem) {
-            whenever(siteListItemBuilder.buildThemesItemIfAvailable(siteModel, onClick)).thenReturn(
-                    themesItem
+            whenever(siteListItemBuilder.buildThemesItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                    THEMES_ITEM
             )
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteListItemBuilderTest.kt
@@ -7,16 +7,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.ui.mysite.MySiteItem.ListItem
 import org.wordpress.android.ui.plugins.PluginUtilsWrapper
 import org.wordpress.android.ui.themes.ThemeBrowserUtils
-import org.wordpress.android.ui.utils.ListItemInteraction
-import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.ScanFeatureConfig
 import org.wordpress.android.util.SiteUtilsWrapper
 
@@ -28,8 +23,6 @@ class SiteListItemBuilderTest {
     @Mock lateinit var scanFeatureConfig: ScanFeatureConfig
     @Mock lateinit var themeBrowserUtils: ThemeBrowserUtils
     @Mock lateinit var siteModel: SiteModel
-    @Mock lateinit var onClick: ListItemInteraction
-    private val business = "business"
     private lateinit var siteListItemBuilder: SiteListItemBuilder
 
     @Before
@@ -52,15 +45,9 @@ class SiteListItemBuilderTest {
                 isWpForTeams = false
         )
 
-        val item = siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_history_alt_white_24dp,
-                        UiStringRes(R.string.activity),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(ACTIVITY_ITEM)
     }
 
     @Test
@@ -72,22 +59,16 @@ class SiteListItemBuilderTest {
                 isWpForTeams = false
         )
 
-        val item = siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_history_alt_white_24dp,
-                        UiStringRes(R.string.activity),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(ACTIVITY_ITEM)
     }
 
     @Test
     fun `activity item not built when site cannot manage options`() {
         setupActivityLogItem(canManageOptions = false)
 
-        val item = siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -96,7 +77,7 @@ class SiteListItemBuilderTest {
     fun `activity item not built when site is WP for teams`() {
         setupActivityLogItem(isWpForTeams = true)
 
-        val item = siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -105,7 +86,7 @@ class SiteListItemBuilderTest {
     fun `activity item not built when site is neither Jetpack nor uses WPComRest`() {
         setupActivityLogItem(isAccessedViaWPComRest = false, isJetpackConnected = false)
 
-        val item = siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -126,22 +107,16 @@ class SiteListItemBuilderTest {
     fun `scan item built if scan feature config enabled`() {
         whenever(scanFeatureConfig.isEnabled()).thenReturn(true)
 
-        val item = siteListItemBuilder.buildScanItemIfAvailable(onClick)
+        val item = siteListItemBuilder.buildScanItemIfAvailable(SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_scan_alt_white_24dp,
-                        UiStringRes(R.string.scan),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(SCAN_ITEM)
     }
 
     @Test
     fun `scan item not built if scan feature config not enabled`() {
         whenever(scanFeatureConfig.isEnabled()).thenReturn(false)
 
-        val item = siteListItemBuilder.buildScanItemIfAvailable(onClick)
+        val item = siteListItemBuilder.buildScanItemIfAvailable(SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -149,52 +124,38 @@ class SiteListItemBuilderTest {
     @Test
     fun `plan item built when plan not empty, site can manage options, is not WP for teams and is WPcom`() {
         setupPlanItem(
-                planShortName = business,
+                planShortName = PLAN_NAME,
                 canManageOptions = true,
                 isWpForTeams = false,
                 isWPCom = true,
                 isAutomatedTransfer = false
         )
 
-        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_plans_white_24dp,
-                        UiStringRes(R.string.plan),
-                        secondaryText = UiStringText(business),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(PLAN_ITEM)
     }
 
     @Test
     fun `plan item built when plan not empty, site can manage options, is not WP for teams and is AT`() {
         setupPlanItem(
-                planShortName = business,
+                planShortName = PLAN_NAME,
                 canManageOptions = true,
                 isWpForTeams = false,
                 isWPCom = false,
                 isAutomatedTransfer = true
         )
 
-        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_plans_white_24dp,
-                        UiStringRes(R.string.plan),
-                        secondaryText = UiStringText(business),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(PLAN_ITEM)
     }
 
     @Test
     fun `plan item not built when plan name is empty`() {
         setupPlanItem(planShortName = "")
 
-        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -203,7 +164,7 @@ class SiteListItemBuilderTest {
     fun `plan item not built when site cannot manage options`() {
         setupPlanItem(canManageOptions = false)
 
-        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -212,7 +173,7 @@ class SiteListItemBuilderTest {
     fun `plan item not built when site is WP for teams`() {
         setupPlanItem(isWpForTeams = true)
 
-        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -221,13 +182,13 @@ class SiteListItemBuilderTest {
     fun `plan item not built when site is neither WP com nor AT`() {
         setupPlanItem(isWPCom = false, isAutomatedTransfer = false)
 
-        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPlanItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
 
     private fun setupPlanItem(
-        planShortName: String = business,
+        planShortName: String = PLAN_NAME,
         canManageOptions: Boolean = true,
         isWpForTeams: Boolean = false,
         isWPCom: Boolean = true,
@@ -244,7 +205,7 @@ class SiteListItemBuilderTest {
     fun `pages item not built when not self-hosted admin and cannot edit pages`() {
         setupPagesItem(isSelfHostedAdmin = false, canEditPages = false)
 
-        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -253,30 +214,18 @@ class SiteListItemBuilderTest {
     fun `pages item built when self-hosted admin`() {
         setupPagesItem(isSelfHostedAdmin = true)
 
-        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_pages_white_24dp,
-                        UiStringRes(R.string.my_site_btn_site_pages),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(PAGES_ITEM)
     }
 
     @Test
     fun `pages item built when can edit pages`() {
         setupPagesItem(canEditPages = true)
 
-        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPagesItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_pages_white_24dp,
-                        UiStringRes(R.string.my_site_btn_site_pages),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(PAGES_ITEM)
     }
 
     private fun setupPagesItem(isSelfHostedAdmin: Boolean = false, canEditPages: Boolean = false) {
@@ -288,55 +237,34 @@ class SiteListItemBuilderTest {
     fun `admin item built when site is not WPCom`() {
         setupAdminItem(isWPCom = false)
 
-        val item = siteListItemBuilder.buildAdminItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildAdminItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_my_sites_white_24dp,
-                        UiStringRes(R.string.my_site_btn_view_admin),
-                        secondaryIcon = R.drawable.ic_external_white_24dp,
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(ADMIN_ITEM)
     }
 
     @Test
     fun `admin item built when site is WPCom and account created before 2015-10-07`() {
         setupAdminItem(isWPCom = true, accountDate = "2015-10-06T02:00:00+0200")
 
-        val item = siteListItemBuilder.buildAdminItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildAdminItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_my_sites_white_24dp,
-                        UiStringRes(R.string.my_site_btn_view_admin),
-                        secondaryIcon = R.drawable.ic_external_white_24dp,
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(ADMIN_ITEM)
     }
 
     @Test
     fun `admin item built when site is WPCom and account date is empty`() {
         setupAdminItem(isWPCom = true, accountDate = "")
 
-        val item = siteListItemBuilder.buildAdminItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildAdminItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_my_sites_white_24dp,
-                        UiStringRes(R.string.my_site_btn_view_admin),
-                        secondaryIcon = R.drawable.ic_external_white_24dp,
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(ADMIN_ITEM)
     }
 
     @Test
     fun `admin item not built when site is WPCom and account created after 2015-10-07`() {
         setupAdminItem(isWPCom = true, accountDate = "2015-10-08T02:00:00+0200")
 
-        val item = siteListItemBuilder.buildAdminItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildAdminItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -352,22 +280,16 @@ class SiteListItemBuilderTest {
     fun `people item built if site can list users`() {
         whenever(siteModel.hasCapabilityListUsers).thenReturn(true)
 
-        val item = siteListItemBuilder.buildPeopleItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPeopleItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_user_white_24dp,
-                        UiStringRes(R.string.people),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(PEOPLE_ITEM)
     }
 
     @Test
     fun `people item not built if site cannot list users`() {
         whenever(siteModel.hasCapabilityListUsers).thenReturn(false)
 
-        val item = siteListItemBuilder.buildPeopleItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPeopleItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -376,22 +298,16 @@ class SiteListItemBuilderTest {
     fun `plugin item built if feature available`() {
         whenever(pluginUtilsWrapper.isPluginFeatureAvailable(siteModel)).thenReturn(true)
 
-        val item = siteListItemBuilder.buildPluginItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPluginItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_plugins_white_24dp,
-                        UiStringRes(R.string.my_site_btn_plugins),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(PLUGINS_ITEM)
     }
 
     @Test
     fun `plugin item not built if feature not available`() {
         whenever(pluginUtilsWrapper.isPluginFeatureAvailable(siteModel)).thenReturn(false)
 
-        val item = siteListItemBuilder.buildPluginItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildPluginItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -400,22 +316,16 @@ class SiteListItemBuilderTest {
     fun `share item built if is accessed through WPCom REST`() {
         whenever(siteUtilsWrapper.isAccessedViaWPComRest(siteModel)).thenReturn(true)
 
-        val item = siteListItemBuilder.buildShareItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildShareItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_share_white_24dp,
-                        UiStringRes(R.string.my_site_btn_sharing),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(SHARING_ITEM)
     }
 
     @Test
     fun `share item not built if is not accessed through WPCom REST`() {
         whenever(siteUtilsWrapper.isAccessedViaWPComRest(siteModel)).thenReturn(false)
 
-        val item = siteListItemBuilder.buildShareItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildShareItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }
@@ -424,37 +334,25 @@ class SiteListItemBuilderTest {
     fun `settings item built if site can manage options`() {
         setupSiteSettings(canManageOptions = true)
 
-        val item = siteListItemBuilder.buildSiteSettingsItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildSiteSettingsItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_cog_white_24dp,
-                        UiStringRes(R.string.my_site_btn_site_settings),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(SITE_SETTINGS_ITEM)
     }
 
     @Test
     fun `settings item built if site is not accessed through WPCom REST`() {
         setupSiteSettings(isAccessedViaWPComRest = false)
 
-        val item = siteListItemBuilder.buildSiteSettingsItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildSiteSettingsItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
-        assertThat(item).isEqualTo(
-                ListItem(
-                        R.drawable.ic_cog_white_24dp,
-                        UiStringRes(R.string.my_site_btn_site_settings),
-                        onClick = onClick
-                )
-        )
+        assertThat(item).isEqualTo(SITE_SETTINGS_ITEM)
     }
 
     @Test
     fun `settings item not built if site is accessed through WPCom REST and cannot manage options`() {
         setupSiteSettings(canManageOptions = false, isAccessedViaWPComRest = true)
 
-        val item = siteListItemBuilder.buildSiteSettingsItemIfAvailable(siteModel, onClick)
+        val item = siteListItemBuilder.buildSiteSettingsItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isNull()
     }


### PR DESCRIPTION
Fixes #13347 

This PR adds logic to list items in the My Site to click on items and a lot of tests. There is almost no logic in place so it should all be fairly straightforward. The only thing that contains logic is clicking on stats where (depending on the site) it opens either stats, login or jetpack install flow.

To test:
- Turn on the my site feature flag and restart the app
- Try clicking on all the items
- Check that the correct screen is opened on click 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
