### PR TITLE
Fix "First preview attempt does not work"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -144,6 +144,7 @@ import org.wordpress.android.ui.posts.InsertMediaDialog.InsertMediaCallback;
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Editor;
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Outcome;
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.PreviewLogicOperationResult;
+import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType;
 import org.wordpress.android.ui.posts.editor.EditorActionsProvider;
 import org.wordpress.android.ui.posts.editor.EditorPhotoPicker;
 import org.wordpress.android.ui.posts.editor.EditorPhotoPickerListener;
@@ -3377,7 +3378,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 AppLog.e(T.POSTS, "REMOTE_AUTO_SAVE_POST failed: " + event.error.type + " - " + event.error.message);
             }
             mEditPostRepository.loadPostByLocalPostId(mEditPostRepository.getId());
-            handleRemoteAutoSave(event.isError(), mEditPostRepository.getPost());
+            handleRemotePreviewUploadResult(event.isError(), mEditPostRepository.getPost(),
+                    RemotePreviewType.REMOTE_PREVIEW_WITH_REMOTE_AUTO_SAVE);
         }
     }
 
@@ -3403,7 +3405,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     @Nullable
-    private PostImmutableModel handleRemoteAutoSave(boolean isError, PostImmutableModel post) {
+    private void handleRemotePreviewUploadResult(boolean isError, PostImmutableModel post,
+                                                 RemotePreviewLogicHelper.RemotePreviewType param) {
         // We are in the process of remote previewing a post from the editor
         if (!isError && isUploadingPostForPreview()) {
             // We were uploading post for preview and we got no error:
@@ -3413,9 +3416,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     EditPostActivity.this,
                     mSite,
                     post,
-                    mPostLoadingState == PostLoadingState.UPLOADING_FOR_PREVIEW
-                            ? RemotePreviewLogicHelper.RemotePreviewType.REMOTE_PREVIEW
-                            : RemotePreviewLogicHelper.RemotePreviewType.REMOTE_PREVIEW_WITH_REMOTE_AUTO_SAVE
+                    param
             );
             updatePostLoadingAndDialogState(PostLoadingState.PREVIEWING, post);
         } else if (isError || isRemoteAutoSaveError()) {
@@ -3424,7 +3425,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
             mUploadUtilsWrapper.showSnackbarError(findViewById(R.id.editor_activity),
                     getString(R.string.remote_preview_operation_error));
         }
-        return post;
     }
 
     @SuppressWarnings("unused")
@@ -3445,7 +3445,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 }
             } else {
                 mEditPostRepository.set(() -> {
-                    handleRemoteAutoSave(event.isError(), post);
+                    handleRemotePreviewUploadResult(event.isError(), post, RemotePreviewType.REMOTE_PREVIEW);
                     return post;
                 });
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3378,8 +3378,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 AppLog.e(T.POSTS, "REMOTE_AUTO_SAVE_POST failed: " + event.error.type + " - " + event.error.message);
             }
             mEditPostRepository.loadPostByLocalPostId(mEditPostRepository.getId());
-            handleRemotePreviewUploadResult(event.isError(), mEditPostRepository.getPost(),
-                    RemotePreviewType.REMOTE_PREVIEW_WITH_REMOTE_AUTO_SAVE);
+            handleRemotePreviewUploadResult(event.isError(), RemotePreviewType.REMOTE_PREVIEW_WITH_REMOTE_AUTO_SAVE);
         }
     }
 
@@ -3405,8 +3404,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     @Nullable
-    private void handleRemotePreviewUploadResult(boolean isError, PostImmutableModel post,
-                                                 RemotePreviewLogicHelper.RemotePreviewType param) {
+    private void handleRemotePreviewUploadResult(boolean isError, RemotePreviewLogicHelper.RemotePreviewType param) {
         // We are in the process of remote previewing a post from the editor
         if (!isError && isUploadingPostForPreview()) {
             // We were uploading post for preview and we got no error:
@@ -3415,10 +3413,10 @@ public class EditPostActivity extends LocaleAwareActivity implements
             ActivityLauncher.previewPostOrPageForResult(
                     EditPostActivity.this,
                     mSite,
-                    post,
+                    mEditPostRepository.getPost(),
                     param
             );
-            updatePostLoadingAndDialogState(PostLoadingState.PREVIEWING, post);
+            updatePostLoadingAndDialogState(PostLoadingState.PREVIEWING, mEditPostRepository.getPost());
         } else if (isError || isRemoteAutoSaveError()) {
             // We got an error from the uploading or from the remote auto save of a post: show snackbar error
             updatePostLoadingAndDialogState(PostLoadingState.NONE);
@@ -3445,7 +3443,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 }
             } else {
                 mEditPostRepository.set(() -> post);
-                handleRemotePreviewUploadResult(event.isError(), post, RemotePreviewType.REMOTE_PREVIEW);
+                handleRemotePreviewUploadResult(event.isError(), RemotePreviewType.REMOTE_PREVIEW);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3378,7 +3378,10 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 AppLog.e(T.POSTS, "REMOTE_AUTO_SAVE_POST failed: " + event.error.type + " - " + event.error.message);
             }
             mEditPostRepository.loadPostByLocalPostId(mEditPostRepository.getId());
-            handleRemotePreviewUploadResult(event.isError(), RemotePreviewType.REMOTE_PREVIEW_WITH_REMOTE_AUTO_SAVE);
+            if (isRemotePreviewingFromEditor()) {
+                handleRemotePreviewUploadResult(event.isError(),
+                        RemotePreviewType.REMOTE_PREVIEW_WITH_REMOTE_AUTO_SAVE);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3377,7 +3377,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 AppLog.e(T.POSTS, "REMOTE_AUTO_SAVE_POST failed: " + event.error.type + " - " + event.error.message);
             }
             mEditPostRepository.loadPostByLocalPostId(mEditPostRepository.getId());
-            mEditPostRepository.replace(postModel -> handleRemoteAutoSave(event.isError(), postModel));
+            handleRemoteAutoSave(event.isError(), mEditPostRepository.getPost());
         }
     }
 
