### PR TITLE
MediaGridAdapter: use Glide to load video thumbnails

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -443,6 +443,11 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
     }
 
+    @Override public void onViewRecycled(@NonNull GridViewHolder holder) {
+        mImageManager.cancelRequestAndClearImageView(holder.mImageView);
+        super.onViewRecycled(holder);
+    }
+
     /*
      * loads the thumbnail for the passed video media item - works with both local and network videos
      */

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -33,7 +33,6 @@ import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ColorUtils;
 import org.wordpress.android.util.DisplayUtils;
-import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.PhotoPickerUtils;
 import org.wordpress.android.util.PhotonUtils;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -455,7 +455,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
     public void cancelPendingRequestsForVisibleItems(@NonNull RecyclerView recyclerView) {
         int firstVisibleItemPosition = mLayoutManager.findFirstVisibleItemPosition();
         int lastVisibleItemPosition = mLayoutManager.findLastVisibleItemPosition();
-        for (int i=firstVisibleItemPosition; i <= lastVisibleItemPosition; i++) {
+        for (int i = firstVisibleItemPosition; i <= lastVisibleItemPosition; i++) {
             GridViewHolder holder = (GridViewHolder) recyclerView.findViewHolderForAdapterPosition(i);
             if (holder != null
                 && (VIEW_TAG_EXTRACT_FROM_REMOTE_VIDEO_URL.equals(

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -474,7 +474,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             return;
         }
 
-        mImageManager.loadThumbnailFromVideoUrl(imageView, ImageType.VIDEO, media.getThumbnailUrl(), ScaleType.CENTER_CROP,
+        mImageManager.loadThumbnailFromVideoUrl(imageView, ImageType.VIDEO, filePath, ScaleType.CENTER_CROP,
                 new ImageManager.RequestListener<Drawable>() {
                     @Override
                     public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -261,12 +261,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
     }
 
-    @Override
-    public void onViewRecycled(GridViewHolder holder) {
-        super.onViewRecycled(holder);
-        holder.mImageView.setTag(R.id.media_grid_file_path_id, null);
-    }
-
     public ArrayList<Integer> getSelectedItems() {
         return mSelectedItems;
     }
@@ -473,7 +467,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             AppLog.w(AppLog.T.MEDIA, "MediaGridAdapter > No path to video thumbnail");
             return;
         }
-        imageView.setTag(R.id.media_grid_file_path_id, filePath);
         // see if we have a cached thumbnail before retrieving it
         Bitmap bitmap = WordPress.getBitmapCache().get(filePath);
         if (bitmap != null) {
@@ -496,11 +489,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                         // create a copy since the original bitmap may by automatically recycled
                         bitmap = bitmap.copy(bitmap.getConfig(), true);
                         WordPress.getBitmapCache().put(filePath, bitmap);
-                        if (imageView.getTag(R.id.media_grid_file_path_id) instanceof String
-                            && (imageView.getTag(R.id.media_grid_file_path_id)).equals(filePath)) {
-                            imageView.setTag(R.id.media_grid_file_path_id, null);
-                            notifyItemChanged(position);
-                        }
                     }
                 });
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -199,11 +199,13 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     public void onStart() {
         super.onStart();
         mDispatcher.register(this);
+        mGridAdapter.refreshCurrentItems(mRecycler);
     }
 
     @Override
     public void onStop() {
         mDispatcher.unregister(this);
+        mGridAdapter.cancelPendingRequestsForVisibleItems(mRecycler);
         super.onStop();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -25,6 +25,7 @@ import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
+import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.AppWidgetTarget
 import com.bumptech.glide.request.target.BaseTarget
 import com.bumptech.glide.request.target.CustomTarget
@@ -98,6 +99,33 @@ class ImageManager @Inject constructor(private val placeholderManager: ImagePlac
                 .addFallback(imageType)
                 .addPlaceholder(imageType)
                 .applyScaleType(scaleType)
+                .into(imageView)
+                .clearOnDetach()
+    }
+
+    /**
+     * Loads the first frame from the "videoUrl" as an image into the ImageView.
+     * Adds a placeholder and an error placeholder depending on the ImageType.
+     *
+     * If no URL is provided, it only loads the placeholder
+     */
+    @JvmOverloads
+    fun loadThumbnailFromVideoUrl(
+        imageView: ImageView,
+        imageType: ImageType,
+        videoUrl: String = "",
+        scaleType: ScaleType = CENTER,
+        requestListener: RequestListener<Drawable>? = null
+    ) {
+        val context = imageView.context
+        if (!context.isAvailable()) return
+        GlideApp.with(context)
+                .load(videoUrl)
+                .addFallback(imageType)
+                .addPlaceholder(imageType)
+                .applyScaleType(scaleType)
+                .attachRequestListener(requestListener)
+                .apply(RequestOptions().frame(0))
                 .into(imageView)
                 .clearOnDetach()
     }

--- a/WordPress/src/main/res/values/ids.xml
+++ b/WordPress/src/main/res/values/ids.xml
@@ -14,6 +14,7 @@
     <item type="id" name="note_block_tag_id" />
     <item type="id" name="bottom_nav_reader_button" />
     <item type="id" name="bottom_nav_new_post_button" />
+    <item type="id" name="media_grid_remote_thumb_extract_id" />
     <item type="id" name="post_menu_item_view_layout_type" />
     <item type="id" name="original_view_pager_fragment_id_tag_key" />
     <item type="id" name="pages_search_recycler_view_id" />

--- a/WordPress/src/main/res/values/ids.xml
+++ b/WordPress/src/main/res/values/ids.xml
@@ -14,7 +14,6 @@
     <item type="id" name="note_block_tag_id" />
     <item type="id" name="bottom_nav_reader_button" />
     <item type="id" name="bottom_nav_new_post_button" />
-    <item type="id" name="media_grid_file_path_id" />
     <item type="id" name="post_menu_item_view_layout_type" />
     <item type="id" name="original_view_pager_fragment_id_tag_key" />
     <item type="id" name="pages_search_recycler_view_id" />


### PR DESCRIPTION
Hopefully fixes #9999 

Foreword: these two comments ([@jd-alexander comment](https://github.com/wordpress-mobile/WordPress-Android/issues/9999#issuecomment-569328174) and [@develric comment](https://github.com/wordpress-mobile/WordPress-Android/issues/9999#issuecomment-667255683)) offer good insight about why this issue exists. 
Go through these first and then come back to this PR's description 👍 

## History
#### First thoughts
I was wondering whether we could alleviate the occurrences of this crash, by avoiding `MediaMetaDataRetriever` having to perform a network call itself. My thought was something like, if the MediaMetaDataRetriever doesn't need to go out and perform the network call itself, then we can perform this in a shorter period of time, and then we would lessen the possiblities of the app going to the background / device going to sleep while all of this is happening. I have run into other various problems with `setDataSource(, headers)` method before, while it proved to be pretty stable when using the MetaDataRetriever on **_local_** files.

That said, the problem with this is that video files are generally large, and we only need a thumbnail 🙃 - it is less desirable to download a video in full just to obtain a thumbnail.

So, if we're showing a WP Media section video item, we should be able to retrieve a preprocessed thumbnail from the WP Media section (or at least that's what I thought).

Unfortunately this is not always the case, and many times there are no thumbnails available on the MediaModel (populated after what comes from the site's API). And in any case, we're already covering the case in [`loadVideoThumbnail()` in `MediaGridAdapter`](https://github.com/wordpress-mobile/WordPress-Android/blob/a9eeed79f6d85fd3a3a55157ff9b2932248c00cc/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java#L455-L458)  - we first try that if the thumbnail exist, and then only start figuring out some fallbacks until there's no other way around it than trying to extract the thumbnail from an actual video frame.

#### Digging further

Looking further I wondered how Glide does this. Both our implementation and Glide's end up correctly calling `release()` (see [Glide's source code here](https://github.com/bumptech/glide/blob/e464e01e0511e96ce78d4049e4110b79da8f5876/library/src/main/java/com/bumptech/glide/load/resource/bitmap/VideoDecoder.java#L183) and  see [this snippet ](https://github.com/wordpress-mobile/WordPress-Android/blob/8e55b05faff828e3d91b8c2c2be6124acabfd31e/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java#L640)in our case)

But a difference I found here is that we were making this run on an anonymous Thread, while Glide will be run as part of our `ImageManager` singleton, which should exist throughout the Application lifecycle timespan. I think this may help avoid this problem given the references  for garbage collector to collect are still managed. 

See the docs for `finalize()` https://developer.android.com/reference/android/media/MediaMetadataRetriever#finalize()

> For example, the finalize method for an object that represents an input/output connection might perform explicit I/O transactions to break the connection before the object is permanently discarded.

One thing that caught my eye is this:
> The Java programming language does not guarantee which thread will invoke the finalize method for any given object. It is guaranteed, however, that the thread that invokes finalize will not be holding any user-visible synchronization locks when finalize is invoked. If an uncaught exception is thrown by the finalize method, the exception is ignored and finalization of that object terminates.
[...]
Any exception thrown by the finalize method causes the finalization of this object to be halted, but is otherwise ignored.


So, according to this, if an exception occurs during the execution of `finalize()` , then such an exception should be ignored. BUT, we have evidence in Sentry that this is not the case, and the app is crashing nevertheless.

That's because the crash comes from the Timeout  exception thrown, as explained  in the [SO question](https://stackoverflow.com/questions/24021609/how-to-handle-java-util-concurrent-timeoutexception-android-os-binderproxy-fin) linked in this [comment](https://github.com/wordpress-mobile/WordPress-Android/issues/9999#issuecomment-569328174) by @jd-alexander 

So I've been investigating and wondered, maybe Glide will kill / suspend its threads more intelligently (as opposed to our plain old Java Thread we launch to fetch each video thumbnail), and as such we may never see this crash (given there's no sleeping threads that will then get their MediaMetadataRetriever objects called on their `release()` method).

However this was not true, although code should be generally more legible by using Glide this way, so I left that improvement in.

But then, how can we solve the problem? The problem can't be really solved at the app's level, but we can at least try to avoid it.

## Workaround
### Hypothesis for this PR
The hypothetical situation described in the SO question might be hard to reproduce, and involves a GC call starting, then the device going to sleep, then resuming. However the hypothesis I used to try the solution in this PR is: when a device goes to sleep the Activity might get killed, but first of all the Activity will be sent a `onStop()` call as it's going to the background. Hence, if we knew which ImageViews are being loaded with the MediaMetadataRetriever extractor, we can cancel those requests and resume them when the Activity comes back to the foreground. Given those calls would be cancelled when we're still in  control of them, we would be avoiding the problem.

This PR then adds some logic to the adapter in methods:
- `cancelPendingRequestsForVisibleItems()` which is called at `onStop()`
- `refreshCurrentItems()` which is called at `onStart()`. This method calls `notifyItemChanged` on the adapter causing the `onBind`  method to get run and as such, the imageManager loader method to get executed.

While I have seen some lag sometimes,  I have tested the app with the memory profiler and haven't found anything unusual (it does seem to use more memory with Glide but it's able to free it up when the GC runs without problem), and I generally can't see any blockers.

**To test:**
Smoke test the app:
- open the Media section of the app, go to the videos tab
- scroll up and down, delete the app's cache
- observe it works as usual

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
