### PR TITLE
Fix gradle substitution for WPUtils

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -85,7 +85,7 @@ if (localBuilds.exists()) {
         includeBuild(ext.localWPUtilsPath) {
             dependencySubstitution {
                 println "Substituting wputils with the local build"
-                substitute module("$gradle.ext.wputilsBinaryPath:WordPressUtils") with project(':WordPressUtils')
+                substitute module("$gradle.ext.wputilsBinaryPath") with project(':WordPressUtils')
             }
         }
     }


### PR DESCRIPTION
`Gradle substitution` for WordPressUtils-Android doesn't work currently because the substitution path is not the expected one. 

This PR: 
- updates the substitution path.
- suppresses some lint errors which seems to be false positives. 

**Background**
Gradle substitution for WPUtils was introduced as a part of [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13466). 
The first version of the PR had the same changes to `lint-baseline.xml` that this new PR is adding, but since suppressing that many errors didn't look good, we looked for other solutions. Eventually, it looked like updating the substitution path fixed the lint errors, so the PR was merged that way. 
After further investigation though, it turned out that the new path is not right and the lint errors disappeared because the substitution didn't work anymore. The thing that fouled us is that `gradle` doesn't raise an error if a inexistent path is added (I guess it just adds the entry to a LUT that it uses later when resolving the dependencies), so the build finished successfully even if the substitution didn't work. 

I'm proposing this PR to re-enable `gradle substitution` to unblock developers who need to work on WPUtils and investigate and try to fix the root cause of the lint errors in a subsequent one. 

**About the lint errors** 
I've checked again the reported lint errors that this PR suppresses and they look false positives to me. The missing class are actually there and building the app and running it works. Also, there's no error when importing the same code as a binary dependency.

I would really appreciate if you can took another look as well anyway.

**To test:**
- Copy local-builds.gradle-example as local-builds.gradle and update localWPUtilsPath to your liking.
- Use Navigate Class shortcut to open UrlUtils which is in WPUtils and add a new static method such as a summation.
- Use Navigate Class shortcut to open ReaderPostLogic (any other class would be fine) which is in WPAndroid and use that function.
- Run the project and verify that it works 🎉.
- Run `gradlew lintVanillaRelease` and verify that it succeeds. 
- Comment out localWPUtilsPath in local-builds.gradle file and verify that the build fails for missing the new method from UrlUtils.
- Discard the changes for ReaderPostLogic, build the app and verify that it works.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