@@ -3403,7 +3403,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     @Nullable
-    private PostModel handleRemoteAutoSave(boolean isError, PostModel post) {
+    private PostImmutableModel handleRemoteAutoSave(boolean isError, PostImmutableModel post) {
         // We are in the process of remote previewing a post from the editor
         if (!isError && isUploadingPostForPreview()) {
             // We were uploading post for preview and we got no error:
@@ -3444,7 +3444,10 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     });
                 }
             } else {
-                mEditPostRepository.set(() -> handleRemoteAutoSave(event.isError(), post));
+                mEditPostRepository.set(() -> {
+                    handleRemoteAutoSave(event.isError(), post);
+                    return post;
+                });
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3444,10 +3444,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     });
                 }
             } else {
-                mEditPostRepository.set(() -> {
-                    handleRemotePreviewUploadResult(event.isError(), post, RemotePreviewType.REMOTE_PREVIEW);
-                    return post;
-                });
+                mEditPostRepository.set(() -> post);
+                handleRemotePreviewUploadResult(event.isError(), post, RemotePreviewType.REMOTE_PREVIEW);
             }
         }
     }


### PR DESCRIPTION
Fixes #12570

This issue was introduced with introduction of `AutoSavePostIfNotDraftUseCase`. This use case uses "push post" endpoint instead of using `remote auto save` endpoint, when the post is a draft in the remote. This shouldn't be an issue, however the EditPostActivity (EPA) is in `REMOTE_PREVIEW_WITH_REMOTE_AUTO_SAVE` state and it doesn't expect that the UploadService/AutoSavePostIfNotDraftUseCase decided to push the post instead of remote auto saving it. The preview doesn't open because of [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/64682b8c16ea79c814139056ba2c63cfc9a2131a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java#L940) where we simply ignore the request to open a browser if we expected remote autosave but the remoteAutoSaveUrl is empty.

The EPA can easily determine if the post was remote auto saved or pushed.
- if the post is pushed [OnPostUploaded](https://github.com/wordpress-mobile/WordPress-Android/blob/b739d8a436e6b2efbeff6584c065409e939b1e28/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L3433) is invoked
- if the post is remote auto saved [OnPostChanged](https://github.com/wordpress-mobile/WordPress-Android/blob/b739d8a436e6b2efbeff6584c065409e939b1e28/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L3360) is invoked


I decided to pass `RemotePreviewType` as parameter in https://github.com/wordpress-mobile/WordPress-Android/commit/b4e796c6e94c58d91c639ddbae2876898e449487 which fixes the issue. The remaining commits are just clean-up commits to make the code a bit more clear.

- https://github.com/wordpress-mobile/WordPress-Android/commit/0f699a586528e7d6c59841f444f865ca0989131d Pass immutable version of PostModel into handleRemoteAutoSave since it doesn't change the post
- https://github.com/wordpress-mobile/WordPress-Android/commit/f35383b6298c14fbc449c874534bd6805e1c6a78 Move handleRemotePreviewUploadResult out of lambda since it's not related to settings the post into the repository
- https://github.com/wordpress-mobile/WordPress-Android/commit/8b5035bdb0a3c48f8d2300bf6dfa8c4e4f0640ce Use the repository directly so we are sure the method uses the up to date post.
- https://github.com/wordpress-mobile/WordPress-Android/commit/b739d8a436e6b2efbeff6584c065409e939b1e28 Make sure we don't invoke `handleRemotePreviewUploadResult` when the remote auto save was not related to remote preview


To test:
1. Open an existing draft
2. Make a change
3. Click on "Preview"
4. Notice the preview opens on the first attempt and the changes are visible
-----------
1. Create a new post
2. Add a title and content
3. Click on "Preview"
4. Notice the preview opens on the first attempt
5. Make a change 
6. Click on Preview
7. Notice the preview opens on the first attempt and you can see all changes
---------------
1. Open an published post
2. Make a change
3. Click on "Preview"
4. Notice the preview opens on the first attempt and the changes are visible

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
