### PR TITLE
Add workaround for building on Windows in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,3 +4,22 @@
 
 Create a `gradle.properties` file in the project root directory with the
 following: `org.gradle.jvmargs=-XX:MaxPermSize=1024m`.
+
+#### Unable to build on Windows
+
+When building on Windows, you may encounter the following error in Android Studio:
+
+```
+The syntax of the command is incorrect.
+npm ERR! code ELIFECYCLE
+npm ERR! errno 1
+...
+Execution failed for task ':@wordpress_react-native-bridge:buildJSBundle'.
+```
+
+The workaround is to disable bundling the JS by
+[setting `wp.BUILD_GUTENBERG_FROM_SOURCE=true`](https://github.com/wordpress-mobile/WordPress-Android/issues/12120#issuecomment-643431502)
+in the top-level `gradle.properties` file.
+
+There is additional context in issue
+[#12120](https://github.com/wordpress-mobile/WordPress-Android/issues/12120).


### PR DESCRIPTION
There are still some issues with building on Windows and the comments in #12120 suggest that there is still some work to be done.

So bubble up the workaround of skipping the JS bundle into the top-level FAQ.

This does not fix any issues but is meant help new contributors avoid any pitfalls related to building on Windows. The workaround is discussed in #12120.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
