### PR TITLE
Add remote field to ActivityLogFiltersFeatureConfig

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 16.5
 -----
 [***] Block Editor: Cross-post suggestions are now available by typing the + character (or long-pressing the toolbar button labelled with an @-symbol) in a post on a P2 site [https://github.com/wordpress-mobile/WordPress-Android/pull/13184]
+[***] Activity Log: Adds support for Date Range and Activity Type filters. [https://github.com/wordpress-mobile/WordPress-Android/issues/13268]
 * [**] Page List: Adds duplicate page functionality [https://github.com/wordpress-mobile/WordPress-Android/pull/13607]
 
  

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ActivityLogFiltersFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ActivityLogFiltersFeatureConfig.kt
@@ -1,15 +1,21 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.ActivityLogFiltersFeatureConfig.Companion.ACTIVITY_LOG_FILTERS
 import javax.inject.Inject
 
 /**
  * Configuration of the Activity Log Filters feature.
  */
-@FeatureInDevelopment
+@Feature(remoteField = ACTIVITY_LOG_FILTERS)
 class ActivityLogFiltersFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.ACTIVITY_LOG_FILTERS
-)
+        BuildConfig.ACTIVITY_LOG_FILTERS,
+        ACTIVITY_LOG_FILTERS
+) {
+    companion object {
+        const val ACTIVITY_LOG_FILTERS = "activity_log_filters_enabled"
+    }
+}


### PR DESCRIPTION
Fixes #13268

This PR enables remote feature flag for the Activity Type Filters and updates release notes.

Note:
I've introduce a remote feature flag and I enabled it by default. 

To test:
1. Clear app data to make sure the manual feature flag configuration gets removed
2. Do NOT manually turn on the feature flag
3. Verify the Activity Log filters are working even though the build time feature flag in build.gradle is set to false (make sure the site has paid plan or backup product)

- All the code related to the feature has been tested. However, it'd be good if you could spent a few minutes testing the feature in its final stage. Thanks!

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
