### PR TITLE
WP Stories: Only show Story block in GB picker if supported by the site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2307,7 +2307,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         boolean unsupportedBlockEditorSwitch = !mIsJetpackSsoEnabled && "gutenberg".equals(mSite.getWebEditor());
 
         return new GutenbergPropsBuilder(
-                mWPStoriesFeatureConfig.isEnabled(),
+                mWPStoriesFeatureConfig.isEnabled() && SiteUtils.supportsStoriesFeature(mSite),
                 enableMentions,
                 isUnsupportedBlockEditorEnabled,
                 unsupportedBlockEditorSwitch,


### PR DESCRIPTION
I noticed that the Story block shows up in the Gutenberg picker for all sites - including non-Jetpack self-hosted sites and sites using older Jetpack versions.

To fix it I added the same check we use in the bottom sheets to determine whether the story feature is available.

Note: This PR should be included in the 16.3 release, so will require a new beta. I'm targeting `fix/stories-for-16.3` for now though because there are one or two other issues that need to be resolved that may as well all be bundled into one updated beta cut.

### To test:
* For a WordPress.com or Jetpack 9.1+ site, check that the Story block shows up in the block picker
* For a self-hosted non-Jetpack site, or a site running an older version of Jetpack, check that the Story block does not show up in the block picker

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
