### PR TITLE
Use function pointers in ListItemInteraction calls

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -136,10 +136,10 @@ class MySiteViewModel
             )
             siteItems.add(
                     QuickActionsBlock(
-                            ListItemInteraction.create { quickActionStatsClick(site) },
-                            ListItemInteraction.create { quickActionPagesClick(site) },
-                            ListItemInteraction.create { quickActionPostsClick(site) },
-                            ListItemInteraction.create { quickActionMediaClick(site) },
+                            ListItemInteraction.create(site, this::quickActionStatsClick),
+                            ListItemInteraction.create(site, this::quickActionPagesClick),
+                            ListItemInteraction.create(site, this::quickActionPostsClick),
+                            ListItemInteraction.create(site, this::quickActionMediaClick),
                             site.isSelfHostedAdmin || site.hasCapabilityEditPages
                     )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementMapper.kt
@@ -17,12 +17,12 @@ import org.wordpress.android.fluxc.store.StatsStore.InsightType.PUBLICIZE
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.TAGS_AND_CATEGORIES
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.TODAY_STATS
 import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementViewModel.InsightListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementViewModel.InsightListItem.Header
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementViewModel.InsightListItem.InsightModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementViewModel.InsightListItem.InsightModel.Status.ADDED
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementViewModel.InsightListItem.InsightModel.Status.REMOVED
+import org.wordpress.android.ui.utils.ListItemInteraction
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -71,7 +71,7 @@ class InsightsManagementMapper
                 type,
                 toName(type),
                 if (addedInsightTypes.any { it == type }) ADDED else REMOVED,
-                ListItemInteraction.create { onClick(type) }
+                ListItemInteraction.create(type, onClick)
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/ListItemInteraction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/ListItemInteraction.kt
@@ -4,10 +4,19 @@ interface ListItemInteraction {
     fun click()
 
     companion object {
+        /**
+         * Use this creator only with function pointer. If you use it with a lambda, the created `ListItemInteraction`
+         * equals method will always fail because two lambdas are never equal. If you need a parametrized function call,
+         * use the other creator method.
+         */
         fun create(action: () -> Unit): ListItemInteraction {
             return NoParams(action)
         }
 
+        /**
+         * Use this creator only with function pointer. If you use it with a lambda, the created `ListItemInteraction`
+         * equals method will always fail because two lambdas are never equal.
+         */
         fun <T> create(data: T, action: (T) -> Unit): ListItemInteraction {
             return OneParam(data, action)
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/utils/ListItemInteractionTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/utils/ListItemInteractionTest.kt
@@ -1,0 +1,70 @@
+package org.wordpress.android.ui.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class ListItemInteractionTest {
+    @Test
+    fun `triggers click without params`() {
+        var clicked = false
+
+        val interaction = ListItemInteraction.create { clicked = true }
+
+        interaction.click()
+
+        assertThat(clicked).isTrue()
+    }
+    @Test
+    fun `triggers click with params`() {
+        val param = "param"
+        var invokedWithParam: String? = null
+
+        val interaction = ListItemInteraction.create(param) { invokedWithParam = it }
+
+        interaction.click()
+
+        assertThat(invokedWithParam).isEqualTo(param)
+    }
+
+    @Test
+    fun `not equals when using lambda`() {
+        val interaction1 = ListItemInteraction.create { emptyFunction() }
+        val interaction2 = ListItemInteraction.create { emptyFunction() }
+
+        assertThat(interaction1).isNotEqualTo(interaction2)
+    }
+
+    @Test
+    fun `equals when using function pointers`() {
+        val interaction1 = ListItemInteraction.create(this::emptyFunction)
+        val interaction2 = ListItemInteraction.create(this::emptyFunction)
+
+        assertThat(interaction1).isEqualTo(interaction2)
+    }
+    @Test
+    fun `not equals when using lambda with a parameter`() {
+        val param = "param"
+        val interaction1 = ListItemInteraction.create { parametrizedEmptyFunction(param) }
+        val interaction2 = ListItemInteraction.create { parametrizedEmptyFunction(param) }
+
+        assertThat(interaction1).isNotEqualTo(interaction2)
+    }
+
+    @Test
+    fun `equals when using function pointers with parameter`() {
+        val param = "param"
+        val interaction1 = ListItemInteraction.create(param, this::parametrizedEmptyFunction)
+        val interaction2 = ListItemInteraction.create(param, this::parametrizedEmptyFunction)
+
+        assertThat(interaction1).isEqualTo(interaction2)
+    }
+
+    private fun emptyFunction() {
+    }
+
+    private fun parametrizedEmptyFunction(param: String) {
+    }
+}


### PR DESCRIPTION
When we're using RecyclerView with data classes, we usually compare them by equality. The problem is that lambdas are never equal (even if they have the same body). This works if you're using function references instead (because they are constant). You can't normally use function references if you need to pass a parameter to the function. That's why I've created the `ListItemInteraction` which allows devs create an object with a parameter and a function reference and use it to pass the function to the view holder. In order for this to work we need to use functional references instead of lambdas. This PR replaces the usage of lambdas with the `ListItemInteraction`. 

In case of QuickActions there shouldn't be a big difference in functionality. There should be just some cases when the quick actions block doesn't get redrawn (when another part of the screen gets changed). We should see a difference when we implement the quick start block because at that point we'll be refreshing the item much more often.

To test:
- Check that the quick actions interactions work as expected
- Check the Stats/Insights management item interactions work as expected

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
