### PR TITLE
Issue/13329 wizard cleanup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.jetpack.backup.download
 
-import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
@@ -26,9 +25,9 @@ import org.wordpress.android.util.wizard.WizardNavigationTarget
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 
+const val KEY_BACKUP_DOWNLOAD_DOWNLOAD_ID = "key_backup_download_download_id"
+
 class BackupDownloadActivity : LocaleAwareActivity() {
-    // todo: annmarie add listeners if needed
-    // todo: annmarie get the values from the bundle for site & activityId
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject internal lateinit var uiHelpers: UiHelpers
     private lateinit var viewModel: BackupDownloadViewModel
@@ -84,30 +83,20 @@ class BackupDownloadActivity : LocaleAwareActivity() {
             }
         })
 
-        // Canceled, Running, Complete -> (Running = kick off status)
         viewModel.wizardFinishedObservable.observe(this, {
             it.applyIfNotHandled {
                 val intent = Intent()
-                val (backupDownloadCreated, _) = when (this) {
-                    // teh request was canceled
+                val (backupDownloadCreated, downloadId) = when (this) {
                     is BackupDownloadCanceled -> Pair(false, null)
-                    is BackupDownloadInProgress -> Pair(true, activityId)
-                    is BackupDownloadCompleted -> Pair(true, activityId)
+                    is BackupDownloadInProgress -> Pair(true, downloadId)
+                    is BackupDownloadCompleted -> Pair(true, null)
                 }
-                // todo: annmarie what information do I need to send back - just to kick off status
-                // intent.putExtra(SOME_KEY_THAT_DESCRIBES_THE_ID, activityId )
+                intent.putExtra(KEY_BACKUP_DOWNLOAD_DOWNLOAD_ID, downloadId)
                 setResult(if (backupDownloadCreated) RESULT_OK else RESULT_CANCELED, intent)
                 finish()
             }
         })
 
-        viewModel.exitFlowObservable.observe(this, {
-            setResult(Activity.RESULT_CANCELED)
-            finish()
-        })
-        viewModel.onBackPressedObservable.observe(this, {
-            super.onBackPressed()
-        })
         viewModel.start(savedInstanceState)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadStep.kt
@@ -4,8 +4,8 @@ import org.wordpress.android.util.wizard.WizardStep
 import javax.inject.Inject
 import javax.inject.Singleton
 
-enum class BackupDownloadStep : WizardStep {
-    DETAILS, PROGRESS, COMPLETE;
+enum class BackupDownloadStep(val id: Int) : WizardStep {
+    DETAILS(0), PROGRESS(1), COMPLETE(2);
 
     companion object {
         fun fromString(input: String): BackupDownloadStep = when (input) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -77,8 +77,7 @@ class BackupDownloadViewModel @Inject constructor(
             // Show the next step only if it's a fresh activity so we can handle the navigation
             wizardManager.showNextStep()
         } else {
-            backupDownloadState = requireNotNull(savedInstanceState.getParcelable(KEY_BACKUP_DOWNLOAD_STATE)
-            )
+            backupDownloadState = requireNotNull(savedInstanceState.getParcelable(KEY_BACKUP_DOWNLOAD_STATE))
             val currentStepIndex = savedInstanceState.getInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP)
             wizardManager.setCurrentStepIndex(currentStepIndex)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -12,7 +12,12 @@ import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.R
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep.COMPLETE
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep.DETAILS
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep.PROGRESS
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.BackupDownloadWizardState.BackupDownloadCanceled
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.BackupDownloadWizardState.BackupDownloadCompleted
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.BackupDownloadWizardState.BackupDownloadInProgress
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
@@ -24,7 +29,6 @@ import javax.inject.Inject
 
 const val KEY_BACKUP_DOWNLOAD_ACTIVITY_ID_KEY = "key_backup_download_activity_id_key"
 const val KEY_BACKUP_DOWNLOAD_CURRENT_STEP = "key_backup_download_current_step"
-const val KEY_BACKUP_DOWNLOAD_COMPLETED = "key_backup_download_completed"
 const val KEY_BACKUP_DOWNLOAD_STATE = "key_backup_download_state"
 
 @Parcelize
@@ -44,7 +48,6 @@ class BackupDownloadViewModel @Inject constructor(
     private val wizardManager: WizardManager<BackupDownloadStep>
 ) : ViewModel() {
     private var isStarted = false
-    private var backupDownloadCompleted = false
 
     private lateinit var backupDownloadState: BackupDownloadState
 
@@ -63,12 +66,6 @@ class BackupDownloadViewModel @Inject constructor(
     private val _toolbarStateObservable = MutableLiveData<ToolbarState>()
     val toolbarStateObservable: LiveData<ToolbarState> = _toolbarStateObservable
 
-    private val _exitFlowObservable = MutableLiveData<Event<Unit>>()
-    val exitFlowObservable: LiveData<Event<Unit>> = _exitFlowObservable
-
-    private val _onBackPressedObservable = MutableLiveData<Event<Unit>>()
-    val onBackPressedObservable: LiveData<Event<Unit>> = _onBackPressedObservable
-
     private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
     val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
@@ -80,7 +77,6 @@ class BackupDownloadViewModel @Inject constructor(
             // Show the next step only if it's a fresh activity so we can handle the navigation
             wizardManager.showNextStep()
         } else {
-            backupDownloadCompleted = savedInstanceState.getBoolean(KEY_BACKUP_DOWNLOAD_COMPLETED, false)
             backupDownloadState = requireNotNull(savedInstanceState.getParcelable(KEY_BACKUP_DOWNLOAD_STATE)
             )
             val currentStepIndex = savedInstanceState.getInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP)
@@ -95,14 +91,26 @@ class BackupDownloadViewModel @Inject constructor(
     }
 
     fun writeToBundle(outState: Bundle) {
-        outState.putBoolean(KEY_BACKUP_DOWNLOAD_COMPLETED, backupDownloadCompleted)
         outState.putInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP, wizardManager.currentStep)
         outState.putParcelable(KEY_BACKUP_DOWNLOAD_STATE, backupDownloadState)
     }
 
     fun onBackPressed() {
-        return exitFlow()
-        // todo: annmarie - what should happen on backPress - always exit, please revisit
+        when (wizardManager.currentStep) {
+            DETAILS.id -> {
+                _wizardFinishedObservable.value = Event(BackupDownloadCanceled)
+            }
+            PROGRESS.id -> {
+                _wizardFinishedObservable.value = if (backupDownloadState.downloadId != null) {
+                    Event(BackupDownloadInProgress(backupDownloadState.downloadId as Long))
+                } else {
+                    Event(BackupDownloadCanceled)
+                }
+            }
+            COMPLETE.id -> {
+                _wizardFinishedObservable.value = Event(BackupDownloadCompleted)
+            }
+        }
     }
 
     private fun clearOldBackupDownloadState(wizardStep: BackupDownloadStep) {
@@ -123,13 +131,13 @@ class BackupDownloadViewModel @Inject constructor(
         wizardManager.showNextStep()
     }
 
+    fun onBackupDownloadDetailsCanceled() {
+        _wizardFinishedObservable.value = Event(BackupDownloadCanceled)
+    }
+
     fun onBackupDownloadProgressFinished(url: String?) {
         backupDownloadState = backupDownloadState.copy(url = url)
         wizardManager.showNextStep()
-    }
-
-    private fun exitFlow() {
-        _exitFlowObservable.value = Event(Unit)
     }
 
     fun setToolbarState(toolbarState: ToolbarState) {
@@ -141,10 +149,10 @@ class BackupDownloadViewModel @Inject constructor(
         object BackupDownloadCanceled : BackupDownloadWizardState()
 
         @Parcelize
-        data class BackupDownloadInProgress(val activityId: String) : BackupDownloadWizardState()
+        data class BackupDownloadInProgress(val downloadId: Long) : BackupDownloadWizardState()
 
         @Parcelize
-        data class BackupDownloadCompleted(val activityId: String) : BackupDownloadWizardState()
+        object BackupDownloadCompleted : BackupDownloadWizardState()
     }
 
     sealed class ToolbarState {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
@@ -95,7 +95,7 @@ class BackupDownloadDetailsViewModel @Inject constructor(
                         )
                 )
             } else {
-                // todo: annmarie - Set the correct activity result & exit wizard
+                parentViewModel.onBackupDownloadDetailsCanceled()
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/progress/BackupDownloadProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/progress/BackupDownloadProgressViewModel.kt
@@ -51,7 +51,6 @@ class BackupDownloadProgressViewModel @Inject constructor(
     private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
     val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
-    // todo: annmarie think about adding state to instanceState
     fun start(
         site: SiteModel,
         backupDownloadState: BackupDownloadState,

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
@@ -1,28 +1,158 @@
 package org.wordpress.android.ui.jetpack.backup.download
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import android.os.Bundle
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.Mockito.clearInvocations
+import org.mockito.Mockito.verify
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.BackupDownloadWizardState
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.BackupDownloadWizardState.BackupDownloadCanceled
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.BackupDownloadWizardState.BackupDownloadCompleted
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.BackupDownloadWizardState.BackupDownloadInProgress
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.CompleteToolbarState
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.DetailsToolbarState
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.ProgressToolbarState
 import org.wordpress.android.util.wizard.WizardManager
+import org.wordpress.android.viewmodel.SingleLiveEvent
+import java.util.Date
 
-@RunWith(MockitoJUnitRunner::class)
-class BackupDownloadViewModelTest {
-    @Rule
-    @JvmField val rule = InstantTaskExecutorRule()
-
+@InternalCoroutinesApi
+class BackupDownloadViewModelTest : BaseUnitTest() {
     @Mock lateinit var wizardManager: WizardManager<BackupDownloadStep>
+    @Mock lateinit var backupDownloadStep: BackupDownloadStep
+    @Mock lateinit var savedInstanceState: Bundle
+    private val wizardManagerNavigatorLiveData = SingleLiveEvent<BackupDownloadStep>()
 
     private lateinit var viewModel: BackupDownloadViewModel
 
+    private val rewindId = "rewindId"
+    private val downloadId = 100L
+    private val published = Date(1609690147756)
+    private val url = "url"
+
+    private val backupDownloadState = BackupDownloadState(
+            activityId = "activityId",
+            rewindId = "rewindId",
+            downloadId = 100L,
+            siteId = 200L,
+            url = null,
+            published = Date(1609690147756)
+    )
+
     @Before
     fun setUp() {
+        whenever(wizardManager.navigatorLiveData).thenReturn(wizardManagerNavigatorLiveData)
+        whenever(wizardManager.showNextStep()).then {
+            wizardManagerNavigatorLiveData.value = backupDownloadStep
+            Unit
+        }
         viewModel = BackupDownloadViewModel(wizardManager)
+    }
+
+    @Test
+    fun `when view model is started, process moves to next step`() {
+        viewModel.start(null)
+
+        verify(wizardManager).showNextStep()
+    }
+
+    @Test
+    fun `when details is finished, process moves to next step`() {
+        viewModel.start(null)
+        // need to clear invocations because nextStep is called on start
+        clearInvocations(wizardManager)
+
+        viewModel.onBackupDownloadDetailsFinished(rewindId, downloadId, published)
+        verify(wizardManager).showNextStep()
+    }
+
+    @Test
+    fun `when progress is finished, process moves to next step`() {
+        viewModel.start(null)
+        clearInvocations(wizardManager)
+
+        viewModel.onBackupDownloadProgressFinished(url)
+        verify(wizardManager).showNextStep()
+    }
+
+    @Test
+    fun `when details is finished, state is updated properly`() {
+        val navigationTargets = initObservers().navigationTargets
+
+        viewModel.start(null)
+        clearInvocations(wizardManager)
+        whenever(wizardManager.showNextStep()).then {
+            wizardManagerNavigatorLiveData.value = BackupDownloadStep.PROGRESS
+            Unit
+        }
+
+        viewModel.onBackupDownloadDetailsFinished(rewindId, downloadId, published)
+
+        assertThat(navigationTargets.last().wizardState.rewindId).isEqualTo(rewindId)
+        assertThat(navigationTargets.last().wizardState.downloadId).isEqualTo(downloadId)
+        assertThat(navigationTargets.last().wizardState.published).isEqualTo(published)
+    }
+
+    @Test
+    fun `when progress is finished, state is updated properly`() {
+        val navigationTargets = initObservers().navigationTargets
+
+        viewModel.start(null)
+        clearInvocations(wizardManager)
+        whenever(wizardManager.showNextStep()).then {
+            wizardManagerNavigatorLiveData.value = BackupDownloadStep.COMPLETE
+            Unit
+        }
+
+        viewModel.onBackupDownloadProgressFinished(url)
+
+        assertThat(navigationTargets.last().wizardState.url).isEqualTo(url)
+    }
+
+    @Test
+    fun `when onBackPressed while in details step, invokes wizard finished with cancel`() {
+        val wizardFinishedObserver = initObservers().wizardFinishedObserver
+
+        viewModel.start(null)
+        clearInvocations(wizardManager)
+
+        whenever(wizardManager.currentStep).thenReturn(0)
+        viewModel.onBackPressed()
+
+        assertThat(wizardFinishedObserver.last()).isInstanceOf(BackupDownloadCanceled::class.java)
+    }
+
+    @Test
+    fun `when onBackPressed while in progress step, invokes wizard finished with BackupDownloadInProgress`() {
+        val wizardFinishedObserver = initObservers().wizardFinishedObserver
+        viewModel.start(null)
+        clearInvocations(wizardManager)
+        viewModel.onBackupDownloadDetailsFinished(rewindId, downloadId, published)
+
+        whenever(wizardManager.currentStep).thenReturn(1)
+        viewModel.onBackPressed()
+
+        assertThat(wizardFinishedObserver.last()).isInstanceOf(BackupDownloadInProgress::class.java)
+    }
+
+    @Test
+    fun `when onBackPressed while in complete step, invokes wizard finished with BackupDownloadCompleted`() {
+        val wizardFinishedObserver = initObservers().wizardFinishedObserver
+        viewModel.start(null)
+        clearInvocations(wizardManager)
+
+        whenever(wizardManager.currentStep).thenReturn(2)
+        viewModel.onBackPressed()
+
+        assertThat(wizardFinishedObserver.last()).isInstanceOf(BackupDownloadCompleted::class.java)
     }
 
     @Test
@@ -34,13 +164,56 @@ class BackupDownloadViewModelTest {
         assertThat(toolbarStates.size).isEqualTo(0)
     }
 
+    @Test
+    fun `backupDownloadState is writtenToBundle`() {
+        viewModel.start(savedInstanceState = null)
+
+        viewModel.writeToBundle(savedInstanceState)
+        verify(savedInstanceState)
+                .putParcelable(any(), argThat { this is BackupDownloadState })
+    }
+
+    @Test
+    fun `when setToolbarState is invoked, toolbar state is updated`() {
+        val toolbarStates = initObservers().toolbarState
+
+        viewModel.start(null)
+        viewModel.setToolbarState(DetailsToolbarState())
+        assertThat(toolbarStates.last()).isInstanceOf(DetailsToolbarState::class.java)
+
+        viewModel.setToolbarState(ProgressToolbarState())
+        assertThat(toolbarStates.last()).isInstanceOf(ProgressToolbarState::class.java)
+
+        viewModel.setToolbarState(CompleteToolbarState())
+        assertThat(toolbarStates.last()).isInstanceOf(CompleteToolbarState::class.java)
+    }
+
+    @Test
+    fun `step index is restored`() {
+        val index = 2
+        whenever(savedInstanceState.getInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP)).thenReturn(index)
+        whenever(savedInstanceState.getParcelable<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
+                .thenReturn(backupDownloadState)
+        viewModel.start(savedInstanceState = savedInstanceState)
+        verify(wizardManager).setCurrentStepIndex(index)
+    }
+
     private fun initObservers(): Observers {
         val toolbarStates = mutableListOf<ToolbarState>()
         viewModel.toolbarStateObservable.observeForever { toolbarStates.add(it) }
-        return Observers(toolbarStates)
+
+        val wizardFinishedObserver = mutableListOf<BackupDownloadWizardState>()
+        viewModel.wizardFinishedObservable.observeForever { wizardFinishedObserver.add(it.peekContent()) }
+
+        val navigationTargetObserver = mutableListOf<NavigationTarget>()
+        viewModel.navigationTargetObservable.observeForever { navigationTargetObserver.add(it) }
+
+        return Observers(toolbarStates, wizardFinishedObserver, navigationTargetObserver)
     }
 
     private data class Observers(
-        val toolbarState: List<ToolbarState>
+        val toolbarState: List<ToolbarState>,
+        val wizardFinishedObserver: List<BackupDownloadWizardState>,
+        val navigationTargets: List<NavigationTarget>
     )
 }


### PR DESCRIPTION
Parent #13329 

This PR cleans up the Backup Download wizard; focusing on removing unused code, handling onBackPressed situations and setting up intent extras for result. This is prep work for handling unhappy paths.

**Notes:**
- Styling has not been addressed
- The buttons are not hooked up, but you can tap on them and see a snackbar
- Testing for button clicks in progress/complete views will be added after the actions are hooked up.

**To Test**
CI Tests should pass

Do a quick run through the process and make sure the pages move through the process as expected
- Launch the app with BackupDownloadConfig flag on
- Navigate to ActivityLog
- Tap the More menu
- Tap Download Backup menu item
- Tap the Create downloadable file button
- The view changes to progress
- Note that the view changes to complete upon conclusion of process


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
