### PR TITLE
Issue/13268 activity log filters visibility

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/FetchJetpackCapabilitiesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/FetchJetpackCapabilitiesUseCase.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.ui.jetpack
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.FetchJetpackCapabilitiesPayload
+import org.wordpress.android.fluxc.store.SiteStore.OnJetpackCapabilitiesFetched
+import org.wordpress.android.modules.BG_THREAD
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+class FetchJetpackCapabilitiesUseCase @Inject constructor(
+    @Suppress("unused") private val siteStore: SiteStore,
+    private val dispatcher: Dispatcher,
+    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+) {
+    private var continuation: Continuation<OnJetpackCapabilitiesFetched>? = null
+
+    suspend fun fetchJetpackCapabilities(remoteSiteId: Long): OnJetpackCapabilitiesFetched {
+        return withContext(bgDispatcher) {
+            if (continuation != null) {
+                throw IllegalStateException("Request already in progress.")
+            }
+
+            dispatcher.register(this@FetchJetpackCapabilitiesUseCase)
+            suspendCoroutine { cont ->
+                val payload = FetchJetpackCapabilitiesPayload(remoteSiteId)
+                continuation = cont
+                dispatcher.dispatch(SiteActionBuilder.newFetchJetpackCapabilitiesAction(payload))
+            }
+        }
+    }
+
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    @SuppressWarnings("unused")
+    fun onJetpackCapabilitiesFetched(event: OnJetpackCapabilitiesFetched) {
+        dispatcher.unregister(this@FetchJetpackCapabilitiesUseCase)
+        continuation?.resume(event)
+        continuation = null
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ActivityLogFiltersFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ActivityLogFiltersFeatureConfig.kt
@@ -1,15 +1,21 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.ActivityLogFiltersFeatureConfig.Companion.ACTIVITY_LOG_FILTERS
 import javax.inject.Inject
 
 /**
  * Configuration of the Activity Log Filters feature.
  */
-@FeatureInDevelopment
+@Feature(remoteField = ACTIVITY_LOG_FILTERS)
 class ActivityLogFiltersFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.ACTIVITY_LOG_FILTERS
-)
+        BuildConfig.ACTIVITY_LOG_FILTERS,
+        ACTIVITY_LOG_FILTERS
+) {
+    companion object {
+        const val ACTIVITY_LOG_FILTERS = "activity_log_filters_enabled"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -9,6 +9,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP
+import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP_DAILY
+import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP_REALTIME
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
@@ -27,6 +30,7 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Header
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Loading
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.RESTORE
+import org.wordpress.android.ui.jetpack.FetchJetpackCapabilitiesUseCase
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService.RewindProgress
 import org.wordpress.android.ui.stats.refresh.utils.DateUtils
@@ -65,6 +69,7 @@ class ActivityLogViewModel @Inject constructor(
     private val backupFeatureConfig: BackupFeatureConfig,
     private val dateUtils: DateUtils,
     private val activityLogTracker: ActivityLogTracker,
+    private val fetchJetpackCapabilitiesUseCase: FetchJetpackCapabilitiesUseCase,
     @param:Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(uiDispatcher) {
     enum class ActivityLogListStatus {
@@ -85,7 +90,7 @@ class ActivityLogViewModel @Inject constructor(
     val eventListStatus: LiveData<ActivityLogListStatus>
         get() = _eventListStatus
 
-    private val _filtersUiState = MutableLiveData<FiltersUiState>()
+    private val _filtersUiState = MutableLiveData<FiltersUiState>(FiltersHidden)
     val filtersUiState: LiveData<FiltersUiState>
         get() = _filtersUiState
 
@@ -167,9 +172,24 @@ class ActivityLogViewModel @Inject constructor(
         reloadEvents(done = true)
         requestEventsUpdate(false)
 
-        refreshFiltersUiState()
+        showFiltersIfSupported()
 
         isStarted = true
+    }
+
+    private fun showFiltersIfSupported() {
+        when {
+            !activityLogFiltersFeatureConfig.isEnabled() -> return
+            !site.hasFreePlan -> refreshFiltersUiState()
+            else -> {
+                launch {
+                    val result = fetchJetpackCapabilitiesUseCase.fetchJetpackCapabilities(site.siteId)
+                    result.capabilities?.find { it == BACKUP || it == BACKUP_DAILY || it == BACKUP_REALTIME }?.let {
+                        refreshFiltersUiState()
+                    }
+                }
+            }
+        }
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -188,20 +188,16 @@ class ActivityLogViewModel @Inject constructor(
     }
 
     private fun refreshFiltersUiState() {
-        _filtersUiState.value = if (activityLogFiltersFeatureConfig.isEnabled()) {
-            val (activityTypeLabel, activityTypeLabelContentDescription) = createActivityTypeFilterLabel()
-            val (dateRangeLabel, dateRangeLabelContentDescription) = createDateRangeFilterLabel()
-            FiltersShown(
-                    dateRangeLabel,
-                    dateRangeLabelContentDescription,
-                    activityTypeLabel,
-                    activityTypeLabelContentDescription,
-                    currentDateRangeFilter?.let { ::onClearDateRangeFilterClicked },
-                    currentActivityTypeFilter.takeIf { it.isNotEmpty() }?.let { ::onClearActivityTypeFilterClicked }
-            )
-        } else {
-            FiltersHidden
-        }
+        val (activityTypeLabel, activityTypeLabelContentDescription) = createActivityTypeFilterLabel()
+        val (dateRangeLabel, dateRangeLabelContentDescription) = createDateRangeFilterLabel()
+        _filtersUiState.value = FiltersShown(
+                dateRangeLabel,
+                dateRangeLabelContentDescription,
+                activityTypeLabel,
+                activityTypeLabelContentDescription,
+                currentDateRangeFilter?.let { ::onClearDateRangeFilterClicked },
+                currentActivityTypeFilter.takeIf { it.isNotEmpty() }?.let { ::onClearActivityTypeFilterClicked }
+        )
     }
 
     private fun createDateRangeFilterLabel(): kotlin.Pair<UiString, UiString> {

--- a/WordPress/src/main/res/layout/activity_log_list_activity.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_activity.xml
@@ -10,6 +10,7 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"
+        android:animateLayoutChanges="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/FetchJetpackCapabilitiesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/FetchJetpackCapabilitiesUseCaseTest.kt
@@ -1,0 +1,65 @@
+package org.wordpress.android.ui.jetpack
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnJetpackCapabilitiesFetched
+import org.wordpress.android.test
+
+private const val SITE_ID = 1L
+@InternalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class FetchJetpackCapabilitiesUseCaseTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    @Mock private lateinit var dispatcher: Dispatcher
+    @Mock private lateinit var store: SiteStore
+    private lateinit var useCase: FetchJetpackCapabilitiesUseCase
+    private lateinit var event: OnJetpackCapabilitiesFetched
+
+    @Before
+    fun setUp() {
+        useCase = FetchJetpackCapabilitiesUseCase(store, dispatcher, TEST_DISPATCHER)
+        event = OnJetpackCapabilitiesFetched(SITE_ID, listOf(), null)
+    }
+
+    @Test
+    fun `coroutine resumed, when result event dispatched`() = test {
+        whenever(dispatcher.dispatch(any())).then { useCase.onJetpackCapabilitiesFetched(event) }
+
+        val resultEvent = useCase.fetchJetpackCapabilities(SITE_ID)
+
+        assertThat(resultEvent).isEqualTo(event)
+    }
+
+    @Test
+    fun `useCase subscribes to event bus`() = test {
+        whenever(dispatcher.dispatch(any())).then { useCase.onJetpackCapabilitiesFetched(event) }
+
+        useCase.fetchJetpackCapabilities(SITE_ID)
+
+        verify(dispatcher).register(useCase)
+    }
+
+    @Test
+    fun `useCase unsubscribes from event bus`() = test {
+        whenever(dispatcher.dispatch(any())).then { useCase.onJetpackCapabilitiesFetched(event) }
+
+        useCase.fetchJetpackCapabilities(SITE_ID)
+
+        verify(dispatcher).unregister(useCase)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -503,7 +503,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun dateRangeFilterClearActionShownWhenFilterNotEmpty() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         whenever(dateUtils.formatDateRange(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn("TEST")
         val dateRange = Pair(10L, 20L)
 
@@ -515,7 +514,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun dateRangeFilterClearActionHiddenWhenFilterEmpty() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         viewModel.onDateRangeSelected(null)
 
         val action = (viewModel.filtersUiState.value as FiltersShown).onClearDateRangeFilterClicked
@@ -524,7 +522,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun onDateRangeFilterClearActionClickClearActionDisappears() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         whenever(dateUtils.formatDateRange(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn("TEST")
         viewModel.onDateRangeSelected(Pair(10L, 20L))
 
@@ -536,8 +533,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun basicDateRangeLabelShownWhenFilterEmpty() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
-
         viewModel.onDateRangeSelected(null)
 
         Assertions.assertThat((viewModel.filtersUiState.value as FiltersShown).dateRangeLabel)
@@ -546,7 +541,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun dateRangeLabelWithDatesShownWhenFilterNotEmpty() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         whenever(dateUtils.formatDateRange(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn("TEST")
 
         viewModel.onDateRangeSelected(Pair(10L, 20L))
@@ -557,7 +551,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun dateRangeLabelFormattingUsesGMT0Timezone() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         whenever(
                 dateUtils.formatDateRange(
                         anyOrNull(),
@@ -574,7 +567,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun dateRangeEndTimestampGetsAdjustedToEndOfDay() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         whenever(
                 dateUtils.formatDateRange(anyOrNull(), anyOrNull(), anyOrNull())
         ).thenReturn("TEST")
@@ -589,7 +581,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun activityTypeFilterClearActionShownWhenFilterNotEmpty() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         viewModel.onActivityTypesSelected(listOf(ActivityTypeModel("user", "User", 10)))
 
         val action = (viewModel.filtersUiState.value as FiltersShown).onClearActivityTypeFilterClicked
@@ -598,7 +589,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun activityTypeFilterClearActionHiddenWhenFilterEmpty() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         viewModel.onActivityTypesSelected(listOf())
 
         val action = (viewModel.filtersUiState.value as FiltersShown).onClearActivityTypeFilterClicked
@@ -607,7 +597,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun onActivityTypeFilterClearActionClickClearActionDisappears() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         viewModel.onActivityTypesSelected(
                 listOf(ActivityTypeModel("user", "User", 10))
         )
@@ -620,7 +609,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun basicActivityTypeLabelShownWhenFilterEmpty() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         viewModel.onActivityTypesSelected(listOf())
 
         Assertions.assertThat((viewModel.filtersUiState.value as FiltersShown).activityTypeLabel)
@@ -629,7 +617,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun activityTypeLabelWithNameShownWhenFilterHasOneItem() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         val activityTypeName = "Backups and Restores"
         val activityTypeCount = 5
         viewModel.onActivityTypesSelected(listOf(ActivityTypeModel("backup", activityTypeName, activityTypeCount)))
@@ -640,7 +627,6 @@ class ActivityLogViewModelTest {
 
     @Test
     fun activityTypeLabelWithCountShownWhenFilterHasMoreThanOneItem() {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         viewModel.onActivityTypesSelected(
                 listOf(
                         ActivityTypeModel("user", "User", 10),

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -49,6 +49,7 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Icon.DEFAUL
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Loading
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.RESTORE
+import org.wordpress.android.ui.jetpack.FetchJetpackCapabilitiesUseCase
 import org.wordpress.android.ui.stats.refresh.utils.DateUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
@@ -69,6 +70,8 @@ private const val DATE_2_IN_MILLIS = 1578787200000L // 2020-01-12T00:00:00+00:00
 private const val TIMEZONE_GMT_0 = "GMT+0"
 private const val ONE_DAY_WITHOUT_SECOND_IN_MILLIS = 1000 * 60 * 60 * 24 - 1000
 
+private const val SITE_ID = 1L
+
 @RunWith(MockitoJUnitRunner::class)
 class ActivityLogViewModelTest {
     @Rule @JvmField val rule = InstantTaskExecutorRule()
@@ -80,6 +83,7 @@ class ActivityLogViewModelTest {
     @Mock private lateinit var backupFeatureConfig: BackupFeatureConfig
     @Mock private lateinit var dateUtils: DateUtils
     @Mock private lateinit var activityLogTracker: ActivityLogTracker
+    @Mock private lateinit var fetchJetpackCapabilitiesUseCase: FetchJetpackCapabilitiesUseCase
     private lateinit var fetchActivityLogCaptor: KArgumentCaptor<FetchActivityLogPayload>
     private lateinit var formatDateRangeTimezoneCaptor: KArgumentCaptor<String>
 
@@ -143,6 +147,7 @@ class ActivityLogViewModelTest {
                 backupFeatureConfig,
                 dateUtils,
                 activityLogTracker,
+                fetchJetpackCapabilitiesUseCase,
                 Dispatchers.Unconfined
         )
         viewModel.site = site
@@ -400,7 +405,7 @@ class ActivityLogViewModelTest {
     fun onActivityTypeFilterClickRemoteSiteIdIsPassed() {
         viewModel.onActivityTypeFilterClicked()
 
-        assertEquals(RemoteId(site.siteId), viewModel.showActivityTypeFilterDialog.value!!.siteId)
+        assertEquals(RemoteId(SITE_ID), viewModel.showActivityTypeFilterDialog.value!!.siteId)
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.8.0-beta-7'
+    fluxCVersion = 'df481707c33821e08fed14d5ee04053e87859aa9'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'df481707c33821e08fed14d5ee04053e87859aa9'
+    fluxCVersion = '1.8.0-beta-8'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'


### PR DESCRIPTION
Parent issue #13268

Merge instructions:
1. Make sure https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1825 is merged
2. Update FluxC hash with tag
3. Remove "Not ready for merge" label
3. Merge this PR

This PR hides the filters bar in Activity Log if
- the user is on a free plan and hasn't purchased any jetpack product
- the user is on paid plan

"Fetch Jetpack Capabilities" endpoint is used to fetch list of product the user has purchased.

To test:
Perform the following test on multiple sites, ideally on 
- .com free (hidden)
- .com paid (visible)
- .com atomic (visible)
- .jetpack free (hidden)
- .jetpack paid (visible)
- .jetpack free with backup product (visible)

1. Make sure "ActivityLogFiltersFeatureConfig" is enabled
2. Open Activity log and check visibility of the filters bar 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
