### PR TITLE
Jetpack Mobile: Scan - ThreatItem

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanListItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanListItemState.kt
@@ -7,8 +7,6 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 
 sealed class ScanListItemState(override val type: ViewType) : JetpackListItemState(type) {
-    override fun longId() = hashCode().toLong()
-
     data class ThreatsHeaderItemState(val text: UiString = UiStringRes(R.string.threats_found)) : ScanListItemState(
         ViewType.THREATS_HEADER
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanListItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanListItemState.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.jetpack.scan
 
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.ViewType
 import org.wordpress.android.ui.utils.UiString
@@ -14,16 +13,9 @@ sealed class ScanListItemState(override val type: ViewType) : JetpackListItemSta
         ViewType.THREATS_HEADER
     )
 
-    // TODO: ashiagr fix threat title, description actual texts based on threat types
-    data class ThreatItemState(val threatId: Long, val title: String, val description: String) : ScanListItemState(
+    data class ThreatItemState(val threatId: Long, val header: UiString, val subHeader: UiString) : ScanListItemState(
         ViewType.THREAT_ITEM
     ) {
-        constructor(model: ThreatModel) : this(
-            model.baseThreatModel.id,
-            model.baseThreatModel.description,
-            model.baseThreatModel.description
-        )
-
         override fun longId() = threatId.hashCode().toLong()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanListItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanListItemState.kt
@@ -13,7 +13,12 @@ sealed class ScanListItemState(override val type: ViewType) : JetpackListItemSta
         ViewType.THREATS_HEADER
     )
 
-    data class ThreatItemState(val threatId: Long, val header: UiString, val subHeader: UiString) : ScanListItemState(
+    data class ThreatItemState(
+        val threatId: Long,
+        val header: UiString,
+        val subHeader: UiString,
+        val onClick: () -> Unit
+    ) : ScanListItemState(
         ViewType.THREAT_ITEM
     ) {
         override fun longId() = threatId.hashCode().toLong()

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanNavigationEvents.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.ui.jetpack.scan
+
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
+
+sealed class ScanNavigationEvents {
+    data class ShowThreatDetail(val threatModel: ThreatModel) : ScanNavigationEvents()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanStateListItemBuilder.kt
@@ -33,7 +33,8 @@ class ScanStateListItemBuilder @Inject constructor(
         model: ScanStateModel,
         site: SiteModel,
         onScanButtonClicked: () -> Unit,
-        onFixAllButtonClicked: () -> Unit
+        onFixAllButtonClicked: () -> Unit,
+        onThreatItemClicked: (threatModel: ThreatModel) -> Unit
     ): List<JetpackListItemState> {
         return when (model.state) {
             ScanStateModel.State.IDLE -> {
@@ -42,7 +43,8 @@ class ScanStateListItemBuilder @Inject constructor(
                         threats,
                         site,
                         onScanButtonClicked,
-                        onFixAllButtonClicked
+                        onFixAllButtonClicked,
+                        onThreatItemClicked
                     )
                 } ?: buildThreatsNotFoundStateItems(model, onScanButtonClicked)
             }
@@ -56,7 +58,8 @@ class ScanStateListItemBuilder @Inject constructor(
         threats: List<ThreatModel>,
         site: SiteModel,
         onScanButtonClicked: () -> Unit,
-        onFixAllButtonClicked: () -> Unit
+        onFixAllButtonClicked: () -> Unit,
+        onThreatItemClicked: (threatModel: ThreatModel) -> Unit
     ): List<JetpackListItemState> {
         val items = mutableListOf<JetpackListItemState>()
 
@@ -75,7 +78,7 @@ class ScanStateListItemBuilder @Inject constructor(
 
         threats.takeIf { it.isNotEmpty() }?.let {
             items.add(ThreatsHeaderItemState())
-            items.addAll(threats.map { threatItemBuilder.buildThreatItem(it) })
+            items.addAll(threats.map { threat -> threatItemBuilder.buildThreatItem(threat, onThreatItemClicked) })
         }
 
         return items

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanStateListItemBuilder.kt
@@ -12,8 +12,8 @@ import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButton
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.DescriptionState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.HeaderState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.IconState
-import org.wordpress.android.ui.jetpack.scan.ScanListItemState.ThreatItemState
 import org.wordpress.android.ui.jetpack.scan.ScanListItemState.ThreatsHeaderItemState
+import org.wordpress.android.ui.jetpack.scan.builders.ThreatItemBuilder
 import org.wordpress.android.ui.reader.utils.DateProvider
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -26,7 +26,8 @@ import javax.inject.Inject
 class ScanStateListItemBuilder @Inject constructor(
     private val dateProvider: DateProvider,
     private val htmlMessageUtils: HtmlMessageUtils,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val threatItemBuilder: ThreatItemBuilder
 ) {
     fun buildScanStateListItems(
         model: ScanStateModel,
@@ -74,7 +75,7 @@ class ScanStateListItemBuilder @Inject constructor(
 
         threats.takeIf { it.isNotEmpty() }?.let {
             items.add(ThreatsHeaderItemState())
-            items.addAll(threats.map { ThreatItemState(it) })
+            items.addAll(threats.map { threatItemBuilder.buildThreatItem(it) })
         }
 
         return items

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.jetpack.scan
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
@@ -8,7 +9,9 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
+import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetail
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.Content
+import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
 class ScanViewModel @Inject constructor(
@@ -19,6 +22,9 @@ class ScanViewModel @Inject constructor(
 
     private val _uiState: MutableLiveData<UiState> = MutableLiveData()
     val uiState: LiveData<UiState> = _uiState
+
+    private val _navigationEvents = MediatorLiveData<Event<ScanNavigationEvents>>()
+    val navigationEvents: LiveData<Event<ScanNavigationEvents>> = _navigationEvents
 
     private val scanStateObserver = Observer<ScanStateModel> {
         _uiState.value = buildContentUiState(it)
@@ -56,7 +62,8 @@ class ScanViewModel @Inject constructor(
     private fun onFixAllButtonClicked() { // TODO ashiagr to be implemented
     }
 
-    private fun onThreatItemClicked(threatModel: ThreatModel) { // TODO ashiagr to be implemented
+    private fun onThreatItemClicked(threatModel: ThreatModel) {
+        _navigationEvents.value = Event(ShowThreatDetail(threatModel))
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.Content
 import javax.inject.Inject
@@ -44,14 +45,18 @@ class ScanViewModel @Inject constructor(
             model,
             site,
             this@ScanViewModel::onScanButtonClicked,
-            this@ScanViewModel::onFixAllButtonClicked
+            this@ScanViewModel::onFixAllButtonClicked,
+            this@ScanViewModel::onThreatItemClicked
         )
     )
 
-    fun onScanButtonClicked() { // TODO ashiagr to be implemented
+    private fun onScanButtonClicked() { // TODO ashiagr to be implemented
     }
 
-    fun onFixAllButtonClicked() { // TODO ashiagr to be implemented
+    private fun onFixAllButtonClicked() { // TODO ashiagr to be implemented
+    }
+
+    private fun onThreatItemClicked(threatModel: ThreatModel) { // TODO ashiagr to be implemented
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/adapters/ScanAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/adapters/ScanAdapter.kt
@@ -33,7 +33,7 @@ class ScanAdapter(
             ViewType.DESCRIPTION.id -> JetpackDescriptionViewHolder(uiHelpers, parent)
             ViewType.ACTION_BUTTON.id -> JetpackButtonViewHolder(uiHelpers, parent)
             ViewType.THREATS_HEADER.id -> ThreatsHeaderViewHolder(uiHelpers, parent)
-            ViewType.THREAT_ITEM.id -> ThreatViewHolder(parent)
+            ViewType.THREAT_ITEM.id -> ThreatViewHolder(uiHelpers, parent)
             else -> throw IllegalArgumentException("Unexpected view type in ${this::class.java.simpleName}")
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/adapters/viewholders/ThreatViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/adapters/viewholders/ThreatViewHolder.kt
@@ -6,11 +6,17 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackViewHolder
 import org.wordpress.android.ui.jetpack.scan.ScanListItemState.ThreatItemState
+import org.wordpress.android.ui.utils.UiHelpers
 
-class ThreatViewHolder(parent: ViewGroup) : JetpackViewHolder(R.layout.scan_list_threat_item, parent) {
+class ThreatViewHolder(
+    private val uiHelpers: UiHelpers,
+    parent: ViewGroup
+) : JetpackViewHolder(R.layout.scan_list_threat_item, parent) {
     override fun onBind(itemUiState: JetpackListItemState) {
-        val threatsFoundState = itemUiState as ThreatItemState
-        // TODO: ashiagr fix title, description texts based on threat types
-        threat_title.text = threatsFoundState.title
+        val threatItemState = itemUiState as ThreatItemState
+        with(uiHelpers) {
+            threat_header.text = getTextOfUiString(itemView.context, threatItemState.header)
+            threat_sub_header.text = getTextOfUiString(itemView.context, threatItemState.subHeader)
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/adapters/viewholders/ThreatViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/adapters/viewholders/ThreatViewHolder.kt
@@ -18,5 +18,6 @@ class ThreatViewHolder(
             threat_header.text = getTextOfUiString(itemView.context, threatItemState.header)
             threat_sub_header.text = getTextOfUiString(itemView.context, threatItemState.subHeader)
         }
+        itemView.setOnClickListener { threatItemState.onClick.invoke() }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -59,7 +59,7 @@ class ThreatItemBuilder @Inject constructor() {
             }
         }
 
-        is GenericThreatModel -> UiStringRes(R.string.threats_found)
+        is GenericThreatModel -> UiStringRes(R.string.threat_item_header_threat_found)
     }
 
     private fun buildThreatItemSubHeader(threatModel: ThreatModel) = when (threatModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -1,0 +1,91 @@
+package org.wordpress.android.ui.jetpack.scan.builders
+
+import dagger.Reusable
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.CoreFileModificationThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.DatabaseThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.FileThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.GenericThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension.ExtensionType
+import org.wordpress.android.ui.jetpack.scan.ScanListItemState.ThreatItemState
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
+import javax.inject.Inject
+
+@Reusable
+class ThreatItemBuilder @Inject constructor() {
+    fun buildThreatItem(threatModel: ThreatModel) = ThreatItemState(
+        threatId = threatModel.baseThreatModel.id,
+        header = buildThreatItemHeader(threatModel),
+        subHeader = buildThreatItemSubHeader(threatModel)
+    )
+
+    private fun buildThreatItemHeader(threatModel: ThreatModel) = when (threatModel) {
+        is CoreFileModificationThreatModel -> UiStringResWithParams(
+            R.string.threat_item_header_infected_core_file,
+            listOf(UiStringText(getDisplayFileName(threatModel.fileName)))
+        )
+
+        is DatabaseThreatModel -> UiStringRes(R.string.threat_item_header_database_threat)
+
+        is FileThreatModel -> UiStringResWithParams(
+            R.string.threat_item_header_file_malicious_code_pattern,
+            listOf(UiStringText(getDisplayFileName(threatModel.fileName)))
+        )
+
+        is VulnerableExtensionThreatModel -> {
+            val slug = threatModel.extension.slug ?: ""
+            val version = threatModel.extension.version ?: ""
+            when (threatModel.extension.type) {
+                ExtensionType.PLUGIN -> UiStringResWithParams(
+                    R.string.threat_item_header_vulnerable_plugin,
+                    listOf(UiStringText(slug), UiStringText(version))
+                )
+                ExtensionType.THEME -> UiStringResWithParams(
+                    R.string.threat_item_header_vulnerable_theme,
+                    listOf(UiStringText(slug), UiStringText(version))
+                )
+                ExtensionType.UNKNOWN -> throw IllegalArgumentException(
+                    "$UNKNOWN_VULNERABLE_EXTENSION_TYPE in ${this::class.java.simpleName}"
+                )
+            }
+        }
+
+        is GenericThreatModel -> UiStringRes(R.string.threats_found)
+    }
+
+    private fun buildThreatItemSubHeader(threatModel: ThreatModel) = when (threatModel) {
+        is CoreFileModificationThreatModel -> UiStringResWithParams(
+            R.string.threat_item_sub_header_core_file,
+            listOf(UiStringText(threatModel.fileName))
+        )
+
+        is DatabaseThreatModel -> UiStringText("")
+
+        is FileThreatModel -> UiStringResWithParams(
+            R.string.threat_item_sub_header_file_signature,
+            listOf(UiStringText(threatModel.baseThreatModel.signature))
+        )
+
+        is VulnerableExtensionThreatModel -> {
+            when (threatModel.extension.type) {
+                ExtensionType.PLUGIN -> UiStringRes(R.string.threat_item_sub_header_vulnerable_plugin)
+                ExtensionType.THEME -> UiStringRes(R.string.threat_item_sub_header_vulnerable_theme)
+                ExtensionType.UNKNOWN -> throw IllegalArgumentException(
+                    "$UNKNOWN_VULNERABLE_EXTENSION_TYPE in ${this::class.java.simpleName}"
+                )
+            }
+        }
+
+        is GenericThreatModel -> UiStringRes(R.string.threat_item_sub_header_misc_vulnerability)
+    }
+
+    private fun getDisplayFileName(fileName: String?) = fileName?.replace(".*/".toRegex(), "") ?: ""
+
+    companion object {
+        private const val UNKNOWN_VULNERABLE_EXTENSION_TYPE = "Unexpected vulnerable extension threat type"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -85,7 +85,10 @@ class ThreatItemBuilder @Inject constructor() {
         is GenericThreatModel -> UiStringRes(R.string.threat_item_sub_header_misc_vulnerability)
     }
 
-    /** Uses regex to remove the whole path except of the file name */
+    /**
+     * Uses regex to remove the whole path except of the file name
+     * e.g. "/var/www/html/jp-scan-daily/wp-admin/index.php" returns "index.php".
+     * */
     private fun getDisplayFileName(fileName: String?) = fileName?.replace(".*/".toRegex(), "") ?: ""
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -31,7 +31,10 @@ class ThreatItemBuilder @Inject constructor() {
             listOf(UiStringText(getDisplayFileName(threatModel.fileName)))
         )
 
-        is DatabaseThreatModel -> UiStringRes(R.string.threat_item_header_database_threat)
+        is DatabaseThreatModel -> UiStringResWithParams(
+            R.string.threat_item_header_database_threat,
+            listOf(UiStringText("${threatModel.rows?.size ?: 0}"))
+        )
 
         is FileThreatModel -> UiStringResWithParams(
             R.string.threat_item_header_file_malicious_code_pattern,
@@ -60,10 +63,7 @@ class ThreatItemBuilder @Inject constructor() {
     }
 
     private fun buildThreatItemSubHeader(threatModel: ThreatModel) = when (threatModel) {
-        is CoreFileModificationThreatModel -> UiStringResWithParams(
-            R.string.threat_item_sub_header_core_file,
-            listOf(UiStringText(threatModel.fileName))
-        )
+        is CoreFileModificationThreatModel -> UiStringRes(R.string.threat_item_sub_header_core_file)
 
         is DatabaseThreatModel -> UiStringText("")
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -85,6 +85,7 @@ class ThreatItemBuilder @Inject constructor() {
         is GenericThreatModel -> UiStringRes(R.string.threat_item_sub_header_misc_vulnerability)
     }
 
+    /** Uses regex to remove the whole path except of the file name */
     private fun getDisplayFileName(fileName: String?) = fileName?.replace(".*/".toRegex(), "") ?: ""
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -17,11 +17,13 @@ import javax.inject.Inject
 
 @Reusable
 class ThreatItemBuilder @Inject constructor() {
-    fun buildThreatItem(threatModel: ThreatModel) = ThreatItemState(
-        threatId = threatModel.baseThreatModel.id,
-        header = buildThreatItemHeader(threatModel),
-        subHeader = buildThreatItemSubHeader(threatModel)
-    )
+    fun buildThreatItem(threatModel: ThreatModel, onThreatItemClicked: (threatModel: ThreatModel) -> Unit) =
+        ThreatItemState(
+            threatId = threatModel.baseThreatModel.id,
+            header = buildThreatItemHeader(threatModel),
+            subHeader = buildThreatItemSubHeader(threatModel),
+            onClick = { onThreatItemClicked(threatModel) }
+        )
 
     private fun buildThreatItemHeader(threatModel: ThreatModel) = when (threatModel) {
         is CoreFileModificationThreatModel -> UiStringResWithParams(

--- a/WordPress/src/main/res/layout/scan_list_threat_item.xml
+++ b/WordPress/src/main/res/layout/scan_list_threat_item.xml
@@ -13,23 +13,27 @@
         style="@style/Scan.Threat.Icon"
         android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/threat_header"
+        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/threat_title"
+        android:id="@+id/threat_header"
         style="@style/Scan.Threat.Header"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/threat_icon"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="Vulnerable plugin: calender (version 1.3.1)"/>
+        tools:text="@string/threat_item_header_vulnerable_plugin" />
 
     <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/threat_description"
+        android:id="@+id/threat_sub_header"
         style="@style/Scan.Threat.SecondaryHeader"
-        app:layout_constraintStart_toStartOf="@+id/threat_title"
-        app:layout_constraintTop_toBottomOf="@+id/threat_title"
-        tools:text="Vulnerability found in plugin"/>
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/threat_header"
+        app:layout_constraintTop_toBottomOf="@+id/threat_header"
+        tools:text="@string/threat_item_sub_header_vulnerable_plugin" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/scan_list_threats_header_item.xml
+++ b/WordPress/src/main/res/layout/scan_list_threats_header_item.xml
@@ -4,4 +4,4 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/header_text"
     style="@style/Scan.Threats.Header"
-    tools:text="@string/threats_found" />
+    tools:text="@string/threat_item_header_threat_found" />

--- a/WordPress/src/main/res/values/scan_styles.xml
+++ b/WordPress/src/main/res/values/scan_styles.xml
@@ -34,8 +34,8 @@
     <style name="Scan.Threat.Header" parent="Scan.TextView">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_marginStart">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginEnd">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginStart">@dimen/margin_medium</item>
+        <item name="android:layout_marginEnd">@dimen/margin_medium</item>
         <item name="android:ellipsize">end</item>
         <item name="android:gravity">start</item>
         <item name="android:maxLines">2</item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1061,7 +1061,7 @@
     <!-- threat item header -->
     <string name="threat_item_header_threat_found">Threat found</string>
     <string name="threat_item_header_infected_core_file">%s: infected core file</string>
-    <string name="threat_item_header_database_threat">Database threat</string>
+    <string name="threat_item_header_database_threat">Database %s threats</string>
     <string name="threat_item_header_file_malicious_code_pattern">%s: malicious code pattern</string>
     <string name="threat_item_header_vulnerable_plugin">Vulnerable Plugin: %s (version %s)</string>
     <string name="threat_item_header_vulnerable_theme">Vulnerable Theme: %s (version %s)</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1058,6 +1058,21 @@
     <string name="threats_fix_all">Fix all</string>
     <string name="threats_found">Threats found</string>
 
+    <!-- threat item header -->
+    <string name="threat_item_header_threat_found">Threat found</string>
+    <string name="threat_item_header_infected_core_file">%s: infected core file</string>
+    <string name="threat_item_header_database_threat">Database threat</string>
+    <string name="threat_item_header_file_malicious_code_pattern">%s: malicious code pattern</string>
+    <string name="threat_item_header_vulnerable_plugin">Vulnerable Plugin: %s (version %s)</string>
+    <string name="threat_item_header_vulnerable_theme">Vulnerable Theme: %s (version %s)</string>
+
+    <!-- threat item sub header -->
+    <string name="threat_item_sub_header_misc_vulnerability">Miscellaneous vulnerability</string>
+    <string name="threat_item_sub_header_core_file">Vulnerability found in WordPress</string>
+    <string name="threat_item_sub_header_file_signature">Threat found %s</string>
+    <string name="threat_item_sub_header_vulnerable_plugin">Vulnerability found in plugin</string>
+    <string name="threat_item_sub_header_vulnerable_theme">Vulnerability found in theme</string>
+
     <!-- stats: labels for timeframes -->
     <string name="stats_timeframe_today">Today</string>
     <string name="stats_timeframe_yesterday">Yesterday</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanStateListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanStateListItemBuilderTest.kt
@@ -5,6 +5,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.jetpack.scan.builders.ThreatItemBuilder
 import org.wordpress.android.ui.reader.utils.DateProvider
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -21,6 +22,7 @@ class ScanStateListItemBuilderTest : BaseUnitTest() {
     @Mock private lateinit var dateProvider: DateProvider
     @Mock private lateinit var htmlMessageUtils: HtmlMessageUtils
     @Mock private lateinit var resourceProvider: ResourceProvider
+    @Mock private lateinit var threatItemBuilder: ThreatItemBuilder
 
 //    private val baseThreatModel = BaseThreatModel(
 //        id = 1L,
@@ -36,7 +38,7 @@ class ScanStateListItemBuilderTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        builder = ScanStateListItemBuilder(dateProvider, htmlMessageUtils, resourceProvider)
+        builder = ScanStateListItemBuilder(dateProvider, htmlMessageUtils, resourceProvider, threatItemBuilder)
 //        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), any())).thenReturn(SpannedString(""))
 //        whenever(site.name).thenReturn((""))
 //        whenever(dateProvider.getCurrentDate()).thenReturn(Date(DUMMY_CURRENT_TIME))

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
@@ -1,0 +1,236 @@
+package org.wordpress.android.ui.jetpack.scan
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.scan.threat.BaseThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.CoreFileModificationThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.DatabaseThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.DatabaseThreatModel.Row
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.FileThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.FileThreatModel.ThreatContext
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.GenericThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.CURRENT
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension.ExtensionType.THEME
+import org.wordpress.android.test
+import org.wordpress.android.ui.jetpack.scan.builders.ThreatItemBuilder
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
+import java.util.Date
+
+private const val FILE_PATH = "/var/www/html/jp-scan-daily/wp-admin/index.php"
+private const val FILE_NAME = "index.php"
+private const val VULNERABLE_THREAT_SLUG = "test slug"
+private const val VULNERABLE_THREAT_VERSION = "test version"
+private const val TEST_SIGNATURE = "test signature"
+
+@InternalCoroutinesApi
+class ThreatItemBuilderTest : BaseUnitTest() {
+    private lateinit var builder: ThreatItemBuilder
+
+    private val baseThreatModel = BaseThreatModel(
+        id = 1L,
+        signature = TEST_SIGNATURE,
+        description = "",
+        status = CURRENT,
+        firstDetected = Date(0)
+    )
+    private val extension = Extension(
+        type = Extension.ExtensionType.PLUGIN,
+        slug = VULNERABLE_THREAT_SLUG,
+        name = "",
+        version = VULNERABLE_THREAT_VERSION,
+        isPremium = false
+    )
+    private val rows = listOf(Row(id = 1, rowNumber = 1))
+    private val coreFileModificationThreatModel = CoreFileModificationThreatModel(
+        baseThreatModel = baseThreatModel,
+        fileName = FILE_PATH,
+        diff = ""
+    )
+    private val databaseThreatModel = DatabaseThreatModel(
+        baseThreatModel = baseThreatModel,
+        rows = rows
+    )
+    private val fileThreatModel = FileThreatModel(
+        baseThreatModel = baseThreatModel,
+        fileName = FILE_NAME,
+        context = ThreatContext(emptyList())
+    )
+    private val vulnerableExtensionThreatModel = VulnerableExtensionThreatModel(
+        baseThreatModel = baseThreatModel,
+        extension = extension
+    )
+    private val genericThreatModel = GenericThreatModel(
+        baseThreatModel = baseThreatModel
+    )
+
+    @Before
+    fun setUp() {
+        builder = ThreatItemBuilder()
+    }
+
+    @Test
+    fun `builds threat header correctly for CoreFileModificationThreatModel`() {
+        // Arrange
+        val expectedHeader = UiStringResWithParams(
+            R.string.threat_item_header_infected_core_file,
+            listOf(UiStringText(FILE_NAME))
+        )
+        // Act
+        val threatItem = buildThreatItem(coreFileModificationThreatModel)
+        // Assert
+        assertThat(threatItem.header).isEqualTo(expectedHeader)
+    }
+
+    @Test
+    fun `builds threat sub header correctly for CoreFileModificationThreatModel`() {
+        // Arrange
+        val expectedSubHeader = UiStringRes(R.string.threat_item_sub_header_core_file)
+        // Act
+        val threatItem = buildThreatItem(coreFileModificationThreatModel)
+        // Assert
+        assertThat(threatItem.subHeader).isEqualTo(expectedSubHeader)
+    }
+
+    @Test
+    fun `builds threat header correctly for DatabaseThreatModel`() {
+        // Arrange
+        val expectedHeader = UiStringResWithParams(
+            R.string.threat_item_header_database_threat,
+            listOf(UiStringText("${rows.size}"))
+        )
+        // Act
+        val threatItem = buildThreatItem(databaseThreatModel)
+        // Assert
+        assertThat(threatItem.header).isEqualTo(expectedHeader)
+    }
+
+    @Test
+    fun `builds threat sub header correctly for DatabaseThreatModel`() {
+        // Arrange
+        val expectedSubHeader = UiStringText("")
+        // Act
+        val threatItem = buildThreatItem(databaseThreatModel)
+        // Assert
+        assertThat(threatItem.subHeader).isEqualTo(expectedSubHeader)
+    }
+
+    @Test
+    fun `builds threat header correctly for FileThreatModel`() {
+        // Arrange
+        val expectedHeader = UiStringResWithParams(
+            R.string.threat_item_header_file_malicious_code_pattern,
+            listOf(UiStringText(FILE_NAME))
+        )
+        // Act
+        val threatItem = buildThreatItem(fileThreatModel)
+        // Assert
+        assertThat(threatItem.header).isEqualTo(expectedHeader)
+    }
+
+    @Test
+    fun `builds threat sub header correctly for FileThreatModel`() {
+        // Arrange
+        val expectedSubHeader = UiStringResWithParams(
+            R.string.threat_item_sub_header_file_signature,
+            listOf(UiStringText(TEST_SIGNATURE))
+        )
+        // Act
+        val threatItem = buildThreatItem(fileThreatModel)
+        // Assert
+        assertThat(threatItem.subHeader).isEqualTo(expectedSubHeader)
+    }
+
+    @Test
+    fun `builds threat header correctly for VulnerableExtensionThreatModel of Plugin type`() {
+        // Arrange
+        val expectedHeader = UiStringResWithParams(
+            R.string.threat_item_header_vulnerable_plugin,
+            listOf(UiStringText(VULNERABLE_THREAT_SLUG), UiStringText(VULNERABLE_THREAT_VERSION))
+        )
+        // Act
+        val threatItem = buildThreatItem(vulnerableExtensionThreatModel)
+        // Assert
+        assertThat(threatItem.header).isEqualTo(expectedHeader)
+    }
+
+    @Test
+    fun `builds threat sub header correctly VulnerableExtensionThreatModel of Plugin type`() {
+        // Arrange
+        val expectedSubHeader = UiStringRes(R.string.threat_item_sub_header_vulnerable_plugin)
+        // Act
+        val threatItem = buildThreatItem(vulnerableExtensionThreatModel)
+        // Assert
+        assertThat(threatItem.subHeader).isEqualTo(expectedSubHeader)
+    }
+
+    @Test
+    fun `builds threat header correctly for VulnerableExtensionThreatModel of Theme type`() {
+        // Arrange
+        val expectedHeader = UiStringResWithParams(
+            R.string.threat_item_header_vulnerable_theme,
+            listOf(UiStringText(VULNERABLE_THREAT_SLUG), UiStringText(VULNERABLE_THREAT_VERSION))
+        )
+        // Act
+        val threatItem = buildThreatItem(vulnerableExtensionThreatModel.copy(extension = extension.copy(type = THEME)))
+        // Assert
+        assertThat(threatItem.header).isEqualTo(expectedHeader)
+    }
+
+    @Test
+    fun `builds threat sub header correctly VulnerableExtensionThreatModel of Theme type`() {
+        // Arrange
+        val expectedSubHeader = UiStringRes(R.string.threat_item_sub_header_vulnerable_theme)
+        // Act
+        val threatItem = buildThreatItem(vulnerableExtensionThreatModel.copy(extension = extension.copy(type = THEME)))
+        // Assert
+        assertThat(threatItem.subHeader).isEqualTo(expectedSubHeader)
+    }
+
+    @Test
+    fun `builds threat header correctly for GenericThreatModel`() {
+        // Arrange
+        val expectedHeader = UiStringRes(R.string.threats_found)
+        // Act
+        val threatItem = buildThreatItem(genericThreatModel)
+        // Assert
+        assertThat(threatItem.header).isEqualTo(expectedHeader)
+    }
+
+    @Test
+    fun `builds threat sub header correctly Plugin GenericThreatModel`() {
+        // Arrange
+        val expectedSubHeader = UiStringRes(R.string.threat_item_sub_header_misc_vulnerability)
+        // Act
+        val threatItem = buildThreatItem(genericThreatModel)
+        // Assert
+        assertThat(threatItem.subHeader).isEqualTo(expectedSubHeader)
+    }
+
+    @Test
+    fun `onThreatItemClicked listener is correctly assigned to ThreatItem's onClick`() = test {
+        // Arrange
+        val onThreatItemClicked: (ThreatModel) -> Unit = mock()
+        val threatItem = buildThreatItem(genericThreatModel, onThreatItemClicked)
+        // Act
+        threatItem.onClick.invoke()
+        // Assert
+        verify(onThreatItemClicked).invoke(genericThreatModel)
+    }
+
+    private fun buildThreatItem(threatModel: ThreatModel, onThreatItemClicked: ((ThreatModel) -> Unit) = mock()) =
+        builder.buildThreatItem(
+            threatModel = threatModel,
+            onThreatItemClicked = onThreatItemClicked
+        )
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
@@ -200,7 +200,7 @@ class ThreatItemBuilderTest : BaseUnitTest() {
     @Test
     fun `builds threat header correctly for GenericThreatModel`() {
         // Arrange
-        val expectedHeader = UiStringRes(R.string.threats_found)
+        val expectedHeader = UiStringRes(R.string.threat_item_header_threat_found)
         // Act
         val threatItem = buildThreatItem(genericThreatModel)
         // Assert

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
@@ -165,7 +165,7 @@ class ThreatItemBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds threat sub header correctly VulnerableExtensionThreatModel of Plugin type`() {
+    fun `builds threat sub header correctly for VulnerableExtensionThreatModel of Plugin type`() {
         // Arrange
         val expectedSubHeader = UiStringRes(R.string.threat_item_sub_header_vulnerable_plugin)
         // Act
@@ -188,7 +188,7 @@ class ThreatItemBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds threat sub header correctly VulnerableExtensionThreatModel of Theme type`() {
+    fun `builds threat sub header correctly for VulnerableExtensionThreatModel of Theme type`() {
         // Arrange
         val expectedSubHeader = UiStringRes(R.string.threat_item_sub_header_vulnerable_theme)
         // Act
@@ -208,7 +208,7 @@ class ThreatItemBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds threat sub header correctly Plugin GenericThreatModel`() {
+    fun `builds threat sub header correctly for GenericThreatModel`() {
         // Arrange
         val expectedSubHeader = UiStringRes(R.string.threat_item_sub_header_misc_vulnerability)
         // Act


### PR DESCRIPTION
Parent: #13326

This PR builds threat item state with header + sub header based on different threat types and click listener that will take it to the threat details screen later on.

**To test** 

Prerequisite: Make sure both Scan feature flag and MySiteImprovements flag are set to on in the App settings.

1. Select a site with scan capability on the My Site tab
2. Notice that scan menu is displayed
3. Click scan menu item
4. Notice that threat items are displayed with header and sub header based on threat types as described in the below table:
(Tests included in `ThreatItemBuilderTest`)

References: Calypso's [header](https://opengrok.a8c.com/source/xref/calypso/client/components/jetpack/threat-item-header/index.tsx?r=43d3beb3) & sub header( [1](https://opengrok.a8c.com/source/xref/calypso/client/components/jetpack/threat-item-subheader/index.tsx?r=e940ccc1#83), [2](https://opengrok.a8c.com/source/xref/calypso/client/components/jetpack/threat-item/utils.ts?r=5a6b257a#39))


Threat Type | Header | SubHeader
-- | -- | --
CoreFileModification | {filename}: infected core file | Vulnerability found in WordPress
Database | Database {rows.size} threats | -
File | {filename}: malicious code pattern | Threat found {signature}
VulnerableExtension.ExtensionType.Plugin | Vulnerable Plugin: {slug} (version {version}) | Vulnerability found in plugin
VulnerableExtension.ExtensionType.Theme | Vulnerable Theme: {slug} (version {version}) | Vulnerability found in theme
Generic | Threat found | Miscellaneous vulnerability

**Note**
1. Ignore all styling
2. Not too much detailing is done for the messages e.g. customising `FileThreatModel`'s `SubHeader` based on threat status (`current`/`fixed`/`ignored`)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
