### PR TITLE
Removing reference to removed string resource from Screenshot tests

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -24,7 +24,6 @@ import org.wordpress.android.util.image.ImageType;
 
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 import static org.wordpress.android.support.WPSupportUtils.clickOnViewWithTag;
-import static org.wordpress.android.support.WPSupportUtils.dialogExistsWithTitle;
 import static org.wordpress.android.support.WPSupportUtils.getCurrentActivity;
 import static org.wordpress.android.support.WPSupportUtils.getTranslatedString;
 import static org.wordpress.android.support.WPSupportUtils.idleFor;
@@ -38,7 +37,6 @@ import static org.wordpress.android.support.WPSupportUtils.swipeDownOnView;
 import static org.wordpress.android.support.WPSupportUtils.swipeLeftOnViewPager;
 import static org.wordpress.android.support.WPSupportUtils.swipeRightOnViewPager;
 import static org.wordpress.android.support.WPSupportUtils.swipeUpOnView;
-import static org.wordpress.android.support.WPSupportUtils.tapButtonInDialogWithTitle;
 import static org.wordpress.android.support.WPSupportUtils.waitForAtLeastOneElementWithIdToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
@@ -116,11 +114,6 @@ public class WPScreenshotTest extends BaseTest {
 
         PostsListPage.scrollToTop();
         PostsListPage.tapPostWithName(name);
-
-        if (dialogExistsWithTitle(getTranslatedString(R.string.dialog_gutenberg_informative_title))) {
-            tapButtonInDialogWithTitle(getTranslatedString(R.string.dialog_button_ok));
-        }
-
 
         waitForElementToBeDisplayed(R.id.editor_activity);
 


### PR DESCRIPTION
Fixes a breakage that I introduced into the screenshot tests when [I removed the block editor popup](https://github.com/wordpress-mobile/WordPress-Android/pull/13593).

To test:

Confirm that you can successfully run the `WordPress:assembleVanillaDebugAndroidTest` task. Since the PR with this breakage was green when I merged it, it seems this isn't run as part of the PR's checks by CI.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
