### PR TITLE
WP Stories: bring upload icon back, to trigger media picker from the camera preview mode

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -11,22 +11,9 @@
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
     </wildcardResourcePatterns>
-    <bytecodeTargetLevel target="1.7">
+    <bytecodeTargetLevel>
       <module name="fluxc-annotations" target="1.7" />
       <module name="fluxc-processor" target="1.7" />
-      <module name="WordPress-Android.@wordpress_react-native-aztec" target="1.8" />
-      <module name="WordPress-Android.@wordpress_react-native-bridge" target="1.8" />
-      <module name="WordPress-Android.libs.analytics.WordPressAnalytics" target="1.8" />
-      <module name="WordPress-Android.libs.editor.WordPressEditor" target="1.8" />
-      <module name="WordPress-Android.libs.image-editor.ImageEditor" target="1.8" />
-      <module name="WordPress-Android.libs.login.WordPressLoginFlow" target="1.8" />
-      <module name="WordPress-Android.libs.networking.WordPressNetworking" target="1.8" />
-      <module name="WordPress-Android.libs.stories-android.stories" target="1.8" />
-      <module name="WordPress-Android.libs.utils.WordPressUtils" target="1.8" />
-      <module name="WordPress-Android.mp4compose" target="1.8" />
-      <module name="WordPress-Android.photoeditor" target="1.8" />
-      <module name="WordPress-Android.WordPress" target="1.8" />
-      <module name="WordPress-Android.WordPressMocks" target="1.8" />
       <module name="WordPressAnnotations" target="1.7" />
       <module name="WordPressProcessors" target="1.7" />
     </bytecodeTargetLevel>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -11,9 +11,22 @@
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
     </wildcardResourcePatterns>
-    <bytecodeTargetLevel>
+    <bytecodeTargetLevel target="1.7">
       <module name="fluxc-annotations" target="1.7" />
       <module name="fluxc-processor" target="1.7" />
+      <module name="WordPress-Android.@wordpress_react-native-aztec" target="1.8" />
+      <module name="WordPress-Android.@wordpress_react-native-bridge" target="1.8" />
+      <module name="WordPress-Android.libs.analytics.WordPressAnalytics" target="1.8" />
+      <module name="WordPress-Android.libs.editor.WordPressEditor" target="1.8" />
+      <module name="WordPress-Android.libs.image-editor.ImageEditor" target="1.8" />
+      <module name="WordPress-Android.libs.login.WordPressLoginFlow" target="1.8" />
+      <module name="WordPress-Android.libs.networking.WordPressNetworking" target="1.8" />
+      <module name="WordPress-Android.libs.stories-android.stories" target="1.8" />
+      <module name="WordPress-Android.libs.utils.WordPressUtils" target="1.8" />
+      <module name="WordPress-Android.mp4compose" target="1.8" />
+      <module name="WordPress-Android.photoeditor" target="1.8" />
+      <module name="WordPress-Android.WordPress" target="1.8" />
+      <module name="WordPress-Android.WordPressMocks" target="1.8" />
       <module name="WordPressAnnotations" target="1.7" />
       <module name="WordPressProcessors" target="1.7" />
     </bytecodeTargetLevel>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2982,7 +2982,6 @@
     <string name="label_frame_errored">errored</string>
     <string name="label_text_alignment_button">Change text alignment</string>
     <string name="label_text_color_button">Change text color</string>
-    <string name="label_control_upload">Upload</string>
     <string name="dialog_discard_page_title">Delete story slide?</string>
     <string name="dialog_discard_page_message">This slide will be removed from your story.</string>
     <string name="dialog_discard_errored_page_message">This slide has not been saved yet. If you delete this slide, you will lose any edits you have made.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2982,6 +2982,7 @@
     <string name="label_frame_errored">errored</string>
     <string name="label_text_alignment_button">Change text alignment</string>
     <string name="label_text_color_button">Change text color</string>
+    <string name="label_control_upload">Upload</string>
     <string name="dialog_discard_page_title">Delete story slide?</string>
     <string name="dialog_discard_page_message">This slide will be removed from your story.</string>
     <string name="dialog_discard_errored_page_message">This slide has not been saved yet. If you delete this slide, you will lose any edits you have made.</string>


### PR DESCRIPTION
Fixes https://github.com/Automattic/stories-android/issues/617

Related stories library PR: https://github.com/Automattic/stories-android/pull/623

To test:
See instructions in the related PR
![upload_icon](https://user-images.githubusercontent.com/6597771/101173502-64ece700-3621-11eb-84a0-23013fe678c4.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
