### PR TITLE
Revert "Fix position of Quick Start focus point in bottom sheet"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ActionListItemViewHolder.kt
@@ -61,7 +61,7 @@ class ActionListItemViewHolder(
                     dimen.quick_start_focus_point_size
             )
             actionRowContainer.post {
-                val verticalOffset = -focusPointSize / 2
+                val verticalOffset = (actionRowContainer.width - focusPointSize) / 2
                 QuickStartUtils.addQuickStartFocusPointAboveTheView(
                         actionRowContainer, actionTitle,
                         verticalOffset, 0


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-Android#13546

Reversion in #13551 broke the layout for the Quick Start focus point, so I need to revert the fix to make it work again.

To test:
- Create a new site.
- Accept Quick Start promptly.
- Navigate to Grow Your Audience QS option.
- Select "Publish a post" task.
- Tap FAB so the bottom sheet would appear.
- Confirm that the QS focus point is correctly placed on "Blog Post" option.