### PR TITLE
WP Stories: re-phrasing error message 

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -208,7 +208,7 @@
     <!-- Delete Media -->
     <string name="cannot_delete_multi_media_items">Some media can\'t be deleted at this time. Try again later.</string>
     <string name="cannot_retry_deleted_media_item">Media has been removed. Delete it from this post?</string>
-    <string name="cannot_retry_deleted_media_item_fatal">Media has been removed. Try editing your Story.</string>
+    <string name="cannot_retry_deleted_media_item_fatal">Media has been removed. Try re-creating your Story.</string>
     <string name="media_empty_list">You don\'t have any media</string>
     <string name="media_empty_search_list">No media matching your search</string>
     <string name="media_empty_image_list">You don\'t have any images</string>


### PR DESCRIPTION
Comes from a suggestion by @ashiagr [here](https://github.com/wordpress-mobile/WordPress-Android/pull/13660#pullrequestreview-557644460)

> Just one odd thing I noticed:
Error message on retry says "Media has been removed. Try editing your story."
When I try editing the story, I get another error message: "Can't edit Story: We couldn't find the media for this story on the site."

> How about we rephrase the first error message and replace "Try editing" with "Try recreating" as editing is not supported in this case? 

👍 

To test:
- follow instructions in #13660 and verify the first error message is now `Media has been removed. Try re-creating your Story.` instead of `Media has been removed. Try editing your Story.`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
