### PR TITLE
Issue/13329 backup complete

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
@@ -131,7 +131,7 @@ class BackupDownloadActivity : LocaleAwareActivity() {
         val fragment = when (target.wizardStep) {
             DETAILS -> BackupDownloadDetailsFragment.newInstance(intent?.extras)
             PROGRESS -> BackupDownloadProgressFragment.newInstance(intent?.extras, target.wizardState)
-            COMPLETE -> BackupDownloadCompleteFragment.newInstance()
+            COMPLETE -> BackupDownloadCompleteFragment.newInstance(intent?.extras, target.wizardState)
         }
         slideInFragment(fragment, target.wizardStep.toString())
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -160,5 +160,10 @@ class BackupDownloadViewModel @Inject constructor(
             @StringRes override val title: Int = R.string.backup_download_progress_page_title,
             @DrawableRes override val icon: Int = R.drawable.ic_close_24px
         ) : ToolbarState()
+
+        data class CompleteToolbarState(
+            @StringRes override val title: Int = R.string.backup_download_complete_page_title,
+            @DrawableRes override val icon: Int = R.drawable.ic_close_24px
+        ) : ToolbarState()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteFragment.kt
@@ -4,12 +4,28 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.backup_download_progress_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadState
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel
+import org.wordpress.android.ui.jetpack.backup.download.complete.BackupDownloadCompleteViewModel.UiState.Content
+import org.wordpress.android.ui.jetpack.backup.download.complete.adapters.BackupDownloadCompleteAdapter
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
+
+private const val ARG_DATA = "arg_backup_download_complete_data"
 
 class BackupDownloadCompleteFragment : Fragment(R.layout.backup_download_complete_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var uiHelpers: UiHelpers
+    @Inject lateinit var imageManager: ImageManager
+    private lateinit var parentViewModel: BackupDownloadViewModel
     private lateinit var viewModel: BackupDownloadCompleteViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,6 +35,7 @@ class BackupDownloadCompleteFragment : Fragment(R.layout.backup_download_complet
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initRecyclerView()
         initViewModel()
     }
 
@@ -26,15 +43,56 @@ class BackupDownloadCompleteFragment : Fragment(R.layout.backup_download_complet
         (requireActivity().application as WordPress).component().inject(this)
     }
 
+    private fun initRecyclerView() {
+        recycler_view.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+        initAdapter()
+    }
+
+    private fun initAdapter() {
+        recycler_view.adapter = BackupDownloadCompleteAdapter(imageManager, uiHelpers)
+    }
+
     private fun initViewModel() {
+        parentViewModel = ViewModelProvider(requireActivity(), viewModelFactory)
+                .get(BackupDownloadViewModel::class.java)
+
         viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(BackupDownloadCompleteViewModel::class.java)
+
+        viewModel.uiState.observe(viewLifecycleOwner, { uiState ->
+            when (uiState) {
+                is Content -> showContent(uiState)
+                is Error -> ToastUtils.showToast(requireContext(), "Implement Error")
+            }
+        })
+
+        val (site, state) = when {
+            arguments != null -> {
+                val site = requireNotNull(arguments).getSerializable(WordPress.SITE) as SiteModel
+                val state = requireNotNull(arguments)
+                        .getParcelable<BackupDownloadState>(ARG_DATA) as BackupDownloadState
+                site to state
+            }
+            else -> throw Throwable("Couldn't initialize ${javaClass.simpleName} view model")
+        }
+
+        viewModel.start(site, state, parentViewModel)
+    }
+
+    private fun showContent(content: Content) {
+        ((recycler_view.adapter) as BackupDownloadCompleteAdapter).update(content.items)
     }
 
     companion object {
-        const val TAG = "BACKUP_DOWNLOAD_COMPLETE_FRAGMENT"
-        fun newInstance(): BackupDownloadCompleteFragment {
-            return BackupDownloadCompleteFragment()
+        fun newInstance(
+            bundle: Bundle? = null,
+            backupDownloadState: BackupDownloadState
+        ): BackupDownloadCompleteFragment {
+            val newBundle = Bundle().apply {
+                putParcelable(ARG_DATA, backupDownloadState)
+            }
+            bundle?.let { newBundle.putAll(bundle) }
+            return BackupDownloadCompleteFragment().apply { arguments = newBundle }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteStateListItemBuilder.kt
@@ -55,13 +55,15 @@ class BackupDownloadCompleteStateListItemBuilder @Inject constructor() {
 
     private fun buildNotifyMeButtonActionState(onClick: () -> Unit) = ActionButtonState(
             text = UiStringRes(R.string.backup_download_complete_download_action_button),
-            contentDescription = UiStringRes(R.string.backup_download_complete_download_action_button_content_description),
+            contentDescription =
+                UiStringRes(R.string.backup_download_complete_download_action_button_content_description),
             onClick = onClick
     )
 
     private fun buildShareLinkButtonActionState(onClick: () -> Unit) = ActionButtonState(
             text = UiStringRes(R.string.backup_download_complete_download_share_action_button),
-            contentDescription = UiStringRes(R.string.backup_download_complete_download_share_action_button_content_description),
+            contentDescription =
+                UiStringRes(R.string.backup_download_complete_download_share_action_button_content_description),
             onClick = onClick
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteStateListItemBuilder.kt
@@ -1,0 +1,71 @@
+package org.wordpress.android.ui.jetpack.backup.download.complete
+
+import dagger.Reusable
+import org.wordpress.android.R
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadListItemState.AdditionalInformationState
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButtonState
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.DescriptionState
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.HeaderState
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.IconState
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.toFormattedDateString
+import org.wordpress.android.util.toFormattedTimeString
+import java.util.Date
+import javax.inject.Inject
+
+@Reusable
+class BackupDownloadCompleteStateListItemBuilder @Inject constructor() {
+    fun buildCompleteListStateItems(
+        published: Date,
+        onDownloadFileClick: () -> Unit,
+        onShareLinkClick: () -> Unit
+    ): List<JetpackListItemState> {
+        return mutableListOf(
+                buildIconState(),
+                buildHeaderState(),
+                buildDescriptionState(published),
+                buildNotifyMeButtonActionState(onDownloadFileClick),
+                buildShareLinkButtonActionState(onShareLinkClick),
+                buildAdditionalInformationState()
+        )
+    }
+
+    private fun buildIconState() = IconState(
+            icon = R.drawable.ic_get_app_24dp, // todo: annmarie replace with cloud icon
+            contentDescription = UiStringRes(R.string.backup_download_complete_icon_content_description),
+            colorResId = R.color.success_50 // todo: annmarie make correct when doing design cleanup
+    )
+
+    private fun buildHeaderState() = HeaderState(
+            UiStringRes(R.string.backup_download_complete_header)
+    )
+
+    private fun buildDescriptionState(published: Date) = DescriptionState(
+            UiStringResWithParams(
+                    R.string.backup_download_complete_description_with_two_parameters,
+                    listOf(
+                            UiStringText(published.toFormattedDateString()),
+                            UiStringText(published.toFormattedTimeString())
+                    )
+            )
+    )
+
+    private fun buildNotifyMeButtonActionState(onClick: () -> Unit) = ActionButtonState(
+            text = UiStringRes(R.string.backup_download_complete_download_action_button),
+            contentDescription = UiStringRes(R.string.backup_download_complete_download_action_button_content_description),
+            onClick = onClick
+    )
+
+    private fun buildShareLinkButtonActionState(onClick: () -> Unit) = ActionButtonState(
+            text = UiStringRes(R.string.backup_download_complete_download_share_action_button),
+            contentDescription = UiStringRes(R.string.backup_download_complete_download_share_action_button_content_description),
+            onClick = onClick
+    )
+
+    private fun buildAdditionalInformationState() = AdditionalInformationState(
+            UiStringRes(R.string.backup_download_complete_info)
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteViewModel.kt
@@ -1,15 +1,84 @@
 package org.wordpress.android.ui.jetpack.backup.download.complete
 
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadState
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.CompleteToolbarState
+import org.wordpress.android.ui.jetpack.backup.download.complete.BackupDownloadCompleteViewModel.UiState.Content
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ScopedViewModel
+import java.util.Date
 import javax.inject.Inject
+import javax.inject.Named
 
-class BackupDownloadCompleteViewModel @Inject constructor() : ViewModel() {
+class BackupDownloadCompleteViewModel @Inject constructor(
+    private val stateListItemBuilder: BackupDownloadCompleteStateListItemBuilder,
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
+) : ScopedViewModel(mainDispatcher) {
+    private lateinit var site: SiteModel
+    private lateinit var backupDownloadState: BackupDownloadState
+    private lateinit var parentViewModel: BackupDownloadViewModel
     private var isStarted = false
 
-    fun start() {
-        if (isStarted) {
-            return
-        }
+    private val _uiState = MutableLiveData<UiState>()
+    val uiState: LiveData<UiState> = _uiState
+
+    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
+    fun start(
+        site: SiteModel,
+        backupDownloadState: BackupDownloadState,
+        parentViewModel: BackupDownloadViewModel
+    ) {
+        if (isStarted) return
         isStarted = true
+
+        this.site = site
+        this.backupDownloadState = backupDownloadState
+        this.parentViewModel = parentViewModel
+
+        parentViewModel.setToolbarState(CompleteToolbarState())
+
+        initSources()
+
+        initView()
+    }
+
+    private fun initSources() {
+        parentViewModel.addSnackbarMessageSource(snackbarEvents)
+    }
+
+    private fun initView() {
+        _uiState.value = Content(
+                items = stateListItemBuilder.buildCompleteListStateItems(
+                        published = backupDownloadState.published as Date,
+                        onDownloadFileClick = this@BackupDownloadCompleteViewModel::onDownloadFileClick,
+                        onShareLinkClick = this@BackupDownloadCompleteViewModel::onShareLinkClick
+                ))
+    }
+
+    private fun onDownloadFileClick() {
+        // todo: annmarie - implement the onDownloadFileClick
+        _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringText("Download clicked"))))
+    }
+
+    private fun onShareLinkClick() {
+        // todo: annmarie - implement the onShareLinkClick
+        _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringText("Share clicked"))))
+    }
+
+    sealed class UiState {
+        data class Content(
+            val items: List<JetpackListItemState>
+        ) : UiState()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/adapters/BackupDownloadCompleteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/adapters/BackupDownloadCompleteAdapter.kt
@@ -1,0 +1,91 @@
+package org.wordpress.android.ui.jetpack.backup.download.complete.adapters
+
+import android.view.ViewGroup
+import androidx.annotation.MainThread
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import org.wordpress.android.ui.jetpack.backup.download.viewholders.BackupDownloadAdditionalInformationViewHolder
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState
+import org.wordpress.android.ui.jetpack.common.ViewType
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackButtonViewHolder
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackDescriptionViewHolder
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackHeaderViewHolder
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackIconViewHolder
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackViewHolder
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.image.ImageManager
+
+class BackupDownloadCompleteAdapter(
+    private val imageManager: ImageManager,
+    private val uiHelpers: UiHelpers
+) : RecyclerView.Adapter<JetpackViewHolder>() {
+    private val items = mutableListOf<JetpackListItemState>()
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): JetpackViewHolder {
+        return when (viewType) {
+            ViewType.ICON.id -> JetpackIconViewHolder(imageManager, parent)
+            ViewType.HEADER.id -> JetpackHeaderViewHolder(uiHelpers, parent)
+            ViewType.DESCRIPTION.id -> JetpackDescriptionViewHolder(uiHelpers, parent)
+            ViewType.ACTION_BUTTON.id -> JetpackButtonViewHolder(uiHelpers, parent)
+            ViewType.BACKUP_ADDITIONAL_INFORMATION.id ->
+                BackupDownloadAdditionalInformationViewHolder(uiHelpers, parent)
+            else -> throw IllegalArgumentException("Unexpected view type in ${this::class.java.simpleName}")
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun getItemId(position: Int): Long {
+        return position.toLong()
+    }
+
+    override fun onBindViewHolder(holder: JetpackViewHolder, position: Int) {
+        holder.onBind(items[position])
+    }
+
+    override fun getItemViewType(position: Int) = items[position].type.id
+
+    @MainThread
+    fun update(newItems: List<JetpackListItemState>) {
+        val diffResult = DiffUtil.calculateDiff(
+                BackupDownloadDetailsListDiffUtils(
+                        items.toList(),
+                        newItems
+                )
+        )
+        items.clear()
+        items.addAll(newItems)
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    private class BackupDownloadDetailsListDiffUtils(
+        val oldItems: List<JetpackListItemState>,
+        val newItems: List<JetpackListItemState>
+    ) : DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = oldItems[oldItemPosition]
+            val newItem = newItems[newItemPosition]
+            if (oldItem::class != newItem::class) {
+                return false
+            }
+
+            // todo: annmarie - adjust this
+            return oldItem.longId() == newItem.longId()
+        }
+
+        override fun getOldListSize(): Int = oldItems.size
+
+        override fun getNewListSize(): Int = newItems.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldItems[oldItemPosition] == newItems[newItemPosition]
+        }
+    }
+}

--- a/WordPress/src/main/res/layout/backup_download_complete_fragment.xml
+++ b/WordPress/src/main/res/layout/backup_download_complete_fragment.xml
@@ -6,14 +6,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/backup_complete_action_button"
-        style="@style/Jetpack.PrimaryButton"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        tools:text="Final step">
-    </com.google.android.material.button.MaterialButton>
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3381,6 +3381,16 @@ translators: sample content for "Services" page template -->
     <string name="backup_item_contents">WP-content directory (excludes themes, plugins, and uploads)</string>
     <string name="backup_item_sqls">Site database (SQL)</string>
 
+    <string name="backup_download_complete_page_title">Your Backup</string>
+    <string name="backup_download_complete_header">Your backup is now available for download</string>
+    <string name="backup_download_complete_description_with_two_parameters">We successfully created a backup of your site from %1$s %2$s.</string>
+    <string name="backup_download_complete_download_action_button">Download</string>
+    <string name="backup_download_complete_download_share_action_button">Share link</string>
+    <string name="backup_download_complete_icon_content_description">Downloadable backup ready icon</string>
+    <string name="backup_download_complete_download_action_button_content_description">Download button</string>
+    <string name="backup_download_complete_download_share_action_button_content_description">Share link button</string>
+    <string name="backup_download_complete_info">We\'ve also emailed you a link to your file.</string>
+
     <string name="jetpack_icon_content_description">icon</string>
 
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadCompleteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadCompleteViewModelTest.kt
@@ -1,23 +1,40 @@
 package org.wordpress.android.ui.jetpack.backup.download
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.test
+import org.wordpress.android.ui.jetpack.backup.download.complete.BackupDownloadCompleteStateListItemBuilder
 import org.wordpress.android.ui.jetpack.backup.download.complete.BackupDownloadCompleteViewModel
+import java.util.Date
 
-@RunWith(MockitoJUnitRunner::class)
-class BackupDownloadCompleteViewModelTest {
-    @Rule
-    @JvmField val rule = InstantTaskExecutorRule()
-
+@InternalCoroutinesApi
+class BackupDownloadCompleteViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: BackupDownloadCompleteViewModel
+    @Mock private lateinit var parentViewModel: BackupDownloadViewModel
+    @Mock private lateinit var site: SiteModel
+    private lateinit var stateListItemBuilder: BackupDownloadCompleteStateListItemBuilder
+
+    private val backupDownloadState = BackupDownloadState(
+            activityId = "activityId",
+            rewindId = "rewindId",
+            downloadId = 100L,
+            siteId = 200L,
+            url = null,
+            published = Date(1609690147756)
+    )
 
     @Before
-    fun setUp() {
-        viewModel = BackupDownloadCompleteViewModel()
+    fun setUp() = test {
+        stateListItemBuilder = BackupDownloadCompleteStateListItemBuilder()
+        viewModel = BackupDownloadCompleteViewModel(
+                stateListItemBuilder,
+                TEST_DISPATCHER
+        )
     }
 
     @Test


### PR DESCRIPTION
Parent #13329 

This PR adds the Backup Download Complete view and includes:

- Updates to `backup_download_complete_fragment.xml` for recyclerView
- Updates to `BackupDownloadCompleteFragment` and `BackupDownloadCompleteViewModel` to support showing  content for the view.
- New `BackupDownloadCompleteStateListItemBuilder` to build the list items for the complete view

**Notes:**
- Styling has not been addressed
- The buttons are not hooked up, but you can tap on them and see a snackbar
- Additional testing will be addressed separately 

**To Test**
- Launch the app with BackupDownloadConfig flag on
- Navigate to ActivityLog
- Tap the More menu
- Tap Download Backup menu item
- Tap the Create downloadable file button
- The view changes to progress
- Note that the view changes to complete upon conclusion of process

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
