### PR TITLE
Fix toolbar menu item color on activity type filter

### DIFF
--- a/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
@@ -25,6 +25,7 @@
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_main"
             style="@style/WordPress.ToolBar"
+            android:theme="@style/Base.Wordpress"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 


### PR DESCRIPTION
Parent issue #13268

This PR changes color  (from grey to black) of "Apply" and "Clear" actions on the Activity Type filter screen to make them consistent with teh rest of the app.

To test:
1. Make sure ActivityLogFiltersFeatureConfig is enabled
2. Open Activity log
3. Open Activity Type filter
4. Notice the action buttons are black

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
