### PR TITLE
[Layout Switching] Sets homepage first only if it is on the top level 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -271,10 +271,10 @@ class PageListViewModel @Inject constructor(
 
         val shouldSortTopologically = filteredPages.size < MAX_TOPOLOGICAL_PAGE_COUNT
         val sortedPages = (if (shouldSortTopologically) {
-            topologicalSort(filteredPages, listType = PUBLISHED)
+            topologicalSort(filteredPages.sortedBy { !(it.isHomepage && it.parent == null) }, listType = PUBLISHED)
         } else {
-            filteredPages.sortedByDescending { it.date }
-        }).sortedBy { !it.isHomepage }
+            filteredPages.sortedByDescending { it.date }.sortedBy { !it.isHomepage }
+        })
 
         return sortedPages
                 .map {


### PR DESCRIPTION
Additional **Fix** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2937

## Description
This PR corrects a misbehaviour introduced with [#13691](https://github.com/wordpress-mobile/WordPress-Android/pull/13691) where a nested page moved to top. As [discussed](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2937#issuecomment-756069847) the reordering should occur only if the homepage is on the top level.

## To test

### Nested Homepage
1. From *My Site* press the *Pages* button or scroll down and select *Site Pages* from the list
1. Create a page hierarchy
1. Press the *dots* at the right of a nested page and choose **Set as Homepage**
1. **Verify** that the homepage does not move to the top

### Homepage with children
1. From *My Site* press the *Pages* button or scroll down and select *Site Pages* from the list
1. Create a page hierarchy
1. Press the *dots* at the right of a page with children and choose **Set as Homepage**
1. If no homepage is set press the *dots* at the right of a page listing and choose **Set as Homepage**
1. **Verify** that the homepage is listed **first** and the children below it

## Screenshots

|Bug|Fix: Nested page does move to top|Top level homepage with children|
|---|---|---|
|![device-2021-01-07-141802](https://user-images.githubusercontent.com/304044/103893915-bbed4c80-50f6-11eb-93de-848762942662.png)|![device-2021-01-07-143737](https://user-images.githubusercontent.com/304044/103893921-be4fa680-50f6-11eb-8d03-ec0a999574fe.png)|![device-2021-01-07-143800](https://user-images.githubusercontent.com/304044/103893923-bf80d380-50f6-11eb-938a-50faea868a35.png)|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
