### PR TITLE
Add content description to activity log filters

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -228,6 +228,8 @@ class ActivityLogListFragment : Fragment() {
 
         with(requireActivity().activity_type_filter) {
             text = uiHelpers.getTextOfUiString(requireContext(), uiState.activityTypeLabel)
+            contentDescription = uiHelpers
+                    .getTextOfUiString(requireContext(), uiState.activityTypeLabelContentDescription)
             isCloseIconVisible = uiState.onClearActivityTypeFilterClicked != null
             setOnCloseIconClickListener { uiState.onClearActivityTypeFilterClicked?.invoke() }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -222,6 +222,7 @@ class ActivityLogListFragment : Fragment() {
     private fun updateFilters(uiState: FiltersShown) {
         with(requireActivity().date_range_picker) {
             text = uiHelpers.getTextOfUiString(requireContext(), uiState.dateRangeLabel)
+            contentDescription = uiHelpers.getTextOfUiString(requireContext(), uiState.dateRangeLabelContentDescription)
             isCloseIconVisible = uiState.onClearDateRangeFilterClicked != null
             setOnCloseIconClickListener { uiState.onClearDateRangeFilterClicked?.invoke() }
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -190,8 +190,10 @@ class ActivityLogViewModel @Inject constructor(
     private fun refreshFiltersUiState() {
         _filtersUiState.value = if (activityLogFiltersFeatureConfig.isEnabled()) {
             val (activityTypeLabel, activityTypeLabelContentDescription) = createActivityTypeFilterLabel()
+            val (dateRangeLabel, dateRangeLabelContentDescription) = createDateRangeFilterLabel()
             FiltersShown(
-                    createDateRangeFilterLabel(),
+                    dateRangeLabel,
+                    dateRangeLabelContentDescription,
                     activityTypeLabel,
                     activityTypeLabelContentDescription,
                     currentDateRangeFilter?.let { ::onClearDateRangeFilterClicked },
@@ -202,10 +204,16 @@ class ActivityLogViewModel @Inject constructor(
         }
     }
 
-    private fun createDateRangeFilterLabel(): UiString {
+    private fun createDateRangeFilterLabel(): kotlin.Pair<UiString, UiString> {
         return currentDateRangeFilter?.let {
-            UiStringText(dateUtils.formatDateRange(requireNotNull(it.first), requireNotNull(it.second), TIMEZONE_GMT_0))
-        } ?: UiStringRes(R.string.activity_log_date_range_filter_label)
+            val label = UiStringText(
+                    dateUtils.formatDateRange(requireNotNull(it.first), requireNotNull(it.second), TIMEZONE_GMT_0)
+            )
+            kotlin.Pair(label, label)
+        } ?: kotlin.Pair(
+                UiStringRes(R.string.activity_log_date_range_filter_label),
+                UiStringRes(R.string.activity_log_date_range_filter_label_content_description)
+        )
     }
 
     private fun createActivityTypeFilterLabel(): kotlin.Pair<UiString, UiString> {
@@ -489,6 +497,7 @@ class ActivityLogViewModel @Inject constructor(
 
         data class FiltersShown(
             val dateRangeLabel: UiString,
+            val dateRangeLabelContentDescription: UiString,
             val activityTypeLabel: UiString,
             val activityTypeLabelContentDescription: UiString,
             val onClearDateRangeFilterClicked: (() -> Unit)?,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -189,9 +189,11 @@ class ActivityLogViewModel @Inject constructor(
 
     private fun refreshFiltersUiState() {
         _filtersUiState.value = if (activityLogFiltersFeatureConfig.isEnabled()) {
+            val (activityTypeLabel, activityTypeLabelContentDescription) = createActivityTypeFilterLabel()
             FiltersShown(
                     createDateRangeFilterLabel(),
-                    createActivityTypeFilterLabel(),
+                    activityTypeLabel,
+                    activityTypeLabelContentDescription,
                     currentDateRangeFilter?.let { ::onClearDateRangeFilterClicked },
                     currentActivityTypeFilter.takeIf { it.isNotEmpty() }?.let { ::onClearActivityTypeFilterClicked }
             )
@@ -206,17 +208,32 @@ class ActivityLogViewModel @Inject constructor(
         } ?: UiStringRes(R.string.activity_log_date_range_filter_label)
     }
 
-    private fun createActivityTypeFilterLabel(): UiString {
+    private fun createActivityTypeFilterLabel(): kotlin.Pair<UiString, UiString> {
         return currentActivityTypeFilter.takeIf { it.isNotEmpty() }?.let {
             if (it.size == 1) {
-                UiStringText("${it[0].name} (${it[0].count})")
+                kotlin.Pair(
+                        UiStringText("${it[0].name} (${it[0].count})"),
+                        UiStringResWithParams(
+                                R.string.activity_log_activity_type_filter_single_item_selected_content_description,
+                                listOf(UiStringText(it[0].name), UiStringText(it[0].count.toString()))
+                        )
+                )
             } else {
-                UiStringResWithParams(
-                        R.string.activity_log_activity_type_filter_active_label,
-                        listOf(UiStringText("${it.size}"))
+                kotlin.Pair(
+                        UiStringResWithParams(
+                                R.string.activity_log_activity_type_filter_active_label,
+                                listOf(UiStringText("${it.size}"))
+                        ),
+                        UiStringResWithParams(
+                                R.string.activity_log_activity_type_filter_multiple_items_selected_content_description,
+                                listOf(UiStringText("${it.size}"))
+                        )
                 )
             }
-        } ?: UiStringRes(R.string.activity_log_activity_type_filter_label)
+        } ?: kotlin.Pair(
+                UiStringRes(R.string.activity_log_activity_type_filter_label),
+                UiStringRes(R.string.activity_log_activity_type_filter_no_item_selected_content_description)
+        )
     }
 
     fun onPullToRefresh() {
@@ -473,6 +490,7 @@ class ActivityLogViewModel @Inject constructor(
         data class FiltersShown(
             val dateRangeLabel: UiString,
             val activityTypeLabel: UiString,
+            val activityTypeLabelContentDescription: UiString,
             val onClearDateRangeFilterClicked: (() -> Unit)?,
             val onClearActivityTypeFilterClicked: (() -> Unit)?
         ) : FiltersUiState(visibility = true)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1030,6 +1030,7 @@
     <string name="activity_log_activity_type_filter_apply">Apply</string>
     <string name="activity_log_activity_type_filter_clear">Clear</string>
     <string name="activity_log_date_range_filter_label">Date Range</string>
+    <string name="activity_log_date_range_filter_label_content_description">Date Range filter</string>
     <string name="activity_log_activity_type_filter_label">Activity Type</string>
     <string name="activity_log_activity_type_filter_active_label">Activity Type (%s)</string>
     <string name="activity_log_activity_type_error_title">No connection</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1036,6 +1036,9 @@
     <string name="activity_log_activity_type_error_subtitle">Please check your internet connection and retry.</string>
     <string name="activity_log_activity_type_empty_title">No activities available</string>
     <string name="activity_log_activity_type_empty_subtitle">No activities recorded in the selected date range.</string>
+    <string name="activity_log_activity_type_filter_no_item_selected_content_description">Activity Type filter</string>
+    <string name="activity_log_activity_type_filter_single_item_selected_content_description">%s (showing %s items)</string>
+    <string name="activity_log_activity_type_filter_multiple_items_selected_content_description">Activity Type filter (%s types selected)</string>
 
     <!-- activity log list popup menu -->
     <string name="activity_log_item_menu_restore_label">Restore to this point</string>


### PR DESCRIPTION
Parent issue #13268

Adds content description for date range and activity type filters.

#### Date Range:
##### No filter selected 
- label: "Date Range"
- content description: "Date Range filter"
##### Filter selected
- label: "Jan 9-10"
- content description: "Jan 9-10"

#### Activity Type
##### No filter selected
- label :"Activity Type"
- content description: "Activity Type filter"
##### One type selected
- label: "Users (55)"
- content description: "Users (showing 55 items)"
##### More types selected
- label: "Activity Type (3)"
- content description: "Activity Type filter (3 types selected)"

To Test:
Verify that labels and content filters match the above description.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
