### PR TITLE
Activity Log filters final design review

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -74,7 +74,6 @@ class ActivityLogViewModel @Inject constructor(
         FETCHING,
         LOADING_MORE
     }
-
     private var isStarted = false
 
     private val _events = MutableLiveData<List<ActivityLogListItem>>()

--- a/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
@@ -32,7 +32,7 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="@dimen/list_divider_height"
-            android:background="@color/divider" />
+            android:background="?attr/wpColorSurfaceSecondary" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -150,7 +150,7 @@
 
     <style name="WordPress.MaterialCalendarHeaderDivider" parent="Widget.MaterialComponents.MaterialCalendar.HeaderDivider">
         <item name="android:visibility">visible</item>
-        <item name="android:background">@color/divider</item>
+        <item name="android:background">?attr/wpColorSurfaceSecondary</item>
     </style>
 
     <style name="WordPress.TextAppearance.MaterialCalendarDaysOfWeek" parent="TextAppearance.MaterialComponents.Body2">


### PR DESCRIPTION
Known issues
1. Activity Log filters are shown even on sites which do not support filtering (PR coming soon)
2. StatusBar and NavigationBar on the date range picker component is black (I reported a bug in the Google repo)


This PR fixes color of divider on Activity log - date range and activity type screens.
To test:
1. Open activity log
2. Notice the color of the divider under the filter bar
3. Open Date Range filter and verify the color of the divider matches activity log
4. Go back to activity log
4. Open Activity Type filter and verify the color of the divider matches activity log
5. Repeat the same steps in dark mode