### PR TITLE
Fix getMediaWithLocalId receiver to accept null value

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.posts.editor
 
 import android.app.Activity
-import android.content.DialogInterface
 import android.net.Uri
 import androidx.appcompat.app.AlertDialog.Builder
 import androidx.lifecycle.Lifecycle

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -287,10 +287,7 @@ class StoriesEventListener @Inject constructor(
                             activity
                     )
                     builder.setTitle(activity.getString(string.cannot_retry_deleted_media_item_fatal))
-                    builder.setPositiveButton(string.yes) { dialog, id -> dialog.dismiss() }
-                    builder.setNegativeButton(activity.getString(string.no),
-                            DialogInterface.OnClickListener { dialog: DialogInterface, id: Int -> dialog.dismiss() }
-                    )
+                    builder.setPositiveButton(string.ok) { dialog, id -> dialog.dismiss() }
                     val dialog = builder.create()
                     dialog.show()
                     return

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -275,7 +275,7 @@ class StoriesEventListener @Inject constructor(
                     (mediaFile as HashMap<String?, Any?>)["id"].toString(), 0
             )
             if (localMediaId != 0) {
-                val media: MediaModel = mediaStore.getMediaWithLocalId(localMediaId)
+                val media: MediaModel? = mediaStore.getMediaWithLocalId(localMediaId)
                 // if we find at least one item in the mediaFiles collection passed
                 // for which we don't have a local MediaModel, just tell the user and bail
                 if (media == null) {


### PR DESCRIPTION
Fixes #13658 

Title has it - the `val` receiving the result from `mediaStore.getMediaWithLocalId()` should accept nulls (we even considered a specific flow for that case a few lines below), but was being declared as `val media: MediaModel` (making Kotlin strict about non-nullability here).

This PR fixes that (df47bbb) and also removes an unneeded `Yes/No` positive/negative option in the informative dialog, making it just `Ok` now (change in 3005c04).

![dialog_null](https://user-images.githubusercontent.com/6597771/102932349-e2688200-447e-11eb-8431-0f35fa471fa6.gif)


To test:
1. create a story with two images (slides) and added text
2. when publishing, tap publish and then immediately turn airplane mode ON
3. wait for the error notification to appear
4. go to the media section of the app, and delete one of the flattened Story images, corresponding to the image you selected plus the text you added (this is the new composed image which was going to be uploaded to the site, as part of your Story post)
5. now go to the Posts list, find your failed post, open it
6. turn airplane mode OFF
7. tap on the Story block which should have the failed overlay and the retry dialog appears
8. tap on the `Retry` option
9. observe a new error dialog appears, stating the image is gone now (as opposed to having the app crash)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
