### PR TITLE
Issue/13268 filters 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -208,15 +208,15 @@ class ActivityLogListFragment : Fragment() {
 
     private fun updateFilters(uiState: FiltersShown) {
         with(requireActivity().date_range_picker) {
-            this.text = uiHelpers.getTextOfUiString(requireContext(), uiState.dateRangeLabel)
-            this.isCloseIconVisible = uiState.clearDateRangeFilterClicked != null
-            this.setOnCloseIconClickListener { uiState.clearDateRangeFilterClicked?.invoke() }
+            text = uiHelpers.getTextOfUiString(requireContext(), uiState.dateRangeLabel)
+            isCloseIconVisible = uiState.clearDateRangeFilterClicked != null
+            setOnCloseIconClickListener { uiState.clearDateRangeFilterClicked?.invoke() }
         }
 
         with(requireActivity().activity_type_filter) {
-            this.text = uiHelpers.getTextOfUiString(requireContext(), uiState.activityTypeLabel)
-            this.isCloseIconVisible = uiState.clearActivityTypeFilterClicked != null
-            this.setOnCloseIconClickListener { uiState.clearActivityTypeFilterClicked?.invoke() }
+            text = uiHelpers.getTextOfUiString(requireContext(), uiState.activityTypeLabel)
+            isCloseIconVisible = uiState.clearActivityTypeFilterClicked != null
+            setOnCloseIconClickListener { uiState.clearActivityTypeFilterClicked?.invoke() }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -209,14 +209,14 @@ class ActivityLogListFragment : Fragment() {
     private fun updateFilters(uiState: FiltersShown) {
         with(requireActivity().date_range_picker) {
             text = uiHelpers.getTextOfUiString(requireContext(), uiState.dateRangeLabel)
-            isCloseIconVisible = uiState.clearDateRangeFilterClicked != null
-            setOnCloseIconClickListener { uiState.clearDateRangeFilterClicked?.invoke() }
+            isCloseIconVisible = uiState.onClearDateRangeFilterClicked != null
+            setOnCloseIconClickListener { uiState.onClearDateRangeFilterClicked?.invoke() }
         }
 
         with(requireActivity().activity_type_filter) {
             text = uiHelpers.getTextOfUiString(requireContext(), uiState.activityTypeLabel)
-            isCloseIconVisible = uiState.clearActivityTypeFilterClicked != null
-            setOnCloseIconClickListener { uiState.clearActivityTypeFilterClicked?.invoke() }
+            isCloseIconVisible = uiState.onClearActivityTypeFilterClicked != null
+            setOnCloseIconClickListener { uiState.onClearActivityTypeFilterClicked?.invoke() }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -137,6 +137,14 @@ class ActivityLogListFragment : Fragment() {
                         requireContext(),
                         uiState.activityTypeLabel
                 )
+
+                requireActivity().date_range_picker.isCloseIconVisible = uiState.clearDateRangeFilterClicked != null
+                requireActivity().date_range_picker
+                        .setOnCloseIconClickListener { uiState.clearDateRangeFilterClicked?.invoke() }
+
+                requireActivity().activity_type_filter.isCloseIconVisible = uiState.clearActivityTypeFilterClicked != null
+                requireActivity().activity_type_filter
+                        .setOnCloseIconClickListener { uiState.clearActivityTypeFilterClicked?.invoke() }
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -128,24 +128,7 @@ class ActivityLogListFragment : Fragment() {
         viewModel.filtersUiState.observe(viewLifecycleOwner, { uiState ->
             uiHelpers.updateVisibility(requireActivity().filters_bar, uiState.visibility)
             uiHelpers.updateVisibility(requireActivity().filters_bar_divider, uiState.visibility)
-            if (uiState is FiltersShown) {
-                requireActivity().date_range_picker.text = uiHelpers.getTextOfUiString(
-                        requireContext(),
-                        uiState.dateRangeLabel
-                )
-                requireActivity().activity_type_filter.text = uiHelpers.getTextOfUiString(
-                        requireContext(),
-                        uiState.activityTypeLabel
-                )
-
-                requireActivity().date_range_picker.isCloseIconVisible = uiState.clearDateRangeFilterClicked != null
-                requireActivity().date_range_picker
-                        .setOnCloseIconClickListener { uiState.clearDateRangeFilterClicked?.invoke() }
-
-                requireActivity().activity_type_filter.isCloseIconVisible = uiState.clearActivityTypeFilterClicked != null
-                requireActivity().activity_type_filter
-                        .setOnCloseIconClickListener { uiState.clearActivityTypeFilterClicked?.invoke() }
-            }
+            if (uiState is FiltersShown) { updateFilters(uiState) }
         })
 
         viewModel.showActivityTypeFilterDialog.observe(viewLifecycleOwner, { event ->
@@ -221,6 +204,20 @@ class ActivityLogListFragment : Fragment() {
     private fun showActivityTypeFilterDialog(remoteSiteId: RemoteId, initialSelection: List<Int>) {
         ActivityLogTypeFilterFragment.newInstance(remoteSiteId, initialSelection)
                 .show(childFragmentManager, ACTIVITY_TYPE_FILTER_TAG)
+    }
+
+    private fun updateFilters(uiState: FiltersShown) {
+        with(requireActivity().date_range_picker) {
+            this.text = uiHelpers.getTextOfUiString(requireContext(), uiState.dateRangeLabel)
+            this.isCloseIconVisible = uiState.clearDateRangeFilterClicked != null
+            this.setOnCloseIconClickListener { uiState.clearDateRangeFilterClicked?.invoke() }
+        }
+
+        with(requireActivity().activity_type_filter) {
+            this.text = uiHelpers.getTextOfUiString(requireContext(), uiState.activityTypeLabel)
+            this.isCloseIconVisible = uiState.clearActivityTypeFilterClicked != null
+            this.setOnCloseIconClickListener { uiState.clearActivityTypeFilterClicked?.invoke() }
+        }
     }
 
     private fun refreshProgressBars(eventListStatus: ActivityLogViewModel.ActivityLogListStatus?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
@@ -52,7 +52,6 @@ class DateUtils @Inject constructor(
     fun formatDateRange(from: Long, to: Long): String =
             DateUtils.formatDateRange(contextProvider.getContext(), from, to, DateUtils.FORMAT_ABBREV_MONTH)
 
-
     private fun getDateTimeFlags(): Int {
         var flags = 0
         flags = flags or DateUtils.FORMAT_SHOW_DATE

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
@@ -49,9 +49,9 @@ class DateUtils @Inject constructor(
         )
     }
 
-    fun formatDateRange(from: Long, to: Long): String {
-        return DateUtils.formatDateRange(contextProvider.getContext(), from, to, DateUtils.FORMAT_ABBREV_MONTH)
-    }
+    fun formatDateRange(from: Long, to: Long): String =
+            DateUtils.formatDateRange(contextProvider.getContext(), from, to, DateUtils.FORMAT_ABBREV_MONTH)
+
 
     private fun getDateTimeFlags(): Int {
         var flags = 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
@@ -49,6 +49,10 @@ class DateUtils @Inject constructor(
         )
     }
 
+    fun formatDateRange(from: Long, to: Long): String {
+        return DateUtils.formatDateRange(contextProvider.getContext(), from, to, DateUtils.FORMAT_ABBREV_MONTH)
+    }
+
     private fun getDateTimeFlags(): Int {
         var flags = 0
         flags = flags or DateUtils.FORMAT_SHOW_DATE

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -176,7 +176,7 @@ class ActivityLogViewModel @Inject constructor(
                     createDateRangeFilterLabel(),
                     UiStringRes(R.string.activity_log_activity_type_filter_label),
                     currentDateRangeFilter?.let { ::onClearDateRangeFilterClicked },
-                    currentActivityTypeFilter?.let { ::onClearActivityTypeFilterClicked }
+                    currentActivityTypeFilter.takeIf { it.isNotEmpty() }?.let { ::onClearActivityTypeFilterClicked }
             )
         } else {
             FiltersHidden
@@ -248,11 +248,12 @@ class ActivityLogViewModel @Inject constructor(
 
     fun onActivityTypesSelected(activityTypeIds: List<Int>) {
         currentActivityTypeFilter = activityTypeIds
+        refreshFiltersUiState()
         // TODO malinjir: refetch/load data
     }
 
     fun onClearActivityTypeFilterClicked() {
-        currentDateRangeFilter = null
+        currentActivityTypeFilter = listOf()
         refreshFiltersUiState()
         // TODO malinjir: refetch/load data
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -26,8 +26,10 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAc
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.RESTORE
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService.RewindProgress
+import org.wordpress.android.ui.stats.refresh.utils.DateUtils
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BackupFeatureConfig
 import org.wordpress.android.util.config.ActivityLogFiltersFeatureConfig
@@ -50,6 +52,7 @@ class ActivityLogViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val activityLogFiltersFeatureConfig: ActivityLogFiltersFeatureConfig,
     private val backupFeatureConfig: BackupFeatureConfig,
+    private val dateUtils: DateUtils,
     @param:Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(uiDispatcher) {
     enum class ActivityLogListStatus {
@@ -170,12 +173,20 @@ class ActivityLogViewModel @Inject constructor(
     private fun refreshFiltersUiState() {
         _filtersUiState.value = if (activityLogFiltersFeatureConfig.isEnabled()) {
             FiltersShown(
-                    UiStringRes(R.string.activity_log_date_range_filter_label),
+                    createDateRangeFilterLabel(),
                     UiStringRes(R.string.activity_log_activity_type_filter_label)
             )
         } else {
             FiltersHidden
         }
+    }
+
+    private fun createDateRangeFilterLabel(): UiString {
+        currentDateRangeFilter?.let {
+            return UiStringText(dateUtils.formatDateRange(requireNotNull(it.first), requireNotNull(it.second)))
+        }
+
+        return UiStringRes(R.string.activity_log_date_range_filter_label);
     }
 
     fun onPullToRefresh() {
@@ -219,6 +230,7 @@ class ActivityLogViewModel @Inject constructor(
 
     fun onDateRangeSelected(dateRange: DateRange?) {
         currentDateRangeFilter = dateRange
+        refreshFiltersUiState()
         // TODO malinjir: refetch/load data
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -434,8 +434,8 @@ class ActivityLogViewModel @Inject constructor(
         data class FiltersShown(
             val dateRangeLabel: UiString,
             val activityTypeLabel: UiString,
-            val clearDateRangeFilterClicked: (() -> Unit)?,
-            val clearActivityTypeFilterClicked: (() -> Unit)?
+            val onClearDateRangeFilterClicked: (() -> Unit)?,
+            val onClearActivityTypeFilterClicked: (() -> Unit)?
         ) : FiltersUiState(visibility = true)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.jetpack.rewind.RewindStatusService.RewindProgres
 import org.wordpress.android.ui.stats.refresh.utils.DateUtils
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BackupFeatureConfig
@@ -174,7 +175,7 @@ class ActivityLogViewModel @Inject constructor(
         _filtersUiState.value = if (activityLogFiltersFeatureConfig.isEnabled()) {
             FiltersShown(
                     createDateRangeFilterLabel(),
-                    UiStringRes(R.string.activity_log_activity_type_filter_label),
+                    createActivityTypeFilterLabel(),
                     currentDateRangeFilter?.let { ::onClearDateRangeFilterClicked },
                     currentActivityTypeFilter.takeIf { it.isNotEmpty() }?.let { ::onClearActivityTypeFilterClicked }
             )
@@ -184,11 +185,23 @@ class ActivityLogViewModel @Inject constructor(
     }
 
     private fun createDateRangeFilterLabel(): UiString {
-        currentDateRangeFilter?.let {
-            return UiStringText(dateUtils.formatDateRange(requireNotNull(it.first), requireNotNull(it.second)))
-        }
+        return currentDateRangeFilter?.let {
+            UiStringText(dateUtils.formatDateRange(requireNotNull(it.first), requireNotNull(it.second)))
+        } ?: UiStringRes(R.string.activity_log_date_range_filter_label)
+    }
 
-        return UiStringRes(R.string.activity_log_date_range_filter_label)
+    private fun createActivityTypeFilterLabel(): UiString {
+        return currentActivityTypeFilter.takeIf { it.isNotEmpty() }?.let {
+             if (it.size == 1) {
+                // TODO malinjir replace it[0] with translated name of the activity type
+                UiStringText("${it[0]}")
+            } else {
+                UiStringResWithParams(
+                        R.string.activity_log_activity_type_filter_active_label,
+                        listOf(UiStringText("${it.size}"))
+                )
+            }
+        } ?: UiStringRes(R.string.activity_log_activity_type_filter_label)
     }
 
     fun onPullToRefresh() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -192,7 +192,7 @@ class ActivityLogViewModel @Inject constructor(
 
     private fun createActivityTypeFilterLabel(): UiString {
         return currentActivityTypeFilter.takeIf { it.isNotEmpty() }?.let {
-             if (it.size == 1) {
+            if (it.size == 1) {
                 // TODO malinjir replace it[0] with translated name of the activity type
                 UiStringText("${it[0]}")
             } else {

--- a/WordPress/src/main/res/layout/activity_log_list_activity.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_activity.xml
@@ -29,6 +29,7 @@
             android:scrollIndicators="none"
             android:visibility="gone"
             app:layout_scrollFlags="noScroll"
+            android:scrollbars="none"
             tools:targetApi="m">
 
             <LinearLayout

--- a/WordPress/src/main/res/layout/activity_log_list_activity.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_activity.xml
@@ -70,7 +70,7 @@
             android:id="@+id/filters_bar_divider"
             android:layout_width="match_parent"
             android:layout_height="@dimen/divider_size"
-            android:background="@color/divider"
+            android:background="?attr/wpColorSurfaceSecondary"
             android:visibility="gone" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1031,6 +1031,7 @@
     <string name="activity_log_activity_type_filter_clear">Clear</string>
     <string name="activity_log_date_range_filter_label">Date range</string>
     <string name="activity_log_activity_type_filter_label">Activity type</string>
+    <string name="activity_log_activity_type_filter_active_label">Activity type (%s)</string>
     <!-- activity log list popup menu -->
     <string name="activity_log_item_menu_restore_label">Restore to this point</string>
     <string name="activity_log_item_menu_download_backup_label">Download backup</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1029,9 +1029,9 @@
     <string name="activity_log_activity_type_filter_header">Filter by Activity Type</string>
     <string name="activity_log_activity_type_filter_apply">Apply</string>
     <string name="activity_log_activity_type_filter_clear">Clear</string>
-    <string name="activity_log_date_range_filter_label">Date range</string>
-    <string name="activity_log_activity_type_filter_label">Activity type</string>
-    <string name="activity_log_activity_type_filter_active_label">Activity type (%s)</string>
+    <string name="activity_log_date_range_filter_label">Date Range</string>
+    <string name="activity_log_activity_type_filter_label">Activity Type</string>
+    <string name="activity_log_activity_type_filter_active_label">Activity Type (%s)</string>
     <!-- activity log list popup menu -->
     <string name="activity_log_item_menu_restore_label">Restore to this point</string>
     <string name="activity_log_item_menu_download_backup_label">Download backup</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -420,7 +420,7 @@ class ActivityLogViewModelTest {
 
         viewModel.onDateRangeSelected(dateRange)
 
-        val action = (viewModel.filtersUiState.value as FiltersShown).clearDateRangeFilterClicked
+        val action = (viewModel.filtersUiState.value as FiltersShown).onClearDateRangeFilterClicked
         Assertions.assertThat(action != null).isTrue
     }
 
@@ -429,7 +429,7 @@ class ActivityLogViewModelTest {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         viewModel.onDateRangeSelected(null)
 
-        val action = (viewModel.filtersUiState.value as FiltersShown).clearDateRangeFilterClicked
+        val action = (viewModel.filtersUiState.value as FiltersShown).onClearDateRangeFilterClicked
         Assertions.assertThat(action == null).isTrue
     }
 
@@ -439,9 +439,9 @@ class ActivityLogViewModelTest {
         whenever(dateUtils.formatDateRange(10L, 20L)).thenReturn("TEST")
         viewModel.onDateRangeSelected(Pair(10L, 20L))
 
-        (viewModel.filtersUiState.value as FiltersShown).clearDateRangeFilterClicked!!.invoke()
+        (viewModel.filtersUiState.value as FiltersShown).onClearDateRangeFilterClicked!!.invoke()
 
-        val action = (viewModel.filtersUiState.value as FiltersShown).clearDateRangeFilterClicked
+        val action = (viewModel.filtersUiState.value as FiltersShown).onClearDateRangeFilterClicked
         Assertions.assertThat(action == null).isTrue
     }
 
@@ -471,7 +471,7 @@ class ActivityLogViewModelTest {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         viewModel.onActivityTypesSelected(listOf(1))
 
-        val action = (viewModel.filtersUiState.value as FiltersShown).clearActivityTypeFilterClicked
+        val action = (viewModel.filtersUiState.value as FiltersShown).onClearActivityTypeFilterClicked
         Assertions.assertThat(action != null).isTrue
     }
 
@@ -480,7 +480,7 @@ class ActivityLogViewModelTest {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         viewModel.onActivityTypesSelected(listOf())
 
-        val action = (viewModel.filtersUiState.value as FiltersShown).clearActivityTypeFilterClicked
+        val action = (viewModel.filtersUiState.value as FiltersShown).onClearActivityTypeFilterClicked
         Assertions.assertThat(action == null).isTrue
     }
 
@@ -489,9 +489,9 @@ class ActivityLogViewModelTest {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         viewModel.onActivityTypesSelected(listOf(1))
 
-        (viewModel.filtersUiState.value as FiltersShown).clearActivityTypeFilterClicked!!.invoke()
+        (viewModel.filtersUiState.value as FiltersShown).onClearActivityTypeFilterClicked!!.invoke()
 
-        val action = (viewModel.filtersUiState.value as FiltersShown).clearActivityTypeFilterClicked
+        val action = (viewModel.filtersUiState.value as FiltersShown).onClearActivityTypeFilterClicked
         Assertions.assertThat(action == null).isTrue
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.viewmodel.activitylog
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.core.util.Pair
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.any
@@ -24,6 +25,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_ACTIVITIES
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
@@ -46,10 +48,15 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Icon.DEFAUL
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Loading
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.RESTORE
+import org.wordpress.android.ui.stats.refresh.utils.DateUtils
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.BackupFeatureConfig
 import org.wordpress.android.util.config.ActivityLogFiltersFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus
+import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.FiltersUiState.FiltersShown
 import java.util.Calendar
 import java.util.Date
 
@@ -62,6 +69,7 @@ class ActivityLogViewModelTest {
     @Mock private lateinit var resourceProvider: ResourceProvider
     @Mock private lateinit var activityLogFiltersFeatureConfig: ActivityLogFiltersFeatureConfig
     @Mock private lateinit var backupFeatureConfig: BackupFeatureConfig
+    @Mock private lateinit var dateUtils: DateUtils
     private lateinit var fetchActivityLogCaptor: KArgumentCaptor<FetchActivityLogPayload>
 
     private var events: MutableList<List<ActivityLogListItem>?> = mutableListOf()
@@ -121,6 +129,7 @@ class ActivityLogViewModelTest {
                 resourceProvider,
                 activityLogFiltersFeatureConfig,
                 backupFeatureConfig,
+                dateUtils,
                 Dispatchers.Unconfined
         )
         viewModel.site = site
@@ -402,6 +411,122 @@ class ActivityLogViewModelTest {
 
         Assertions.assertThat(navigationEvents.last().peekContent()).isInstanceOf(ShowBackupDownload::class.java)
     }
+
+    @Test
+    fun dateRangeFilterClearActionShownWhenFilterNotEmpty() {
+        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(dateUtils.formatDateRange(10L, 20L)).thenReturn("TEST")
+        val dateRange = Pair(10L, 20L)
+
+        viewModel.onDateRangeSelected(dateRange)
+
+        val action = (viewModel.filtersUiState.value as FiltersShown).clearDateRangeFilterClicked
+        Assertions.assertThat(action != null).isTrue
+    }
+
+    @Test
+    fun dateRangeFilterClearActionHiddenWhenFilterEmpty() {
+        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
+        viewModel.onDateRangeSelected(null)
+
+        val action = (viewModel.filtersUiState.value as FiltersShown).clearDateRangeFilterClicked
+        Assertions.assertThat(action == null).isTrue
+    }
+
+    @Test
+    fun onDateRangeFilterClearActionClickClearActionDisappears() {
+        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(dateUtils.formatDateRange(10L, 20L)).thenReturn("TEST")
+        viewModel.onDateRangeSelected(Pair(10L, 20L))
+
+        (viewModel.filtersUiState.value as FiltersShown).clearDateRangeFilterClicked!!.invoke()
+
+        val action = (viewModel.filtersUiState.value as FiltersShown).clearDateRangeFilterClicked
+        Assertions.assertThat(action == null).isTrue
+    }
+
+    @Test
+    fun basicDateRangeLabelShownWhenFilterEmpty() {
+        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
+
+        viewModel.onDateRangeSelected(null)
+
+        Assertions.assertThat((viewModel.filtersUiState.value as FiltersShown).dateRangeLabel)
+                .isEqualTo(UiStringRes(R.string.activity_log_date_range_filter_label))
+    }
+
+    @Test
+    fun dateRangeLabelWithDatesShownWhenFilterNotEmpty() {
+        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(dateUtils.formatDateRange(10L, 20L)).thenReturn("TEST")
+
+        viewModel.onDateRangeSelected(Pair(10L, 20L))
+
+        Assertions.assertThat((viewModel.filtersUiState.value as FiltersShown).dateRangeLabel)
+                .isEqualTo(UiStringText("TEST"))
+    }
+
+    @Test
+    fun activityTypeFilterClearActionShownWhenFilterNotEmpty() {
+        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
+        viewModel.onActivityTypesSelected(listOf(1))
+
+        val action = (viewModel.filtersUiState.value as FiltersShown).clearActivityTypeFilterClicked
+        Assertions.assertThat(action != null).isTrue
+    }
+
+    @Test
+    fun activityTypeFilterClearActionHiddenWhenFilterEmpty() {
+        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
+        viewModel.onActivityTypesSelected(listOf())
+
+        val action = (viewModel.filtersUiState.value as FiltersShown).clearActivityTypeFilterClicked
+        Assertions.assertThat(action == null).isTrue
+    }
+
+    @Test
+    fun onActivityTypeFilterClearActionClickClearActionDisappears() {
+        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
+        viewModel.onActivityTypesSelected(listOf(1))
+
+        (viewModel.filtersUiState.value as FiltersShown).clearActivityTypeFilterClicked!!.invoke()
+
+        val action = (viewModel.filtersUiState.value as FiltersShown).clearActivityTypeFilterClicked
+        Assertions.assertThat(action == null).isTrue
+    }
+
+    @Test
+    fun basicActivityTypeLabelShownWhenFilterEmpty() {
+        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
+        viewModel.onActivityTypesSelected(listOf())
+
+        Assertions.assertThat((viewModel.filtersUiState.value as FiltersShown).activityTypeLabel)
+                .isEqualTo(UiStringRes(R.string.activity_log_activity_type_filter_label))
+    }
+
+    @Test
+    fun activityTypeLabelWithNameShownWhenFilterHasOneItem() {
+        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
+        viewModel.onActivityTypesSelected(listOf(1))
+
+        Assertions.assertThat((viewModel.filtersUiState.value as FiltersShown).activityTypeLabel)
+                .isEqualTo(UiStringText("1"))
+    }
+
+    @Test
+    fun activityTypeLabelWithCountShownWhenFilterHasMoreThanOneItem() {
+        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
+        viewModel.onActivityTypesSelected(listOf(1,2))
+
+        Assertions.assertThat((viewModel.filtersUiState.value as FiltersShown).activityTypeLabel)
+                .isEqualTo(
+                        UiStringResWithParams(
+                                R.string.activity_log_activity_type_filter_active_label,
+                                listOf(UiStringText("2")))
+                )
+    }
+
+
 
     private suspend fun assertFetchEvents(canLoadMore: Boolean = false) {
         verify(store).fetchActivities(fetchActivityLogCaptor.capture())

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -516,17 +516,16 @@ class ActivityLogViewModelTest {
     @Test
     fun activityTypeLabelWithCountShownWhenFilterHasMoreThanOneItem() {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
-        viewModel.onActivityTypesSelected(listOf(1,2))
+        viewModel.onActivityTypesSelected(listOf(1, 2))
 
         Assertions.assertThat((viewModel.filtersUiState.value as FiltersShown).activityTypeLabel)
                 .isEqualTo(
                         UiStringResWithParams(
                                 R.string.activity_log_activity_type_filter_active_label,
-                                listOf(UiStringText("2")))
+                                listOf(UiStringText("2"))
+                        )
                 )
     }
-
-
 
     private suspend fun assertFetchEvents(canLoadMore: Boolean = false) {
         verify(store).fetchActivities(fetchActivityLogCaptor.capture())


### PR DESCRIPTION
Parent #13268

This PR
- implements cancel actions for both activity log filters
- updates filter labels based on selected filters
      - "Activity Type" when the filter is empty
      - "Activity Type (N)" when there is more than 1 activity selected
      - "[ActivityName]" when there is exactly 1 activity selected (this is implemented just partially, activity type id is used as name)
      -  "Date Range" when filter is empty
      - "Nov 14 - 17" when both selected dates are within one month
      - "Nov 14 - Dec 18" when dates are not within one month
      - "Nov 15, 2020 - Jan 1, 2021" when dates are not within on year
      

<img width="1135" alt="Screenshot 2020-12-16 at 14 12 30" src="https://user-images.githubusercontent.com/2261188/102352976-cbbaba80-3fa8-11eb-9b0f-e77696012b19.png">



Notes:
- The actual filtering is not implemented yet
- @osullivanchris All design feedback related to the filter bar is welcome (including scrolling behavior)

To test:
- Verify that all the states mentioned above work as expected
- Verify both clear actions work as expected

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
