### PR TITLE
Removes `background-color` from reader posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -492,6 +492,10 @@ public class ReaderPostRenderer {
                 "(gallery-group) ([\\s\"'])",
                 "(tiled-gallery-item) ([\\s\"'])");
         String contentCustomised = content;
+
+        // removes background-color property from original content
+        contentCustomised = contentCustomised.replaceAll("\\s*(background-color)\\s*:\\s*.+?\\s*;\\s*", "");
+
         for (String classToAmend : classAmendRegexes) {
             contentCustomised = contentCustomised.replaceAll(classToAmend, "$1 " + galleryOnlyClass + "$2");
         }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/13496

## Description
Strips `background-color` from reader posts content. This aligns with the iOS that does not render background colors in the Reader.

*Note: This PR fixes the original reported issue in the Reader. The [editor issue reported in the comments](https://github.com/wordpress-mobile/WordPress-Android/issues/13496#issuecomment-732496180) should be handled in a separate issue/PR. Note that this is an issue on both platform*
<details>
 <summary>Editor Background Colors</summary>
 
|Android Editor Dark Mode|iOS Editor Dark Mode|Android Editor Normal Mode|iOS Editor Normal Mode|
|---|---|---|---|
|![device-2020-12-01-233555](https://user-images.githubusercontent.com/304044/100799823-58546d00-342e-11eb-806a-5f0129ee4975.png)|![Simulator Screen Shot - iPhone 11 - 2020-12-01 at 23 34 59](https://user-images.githubusercontent.com/304044/100799834-5d192100-342e-11eb-9d9a-7ee2e4a12b74.png)|![device-2020-12-01-233625](https://user-images.githubusercontent.com/304044/100799827-5ab6c700-342e-11eb-9b86-98e5afbb0eac.png)|![Simulator Screen Shot - iPhone 11 - 2020-12-01 at 23 37 18](https://user-images.githubusercontent.com/304044/100799830-5c808a80-342e-11eb-9ef6-eebf246839ba.png)|
</details>

## To test:
1. Create a post with a paragraph block from the browser and assign a light colored background to it.
1. View this post in the Reader in the app using Dark Mode.
!. You'll notice the color of the background is removed

## Screenshots

|Before: Android Dark Mode|After: Android Dark Mode|
|---|---|
|![device-2020-12-01-221035](https://user-images.githubusercontent.com/304044/100797891-82586000-342b-11eb-81b9-d4df977b7f7a.png)|![device-2020-12-01-232549](https://user-images.githubusercontent.com/304044/100798772-c26c1280-342c-11eb-84d1-a41f62cb4404.png)|

|Before: Android Normal Mode|After: Android Normal Mode|
|---|---|
|![device-2020-12-01-220906](https://user-images.githubusercontent.com/304044/100797882-7e2c4280-342b-11eb-939a-a448e8681a84.png)|![device-2020-12-01-232604](https://user-images.githubusercontent.com/304044/100798755-bed88b80-342c-11eb-8916-89de1a3e481d.png)|

|Before: Android Dark Mode|After: Android Dark Mode|
|---|---|
|![device-2020-12-01-222026](https://user-images.githubusercontent.com/304044/100797906-884e4100-342b-11eb-86ff-449d688933bd.png)|![device-2020-12-01-232129](https://user-images.githubusercontent.com/304044/100798284-1d513a00-342c-11eb-9f96-c19039cfde73.png)|

|Web Editor Content|iOS Normal Mode|iOS Dark Mode|
|---|---|---|
|![Screenshot 2020-12-01 at 10 57 28 PM](https://user-images.githubusercontent.com/304044/100797459-d4e54c80-342a-11eb-9c96-349c314a5231.png)|![Simulator Screen Shot - iPhone 11 - 2020-12-01 at 23 07 38](https://user-images.githubusercontent.com/304044/100797502-e890b300-342a-11eb-8974-cad2fe458daa.png)|![Simulator Screen Shot - iPhone 11 - 2020-12-01 at 23 06 59](https://user-images.githubusercontent.com/304044/100797513-ed556700-342a-11eb-88b3-27536d90df71.png)|


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
