### PR TITLE
Add SuggestionSourceModule to AppComponentTest

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.module.ReleaseToolsModule
 import org.wordpress.android.login.di.LoginFragmentModule
 import org.wordpress.android.login.di.LoginServiceModule
 import org.wordpress.android.ui.stats.refresh.StatsModule
+import org.wordpress.android.ui.suggestion.SuggestionSourceSubcomponent.SuggestionSourceModule
 import javax.inject.Singleton
 
 @Singleton
@@ -32,7 +33,8 @@ import javax.inject.Singleton
     LoginFragmentModule::class,
     LoginServiceModule::class,
     SupportModule::class,
-    ThreadModule::class])
+    ThreadModule::class,
+    SuggestionSourceModule::class])
 interface AppComponentTest : AppComponent {
     @Component.Builder
     interface Builder : AppComponent.Builder {


### PR DESCRIPTION
Fixes Android Connected Tests build (example failure) by adding the `SuggestionSourceModule` to the `AppComponentTest` class.

Follow-up to https://github.com/wordpress-mobile/WordPress-Android/pull/13184

To test:

1. Trigger the optional UI/connected tests to ensure they pass
2. Run `./gradlew WordPress:assembleVanillaDebugAndroidTest` locally and ensure it completes successfully.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
