### PR TITLE
Rename and move package location for reuse

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadListItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadListItemState.kt
@@ -5,6 +5,6 @@ import org.wordpress.android.ui.jetpack.common.ViewType
 import org.wordpress.android.ui.utils.UiString
 
 sealed class BackupDownloadListItemState(override val type: ViewType) : JetpackListItemState(type) {
-    data class DetailsSubHeaderState(val text: UiString) :
+    data class SubHeaderState(val text: UiString) :
             BackupDownloadListItemState(ViewType.BACKUP_SUB_HEADER)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsStateListItemBuilder.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.jetpack.backup.download.details
 
 import dagger.Reusable
 import org.wordpress.android.R
-import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadListItemState.DetailsSubHeaderState
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadListItemState.SubHeaderState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButtonState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.CheckboxState
@@ -73,7 +73,7 @@ class BackupDownloadDetailsStateListItemBuilder @Inject constructor() {
             onClick = onClick
     )
 
-    private fun buildDetailsSubHeader() = DetailsSubHeaderState(
+    private fun buildDetailsSubHeader() = SubHeaderState(
             text = UiStringRes(R.string.backup_download_details_choose_items_header)
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/adapters/BackupDownloadDetailsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/adapters/BackupDownloadDetailsAdapter.kt
@@ -4,7 +4,7 @@ import android.view.ViewGroup
 import androidx.annotation.MainThread
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import org.wordpress.android.ui.jetpack.backup.download.details.adapters.viewholders.BackupDownloadDetailsSubHeaderViewHolder
+import org.wordpress.android.ui.jetpack.backup.download.viewholders.BackupDownloadSubHeaderViewHolder
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.ViewType
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackButtonViewHolder
@@ -36,7 +36,7 @@ class BackupDownloadDetailsAdapter(
             ViewType.DESCRIPTION.id -> JetpackDescriptionViewHolder(uiHelpers, parent)
             ViewType.ACTION_BUTTON.id -> JetpackButtonViewHolder(uiHelpers, parent)
             ViewType.CHECKBOX.id -> JetpackCheckboxViewHolder(uiHelpers, parent)
-            ViewType.BACKUP_SUB_HEADER.id -> BackupDownloadDetailsSubHeaderViewHolder(
+            ViewType.BACKUP_SUB_HEADER.id -> BackupDownloadSubHeaderViewHolder(
                     uiHelpers,
                     parent
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/viewholders/BackupDownloadSubHeaderViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/viewholders/BackupDownloadSubHeaderViewHolder.kt
@@ -1,20 +1,20 @@
-package org.wordpress.android.ui.jetpack.backup.download.details.adapters.viewholders
+package org.wordpress.android.ui.jetpack.backup.download.viewholders
 
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.backup_list_subheader_item.*
 import org.wordpress.android.R
-import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadListItemState.DetailsSubHeaderState
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadListItemState.SubHeaderState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 
 // todo: Annmarie - can this viewHolder be common to restore and backup download?
-class BackupDownloadDetailsSubHeaderViewHolder(
+class BackupDownloadSubHeaderViewHolder(
     private val uiHelpers: UiHelpers,
     parent: ViewGroup
 ) : JetpackViewHolder(R.layout.backup_list_subheader_item, parent) {
     override fun onBind(itemUiState: JetpackListItemState) {
-        val subHeaderItemState = itemUiState as DetailsSubHeaderState
+        val subHeaderItemState = itemUiState as SubHeaderState
         subheader.text = uiHelpers.getTextOfUiString(itemView.context, subHeaderItemState.text)
     }
 }


### PR DESCRIPTION
Parent #13329 

This PR preps SubHeader viewholder and state for reuse. It moves the class into a shared `ViewHolders` package from details to backup -> download

**Merge Instructions**
- ~~Make sure PR #13702 has been merged~~
- ~~Remove Not Ready for Merge label~~
- Merge as normal

**To Test**
There is nothing explicit to test in this PR; however you can make sure the app still functions as expected.

- Launch the app with BackupDownloadConfig flag on
- Navigate to ActivityLog
- Tap the More menu
- Tap Download Backup menu item
- Note that the Download Backup Details view is shown as expected

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
