### PR TITLE
WP Stories: skip Post processing for uploaded media if the passed media does not yet have a remote mediaID

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.stories
 
+import android.text.TextUtils
 import com.google.gson.Gson
 import com.wordpress.stories.compose.frame.FrameIndex
 import com.wordpress.stories.compose.story.StoryFrameItem
@@ -114,6 +115,11 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
     }
 
     fun replaceLocalMediaIdsWithRemoteMediaIdsInPost(postModel: PostModel, mediaFile: MediaFile) {
+        if (TextUtils.isEmpty(mediaFile.mediaId)) {
+            // if for any reason we couldn't obtain a remote mediaId, it's not worth spending time
+            // looking to replace anything in the Post. Skip processing for later in error handling.
+            return
+        }
         val gson = Gson()
         findAllStoryBlocksInPostAndPerformOnEachMediaFilesJson(
                 postModel,


### PR DESCRIPTION

Fixes #13650

This PR just omits processing a Post to replace the media local iDs with the remote media ids, for media items that do not have yet a remote id assigned (it doesn't even make sense to parse the whole Post if we end up not being able to replace the id because we don't have a new one to assign in the first place).

To test:
N/A - I haven't been able to reproduce the crash, but I think having a Story with multiple slides, where one of the slides may fail getting uploaded, could potentially get the `MediaUploadReadyProcessor` to get executed nevertheless (for the rest of media, which have been successful), and this failed one could cause the problem to be run into.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
