### PR TITLE
Suppress a lint false positive related to WordPress-Android-Utils

### DIFF
--- a/WordPress/lint-baseline.xml
+++ b/WordPress/lint-baseline.xml
@@ -4060,4 +4060,20 @@
             column="28"/>
     </issue>
 
+    <issue
+        id="ResourceType"
+        severity="Error"
+        message="Expected a color resource id (`R.color.`) but received an RGB integer"
+        category="Correctness"
+        priority="7"
+        summary="Wrong Resource Type"
+        explanation="Ensures that resource id&apos;s passed to APIs are of the right type; for example, calling `Resources.getColor(R.string.name)` is wrong."
+        errorLine1="        return new SwipeToRefreshHelper(swipeRefreshLayout, listener, backgroundColor, primaryProgressColor,"
+        errorLine2="                                                                      ~~~~~~~~~~~~~~~">
+        <location
+            file="../WordPress/src/main/java/org/wordpress/android/util/WPSwipeToRefreshHelper.java"
+            line="33"
+            column="71"/>
+    </issue>
+
 </issues>


### PR DESCRIPTION
After having merged https://github.com/wordpress-mobile/WordPress-Android/pull/13466, we have started to experience random lint failures on CI.

After some more analysis, it still seems a false positive to me: 
- It looks like the failure is raised the first time a new commit is built and gets resolved by building a second time. 
- the error itself says that `SwipeToRefreshHelper` expects a resource id, but [looking at the code](https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/a15474122f61bce40117ad1fc9cd90458232b75a/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java#L53), it doesn't seem to be the case. 

**To Test:**
1. Double check the code to make sure I'm not blind and missing an actual error. 
2. Verify that CI is green. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
