### PR TITLE
Add Domain Registration item to the improved My Site fragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -97,7 +97,6 @@ import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.TextInputDialogFragment
 import org.wordpress.android.ui.accounts.LoginActivity
-import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria.ALL
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.domains.DomainRegistrationResultFragment
 import org.wordpress.android.ui.main.WPMainActivity.OnScrollToTopListener
@@ -784,8 +783,6 @@ class MySiteFragment : Fragment(),
                 ActivityLauncher.viewBlogStats(activity, selectedSite)
             }
             RequestCodes.SITE_PICKER -> if (resultCode == Activity.RESULT_OK) {
-                // reset comments status filter
-                AppPrefs.setCommentsStatusFilter(ALL)
                 // reset domain credit flag - it will be checked in onSiteChanged
                 isDomainCreditAvailable = false
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -143,6 +143,7 @@ import static org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartVari
 import static org.wordpress.android.login.LoginAnalyticsListener.CreatedAccountSource.EMAIL;
 import static org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE;
 import static org.wordpress.android.ui.JetpackConnectionSource.NOTIFICATIONS;
+import static org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria.ALL;
 
 /**
  * Main activity which hosts sites, reader, me and notifications pages
@@ -1055,6 +1056,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         QuickStartUtils.cancelQuickStartReminder(this);
                         AppPrefs.setQuickStartNoticeRequired(false);
                         AppPrefs.setLastSkippedQuickStartTask(null);
+                        AppPrefs.setCommentsStatusFilter(ALL); // reset comments status filter
                         mPrivateAtomicCookie.clearCookie();
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/DomainRegistrationHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/DomainRegistrationHandler.kt
@@ -1,0 +1,58 @@
+package org.wordpress.android.ui.mysite
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore.OnPlansFetched
+import org.wordpress.android.ui.plans.isDomainCreditAvailable
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.DOMAIN_REGISTRATION
+import org.wordpress.android.util.SiteUtilsWrapper
+import javax.inject.Inject
+
+class DomainRegistrationHandler
+@Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val siteUtils: SiteUtilsWrapper
+) {
+    private val _sitePlansFetched = MutableLiveData<OnPlansFetched>()
+    val isDomainCreditAvailable: LiveData<Boolean> = MediatorLiveData<Boolean>().apply {
+        addSource(selectedSiteRepository.selectedSiteChange) {
+            it?.let { site ->
+                if (shouldFetchPlans(site)) {
+                    fetchPlans(site)
+                } else {
+                    postValue(false)
+                }
+            }
+        }
+        addSource(_sitePlansFetched) { event ->
+            if (event.isError) {
+                AppLog.e(DOMAIN_REGISTRATION, "An error occurred while fetching plans : " + event.error.message)
+            } else if (selectedSiteRepository.getSelectedSite()?.id == event.site.id) {
+                postValue(isDomainCreditAvailable(event.plans))
+            }
+        }
+    }
+
+    init {
+        dispatcher.register(this)
+    }
+
+    fun clear() {
+        dispatcher.unregister(this)
+    }
+
+    private fun shouldFetchPlans(site: SiteModel) = !siteUtils.onFreePlan(site) && !siteUtils.hasCustomDomain(site)
+
+    private fun fetchPlans(site: SiteModel) = dispatcher.dispatch(SiteActionBuilder.newFetchPlansAction(site))
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onPlansFetched(event: OnPlansFetched) = _sitePlansFetched.postValue(event)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/DomainRegistrationViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/DomainRegistrationViewHolder.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.ui.mysite
+
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.domain_registration_block.view.*
+import org.wordpress.android.R
+import org.wordpress.android.ui.mysite.MySiteItem.DomainRegistrationBlock
+
+class DomainRegistrationViewHolder(
+    parent: ViewGroup
+) : MySiteItemViewHolder(parent, R.layout.domain_registration_block) {
+    fun bind(item: DomainRegistrationBlock) = itemView.apply {
+        my_site_register_domain_cta.setOnClickListener { item.onClick.click() }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.TextInputDialogFragment
+import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
 import org.wordpress.android.ui.main.utils.MeGravatarLoader
 import org.wordpress.android.ui.mysite.SiteIconUploadHandler.ItemUploadedModel
 import org.wordpress.android.ui.mysite.SiteNavigationAction.AddNewStory
@@ -35,6 +36,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenActivityLog
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenAdmin
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenComments
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenCropActivity
+import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomainRegistration
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenJetpackSettings
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMeScreen
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMedia
@@ -225,6 +227,11 @@ class ImprovedMySiteFragment : Fragment(),
                                 action.source,
                                 action.mediaUris.toTypedArray()
                         )
+                    is OpenDomainRegistration -> ActivityLauncher.viewDomainRegistrationActivityForResult(
+                            activity,
+                            action.site,
+                            CTA_DOMAIN_CREDIT_REDEMPTION
+                    )
                 }
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.TextInputDialogFragment
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
+import org.wordpress.android.ui.domains.DomainRegistrationResultFragment.Companion.RESULT_REGISTERED_DOMAIN_EMAIL
 import org.wordpress.android.ui.main.utils.MeGravatarLoader
 import org.wordpress.android.ui.mysite.SiteIconUploadHandler.ItemUploadedModel
 import org.wordpress.android.ui.mysite.SiteNavigationAction.AddNewStory
@@ -358,6 +359,9 @@ class ImprovedMySiteFragment : Fragment(),
                     )
                 }
                 viewModel.handleCropResult(UCrop.getOutput(data), resultCode == Activity.RESULT_OK)
+            }
+            RequestCodes.DOMAIN_REGISTRATION -> if (resultCode == Activity.RESULT_OK) {
+                viewModel.handleSuccessfulDomainRegistrationResult(data.getStringExtra(RESULT_REGISTERED_DOMAIN_EMAIL))
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -4,10 +4,12 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import org.wordpress.android.ui.mysite.MySiteItem.CategoryHeader
+import org.wordpress.android.ui.mysite.MySiteItem.DomainRegistrationBlock
 import org.wordpress.android.ui.mysite.MySiteItem.ListItem
 import org.wordpress.android.ui.mysite.MySiteItem.QuickActionsBlock
 import org.wordpress.android.ui.mysite.MySiteItem.SiteInfoBlock
 import org.wordpress.android.ui.mysite.MySiteItem.Type.CATEGORY_HEADER
+import org.wordpress.android.ui.mysite.MySiteItem.Type.DOMAIN_REGISTRATION_BLOCK
 import org.wordpress.android.ui.mysite.MySiteItem.Type.LIST_ITEM
 import org.wordpress.android.ui.mysite.MySiteItem.Type.QUICK_ACTIONS_BLOCK
 import org.wordpress.android.ui.mysite.MySiteItem.Type.SITE_INFO_BLOCK
@@ -28,6 +30,7 @@ class MySiteAdapter(val imageManager: ImageManager, val uiHelpers: UiHelpers) : 
         return when (viewType) {
             SITE_INFO_BLOCK.ordinal -> MySiteInfoViewHolder(parent, imageManager)
             QUICK_ACTIONS_BLOCK.ordinal -> QuickActionsViewHolder(parent)
+            DOMAIN_REGISTRATION_BLOCK.ordinal -> DomainRegistrationViewHolder(parent)
             CATEGORY_HEADER.ordinal -> MySiteCategoryViewHolder(parent, uiHelpers)
             LIST_ITEM.ordinal -> MySiteListItemViewHolder(parent, uiHelpers)
             else -> throw IllegalArgumentException("Unexpected view type")
@@ -38,6 +41,7 @@ class MySiteAdapter(val imageManager: ImageManager, val uiHelpers: UiHelpers) : 
         when (holder) {
             is MySiteInfoViewHolder -> holder.bind(items[position] as SiteInfoBlock)
             is QuickActionsViewHolder -> holder.bind(items[position] as QuickActionsBlock)
+            is DomainRegistrationViewHolder -> holder.bind(items[position] as DomainRegistrationBlock)
             is MySiteCategoryViewHolder -> holder.bind(items[position] as CategoryHeader)
             is MySiteListItemViewHolder -> holder.bind(items[position] as ListItem)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.mysite
 import androidx.recyclerview.widget.DiffUtil
 import org.apache.commons.lang3.NotImplementedException
 import org.wordpress.android.ui.mysite.MySiteItem.CategoryHeader
+import org.wordpress.android.ui.mysite.MySiteItem.DomainRegistrationBlock
 import org.wordpress.android.ui.mysite.MySiteItem.ListItem
 import org.wordpress.android.ui.mysite.MySiteItem.QuickActionsBlock
 import org.wordpress.android.ui.mysite.MySiteItem.SiteInfoBlock
@@ -21,6 +22,7 @@ class MySiteAdapterDiffCallback(
         return oldItem.type == updatedItem.type && when {
             oldItem is SiteInfoBlock && updatedItem is SiteInfoBlock -> true
             oldItem is QuickActionsBlock && updatedItem is QuickActionsBlock -> true
+            oldItem is DomainRegistrationBlock && updatedItem is DomainRegistrationBlock -> true
             oldItem is CategoryHeader && updatedItem is CategoryHeader -> oldItem.title == updatedItem.title
             oldItem is ListItem && updatedItem is ListItem -> oldItem.primaryText == updatedItem.primaryText
             else -> throw NotImplementedException("Diff not implemented yet")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.mysite
 
 import androidx.annotation.DrawableRes
 import org.wordpress.android.ui.mysite.MySiteItem.Type.CATEGORY_HEADER
+import org.wordpress.android.ui.mysite.MySiteItem.Type.DOMAIN_REGISTRATION_BLOCK
 import org.wordpress.android.ui.mysite.MySiteItem.Type.LIST_ITEM
 import org.wordpress.android.ui.mysite.MySiteItem.Type.QUICK_ACTIONS_BLOCK
 import org.wordpress.android.ui.mysite.MySiteItem.Type.SITE_INFO_BLOCK
@@ -12,6 +13,7 @@ sealed class MySiteItem(val type: Type) {
     enum class Type {
         SITE_INFO_BLOCK,
         QUICK_ACTIONS_BLOCK,
+        DOMAIN_REGISTRATION_BLOCK,
         CATEGORY_HEADER,
         LIST_ITEM
     }
@@ -38,6 +40,8 @@ sealed class MySiteItem(val type: Type) {
         val onMediaClick: ListItemInteraction,
         val showPages: Boolean = true
     ) : MySiteItem(QUICK_ACTIONS_BLOCK)
+
+    data class DomainRegistrationBlock(val onClick: ListItemInteraction) : MySiteItem(DOMAIN_REGISTRATION_BLOCK)
 
     data class CategoryHeader(val title: UiString) : MySiteItem(CATEGORY_HEADER)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.ui.mysite.ListItemAction.SITE_SETTINGS
 import org.wordpress.android.ui.mysite.ListItemAction.STATS
 import org.wordpress.android.ui.mysite.ListItemAction.THEMES
 import org.wordpress.android.ui.mysite.ListItemAction.VIEW_SITE
+import org.wordpress.android.ui.mysite.MySiteItem.DomainRegistrationBlock
 import org.wordpress.android.ui.mysite.MySiteItem.QuickActionsBlock
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ChangeSiteIconDialogModel
@@ -146,6 +147,7 @@ class MySiteViewModel
                             site.isSelfHostedAdmin || site.hasCapabilityEditPages
                     )
             )
+            siteItems.add(DomainRegistrationBlock(ListItemInteraction.create { domainRegistrationClick(site) }))
             siteItems.addAll(siteItemsBuilder.buildSiteItems(site, this::onItemClick))
             siteItems
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_ICON_CROPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_ICON_GALLERY_PICKED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_ICON_REMOVED
@@ -49,6 +50,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenActivityLog
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenAdmin
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenComments
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenCropActivity
+import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomainRegistration
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenJetpackSettings
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMeScreen
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMedia
@@ -252,6 +254,11 @@ class MySiteViewModel
     private fun quickActionMediaClick(site: SiteModel) {
         analyticsTrackerWrapper.track(QUICK_ACTION_MEDIA_TAPPED)
         _onNavigation.value = Event(OpenMedia(site))
+    }
+
+    private fun domainRegistrationClick(site: SiteModel) {
+        analyticsTrackerWrapper.track(DOMAIN_CREDIT_REDEMPTION_TAPPED, site)
+        _onNavigation.value = Event(OpenDomainRegistration(site))
     }
 
     fun refresh() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_ICON_CROPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.MY_SITE_ICON_GALLERY_PICKED
@@ -86,6 +87,7 @@ import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.distinct
+import org.wordpress.android.util.getEmailValidationMessage
 import org.wordpress.android.util.merge
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.Event
@@ -346,6 +348,11 @@ class MySiteViewModel
 
     fun handleSuccessfulLoginResult() {
         selectedSiteRepository.getSelectedSite()?.let { site -> _onNavigation.value = Event(OpenStats(site)) }
+    }
+
+    fun handleSuccessfulDomainRegistrationResult(email: String?) {
+        analyticsTrackerWrapper.track(DOMAIN_CREDIT_REDEMPTION_SUCCESS)
+        _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(getEmailValidationMessage(email))))
     }
 
     private fun startSiteIconUpload(filePath: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -45,4 +45,5 @@ sealed class SiteNavigationAction {
         val source: PagePostCreationSourcesDetail,
         val mediaUris: List<String>
     ) : SiteNavigationAction()
+    data class OpenDomainRegistration(val site: SiteModel) : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/DomainRegistrationUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DomainRegistrationUtils.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.text.TextUtils
 import android.view.Gravity
 import org.wordpress.android.R
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.ToastUtils.Duration
 
 fun requestEmailValidation(context: Context, email: String?) {
@@ -21,4 +24,10 @@ fun requestEmailValidation(context: Context, email: String?) {
             0,
             context.resources.getDimensionPixelOffset(R.dimen.smart_toast_offset_y)
     )
+}
+
+fun getEmailValidationMessage(email: String?) = if (email.isNullOrEmpty()) {
+    UiStringRes(R.string.my_site_verify_your_email_without_email)
+} else {
+    UiStringResWithParams(R.string.my_site_verify_your_email, listOf(UiStringText(email)))
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
@@ -19,4 +19,6 @@ class SiteUtilsWrapper @Inject constructor() {
             SiteUtils.getAccessibilityInfoFromSite(site)
 
     fun isAccessedViaWPComRest(site: SiteModel): Boolean = SiteUtils.isAccessedViaWPComRest(site)
+    fun onFreePlan(site: SiteModel): Boolean = SiteUtils.onFreePlan(site)
+    fun hasCustomDomain(site: SiteModel): Boolean = SiteUtils.hasCustomDomain(site)
 }

--- a/WordPress/src/main/res/layout/domain_registration_block.xml
+++ b/WordPress/src/main/res/layout/domain_registration_block.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/my_site_register_domain_cta"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/margin_large">
+
+    <!--Register Domain-->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <LinearLayout
+            style="@style/MySiteListRowLayout"
+            android:foreground="@null"
+            tools:ignore="UnusedAttribute">
+
+            <ImageView
+                android:id="@+id/my_site_register_domain_icon"
+                style="@style/MySiteListRowAlertIcon"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_notice_white_24dp" />
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/my_site_register_domain_text_view"
+                style="@style/MySiteListRowTextView"
+                android:text="@string/register_domain" />
+        </LinearLayout>
+
+        <com.google.android.material.textview.MaterialTextView
+            style="@style/MySiteListRowDescription"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="@string/my_site_custom_domain_name" />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/DomainRegistrationHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/DomainRegistrationHandlerTest.kt
@@ -1,0 +1,165 @@
+package org.wordpress.android.ui.mysite
+
+import androidx.lifecycle.MutableLiveData
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.PlanModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore.OnPlansFetched
+import org.wordpress.android.fluxc.store.SiteStore.PlansError
+import org.wordpress.android.fluxc.store.SiteStore.PlansErrorType
+import org.wordpress.android.fluxc.store.SiteStore.PlansErrorType.GENERIC_ERROR
+import org.wordpress.android.ui.plans.PlansConstants.PREMIUM_PLAN_ID
+import org.wordpress.android.util.SiteUtilsWrapper
+
+class DomainRegistrationHandlerTest : BaseUnitTest() {
+    @Mock lateinit var dispatcher: Dispatcher
+    @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
+    @Mock lateinit var siteUtils: SiteUtilsWrapper
+    @Mock lateinit var site: SiteModel
+    private lateinit var isDomainCreditAvailableEvents: MutableList<Boolean>
+    private lateinit var handler: DomainRegistrationHandler
+    private val onSiteChange = MutableLiveData<SiteModel>()
+
+    @Before
+    fun setUp() {
+        whenever(selectedSiteRepository.selectedSiteChange).thenReturn(onSiteChange)
+        whenever(selectedSiteRepository.getSelectedSite()).thenAnswer { onSiteChange.value }
+
+        isDomainCreditAvailableEvents = mutableListOf()
+        handler = DomainRegistrationHandler(dispatcher, selectedSiteRepository, siteUtils)
+        handler.isDomainCreditAvailable.observeForever { isDomainCreditAvailableEvents.add(it) }
+    }
+
+    @Test
+    fun `when site is null, don't emit value and don't fetch`() {
+        onSiteChange.postValue(null)
+
+        assertThat(isDomainCreditAvailableEvents).hasSize(0)
+
+        verify(dispatcher, never()).dispatch(any())
+    }
+
+    @Test
+    fun `when site is free, emit false and don't fetch`() {
+        setupSite(site = site, isFree = true, hasCustomDomain = false)
+
+        onSiteChange.postValue(site)
+
+        assertThat(isDomainCreditAvailableEvents).hasSize(1)
+        assertThat(isDomainCreditAvailableEvents.last()).isFalse
+
+        verify(dispatcher, never()).dispatch(any())
+    }
+
+    @Test
+    fun `when site has custom domain, emit false and don't fetch`() {
+        setupSite(site = site, isFree = true, hasCustomDomain = false)
+
+        onSiteChange.postValue(site)
+
+        assertThat(isDomainCreditAvailableEvents).hasSize(1)
+        assertThat(isDomainCreditAvailableEvents.last()).isFalse
+
+        verify(dispatcher, never()).dispatch(any())
+    }
+
+    @Test
+    fun `when site is not free and doesn't have custom domain, don't emit value and start fetch`() {
+        setupSite(site = site, isFree = false, hasCustomDomain = false)
+
+        onSiteChange.postValue(site)
+
+        assertThat(isDomainCreditAvailableEvents).hasSize(0)
+
+        verify(dispatcher, times(1)).dispatch(any())
+    }
+
+    @Test
+    fun `when fetched site has a plan with credits, emit true`() {
+        setupSite(site = site, currentPlan = buildPlan(hasDomainCredit = true))
+
+        onSiteChange.postValue(site)
+
+        assertThat(isDomainCreditAvailableEvents).hasSize(1)
+        assertThat(isDomainCreditAvailableEvents.last()).isTrue
+    }
+
+    @Test
+    fun `when fetched site doesn't have a plan with credits, emit false`() {
+        setupSite(site = site, currentPlan = buildPlan(hasDomainCredit = false))
+
+        onSiteChange.postValue(site)
+
+        assertThat(isDomainCreditAvailableEvents).hasSize(1)
+        assertThat(isDomainCreditAvailableEvents.last()).isFalse
+    }
+
+    @Test
+    fun `when fetched site is different from currently selected site, don't emit value`() {
+        val selectedSite = SiteModel().apply { id = 1 }
+
+        setupSite(site = selectedSite, currentPlan = buildPlan(hasDomainCredit = false))
+
+        onSiteChange.postValue(selectedSite)
+
+        val fetchedSite = SiteModel().apply { id = 2 }
+
+        buildOnPlansFetchedEvent(site = fetchedSite, currentPlan = buildPlan(hasDomainCredit = true))?.let { event ->
+            handler.onPlansFetched(event)
+        }
+
+        assertThat(isDomainCreditAvailableEvents).hasSize(1)
+        assertThat(isDomainCreditAvailableEvents.last()).isFalse
+    }
+
+    @Test
+    fun `when fetch fails, don't emit value`() {
+        setupSite(site = site, error = GENERIC_ERROR)
+
+        onSiteChange.postValue(site)
+
+        assertThat(isDomainCreditAvailableEvents).hasSize(0)
+    }
+
+    private fun setupSite(
+        site: SiteModel,
+        isFree: Boolean = false,
+        hasCustomDomain: Boolean = false,
+        currentPlan: PlanModel? = null,
+        error: PlansErrorType? = null
+    ) {
+        whenever(siteUtils.onFreePlan(any())).thenReturn(isFree)
+        whenever(siteUtils.hasCustomDomain(any())).thenReturn(hasCustomDomain)
+        buildOnPlansFetchedEvent(site, currentPlan, error)?.let { event ->
+            whenever(dispatcher.dispatch(any())).then { handler.onPlansFetched(event) }
+        }
+    }
+
+    private fun buildOnPlansFetchedEvent(
+        site: SiteModel,
+        currentPlan: PlanModel? = null,
+        error: PlansErrorType? = null
+    ) = if (currentPlan != null || error != null) {
+        OnPlansFetched(site, currentPlan?.let { listOf(it) }, error?.let { PlansError(it) })
+    } else {
+        null
+    }
+
+    private fun buildPlan(hasDomainCredit: Boolean) = PlanModel(
+            productId = PREMIUM_PLAN_ID.toInt(),
+            productSlug = null,
+            productName = null,
+            isCurrentPlan = true,
+            hasDomainCredit = hasDomainCredit
+    )
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -697,7 +697,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `snackbar is shown and correct event is tracked when handling successful domain registration result without email`() {
+    fun `snackbar is shown and event is tracked when handling successful domain registration result without email`() {
         viewModel.handleSuccessfulDomainRegistrationResult(null)
 
         verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_REDEMPTION_SUCCESS)
@@ -708,7 +708,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `snackbar is shown and correct event is tracked when handling successful domain registration result with email`() {
+    fun `snackbar is shown and event is tracked when handling successful domain registration result with email`() {
         viewModel.handleSuccessfulDomainRegistrationResult(emailAddress)
 
         verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_REDEMPTION_SUCCESS)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -84,6 +84,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var contextProvider: ContextProvider
     @Mock lateinit var siteIconUploadHandler: SiteIconUploadHandler
     @Mock lateinit var siteStoriesHandler: SiteStoriesHandler
+    @Mock lateinit var domainRegistrationHandler: DomainRegistrationHandler
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<UiModel>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -120,7 +121,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 fluxCUtilsWrapper,
                 contextProvider,
                 siteIconUploadHandler,
-                siteStoriesHandler
+                siteStoriesHandler,
+                domainRegistrationHandler
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -15,7 +15,11 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.R.string
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
@@ -33,6 +37,7 @@ import org.wordpress.android.ui.mysite.ListItemAction.SITE_SETTINGS
 import org.wordpress.android.ui.mysite.ListItemAction.STATS
 import org.wordpress.android.ui.mysite.ListItemAction.THEMES
 import org.wordpress.android.ui.mysite.ListItemAction.VIEW_SITE
+import org.wordpress.android.ui.mysite.MySiteItem.DomainRegistrationBlock
 import org.wordpress.android.ui.mysite.MySiteItem.QuickActionsBlock
 import org.wordpress.android.ui.mysite.MySiteItem.SiteInfoBlock
 import org.wordpress.android.ui.mysite.MySiteItem.SiteInfoBlock.IconState
@@ -48,6 +53,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.ConnectJetpackForSta
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenActivityLog
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenAdmin
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenComments
+import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomainRegistration
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMeScreen
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenMedia
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenPages
@@ -64,6 +70,8 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenThemes
 import org.wordpress.android.ui.mysite.SiteNavigationAction.StartWPComLoginForJetpackStats
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
@@ -95,18 +103,22 @@ class MySiteViewModelTest : BaseUnitTest() {
     private val siteUrl = "http://site.com"
     private val siteIcon = "http://site.com/icon.jpg"
     private val siteName = "Site"
+    private val emailAddress = "test@email.com"
     private lateinit var site: SiteModel
     private lateinit var siteInfoBlock: SiteInfoBlock
     private val onSiteChange = MutableLiveData<SiteModel>()
     private val onShowSiteIconProgressBar = MutableLiveData<Boolean>()
+    private val isDomainCreditAvailable = MutableLiveData<Boolean>()
 
     @InternalCoroutinesApi
     @Before
     fun setUp() {
         onSiteChange.value = null
         onShowSiteIconProgressBar.value = null
+        isDomainCreditAvailable.value = null
         whenever(selectedSiteRepository.selectedSiteChange).thenReturn(onSiteChange)
         whenever(selectedSiteRepository.showSiteIconProgressBar).thenReturn(onShowSiteIconProgressBar)
+        whenever(domainRegistrationHandler.isDomainCreditAvailable).thenReturn(isDomainCreditAvailable)
         viewModel = MySiteViewModel(
                 networkUtilsWrapper,
                 TEST_DISPATCHER,
@@ -664,11 +676,56 @@ class MySiteViewModelTest : BaseUnitTest() {
         assertThat(navigationActions).containsExactly(ConnectJetpackForStats(site))
     }
 
+    @Test
+    fun `domain registration item click opens domain registration`() {
+        onSiteChange.postValue(site)
+        isDomainCreditAvailable.postValue(true)
+
+        findDomainRegistrationBlock()?.onClick?.click()
+
+        verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_REDEMPTION_TAPPED, site)
+
+        assertThat(navigationActions).containsOnly(OpenDomainRegistration(site))
+    }
+
+    @Test
+    fun `correct event is tracked when domain registration item is shown`() {
+        onSiteChange.postValue(site)
+        isDomainCreditAvailable.postValue(true)
+
+        verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_PROMPT_SHOWN)
+    }
+
+    @Test
+    fun `snackbar is shown and correct event is tracked when handling successful domain registration result without email`() {
+        viewModel.handleSuccessfulDomainRegistrationResult(null)
+
+        verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_REDEMPTION_SUCCESS)
+
+        val message = UiStringRes(R.string.my_site_verify_your_email_without_email)
+
+        assertThat(snackbars).containsOnly(SnackbarMessageHolder(message))
+    }
+
+    @Test
+    fun `snackbar is shown and correct event is tracked when handling successful domain registration result with email`() {
+        viewModel.handleSuccessfulDomainRegistrationResult(emailAddress)
+
+        verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_REDEMPTION_SUCCESS)
+
+        val message = UiStringResWithParams(string.my_site_verify_your_email, listOf(UiStringText(emailAddress)))
+
+        assertThat(snackbars).containsOnly(SnackbarMessageHolder(message))
+    }
+
     private fun setupAccount(account: AccountModel?) = whenever(accountStore.account).thenReturn(account)
 
     private fun buildAccountWithAvatarUrl(avatarUrl: String?) = AccountModel().apply { this.avatarUrl = avatarUrl }
 
     private fun findQuickActionsBlock() = uiModels.last().items.find { it is QuickActionsBlock } as QuickActionsBlock?
+
+    private fun findDomainRegistrationBlock() =
+            uiModels.last().items.find { it is DomainRegistrationBlock } as DomainRegistrationBlock?
 
     private fun invokeSiteInfoBlockAction(action: SiteInfoBlockAction) {
         val argument = when (action) {


### PR DESCRIPTION
Fixes #13508

This PR adds a `DomainRegistrationBlock` item to the improved My Site fragment:

<img height=300 src="https://user-images.githubusercontent.com/830056/101564560-243af800-39aa-11eb-803f-f27e57cb5ede.jpeg"/>

Most of the logic related to this item is concentrated in `DomainRegistrationHandler`.

### To test

1. Turn on the Improved My Site flag and restart the app.
1. Go to the My Site screen.
1. Switch to a site on a free plan.
1. Notice the domain registration item is not shown.
1. Switch to a site on any paid plan and with unredeemed domain credit.
1. Notice the domain registration item is now being shown.
1. Tap on the domain registration item and notice the Domain Registration screen.
1. Register a domain name.
1. Back on the My Site screen, notice the domain registration item is not shown anymore.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
