### PR TITLE
Issue/13735 fix activity log empty screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -133,6 +133,17 @@ class ActivityLogListFragment : Fragment() {
             if (uiState is FiltersShown) { updateFilters(uiState) }
         })
 
+        viewModel.emptyUiState.observe(viewLifecycleOwner, { emptyState ->
+            actionable_empty_view.title.text = uiHelpers.getTextOfUiString(
+                    requireContext(),
+                    emptyState.emptyScreenTitle
+            )
+            actionable_empty_view.subtitle.text = uiHelpers.getTextOfUiString(
+                    requireContext(),
+                    emptyState.emptyScreenSubtitle
+            )
+        })
+
         viewModel.showActivityTypeFilterDialog.observe(viewLifecycleOwner, { event ->
             showActivityTypeFilterDialog(event.siteId, event.initialSelection, event.dateRange)
         })

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -532,12 +532,12 @@ class ActivityLogViewModel @Inject constructor(
         abstract val emptyScreenTitle: UiString
         abstract val emptyScreenSubtitle: UiString
 
-        object EmptyFilters: EmptyUiState() {
+        object EmptyFilters : EmptyUiState() {
             override val emptyScreenTitle = UiStringRes(R.string.activity_log_empty_title)
             override val emptyScreenSubtitle = UiStringRes(R.string.activity_log_empty_subtitle)
         }
 
-        object ActiveFilters: EmptyUiState() {
+        object ActiveFilters : EmptyUiState() {
             override val emptyScreenTitle = UiStringRes(R.string.activity_log_active_filter_empty_title)
             override val emptyScreenSubtitle = UiStringRes(R.string.activity_log_active_filter_empty_subtitle)
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -93,6 +93,9 @@ class ActivityLogViewModel @Inject constructor(
     val filtersUiState: LiveData<FiltersUiState>
         get() = _filtersUiState
 
+    private val _emptyUiState = MutableLiveData<EmptyUiState>(EmptyUiState.EmptyFilters)
+    val emptyUiState: LiveData<EmptyUiState> = _emptyUiState
+
     private val _showRewindDialog = SingleLiveEvent<ActivityLogListItem>()
     val showRewindDialog: LiveData<ActivityLogListItem>
         get() = _showRewindDialog
@@ -217,6 +220,11 @@ class ActivityLogViewModel @Inject constructor(
                 currentDateRangeFilter?.let { ::onClearDateRangeFilterClicked },
                 currentActivityTypeFilter.takeIf { it.isNotEmpty() }?.let { ::onClearActivityTypeFilterClicked }
         )
+        if (currentDateRangeFilter != null || currentActivityTypeFilter.isNotEmpty()) {
+            _emptyUiState.value = EmptyUiState.ActiveFilters
+        } else {
+            _emptyUiState.value = EmptyUiState.EmptyFilters
+        }
     }
 
     private fun createDateRangeFilterLabel(): kotlin.Pair<UiString, UiString> {
@@ -518,5 +526,20 @@ class ActivityLogViewModel @Inject constructor(
             val onClearDateRangeFilterClicked: (() -> Unit)?,
             val onClearActivityTypeFilterClicked: (() -> Unit)?
         ) : FiltersUiState(visibility = true)
+    }
+
+    sealed class EmptyUiState {
+        abstract val emptyScreenTitle: UiString
+        abstract val emptyScreenSubtitle: UiString
+
+        object EmptyFilters: EmptyUiState() {
+            override val emptyScreenTitle = UiStringRes(R.string.activity_log_empty_title)
+            override val emptyScreenSubtitle = UiStringRes(R.string.activity_log_empty_subtitle)
+        }
+
+        object ActiveFilters: EmptyUiState() {
+            override val emptyScreenTitle = UiStringRes(R.string.activity_log_active_filter_empty_title)
+            override val emptyScreenSubtitle = UiStringRes(R.string.activity_log_active_filter_empty_subtitle)
+        }
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1015,8 +1015,10 @@
     <string name="rewind">Restore</string>
     <string name="activity_log_button">Activity Log action button</string>
     <string name="activity_log_jetpack_icon">Jetpack icon</string>
-    <string name="activity_log_empty_title">No matching events found</string>
-    <string name="activity_log_empty_subtitle">Try adjusting your date range or activity type filters.</string>
+    <string name="activity_log_empty_title">No activity yet</string>
+    <string name="activity_log_empty_subtitle">When you make changes to your site you\'ll be able to see your activity history here</string>
+    <string name="activity_log_active_filter_empty_title">No matching events found</string>
+    <string name="activity_log_active_filter_empty_subtitle">Try adjusting your date range or activity type filters.</string>
     <string name="activity_log_rewind_started_snackbar_message">Your site is being restored\nRestoring to %1$s %2$s</string>
     <string name="activity_log_rewind_finished_snackbar_message">Your site has been successfully restored\nRestored to %1$s %2$s</string>
     <string name="activity_log_rewind_finished_snackbar_message_no_dates">Your site has been successfully restored</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1018,7 +1018,7 @@
     <string name="activity_log_empty_title">No activity yet</string>
     <string name="activity_log_empty_subtitle">When you make changes to your site you\'ll be able to see your activity history here</string>
     <string name="activity_log_active_filter_empty_title">No matching events found</string>
-    <string name="activity_log_active_filter_empty_subtitle">Try adjusting your date range or activity type filters.</string>
+    <string name="activity_log_active_filter_empty_subtitle">Try adjusting your date range or activity type filters</string>
     <string name="activity_log_rewind_started_snackbar_message">Your site is being restored\nRestoring to %1$s %2$s</string>
     <string name="activity_log_rewind_finished_snackbar_message">Your site has been successfully restored\nRestored to %1$s %2$s</string>
     <string name="activity_log_rewind_finished_snackbar_message_no_dates">Your site has been successfully restored</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -65,6 +65,7 @@ import org.wordpress.android.util.analytics.ActivityLogTracker
 import org.wordpress.android.util.config.ActivityLogFiltersFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus
+import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.EmptyUiState
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.FiltersUiState.FiltersShown
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ShowDateRangePicker
 import java.util.Calendar
@@ -641,6 +642,28 @@ class ActivityLogViewModelTest {
                                 listOf(UiStringText("2"))
                         )
                 )
+    }
+
+    @Test
+    fun verifyEmptyScreenTextsWhenFiltersAreEmpty() {
+        viewModel.onClearDateRangeFilterClicked()
+        viewModel.onClearActivityTypeFilterClicked()
+
+        Assertions.assertThat(viewModel.emptyUiState.value).isEqualTo(EmptyUiState.EmptyFilters)
+    }
+
+    @Test
+    fun verifyEmptyScreenTextsWhenDateRangeFilterSet() {
+        viewModel.onDateRangeSelected(Pair(1L, 2L))
+
+        Assertions.assertThat(viewModel.emptyUiState.value).isEqualTo(EmptyUiState.ActiveFilters)
+    }
+
+    @Test
+    fun verifyEmptyScreenTextsWhenActivityTypeFilterSet() {
+        viewModel.onActivityTypesSelected(listOf(ActivityTypeModel("user", "User", 10)))
+
+        Assertions.assertThat(viewModel.emptyUiState.value).isEqualTo(EmptyUiState.ActiveFilters)
     }
 
     private suspend fun assertFetchEvents(canLoadMore: Boolean = false) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -654,6 +654,8 @@ class ActivityLogViewModelTest {
 
     @Test
     fun verifyEmptyScreenTextsWhenDateRangeFilterSet() {
+        whenever(dateUtils.formatDateRange(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn("TEST")
+
         viewModel.onDateRangeSelected(Pair(1L, 2L))
 
         Assertions.assertThat(viewModel.emptyUiState.value).isEqualTo(EmptyUiState.ActiveFilters)


### PR DESCRIPTION
Fixes #13735 

Fixes texts on Activity Log empty screen.

When the filters are empty (revert changes made in 1102d3a78df16148fdacbe7136281150fdd01b79 )
Title: No activity yet
Subtitle: When you make changes to your site you'll be able to see your activity history here

When the filters are not empty
Title: No matching events found
Subtitle: Try adjusting your date range or activity type filters

To test:
1. Select a site which doesn't have any items in the activity log
2. Open Activity Log and verify the title is "No activity yet" and subtitle is "When you make changes to your site you'll be able to see your activity history here"
3. Select a date range and verify the empty title is "No matching events found" and subtitle "Try adjusting your date range or activity type filters"

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
