### PR TITLE
Add use case

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/GetActivityLogItemUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/GetActivityLogItemUseCase.kt
@@ -10,7 +10,7 @@ import javax.inject.Named
 
 class GetActivityLogItemUseCase @Inject constructor(
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
-    private val activityLogStore: ActivityLogStore,
+    private val activityLogStore: ActivityLogStore
 ) {
     suspend fun get(
         activityId: String

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/GetActivityLogItemUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/GetActivityLogItemUseCase.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.ui.jetpack.backup.download
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.activity.ActivityLogModel
+import org.wordpress.android.fluxc.store.ActivityLogStore
+import org.wordpress.android.modules.IO_THREAD
+import javax.inject.Inject
+import javax.inject.Named
+
+class GetActivityLogItemUseCase @Inject constructor(
+    @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher,
+    private val activityLogStore: ActivityLogStore,
+) {
+    suspend fun get(
+        activityId: String
+    ): ActivityLogModel? =
+            withContext(ioDispatcher) {
+                activityLogStore.getActivityLogItemByActivityId(activityId)
+            }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
@@ -8,7 +8,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.DetailsToolbarState
-import org.wordpress.android.ui.jetpack.backup.download.GetActivityLogItemUseCase
+import org.wordpress.android.ui.jetpack.usecases.GetActivityLogItemUseCase
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.CheckboxState

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
@@ -5,10 +5,10 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.DetailsToolbarState
+import org.wordpress.android.ui.jetpack.backup.download.GetActivityLogItemUseCase
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.CheckboxState
@@ -21,7 +21,7 @@ import javax.inject.Named
 
 class BackupDownloadDetailsViewModel @Inject constructor(
     private val availableItemsProvider: JetpackAvailableItemsProvider,
-    private val activityLogStore: ActivityLogStore,
+    private val getActivityLogItemUseCase: GetActivityLogItemUseCase,
     private val stateListItemBuilder: BackupDownloadDetailsStateListItemBuilder,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {
@@ -49,8 +49,7 @@ class BackupDownloadDetailsViewModel @Inject constructor(
     private fun getData() {
         launch {
             val availableItems = availableItemsProvider.getAvailableItems()
-            // todo: annmarie move this to a useCase
-            val activityLogModel = activityLogStore.getActivityLogItemByActivityId(activityId)
+            val activityLogModel = getActivityLogItemUseCase.get(activityId)
             if (activityLogModel != null) {
                 _uiState.value = Content(
                         items = stateListItemBuilder.buildDetailsListStateItems(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/usecases/GetActivityLogItemUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/usecases/GetActivityLogItemUseCase.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.jetpack.backup.download
+package org.wordpress.android.ui.jetpack.usecases
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadDetailsViewModelTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDe
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.CheckboxState
+import org.wordpress.android.ui.jetpack.usecases.GetActivityLogItemUseCase
 import java.util.Date
 
 @InternalCoroutinesApi

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadDetailsViewModelTest.kt
@@ -11,7 +11,6 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
-import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.test
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsStateListItemBuilder
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider
@@ -25,23 +24,23 @@ import java.util.Date
 class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: BackupDownloadDetailsViewModel
     private lateinit var availableItemsProvider: JetpackAvailableItemsProvider
-    @Mock private lateinit var activityLogStore: ActivityLogStore
+    @Mock private lateinit var getActivityLogItemUseCase: GetActivityLogItemUseCase
     private lateinit var backupDownloadDetailsStateListItemBuilder: BackupDownloadDetailsStateListItemBuilder
     @Mock private lateinit var parentViewModel: BackupDownloadViewModel
     @Mock private lateinit var site: SiteModel
     private val activityId = "1"
 
     @Before
-    fun setUp() {
+    fun setUp() = test {
         availableItemsProvider = JetpackAvailableItemsProvider()
         backupDownloadDetailsStateListItemBuilder = BackupDownloadDetailsStateListItemBuilder()
         viewModel = BackupDownloadDetailsViewModel(
                 availableItemsProvider,
-                activityLogStore,
+                getActivityLogItemUseCase,
                 backupDownloadDetailsStateListItemBuilder,
                 TEST_DISPATCHER
         )
-        whenever(activityLogStore.getActivityLogItemByActivityId(anyOrNull())).thenReturn(fakeActivityLogModel)
+        whenever(getActivityLogItemUseCase.get(anyOrNull())).thenReturn(fakeActivityLogModel)
     }
 
     @Test


### PR DESCRIPTION
Parent #13329 

This PR adds the `GetActivityLogItemUseCase` and replaces the direct call to ActivityLogStore in the VM.

**To test:**
- Launch the app with BackupDownloadConfig flag on
- Navigate to ActivityLog
- Tap the More menu
- Tap Download Backup menu item
- Note that the view is shown as expected and the date in the description matches the activity log item date

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
