### PR TITLE
Issue/fix zendek colors in dark mode

### DIFF
--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -124,7 +124,7 @@
         <item name="android:background">?android:attr/listDivider</item>
     </style>
 
-    <style name="WordPress.ZenDesk"  />
+    <style name="WordPress.ZenDesk" />
 
     <!-- Overload of Zendesk FAB style -->
     <style name="zs_contact_us_fab">

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -124,7 +124,7 @@
         <item name="android:background">?android:attr/listDivider</item>
     </style>
 
-    <style name="WordPress.ZenDesk" parent="ZendeskSdkTheme.Dark" />
+    <style name="WordPress.ZenDesk"  />
 
     <!-- Overload of Zendesk FAB style -->
     <style name="zs_contact_us_fab">

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android">
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android">
 
     <style name="Base.Wordpress" parent="Theme.MaterialComponents.DayNight.Bridge">
         <item name="colorPrimary">@color/blue_30</item>
@@ -124,18 +124,20 @@
         <item name="android:background">?android:attr/listDivider</item>
     </style>
 
-    <style name="WordPress.ZenDesk" />
-
-    <!-- Overload of Zendesk FAB style -->
-    <style name="zs_contact_us_fab">
-        <item name="android:gravity">bottom|end</item>
-        <item name="android:layout_margin">@dimen/zs_fab_margin</item>
-        <item name="android:contentDescription">
-            @string/zs_general_contact_us_button_label_accessibility
+    <style name="WordPress.ZenDesk" parent="WordPress.NoActionBar">
+        <item name="toolbarStyle">@style/WordPress.ZenDesk.Toolbar</item>
+        <item name="android:statusBarColor">@color/primary_dark</item>
+        <item name="titleTextColor">?attr/colorOnSurface</item>
+        <item name="toolbarNavigationButtonStyle">
+            @style/Widget.AppCompat.Toolbar.Button.Navigation
         </item>
-        <item name="android:visibility">gone</item>
-        <item name="android:src">@drawable/zs_create_ticket_fab</item>
-        <item name="android:backgroundTint">@color/pink_50</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+    </style>
+
+    <style name="WordPress.ZenDesk.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
+        <item name="titleTextColor">?attr/colorOnSurface</item>
+        <item name="colorControlNormal">?attr/colorOnSurface</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Fixes #13623 

In the new version of zendesk the default dark theme was removed (now it points to the default dark material theme), and colors got all funky, as you can see in the issue.

This PR brings the colors in dark mode _closer_ to our branding using available colors. It's not perfect, but it also does not make your eyes bleed.

[![Image from Gyazo](https://i.gyazo.com/1e78fc59a9aff7e3d74f039a07bf9437.png)](https://gyazo.com/1e78fc59a9aff7e3d74f039a07bf9437)

To test:
- Make sure Zendesk looks decent.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
