### PR TITLE
Fix crash on calling tracking method in notifications details

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -149,7 +149,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
         }
         // track initial comment note view
-        if (savedInstanceState == null) {
+        if (savedInstanceState == null && note != null) {
             trackCommentNote(note);
         }
     }
@@ -245,7 +245,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
         mViewPager.addOnPageChangeListener(mOnPageChangeListener);
     }
 
-    private void trackCommentNote(Note note) {
+    private void trackCommentNote(@NotNull Note note) {
         if (note.isCommentType()) {
             SiteModel site = mSiteStore.getSiteBySiteId(note.getSiteId());
             AnalyticsUtils.trackCommentActionWithSiteDetails(


### PR DESCRIPTION
Fixes #13643

I was not able to reproduce the crash but the root cause is [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java#L153) where we're passing a nullable note to the `trackCommentNote` method.

This PR checks for note's nullability and adds `@NotNull` annotation to the `trackCommentNote`'s `note` param.

Also note that when the note is `null`, the preceding method [updateUIAndNote](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java#L145) already displays an error and returns [after initiating activity finish](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java#L171-L175), after which the erroneous line gets executed. Since the activity is already finishing, it seems fine to just add this null check and not call the tracking method.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
