### PR TITLE
Stories: Fix StringIndexOutOfBoundsException when below another block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -101,9 +101,10 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
         while (storyBlockStartIndex > -1 && storyBlockStartIndex < content.length) {
             storyBlockStartIndex = content.indexOf(HEADING_START, storyBlockStartIndex)
             if (storyBlockStartIndex > -1) {
+                val storyBlockEndIndex = content.indexOf(HEADING_END, storyBlockStartIndex)
                 val jsonString: String = content.substring(
                         storyBlockStartIndex + HEADING_START.length,
-                        content.indexOf(HEADING_END))
+                        storyBlockEndIndex)
                 content = listener.doWithMediaFilesJson(content, jsonString)
                 storyBlockStartIndex += HEADING_START.length
             }


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/615.

It turns out that the `StringIndexOutOfBoundsException` was happening when the Story block was not the first block in the post. The end of the first block in the post would be matched, causing the substring end index to be earlier than the start index.

Fixed by calculating the end of the Story block relative to its start.

### To test:
* Create a new post in Gutenberg
* Add a block, e.g. a paragraph block
* Below it, add a Story block, and add some slides
* Exit the story editor and try to save the post
* Confirm that the post is saved and there is no crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
