### PR TITLE
Added EditorMediaListener as a parameter of StoriesEventListener to use in internal EditorMedia

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -677,7 +677,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
         setupPrepublishingBottomSheetRunnable();
 
-        mStoriesEventListener.start(this.getLifecycle(), mSite, mEditPostRepository);
+        mStoriesEventListener.start(this.getLifecycle(), mSite, mEditPostRepository, this);
         setupPreviewUI();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.editor.media.EditorMedia
+import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
 import org.wordpress.android.ui.stories.SaveStoryGutenbergBlockUseCase.Companion.TEMPORARY_ID_PREFIX
 import org.wordpress.android.ui.stories.StoryRepositoryWrapper
 import org.wordpress.android.ui.stories.media.StoryMediaSaveUploadBridge.StoryFrameMediaModelCreatedEvent
@@ -80,11 +81,17 @@ class StoriesEventListener @Inject constructor(
         eventBusWrapper.unregister(this)
     }
 
-    fun start(lifecycle: Lifecycle, site: SiteModel, editPostRepository: EditPostRepository) {
+    fun start(
+        lifecycle: Lifecycle,
+        site: SiteModel,
+        editPostRepository: EditPostRepository,
+        editorMediaListener: EditorMediaListener
+    ) {
         this.site = site
         this.editPostRepository = editPostRepository
         this.lifecycle = lifecycle
         this.lifecycle.addObserver(this)
+        this.editorMedia.start(site, editorMediaListener)
     }
 
     fun setSaveMediaListener(newListener: StorySaveMediaListener) {


### PR DESCRIPTION
Fixes #13649

This issue was happening because the  `StoriesEventListener` class has the injected instance of `EditorMedia` within, but is only initialized when `start()` is called on it. This instance is correctly initialized in `EditPostActivity`'s `onCreate()` method, but the StoriesEventListener does not hold a reference to the EditorMedia's EditorMediaListener until an actual upload of media for a Story is performed. 

With that, if a Story was created and one of its media items failed to get uploaded, then you opened the Gutenberg editor, the variable was uninitialized, causing the first events received when tapping on "Retry" on the retry upload dialog to incur in the uninitialized variable exception being thrown.

To test:
1. create a story with a new slide and add some text on it (on the My site or Posts list, tap the FAB button, then Story)
2. once you tap on publish button on the pre-publish bottom sheet, turn airplane mode ON to prevent the image from being uploaded and incur in error
3. wait for the error to appear
4. open the failed Post in the draft post list
5. at this point you could turn airplane mode off.
6. Tap on the failed Story block, and when the retry dialog appears, tap RETRY
7. wait for a few seconds and watch it start uploading and everything should end up well (without crashes)

Video showing this: https://cloudup.com/cTrUaFFe1ZD

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
