### PR TITLE
Issue/13268 data filtering

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.activitylog.list.filter
 
+import androidx.core.util.Pair
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
@@ -139,11 +140,11 @@ class ActivityLogTypeFilterViewModel @Inject constructor(
                 }
             }
 
-    private fun getSelectedActivityTypeIds(): List<String> =
+    private fun getSelectedActivityTypeIds(): List<Pair<String, UiString>> =
             (_uiState.value as Content).items
                     .filterIsInstance(ListItemUiState.ActivityType::class.java)
                     .filter { it.checked }
-                    .map { it.id }
+                    .map { Pair(it.id, it.title) }
 
     sealed class UiState {
         open val contentVisibility = false

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -168,6 +168,13 @@ class ActivityLogViewModel @Inject constructor(
         rewindStatusService.rewindAvailable.removeObserver(rewindAvailableObserver)
         rewindStatusService.rewindProgress.removeObserver(rewindProgressObserver)
         rewindStatusService.stop()
+        if (currentDateRangeFilter != null || currentActivityTypeFilter.isNotEmpty()) {
+            /**
+             * Clear cache when filters are not empty. Filters are not retained across sessions, therefore the data is
+             * not relevant when the screen is accessed next time.
+             */
+            activityLogStore.clearActivityLogCache(site)
+        }
 
         super.onCleared()
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -125,7 +125,7 @@ class ActivityLogViewModel @Inject constructor(
     private var lastRewindStatus: Status? = null
 
     private var currentDateRangeFilter: DateRange? = null
-    private var currentActivityTypeFilter: List<String> = listOf()
+    private var currentActivityTypeFilter: List<Pair<String, UiString>> = listOf()
 
     private val rewindProgressObserver = Observer<RewindProgress> {
         if (it?.activityLogItem?.activityID != lastRewindActivityId || it?.status != lastRewindStatus) {
@@ -202,8 +202,7 @@ class ActivityLogViewModel @Inject constructor(
     private fun createActivityTypeFilterLabel(): UiString {
         return currentActivityTypeFilter.takeIf { it.isNotEmpty() }?.let {
             if (it.size == 1) {
-                // TODO malinjir replace it[0] with translated name of the activity type
-                UiStringText("${it[0]}")
+                it[0].second
             } else {
                 UiStringResWithParams(
                         R.string.activity_log_activity_type_filter_active_label,
@@ -267,12 +266,12 @@ class ActivityLogViewModel @Inject constructor(
     fun onActivityTypeFilterClicked() {
         _showActivityTypeFilterDialog.value = ShowActivityTypePicker(
                 RemoteId(site.siteId),
-                currentActivityTypeFilter,
+                currentActivityTypeFilter.mapNotNull { it.first },
                 currentDateRangeFilter
         )
     }
 
-    fun onActivityTypesSelected(activityTypeIds: List<String>) {
+    fun onActivityTypesSelected(activityTypeIds: List<Pair<String, UiString>>) {
         currentActivityTypeFilter = activityTypeIds
         refreshFiltersUiState()
         requestEventsUpdate(false)
@@ -380,7 +379,7 @@ class ActivityLogViewModel @Inject constructor(
                 loadMore,
                 currentDateRangeFilter?.first?.let { Date(it) },
                 currentDateRangeFilter?.second?.let { Date(it) },
-                currentActivityTypeFilter
+                currentActivityTypeFilter.mapNotNull { it.first }
         )
         fetchActivitiesJob = launch {
             val result = activityLogStore.fetchActivities(payload)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
+import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.CAN_LOAD_MORE
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.DONE
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.LOADING_MORE
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.FiltersUiState.FiltersHidden
@@ -365,9 +366,10 @@ class ActivityLogViewModel @Inject constructor(
     }
 
     private fun requestEventsUpdate(loadMore: Boolean) {
-        val isLoadingMore = fetchActivitiesJob != null && _eventListStatus.value == ActivityLogListStatus.CAN_LOAD_MORE
-        if (isLoadingMore && loadMore) {
-            // Ignore loadMore request when already loading more items
+        val isLoadingMore = fetchActivitiesJob != null && _eventListStatus.value == ActivityLogListStatus.LOADING_MORE
+        val canLoadMore = _eventListStatus.value == CAN_LOAD_MORE
+        if (loadMore && (isLoadingMore || !canLoadMore)) {
+            // Ignore loadMore request when already loading more items or there are no more items to load
             return
         }
         fetchActivitiesJob?.cancel()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -416,17 +416,15 @@ class ActivityLogViewModel @Inject constructor(
             return
         }
 
-        if (event.rowsAffected > 0) {
-            reloadEvents(
-                    !rewindStatusService.isRewindAvailable,
-                    rewindStatusService.isRewindInProgress,
-                    !event.canLoadMore
-            )
-            if (!loadingMore) {
-                moveToTop.call()
-            }
-            rewindStatusService.requestStatusUpdate()
+        reloadEvents(
+                !rewindStatusService.isRewindAvailable,
+                rewindStatusService.isRewindInProgress,
+                !event.canLoadMore
+        )
+        if (!loadingMore) {
+            moveToTop.call()
         }
+        rewindStatusService.requestStatusUpdate()
 
         if (event.canLoadMore) {
             _eventListStatus.value = ActivityLogListStatus.CAN_LOAD_MORE

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -423,15 +423,17 @@ class ActivityLogViewModel @Inject constructor(
             return
         }
 
-        reloadEvents(
-                !rewindStatusService.isRewindAvailable,
-                rewindStatusService.isRewindInProgress,
-                !event.canLoadMore
-        )
-        if (!loadingMore) {
-            moveToTop.call()
+        if (event.rowsAffected > 0) {
+            reloadEvents(
+                    !rewindStatusService.isRewindAvailable,
+                    rewindStatusService.isRewindInProgress,
+                    !event.canLoadMore
+            )
+            if (!loadingMore) {
+                moveToTop.call()
+            }
+            rewindStatusService.requestStatusUpdate()
         }
-        rewindStatusService.requestStatusUpdate()
 
         if (event.canLoadMore) {
             _eventListStatus.value = ActivityLogListStatus.CAN_LOAD_MORE

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -324,20 +324,20 @@ class ActivityLogViewModel @Inject constructor(
                 resourceProvider.getString(R.string.activity_log_currently_restoring_message_no_dates))
     }
 
-    private fun requestEventsUpdate(isLoadingMore: Boolean) {
-        if (canRequestEventsUpdate(isLoadingMore)) {
-            val newStatus = if (isLoadingMore) LOADING_MORE else ActivityLogListStatus.FETCHING
+    private fun requestEventsUpdate(loadMore: Boolean) {
+        if (canRequestEventsUpdate(loadMore)) {
+            val newStatus = if (loadMore) LOADING_MORE else ActivityLogListStatus.FETCHING
             _eventListStatus.value = newStatus
             val payload = ActivityLogStore.FetchActivityLogPayload(
                     site,
-                    isLoadingMore,
+                    loadMore,
                     currentDateRangeFilter?.first?.let { Date(it) },
                     currentDateRangeFilter?.second?.let { Date(it) },
                     currentActivityTypeFilter
             )
             launch {
                 val result = activityLogStore.fetchActivities(payload)
-                onActivityLogFetched(result, isLoadingMore)
+                onActivityLogFetched(result, loadMore)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.Activity
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.LOADING_MORE
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.FiltersUiState.FiltersHidden
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.FiltersUiState.FiltersShown
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -219,7 +220,14 @@ class ActivityLogViewModel @Inject constructor(
 
     fun onDateRangeSelected(dateRange: DateRange?) {
         currentDateRangeFilter = dateRange
-        // TODO malinjir: refetch/load data
+        refreshFiltersUiState()
+        requestEventsUpdate(false)
+    }
+
+    fun onClearDateRangeFilterClicked() {
+        currentDateRangeFilter = null
+        refreshFiltersUiState()
+        requestEventsUpdate(false)
     }
 
     fun onActivityTypeFilterClicked() {
@@ -232,7 +240,14 @@ class ActivityLogViewModel @Inject constructor(
 
     fun onActivityTypesSelected(activityTypeIds: List<String>) {
         currentActivityTypeFilter = activityTypeIds
-        // TODO malinjir: refetch/load data
+        refreshFiltersUiState()
+        requestEventsUpdate(false)
+    }
+
+    fun onClearActivityTypeFilterClicked() {
+        currentActivityTypeFilter = listOf()
+        refreshFiltersUiState()
+        requestEventsUpdate(false)
     }
 
     fun onRewindConfirmed(rewindId: String) {
@@ -313,7 +328,13 @@ class ActivityLogViewModel @Inject constructor(
         if (canRequestEventsUpdate(isLoadingMore)) {
             val newStatus = if (isLoadingMore) LOADING_MORE else ActivityLogListStatus.FETCHING
             _eventListStatus.value = newStatus
-            val payload = ActivityLogStore.FetchActivityLogPayload(site, isLoadingMore)
+            val payload = ActivityLogStore.FetchActivityLogPayload(
+                    site,
+                    isLoadingMore,
+                    currentDateRangeFilter?.first?.let { Date(it) },
+                    currentDateRangeFilter?.second?.let { Date(it) },
+                    currentActivityTypeFilter
+            )
             launch {
                 val result = activityLogStore.fetchActivities(payload)
                 onActivityLogFetched(result, isLoadingMore)

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
@@ -161,7 +161,7 @@ class ActivityLogTypeFilterViewModelTest : BaseUnitTest() {
 
         (observers.uiStates.last() as Content).primaryAction.action.invoke()
 
-        verify(parentViewModel).onActivityTypesSelected(listOf(activityType.id))
+        verify(parentViewModel).onActivityTypesSelected(listOf(Pair(activityType.id, activityType.title)))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -49,6 +49,7 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Loading
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.RESTORE
 import org.wordpress.android.ui.stats.refresh.utils.DateUtils
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -390,12 +391,15 @@ class ActivityLogViewModelTest {
 
     @Test
     fun onActivityTypeFilterClickPreviouslySelectedTypesPassed() {
-        val selectedItems = listOf("1", "4")
+        val selectedItems = listOf(
+                Pair("backup", UiStringText("Backups and Restores") as UiString),
+                Pair("user", UiStringText("Users") as UiString)
+        )
         viewModel.onActivityTypesSelected(selectedItems)
 
         viewModel.onActivityTypeFilterClicked()
 
-        assertEquals(selectedItems, viewModel.showActivityTypeFilterDialog.value!!.initialSelection)
+        assertEquals(selectedItems.map { it.first }, viewModel.showActivityTypeFilterDialog.value!!.initialSelection)
     }
 
     @Test
@@ -469,7 +473,9 @@ class ActivityLogViewModelTest {
     @Test
     fun activityTypeFilterClearActionShownWhenFilterNotEmpty() {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
-        viewModel.onActivityTypesSelected(listOf("1"))
+        viewModel.onActivityTypesSelected(
+                listOf(Pair("backup", UiStringText("Backups and Restores") as UiString))
+        )
 
         val action = (viewModel.filtersUiState.value as FiltersShown).onClearActivityTypeFilterClicked
         Assertions.assertThat(action != null).isTrue
@@ -487,7 +493,9 @@ class ActivityLogViewModelTest {
     @Test
     fun onActivityTypeFilterClearActionClickClearActionDisappears() {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
-        viewModel.onActivityTypesSelected(listOf("1"))
+        viewModel.onActivityTypesSelected(
+                listOf(Pair("backup", UiStringText("Backups and Restores") as UiString))
+        )
 
         (viewModel.filtersUiState.value as FiltersShown).onClearActivityTypeFilterClicked!!.invoke()
 
@@ -507,16 +515,24 @@ class ActivityLogViewModelTest {
     @Test
     fun activityTypeLabelWithNameShownWhenFilterHasOneItem() {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
-        viewModel.onActivityTypesSelected(listOf("1"))
+        val activityTypeName = "Backups and Restores"
+        viewModel.onActivityTypesSelected(
+                listOf(Pair("backup", UiStringText(activityTypeName) as UiString))
+        )
 
         Assertions.assertThat((viewModel.filtersUiState.value as FiltersShown).activityTypeLabel)
-                .isEqualTo(UiStringText("1"))
+                .isEqualTo(UiStringText(activityTypeName))
     }
 
     @Test
     fun activityTypeLabelWithCountShownWhenFilterHasMoreThanOneItem() {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
-        viewModel.onActivityTypesSelected(listOf("1", "2"))
+        viewModel.onActivityTypesSelected(
+                listOf(
+                        Pair("backup", UiStringText("Backups and Restores") as UiString),
+                        Pair("user", UiStringText("Users") as UiString)
+                )
+        )
 
         Assertions.assertThat((viewModel.filtersUiState.value as FiltersShown).activityTypeLabel)
                 .isEqualTo(

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1131fb9510a7ff4036f54937122105b23f4d1540'
+    fluxCVersion = '1.8.0-beta-4'
 
 
     appCompatVersion = '1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.8.0-beta-3'
+    fluxCVersion = '1131fb9510a7ff4036f54937122105b23f4d1540'
 
 
     appCompatVersion = '1.0.2'


### PR DESCRIPTION
Parent issue #13268

Merge instructions
1. Make sure https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1815 is merged
2. Replace FluxC hash with a tag
3. Remove "Not ready for merge" label
3. Merge this PR

- https://github.com/wordpress-mobile/WordPress-Android/commit/e40023db3f473c4c6456c5aedf28d5c5198d2745 - start passing currently set filters to the fetchActivities request
- https://github.com/wordpress-mobile/WordPress-Android/commit/82b49caf65bfce16627349ad2ef3a79b952a17d6 - renames parameter name from isLoadingMore to loadMore. Since the parameter says that the caller wants to load more items, not that loading more items is in progress.
- https://github.com/wordpress-mobile/WordPress-Android/commit/01fa6585c761d476eb3ab8729b3df0317001482b - previously the app would ignore requests to fetch data when there was an ongoing request. This commit changes this behavior so that any previous request gets canceled. The only exception to this behavior is when the app is loading more items and the caller wants to load more items again. (*)
- https://github.com/wordpress-mobile/WordPress-Android/commit/6fe25a257e6b26d766893a971371f58f027afbf1 - fixes a bug where the app wouldn't refresh the content when no items were found for the currently selected filters. I reverted this fix in https://github.com/wordpress-mobile/WordPress-Android/pull/13647/commits/cc39f74f0914e2125ad5f3f7123b2294b5a3e0bb and fixed it on the FluxC's side in [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1815/commits/27dca61ba6575f828d2d161196c3ab92b535f545) (*)
- 35430ab79d88edfbb2264739b4cb803cf124b1e5 - clears cache when the user leaves the screen and the filters are not empty. Since filters are not retained across sessions, the data in cache need to be cleared so they are not displayed the next time user accesses this screen. This is a naive implementation but I think it is good enough for now. We considered implementing a more robust solution which would allow us to save different data sets (based on the filters) into the cache, but decided against it for now (it's not worth the effort).
- 



Known issues which will be fixed in upcoming PRs
1. When there are no data for a certain filter combination, "No Activity Yet" empty screen is shown. This will be fix in an upcoming PR.
2. When a date range with no data available is selected and the user opens Activity Type filter, an empty list is shown. This will be fix in an upcoming PR.
3. The filters are accessible even on sites which don't support filtering. This will be fix in an upcoming PR.
4. **Filters are shown for all site types, however, they don't work everywhere. I'm not 100% sure yet, what are the conditions. But I tested it on an atomic site and a self-hosted site with Jetpack Premium plan and it worked there. Use one of these site types for the tests** 


To test:

`Test filters 1`
- Enable ActivityLogFiltersFeatureConfig

1. Open Activity Log
2. Verify data get loaded
3. Set date range to today
4. Verify data get filtered
5. Set an Activity Type filter
6. Verify data get filtered
7. Clear Date range filter
8. Notice data get refreshed and verify only data for activity type filter are shown
9. Continue playing with the filters and verify everything works

-------------
`Test filters 2`
- Enable ActivityLogFiltersFeatureConfig

1. Open Activity Log
2. Verify data get loaded
3. Set date range filter 4 months ago (any date range for which there aren't any activities available)
4. Notice an empty screen is shown - before https://github.com/wordpress-mobile/WordPress-Android/commit/6fe25a257e6b26d766893a971371f58f027afbf1  the app would keep showing the previous content
----------------------
`Test Clear cache action`
- Enable ActivityLogFiltersFeatureConfig
 
1. Open Activity Log
2. Wait until the data are shown
3. Click on back
4. Turn on Airplane mode
5. Open Activity Log - verify cached data are shown (the cache didn't get cleared)
6. Turn off airplane mode
7. Set an Activity Type filter
8. Wait until the data get filtered
9. Click on back
10. Turn on airplane mode
11. Open Activity log - verify no data are shown ( the cache got cleared)
------------------------
`Test cancelation of an ongoing request`
- Enable ActivityLogFiltersFeatureConfig
1. Throttle your network speed/quality (or use a proxy and pause the request)
2. Open Activity Log
3. Pull to refresh and really quickly open the date range picker, select a date and click on Save
4. Verify data for the correct date range are shown (the request didn't get canceled because of the ongoing "load more" request)
5. Clear the filter
6. Scroll to bottom and notice the app is loading more items -> before the request completes scroll a bit to top (few pixels) and scroll to bottom again -> keep doing this until more data get loaded (the load more request doesn't get cancelled even)
---------------------------------
- Disable ActivityLogFiltersFeatureConfig and make sure the activity log still works as expected. Commits marked with `*` affect even the activity log without filters and these changes will go live with the next version of the app. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
