### PR TITLE
Set default value of ActivityLogFiltersFeatureConfig

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/ActivityLogFiltersFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ActivityLogFiltersFeatureConfig.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 /**
  * Configuration of the Activity Log Filters feature.
  */
-@Feature(remoteField = ACTIVITY_LOG_FILTERS)
+@Feature(remoteField = ACTIVITY_LOG_FILTERS, defaultValue = true)
 class ActivityLogFiltersFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,


### PR DESCRIPTION
Parent issue #13268

Sets default value for ActivityLogFiltersFeatureConfig. We want to enable the feature even for users who haven't pulled the Firebase remote config yet.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
