### PR TITLE
WP Stories: removed checks for TEMPORARY_ID_PREFIX prefix and alternative code flow in StoriesSaveListener

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -126,33 +126,24 @@ class StoriesEventListener @Inject constructor(
         if (!lifecycle.currentState.isAtLeast(CREATED)) {
             return
         }
+        // in onStoryFrameSaveCompleted we should always get a frameId that has the TEMPORARY_ID_PREFIX prefix
         val localMediaId = requireNotNull(event.frameId)
 
-        // check whether this is a temporary file being just saved (so we don't have a proper local MediaModel yet)
-        // catch ( NumberFormatException e)
-        if (localMediaId.startsWith(TEMPORARY_ID_PREFIX)) {
-            val (frames) = storyRepositoryWrapper.getStoryAtIndex(event.storyIndex)
+        val (frames) = storyRepositoryWrapper.getStoryAtIndex(event.storyIndex)
 
-            // first, update the media's url
-            val frame = frames[event.frameIndex]
-            storySaveMediaListener?.onMediaSaveSucceeded(
-                    localMediaId,
-                    Uri.fromFile(frame.composedFrameFile).toString()
-            )
+        // first, update the media's url
+        val frame = frames[event.frameIndex]
+        storySaveMediaListener?.onMediaSaveSucceeded(
+                localMediaId,
+                Uri.fromFile(frame.composedFrameFile).toString()
+        )
 
-            // now update progress
-            val totalProgress: Float = storyRepositoryWrapper.getCurrentStorySaveProgress(
-                    event.storyIndex,
-                    0.0f
-            )
-            storySaveMediaListener?.onMediaSaveProgress(localMediaId, totalProgress)
-        } else {
-            val mediaModel: MediaModel = mediaStore.getSiteMediaWithId(site, localMediaId.toLong())
-            if (mediaModel != null) {
-                val mediaFile: MediaFile = FluxCUtils.mediaFileFromMediaModel(mediaModel)
-                storySaveMediaListener?.onMediaSaveSucceeded(localMediaId, mediaFile.getFileURL())
-            }
-        }
+        // now update progress
+        val totalProgress: Float = storyRepositoryWrapper.getCurrentStorySaveProgress(
+                event.storyIndex,
+                0.0f
+        )
+        storySaveMediaListener?.onMediaSaveProgress(localMediaId, totalProgress)
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -33,7 +33,6 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.editor.media.EditorMedia
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
-import org.wordpress.android.ui.stories.SaveStoryGutenbergBlockUseCase.Companion.TEMPORARY_ID_PREFIX
 import org.wordpress.android.ui.stories.StoryRepositoryWrapper
 import org.wordpress.android.ui.stories.media.StoryMediaSaveUploadBridge.StoryFrameMediaModelCreatedEvent
 import org.wordpress.android.ui.stories.usecase.LoadStoryFromStoriesPrefsUseCase
@@ -43,7 +42,6 @@ import org.wordpress.android.util.AppLog.T.MEDIA
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.FluxCUtils
 import org.wordpress.android.util.StringUtils
-import org.wordpress.android.util.helpers.MediaFile
 import java.util.ArrayList
 import java.util.HashMap
 import javax.inject.Inject


### PR DESCRIPTION
Fixes #13680

After going with the "smallest behavior change possible" approach in https://github.com/wordpress-mobile/WordPress-Android/pull/13683, I realized that the `else` in that`if/else` flow in code shouldn't ever be run, the rationale being the following:

When a new Story frame is being saved, it should be assigned a temporary Id that holds the `TEMPORARY_ID_PREFIX` prefix, because the image / video file does not yet exist but we still propagate file save progress updates so the user can be informed about the saving process.
Hence, when we receive a `FrameSaveCompleted` event in `StoriesEventListener`, this means at this point the id should definitely have been assigned, and there is no doubt the assigned id has to have been a temporary id (given the file does not exist up until this moment, and we have not yet passed the file up to FluxC to create a backing MediaFile / MediaModel out of it). As such, it doesn't make sense to check for the prefix, we just need the `frameId` to not be null that's all.

That's what this PR does: we removed the code checks for the prefix, and removed the code that was attempting to use the potentially non-temporary id to retrieve the file from FluxC (which doesn't make sense at all, given we're just receiving the `FrameSaveCompleted` signal here, which means we don't have this file in FluxC yet).

This related Stories PR https://github.com/Automattic/stories-android/pull/629 explains that what was going on here in order for us ending up having the wrong id (instead of a temporary id) ,and it was because if someone edited an existing story and the Editor activity would be killed, we would be pointing to an old duplicate of the story, and hence we got the wrong (old) ID instead of a temporary id.

So yes, at this point when any `FrameSavexxxx` event (start, progress, result) is gotten, we should always be given a temporary id for each frame at the StoriesEventListener level. Hence, we shouldn't need to check or validate the prefix.

Both this PR and the one in Stories are complimentary (ideally we also update the hash lib, but it was not entirely necessary for the point addressed in this PR alone).

~This PR is also related to this one https://github.com/wordpress-mobile/WordPress-Android/pull/13684, in the sense that #13684 makes sure to assign a temporary ID to the StoryFrameItem being saved as soon as the save process starts in the Editor flow, and everything is tied together, but I decided to write separate PRs to make it easier to understand how the PR contributes to fixing the specific crashes.~ closed #13684 given the approach was flawed (tackling the problem where the symptom appears instead of going to the root cause)

To test:
N/A - I haven't been able to reproduce

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
