### PR TITLE
Jetpack Mobile: Threat Details - custom views

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/ViewType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/ViewType.kt
@@ -10,5 +10,5 @@ enum class ViewType(val id: Int) {
     CHECKBOX(6),
     BACKUP_SUB_HEADER(7),
     THREAT_CONTEXT_LINES(8),
-    FILE_NAME(9)
+    THREAT_FILE_NAME(9)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/ViewType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/ViewType.kt
@@ -9,5 +9,6 @@ enum class ViewType(val id: Int) {
     THREAT_ITEM(5),
     CHECKBOX(6),
     BACKUP_SUB_HEADER(7),
-    THREAT_CONTEXT_LINES(8)
+    THREAT_CONTEXT_LINES(8),
+    FILE_NAME(9)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/ViewType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/ViewType.kt
@@ -8,5 +8,6 @@ enum class ViewType(val id: Int) {
     THREATS_HEADER(4),
     THREAT_ITEM(5),
     CHECKBOX(6),
-    BACKUP_SUB_HEADER(7)
+    BACKUP_SUB_HEADER(7),
+    THREAT_CONTEXT_LINES(8)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemState.kt
@@ -20,5 +20,5 @@ sealed class ThreatDetailsListItemState(override val type: ViewType) : JetpackLi
         )
     }
 
-    data class FileNameState(val fileName: UiString) : ThreatDetailsListItemState(ViewType.FILE_NAME)
+    data class ThreatFileNameState(val fileName: UiString) : ThreatDetailsListItemState(ViewType.THREAT_FILE_NAME)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemState.kt
@@ -4,6 +4,7 @@ import androidx.annotation.ColorRes
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.FileThreatModel.ThreatContext.ContextLine
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.ViewType
+import org.wordpress.android.ui.utils.UiString
 
 sealed class ThreatDetailsListItemState(override val type: ViewType) : JetpackListItemState(type) {
     data class ThreatContextLinesItemState(val lines: List<ThreatContextLineItemState>) : ThreatDetailsListItemState(
@@ -18,4 +19,6 @@ sealed class ThreatDetailsListItemState(override val type: ViewType) : JetpackLi
             @ColorRes val normalTextColorRes: Int
         )
     }
+
+    data class FileNameState(val fileName: UiString) : ThreatDetailsListItemState(ViewType.FILE_NAME)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemState.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.ui.jetpack.scan.details
+
+import androidx.annotation.ColorRes
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.FileThreatModel.ThreatContext.ContextLine
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState
+import org.wordpress.android.ui.jetpack.common.ViewType
+
+sealed class ThreatDetailsListItemState(override val type: ViewType) : JetpackListItemState(type) {
+    data class ThreatContextLinesItemState(val lines: List<ThreatContextLineItemState>) : ThreatDetailsListItemState(
+        ViewType.THREAT_CONTEXT_LINES
+    ) {
+        data class ThreatContextLineItemState(
+            val line: ContextLine,
+            @ColorRes val lineNumberBackgroundColorRes: Int,
+            @ColorRes val contentBackgroundColorRes: Int,
+            @ColorRes val highlightedBackgroundColorRes: Int,
+            @ColorRes val highlightedTextColorRes: Int,
+            @ColorRes val normalTextColorRes: Int
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilder.kt
@@ -1,12 +1,44 @@
 package org.wordpress.android.ui.jetpack.scan.details
 
 import dagger.Reusable
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.FileThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.FileThreatModel.ThreatContext
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.FileThreatModel.ThreatContext.ContextLine
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsListItemState.ThreatContextLinesItemState
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsListItemState.ThreatContextLinesItemState.ThreatContextLineItemState
 import javax.inject.Inject
 
 @Reusable
 class ThreatDetailsListItemsBuilder @Inject constructor() {
     // TODO ashiagr to be implemented
-    fun buildThreatDetailsListItems(model: ThreatModel) = emptyList<JetpackListItemState>()
+    fun buildThreatDetailsListItems(threatModel: ThreatModel): List<JetpackListItemState> {
+        val items = mutableListOf<JetpackListItemState>()
+        if (threatModel is FileThreatModel) {
+            val threatContextLines = buildThreatContextLines(threatModel.context)
+            items.add(threatContextLines)
+        }
+        return items
+    }
+
+    private fun buildThreatContextLines(context: ThreatContext) =
+        ThreatContextLinesItemState(lines = context.lines.map { buildThreatContextLine(it) })
+
+    private fun buildThreatContextLine(line: ContextLine): ThreatContextLineItemState {
+        val isHighlighted = line.highlights?.isNotEmpty() == true
+
+        val lineNumberBackgroundColorRes = if (isHighlighted) R.color.pink_5 else R.color.gray_20
+        val contentBackgroundColorRes = if (isHighlighted) R.color.pink_5 else R.color.gray_5
+
+        return ThreatContextLineItemState(
+            line = line,
+            lineNumberBackgroundColorRes = lineNumberBackgroundColorRes,
+            contentBackgroundColorRes = contentBackgroundColorRes,
+            highlightedBackgroundColorRes = R.color.red,
+            highlightedTextColorRes = R.color.white,
+            normalTextColorRes = R.color.black
+        )
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/ThreatContextLinesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/ThreatContextLinesAdapter.kt
@@ -1,0 +1,46 @@
+package org.wordpress.android.ui.jetpack.scan.details.adapters
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView.Adapter
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsListItemState.ThreatContextLinesItemState.ThreatContextLineItemState
+import org.wordpress.android.ui.jetpack.scan.details.adapters.viewholders.ThreatContextLineViewHolder
+
+class ThreatContextLinesAdapter : Adapter<ThreatContextLineViewHolder>() {
+    private val items = mutableListOf<ThreatContextLineItemState>()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = ThreatContextLineViewHolder(parent)
+
+    override fun onBindViewHolder(holder: ThreatContextLineViewHolder, position: Int) {
+        holder.onBind(items[position])
+    }
+
+    override fun getItemCount() = items.size
+
+    fun update(newItems: List<ThreatContextLineItemState>) {
+        val diffResult = DiffUtil.calculateDiff(ThreatContextLineDiffCallback(items.toList(), newItems))
+        items.clear()
+        items.addAll(newItems)
+
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    class ThreatContextLineDiffCallback(
+        private val oldList: List<ThreatContextLineItemState>,
+        private val newList: List<ThreatContextLineItemState>
+    ) : DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = oldList[oldItemPosition]
+            val newItem = newList[newItemPosition]
+            return oldItem == newItem
+        }
+
+        override fun getOldListSize() = oldList.size
+
+        override fun getNewListSize() = newList.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldList[oldItemPosition] == newList[newItemPosition]
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/ThreatDetailsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/ThreatDetailsAdapter.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.ui.jetpack.common.ViewType
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackDescriptionViewHolder
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackIconViewHolder
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackViewHolder
+import org.wordpress.android.ui.jetpack.scan.details.adapters.viewholders.FileNameViewHolder
 import org.wordpress.android.ui.jetpack.scan.details.adapters.viewholders.ThreatContextLinesViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
@@ -26,6 +27,7 @@ class ThreatDetailsAdapter(
         return when (viewType) {
             ViewType.ICON.id -> JetpackIconViewHolder(imageManager, parent)
             ViewType.DESCRIPTION.id -> JetpackDescriptionViewHolder(uiHelpers, parent)
+            ViewType.FILE_NAME.id -> FileNameViewHolder(uiHelpers, parent)
             ViewType.THREAT_CONTEXT_LINES.id -> ThreatContextLinesViewHolder(parent)
             else -> throw IllegalArgumentException("Unexpected view type in ${this::class.java.simpleName}")
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/ThreatDetailsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/ThreatDetailsAdapter.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.ui.jetpack.common.ViewType
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackDescriptionViewHolder
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackIconViewHolder
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackViewHolder
+import org.wordpress.android.ui.jetpack.scan.details.adapters.viewholders.ThreatContextLinesViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 
@@ -25,6 +26,7 @@ class ThreatDetailsAdapter(
         return when (viewType) {
             ViewType.ICON.id -> JetpackIconViewHolder(imageManager, parent)
             ViewType.DESCRIPTION.id -> JetpackDescriptionViewHolder(uiHelpers, parent)
+            ViewType.THREAT_CONTEXT_LINES.id -> ThreatContextLinesViewHolder(parent)
             else -> throw IllegalArgumentException("Unexpected view type in ${this::class.java.simpleName}")
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/ThreatDetailsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/ThreatDetailsAdapter.kt
@@ -8,8 +8,8 @@ import org.wordpress.android.ui.jetpack.common.ViewType
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackDescriptionViewHolder
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackIconViewHolder
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackViewHolder
-import org.wordpress.android.ui.jetpack.scan.details.adapters.viewholders.FileNameViewHolder
 import org.wordpress.android.ui.jetpack.scan.details.adapters.viewholders.ThreatContextLinesViewHolder
+import org.wordpress.android.ui.jetpack.scan.details.adapters.viewholders.ThreatFileNameViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 
@@ -27,7 +27,7 @@ class ThreatDetailsAdapter(
         return when (viewType) {
             ViewType.ICON.id -> JetpackIconViewHolder(imageManager, parent)
             ViewType.DESCRIPTION.id -> JetpackDescriptionViewHolder(uiHelpers, parent)
-            ViewType.FILE_NAME.id -> FileNameViewHolder(uiHelpers, parent)
+            ViewType.THREAT_FILE_NAME.id -> ThreatFileNameViewHolder(uiHelpers, parent)
             ViewType.THREAT_CONTEXT_LINES.id -> ThreatContextLinesViewHolder(parent)
             else -> throw IllegalArgumentException("Unexpected view type in ${this::class.java.simpleName}")
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/viewholders/FileNameViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/viewholders/FileNameViewHolder.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.ui.jetpack.scan.details.adapters.viewholders
+
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.threat_details_list_file_name_item.*
+import org.wordpress.android.R
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackViewHolder
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsListItemState.FileNameState
+import org.wordpress.android.ui.utils.UiHelpers
+
+class FileNameViewHolder(private val uiHelpers: UiHelpers, parent: ViewGroup) : JetpackViewHolder(
+    R.layout.threat_details_list_file_name_item,
+    parent
+) {
+    override fun onBind(itemUiState: JetpackListItemState) {
+        val fileNameState = itemUiState as FileNameState
+        file_name.text = uiHelpers.getTextOfUiString(itemView.context, fileNameState.fileName)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/viewholders/ThreatContextLineViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/viewholders/ThreatContextLineViewHolder.kt
@@ -1,0 +1,72 @@
+package org.wordpress.android.ui.jetpack.scan.details.adapters.viewholders
+
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.extensions.LayoutContainer
+import kotlinx.android.synthetic.main.threat_context_lines_list_context_line_item.*
+import org.wordpress.android.R
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsListItemState.ThreatContextLinesItemState.ThreatContextLineItemState
+import org.wordpress.android.ui.utils.PaddingBackgroundColorSpan
+
+class ThreatContextLineViewHolder(
+    parent: ViewGroup,
+    override val containerView: View = LayoutInflater.from(parent.context)
+        .inflate(R.layout.threat_context_lines_list_context_line_item, parent, false)
+) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+    private val highlightedContentTextPadding = itemView.context.resources.getDimensionPixelSize(R.dimen.margin_small)
+
+    fun onBind(itemState: ThreatContextLineItemState) {
+        updateLineNumber(itemState)
+        updateContent(itemState)
+    }
+
+    private fun updateLineNumber(itemState: ThreatContextLineItemState) {
+        with(line_number) {
+            setBackgroundColor(ContextCompat.getColor(itemView.context, itemState.lineNumberBackgroundColorRes))
+            setTextColor(ContextCompat.getColor(itemView.context, itemState.normalTextColorRes))
+            text = itemState.line.lineNumber.toString()
+        }
+    }
+
+    private fun updateContent(itemState: ThreatContextLineItemState) {
+        with(content) {
+            setBackgroundColor(ContextCompat.getColor(itemView.context, itemState.contentBackgroundColorRes))
+            setTextColor(ContextCompat.getColor(itemView.context, itemState.normalTextColorRes))
+            text = getHighlightedContentText(itemState)
+            // Fixes highlighted background clip by the bounds of the TextView
+            setShadowLayer(highlightedContentTextPadding.toFloat(), 0f, 0f, 0)
+        }
+    }
+
+    private fun getHighlightedContentText(itemState: ThreatContextLineItemState): SpannableString {
+        val spannableText: SpannableString
+
+        with(itemState) {
+            spannableText = SpannableString(line.contents)
+
+            line.highlights?.map {
+                val (startIndex, lastIndex) = it
+                val context = itemView.context
+
+                val foregroundSpan = ForegroundColorSpan(ContextCompat.getColor(context, highlightedTextColorRes))
+                val backgroundSpan = PaddingBackgroundColorSpan(
+                    backgroundColor = ContextCompat.getColor(context, highlightedBackgroundColorRes),
+                    padding = highlightedContentTextPadding
+                )
+
+                with(spannableText) {
+                    setSpan(foregroundSpan, startIndex, lastIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    setSpan(backgroundSpan, startIndex, lastIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+                }
+            }
+        }
+
+        return spannableText
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/viewholders/ThreatContextLinesViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/viewholders/ThreatContextLinesViewHolder.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.jetpack.scan.details.adapters.viewholders
+
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.threat_details_list_context_lines_item.*
+import org.wordpress.android.R
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackViewHolder
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsListItemState.ThreatContextLinesItemState
+import org.wordpress.android.ui.jetpack.scan.details.adapters.ThreatContextLinesAdapter
+
+class ThreatContextLinesViewHolder(parent: ViewGroup) : JetpackViewHolder(
+    R.layout.threat_details_list_context_lines_item,
+    parent
+) {
+    init {
+        recycler_view.adapter = ThreatContextLinesAdapter()
+    }
+
+    override fun onBind(itemUiState: JetpackListItemState) {
+        val contextLinesItemState = itemUiState as ThreatContextLinesItemState
+        (recycler_view.adapter as ThreatContextLinesAdapter).update(contextLinesItemState.lines)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/viewholders/ThreatFileNameViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/viewholders/ThreatFileNameViewHolder.kt
@@ -5,15 +5,15 @@ import kotlinx.android.synthetic.main.threat_details_list_file_name_item.*
 import org.wordpress.android.R
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackViewHolder
-import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsListItemState.FileNameState
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsListItemState.ThreatFileNameState
 import org.wordpress.android.ui.utils.UiHelpers
 
-class FileNameViewHolder(private val uiHelpers: UiHelpers, parent: ViewGroup) : JetpackViewHolder(
+class ThreatFileNameViewHolder(private val uiHelpers: UiHelpers, parent: ViewGroup) : JetpackViewHolder(
     R.layout.threat_details_list_file_name_item,
     parent
 ) {
     override fun onBind(itemUiState: JetpackListItemState) {
-        val fileNameState = itemUiState as FileNameState
-        file_name.text = uiHelpers.getTextOfUiString(itemView.context, fileNameState.fileName)
+        val threatFileNameState = itemUiState as ThreatFileNameState
+        file_name.text = uiHelpers.getTextOfUiString(itemView.context, threatFileNameState.fileName)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/PaddingBackgroundColorSpan.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/PaddingBackgroundColorSpan.kt
@@ -1,0 +1,40 @@
+package org.wordpress.android.ui.utils
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Rect
+import android.text.style.LineBackgroundSpan
+import kotlin.math.roundToInt
+
+/**
+ * Creates BackgroundColorSpan with padding
+ * Credits: https://medium.com/@tokudu/android-adding-padding-to-backgroundcolorspan-179ab4fae187
+ */
+class PaddingBackgroundColorSpan(private val backgroundColor: Int, private val padding: Int) : LineBackgroundSpan {
+    private val bgRect: Rect = Rect()
+    override fun drawBackground(
+        canvas: Canvas,
+        paint: Paint,
+        left: Int,
+        right: Int,
+        top: Int,
+        baseline: Int,
+        bottom: Int,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        lnum: Int
+    ) {
+        val textWidth = paint.measureText(text, start, end).roundToInt()
+        val paintColor = paint.color
+        bgRect.set(
+            left - padding,
+            top - if (lnum == 0) padding / 2 else -(padding / 2),
+            left + textWidth + padding,
+            bottom + padding / 2
+        )
+        paint.color = backgroundColor
+        canvas.drawRect(bgRect, paint)
+        paint.color = paintColor
+    }
+}

--- a/WordPress/src/main/res/layout/threat_context_lines_list_context_line_item.xml
+++ b/WordPress/src/main/res/layout/threat_context_lines_list_context_line_item.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/line_number"
+        style="@style/Scan.ThreatDetails.ContextLine.LineNumber"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="4" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/content"
+        style="@style/Scan.ThreatDetails.ContextLine.Content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/line_number"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="X5O!P%@AP" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+
+

--- a/WordPress/src/main/res/layout/threat_details_list_context_lines_item.xml
+++ b/WordPress/src/main/res/layout/threat_details_list_context_lines_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<HorizontalScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:scrollbars="none">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+</HorizontalScrollView>
+

--- a/WordPress/src/main/res/layout/threat_details_list_file_name_item.xml
+++ b/WordPress/src/main/res/layout/threat_details_list_file_name_item.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/item_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/margin_small_medium"
+    android:background="@color/gray_5">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/file_name"
+        style="@style/Scan.ThreatDetails.FileName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="/var/html/www/index.php" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/scan_styles.xml
+++ b/WordPress/src/main/res/values/scan_styles.xml
@@ -75,4 +75,16 @@
         <item name="android:padding">@dimen/margin_small_medium</item>
     </style>
 
+    <!--Threat Details - FileName-->
+    <style name="Scan.ThreatDetails.FileName" parent="Scan.TextView">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textAlignment">viewStart</item>
+        <item name="android:textAppearance">?attr/textAppearanceBody2</item>
+        <item name="android:gravity">center_vertical|start</item>
+        <item name="android:paddingTop">@dimen/margin_small_medium</item>
+        <item name="android:paddingBottom">@dimen/margin_small_medium</item>
+    </style>
+
 </resources>

--- a/WordPress/src/main/res/values/scan_styles.xml
+++ b/WordPress/src/main/res/values/scan_styles.xml
@@ -19,7 +19,7 @@
         <item name="android:textAppearance">?attr/textAppearanceBody2</item>
     </style>
 
-    <!--Threat Item-->
+    <!--Threat List Item-->
     <style name="Scan.Threat.Icon" parent="">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
@@ -53,4 +53,26 @@
         <item name="android:textAlignment">viewStart</item>
         <item name="android:textAppearance">?attr/textAppearanceCaption</item>
     </style>
+
+    <!--Threat Details: ContextLine-->
+    <style name="Scan.ThreatDetails.ContextLine" parent="Scan.TextView">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:gravity">start</item>
+        <item name="android:singleLine">true</item>
+        <item name="android:textAlignment">viewStart</item>
+        <item name="android:textAppearance">?attr/textAppearanceCaption</item>
+    </style>
+    <style name="Scan.ThreatDetails.ContextLine.LineNumber" parent="Scan.ThreatDetails.ContextLine">
+        <item name="android:layout_marginBottom">@dimen/margin_extra_extra_small</item>
+        <item name="android:background">@color/gray_20</item>
+        <item name="android:padding">@dimen/margin_small_medium</item>
+        <item name="android:paddingStart">@dimen/margin_medium_large</item>
+    </style>
+    <style name="Scan.ThreatDetails.ContextLine.Content" parent="Scan.ThreatDetails.ContextLine">
+        <item name="android:layout_marginBottom">@dimen/margin_extra_extra_small</item>
+        <item name="android:background">@color/gray_5</item>
+        <item name="android:padding">@dimen/margin_small_medium</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Parent: #13703

This PR creates custom `ViewTypes`  for `ThreatContext` and `FileName` for "Threat Details" screen.

References: [Scan design iteration i5](https://jetpackmobile.files.wordpress.com/2020/12/ios-scan-i5.png)

![device-2021-01-04-131412](https://user-images.githubusercontent.com/1405144/103512507-d4f3c480-4e8e-11eb-89c5-0951949f248c.png)

### To test
Prerequisite: 
1. Make sure both Scan feature flag and MySiteImprovements flag are set to on in the App settings.
2. WP.com account with a site having scan capability and different threats (e.g. http://do.wpmt.co/jp-scan-daily/).

- Login to the app using above WP.com account and select the site on the My Site tab
- Notice that scan menu is displayed
- Click scan menu item followed by threat item
- Notice that `ThreatContext.lines `are shown correctly with a highlighted line
- `ViewType` for `ThreatFileName` can be tested by putting below line above [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/512b5f7f1252efca1ce0f7692fb65b7f03cbc89d/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilder.kt#L20) in `ThreatDetailsListItemsBuilder`: 
`threatModel.fileName?.let { items.add(ThreatFileNameState(UiStringText(it))) }`

### Notes
1. Ignore all styling
2. Tests covered in parent PR #13703

### Merge Instructions

1. Make sure #13675 is merged
2. Remove the "Not Ready for Merge label"
3. Merge this PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
