### PR TITLE
Fix crash on calling method to track comment note

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -149,7 +149,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
         }
         // track initial comment note view
-        if (savedInstanceState == null) {
+        if (savedInstanceState == null && note != null) {
             trackCommentNote(note);
         }
     }
@@ -245,7 +245,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
         mViewPager.addOnPageChangeListener(mOnPageChangeListener);
     }
 
-    private void trackCommentNote(Note note) {
+    private void trackCommentNote(@NotNull Note note) {
         if (note.isCommentType()) {
             SiteModel site = mSiteStore.getSiteBySiteId(note.getSiteId());
             AnalyticsUtils.trackCommentActionWithSiteDetails(


### PR DESCRIPTION
Fixes #13643

Originally fixed and reviewed here: https://github.com/wordpress-mobile/WordPress-Android/pull/13654
Targeting `release/16.4` due to almost doubling of user count and events in the past 2 days:

User Count: 45 -> 80
Count: 69 -> 117

(Issue introduced in the last release `16.3-rc-1+962`)

To test: N/A 
(I just cherry picked already reviewed commit.)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
