### PR TITLE
Follow unfollow unit test

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/PostSubscribersApiCallsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/PostSubscribersApiCallsProvider.kt
@@ -13,13 +13,13 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.VolleyUtils
 import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
-import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 class PostSubscribersApiCallsProvider @Inject constructor(
     private val contextProvider: ContextProvider
 ) {
-    fun getCanFollowComments(blogId: Long, cont: Continuation<Boolean>) {
+    suspend fun getCanFollowComments(blogId: Long): Boolean = suspendCoroutine { cont ->
         val endPointPath = "/sites/$blogId/"
 
         val listener = Listener { jsonObject ->
@@ -45,7 +45,7 @@ class PostSubscribersApiCallsProvider @Inject constructor(
         )
     }
 
-    fun getMySubscriptionToPost(blogId: Long, postId: Long, cont: Continuation<PostSubscribersCallResult>) {
+    suspend fun getMySubscriptionToPost(blogId: Long, postId: Long): PostSubscribersCallResult = suspendCoroutine { cont ->
         val endPointPath = "/sites/$blogId/posts/$postId/subscribers/mine"
 
         val listener = Listener { jsonObject ->
@@ -68,7 +68,7 @@ class PostSubscribersApiCallsProvider @Inject constructor(
         )
     }
 
-    fun subscribeMeToPost(blogId: Long, postId: Long, cont: Continuation<PostSubscribersCallResult>) {
+    suspend fun subscribeMeToPost(blogId: Long, postId: Long): PostSubscribersCallResult = suspendCoroutine { cont ->
         val endPointPath = "/sites/$blogId/posts/$postId/subscribers/new"
 
         val listener = Listener { jsonObject ->
@@ -91,7 +91,7 @@ class PostSubscribersApiCallsProvider @Inject constructor(
         )
     }
 
-    fun unsubscribeMeFromPost(blogId: Long, postId: Long, cont: Continuation<PostSubscribersCallResult>) {
+    suspend fun unsubscribeMeFromPost(blogId: Long, postId: Long): PostSubscribersCallResult = suspendCoroutine { cont ->
         val endPointPath = "/sites/$blogId/posts/$postId/subscribers/mine/delete"
 
         val listener = Listener { jsonObject ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/PostSubscribersApiCallsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/PostSubscribersApiCallsProvider.kt
@@ -45,7 +45,10 @@ class PostSubscribersApiCallsProvider @Inject constructor(
         )
     }
 
-    suspend fun getMySubscriptionToPost(blogId: Long, postId: Long): PostSubscribersCallResult = suspendCoroutine { cont ->
+    suspend fun getMySubscriptionToPost(
+        blogId: Long,
+        postId: Long
+    ): PostSubscribersCallResult = suspendCoroutine { cont ->
         val endPointPath = "/sites/$blogId/posts/$postId/subscribers/mine"
 
         val listener = Listener { jsonObject ->
@@ -91,7 +94,10 @@ class PostSubscribersApiCallsProvider @Inject constructor(
         )
     }
 
-    suspend fun unsubscribeMeFromPost(blogId: Long, postId: Long): PostSubscribersCallResult = suspendCoroutine { cont ->
+    suspend fun unsubscribeMeFromPost(
+        blogId: Long,
+        postId: Long
+    ): PostSubscribersCallResult = suspendCoroutine { cont ->
         val endPointPath = "/sites/$blogId/posts/$postId/subscribers/mine/delete"
 
         val listener = Listener { jsonObject ->

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderCommentListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderCommentListViewModelTest.kt
@@ -1,13 +1,23 @@
 package org.wordpress.android.ui.reader
 
+import androidx.lifecycle.MutableLiveData
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.test
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.reader.FollowCommentsUiStateType.VISIBLE_WITH_STATE
 import org.wordpress.android.ui.reader.ReaderCommentListViewModel.ScrollPosition
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FollowStateChanged
 import org.wordpress.android.util.config.FollowUnfollowCommentsFeatureConfig
 import org.wordpress.android.viewmodel.Event
 
@@ -17,9 +27,18 @@ class ReaderCommentListViewModelTest : BaseUnitTest() {
     @Mock lateinit var followUnfollowCommentsFeatureConfig: FollowUnfollowCommentsFeatureConfig
 
     private lateinit var viewModel: ReaderCommentListViewModel
+    private val blogId = 100L
+    private val postId = 1000L
+    private var snackbarEvents = MutableLiveData<Event<SnackbarMessageHolder>>()
+    private var followStatusUpdate = MutableLiveData<FollowCommentsState>()
+    private var uiState: FollowCommentsUiState? = null
 
     @Before
     fun setUp() {
+        whenever(followCommentsHandler.snackbarEvents).thenReturn(snackbarEvents)
+        whenever(followCommentsHandler.followStatusUpdate).thenReturn(followStatusUpdate)
+        whenever(followUnfollowCommentsFeatureConfig.isEnabled()).thenReturn(true)
+
         viewModel = ReaderCommentListViewModel(
                 followCommentsHandler,
                 TEST_DISPATCHER,
@@ -44,5 +63,63 @@ class ReaderCommentListViewModelTest : BaseUnitTest() {
 
         assertThat(scrollPosition.isSmooth).isEqualTo(isSmooth)
         assertThat(scrollPosition.position).isEqualTo(expectedPosition)
+    }
+
+    @Test
+    fun `follow ui state is DISABLED on start`() {
+        setupObserversAndStart()
+
+        assertThat(uiState).isNotNull
+        assertThat(uiState!!.type).isEqualTo(FollowCommentsUiStateType.DISABLED)
+    }
+
+    @Test
+    fun `onSwipeToRefresh updates follow conversation status`() = test {
+        val stateChanged = FollowStateChanged(blogId, postId, true)
+        doAnswer {
+            followStatusUpdate.postValue(stateChanged)
+        }.whenever(followCommentsHandler).handleFollowCommentsStatusRequest(anyLong(), anyLong(), anyBoolean())
+
+        setupObserversAndStart()
+
+        viewModel.onSwipeToRefresh()
+
+        requireNotNull(uiState).let {
+            assertThat(it.type).isEqualTo(VISIBLE_WITH_STATE)
+        }
+    }
+
+    @Test
+    fun `onFollowConversationClicked toggles follow button status`() = test {
+        var stateChanged = FollowStateChanged(blogId, postId, true)
+        doAnswer {
+            followStatusUpdate.postValue(stateChanged)
+        }.whenever(followCommentsHandler).handleFollowCommentsStatusRequest(anyLong(), anyLong(), anyBoolean())
+
+        doAnswer {
+            stateChanged = FollowStateChanged(blogId, postId, false)
+            followStatusUpdate.postValue(stateChanged)
+        }.whenever(followCommentsHandler).handleFollowCommentsClicked(blogId, postId, false)
+
+        setupObserversAndStart()
+
+        requireNotNull(uiState).let {
+            assertThat(it.type).isEqualTo(VISIBLE_WITH_STATE)
+            assertThat(it.isFollowing).isTrue()
+            it.onFollowButtonClick?.invoke(false)
+        }
+
+        requireNotNull(uiState).let {
+            assertThat(it.type).isEqualTo(VISIBLE_WITH_STATE)
+            assertThat(it.isFollowing).isFalse()
+        }
+    }
+
+    private fun setupObserversAndStart() {
+        viewModel.updateFollowUiState.observeForever {
+            uiState = it
+        }
+
+        viewModel.start(blogId, postId)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderCommentListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderCommentListViewModelTest.kt
@@ -75,17 +75,28 @@ class ReaderCommentListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onSwipeToRefresh updates follow conversation status`() = test {
-        val stateChanged = FollowStateChanged(blogId, postId, true)
+        var stateChanged = FollowStateChanged(blogId, postId, true, true)
         doAnswer {
             followStatusUpdate.postValue(stateChanged)
         }.whenever(followCommentsHandler).handleFollowCommentsStatusRequest(anyLong(), anyLong(), anyBoolean())
 
         setupObserversAndStart()
 
+        requireNotNull(uiState).let {
+            assertThat(it.type).isEqualTo(VISIBLE_WITH_STATE)
+            assertThat(it.animate).isFalse()
+        }
+
+        stateChanged = FollowStateChanged(blogId, postId, true, false)
+        doAnswer {
+            followStatusUpdate.postValue(stateChanged)
+        }.whenever(followCommentsHandler).handleFollowCommentsStatusRequest(anyLong(), anyLong(), anyBoolean())
+
         viewModel.onSwipeToRefresh()
 
         requireNotNull(uiState).let {
             assertThat(it.type).isEqualTo(VISIBLE_WITH_STATE)
+            assertThat(it.animate).isTrue()
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFollowCommentsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFollowCommentsHandlerTest.kt
@@ -1,0 +1,110 @@
+package org.wordpress.android.ui.reader
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.test
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState
+import org.wordpress.android.ui.utils.UiString.UiStringText
+
+@InternalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class ReaderFollowCommentsHandlerTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    @Mock lateinit var readerCommentsFollowUseCase: ReaderCommentsFollowUseCase
+
+    private lateinit var followCommentsHandler: ReaderFollowCommentsHandler
+    private val blogId = 100L
+    private val postId = 1000L
+    private var uiState: FollowCommentsState? = null
+    private var holder: SnackbarMessageHolder? = null
+
+    @Before
+    fun setup() {
+        followCommentsHandler = ReaderFollowCommentsHandler(readerCommentsFollowUseCase, TEST_DISPATCHER)
+    }
+
+    @Test
+    fun `handleFollowCommentsStatusRequest collects expected state`() = test {
+        val userMessage = UiStringText("handleFollowCommentsStatusRequest")
+        val state = FollowCommentsState.FollowStateChanged(
+                blogId = blogId,
+                postId = postId,
+                isFollowing = true,
+                isInit = false,
+                userMessage = userMessage
+        )
+
+        whenever(readerCommentsFollowUseCase.getMySubscriptionToPost(blogId, postId, false)).thenReturn(
+                flow { emit(state) }
+        )
+
+        setupObservers()
+
+        followCommentsHandler.handleFollowCommentsStatusRequest(blogId, postId, false)
+
+        requireNotNull(uiState).let {
+            assertThat(it).isEqualTo(state)
+        }
+
+        requireNotNull(holder).let {
+            assertThat(it.message).isEqualTo(userMessage)
+        }
+    }
+
+    @Test
+    fun `handleFollowCommentsClicked collects expected state`() = test {
+        val userMessage = UiStringText("handleFollowCommentsClicked")
+        val state = FollowCommentsState.FollowStateChanged(
+                blogId = blogId,
+                postId = postId,
+                isFollowing = true,
+                isInit = false,
+                userMessage = userMessage
+        )
+
+        whenever(readerCommentsFollowUseCase.setMySubscriptionToPost(blogId, postId, true)).thenReturn(
+                flow { emit(state) }
+        )
+
+        setupObservers()
+
+        followCommentsHandler.handleFollowCommentsClicked(blogId, postId, true)
+
+        requireNotNull(uiState).let {
+            assertThat(it).isEqualTo(state)
+        }
+
+        requireNotNull(holder).let {
+            assertThat(it.message).isEqualTo(userMessage)
+        }
+    }
+
+    private fun setupObservers() {
+        uiState = null
+
+        followCommentsHandler.followStatusUpdate.observeForever {
+            uiState = it
+        }
+
+        holder = null
+        followCommentsHandler.snackbarEvents.observeForever { event ->
+            event.applyIfNotHandled {
+                holder = this
+            }
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCaseTest.kt
@@ -74,7 +74,9 @@ class ReaderCommentsFollowUseCaseTest {
 
         val flow = followCommentsUseCase.getMySubscriptionToPost(blogId, postId, false)
 
-        assertThat(flow.toList()).isEqualTo(listOf(Loading, Failure(blogId, postId, UiStringRes(string.error_network_connection))))
+        assertThat(flow.toList()).isEqualTo(
+                listOf(Loading, Failure(blogId, postId, UiStringRes(string.error_network_connection)))
+        )
     }
 
     @Test
@@ -89,7 +91,8 @@ class ReaderCommentsFollowUseCaseTest {
     @Test
     fun `getMySubscriptionToPost emits expected state when can follow with success`() = test {
         whenever(postSubscribersApiCallsProvider.getCanFollowComments(anyLong())).thenReturn(true)
-        whenever(postSubscribersApiCallsProvider.getMySubscriptionToPost(anyLong(), anyLong())).thenReturn(PostSubscribersCallResult.Success(true))
+        whenever(postSubscribersApiCallsProvider.getMySubscriptionToPost(anyLong(), anyLong()))
+                .thenReturn(PostSubscribersCallResult.Success(true))
 
         val flow = followCommentsUseCase.getMySubscriptionToPost(blogId, postId, false)
 
@@ -126,12 +129,15 @@ class ReaderCommentsFollowUseCaseTest {
 
         val flow = followCommentsUseCase.setMySubscriptionToPost(blogId, postId, true)
 
-        assertThat(flow.toList()).isEqualTo(listOf(Loading, Failure(blogId, postId, UiStringRes(string.error_network_connection))))
+        assertThat(flow.toList()).isEqualTo(
+                listOf(Loading, Failure(blogId, postId, UiStringRes(string.error_network_connection)))
+        )
     }
 
     @Test
     fun `setMySubscriptionToPost emits expected state when subscribing with success`() = test {
-        whenever(postSubscribersApiCallsProvider.subscribeMeToPost(anyLong(), anyLong())).thenReturn(PostSubscribersCallResult.Success(true))
+        whenever(postSubscribersApiCallsProvider.subscribeMeToPost(anyLong(), anyLong()))
+                .thenReturn(PostSubscribersCallResult.Success(true))
 
         val flow = followCommentsUseCase.setMySubscriptionToPost(blogId, postId, true)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderCommentsFollowUseCaseTest.kt
@@ -1,0 +1,164 @@
+package org.wordpress.android.ui.reader.usecases
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.test
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.Failure
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FollowCommentsNotAllowed
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FollowStateChanged
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.Loading
+import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.UserNotAuthenticated
+import org.wordpress.android.ui.reader.utils.PostSubscribersApiCallsProvider
+import org.wordpress.android.ui.reader.utils.PostSubscribersApiCallsProvider.PostSubscribersCallResult
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+
+@InternalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class ReaderCommentsFollowUseCaseTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    @Mock private lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    @Mock private lateinit var postSubscribersApiCallsProvider: PostSubscribersApiCallsProvider
+    @Mock private lateinit var accountStore: AccountStore
+    @Mock private lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
+    @Mock private lateinit var readerPostTableWrapper: ReaderPostTableWrapper
+
+    private lateinit var followCommentsUseCase: ReaderCommentsFollowUseCase
+
+    private val blogId = 100L
+    private val postId = 1000L
+
+    @Before
+    fun setup() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+
+        followCommentsUseCase = ReaderCommentsFollowUseCase(
+                networkUtilsWrapper,
+                postSubscribersApiCallsProvider,
+                accountStore,
+                analyticsUtilsWrapper,
+                readerPostTableWrapper
+        )
+    }
+
+    @Test
+    fun `getMySubscriptionToPost emits expected state when user not logged in`() = test {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        val flow = followCommentsUseCase.getMySubscriptionToPost(blogId, postId, false)
+
+        assertThat(flow.toList()).isEqualTo(listOf(UserNotAuthenticated))
+    }
+
+    @Test
+    fun `getMySubscriptionToPost emits expected state when no network`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        val flow = followCommentsUseCase.getMySubscriptionToPost(blogId, postId, false)
+
+        assertThat(flow.toList()).isEqualTo(listOf(Loading, Failure(blogId, postId, UiStringRes(string.error_network_connection))))
+    }
+
+    @Test
+    fun `getMySubscriptionToPost emits expected state when cannot follow comments`() = test {
+        whenever(postSubscribersApiCallsProvider.getCanFollowComments(anyLong())).thenReturn(false)
+
+        val flow = followCommentsUseCase.getMySubscriptionToPost(blogId, postId, false)
+
+        assertThat(flow.toList()).isEqualTo(listOf(Loading, FollowCommentsNotAllowed))
+    }
+
+    @Test
+    fun `getMySubscriptionToPost emits expected state when can follow with success`() = test {
+        whenever(postSubscribersApiCallsProvider.getCanFollowComments(anyLong())).thenReturn(true)
+        whenever(postSubscribersApiCallsProvider.getMySubscriptionToPost(anyLong(), anyLong())).thenReturn(PostSubscribersCallResult.Success(true))
+
+        val flow = followCommentsUseCase.getMySubscriptionToPost(blogId, postId, false)
+
+        assertThat(flow.toList()).isEqualTo(listOf(
+                        Loading,
+                        FollowStateChanged(
+                            blogId,
+                            postId,
+                            true,
+                            false
+                        )
+        ))
+    }
+
+    @Test
+    fun `getMySubscriptionToPost emits expected state when can follow with failure`() = test {
+        val errorMessage = "There was an error"
+        val failure = PostSubscribersCallResult.Failure(errorMessage)
+
+        whenever(postSubscribersApiCallsProvider.getCanFollowComments(anyLong())).thenReturn(true)
+        whenever(postSubscribersApiCallsProvider.getMySubscriptionToPost(anyLong(), anyLong())).thenReturn(failure)
+
+        val flow = followCommentsUseCase.getMySubscriptionToPost(blogId, postId, false)
+
+        assertThat(flow.toList()).isEqualTo(listOf(
+                Loading,
+                Failure(blogId, postId, UiStringText(errorMessage))
+        ))
+    }
+
+    @Test
+    fun `setMySubscriptionToPost emits expected state when no network`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        val flow = followCommentsUseCase.setMySubscriptionToPost(blogId, postId, true)
+
+        assertThat(flow.toList()).isEqualTo(listOf(Loading, Failure(blogId, postId, UiStringRes(string.error_network_connection))))
+    }
+
+    @Test
+    fun `setMySubscriptionToPost emits expected state when subscribing with success`() = test {
+        whenever(postSubscribersApiCallsProvider.subscribeMeToPost(anyLong(), anyLong())).thenReturn(PostSubscribersCallResult.Success(true))
+
+        val flow = followCommentsUseCase.setMySubscriptionToPost(blogId, postId, true)
+
+        assertThat(flow.toList()).isEqualTo(listOf(
+                Loading,
+                FollowStateChanged(
+                        blogId,
+                        postId,
+                        true,
+                        false,
+                        UiStringRes(R.string.reader_follow_comments_subscribe_success)
+                )
+        ))
+    }
+
+    @Test
+    fun `setMySubscriptionToPost emits expected state when unsubscribing with failure`() = test {
+        val errorMessage = "There was an error"
+        val failure = PostSubscribersCallResult.Failure(errorMessage)
+
+        whenever(postSubscribersApiCallsProvider.unsubscribeMeFromPost(anyLong(), anyLong())).thenReturn(failure)
+
+        val flow = followCommentsUseCase.setMySubscriptionToPost(blogId, postId, false)
+
+        assertThat(flow.toList()).isEqualTo(listOf(
+                Loading,
+                Failure(blogId, postId, UiStringText(errorMessage))
+        ))
+    }
+}


### PR DESCRIPTION
This PR is related to #13473

It adds unit testing to cover the follow/unfollow comments feature.

While creating unit testing for `ReaderCommentsFollowUseCase` I had some issues mocking the `PostSubscribersApiCallsProvider` due to the continuation I was passing as a parameter to PostSubscribersApiCallsProvider functions (was trying to capture the continuation so to be able to resume but got all sorts of errors 😄 ). I ended up removing the `suspendCoroutine` from the ReaderCommentsFollowUseCase and making the PostSubscribersApiCallsProvider function suspend function wrapping a suspendCoroutine themselves. In this way the mocking issue can be avoided and moreover I actually find the overall code result cleaner 😄  !

### To test

- Check the tests pass in CI
- Since I moved the suspendCoroutine to PostSubscribersApiCallsProvider, smoke test the follow/unfollow comments feature (you can high level follow the instructions in #13473 if needed)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
