### PR TITLE
Issue/13268 date range fixes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
@@ -49,8 +49,17 @@ class DateUtils @Inject constructor(
         )
     }
 
-    fun formatDateRange(from: Long, to: Long): String =
-            DateUtils.formatDateRange(contextProvider.getContext(), from, to, DateUtils.FORMAT_ABBREV_MONTH)
+    fun formatDateRange(from: Long, to: Long, timezone: String): String {
+        val formatter = java.util.Formatter(StringBuilder(50), localeManagerWrapper.getLocale())
+        return DateUtils.formatDateRange(
+                contextProvider.getContext(),
+                formatter,
+                from,
+                to,
+                DateUtils.FORMAT_ABBREV_MONTH,
+                timezone
+        ).toString()
+    }
 
     private fun getDateTimeFlags(): Int {
         var flags = 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateUtils.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.util.capitalizeWithLocaleWithoutLint
 import org.wordpress.android.viewmodel.ContextProvider
 import java.text.SimpleDateFormat
 import java.util.Calendar
+import java.util.Formatter
 import javax.inject.Inject
 
 class DateUtils @Inject constructor(
@@ -50,7 +51,7 @@ class DateUtils @Inject constructor(
     }
 
     fun formatDateRange(from: Long, to: Long, timezone: String): String {
-        val formatter = java.util.Formatter(StringBuilder(50), localeManagerWrapper.getLocale())
+        val formatter = Formatter(StringBuilder(50), localeManagerWrapper.getLocale())
         return DateUtils.formatDateRange(
                 contextProvider.getContext(),
                 formatter,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -49,6 +49,10 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
 
+private const val DAY_IN_MILLIS = 1000 * 60 * 60 * 24
+private const val ONE_SECOND_IN_MILLIS = 1000
+private const val TIMEZONE_UTC = "UTC"
+
 typealias DateRange = Pair<Long, Long>
 
 class ActivityLogViewModel @Inject constructor(
@@ -195,7 +199,7 @@ class ActivityLogViewModel @Inject constructor(
 
     private fun createDateRangeFilterLabel(): UiString {
         return currentDateRangeFilter?.let {
-            UiStringText(dateUtils.formatDateRange(requireNotNull(it.first), requireNotNull(it.second)))
+            UiStringText(dateUtils.formatDateRange(requireNotNull(it.first), requireNotNull(it.second), TIMEZONE_UTC))
         } ?: UiStringRes(R.string.activity_log_date_range_filter_label)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -257,7 +257,11 @@ class ActivityLogViewModel @Inject constructor(
     }
 
     fun onDateRangeSelected(dateRange: DateRange?) {
-        currentDateRangeFilter = dateRange
+        val adjustedDateRange = dateRange?.let {
+            // adjust time of the end of the date range to 23:59:59
+            Pair(dateRange.first, dateRange.second?.let { it + DAY_IN_MILLIS - ONE_SECOND_IN_MILLIS })
+        }
+        currentDateRangeFilter = adjustedDateRange
         refreshFiltersUiState()
         requestEventsUpdate(false)
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -51,7 +51,7 @@ import javax.inject.Named
 
 private const val DAY_IN_MILLIS = 1000 * 60 * 60 * 24
 private const val ONE_SECOND_IN_MILLIS = 1000
-private const val TIMEZONE_UTC = "UTC"
+private const val TIMEZONE_GMT_0 = "GMT+0"
 
 typealias DateRange = Pair<Long, Long>
 
@@ -199,7 +199,7 @@ class ActivityLogViewModel @Inject constructor(
 
     private fun createDateRangeFilterLabel(): UiString {
         return currentDateRangeFilter?.let {
-            UiStringText(dateUtils.formatDateRange(requireNotNull(it.first), requireNotNull(it.second), TIMEZONE_UTC))
+            UiStringText(dateUtils.formatDateRange(requireNotNull(it.first), requireNotNull(it.second), TIMEZONE_GMT_0))
         } ?: UiStringRes(R.string.activity_log_date_range_filter_label)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterViewModelTest.kt
@@ -127,7 +127,7 @@ class ActivityLogTypeFilterViewModelTest : BaseUnitTest() {
 
         ((uiStates.last() as Content).items[1] as ActivityType).onClick.invoke()
 
-        assertThat(((uiStates.last() as Content).items[1] as ActivityType).checked).isTrue()
+        assertThat(((uiStates.last() as Content).items[1] as ActivityType).checked).isTrue
     }
 
     @Test
@@ -138,7 +138,7 @@ class ActivityLogTypeFilterViewModelTest : BaseUnitTest() {
         ((uiStates.last() as Content).items[1] as ActivityType).onClick.invoke()
         ((uiStates.last() as Content).items[1] as ActivityType).onClick.invoke()
 
-        assertThat(((uiStates.last() as Content).items[1] as ActivityType).checked).isFalse()
+        assertThat(((uiStates.last() as Content).items[1] as ActivityType).checked).isFalse
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -415,7 +415,7 @@ class ActivityLogViewModelTest {
     @Test
     fun dateRangeFilterClearActionShownWhenFilterNotEmpty() {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(dateUtils.formatDateRange(10L, 20L)).thenReturn("TEST")
+        whenever(dateUtils.formatDateRange(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn("TEST")
         val dateRange = Pair(10L, 20L)
 
         viewModel.onDateRangeSelected(dateRange)
@@ -436,7 +436,7 @@ class ActivityLogViewModelTest {
     @Test
     fun onDateRangeFilterClearActionClickClearActionDisappears() {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(dateUtils.formatDateRange(10L, 20L)).thenReturn("TEST")
+        whenever(dateUtils.formatDateRange(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn("TEST")
         viewModel.onDateRangeSelected(Pair(10L, 20L))
 
         (viewModel.filtersUiState.value as FiltersShown).onClearDateRangeFilterClicked!!.invoke()
@@ -458,7 +458,7 @@ class ActivityLogViewModelTest {
     @Test
     fun dateRangeLabelWithDatesShownWhenFilterNotEmpty() {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(dateUtils.formatDateRange(10L, 20L)).thenReturn("TEST")
+        whenever(dateUtils.formatDateRange(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn("TEST")
 
         viewModel.onDateRangeSelected(Pair(10L, 20L))
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -513,8 +513,6 @@ class ActivityLogViewModelTest {
         )
     }
 
-
-
     @Test
     fun activityTypeFilterClearActionShownWhenFilterNotEmpty() {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -65,7 +65,7 @@ import java.util.Date
 private const val DATE_1_IN_MILLIS = 1578614400000L // 2020-01-10T00:00:00+00:00
 private const val DATE_2_IN_MILLIS = 1578787200000L // 2020-01-12T00:00:00+00:00
 
-private const val TIMEZONE_UTC = "UTC"
+private const val TIMEZONE_GMT_0 = "GMT+0"
 private const val ONE_DAY_WITHOUT_SECOND_IN_MILLIS = 1000 * 60 * 60 * 24 - 1000
 
 @RunWith(MockitoJUnitRunner::class)
@@ -482,7 +482,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun dateRangeLabelFormattingUsesUTCTimezone() {
+    fun dateRangeLabelFormattingUsesGMT0Timezone() {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         whenever(
                 dateUtils.formatDateRange(
@@ -495,7 +495,7 @@ class ActivityLogViewModelTest {
         viewModel.onDateRangeSelected(Pair(10L, 20L))
 
         Assertions.assertThat(formatDateRangeTimezoneCaptor.firstValue)
-                .isEqualTo(TIMEZONE_UTC)
+                .isEqualTo(TIMEZONE_GMT_0)
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'd9dc7ec93728355a402affe8accd5b2d8b3d61db'
+    fluxCVersion = '1.8.0-beta-4'
 
 
     appCompatVersion = '1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1131fb9510a7ff4036f54937122105b23f4d1540'
+    fluxCVersion = 'd9dc7ec93728355a402affe8accd5b2d8b3d61db'
 
 
     appCompatVersion = '1.0.2'


### PR DESCRIPTION
Parent issue #13268

This PR fixes a few issues related to DateRange filtering in Activity Log

Merge instructions:
1. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/13647 is merged
2. Update FLuxC hash with tag (https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1816)
3. Remove the "Not Ready for Merge label"
4. Merge this PR

### Issue 1
DateRange provided by the MaterialDateRangePicker is in GMT+0. However, the user wants to see data for dateRange in their timezone not in UTC. This issue is fixed in FluxC - more info on [this PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1816).
Fixed in https://github.com/wordpress-mobile/WordPress-Android/commit/92876fd2050fdf11aac4e53350973c1476f5db74

### Issue 2
Label on the dateRange filter chip was being formatted using device timezone. However, MaterialDateRangePicker is using GMT+0. This lead to an issue when device timezone was `GMT-N`. For example when the user selected "Nov 10-12th" in "GMT-7", the label was "Nov 9 - 11".
This issue is fixed in https://github.com/wordpress-mobile/WordPress-Android/commit/caa13cf374fe6b13602489145cf1fc01a84e82ae

### Issue 3
When user selected any date range, the end date was set to start of the day instead of end of the day. This lead to multiple issues. For example selecting date range for a single day "Nov 10-10" would never show any data, since the range had duration equal to 0seconds. 
Fixed in https://github.com/wordpress-mobile/WordPress-Android/commit/214cc2dad56072e1b55bb2fefc7b5abdad681aa2

To test:
1. Set device timezone to "GMT-7"(Denver)
2. Restart the app
3. Open Activity Log
4. Open Date Range filter
4. Select 10-12th of December 2020
5. Start Stetho or an alternative -> Click on Apply/Save
6. Verify the label is "Dec 10 - 12" (it was "Dec 9 - 11" before this PR) (`Issue 2`)
7. Look at Stetho and verify the request
    a) Timezone is GMT+0 (contains `+00:00`) (this change was not necessary but I decided to stay consistent with calypso)
    b)  Date range is taking into account user timezone (it's 7 hours from midnight since we are using GMT-7) (`Issue 1`)
    c)  `before`(range end) parameter is selected date plus 23h 59m 59s

`?page=1&number=10&after=2020-12-10T07:00:00+00:00&before=2020-12-13T06:59:59+00:00&_locale=en_US`


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
