### PR TITLE
Fix position of Quick Start focus point in bottom sheet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
@@ -69,7 +69,7 @@ class ActionListItemViewHolder(
                     dimen.quick_start_focus_point_size
             )
             actionRowContainer.post {
-                val verticalOffset = -focusPointSize/2
+                val verticalOffset = -focusPointSize / 2
                 QuickStartUtils.addQuickStartFocusPointAboveTheView(
                         actionRowContainer, actionTitle,
                         verticalOffset, 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
@@ -69,7 +69,7 @@ class ActionListItemViewHolder(
                     dimen.quick_start_focus_point_size
             )
             actionRowContainer.post {
-                val verticalOffset = (actionRowContainer.width - focusPointSize) / 2
+                val verticalOffset = -focusPointSize/2
                 QuickStartUtils.addQuickStartFocusPointAboveTheView(
                         actionRowContainer, actionTitle,
                         verticalOffset, 0


### PR DESCRIPTION
Fixed the vertical offset of QS focus point in the bottom sheet. It will now appear right next to the title (in any locale), and not in the center, where it potentially can cover it.

[![Image from Gyazo](https://i.gyazo.com/f325c3af2ff245a2d8c67a5198ea89b9.png)](https://gyazo.com/f325c3af2ff245a2d8c67a5198ea89b9)

To test:
- Create a new site and start Quick Start flow.
- Navigate to `Grow your audience` category and select `Publish a post` task.
- Tap on the FAB and make sure that the quick start indicator in the bottom sheet is visible next to the `Blog post` title on the first row of bottom sheet.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
