### PR TITLE
1ssue/13329 details add extras

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
@@ -104,7 +104,7 @@ class BackupDownloadActivity : LocaleAwareActivity() {
 
     private fun showStep(target: WizardNavigationTarget<BackupDownloadStep, BackupDownloadState>) {
         val fragment = when (target.wizardStep) {
-            DETAILS -> BackupDownloadDetailsFragment.newInstance()
+            DETAILS -> BackupDownloadDetailsFragment.newInstance(intent?.extras)
             PROGRESS -> BackupDownloadProgressFragment.newInstance()
             COMPLETE -> BackupDownloadCompleteFragment.newInstance()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsFragment.kt
@@ -11,8 +11,9 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.backup_download_details_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel
-import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.DetailsToolbarState
+import org.wordpress.android.ui.jetpack.backup.download.KEY_BACKUP_DOWNLOAD_ACTIVITY_ID_KEY
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Error
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Loading
@@ -67,8 +68,18 @@ class BackupDownloadDetailsFragment : Fragment() {
             }
         })
 
-        parentViewModel.setToolbarState(DetailsToolbarState())
-        viewModel.start()
+        val (site, activityId) = when {
+            arguments != null -> {
+                val site = requireNotNull(arguments).getSerializable(WordPress.SITE) as SiteModel
+                val activityId = requireNotNull(arguments).getString(
+                        KEY_BACKUP_DOWNLOAD_ACTIVITY_ID_KEY
+                ) as String
+                site to activityId
+            }
+            else -> throw Throwable("Couldn't initialize BackupDownloadDetails view model")
+        }
+
+        viewModel.start(site, activityId, parentViewModel)
     }
 
     private fun showContent(content: Content) {
@@ -78,18 +89,14 @@ class BackupDownloadDetailsFragment : Fragment() {
     // todo: annmarie -(REMOVE) this dummy method references layout files that lint says aren't
     // used, but they will be in the next PR because there were too many changes for 1 PR
     private fun dummyAccess() {
-        val buttonLayoutId = R.layout.jetpack_list_button_item
         val checkboxLayoutId = R.layout.backup_download_list_checkbox_item
-        val descriptionLayoutId = R.layout.jetpack_list_description_item
-        val headerLayoutId = R.layout.jetpack_list_header_item
         val subheaderLayoutId = R.layout.backup_download_list_subheader_item
-        val imageLayoutId = R.layout.jetpack_list_icon_item
     }
 
     companion object {
         const val TAG = "BACKUP_DOWNLOAD_DETAILS_FRAGMENT"
-        fun newInstance(): BackupDownloadDetailsFragment {
-            return BackupDownloadDetailsFragment()
+        fun newInstance(bundle: Bundle?): BackupDownloadDetailsFragment {
+            return BackupDownloadDetailsFragment().apply { arguments = bundle }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
@@ -34,9 +34,9 @@ class BackupDownloadDetailsViewModel @Inject constructor(
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
 
-    fun start(site: SiteModel, activityLogId: String, parentViewModel: BackupDownloadViewModel) {
+    fun start(site: SiteModel, activityId: String, parentViewModel: BackupDownloadViewModel) {
         this.site = site
-        this.activityId = activityLogId
+        this.activityId = activityId
         this.parentViewModel = parentViewModel
 
         parentViewModel.setToolbarState(DetailsToolbarState())

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
@@ -6,11 +6,14 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.jetpack.BackupAvailableItemsProvider
 import org.wordpress.android.ui.jetpack.BackupAvailableItemsProvider.BackupAvailableItem
 import org.wordpress.android.ui.jetpack.BackupAvailableItemsProvider.BackupAvailableItemType
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.DetailsToolbarState
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -23,16 +26,24 @@ class BackupDownloadDetailsViewModel @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {
+    private lateinit var site: SiteModel
+    private lateinit var activityId: String
+    private lateinit var parentViewModel: BackupDownloadViewModel
     private var isStarted: Boolean = false
 
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
 
-    fun start() {
+    fun start(site: SiteModel, activityLogId: String, parentViewModel: BackupDownloadViewModel) {
+        this.site = site
+        this.activityId = activityLogId
+        this.parentViewModel = parentViewModel
+
+        parentViewModel.setToolbarState(DetailsToolbarState())
+
         if (isStarted) return
         isStarted = true
 
-        // todo: annmarie - this is a temp name until useCase has been added for record dets :)
         getData()
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadDetailsViewModelTest.kt
@@ -4,8 +4,10 @@ import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.test
 import org.wordpress.android.ui.jetpack.BackupAvailableItemsProvider
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel
@@ -13,9 +15,12 @@ import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDe
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Content
 
 @InternalCoroutinesApi
-class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
+class    : BaseUnitTest() {
     private lateinit var viewModel: BackupDownloadDetailsViewModel
     private lateinit var availableItemsProvider: BackupAvailableItemsProvider
+    @Mock private lateinit var parentViewModel: BackupDownloadViewModel
+    @Mock private lateinit var site: SiteModel
+    private val activityId = "1"
 
     @Before
     fun setUp() {
@@ -31,7 +36,7 @@ class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
     fun `when available items are fetched, the content view is shown`() = test {
         val uiStates = initObservers().uiStates
 
-        viewModel.start()
+        viewModel.start(site, activityId, parentViewModel)
 
         assertThat(uiStates[0]).isInstanceOf(Content::class.java)
     }
@@ -40,7 +45,7 @@ class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
     fun `given item is checked, when item is clicked, then item gets unchecked`() = test {
         val uiStates = initObservers().uiStates
 
-        viewModel.start()
+        viewModel.start(site, activityId, parentViewModel)
 
         ((uiStates.last() as Content).items[1]).onClick.invoke()
 
@@ -51,7 +56,7 @@ class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
     fun `given item is unchecked, when item is clicked, then item gets checked`() = test {
         val uiStates = initObservers().uiStates
 
-        viewModel.start()
+        viewModel.start(site, activityId, parentViewModel)
 
         ((uiStates.last() as Content).items[1]).onClick.invoke()
         ((uiStates.last() as Content).items[1]).onClick.invoke()

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadDetailsViewModelTest.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDe
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Content
 
 @InternalCoroutinesApi
-class    : BaseUnitTest() {
+class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: BackupDownloadDetailsViewModel
     private lateinit var availableItemsProvider: BackupAvailableItemsProvider
     @Mock private lateinit var parentViewModel: BackupDownloadViewModel


### PR DESCRIPTION
Parent #13329 

This PR 
- Passes needed intent extras to `BackupDownloadDetailsViewModel`
- Moves setting toolbar state into `BackupDownloadDetailsViewModel` and out of `BackupDownloadDetailsFragment`

To test:
- Launch the app with BackupDownloadConfig flag on
- Navigate to ActivityLog
- Tap the More menu
- Tap Donwload Backup menu item
- Note that the view is shown as expected

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
