### PR TITLE
WP Stories: changed flow for remote media from WP site to be copied locally

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -325,12 +325,7 @@ public class PhotoPickerActivity extends LocaleAwareActivity
         if (mediaIds != null && mediaIds.size() > 0) {
             if (mBrowserType == MediaBrowserType.WP_STORIES_MEDIA_PICKER) {
                 // TODO WPSTORIES add TRACKS (see how it's tracked below? maybe do along the same lines)
-                Intent data = new Intent()
-                        .putExtra(MediaBrowserActivity.RESULT_IDS, ListUtils.toLongArray(mediaIds))
-                        .putExtra(ARG_BROWSER_TYPE, mBrowserType)
-                        .putExtra(MediaPickerConstants.EXTRA_MEDIA_SOURCE, source.name());
-                setResult(RESULT_OK, data);
-                finish();
+                getPickerFragment().mediaIdsSelectedFromWPMediaPicker(mediaIds);
             } else {
                 // if user chose a featured image, track image picked event
                 if (mBrowserType == MediaBrowserType.FEATURED_IMAGE_PICKER) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -474,6 +474,10 @@ class PhotoPickerFragment : Fragment() {
         viewModel.urisSelectedFromSystemPicker(uris.map { UriWrapper(it) })
     }
 
+    fun mediaIdsSelectedFromWPMediaPicker(mediaIds: List<Long>) {
+        viewModel.mediaIdsSelectedFromWPMediaPicker(mediaIds)
+    }
+
     companion object {
         private const val KEY_LAST_TAPPED_ICON = "last_tapped_icon"
         private const val KEY_SELECTED_POSITIONS = "selected_positions"

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModel.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.MEDIA_PICKER_OPEN_W
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.MEDIA_PICKER_OPEN_WP_STORIES_CAPTURE
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.MEDIA_PICKER_PREVIEW_OPENED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.MEDIA_PICKER_RECENT_MEDIA_SELECTED
-import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.photopicker
 
 import android.Manifest.permission
+import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
@@ -16,6 +17,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.MEDIA_PICKER_OPEN_W
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.MEDIA_PICKER_OPEN_WP_STORIES_CAPTURE
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.MEDIA_PICKER_PREVIEW_OPENED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.MEDIA_PICKER_RECENT_MEDIA_SELECTED
+import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
@@ -41,6 +43,7 @@ import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.BottomBarUiMode
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.BottomBarUiModel.BottomBar.NONE
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PopupMenuUiModel.PopupMenuItem
 import org.wordpress.android.ui.posts.editor.media.CopyMediaToAppStorageUseCase
+import org.wordpress.android.ui.posts.editor.media.GetMediaModelUseCase
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -75,7 +78,8 @@ class PhotoPickerViewModel @Inject constructor(
     private val permissionsHandler: PermissionsHandler,
     private val tenorFeatureConfig: TenorFeatureConfig,
     private val resourceProvider: ResourceProvider,
-    private val copyMediaToAppStorageUseCase: CopyMediaToAppStorageUseCase
+    private val copyMediaToAppStorageUseCase: CopyMediaToAppStorageUseCase,
+    private val getMediaModelUseCase: GetMediaModelUseCase
 ) : ScopedViewModel(mainDispatcher) {
     private val _navigateToPreview = MutableLiveData<Event<UriWrapper>>()
     private val _onInsert = MutableLiveData<Event<List<UriWrapper>>>()
@@ -478,6 +482,18 @@ class PhotoPickerViewModel @Inject constructor(
     }
 
     fun urisSelectedFromSystemPicker(uris: List<UriWrapper>) {
+        copySelectedUrisLocally(uris)
+    }
+
+    fun mediaIdsSelectedFromWPMediaPicker(mediaIds: List<Long>) {
+        launch {
+            val mediaModels = getMediaModelUseCase
+                    .loadMediaByRemoteId(requireNotNull(site), mediaIds)
+            copySelectedUrisLocally(mediaModels.map { UriWrapper(Uri.parse(it.url)) })
+        }
+    }
+
+    fun copySelectedUrisLocally(uris: List<UriWrapper>) {
         launch {
             _showProgressDialog.value = ProgressDialogUiModel.Visible(R.string.uploading_title) {
                 _showProgressDialog.postValue(ProgressDialogUiModel.Hidden)

--- a/WordPress/src/test/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/photopicker/PhotoPickerViewModelTest.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PhotoListUiMode
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.PhotoPickerUiState
 import org.wordpress.android.ui.photopicker.PhotoPickerViewModel.SoftAskViewUiModel
 import org.wordpress.android.ui.posts.editor.media.CopyMediaToAppStorageUseCase
+import org.wordpress.android.ui.posts.editor.media.GetMediaModelUseCase
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -50,6 +51,7 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
     @Mock lateinit var context: Context
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var copyMediaToAppStorageUseCase: CopyMediaToAppStorageUseCase
+    @Mock lateinit var getMediaModelUseCase: GetMediaModelUseCase
     private lateinit var viewModel: PhotoPickerViewModel
     private var uiStates = mutableListOf<PhotoPickerUiState>()
     private var navigateEvents = mutableListOf<Event<UriWrapper>>()
@@ -71,7 +73,8 @@ class PhotoPickerViewModelTest : BaseUnitTest() {
                 permissionsHandler,
                 tenorFeatureConfig,
                 resourceProvider,
-                copyMediaToAppStorageUseCase
+                copyMediaToAppStorageUseCase,
+                getMediaModelUseCase
         )
         uiStates.clear()
         firstItem = PhotoPickerItem(1, uriWrapper1, false)


### PR DESCRIPTION
With this change, instead of passing a remote URL to StoryComposerActivity through `onActivityResult()`, we're first making a local copy of it and then passing it over to the composer.

It has proven to have better results and avoid metadata extractor not to be ready when needed in order to calculate the video size and rotation and so on.

I only made this test in the old PhotoPicker. We should follow up on this on the new media picker when it's also used in Stories. EDIT - tracked in https://github.com/wordpress-mobile/WordPress-Android/issues/13549

To test:
1. download [this video](https://cloudup.com/cbGwE3rsv1R) to a your emulator / handset. (this one has proven to show especial trouble on a Pixel 3 emulator, a Pixel 2 actual device, and a Samsung S5e tablet).
2. go to the Media section of the app and upload that video from your handset. Follow the next steps when ready.
3. from the Posts list or from the My Site screen on the app, tap on the FAB and tap on new Story
4. when the media picker appears, tap on the W option to see the site's media items
5. you should see the video you recently uploaded. Select that one and then tap on the ✔️ on the top-right corner of the screen
6. observe a dialog reading "Uploading..." appears briefly (for as long as it takes for the video to get copied), then the Story composer appears and the video starts playing in a loop.
7. go ahead and add some text to your slide
8. publish your story
9. verify it gets saved correctly and it gets published correctly.

Before this change, it would randomly err or crash when trying to save the video.

![nice_video](https://user-images.githubusercontent.com/6597771/101222409-79a09d80-3668-11eb-94c3-e9af9d6847a7.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
