### PR TITLE
Issue/13329 backup toolbar state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/BackupDownloadActivity.kt
@@ -68,10 +68,11 @@ class BackupDownloadActivity : LocaleAwareActivity() {
             }
         })
 
-        viewModel.screenTitleObservable.observe(this, { title ->
-            supportActionBar?.title = getString(title)
+        viewModel.toolbarStateObservable.observe(this, { state ->
+            supportActionBar?.title = getString(state.title)
+            supportActionBar?.setHomeAsUpIndicator(state.icon)
             // Change the activity title for accessibility purposes
-            this.title = getString(title)
+            this.title = getString(state.title)
         })
 
         // Canceled, Running, Complete -> (Running = kick off status)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/BackupDownloadViewModel.kt
@@ -3,12 +3,14 @@ package org.wordpress.android.ui.jetpack.backup
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import kotlinx.android.parcel.Parcelize
+import org.wordpress.android.R
 import org.wordpress.android.ui.jetpack.backup.BackupDownloadStep.COMPLETE
 import org.wordpress.android.ui.jetpack.backup.BackupDownloadStep.DETAILS
 import org.wordpress.android.ui.jetpack.backup.BackupDownloadStep.PROGRESS
@@ -54,8 +56,8 @@ class BackupDownloadViewModel @Inject constructor(
     private val _wizardFinishedObservable = MutableLiveData<Event<BackupDownloadWizardState>>()
     val wizardFinishedObservable: LiveData<Event<BackupDownloadWizardState>> = _wizardFinishedObservable
 
-    private val _screenTitleObservable = SingleLiveEvent<@StringRes Int>()
-    val screenTitleObservable: LiveData<Int> = _screenTitleObservable
+    private val _toolbarStateObservable = MutableLiveData<ToolbarState>()
+    val toolbarStateObservable: LiveData<ToolbarState> = _toolbarStateObservable
 
     private val _exitFlowObservable = MutableLiveData<Event<Unit>>()
     val exitFlowObservable: LiveData<Event<Unit>> = _exitFlowObservable
@@ -107,8 +109,8 @@ class BackupDownloadViewModel @Inject constructor(
         _exitFlowObservable.value = Event(Unit)
     }
 
-    fun setTitle(@StringRes title: Int) {
-        _screenTitleObservable.value = title
+    fun setToolbarState(toolbarState: ToolbarState) {
+        _toolbarStateObservable.value = toolbarState
     }
 
     sealed class BackupDownloadWizardState : Parcelable {
@@ -120,5 +122,15 @@ class BackupDownloadViewModel @Inject constructor(
 
         @Parcelize
         data class BackupDownloadCompleted(val activityId: String) : BackupDownloadWizardState()
+    }
+
+    sealed class ToolbarState {
+        abstract val title: Int
+        abstract val icon: Int
+
+        data class DetailsToolbarState(
+            @StringRes override val title: Int = R.string.backup_download_details_page_title,
+            @DrawableRes override val icon: Int = R.drawable.ic_arrow_back
+        ) : ToolbarState()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/BackupDownloadViewModel.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.util.wizard.WizardNavigationTarget
 import org.wordpress.android.util.wizard.WizardState
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.SingleEventObservable
-import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 
 const val KEY_BACKUP_DOWNLOAD_ACTIVITY_ID_KEY = "key_backup_download_activity_id_key"

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/details/BackupDownloadDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/details/BackupDownloadDetailsFragment.kt
@@ -12,6 +12,7 @@ import kotlinx.android.synthetic.main.backup_download_details_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.jetpack.backup.BackupDownloadViewModel
+import org.wordpress.android.ui.jetpack.backup.BackupDownloadViewModel.ToolbarState.DetailsToolbarState
 import org.wordpress.android.ui.jetpack.backup.details.BackupDownloadDetailsViewModel.UiState.Error
 import org.wordpress.android.ui.jetpack.backup.details.BackupDownloadDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.backup.details.BackupDownloadDetailsViewModel.UiState.Loading
@@ -66,7 +67,7 @@ class BackupDownloadDetailsFragment : Fragment() {
             }
         })
 
-        parentViewModel.setTitle(R.string.backup_download_details_page_title)
+        parentViewModel.setToolbarState(DetailsToolbarState())
         viewModel.start()
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/BackupDownloadViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/BackupDownloadViewModelTest.kt
@@ -1,12 +1,14 @@
 package org.wordpress.android.ui.jetpack.backup
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.jetpack.backup.BackupDownloadViewModel.ToolbarState
 import org.wordpress.android.util.wizard.WizardManager
 
 @RunWith(MockitoJUnitRunner::class)
@@ -24,6 +26,21 @@ class BackupDownloadViewModelTest {
     }
 
     @Test
-    fun `sample test`() {
-    } // TODO:
+    fun `when viewModel starts, toolbarState contains no entries`() {
+        val toolbarStates = initObservers().toolbarState
+
+        viewModel.start(savedInstanceState = null)
+
+        assertThat(toolbarStates.size).isEqualTo(0)
+    }
+
+    private fun initObservers(): Observers {
+        val toolbarStates = mutableListOf<ToolbarState>()
+        viewModel.toolbarStateObservable.observeForever { toolbarStates.add(it) }
+        return Observers(toolbarStates)
+    }
+
+    private data class Observers(
+        val toolbarState: List<ToolbarState>
+    )
 }


### PR DESCRIPTION
Parent #13329 

This PR replaces the `titleObserverable` with `toolbarStateObserverable` to support title/icon changes by each individual wizard step.

To test:
- Launch the app with BackupFeatureConfig on
- Tap Activity
- Tap a row with a more menu
- Tap the Download Backup menu item
- Ensure there is a title in the toolbar and it matches "Download Backup"

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
