### PR TITLE
Issue/10572 update work manager

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -219,6 +219,8 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
     // LiveData
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
+    // ProcessLifecycleOwner
+    implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
 
     testImplementation("androidx.arch.core:core-testing:$androidxArchCoreVersion", {
         exclude group: 'com.android.support', module: 'support-compat'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -212,6 +212,8 @@ dependencies {
     implementation "androidx.preference:preference:$preferenceVersion"
     implementation "androidx.work:work-runtime:$androidxWorkVersion"
     implementation "androidx.work:work-runtime-ktx:$androidxWorkVersion"
+    // GCMNetworkManager on api <= 22
+    implementation "androidx.work:work-gcm:$androidxWorkVersion"
 
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/UploadWorkerTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/UploadWorkerTest.kt
@@ -47,8 +47,8 @@ class UploadWorkerTest {
 
     @Test
     fun testOneTimeUploadWorker() {
-        val testDriver = WorkManagerTestInitHelper.getTestDriver()
-        val workManager = WorkManager.getInstance()
+        val testDriver = WorkManagerTestInitHelper.getTestDriver(mock())
+        val workManager = WorkManager.getInstance(mock())
 
         // Define inputs
         val site = SiteModel()
@@ -58,7 +58,7 @@ class UploadWorkerTest {
         val (request, operation) = enqueueUploadWorkRequestForSite(site)
 
         // Meet constraints
-        testDriver.setAllConstraintsMet(request.id)
+        testDriver!!.setAllConstraintsMet(request.id)
 
         // Wait for result
         operation.result.get()
@@ -77,7 +77,7 @@ class UploadWorkerTest {
         val site = SiteModel()
         whenever(siteStore.getSiteByLocalId(any())).doReturn(site)
 
-        val workManager = WorkManager.getInstance()
+        val workManager = WorkManager.getInstance(mock())
 
         // Enqueue
         val (request, operation) = enqueueUploadWorkRequestForSite(site)
@@ -96,14 +96,14 @@ class UploadWorkerTest {
     @Test
     fun testPeriodicUploadWorkerWithMetConstraints() {
         // Define input data
-        val testDriver = WorkManagerTestInitHelper.getTestDriver()
-        val workManager = WorkManager.getInstance()
+        val testDriver = WorkManagerTestInitHelper.getTestDriver(mock())
+        val workManager = WorkManager.getInstance(mock())
 
         // Enqueue
         val (request, operation) = enqueuePeriodicUploadWorkRequestForAllSites()
 
         // Meet constraints and delay
-        testDriver.setAllConstraintsMet(request.id)
+        testDriver!!.setAllConstraintsMet(request.id)
         testDriver.setPeriodDelayMet(request.id)
 
         // Wait for result
@@ -120,15 +120,15 @@ class UploadWorkerTest {
     @Test
     fun testPeriodicUploadWorkerWithMetConstraintsCalledTwice() {
         // Define input data
-        val testDriver = WorkManagerTestInitHelper.getTestDriver()
-        val workManager = WorkManager.getInstance()
+        val testDriver = WorkManagerTestInitHelper.getTestDriver(mock())
+        val workManager = WorkManager.getInstance(mock())
 
         // Enqueue
         val (request, operation) = enqueuePeriodicUploadWorkRequestForAllSites()
 
         // ############### First round
         // Meet delay, constraints, and wait for result
-        testDriver.setAllConstraintsMet(request.id)
+        testDriver!!.setAllConstraintsMet(request.id)
         testDriver.setPeriodDelayMet(request.id)
         operation.result.get()
 

--- a/WordPress/src/debug/java/org/wordpress/android/WordPressDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/WordPressDebug.java
@@ -3,6 +3,7 @@ package org.wordpress.android;
 import android.os.StrictMode;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.work.Configuration;
 import androidx.work.WorkManager;
 
@@ -14,7 +15,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.UploadWorker;
 
-public class WordPressDebug extends WordPress {
+public class WordPressDebug extends WordPress implements Configuration.Provider {
     @Override
     public void onCreate() {
         super.onCreate();
@@ -25,13 +26,14 @@ public class WordPressDebug extends WordPress {
         Stetho.initializeWithDefaults(this);
     }
 
+    @NonNull
     @Override
-    protected void initWorkManager() {
-        Configuration config = (new Configuration.Builder())
+    public androidx.work.Configuration getWorkManagerConfiguration() {
+        UploadWorker.Factory factory = new UploadWorker.Factory(mUploadStarter, mSiteStore);
+        return (new androidx.work.Configuration.Builder())
                 .setMinimumLoggingLevel(Log.DEBUG)
-                .setWorkerFactory(new UploadWorker.Factory(mUploadStarter, mSiteStore))
+                .setWorkerFactory(factory)
                 .build();
-        WorkManager.initialize(this, config);
     }
 
     @Override

--- a/WordPress/src/debug/java/org/wordpress/android/WordPressDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/WordPressDebug.java
@@ -3,7 +3,6 @@ package org.wordpress.android;
 import android.os.StrictMode;
 import android.util.Log;
 
-import androidx.annotation.NonNull;
 import androidx.work.Configuration;
 import androidx.work.WorkManager;
 
@@ -15,7 +14,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.UploadWorker;
 
-public class WordPressDebug extends WordPress implements Configuration.Provider {
+public class WordPressDebug extends WordPress {
     @Override
     public void onCreate() {
         super.onCreate();
@@ -26,14 +25,13 @@ public class WordPressDebug extends WordPress implements Configuration.Provider 
         Stetho.initializeWithDefaults(this);
     }
 
-    @NonNull
     @Override
-    public androidx.work.Configuration getWorkManagerConfiguration() {
-        UploadWorker.Factory factory = new UploadWorker.Factory(mUploadStarter, mSiteStore);
-        return (new androidx.work.Configuration.Builder())
+    protected void initWorkManager() {
+        Configuration config = (new Configuration.Builder())
                 .setMinimumLoggingLevel(Log.DEBUG)
-                .setWorkerFactory(factory)
+                .setWorkerFactory(new UploadWorker.Factory(mUploadStarter, mSiteStore))
                 .build();
+        WorkManager.initialize(this, config);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -22,7 +22,6 @@ import android.util.AndroidRuntimeException;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.provider.FontRequest;
@@ -137,8 +136,7 @@ import kotlinx.coroutines.CoroutineScope;
 
 import static org.wordpress.android.modules.ThreadModuleKt.DEFAULT_SCOPE;
 
-public class WordPress extends MultiDexApplication
-        implements HasAndroidInjector, LifecycleObserver, androidx.work.Configuration.Provider {
+public class WordPress extends MultiDexApplication implements HasAndroidInjector, LifecycleObserver {
     public static final String SITE = "SITE";
     public static final String LOCAL_SITE_ID = "LOCAL_SITE_ID";
     public static final String REMOTE_SITE_ID = "REMOTE_SITE_ID";
@@ -346,6 +344,8 @@ public class WordPress extends MultiDexApplication
                 .build();
         mCredentialsClient.connect();
 
+        initWorkManager();
+
         // Enqueue our periodic upload work request. The UploadWorkRequest will be called even if the app is closed.
         // It will upload local draft or published posts with local changes to the server.
         UploadWorkerKt.enqueuePeriodicUploadWorkRequestForAllSites();
@@ -364,11 +364,11 @@ public class WordPress extends MultiDexApplication
         ProcessLifecycleOwner.get().getLifecycle().addObserver(mStoryMediaSaveUploadBridge);
     }
 
-    @NonNull
-    @Override
-    public androidx.work.Configuration getWorkManagerConfiguration() {
+    protected void initWorkManager() {
         UploadWorker.Factory factory = new UploadWorker.Factory(mUploadStarter, mSiteStore);
-        return (new androidx.work.Configuration.Builder()).setWorkerFactory(factory).build();
+        androidx.work.Configuration config =
+                (new androidx.work.Configuration.Builder()).setWorkerFactory(factory).build();
+        WorkManager.initialize(this, config);
     }
 
     // note that this is overridden in WordPressDebug

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -22,6 +22,7 @@ import android.util.AndroidRuntimeException;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.provider.FontRequest;
@@ -136,7 +137,8 @@ import kotlinx.coroutines.CoroutineScope;
 
 import static org.wordpress.android.modules.ThreadModuleKt.DEFAULT_SCOPE;
 
-public class WordPress extends MultiDexApplication implements HasAndroidInjector, LifecycleObserver {
+public class WordPress extends MultiDexApplication
+        implements HasAndroidInjector, LifecycleObserver, androidx.work.Configuration.Provider {
     public static final String SITE = "SITE";
     public static final String LOCAL_SITE_ID = "LOCAL_SITE_ID";
     public static final String REMOTE_SITE_ID = "REMOTE_SITE_ID";
@@ -344,8 +346,6 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
                 .build();
         mCredentialsClient.connect();
 
-        initWorkManager();
-
         // Enqueue our periodic upload work request. The UploadWorkRequest will be called even if the app is closed.
         // It will upload local draft or published posts with local changes to the server.
         UploadWorkerKt.enqueuePeriodicUploadWorkRequestForAllSites();
@@ -364,11 +364,11 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
         ProcessLifecycleOwner.get().getLifecycle().addObserver(mStoryMediaSaveUploadBridge);
     }
 
-    protected void initWorkManager() {
+    @NonNull
+    @Override
+    public androidx.work.Configuration getWorkManagerConfiguration() {
         UploadWorker.Factory factory = new UploadWorker.Factory(mUploadStarter, mSiteStore);
-        androidx.work.Configuration config =
-                (new androidx.work.Configuration.Builder()).setWorkerFactory(factory).build();
-        WorkManager.initialize(this, config);
+        return (new androidx.work.Configuration.Builder()).setWorkerFactory(factory).build();
     }
 
     // note that this is overridden in WordPressDebug

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -11,7 +11,6 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.jetpack_remote_install_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -36,8 +35,7 @@ class JetpackRemoteInstallFragment : Fragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         requireActivity().let { activity ->
-            viewModel = ViewModelProviders.of(this, viewModelFactory)
-                    .get<JetpackRemoteInstallViewModel>(JetpackRemoteInstallViewModel::class.java)
+            viewModel = ViewModelProvider(this, viewModelFactory).get(JetpackRemoteInstallViewModel::class.java)
 
             val intent = activity.intent
             val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -29,7 +29,6 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 
 import com.google.android.material.elevation.ElevationOverlayProvider;
 import com.google.android.material.snackbar.Snackbar;
@@ -284,7 +283,7 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
     }
 
     private void initViewModel(WPWebViewUsageCategory webViewUsageCategory) {
-        mViewModel = ViewModelProviders.of(this, mViewModelFactory).get(WPWebViewViewModel.class);
+        mViewModel = new ViewModelProvider(this, mViewModelFactory).get(WPWebViewViewModel.class);
         mViewModel.getUiState().observe(this, new Observer<WebPreviewUiState>() {
             @Override public void onChanged(@Nullable WebPreviewUiState webPreviewUiState) {
                 if (webPreviewUiState != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.accounts
 import android.os.Bundle
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.post_signup_interstitial_default.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -28,7 +27,7 @@ class PostSignupInterstitialActivity : LocaleAwareActivity() {
 
         setContentView(R.layout.post_signup_interstitial_activity)
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(PostSignupInterstitialViewModel::class.java)
 
         viewModel.onInterstitialShown()

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.activity_log_item_detail.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -49,7 +48,7 @@ class ActivityLogDetailFragment : Fragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         activity?.let { activity ->
-            viewModel = ViewModelProviders.of(activity, viewModelFactory)
+            viewModel = ViewModelProvider(activity, viewModelFactory)
                     .get<ActivityLogDetailViewModel>(ActivityLogDetailViewModel::class.java)
 
             val intent = activity.intent

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -8,7 +8,6 @@ import androidx.core.util.Pair
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.datepicker.MaterialDatePicker
@@ -64,7 +63,7 @@ class ActivityLogListFragment : Fragment() {
 
         (nonNullActivity.application as WordPress).component()?.inject(this)
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(ActivityLogViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(ActivityLogViewModel::class.java)
 
         val site = if (savedInstanceState == null) {
             val nonNullIntent = checkNotNull(nonNullActivity.intent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -10,7 +10,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.activity_log_type_filter_fragment.*
@@ -80,10 +79,10 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(ActivityLogTypeFilterViewModel::class.java)
 
-        val parentViewModel = ViewModelProviders.of(requireParentFragment(), viewModelFactory)
+        val parentViewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
                 .get(ActivityLogViewModel::class.java)
 
         viewModel.uiState.observe(viewLifecycleOwner, Observer { uiState ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -7,7 +7,6 @@ import android.view.MenuItem
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.domain_suggestions_activity.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -47,7 +46,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
     }
 
     private fun setupViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(DomainRegistrationMainViewModel::class.java)
         viewModel.start()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -17,7 +17,6 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -86,9 +85,9 @@ class DomainRegistrationDetailsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        mainViewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        mainViewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(DomainRegistrationMainViewModel::class.java)
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(DomainRegistrationDetailsViewModel::class.java)
         setupObservers()
 
@@ -452,7 +451,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
                 throw IllegalStateException("StatePickerDialogFragment is missing a targetFragment ")
             }
 
-            viewModel = ViewModelProviders.of(targetFragment!!, viewModelFactory)
+            viewModel = ViewModelProvider(targetFragment!!, viewModelFactory)
                     .get(DomainRegistrationDetailsViewModel::class.java)
             val builder = MaterialAlertDialogBuilder(requireContext())
             builder.setTitle(R.string.domain_registration_state_picker_dialog_title)
@@ -502,7 +501,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
                 throw IllegalStateException("CountryPickerDialogFragment is missing a targetFragment ")
             }
 
-            viewModel = ViewModelProviders.of(targetFragment!!, viewModelFactory)
+            viewModel = ViewModelProvider(targetFragment!!, viewModelFactory)
                     .get(DomainRegistrationDetailsViewModel::class.java)
             val builder = MaterialAlertDialogBuilder(requireContext())
             builder.setTitle(R.string.domain_registration_country_picker_dialog_title)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -10,7 +10,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.domain_suggestions_fragment.*
@@ -50,10 +49,10 @@ class DomainSuggestionsFragment : Fragment() {
         val nonNullActivity = requireActivity()
         (nonNullActivity.application as WordPress).component().inject(this)
 
-        mainViewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        mainViewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(DomainRegistrationMainViewModel::class.java)
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(DomainSuggestionsViewModel::class.java)
 
         val nonNullIntent = checkNotNull(nonNullActivity.intent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerActivity.kt
@@ -11,7 +11,7 @@ import android.widget.RelativeLayout
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.GridLayoutManager
 import kotlinx.android.synthetic.main.media_picker_activity.*
 import org.wordpress.android.R
@@ -69,7 +69,7 @@ class GifPickerActivity : LocaleAwareActivity() {
         val requestCode = intent.getIntExtra(KEY_REQUEST_CODE, 0)
         isMultiSelectEnabled = requestCode == RequestCodes.GIF_PICKER_MULTI_SELECT
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(GifPickerViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(GifPickerViewModel::class.java)
         viewModel.start(site, isMultiSelectEnabled)
 
         // We are intentionally reusing this layout since the UI is very similar.

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -39,7 +38,7 @@ class MainBottomSheetFragment : BottomSheetDialogFragment() {
         recyclerView.layoutManager = LinearLayoutManager(requireActivity())
         recyclerView.adapter = AddContentAdapter(requireActivity())
 
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory).get(WPMainActivityViewModel::class.java)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(WPMainActivityViewModel::class.java)
 
         viewModel.mainActions.observe(this, Observer {
             (dialog?.content_recycler_view?.adapter as? AddContentAdapter)?.update(it ?: listOf())

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -15,7 +15,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
@@ -137,7 +136,7 @@ class MeFragment : Fragment(), OnScrollToTopListener {
             }
         }
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(MeViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(MeViewModel::class.java)
         viewModel.showDisconnectDialog.observe(viewLifecycleOwner, Observer {
             it.applyIfNotHandled {
                 when (this) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -16,7 +16,6 @@ import androidx.appcompat.view.ActionMode;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.LinearLayoutManager;
 
@@ -122,7 +121,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
 
-        mViewModel = ViewModelProviders.of(this, mViewModelFactory).get(SitePickerViewModel.class);
+        mViewModel = new ViewModelProvider(this, mViewModelFactory).get(SitePickerViewModel.class);
 
         setContentView(R.layout.site_picker_activity);
         restoreSavedInstanceState(savedInstanceState);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -22,7 +22,6 @@ import androidx.core.app.RemoteInput;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -400,8 +399,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
         mFloatingActionButton = findViewById(R.id.fab_button);
         mFabTooltip = findViewById(R.id.fab_tooltip);
 
-        mViewModel = ViewModelProviders.of(this, mViewModelFactory).get(WPMainActivityViewModel.class);
-        mMLPViewModel = ViewModelProviders.of(this, mViewModelFactory).get(ModalLayoutPickerViewModel.class);
+        mViewModel = new ViewModelProvider(this, mViewModelFactory).get(WPMainActivityViewModel.class);
+        mMLPViewModel = new ViewModelProvider(this, mViewModelFactory).get(ModalLayoutPickerViewModel.class);
 
         // Setup Observers
         mViewModel.getFabUiState().observe(this, fabUiState -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -22,7 +22,6 @@ import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.GridLayoutManager.SpanSizeLookup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -193,7 +192,7 @@ class MediaPickerFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(MediaPickerViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(MediaPickerViewModel::class.java)
         setHasOptionsMenu(true)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -10,7 +10,6 @@ import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener
@@ -162,7 +161,7 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
     }
 
     private fun setupViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(ModalLayoutPickerViewModel::class.java)
 
         loadSavedState(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -11,7 +11,6 @@ import android.view.ViewGroup
 import androidx.appcompat.widget.TooltipCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener
 import com.google.android.material.snackbar.Snackbar
@@ -90,8 +89,8 @@ class ImprovedMySiteFragment : Fragment(),
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(MySiteViewModel::class.java)
-        dialogViewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(MySiteViewModel::class.java)
+        dialogViewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(BasicDialogViewModel::class.java)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.RecyclerView
@@ -72,10 +71,10 @@ class PageListFragment : ViewPagerFragment() {
     }
 
     private fun initializeViewModels(activity: FragmentActivity) {
-        val pagesViewModel = ViewModelProviders.of(activity, viewModelFactory).get(PagesViewModel::class.java)
+        val pagesViewModel = ViewModelProvider(activity, viewModelFactory).get(PagesViewModel::class.java)
 
         val listType = arguments?.getSerializable(typeKey) as PageListType
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(listType.name, PageListViewModel::class.java)
 
         viewModel.start(listType, pagesViewModel)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
@@ -17,7 +17,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.page_parent_fragment.*
@@ -179,7 +178,7 @@ class PageParentFragment : Fragment() {
         pageId: Long,
         isFirstStart: Boolean
     ) {
-        viewModel = ViewModelProviders.of(activity, viewModelFactory)
+        viewModel = ViewModelProvider(activity, viewModelFactory)
                 .get(PageParentViewModel::class.java)
 
         setupObservers()

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.pages_list_fragment.*
@@ -63,10 +62,10 @@ class PageParentSearchFragment : Fragment() {
     }
 
     private fun initializeViewModels(activity: FragmentActivity) {
-        val pageParentViewModel = ViewModelProviders.of(activity, viewModelFactory)
+        val pageParentViewModel = ViewModelProvider(activity, viewModelFactory)
                 .get(PageParentViewModel::class.java)
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(PageParentSearchViewModel::class.java)
         viewModel.start(pageParentViewModel)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -24,7 +24,6 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.pages_fragment.*
@@ -283,8 +282,8 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
     }
 
     private fun initializeViewModels(activity: FragmentActivity, savedInstanceState: Bundle?) {
-        viewModel = ViewModelProviders.of(activity, viewModelFactory).get(PagesViewModel::class.java)
-        mlpViewModel = ViewModelProviders.of(activity, viewModelFactory).get(ModalLayoutPickerViewModel::class.java)
+        viewModel = ViewModelProvider(activity, viewModelFactory).get(PagesViewModel::class.java)
+        mlpViewModel = ViewModelProvider(activity, viewModelFactory).get(ModalLayoutPickerViewModel::class.java)
 
         setupObservers(activity)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.pages_list_fragment.*
@@ -58,9 +57,9 @@ class SearchListFragment : Fragment() {
     }
 
     private fun initializeViewModels(activity: FragmentActivity) {
-        val pagesViewModel = ViewModelProviders.of(activity, viewModelFactory).get(PagesViewModel::class.java)
+        val pagesViewModel = ViewModelProvider(activity, viewModelFactory).get(PagesViewModel::class.java)
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(SearchListViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(SearchListViewModel::class.java)
         viewModel.start(pagesViewModel)
 
         setupObservers()

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -15,7 +15,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.android.synthetic.main.photo_picker_fragment.*
@@ -91,7 +90,7 @@ class PhotoPickerFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(PhotoPickerViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(PhotoPickerViewModel::class.java)
     }
 
     override fun onCreateView(

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansListFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.plans_list_fragment.*
@@ -58,7 +57,7 @@ class PlansListFragment : Fragment() {
 
         (nonNullActivity.application as WordPress).component()?.inject(this)
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(PlansViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(PlansViewModel::class.java)
         setObservers()
         viewModel.create()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -22,7 +22,6 @@ import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -81,7 +80,7 @@ public class PluginBrowserActivity extends LocaleAwareActivity
         ((WordPress) getApplication()).component().inject(this);
         setContentView(R.layout.plugin_browser_activity);
 
-        mViewModel = ViewModelProviders.of(this, mViewModelFactory).get(PluginBrowserViewModel.class);
+        mViewModel = new ViewModelProvider(this, mViewModelFactory).get(PluginBrowserViewModel.class);
 
         mSitePluginsRecycler = findViewById(R.id.installed_plugins_recycler);
         mFeaturedPluginsRecycler = findViewById(R.id.featured_plugins_recycler);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -19,7 +19,6 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -87,7 +86,7 @@ public class PluginListFragment extends Fragment {
         setHasOptionsMenu(mListType != PluginListType.SEARCH);
 
         // Use the same view model as the PluginBrowserActivity
-        mViewModel = ViewModelProviders.of(getActivity(), mViewModelFactory).get(PluginBrowserViewModel.class);
+        mViewModel = new ViewModelProvider(getActivity(), mViewModelFactory).get(PluginBrowserViewModel.class);
         setupObservers();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicDialog.kt
@@ -6,7 +6,6 @@ import android.content.DialogInterface
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.android.support.AndroidSupportInjection
 import org.wordpress.android.ui.posts.BasicDialogViewModel.BasicDialogModel
@@ -44,7 +43,7 @@ class BasicDialog : AppCompatDialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(BasicDialogViewModel::class.java)
         val builder = MaterialAlertDialogBuilder(requireActivity())
         builder.setMessage(model.message)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -37,7 +37,6 @@ import androidx.fragment.app.FragmentStatePagerAdapter;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
@@ -465,8 +464,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
         mDispatcher.register(this);
-        mViewModel =
-                ViewModelProviders.of(this, mViewModelFactory).get(StorePostViewModel.class);
+        mViewModel = new ViewModelProvider(this, mViewModelFactory).get(StorePostViewModel.class);
         setContentView(R.layout.new_edit_post_activity);
 
         if (savedInstanceState == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsFragment.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.posts
 
 import android.os.Bundle
 import android.view.ViewGroup
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.posts.PublishSettingsFragmentType.EDIT_POST
@@ -15,7 +15,7 @@ class EditPostPublishSettingsFragment : PublishSettingsFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().applicationContext as WordPress).component().inject(this)
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(EditPostPublishSettingsViewModel::class.java)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -25,7 +25,6 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.greenrobot.eventbus.Subscribe;
@@ -164,8 +163,8 @@ public class EditPostSettingsFragment extends Fragment {
                 new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.post_format_keys)));
         mDefaultPostFormatNames = new ArrayList<>(Arrays.asList(getResources()
                 .getStringArray(R.array.post_format_display_names)));
-        mPublishedViewModel =
-                ViewModelProviders.of(getActivity(), mViewModelFactory).get(EditPostPublishSettingsViewModel.class);
+        mPublishedViewModel = new ViewModelProvider(getActivity(), mViewModelFactory)
+                .get(EditPostPublishSettingsViewModel.class);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -9,7 +9,6 @@ import androidx.annotation.NonNull
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.history_list_fragment.*
@@ -61,7 +60,7 @@ class HistoryListFragment : Fragment() {
 
         (requireActivity().application as WordPress).component()?.inject(this)
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(HistoryViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(HistoryViewModel::class.java)
     }
 
     override fun onAttach(context: Context) {
@@ -89,7 +88,7 @@ class HistoryListFragment : Fragment() {
 
         (nonNullActivity.application as WordPress).component()?.inject(this)
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(HistoryViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(HistoryViewModel::class.java)
         viewModel.create(
                 localPostId = arguments?.getInt(KEY_POST_LOCAL_ID) ?: 0,
                 site = arguments?.get(KEY_SITE) as SiteModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
@@ -7,7 +7,6 @@ import android.content.DialogInterface
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.posts.PublishSettingsFragmentType.EDIT_POST
@@ -25,9 +24,9 @@ class PostDatePickerDialogFragment : DialogFragment() {
         )
 
         when (publishSettingsFragmentType) {
-            EDIT_POST -> viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+            EDIT_POST -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                     .get(EditPostPublishSettingsViewModel::class.java)
-            PREPUBLISHING_NUDGES -> viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+            PREPUBLISHING_NUDGES -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                     .get(PrepublishingPublishSettingsViewModel::class.java)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListCreateMenuFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListCreateMenuFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -38,7 +37,7 @@ class PostListCreateMenuFragment : BottomSheetDialogFragment() {
         content_recycler_view.layoutManager = LinearLayoutManager(requireActivity())
         content_recycler_view.adapter = AddContentAdapter(requireActivity())
 
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(PostListCreateMenuViewModel::class.java)
         viewModel.mainActions.observe(this, Observer {
             (dialog?.content_recycler_view?.adapter as? AddContentAdapter)?.update(it ?: listOf())

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -10,7 +10,6 @@ import android.widget.ProgressBar
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
@@ -99,7 +98,7 @@ class PostListFragment : ViewPagerFragment() {
             recyclerView?.id = R.id.posts_search_recycler_view_id
         }
 
-        mainViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+        mainViewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
                 .get(PostListMainViewModel::class.java)
 
         mainViewModel.viewLayoutType.observe(viewLifecycleOwner, Observer { optionaLayoutType ->
@@ -134,7 +133,7 @@ class PostListFragment : ViewPagerFragment() {
 
         val postListViewModelConnector = mainViewModel.getPostListViewModelConnector(postListType)
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(PostListViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(PostListViewModel::class.java)
 
         val displayWidth = DisplayUtils.getDisplayPixelWidth(context)
         val contentSpacing = nonNullActivity.resources.getDimensionPixelSize(R.dimen.content_margin)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.widget.RadioGroup
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -30,9 +29,9 @@ class PostNotificationScheduleTimeDialogFragment : DialogFragment() {
         )
 
         when (publishSettingsFragmentType) {
-            EDIT_POST -> viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+            EDIT_POST -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                     .get(EditPostPublishSettingsViewModel::class.java)
-            PREPUBLISHING_NUDGES -> viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+            PREPUBLISHING_NUDGES -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                     .get(PrepublishingPublishSettingsViewModel::class.java)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import android.text.format.DateFormat
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.posts.PublishSettingsFragmentType.EDIT_POST
 import org.wordpress.android.ui.posts.PublishSettingsFragmentType.PREPUBLISHING_NUDGES
@@ -26,9 +25,9 @@ class PostTimePickerDialogFragment : DialogFragment() {
         )
 
         when (publishSettingsFragmentType) {
-            EDIT_POST -> viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+            EDIT_POST -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                     .get(EditPostPublishSettingsViewModel::class.java)
-            PREPUBLISHING_NUDGES -> viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+            PREPUBLISHING_NUDGES -> viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                     .get(PrepublishingPublishSettingsViewModel::class.java)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -19,7 +19,6 @@ import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
@@ -232,7 +231,7 @@ class PostsListActivity : LocaleAwareActivity(),
     }
 
     private fun initCreateMenuViewModel() {
-        postListCreateMenuViewModel = ViewModelProviders.of(this, viewModelFactory)
+        postListCreateMenuViewModel = ViewModelProvider(this, viewModelFactory)
                 .get(PostListCreateMenuViewModel::class.java)
 
         postListCreateMenuViewModel.isBottomSheetShowing.observe(this, Observer { event ->
@@ -276,7 +275,7 @@ class PostsListActivity : LocaleAwareActivity(),
     }
 
     private fun initViewModel(initPreviewState: PostListRemotePreviewState, currentBottomSheetPostId: LocalId) {
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(PostListMainViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(PostListMainViewModel::class.java)
         viewModel.start(site, initPreviewState, currentBottomSheetPostId, editPostRepository, this)
 
         viewModel.viewState.observe(this, Observer { state ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -9,7 +9,6 @@ import android.widget.AdapterView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.add_category.*
 import kotlinx.android.synthetic.main.prepublishing_toolbar.*
 import org.wordpress.android.R
@@ -132,9 +131,9 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(PrepublishingAddCategoryViewModel::class.java)
-        parentViewModel = ViewModelProviders.of(requireParentFragment(), viewModelFactory)
+        parentViewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
                 .get(PrepublishingViewModel::class.java)
 
         startObserving()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -14,7 +14,6 @@ import androidx.annotation.NonNull
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import kotlinx.android.synthetic.main.post_prepublishing_bottom_sheet.*
@@ -146,7 +145,7 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
     }
 
     private fun initViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(PrepublishingViewModel::class.java)
 
         viewModel.navigationTarget.observe(this, Observer { event ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -109,9 +108,9 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(PrepublishingCategoriesViewModel::class.java)
-        parentViewModel = ViewModelProviders.of(requireParentFragment(), viewModelFactory)
+        parentViewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
                 .get(PrepublishingViewModel::class.java)
         startObserving()
         val siteModel = requireArguments().getSerializable(WordPress.SITE) as SiteModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.synthetic.main.post_prepublishing_home_fragment.*
 import org.wordpress.android.R
@@ -71,7 +70,7 @@ class PrepublishingHomeFragment : Fragment() {
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(PrepublishingHomeViewModel::class.java)
 
         viewModel.storyTitleUiState.observe(viewLifecycleOwner, Observer { storyTitleUiState ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.fragment_post_settings_tags.*
 import kotlinx.android.synthetic.main.prepublishing_toolbar.*
 import org.wordpress.android.R
@@ -83,7 +82,7 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(PrepublishingTagsViewModel::class.java)
 
         viewModel.dismissKeyboard.observe(viewLifecycleOwner, Observer { event ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingPublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingPublishSettingsFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.posts.PrepublishingScreenClosedListener
@@ -26,7 +26,7 @@ class PrepublishingPublishSettingsFragment : PublishSettingsFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().applicationContext as WordPress).component().inject(this)
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(PrepublishingPublishSettingsViewModel::class.java)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
@@ -15,7 +15,6 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.android.synthetic.main.site_settings_homepage_dialog.view.*
 import org.wordpress.android.R
@@ -59,7 +58,7 @@ class HomepageSettingsDialog : DialogFragment() {
         builder.setNegativeButton(R.string.cancel) { _, _ -> }
         builder.setView(view)
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(HomepageSettingsViewModel::class.java)
         viewModel.uiState.observe(this, Observer { uiState ->
             uiState?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -24,7 +24,6 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.LinearSmoothScroller;
 import androidx.recyclerview.widget.RecyclerView;
@@ -152,7 +151,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity {
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
         setContentView(R.layout.reader_activity_comment_list);
-        mViewModel = ViewModelProviders.of(this, mViewModelFactory).get(ReaderCommentListViewModel.class);
+        mViewModel = new ViewModelProvider(this, mViewModelFactory).get(ReaderCommentListViewModel.class);
 
         AppBarLayout appBarLayout = findViewById(R.id.appbar_main);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -9,7 +9,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayoutMediator
@@ -117,7 +116,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReaderViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(ReaderViewModel::class.java)
         startObserving()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -36,8 +36,8 @@ import androidx.core.graphics.BlendModeCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.Factory
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -375,7 +375,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReaderPostDetailViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(ReaderPostDetailViewModel::class.java)
 
         viewModel.uiState.observe(
                 viewLifecycleOwner,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -27,7 +27,6 @@ import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -404,10 +403,10 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
     @Override public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        mViewModel = ViewModelProviders.of(this, mViewModelFactory)
+        mViewModel = new ViewModelProvider(this, mViewModelFactory)
                                        .get(ReaderPostListViewModel.class);
         if (mIsTopLevel) {
-            mReaderViewModel = ViewModelProviders.of(getParentFragment(), mViewModelFactory)
+            mReaderViewModel = new ViewModelProvider(getParentFragment(), mViewModelFactory)
                                                  .get(ReaderViewModel.class);
         }
 
@@ -519,9 +518,9 @@ public class ReaderPostListFragment extends ViewPagerFragment
     }
 
     private void initSubFilterViewModel() {
-        WPMainActivityViewModel wpMainActivityViewModel = ViewModelProviders.of(requireActivity(), mViewModelFactory)
+        WPMainActivityViewModel wpMainActivityViewModel = new ViewModelProvider(requireActivity(), mViewModelFactory)
                                                      .get(WPMainActivityViewModel.class);
-        mSubFilterViewModel = ViewModelProviders.of(requireActivity(), mViewModelFactory)
+        mSubFilterViewModel = new ViewModelProvider(requireActivity(), mViewModelFactory)
                                                      .get(SubFilterViewModel.class);
 
         mSubFilterViewModel.getCurrentSubFilter().observe(getViewLifecycleOwner(), subfilterListItem -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -9,7 +9,6 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.viewpager.widget.ViewPager
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -39,7 +38,7 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(SubFilterViewModel::class.java)
 
         val pager = view.findViewById<ViewPager>(R.id.view_pager)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -86,8 +85,8 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReaderDiscoverViewModel::class.java)
-        parentViewModel = ViewModelProviders.of(requireParentFragment()).get(ReaderViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(ReaderDiscoverViewModel::class.java)
+        parentViewModel = ViewModelProvider(requireParentFragment()).get(ReaderViewModel::class.java)
         viewModel.uiState.observe(viewLifecycleOwner, Observer {
             when (it) {
                 is ContentUiState -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.chip.Chip
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.reader_fullscreen_error_with_retry.*
@@ -61,8 +60,8 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReaderInterestsViewModel::class.java)
-        parentViewModel = ViewModelProviders.of(requireParentFragment()).get(ReaderViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(ReaderInterestsViewModel::class.java)
+        parentViewModel = ViewModelProvider(requireParentFragment()).get(ReaderViewModel::class.java)
         startObserving()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -13,7 +13,6 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.android.support.DaggerFragment
@@ -66,7 +65,7 @@ class SubfilterPageFragment : DaggerFragment() {
 
         val category = arguments?.getSerializable(CATEGORY_KEY) as SubfilterCategory
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(SubfilterPageViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(SubfilterPageViewModel::class.java)
         viewModel.start(category)
 
         recyclerView = view.findViewById(R.id.content_recycler_view)
@@ -77,7 +76,7 @@ class SubfilterPageFragment : DaggerFragment() {
         title = emptyStateContainer.findViewById(R.id.title)
         actionButton = emptyStateContainer.findViewById(R.id.action_button)
 
-        subFilterViewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        subFilterViewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(SubFilterViewModel::class.java)
 
         subFilterViewModel.subFilters.observe(viewLifecycleOwner, Observer {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -7,7 +7,6 @@ import android.view.MenuItem
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.ActivityLauncher
@@ -57,8 +56,8 @@ class SiteCreationActivity : LocaleAwareActivity(),
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
         setContentView(R.layout.site_creation_activity)
-        mainViewModel = ViewModelProviders.of(this, viewModelFactory).get(SiteCreationMainVM::class.java)
-        hppViewModel = ViewModelProviders.of(this, viewModelFactory).get(HomePagePickerViewModel::class.java)
+        mainViewModel = ViewModelProvider(this, viewModelFactory).get(SiteCreationMainVM::class.java)
+        hppViewModel = ViewModelProvider(this, viewModelFactory).get(HomePagePickerViewModel::class.java)
         mainViewModel.start(savedInstanceState)
         hppViewModel.loadSavedState(savedInstanceState)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -9,7 +9,6 @@ import androidx.appcompat.widget.AppCompatButton
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.site_creation_domains_screen.*
@@ -94,7 +93,7 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(SiteCreationDomainsViewModel::class.java)
 
         viewModel.uiState.observe(this, Observer { uiState ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -20,7 +20,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.fullscreen_error_with_retry.*
 import kotlinx.android.synthetic.main.site_creation_preview_header_item.*
 import kotlinx.android.synthetic.main.site_creation_preview_screen_default.*
@@ -104,7 +103,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(SitePreviewViewModel::class.java)
         viewModel.uiState.observe(this, Observer { uiState ->
             uiState?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/SiteCreationSegmentsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/segments/SiteCreationSegmentsFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.fullscreen_error_with_retry.*
@@ -62,7 +61,7 @@ class SiteCreationSegmentsFragment : SiteCreationBaseFormFragment() {
     }
 
     private fun initViewModel() {
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(SiteCreationSegmentsViewModel::class.java)
 
         viewModel.segmentsUiState.observe(this, Observer { state ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/DesignPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/DesignPreviewFragment.kt
@@ -11,7 +11,6 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.home_page_picker_preview_fragment.*
 import kotlinx.android.synthetic.main.home_page_picker_preview_fragment.errorView
 import org.wordpress.android.R
@@ -61,7 +60,7 @@ class DesignPreviewFragment : FullscreenBottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory).get(HomePagePickerViewModel::class.java)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(HomePagePickerViewModel::class.java)
 
         viewModel.previewState.observe(viewLifecycleOwner, Observer { state ->
             when (state) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.appbar.AppBarLayout
 import kotlinx.android.synthetic.main.home_page_picker_bottom_toolbar.*
@@ -75,7 +74,7 @@ class HomePagePickerFragment : Fragment() {
     }
 
     private fun setupViewModel() {
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(HomePagePickerViewModel::class.java)
 
         viewModel.uiState.observe(viewLifecycleOwner, Observer { uiState ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.stats_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -43,7 +42,7 @@ class StatsActivity : LocaleAwareActivity() {
         intent?.let {
             val siteId = intent.getIntExtra(WordPress.LOCAL_SITE_ID, -1)
             if (siteId > -1) {
-                viewModel = ViewModelProviders.of(this, viewModelFactory).get(StatsViewModel::class.java)
+                viewModel = ViewModelProvider(this, viewModelFactory).get(StatsViewModel::class.java)
                 viewModel.start(intent, restart = true)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -13,7 +13,6 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.google.android.material.tabs.TabLayout.Tab
@@ -85,7 +84,7 @@ class StatsFragment : DaggerFragment(), ScrollableViewInitializedListener {
         isFirstStart: Boolean,
         savedInstanceState: Bundle?
     ) {
-        viewModel = ViewModelProviders.of(activity, viewModelFactory).get(StatsViewModel::class.java)
+        viewModel = ViewModelProvider(activity, viewModelFactory).get(StatsViewModel::class.java)
 
         viewModel.onRestoreInstanceState(savedInstanceState)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -9,7 +9,7 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout.LayoutParams
@@ -148,7 +148,7 @@ class StatsViewAllFragment : DaggerFragment() {
         statsSiteProvider.start(siteId)
 
         val viewModelFactory = viewModelFactoryBuilder.build(type, granularity)
-        viewModel = ViewModelProviders.of(activity, viewModelFactory).get(StatsViewAllViewModel::class.java)
+        viewModel = ViewModelProvider(activity, viewModelFactory).get(StatsViewAllViewModel::class.java)
 
         val selectedDate = if (savedInstanceState == null) {
             nonNullIntent.getParcelableExtra(ARGS_SELECTED_DATE) as SelectedDate?

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
@@ -149,7 +148,7 @@ class StatsListFragment : ViewPagerFragment() {
             StatsSection.YEARS -> YearsListViewModel::class.java
         }
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(statsSection.name, viewModelClass)
 
         setupObservers(activity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.stats_detail_fragment.*
 import org.wordpress.android.R
@@ -58,7 +57,7 @@ class StatsDetailFragment : DaggerFragment() {
         val postTitle = activity.intent?.getSerializableExtra(POST_TITLE) as String?
         val postUrl = activity.intent?.getSerializableExtra(POST_URL) as String?
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(StatsSection.DETAIL.name, StatsDetailViewModel::class.java)
         viewModel.init(
                 checkNotNull(postId),

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
@@ -10,7 +10,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.android.support.DaggerFragment
@@ -58,7 +57,7 @@ class InsightsManagementFragment : DaggerFragment() {
     }
 
     private fun initializeViewModels(activity: FragmentActivity, siteId: Int?) {
-        viewModel = ViewModelProviders.of(activity, viewModelFactory).get(InsightsManagementViewModel::class.java)
+        viewModel = ViewModelProvider(activity, viewModelFactory).get(InsightsManagementViewModel::class.java)
 
         viewModel.start(siteId)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetColorSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetColorSelectionDialogFragment.kt
@@ -7,7 +7,6 @@ import android.widget.RadioGroup
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.android.support.AndroidSupportInjection
 import org.wordpress.android.R
@@ -23,7 +22,7 @@ class StatsWidgetColorSelectionDialogFragment : AppCompatDialogFragment() {
     private lateinit var viewModel: StatsColorSelectionViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(StatsColorSelectionViewModel::class.java)
         val alertDialogBuilder = MaterialAlertDialogBuilder(requireActivity())
         val view = requireActivity().layoutInflater.inflate(R.layout.stats_color_selector, null) as RadioGroup

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -12,7 +12,6 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.stats_widget_configure_fragment.*
 import org.wordpress.android.R
@@ -70,11 +69,11 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val nonNullActivity = requireActivity()
-        viewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+        viewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
                 .get(StatsWidgetConfigureViewModel::class.java)
-        siteSelectionViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+        siteSelectionViewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
                 .get(StatsSiteSelectionViewModel::class.java)
-        colorSelectionViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+        colorSelectionViewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
                 .get(StatsColorSelectionViewModel::class.java)
         nonNullActivity.setResult(AppCompatActivity.RESULT_CANCELED)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetDataTypeSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetDataTypeSelectionDialogFragment.kt
@@ -7,7 +7,6 @@ import android.widget.RadioGroup
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.android.support.AndroidSupportInjection
 import org.wordpress.android.R
@@ -26,7 +25,7 @@ class StatsWidgetDataTypeSelectionDialogFragment : AppCompatDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val nonNullActivity = requireActivity()
-        viewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+        viewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
                 .get(StatsDataTypeSelectionViewModel::class.java)
         val alertDialogBuilder = MaterialAlertDialogBuilder(nonNullActivity)
         val view = nonNullActivity.layoutInflater.inflate(R.layout.stats_data_type_selector, null) as RadioGroup

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteSelectionDialogFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -36,7 +35,7 @@ class StatsWidgetSiteSelectionDialogFragment : AppCompatDialogFragment() {
         alertDialogBuilder.setNegativeButton(R.string.cancel) { _, _ -> }
         alertDialogBuilder.setCancelable(true)
 
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(StatsSiteSelectionViewModel::class.java)
         viewModel.sites.observe(this, Observer {
             (requireDialog().recycler_view.adapter as? StatsWidgetSiteAdapter)?.update(it ?: listOf())

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -10,7 +10,6 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.stats_widget_configure_fragment.*
 import org.wordpress.android.R
@@ -49,13 +48,13 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val nonNullActivity = requireActivity()
-        viewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+        viewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
                 .get(StatsMinifiedWidgetConfigureViewModel::class.java)
-        siteSelectionViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+        siteSelectionViewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
                 .get(StatsSiteSelectionViewModel::class.java)
-        colorSelectionViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+        colorSelectionViewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
                 .get(StatsColorSelectionViewModel::class.java)
-        dataTypeSelectionViewModel = ViewModelProviders.of(nonNullActivity, viewModelFactory)
+        dataTypeSelectionViewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
                 .get(StatsDataTypeSelectionViewModel::class.java)
         nonNullActivity.setResult(AppCompatActivity.RESULT_CANCELED)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -9,7 +9,6 @@ import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.snackbar.Snackbar
 import com.wordpress.stories.compose.AuthenticationHeadersProvider
 import com.wordpress.stories.compose.ComposeLoopFrameActivity
@@ -177,7 +176,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         val postEditorAnalyticsSession =
                 savedInstanceState?.getSerializable(STATE_KEY_EDITOR_SESSION_DATA) as PostEditorAnalyticsSession?
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(StoryComposerViewModel::class.java)
 
         site?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
@@ -12,7 +12,6 @@ import android.view.Window
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.stories_intro_dialog_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.R.attr
@@ -48,7 +47,7 @@ class StoriesIntroDialogFragment : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState)
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(StoriesIntroViewModel::class.java)
 
         if (VERSION.SDK_INT >= VERSION_CODES.M) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementDialogFragment.kt
@@ -13,7 +13,6 @@ import android.widget.TextView
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
@@ -38,7 +37,7 @@ class FeatureAnnouncementDialogFragment : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState)
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(FeatureAnnouncementViewModel::class.java)
 
         if (VERSION.SDK_INT >= VERSION_CODES.M) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementListAdapter.kt
@@ -7,7 +7,6 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import org.wordpress.android.R
@@ -28,7 +27,7 @@ class FeatureAnnouncementListAdapter(
 
     init {
         (fragment.requireActivity().applicationContext as WordPress).component().inject(this)
-        viewModel = ViewModelProviders.of(fragment, viewModelFactory)
+        viewModel = ViewModelProvider(fragment, viewModelFactory)
                 .get(FeatureAnnouncementViewModel::class.java)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/UploadWorker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/UploadWorker.kt
@@ -69,7 +69,7 @@ fun enqueueUploadWorkRequestForSite(site: SiteModel): Pair<WorkRequest, Operatio
             .setConstraints(getUploadConstraints())
             .setInputData(workDataOf(WordPress.LOCAL_SITE_ID to site.id))
             .build()
-    val operation = WorkManager.getInstance().enqueueUniqueWork(
+    val operation = WorkManager.getInstance(WordPress.getContext()).enqueueUniqueWork(
             "auto-upload-" + site.id,
             ExistingWorkPolicy.KEEP, request
     )
@@ -80,7 +80,7 @@ fun enqueuePeriodicUploadWorkRequestForAllSites(): Pair<WorkRequest, Operation> 
     val request = PeriodicWorkRequestBuilder<UploadWorker>(8, HOURS, 6, HOURS)
             .setConstraints(getUploadConstraints())
             .build()
-    val operation = WorkManager.getInstance().enqueueUniquePeriodicWork(
+    val operation = WorkManager.getInstance(WordPress.getContext()).enqueueUniquePeriodicWork(
             "periodic auto-upload",
             ExistingPeriodicWorkPolicy.KEEP, request
     )

--- a/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.android.support.DaggerFragment
@@ -31,7 +30,7 @@ class ManualFeatureConfigFragment : DaggerFragment() {
         recycler_view.layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         recycler_view.addItemDecoration(RecyclerItemDecoration(0, DisplayUtils.dpToPx(activity, 1)))
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(ManualFeatureConfigViewModel::class.java)
         viewModel.uiState.observe(viewLifecycleOwner, Observer {
             it?.let { uiState ->

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     ext.kotlin_coroutines_version = '1.3.9'
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
-    ext.androidx_work_version = "2.0.1"
     ext.buildGutenbergMobileJSBundle = 1
 
     repositories {
@@ -127,7 +126,7 @@ ext {
     targetSdkVersion = 29
 
     coroutinesVersion = '1.3.9'
-    androidxWorkVersion = "2.0.1"
+    androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
     fluxCVersion = '1.6.27'

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,12 @@ allprojects {
         toolVersion = '8.3'
         configFile file("${project.rootDir}/config/checkstyle.xml")
     }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
+    }
 }
 
 subprojects {


### PR DESCRIPTION
Fixes #10572

I'm not able to replicate the issue. This PR updates `androidx.work:` to it's newest stable version (2.4.0).

Release notes are [here](https://developer.android.com/jetpack/androidx/releases/work).

I recommend reviewing this PR by commits:
- https://github.com/wordpress-mobile/WordPress-Android/commit/67ae87054e7f8d94626cfbba696a283c11409389 - v2.1.0 requires java 8 (see [this](https://developer.android.com/jetpack/androidx/releases/work#2.1.0))
- https://github.com/wordpress-mobile/WordPress-Android/commit/6c5d9e579ed70d4a91b03628d1be4fb65ce26665 - `lifecycle-extensions` was deprecated, this PR adds required dependencies explicitly (see [this](https://developer.android.com/jetpack/androidx/releases/lifecycle#declaring_dependencies))
- https://github.com/wordpress-mobile/WordPress-Android/commit/9f3a44583c00e987294053c368f2637787cb16e8 - `ViewModelProviders` were removed with the deprecation of `lifecycle-extensions`
- https://github.com/wordpress-mobile/WordPress-Android/commit/f594c5733e34f65d0fa94e277fbde04f46b76f3d implemented on demand initialization of the Worker, reverted this change in https://github.com/wordpress-mobile/WordPress-Android/commit/eb0c774f2feed6eb364de2c21359933138d10104 since we schedule a periodic worker on apps startup anyway
- https://github.com/wordpress-mobile/WordPress-Android/commit/f1b503925a01b51cf86a1681bdfb9798f782d351 - updated usages of deprecated `WorkManager.getInstance()` with `WorkManager.getInstance(context)`
- 82b0c50cb5cb44a320e1b8e6bcf5a7c71e1efeb7 - use GCMNetworkManager on API <= 22 (see [this](https://developer.android.com/jetpack/androidx/releases/work#2.2.0))


To test - test on a newer API and API <= 22

1. Start the app in airplane mode
2. Create a new post, write a title, press Publish
3. Close the app.
4. Turn off airplane mode.
5. Make sure your device is not on data roaming.
6. Notice the the post gets uploaded almost immediately

------------------------------------
Run ` adb shell dumpsys jobscheduler` (API 23+) and find the periodic task in the list. 
Note: I spent quite some time investigating why `JobInfo` for the periodic task doesn't contain 
```
PERIODIC: interval=+8h0m0s0ms flex=+6h0m0s0ms
```
It does contain this line when running the app before this PR. I haven't find any information in docs about this change, but I tried [switching the interval for the task to "15 minutes" and flex to "5 minutes"](https://github.com/wordpress-mobile/WordPress-Android/blob/94a352cb0cd173cfb3ff9cc26650cfe910783a40/WordPress/src/main/java/org/wordpress/android/util/UploadWorker.kt#L80) and verified it runs periodically.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
