### PR TITLE
Fix logic showing Jetpack header

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteCategoryItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteCategoryItemBuilder.kt
@@ -12,9 +12,7 @@ class SiteCategoryItemBuilder
 @Inject constructor(private val themeBrowserUtils: ThemeBrowserUtils, private val siteUtilsWrapper: SiteUtilsWrapper) {
     fun buildJetpackCategoryIfAvailable(site: SiteModel): MySiteItem? {
         val jetpackSettingsVisible = site.isJetpackConnected && // jetpack is installed and connected
-                !site.isWPComAtomic &&
-                siteUtilsWrapper.isAccessedViaWPComRest(site) && // is using .com login
-                site.hasCapabilityManageOptions // has permissions to manage the site
+                !site.isWPComAtomic // isn't atomic site
         return if (jetpackSettingsVisible) {
             CategoryHeader(UiStringRes(R.string.my_site_header_jetpack))
         } else null

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteCategoryItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteCategoryItemBuilderTest.kt
@@ -28,7 +28,7 @@ class SiteCategoryItemBuilderTest {
 
     @Test
     fun `returns jetpack header when site is jetpack, WPCom, can manage options and is not atomic`() {
-        setupJetpackHeader(isJetpackConnected = true, isWpCom = true, canManageOptions = true, isAtomic = false)
+        setupJetpackHeader(isJetpackConnected = true, isAtomic = false)
 
         val lookAndFeelHeader = siteCategoryItemBuilder.buildJetpackCategoryIfAvailable(siteModel)
 
@@ -38,24 +38,6 @@ class SiteCategoryItemBuilderTest {
     @Test
     fun `does not return jetpack header when site is not jetpack`() {
         setupJetpackHeader(isJetpackConnected = false)
-
-        val lookAndFeelHeader = siteCategoryItemBuilder.buildJetpackCategoryIfAvailable(siteModel)
-
-        assertThat(lookAndFeelHeader).isNull()
-    }
-
-    @Test
-    fun `does not return jetpack header when site is not WPCom`() {
-        setupJetpackHeader(isWpCom = false)
-
-        val lookAndFeelHeader = siteCategoryItemBuilder.buildJetpackCategoryIfAvailable(siteModel)
-
-        assertThat(lookAndFeelHeader).isNull()
-    }
-
-    @Test
-    fun `does not return jetpack header when site can manage options`() {
-        setupJetpackHeader(canManageOptions = false)
 
         val lookAndFeelHeader = siteCategoryItemBuilder.buildJetpackCategoryIfAvailable(siteModel)
 
@@ -127,14 +109,10 @@ class SiteCategoryItemBuilderTest {
 
     private fun setupJetpackHeader(
         isJetpackConnected: Boolean = true,
-        isAtomic: Boolean = false,
-        isWpCom: Boolean = true,
-        canManageOptions: Boolean = true
+        isAtomic: Boolean = false
     ) {
         whenever(siteModel.isJetpackConnected).thenReturn(isJetpackConnected)
         whenever(siteModel.isWPComAtomic).thenReturn(isAtomic)
-        whenever(siteUtilsWrapper.isAccessedViaWPComRest(siteModel)).thenReturn(isWpCom)
-        whenever(siteModel.hasCapabilityManageOptions).thenReturn(canManageOptions)
     }
 
     private fun setupConfigurationHeader(


### PR DESCRIPTION
I've noticed the Jetpack header should be visible when you're logged in with a self-hosted Jetpack site but you don't have a WPCom account. In this case the site settings are not visible. This PR fixes this use case. 

![Screenshot_1606991896](https://user-images.githubusercontent.com/1079756/100998623-0e69a500-355c-11eb-99f6-3d83e2f2901c.png)


To test:
- Log in with a self-hosted Jetpack site
- Notice the "Jetpack" header is visible
- Notice the "Jetpack settings" item is gone
- Login to a WPCom account (for example through Stats)
- Notice the "Jetpack settings" item appears

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
