### PR TITLE
Skip prechecks on release builds on CI

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -241,7 +241,7 @@ ENV["validate_translations"]="lintVanillaRelease"
   # This lane builds the final release of the app and uploads it
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>] [skip_prechecks:<skip confirm>] [create_release:<Create release on GH> ]
+  # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>] [skip_prechecks:<skip prechecks>] [create_release:<Create release on GH> ]
   #
   # Example:
   # bundle exec fastlane build_and_upload_release

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -255,7 +255,7 @@ ENV["validate_translations"]="lintVanillaRelease"
       alpha: false,
       beta: false,
       final: true)
-    android_build_preflight() unless (options[:skip_prechecks])
+    android_build_preflight() unless options[:skip_prechecks]
 
     # Create the file names
     version=android_get_release_version()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -241,11 +241,12 @@ ENV["validate_translations"]="lintVanillaRelease"
   # This lane builds the final release of the app and uploads it
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
+  # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>] [skip_prechecks:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
   # bundle exec fastlane build_and_upload_release
   # bundle exec fastlane build_and_upload_release skip_confirm:true
+  # bundle exec fastlane build_and_upload_release skip_prechecks:true
   # bundle exec fastlane build_and_upload_release create_release:true 
   #####################################################################################
   desc "Builds and updates for distribution"
@@ -254,7 +255,7 @@ ENV["validate_translations"]="lintVanillaRelease"
       alpha: false,
       beta: false,
       final: true)
-    android_build_preflight()
+    android_build_preflight() unless (options[:skip_prechecks])
 
     # Create the file names
     version=android_get_release_version()


### PR DESCRIPTION
This PR adds the management of the `skip_prechecks` flag to the `build_and_upload_release` lane. 
This flag is intended to skip some pre-build checks  that are not required or even dangerous on CI. 
In particular, we want to skip the [preflight step](https://github.com/wordpress-mobile/release-toolkit/blob/develop/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_preflight.rb) as it invokes `configure_apply`. Configuration is done in a previous step on CI and, after that, some changes are applied to the `gradle.build` file in order to make the build work, so rerunning `configure_apply` at this point makes the build fail. 
The only other check run by `android_build_preflight` is to check that the bundle tool is correctly installed, which is something we don't need as well on CI. 

The flag is [already invoked](https://github.com/wordpress-mobile/WordPress-Android/blob/95b15937bb6a342f3cdfb80e8e5e744a0c0aff82/.circleci/config.yml#L297), so it looks like an oversight that it isn't already implemented here. 

Using `skip_prechecks` to skip the `build_preflight` step may seem confusing, but this seems to be what we do everywhere, so I think it's fine to maintain the same convention here. Actually, I'm not sure why we have two precheck steps (prechecks and preflight): I think that the best way to make this part clearer is to merge the two actions in the `release_toolkit`. Because of these reasons, I'm not introducing a new `skip_preflight` flag. 

I'm targeting the release branch because it would be nice to have this for the next release and it seems quite a safe change. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
