### PR TITLE
Add snackbar observable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
@@ -114,14 +114,14 @@ class BackupDownloadActivity : LocaleAwareActivity() {
     private fun SnackbarMessageHolder.showSnackbar() {
         val snackbar = WPSnackbar.make(
                 coordinator_layout,
-                uiHelpers.getTextOfUiString(this@BackupDownloadActivity, this.message),
+                uiHelpers.getTextOfUiString(this@BackupDownloadActivity, message),
                 Snackbar.LENGTH_LONG
         )
-        if (this.buttonTitle != null) {
+        if (buttonTitle != null) {
             snackbar.setAction(
-                    uiHelpers.getTextOfUiString(this@BackupDownloadActivity, this.buttonTitle)
+                    uiHelpers.getTextOfUiString(this@BackupDownloadActivity, buttonTitle)
             ) {
-                this.buttonAction.invoke()
+                buttonAction.invoke()
             }
         }
         snackbar.show()

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -6,6 +6,7 @@ import android.os.Parcelable
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
@@ -14,6 +15,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep.COMPLETE
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep.DETAILS
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep.PROGRESS
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
 import org.wordpress.android.util.wizard.WizardState
@@ -64,6 +66,9 @@ class BackupDownloadViewModel @Inject constructor(
     private val _onBackPressedObservable = MutableLiveData<Event<Unit>>()
     val onBackPressedObservable: LiveData<Event<Unit>> = _onBackPressedObservable
 
+    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
     fun start(savedInstanceState: Bundle?) {
         if (isStarted) return
         isStarted = true
@@ -80,6 +85,11 @@ class BackupDownloadViewModel @Inject constructor(
         }
     }
 
+    fun addSnackbarMessageSource(snackbarEvents: LiveData<Event<SnackbarMessageHolder>>) {
+        _snackbarEvents.addSource(snackbarEvents) { event ->
+            _snackbarEvents.value = event
+        }
+    }
     fun writeToBundle(outState: Bundle) {
         outState.putBoolean(KEY_BACKUP_DOWNLOAD_COMPLETED, backupDownloadCompleted)
         outState.putInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP, wizardManager.currentStep)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -90,6 +90,7 @@ class BackupDownloadViewModel @Inject constructor(
             _snackbarEvents.value = event
         }
     }
+    
     fun writeToBundle(outState: Bundle) {
         outState.putBoolean(KEY_BACKUP_DOWNLOAD_COMPLETED, backupDownloadCompleted)
         outState.putInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP, wizardManager.currentStep)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -90,7 +90,7 @@ class BackupDownloadViewModel @Inject constructor(
             _snackbarEvents.value = event
         }
     }
-    
+
     fun writeToBundle(outState: Bundle) {
         outState.putBoolean(KEY_BACKUP_DOWNLOAD_COMPLETED, backupDownloadCompleted)
         outState.putInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP, wizardManager.currentStep)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.jetpack.backup.download.details
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
@@ -15,6 +16,9 @@ import org.wordpress.android.ui.jetpack.common.JetpackListItemState.CheckboxStat
 import org.wordpress.android.ui.jetpack.common.ViewType.CHECKBOX
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -33,17 +37,25 @@ class BackupDownloadDetailsViewModel @Inject constructor(
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
 
+    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
     fun start(site: SiteModel, activityId: String, parentViewModel: BackupDownloadViewModel) {
+        if (isStarted) return
+        isStarted = true
+
         this.site = site
         this.activityId = activityId
         this.parentViewModel = parentViewModel
 
         parentViewModel.setToolbarState(DetailsToolbarState())
 
-        if (isStarted) return
-        isStarted = true
-
+        initSources()
         getData()
+    }
+
+    private fun initSources() {
+        parentViewModel.addSnackbarMessageSource(snackbarEvents)
     }
 
     private fun getData() {
@@ -67,6 +79,7 @@ class BackupDownloadDetailsViewModel @Inject constructor(
 
     private fun onCreateDownloadClick() {
         // todo: annmarie implement onActionButtonClicked
+        _snackbarEvents.value = Event(SnackbarMessageHolder((UiStringText("Create downloadable file clicked"))))
     }
 
     private fun onCheckboxItemClicked(itemType: JetpackAvailableItemType) {


### PR DESCRIPTION
Parent #13329 

This PR adds a snackbar observerable to `BackupDownloadDetailsViewModel` and `BackupDownloadViewModel` to support notifications to the user. 

Unit tests will be in a separate PR

**To test:**
- Launch the app with BackupDownloadConfig flag on
- Navigate to ActivityLog
- Tap the More menu
- Tap Download Backup menu item
- Tap the "Create Downloadable file" button
- Note: A snackbar stating that you tapped the button will display. This is a temporary message.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
