### PR TITLE
Jetpack Section: Backup Screen - Introduce Feature Flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -77,6 +77,7 @@ android {
         buildConfigField "boolean", "ANY_FILE_UPLOAD", "true"
         buildConfigField "boolean", "CONSOLIDATED_MEDIA_PICKER", "false"
         buildConfigField "boolean", "ACTIVITY_LOG_FILTERS", "false"
+        buildConfigField "boolean", "BACKUPS_AVAILABLE", "false"
         buildConfigField "boolean", "SCAN_AVAILABLE", "false"
         buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "true"
         buildConfigField "boolean", "MY_SITE_IMPROVEMENTS", "false"

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -407,6 +407,9 @@ class MySiteFragment : Fragment(),
                     selectedSite
             )
         }
+        row_backup.setOnClickListener {
+            // Do nothing. TODO: Launch 'Backups' screen.
+        }
         row_scan.setOnClickListener {
             ActivityLauncher.viewScan(
                     activity,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -35,8 +35,6 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
-import org.wordpress.android.R.attr
-import org.wordpress.android.R.string
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
@@ -961,7 +959,7 @@ class MySiteFragment : Fragment(),
         options.setShowCropGrid(false)
         options.setStatusBarColor(context.getColorFromAttribute(android.R.attr.statusBarColor))
         options.setToolbarColor(context.getColorFromAttribute(R.attr.wpColorAppBar))
-        options.setToolbarWidgetColor(context.getColorFromAttribute(attr.colorOnSurface))
+        options.setToolbarWidgetColor(context.getColorFromAttribute(R.attr.colorOnSurface))
         options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.NONE)
         options.setHideBottomControls(true)
         UCrop.of(uri, Uri.fromFile(File(context.cacheDir, "cropped_for_site_icon.jpg")))
@@ -1191,7 +1189,7 @@ class MySiteFragment : Fragment(),
         if (!event.isSuccess()) {
             // note: no tracking added here as we'll perform tracking in StoryMediaSaveUploadBridge
             val errorText = String.format(
-                    getString(string.story_saving_snackbar_finished_with_error),
+                    getString(R.string.story_saving_snackbar_finished_with_error),
                     getStoryAtIndex(event.storyIndex).title
             )
             val snackbarMessage = buildSnackbarErrorMessage(
@@ -1202,7 +1200,7 @@ class MySiteFragment : Fragment(),
             uploadUtilsWrapper.showSnackbarError(
                     requireActivity().findViewById<View>(R.id.coordinator),
                     snackbarMessage,
-                    string.story_saving_failed_quick_action_manage
+                    R.string.story_saving_failed_quick_action_manage
             ) {
                 // TODO WPSTORIES add TRACKS: the putExtra described here below for NOTIFICATION_TYPE
                 // is meant to be used for tracking purposes. Use it!
@@ -1224,7 +1222,7 @@ class MySiteFragment : Fragment(),
     fun onStorySaveStart(event: StorySaveProcessStart) {
         EventBus.getDefault().removeStickyEvent(event)
         val snackbarMessage = String.format(
-                getString(string.story_saving_snackbar_started),
+                getString(R.string.story_saving_snackbar_started),
                 getStoryAtIndex(event.storyIndex).title
         )
         uploadUtilsWrapper.showSnackbar(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -154,6 +154,7 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.util.config.BackupsFeatureConfig
 import org.wordpress.android.util.config.ConsolidatedMediaPickerFeatureConfig
 import org.wordpress.android.util.getColorFromAttribute
 import org.wordpress.android.util.image.BlavatarShape.SQUARE
@@ -197,6 +198,7 @@ class MySiteFragment : Fragment(),
     @Inject lateinit var mediaPickerLauncher: MediaPickerLauncher
     @Inject lateinit var storiesMediaPickerResultHandler: StoriesMediaPickerResultHandler
     @Inject lateinit var consolidatedMediaPickerFeatureConfig: ConsolidatedMediaPickerFeatureConfig
+    @Inject lateinit var backupsFeatureConfig: BackupsFeatureConfig
     @Inject lateinit var scanFeatureConfig: ScanFeatureConfig
     @Inject lateinit var selectedSiteRepository: SelectedSiteRepository
     @Inject lateinit var uiHelpers: UiHelpers
@@ -237,6 +239,7 @@ class MySiteFragment : Fragment(),
         // Site details may have changed (e.g. via Settings and returning to this Fragment) so update the UI
         refreshSelectedSiteDetails(selectedSite)
         selectedSite?.let { site ->
+            updateBackupMenuVisibility()
             updateScanMenuVisibility()
 
             val isNotAdmin = !site.hasCapabilityManageOptions
@@ -256,6 +259,10 @@ class MySiteFragment : Fragment(),
             showQuickStartDialogMigration()
         }
         showQuickStartNoticeIfNecessary()
+    }
+
+    private fun updateBackupMenuVisibility() {
+        row_backup.setVisible(backupsFeatureConfig.isEnabled())
     }
 
     private fun updateScanMenuVisibility() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.AddNewStoryWithMedia
 import org.wordpress.android.ui.mysite.SiteNavigationAction.ConnectJetpackForStats
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenActivityLog
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenAdmin
+import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenBackup
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenComments
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenCropActivity
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomainRegistration
@@ -191,6 +192,7 @@ class ImprovedMySiteFragment : Fragment(),
                     is OpenMediaPicker -> mediaPickerLauncher.showSiteIconPicker(this, action.site)
                     is OpenCropActivity -> startCropActivity(action.imageUri)
                     is OpenActivityLog -> ActivityLauncher.viewActivityLogList(activity, action.site)
+                    is OpenBackup -> Unit // Do nothing. TODO: Launch 'Backups' screen.
                     is OpenScan -> ActivityLauncher.viewScan(activity, action.site)
                     is OpenPlan -> ActivityLauncher.viewBlogPlans(activity, action.site)
                     is OpenPosts -> ActivityLauncher.viewCurrentBlogPosts(requireActivity(), action.site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ListItemAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ListItemAction.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.mysite
 
 enum class ListItemAction {
     ACTIVITY_LOG,
+    BACKUP,
     SCAN,
     JETPACK_SETTINGS,
     PLAN,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -27,10 +27,11 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.jetpack.scan.ScanStatusService
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_MY_SITE
+import org.wordpress.android.ui.jetpack.scan.ScanStatusService
 import org.wordpress.android.ui.mysite.ListItemAction.ACTIVITY_LOG
 import org.wordpress.android.ui.mysite.ListItemAction.ADMIN
+import org.wordpress.android.ui.mysite.ListItemAction.BACKUP
 import org.wordpress.android.ui.mysite.ListItemAction.COMMENTS
 import org.wordpress.android.ui.mysite.ListItemAction.JETPACK_SETTINGS
 import org.wordpress.android.ui.mysite.ListItemAction.MEDIA
@@ -193,6 +194,7 @@ class MySiteViewModel
         selectedSiteRepository.getSelectedSite()?.let { site ->
             val navigationAction = when (action) {
                 ACTIVITY_LOG -> OpenActivityLog(site)
+                BACKUP -> TODO()
                 SCAN -> OpenScan(site)
                 PLAN -> OpenPlan(site)
                 POSTS -> OpenPosts(site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -171,7 +171,11 @@ class MySiteViewModel
                 analyticsTrackerWrapper.track(DOMAIN_CREDIT_PROMPT_SHOWN)
                 siteItems.add(DomainRegistrationBlock(ListItemInteraction.create(site, this::domainRegistrationClick)))
             }
-            siteItems.addAll(siteItemsBuilder.buildSiteItems(site, this::onItemClick, scanAvailable ?: false))
+            siteItems.addAll(siteItemsBuilder.buildSiteItems(
+                    site,
+                    this::onItemClick,
+                    scanAvailable ?: false
+            ))
             siteItems
         } else {
             listOf()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -174,12 +174,14 @@ class MySiteViewModel
                 analyticsTrackerWrapper.track(DOMAIN_CREDIT_PROMPT_SHOWN)
                 siteItems.add(DomainRegistrationBlock(ListItemInteraction.create(site, this::domainRegistrationClick)))
             }
-            siteItems.addAll(siteItemsBuilder.buildSiteItems(
-                    site,
-                    this::onItemClick,
-                    backupsFeatureConfig.isEnabled(),
-                    scanAvailable ?: false
-            ))
+            siteItems.addAll(
+                    siteItemsBuilder.buildSiteItems(
+                            site,
+                            this::onItemClick,
+                            backupsFeatureConfig.isEnabled(),
+                            scanAvailable ?: false
+                    )
+            )
             siteItems
         } else {
             listOf()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.ui.mysite.SiteDialogModel.ChangeSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteNavigationAction.ConnectJetpackForStats
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenActivityLog
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenAdmin
+import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenBackup
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenComments
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenCropActivity
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenDomainRegistration
@@ -201,7 +202,7 @@ class MySiteViewModel
         selectedSiteRepository.getSelectedSite()?.let { site ->
             val navigationAction = when (action) {
                 ACTIVITY_LOG -> OpenActivityLog(site)
-                BACKUP -> TODO()
+                BACKUP -> OpenBackup(site)
                 SCAN -> OpenScan(site)
                 PLAN -> OpenPlan(site)
                 POSTS -> OpenPosts(site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -89,6 +89,7 @@ import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.BackupsFeatureConfig
 import org.wordpress.android.util.distinct
 import org.wordpress.android.util.getEmailValidationMessage
 import org.wordpress.android.util.merge
@@ -116,6 +117,7 @@ class MySiteViewModel
     private val siteIconUploadHandler: SiteIconUploadHandler,
     private val siteStoriesHandler: SiteStoriesHandler,
     private val domainRegistrationHandler: DomainRegistrationHandler,
+    private val backupsFeatureConfig: BackupsFeatureConfig,
     private val scanStatusService: ScanStatusService
 ) : ScopedViewModel(mainDispatcher) {
     private var currentSiteId: Int = 0
@@ -174,6 +176,7 @@ class MySiteViewModel
             siteItems.addAll(siteItemsBuilder.buildSiteItems(
                     site,
                     this::onItemClick,
+                    backupsFeatureConfig.isEnabled(),
                     scanAvailable ?: false
             ))
             siteItems

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteItemsBuilder.kt
@@ -16,6 +16,7 @@ class SiteItemsBuilder
     fun buildSiteItems(
         site: SiteModel,
         onClick: (ListItemAction) -> Unit,
+        isBackupsAvailable: Boolean = false,
         isScanAvailable: Boolean = false
     ): List<MySiteItem> {
         return listOfNotNull(
@@ -27,6 +28,7 @@ class SiteItemsBuilder
                         onClick = ListItemInteraction.create(ListItemAction.STATS, onClick)
                 ),
                 siteListItemBuilder.buildActivityLogItemIfAvailable(site, onClick),
+                siteListItemBuilder.buildBackupItemIfAvailable(onClick, isBackupsAvailable),
                 siteListItemBuilder.buildScanItemIfAvailable(onClick, isScanAvailable),
                 siteListItemBuilder.buildJetpackItemIfAvailable(site, onClick),
                 CategoryHeader(UiStringRes(R.string.my_site_header_publish)),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.ScanFeatureConfig
 import org.wordpress.android.util.SiteUtilsWrapper
+import org.wordpress.android.util.config.BackupsFeatureConfig
 import java.util.GregorianCalendar
 import java.util.TimeZone
 import javax.inject.Inject
@@ -23,6 +24,7 @@ class SiteListItemBuilder
     private val accountStore: AccountStore,
     private val pluginUtilsWrapper: PluginUtilsWrapper,
     private val siteUtilsWrapper: SiteUtilsWrapper,
+    private val backupsFeatureConfig: BackupsFeatureConfig,
     private val scanFeatureConfig: ScanFeatureConfig,
     private val themeBrowserUtils: ThemeBrowserUtils
 ) {
@@ -35,6 +37,16 @@ class SiteListItemBuilder
                     R.drawable.ic_history_alt_white_24dp,
                     UiStringRes(R.string.activity),
                     onClick = ListItemInteraction.create(ListItemAction.ACTIVITY_LOG, onClick)
+            )
+        } else null
+    }
+
+    fun buildBackupItemIfAvailable(onClick: (ListItemAction) -> Unit, isBackupsAvailable: Boolean = false): ListItem? {
+        return if (backupsFeatureConfig.isEnabled() && isBackupsAvailable) {
+            ListItem(
+                    R.drawable.ic_backup_alt_white_24dp,
+                    UiStringRes(R.string.backup),
+                    onClick = ListItemInteraction.create(ListItemAction.BACKUP, onClick)
             )
         } else null
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -12,6 +12,7 @@ sealed class SiteNavigationAction {
     data class OpenMediaPicker(val site: SiteModel) : SiteNavigationAction()
     data class OpenCropActivity(val imageUri: UriWrapper) : SiteNavigationAction()
     data class OpenActivityLog(val site: SiteModel) : SiteNavigationAction()
+    data class OpenBackup(val site: SiteModel) : SiteNavigationAction()
     data class OpenScan(val site: SiteModel) : SiteNavigationAction()
     data class OpenPlan(val site: SiteModel) : SiteNavigationAction()
     data class OpenPosts(val site: SiteModel) : SiteNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BackupsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BackupsFeatureConfig.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration of the 'Jetpack Backups' feature.
+ */
+@FeatureInDevelopment
+class BackupsFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.BACKUPS_AVAILABLE
+)

--- a/WordPress/src/main/res/drawable/ic_backup_alt_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_backup_alt_white_24dp.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+
+    <path
+        android:fillColor="#50575E"
+        android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4H7l5,-5 5,5h-3z" />
+
+</vector>

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -445,6 +445,24 @@
 
                     </LinearLayout>
 
+                    <!--Backup-->
+                    <LinearLayout
+                        android:id="@+id/row_backup"
+                        style="@style/MySiteListRowLayout">
+
+                        <ImageView
+                            android:id="@+id/my_site_backup_icon"
+                            style="@style/MySiteListRowIcon"
+                            android:importantForAccessibility="no"
+                            android:src="@drawable/ic_backup_alt_white_24dp" />
+
+                        <org.wordpress.android.widgets.WPTextView
+                            android:id="@+id/my_site_backup_text_view"
+                            style="@style/MySiteListRowTextView"
+                            android:text="@string/backup" />
+
+                    </LinearLayout>
+
                     <!--Scan-->
                     <LinearLayout
                         android:id="@+id/row_scan"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1037,6 +1037,7 @@
     <string name="activity_log_item_menu_download_backup_label">Download backup</string>
 
     <!-- scan -->
+    <string name="backup">Backup</string>
     <string name="scan">Scan</string>
 
     <string name="scan_state_icon">Scan state icon</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1036,8 +1036,10 @@
     <string name="activity_log_item_menu_restore_label">Restore to this point</string>
     <string name="activity_log_item_menu_download_backup_label">Download backup</string>
 
-    <!-- scan -->
+    <!-- backup -->
     <string name="backup">Backup</string>
+
+    <!-- scan -->
     <string name="scan">Scan</string>
 
     <string name="scan_state_icon">Scan state icon</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -802,7 +802,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         doAnswer {
             clickAction = it.getArgument(1)
             listOf<MySiteItem>()
-        }.whenever(siteItemsBuilder).buildSiteItems(eq(site), any(), any())
+        }.whenever(siteItemsBuilder).buildSiteItems(eq(site), any(), any(), any())
 
         onSiteChange.postValue(site)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -78,6 +79,7 @@ import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.BackupsFeatureConfig
 import org.wordpress.android.viewmodel.ContextProvider
 
 class MySiteViewModelTest : BaseUnitTest() {
@@ -94,6 +96,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var siteIconUploadHandler: SiteIconUploadHandler
     @Mock lateinit var siteStoriesHandler: SiteStoriesHandler
     @Mock lateinit var domainRegistrationHandler: DomainRegistrationHandler
+    @Mock lateinit var backupsFeatureConfig: BackupsFeatureConfig
     @Mock lateinit var scanStatusService: ScanStatusService
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<UiModel>
@@ -140,6 +143,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 siteIconUploadHandler,
                 siteStoriesHandler,
                 domainRegistrationHandler,
+                backupsFeatureConfig,
                 scanStatusService
         )
         uiModels = mutableListOf()
@@ -736,6 +740,20 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `site items builder invoked with the selected site's backups availability`() {
+        whenever(backupsFeatureConfig.isEnabled()).thenReturn(true)
+
+        onSiteChange.postValue(site)
+
+        verify(siteItemsBuilder, times(2)).buildSiteItems(
+                site = eq(site),
+                onClick = any(),
+                isBackupsAvailable = eq(true),
+                isScanAvailable = any()
+        )
+    }
+
+    @Test
     fun `site items builder invoked with the selected site's scan availability`() {
         whenever(scanStatusService.start(site)).thenAnswer {
             onScanAvailable.postValue(true)
@@ -745,6 +763,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         verify(siteItemsBuilder).buildSiteItems(
                 site = eq(site),
                 onClick = any(),
+                isBackupsAvailable = any(),
                 isScanAvailable = eq(true)
         )
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -210,7 +210,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         assertThat(uiModels).hasSize(3)
         assertThat(uiModels.last().items).hasSize(2)
-        assertThat(uiModels.last().items.first() is SiteInfoBlock).isTrue()
+        assertThat(uiModels.last().items.first() is SiteInfoBlock).isTrue
     }
 
     @Test
@@ -792,7 +792,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         onSiteChange.postValue(site)
 
-        assertThat(clickAction).isNotNull()
+        assertThat(clickAction).isNotNull
         clickAction!!.invoke(site)
     }
 
@@ -806,7 +806,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         onSiteChange.postValue(site)
 
-        assertThat(clickAction).isNotNull()
+        assertThat(clickAction).isNotNull
         clickAction!!.invoke(action)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -16,7 +16,6 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
@@ -727,7 +726,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         verify(analyticsTrackerWrapper).track(DOMAIN_CREDIT_REDEMPTION_SUCCESS)
 
-        val message = UiStringResWithParams(string.my_site_verify_your_email, listOf(UiStringText(emailAddress)))
+        val message = UiStringResWithParams(R.string.my_site_verify_your_email, listOf(UiStringText(emailAddress)))
 
         assertThat(snackbars).containsOnly(SnackbarMessageHolder(message))
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -758,6 +758,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(scanStatusService.start(site)).thenAnswer {
             onScanAvailable.postValue(true)
         }
+
         onSiteChange.postValue(site)
 
         verify(siteItemsBuilder).buildSiteItems(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemFixtures.kt
@@ -41,6 +41,11 @@ val ACTIVITY_ITEM = ListItem(
         UiStringRes(R.string.activity),
         onClick = ListItemInteraction.create(ListItemAction.ACTIVITY_LOG, SITE_ITEM_ACTION)
 )
+val BACKUP_ITEM = ListItem(
+        R.drawable.ic_backup_alt_white_24dp,
+        UiStringRes(R.string.backup),
+        onClick = ListItemInteraction.create(ListItemAction.BACKUP, SITE_ITEM_ACTION)
+)
 val SCAN_ITEM = ListItem(
         R.drawable.ic_scan_alt_white_24dp,
         UiStringRes(R.string.scan),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemsBuilderTest.kt
@@ -54,6 +54,7 @@ class SiteItemsBuilderTest {
                 addShareItem = true,
                 addSiteSettingsItem = true,
                 addThemesItem = true,
+                addBackupItem = true,
                 addScanItem = true
         )
 
@@ -64,6 +65,7 @@ class SiteItemsBuilderTest {
                 JETPACK_HEADER,
                 STATS_ITEM,
                 ACTIVITY_ITEM,
+                BACKUP_ITEM,
                 SCAN_ITEM,
                 JETPACK_ITEM,
                 PUBLISH_HEADER,
@@ -98,6 +100,7 @@ class SiteItemsBuilderTest {
         addShareItem: Boolean = false,
         addSiteSettingsItem: Boolean = false,
         addThemesItem: Boolean = false,
+        addBackupItem: Boolean = false,
         addScanItem: Boolean = false
     ) {
         if (addJetpackHeader) {
@@ -128,6 +131,11 @@ class SiteItemsBuilderTest {
         if (addActivityLogItem) {
             whenever(siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
                     ACTIVITY_ITEM
+            )
+        }
+        if (addBackupItem) {
+            whenever(siteListItemBuilder.buildBackupItemIfAvailable(SITE_ITEM_ACTION)).thenReturn(
+                    BACKUP_ITEM
             )
         }
         if (addScanItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteListItemBuilderTest.kt
@@ -14,12 +14,14 @@ import org.wordpress.android.ui.plugins.PluginUtilsWrapper
 import org.wordpress.android.ui.themes.ThemeBrowserUtils
 import org.wordpress.android.util.ScanFeatureConfig
 import org.wordpress.android.util.SiteUtilsWrapper
+import org.wordpress.android.util.config.BackupsFeatureConfig
 
 @RunWith(MockitoJUnitRunner::class)
 class SiteListItemBuilderTest {
     @Mock lateinit var accountStore: AccountStore
     @Mock lateinit var pluginUtilsWrapper: PluginUtilsWrapper
     @Mock lateinit var siteUtilsWrapper: SiteUtilsWrapper
+    @Mock lateinit var backupsFeatureConfig: BackupsFeatureConfig
     @Mock lateinit var scanFeatureConfig: ScanFeatureConfig
     @Mock lateinit var themeBrowserUtils: ThemeBrowserUtils
     @Mock lateinit var siteModel: SiteModel
@@ -31,6 +33,7 @@ class SiteListItemBuilderTest {
                 accountStore,
                 pluginUtilsWrapper,
                 siteUtilsWrapper,
+                backupsFeatureConfig,
                 scanFeatureConfig,
                 themeBrowserUtils
         )
@@ -101,6 +104,25 @@ class SiteListItemBuilderTest {
         whenever(siteModel.isJetpackConnected).thenReturn(isJetpackConnected)
         whenever(siteModel.hasCapabilityManageOptions).thenReturn(canManageOptions)
         whenever(siteModel.isWpForTeamsSite).thenReturn(isWpForTeams)
+    }
+
+    @Test
+    fun `backup item built if backups feature config enabled & backups feature is available`() {
+        val isBackupsAvailable = true
+        whenever(backupsFeatureConfig.isEnabled()).thenReturn(true)
+
+        val item = siteListItemBuilder.buildBackupItemIfAvailable(SITE_ITEM_ACTION, isBackupsAvailable)
+
+        assertThat(item).isEqualTo(BACKUP_ITEM)
+    }
+
+    @Test
+    fun `backup item not built if backups feature config not enabled`() {
+        whenever(backupsFeatureConfig.isEnabled()).thenReturn(false)
+
+        val item = siteListItemBuilder.buildBackupItemIfAvailable(SITE_ITEM_ACTION)
+
+        assertThat(item).isNull()
     }
 
     @Test


### PR DESCRIPTION
Parent #13629 

This PR introduces a local feature flag for the `Backups` feature. When the feature flag is enabled a `Backup` menu is shown on the `My Site` tab (currently irrespective of the site plan).

To test:

- Launch app and go to `My Site` tab.
- Notice that `Backup` menu is hidden.
- Go to `My Site` -> `Toolbar Avatar` -> `App Settings` -> `Test feature configuration`.
- Enable `BackupsFeatureConfig`, scroll down and click the `RESTART THE APP` button. **DO NOT** confuse this feature flag with the `BackupFeatureConfig` (singular). Make sure to enable the right feature flag.
- Go back to `My Site` tab and notice `Backup` menu is shown.

<img src="https://user-images.githubusercontent.com/9729923/103663387-b5859600-4f79-11eb-85f0-8110a5a3c1ff.png" width="250" height="500">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
