### PR TITLE
Remove injected CSS/JS that is no longer needed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -4,7 +4,6 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
-import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
 import android.text.Spannable
@@ -14,7 +13,6 @@ import android.view.View
 import android.view.View.OnLayoutChangeListener
 import android.view.ViewGroup
 import android.view.animation.DecelerateInterpolator
-import android.webkit.WebView
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
@@ -124,9 +122,6 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
                 sitePreviewWebView.settings.userAgentString = WordPress.getUserAgent()
                 sitePreviewWebView.loadUrl(url)
             }
-        })
-        viewModel.hideGetStartedBar.observe(this, Observer<Unit> {
-            hideGetStartedBar(sitePreviewWebView)
         })
         viewModel.startCreateSiteService.observe(this, Observer { startServiceData ->
             startServiceData?.let {
@@ -299,19 +294,6 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
 
     override fun onWebViewReceivedError() {
         viewModel.onWebViewError()
-    }
-
-    // Hacky solution to https://github.com/wordpress-mobile/WordPress-Android/issues/8233
-    // Ideally we would hide "get started" bar on server side
-    @SuppressLint("SetJavaScriptEnabled")
-    private fun hideGetStartedBar(webView: WebView) {
-        webView.settings.javaScriptEnabled = true
-        val javascript = "document.querySelector('html').style.cssText += '; margin-top: 0 !important;';\n" +
-                "document.getElementById('wpadminbar').style.display = 'none';\n"
-
-        webView.evaluateJavascript(
-                javascript
-        ) { webView.settings.javaScriptEnabled = false }
     }
 
     override fun onHelp() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -91,9 +91,6 @@ class SitePreviewViewModel @Inject constructor(
     private val _startCreateSiteService: SingleLiveEvent<SitePreviewStartServiceData> = SingleLiveEvent()
     val startCreateSiteService: LiveData<SitePreviewStartServiceData> = _startCreateSiteService
 
-    private val _hideGetStartedBar: SingleLiveEvent<Unit> = SingleLiveEvent()
-    val hideGetStartedBar: LiveData<Unit> = _hideGetStartedBar
-
     private val _onHelpClicked = SingleLiveEvent<Unit>()
     val onHelpClicked: LiveData<Unit> = _onHelpClicked
 
@@ -252,7 +249,6 @@ class SitePreviewViewModel @Inject constructor(
     }
 
     fun onUrlLoaded() {
-        _hideGetStartedBar.call()
         if (!webviewFullyLoadedTracked) {
             webviewFullyLoadedTracked = true
             tracker.trackPreviewWebviewFullyLoaded()

--- a/WordPress/src/main/res/layout/site_creation_preview_web_view_container.xml
+++ b/WordPress/src/main/res/layout/site_creation_preview_web_view_container.xml
@@ -42,7 +42,7 @@
             </FrameLayout>
         </com.google.android.material.card.MaterialCardView>
 
-        <org.wordpress.android.ui.WPWebView
+        <org.wordpress.android.widgets.NestedWebView
             android:id="@+id/sitePreviewWebView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -69,7 +69,6 @@ class SitePreviewViewModelTest {
     @Mock private lateinit var onHelpedClickedObserver: Observer<Unit>
     @Mock private lateinit var onCancelWizardClickedObserver: Observer<CreateSiteState>
     @Mock private lateinit var onOkClickedObserver: Observer<CreateSiteState>
-    @Mock private lateinit var hideGetStartedObserver: Observer<Unit>
     @Mock private lateinit var preloadPreviewObserver: Observer<String>
 
     private lateinit var viewModel: SitePreviewViewModel
@@ -92,7 +91,6 @@ class SitePreviewViewModelTest {
         viewModel.onHelpClicked.observeForever(onHelpedClickedObserver)
         viewModel.onCancelWizardClicked.observeForever(onCancelWizardClickedObserver)
         viewModel.onOkButtonClicked.observeForever(onOkClickedObserver)
-        viewModel.hideGetStartedBar.observeForever(hideGetStartedObserver)
         viewModel.preloadPreview.observeForever(preloadPreviewObserver)
         whenever(networkUtils.isNetworkAvailable()).thenReturn(true)
         whenever(urlUtils.extractSubDomain(URL)).thenReturn(SUB_DOMAIN)
@@ -200,13 +198,6 @@ class SitePreviewViewModelTest {
     fun `on OK click is propagated`() {
         viewModel.onOkButtonClicked()
         assertThat(viewModel.onOkButtonClicked.value).isEqualTo(SiteNotCreated)
-    }
-
-    @Test
-    fun `hide GetStartedBar on UrlLoaded`() {
-        initViewModel()
-        viewModel.onUrlLoaded()
-        verify(hideGetStartedObserver).onChanged(null)
     }
 
     @Test


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-Android/issues/13501

### To test:
1. Navigate to the Create WordPress.com site
    - Choose site > ➕ > Create WordPress.com site
1. Choose a Design or Select Skip
1. Search for and choose a domain
1. Select Create Site
1. Wait for your site to be created and for the preview to load
1. **Expect** 
    - To not see a header like the admin bar, the cookie notice or the create a page on WordPress.com notice
    - You also shouldn't be able to click any of the buttons or links on the preview webview. 
        - The menu will open but you shouldn't be able to navigate within there

📓 Just to tie the original PR to this one. This code was originally added here: https://github.com/wordpress-mobile/WordPress-Android/pull/8382

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
