### PR TITLE
Remove checkmark in reader subfilter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
@@ -17,10 +17,6 @@ open class SubfilterListItemViewHolder(
     @LayoutRes layout: Int
 ) : ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
     open fun bind(filter: SubfilterListItem, uiHelpers: UiHelpers) {
-        val selectedTick: ImageView? = this.itemView.findViewById(R.id.item_selected)
-        selectedTick?.let {
-            it.visibility = if (filter.isSelected) View.VISIBLE else View.GONE
-        }
         val itemText: TextView? = this.itemView.findViewById(R.id.item_title)
         itemText?.let {
             it.setTextColor(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SubfilterListItemViewHolder.kt
@@ -1,9 +1,7 @@
 package org.wordpress.android.ui.reader.subfilter.viewholders
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.recyclerview.widget.RecyclerView.ViewHolder

--- a/WordPress/src/main/res/color/primary_on_surface_selector.xml
+++ b/WordPress/src/main/res/color/primary_on_surface_selector.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:color="?attr/colorOnSurface" android:state_selected="false" />
-    <item android:color="?attr/colorPrimary" />
-
-</selector>

--- a/WordPress/src/main/res/layout/subfilter_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/subfilter_bottom_sheet.xml
@@ -33,8 +33,7 @@
             app:tabIndicatorColor="?attr/colorPrimary"
             app:tabMode="scrollable"
             app:tabPaddingEnd="@dimen/content_bottom_sheet_tab_padding"
-            app:tabPaddingStart="@dimen/content_bottom_sheet_tab_padding"
-            app:tabTextColor="@color/primary_on_surface_selector" />
+            app:tabPaddingStart="@dimen/content_bottom_sheet_tab_padding" />
 
         <androidx.viewpager.widget.ViewPager
             android:id="@+id/view_pager"

--- a/WordPress/src/main/res/layout/subfilter_list_item.xml
+++ b/WordPress/src/main/res/layout/subfilter_list_item.xml
@@ -10,7 +10,7 @@
         style="@style/SiteTagFilteredTitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toStartOf="@+id/item_selected"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/item_url"
         app:layout_constraintTop_toTopOf="parent"
@@ -23,23 +23,10 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/item_selected"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/item_title"
         android:visibility="visible"
         tools:text="www.unknown.com" />
-
-    <ImageView
-        android:id="@+id/item_selected"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_done_white_24dp"
-        app:tint="?attr/colorPrimary"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:visibility="gone"
-        tools:visibility="visible"
-        android:contentDescription="@string/reader_btn_selected_filter_tick_content_description" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1780,7 +1780,6 @@
     <!-- accessibility content desciptions -->
     <string name="reader_btn_remove_filter_content_description">Remove the current filter</string>
     <string name="reader_btn_select_filter_content_description">Select a Site or Tag to filter posts</string>
-    <string name="reader_btn_selected_filter_tick_content_description">Selected</string>
     <string name="reader_bottom_sheet_content_description">Select a Tag or Site, Pop Up Window</string>
     <string name="reader_choose_interests_content_description">Choose your interests</string>
 


### PR DESCRIPTION
Fixes #13648

This PR removes the checkmark that was visualized on the selected item in the reader bottom sheet. This is done to pair with iOS subsequent implementation. Also it is in preparation to unread posts count modification as per issue #13454

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/102824519-4d617c80-43dd-11eb-95e2-b7cd7ba51ac2.png) | ![image](https://user-images.githubusercontent.com/47797566/102824319-e5129b00-43dc-11eb-95b7-6329747d4382.png) |

While looking into this I noticed that the color of the not selected tab text was wrong in light mode (I would expect the same color scheme of the main tabs reader for example). I think the issue is setting explicitly the `app:tabTextColor="@color/primary_on_surface_selector"` in the `subfilter_bottom_sheet`. Removing it allows to use the styles set for the for the tabs in the app theme.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/102824927-12137d80-43de-11eb-9531-c168abd10af7.png) | ![image](https://user-images.githubusercontent.com/47797566/102825092-64ed3500-43de-11eb-8be8-a3e3d2c67305.png) |

Also Dark mode aligns better (looking to the unselected tab text) with the main reader tabs color scheme.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/102825355-e04ee680-43de-11eb-9a91-733b9fae40bb.png) | ![image](https://user-images.githubusercontent.com/47797566/102825156-864e2100-43de-11eb-891c-1a88de39253e.png) |


## To test
### Removing checkmark
- Open the reader subfilter
- Select a site 
- Open the filter again and notice the checkmark is not present
- Check the same with Topics
- Smoke test the subfilter

### Align Tabs text color to theme schema
- Set the light app theme
- In the reader Following tab open the subfilter
- Check the tabs color for selected and unselected reflect that in the main reader tabs
- Check the same with dark app theme

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
