### PR TITLE
Targeting the correct WPUtils lib version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
     ext.buildGutenbergMobileJSBundle = 1
-    ext.wordPressUtilsVersion = '55-50744cbfda553ad7b754a20dc58ed2740821b290'
+    ext.wordPressUtilsVersion = '1.30.1-beta.2'
 
     repositories {
         google()


### PR DESCRIPTION
This PR is a follow up to #13515 and points the WPUtils lib version to the correct `1.30.1-beta.2` instead of the temporary SHA `55-50744cbfda553ad7b754a20dc58ed2740821b290`.

## To test
Should be enough to check the CI completes correctly.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
