### PR TITLE
Revert "Stories: Show 'New' tag for Story entry in bottom sheets"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
@@ -24,7 +24,6 @@ class ActionListItemViewHolder(
     fun bind(action: CreateAction) {
         val actionIcon: ImageView = this.itemView.findViewById(R.id.action_icon)
         val actionTitle: TextView = this.itemView.findViewById(R.id.action_title)
-        val actionTag: TextView = this.itemView.findViewById(R.id.action_tag)
         val actionRowContainer: ViewGroup = this.itemView.findViewById(R.id.action_row_container)
 
         if (action.iconRes > 0) {
@@ -45,13 +44,6 @@ class ActionListItemViewHolder(
             actionTitle.visibility = View.VISIBLE
         } else {
             actionTitle.visibility = View.GONE
-        }
-
-        if (action.tagRes > 0) {
-            actionTag.setText(action.tagRes)
-            actionTag.visibility = View.VISIBLE
-        } else {
-            actionTag.visibility = View.GONE
         }
 
         if (action.onClickAction == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainActionListItem.kt
@@ -17,7 +17,6 @@ sealed class MainActionListItem {
         override val actionType: ActionType,
         @DrawableRes val iconRes: Int,
         @StringRes val labelRes: Int,
-        @StringRes val tagRes: Int = 0,
         val onClickAction: ((actionType: ActionType) -> Unit)?,
         val showQuickStartFocusPoint: Boolean = false
     ) : MainActionListItem()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -114,7 +114,6 @@ class WPMainActivityViewModel @Inject constructor(
                     actionType = CREATE_NEW_STORY,
                     iconRes = R.drawable.ic_story_icon_24dp,
                     labelRes = R.string.my_site_bottom_sheet_add_story,
-                    tagRes = R.string.my_site_bottom_sheet_story_tag_new,
                     onClickAction = ::onCreateActionClicked
             ))
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
@@ -75,7 +75,6 @@ class PostListCreateMenuViewModel @Inject constructor(
                         actionType = CREATE_NEW_STORY,
                         iconRes = drawable.ic_story_icon_24dp,
                         labelRes = string.my_site_bottom_sheet_add_story,
-                        tagRes = string.my_site_bottom_sheet_story_tag_new,
                         onClickAction = ::onCreateActionClicked
 
                 )

--- a/WordPress/src/main/res/layout/main_action_list_item.xml
+++ b/WordPress/src/main/res/layout/main_action_list_item.xml
@@ -12,37 +12,11 @@
         android:contentDescription="@null"
         style="@style/MainBottomSheetRowIcon"/>
 
-    <LinearLayout
+    <com.google.android.material.textview.MaterialTextView
         android:gravity="start"
         android:layout_toEndOf="@+id/action_icon"
-        android:layout_centerVertical="true"
-        android:layout_alignParentEnd="true"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <com.google.android.material.textview.MaterialTextView
-            style="@style/MainBottomSheetRowTextView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="start"
-            android:id="@+id/action_title"
-            tools:text="@string/my_site_bottom_sheet_add_post" />
-
-        <com.google.android.material.textview.MaterialTextView
-            style="@style/MainBottomSheetRowTextView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/action_tag"
-            android:textAppearance="?attr/textAppearanceBody2"
-            android:textColor="?attr/colorOnPrimarySurface"
-            android:backgroundTint="?attr/colorError"
-            android:background="@drawable/bg_rectangle_red_50_radius_2dp"
-            android:paddingStart="@dimen/margin_medium"
-            android:paddingTop="@dimen/margin_extra_small"
-            android:paddingEnd="@dimen/margin_medium"
-            android:paddingBottom="@dimen/margin_extra_small"
-            tools:text="@string/my_site_bottom_sheet_story_tag_new" />
-
-    </LinearLayout>
+        android:id="@+id/action_title"
+        style="@style/MainBottomSheetRowTextView"
+        tools:text="@string/my_site_bottom_sheet_add_post" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1961,7 +1961,6 @@
     <string name="my_site_bottom_sheet_add_post">Blog post</string>
     <string name="my_site_bottom_sheet_add_page">Site page</string>
     <string name="my_site_bottom_sheet_add_story">Story post</string>
-    <string name="my_site_bottom_sheet_story_tag_new">New</string>
 
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-Android#13436, removing the 'New' tag from the Story entry in the bottom sheets.

We only wanted to keep that for one release cycle (and in fact the current release cycle is a full month long), so with the original change set for release in `16.3`, we can remove it from `develop` so it's removed in `16.4`.

![bottom-sheet-after](https://user-images.githubusercontent.com/9613966/99768393-0830fd00-2b48-11eb-91be-a265d719d2e7.png)

### To test:

1. Make sure the Stories feature is enabled and you're on a site that supports them (WordPress.com or Jetpack 9.1+)
2. Tap the FAB in the My site, check that the Story post entry appears in the bottom sheet
3. Check that there's no 'New' tag next to it
4. Do the same from the post list

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.