### PR TITLE
Rename backup_download_details_description to avoid lint error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsStateListItemBuilder.kt
@@ -60,7 +60,7 @@ class BackupDownloadDetailsStateListItemBuilder @Inject constructor() {
 
     private fun buildDescriptionState(published: Date) = DescriptionState(
             UiStringResWithParams(
-                    R.string.backup_download_details_description,
+                    R.string.backup_download_details_description_with_two_parameters,
                     listOf(
                             UiStringText(published.toFormattedDateString()),
                             UiStringText(published.toFormattedTimeString())

--- a/WordPress/src/main/res/layout/jetpack_list_description_item.xml
+++ b/WordPress/src/main/res/layout/jetpack_list_description_item.xml
@@ -14,6 +14,6 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         tools:text="October 21, 2020 at 3:40 AM is the selected point to create a downloadable backup."
-        android:text="@string/backup_download_details_description"/>
+        android:text="@string/backup_download_details_description_with_two_parameters"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3353,7 +3353,7 @@ translators: sample content for "Services" page template -->
     <string name="backup_download">Backup Download</string>
     <string name="backup_download_details_page_title">Download Backup</string>
     <string name="backup_download_details_header">Create downloadable backup</string>
-    <string name="backup_download_details_description">%1$s %2$s is the selected point to create a downloadable backup.</string>
+    <string name="backup_download_details_description_with_two_parameters">%1$s %2$s is the selected point to create a downloadable backup.</string>
     <string name="backup_download_details_choose_items_header">Choose the items you wish to include in the download:</string>
     <string name="backup_download_details_action_button">Create downloadable file</string>
     <string name="backup_download_details_icon_content_description">Create downloadable backup icon</string>


### PR DESCRIPTION
This string has been translated in the release branch for a single
parameter but updated in `develop` to have 2 parameters which results in a
lint error. Renaming the string in `develop` bypasses the issue.

**To test:**
If CI passes, that should be enough since it's just a resource name change.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
