### PR TITLE
Gutenberg - Fix Gallery block uploads when the editor is closed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] My Site: Fixes crash on rotation while editing site title [https://github.com/wordpress-mobile/WordPress-Android/pull/13505]
 * [**] Posts List: Adds duplicate post functionality [https://github.com/wordpress-mobile/WordPress-Android/pull/13521]
+* [*] Block Editor: Fix Gallery block uploads when the editor is closed [https://github.com/wordpress-mobile/WordPress-Android/pull/13570]
 
 16.3
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/GalleryBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/GalleryBlockProcessor.java
@@ -48,10 +48,10 @@ public class GalleryBlockProcessor extends BlockProcessor {
             Element parent = targetImg.parent();
             if (parent != null && parent.is("a") && mLinkTo != null) {
                 switch (mLinkTo) {
-                    case "media":
+                    case "file":
                         parent.attr("href", mRemoteUrl);
                         break;
-                    case "attachment":
+                    case "post":
                         parent.attr("href", mAttachmentPageUrl);
                         break;
                     default:

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
@@ -176,7 +176,7 @@ object TestContent {
 <!-- /wp:gallery -->
 """
 
-    const val oldGalleryBlockIdsNotFirst = """<!-- wp:gallery {"linkTo":"attachment","ids":[203,${localMediaId},369]} -->
+    const val oldGalleryBlockIdsNotFirst = """<!-- wp:gallery {"linkTo":"post","ids":[203,${localMediaId},369]} -->
 <figure class="wp-block-gallery columns-3 is-cropped">
   <ul class="blocks-gallery-grid">
     <li class="blocks-gallery-item">
@@ -193,7 +193,7 @@ object TestContent {
 <!-- /wp:gallery -->
 """
 
-    const val newGalleryBlockIdsNotFirst = """<!-- wp:gallery {"linkTo":"attachment","ids":[203,${remoteMediaId},369]} -->
+    const val newGalleryBlockIdsNotFirst = """<!-- wp:gallery {"linkTo":"post","ids":[203,${remoteMediaId},369]} -->
 <figure class="wp-block-gallery columns-3 is-cropped">
   <ul class="blocks-gallery-grid">
     <li class="blocks-gallery-item">
@@ -294,7 +294,7 @@ object TestContent {
 <!-- /wp:video -->
 """
 
-    const val oldGalleryBlockLinkToMediaFile = """<!-- wp:gallery {"ids":[203,${localMediaId},369],"linkTo":"media"} -->
+    const val oldGalleryBlockLinkToMediaFile = """<!-- wp:gallery {"ids":[203,${localMediaId},369],"linkTo":"file"} -->
 <figure class="wp-block-gallery columns-3 is-cropped">
   <ul class="blocks-gallery-grid">
     <li class="blocks-gallery-item">
@@ -311,7 +311,7 @@ object TestContent {
 <!-- /wp:gallery -->
 """
 
-    const val newGalleryBlockLinkToMediaFile = """<!-- wp:gallery {"ids":[203,${remoteMediaId},369],"linkTo":"media"} -->
+    const val newGalleryBlockLinkToMediaFile = """<!-- wp:gallery {"ids":[203,${remoteMediaId},369],"linkTo":"file"} -->
 <figure class="wp-block-gallery columns-3 is-cropped">
   <ul class="blocks-gallery-grid">
     <li class="blocks-gallery-item">
@@ -328,7 +328,7 @@ object TestContent {
 <!-- /wp:gallery -->
 """
 
-    const val oldGalleryBlockLinkToAttachmentPage = """<!-- wp:gallery {"ids":[203,${localMediaId},369],"linkTo":"attachment"} -->
+    const val oldGalleryBlockLinkToAttachmentPage = """<!-- wp:gallery {"ids":[203,${localMediaId},369],"linkTo":"post"} -->
 <figure class="wp-block-gallery columns-3 is-cropped">
   <ul class="blocks-gallery-grid">
     <li class="blocks-gallery-item">
@@ -345,7 +345,7 @@ object TestContent {
 <!-- /wp:gallery -->
 """
 
-    const val newGalleryBlockLinkToAttachmentPage = """<!-- wp:gallery {"ids":[203,${remoteMediaId},369],"linkTo":"attachment"} -->
+    const val newGalleryBlockLinkToAttachmentPage = """<!-- wp:gallery {"ids":[203,${remoteMediaId},369],"linkTo":"post"} -->
 <figure class="wp-block-gallery columns-3 is-cropped">
   <ul class="blocks-gallery-grid">
     <li class="blocks-gallery-item">


### PR DESCRIPTION
Fixes an issue found while sanity testing the `1.43.0` Gutenberg mobile [release](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2874).

Fixes https://github.com/WordPress/gutenberg/issues/27618

Due to this [Gutenberg change](https://github.com/WordPress/gutenberg/pull/25582) that updated the values for the `linkTo` attribute, the Gallery processor stopped working correctly. This PR updates the values to the new ones:

* `media` → `file` 
* `attachment` → `post`

To test:

- [ ] Gallery block - Close post with an ongoing image upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/gallery.md#tc002)

Test the different Gallery link to options: `None`, `Media File`, and `Attachment Page`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
