### PR TITLE
Issue/uppercase thousands suffix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderBlog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderBlog.java
@@ -82,9 +82,7 @@ public class ReaderBlog {
             blog.numSubscribers = json.optInt("subscribers_count");
         }
 
-        if (json.has("unseen_count")) {
-            blog.numUnseenPosts = json.optInt("unseen_count");
-        }
+        blog.numUnseenPosts = json.optInt("unseen_count");
 
         // blogId will be empty for feeds, so set it to the feedId (consistent with /read/ endpoints)
         if (blog.blogId == 0 && blog.feedId != 0) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -937,7 +937,7 @@
 
     <!-- Number suffixes -->
     <string name="negative_prefix">-%s</string>
-    <string name="suffix_1_000">%sk</string>
+    <string name="suffix_1_000">%sK</string>
     <string name="suffix_1_000_000">%sM</string>
     <string name="suffix_1_000_000_000">%sB</string>
     <string name="suffix_1_000_000_000_000">%sT</string>


### PR DESCRIPTION
In this PR we are uppercasing an English suffix for 1000 (k > K) to align with iOS, as mentioned [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/15581#discussion_r552209976). That string is translatable, so other locales could use an appropriate suffix.

The suffix will be changed in the stats and unread posts counter.

[![Image from Gyazo](https://i.gyazo.com/36c8114d0486aecd284d06c9976d1a6d.png)](https://gyazo.com/36c8114d0486aecd284d06c9976d1a6d)

In addition, I removed the unneeded `has()` check, that was mentioned [here](https://github.com/wordpress-mobile/WordPress-Android/pull/13625#discussion_r552176448).

To test:
- You can check the new uppercase suffix in Stats (for values > 9999) or in unread posts count (if you have enough posts).

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
