### PR TITLE
Issue/13329 error handling

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
@@ -85,7 +85,7 @@ class BackupDownloadActivity : LocaleAwareActivity() {
 
         viewModel.errorEvents.observe(this, {
             it?.applyIfNotHandled {
-                viewModel.transitionToError()
+                viewModel.transitionToError(this)
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
@@ -83,6 +83,12 @@ class BackupDownloadActivity : LocaleAwareActivity() {
             }
         })
 
+        viewModel.errorEvents.observe(this, {
+            it?.applyIfNotHandled {
+                viewModel.transitionToError()
+            }
+        })
+
         viewModel.wizardFinishedObservable.observe(this, {
             it.applyIfNotHandled {
                 val intent = Intent()

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadErrorTypes.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadErrorTypes.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.ui.jetpack.backup.download
+
+enum class BackupDownloadErrorTypes(val id: Int) {
+    NetworkUnavailable(0), RemoteRequestFailure(1), GenericFailure(2);
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadStep.kt
@@ -14,6 +14,8 @@ enum class BackupDownloadStep(val id: Int) : WizardStep {
             "backup_download_complete" -> COMPLETE
             else -> throw IllegalArgumentException("SiteCreationStep not recognized: \$input")
         }
+
+        fun indexForErrorTransition(): Int = PROGRESS.id
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -40,7 +40,7 @@ data class BackupDownloadState(
     val downloadId: Long? = null,
     val published: Date? = null,
     val url: String? = null,
-    val isError: Boolean = false
+    val errorType: Int? = null
 ) : WizardState, Parcelable
 
 typealias NavigationTarget = WizardNavigationTarget<BackupDownloadStep, BackupDownloadState>
@@ -70,8 +70,8 @@ class BackupDownloadViewModel @Inject constructor(
     private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
     val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
-    private val _errorEvents = MediatorLiveData<Event<Boolean>>()
-    val errorEvents: LiveData<Event<Boolean>> = _errorEvents
+    private val _errorEvents = MediatorLiveData<Event<BackupDownloadErrorTypes>>()
+    val errorEvents: LiveData<Event<BackupDownloadErrorTypes>> = _errorEvents
 
     fun start(savedInstanceState: Bundle?) {
         if (isStarted) return
@@ -93,7 +93,7 @@ class BackupDownloadViewModel @Inject constructor(
         }
     }
 
-    fun addErrorMessageSource(errorEvents: LiveData<Event<Boolean>>) {
+    fun addErrorMessageSource(errorEvents: LiveData<Event<BackupDownloadErrorTypes>>) {
         _errorEvents.addSource(errorEvents) { event ->
             _errorEvents.value = event
         }
@@ -128,7 +128,7 @@ class BackupDownloadViewModel @Inject constructor(
                     rewindId = null,
                     downloadId = null,
                     url = null,
-                    isError = false
+                    errorType = null
             )
         }
     }
@@ -154,8 +154,8 @@ class BackupDownloadViewModel @Inject constructor(
         _toolbarStateObservable.value = toolbarState
     }
 
-    fun transitionToError() {
-        backupDownloadState = backupDownloadState.copy(isError = true)
+    fun transitionToError(errorType: BackupDownloadErrorTypes) {
+        backupDownloadState = backupDownloadState.copy(errorType = errorType.id)
         wizardManager.setCurrentStepIndex(BackupDownloadStep.indexForErrorTransition())
         wizardManager.showNextStep()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteFragment.kt
@@ -12,10 +12,9 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadState
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel
-import org.wordpress.android.ui.jetpack.backup.download.complete.BackupDownloadCompleteViewModel.UiState.Content
+import org.wordpress.android.ui.jetpack.backup.download.complete.BackupDownloadCompleteViewModel.UiState
 import org.wordpress.android.ui.jetpack.backup.download.complete.adapters.BackupDownloadCompleteAdapter
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
@@ -59,12 +58,7 @@ class BackupDownloadCompleteFragment : Fragment(R.layout.backup_download_complet
         viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(BackupDownloadCompleteViewModel::class.java)
 
-        viewModel.uiState.observe(viewLifecycleOwner, { uiState ->
-            when (uiState) {
-                is Content -> showContent(uiState)
-                is Error -> ToastUtils.showToast(requireContext(), "Implement Error")
-            }
-        })
+        viewModel.uiState.observe(viewLifecycleOwner, { showView(it) })
 
         val (site, state) = when {
             arguments != null -> {
@@ -79,8 +73,8 @@ class BackupDownloadCompleteFragment : Fragment(R.layout.backup_download_complet
         viewModel.start(site, state, parentViewModel)
     }
 
-    private fun showContent(content: Content) {
-        ((recycler_view.adapter) as BackupDownloadCompleteAdapter).update(content.items)
+    private fun showView(uiState: UiState) {
+        ((recycler_view.adapter) as BackupDownloadCompleteAdapter).update(uiState.items)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteStateListItemBuilder.kt
@@ -23,7 +23,7 @@ class BackupDownloadCompleteStateListItemBuilder @Inject constructor() {
         onDownloadFileClick: () -> Unit,
         onShareLinkClick: () -> Unit
     ): List<JetpackListItemState> {
-        return mutableListOf(
+        return listOf(
                 buildIconState(),
                 buildHeaderState(),
                 buildDescriptionState(published),
@@ -71,7 +71,7 @@ class BackupDownloadCompleteStateListItemBuilder @Inject constructor() {
             UiStringRes(R.string.backup_download_complete_info)
     )
 
-    fun buildCompleteListStateErrorItems(onDoneClick: () -> Unit) = mutableListOf(
+    fun buildCompleteListStateErrorItems(onDoneClick: () -> Unit) = listOf(
                 buildErrorIconState(),
                 buildErrorDescriptionState(),
             buildErrorDoneActionState(onDoneClick)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteStateListItemBuilder.kt
@@ -70,4 +70,27 @@ class BackupDownloadCompleteStateListItemBuilder @Inject constructor() {
     private fun buildAdditionalInformationState() = AdditionalInformationState(
             UiStringRes(R.string.backup_download_complete_info)
     )
+
+    fun buildCompleteListStateErrorItems(onDoneClick: () -> Unit) = mutableListOf(
+                buildErrorIconState(),
+                buildErrorDescriptionState(),
+            buildErrorDoneActionState(onDoneClick)
+    )
+
+    private fun buildErrorIconState() = IconState(
+            icon = R.drawable.ic_get_app_24dp, // todo: annmarie replace with cloud icon
+            contentDescription = UiStringRes(R.string.backup_download_complete_failed_icon_content_description),
+            colorResId = R.color.error_50 // todo: annmarie make correct when doing design cleanup
+    )
+
+    private fun buildErrorDescriptionState() = DescriptionState(
+            UiStringRes(R.string.backup_download_complete_failed_description)
+    )
+
+    private fun buildErrorDoneActionState(onClick: () -> Unit) = ActionButtonState(
+            text = UiStringRes(R.string.backup_download_complete_failed_action_button),
+            contentDescription =
+            UiStringRes(R.string.backup_download_complete_failed_action_button_content_description),
+            onClick = onClick
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteViewModel.kt
@@ -55,7 +55,7 @@ class BackupDownloadCompleteViewModel @Inject constructor(
     }
 
     private fun initView() {
-        if (backupDownloadState.isError) {
+        if (backupDownloadState.errorType != null) {
             parentViewModel.setToolbarState(ErrorToolbarState())
             _uiState.value = UiState(
                 items = stateListItemBuilder.buildCompleteListStateErrorItems(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsFragment.kt
@@ -14,11 +14,9 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel
 import org.wordpress.android.ui.jetpack.backup.download.KEY_BACKUP_DOWNLOAD_ACTIVITY_ID_KEY
-import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Error
-import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Content
+import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState
 import org.wordpress.android.ui.jetpack.backup.download.details.adapters.BackupDownloadDetailsAdapter
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
@@ -62,12 +60,7 @@ class BackupDownloadDetailsFragment : Fragment() {
         viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(BackupDownloadDetailsViewModel::class.java)
 
-        viewModel.uiState.observe(viewLifecycleOwner, { uiState ->
-            when (uiState) {
-                is Content -> showContent(uiState)
-                is Error -> ToastUtils.showToast(requireContext(), "Implement Error")
-            }
-        })
+        viewModel.uiState.observe(viewLifecycleOwner, { showView(it) })
 
         val (site, activityId) = when {
             arguments != null -> {
@@ -83,7 +76,7 @@ class BackupDownloadDetailsFragment : Fragment() {
         viewModel.start(site, activityId, parentViewModel)
     }
 
-    private fun showContent(content: Content) {
+    private fun showView(content: UiState) {
         ((recycler_view.adapter) as BackupDownloadDetailsAdapter).update(content.items)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadRequestTypes
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadErrorTypes
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState.Failure.NetworkUnavailable
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState.Failure.OtherRequestRunning
@@ -56,8 +57,8 @@ class BackupDownloadDetailsViewModel @Inject constructor(
     private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
     val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
-    private val _errorEvents = MediatorLiveData<Event<Boolean>>()
-    val errorEvents: LiveData<Event<Boolean>> = _errorEvents
+    private val _errorEvents = MediatorLiveData<Event<BackupDownloadErrorTypes>>()
+    val errorEvents: LiveData<Event<BackupDownloadErrorTypes>> = _errorEvents
 
     private fun extractPublishedDate(): Date {
         return _uiState.value?.activityLogModel?.published as Date
@@ -97,7 +98,7 @@ class BackupDownloadDetailsViewModel @Inject constructor(
                         )
                 )
             } else {
-                _errorEvents.value = Event(true)
+                _errorEvents.value = Event(BackupDownloadErrorTypes.GenericFailure)
             }
         }
     }
@@ -123,7 +124,7 @@ class BackupDownloadDetailsViewModel @Inject constructor(
     private fun onCreateDownloadClick() {
         val (rewindId, types) = getParams()
         if (rewindId == null) {
-            _errorEvents.value = Event(true)
+            _errorEvents.value = Event(BackupDownloadErrorTypes.GenericFailure)
         } else {
             launch {
                 val result = postBackupDownloadUseCase.postBackupDownloadRequest(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/details/BackupDownloadDetailsViewModel.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestSta
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.DetailsToolbarState
 import org.wordpress.android.ui.jetpack.usecases.GetActivityLogItemUseCase
-import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.backup.download.usecases.PostBackupDownloadUseCase
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.CheckboxState
@@ -57,9 +56,11 @@ class BackupDownloadDetailsViewModel @Inject constructor(
     private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
     val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
+    private val _errorEvents = MediatorLiveData<Event<Boolean>>()
+    val errorEvents: LiveData<Event<Boolean>> = _errorEvents
+
     private fun extractPublishedDate(): Date {
-        // todo: annmarie do something about all these null checks
-        return (_uiState.value as? Content)?.activityLogModel?.published as Date
+        return _uiState.value?.activityLogModel?.published as Date
     }
 
     fun start(site: SiteModel, activityId: String, parentViewModel: BackupDownloadViewModel) {
@@ -78,6 +79,7 @@ class BackupDownloadDetailsViewModel @Inject constructor(
 
     private fun initSources() {
         parentViewModel.addSnackbarMessageSource(snackbarEvents)
+        parentViewModel.addErrorMessageSource(errorEvents)
     }
 
     private fun getData() {
@@ -85,7 +87,7 @@ class BackupDownloadDetailsViewModel @Inject constructor(
             val availableItems = availableItemsProvider.getAvailableItems()
             val activityLogModel = getActivityLogItemUseCase.get(activityId)
             if (activityLogModel != null) {
-                _uiState.value = Content(
+                _uiState.value = UiState(
                         activityLogModel = activityLogModel,
                         items = stateListItemBuilder.buildDetailsListStateItems(
                                 availableItems = availableItems,
@@ -95,14 +97,14 @@ class BackupDownloadDetailsViewModel @Inject constructor(
                         )
                 )
             } else {
-                parentViewModel.onBackupDownloadDetailsCanceled()
+                _errorEvents.value = Event(true)
             }
         }
     }
 
     private fun onCheckboxItemClicked(itemType: JetpackAvailableItemType) {
-        (_uiState.value as? Content)?.let { content ->
-            val updatedList = content.items.map { contentState ->
+        _uiState.value?.let { uiState ->
+            val updatedList = uiState.items.map { contentState ->
                 if (contentState.type == CHECKBOX) {
                     contentState as CheckboxState
                     if (contentState.availableItemType == itemType) {
@@ -114,23 +116,29 @@ class BackupDownloadDetailsViewModel @Inject constructor(
                     contentState
                 }
             }
-            _uiState.postValue(content.copy(items = updatedList))
+            _uiState.postValue(uiState.copy(items = updatedList))
         }
     }
 
     private fun onCreateDownloadClick() {
         val (rewindId, types) = getParams()
-        launch {
-            val result = postBackupDownloadUseCase.postBackupDownloadRequest(rewindId, site, types)
-            handleBackupDownloadRequestResult(result)
+        if (rewindId == null) {
+            _errorEvents.value = Event(true)
+        } else {
+            launch {
+                val result = postBackupDownloadUseCase.postBackupDownloadRequest(
+                        rewindId,
+                        site,
+                        types
+                )
+                handleBackupDownloadRequestResult(result)
+            }
         }
     }
 
-    private fun getParams(): Pair<String, BackupDownloadRequestTypes> {
-        val rewindId = (_uiState.value as Content).activityLogModel.rewindID
-        val items = (_uiState.value as Content).items
-        if (rewindId == null)
-            throw Throwable("State is all off - can not continue - what should I do here?")
+    private fun getParams(): Pair<String?, BackupDownloadRequestTypes> {
+        val rewindId = _uiState.value?.activityLogModel?.rewindID
+        val items = _uiState.value?.items ?: mutableListOf()
         val types = buildBackupDownloadRequestTypes(items)
         return rewindId to types
     }
@@ -177,13 +185,8 @@ class BackupDownloadDetailsViewModel @Inject constructor(
                 UiStringRes(R.string.backup_download_another_download_running))
     }
 
-    sealed class UiState {
-        // todo: annmarie - add error states or maybe not if we dump out or show snackbar
-        data class Error(val message: String) : UiState()
-
-        data class Content(
-            val activityLogModel: ActivityLogModel,
-            val items: List<JetpackListItemState>
-        ) : UiState()
-    }
+    data class UiState(
+        val activityLogModel: ActivityLogModel,
+        val items: List<JetpackListItemState>
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/progress/BackupDownloadProgressFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/progress/BackupDownloadProgressFragment.kt
@@ -12,11 +12,9 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadState
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel
-import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressViewModel.UiState.Error
-import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressViewModel.UiState.Content
+import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressViewModel.UiState
 import org.wordpress.android.ui.jetpack.backup.download.progress.adapters.BackupDownloadProgressAdapter
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
 
@@ -60,12 +58,7 @@ class BackupDownloadProgressFragment : Fragment(R.layout.backup_download_progres
         viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(BackupDownloadProgressViewModel::class.java)
 
-        viewModel.uiState.observe(viewLifecycleOwner, { uiState ->
-            when (uiState) {
-                is Content -> showContent(uiState)
-                is Error -> ToastUtils.showToast(requireContext(), "Implement Error")
-            }
-        })
+        viewModel.uiState.observe(viewLifecycleOwner, { showView(it) })
 
         val (site, state) = when {
             arguments != null -> {
@@ -80,8 +73,8 @@ class BackupDownloadProgressFragment : Fragment(R.layout.backup_download_progres
         viewModel.start(site, state, parentViewModel)
     }
 
-    private fun showContent(content: Content) {
-        ((recycler_view.adapter) as BackupDownloadProgressAdapter).update(content.items)
+    private fun showView(uiState: UiState) {
+        ((recycler_view.adapter) as BackupDownloadProgressAdapter).update(uiState.items)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/progress/BackupDownloadProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/progress/BackupDownloadProgressViewModel.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.
 import org.wordpress.android.ui.jetpack.backup.download.usecases.GetBackupDownloadStatusUseCase
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.ViewType.BACKUP_PROGRESS
-import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.viewmodel.Event
@@ -45,9 +44,6 @@ class BackupDownloadProgressViewModel @Inject constructor(
 
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
-
-    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
-    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
     private val _errorEvents = MediatorLiveData<Event<Boolean>>()
     val errorEvents: LiveData<Event<Boolean>> = _errorEvents
@@ -73,7 +69,6 @@ class BackupDownloadProgressViewModel @Inject constructor(
     }
 
     private fun initSources() {
-        parentViewModel.addSnackbarMessageSource(snackbarEvents)
         parentViewModel.addErrorMessageSource(errorEvents)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/progress/BackupDownloadProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/progress/BackupDownloadProgressViewModel.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadErrorTypes
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadListItemState.ProgressState
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState.Complete
@@ -45,8 +46,8 @@ class BackupDownloadProgressViewModel @Inject constructor(
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> = _uiState
 
-    private val _errorEvents = MediatorLiveData<Event<Boolean>>()
-    val errorEvents: LiveData<Event<Boolean>> = _errorEvents
+    private val _errorEvents = MediatorLiveData<Event<BackupDownloadErrorTypes>>()
+    val errorEvents: LiveData<Event<BackupDownloadErrorTypes>> = _errorEvents
 
     fun start(
         site: SiteModel,
@@ -97,10 +98,10 @@ class BackupDownloadProgressViewModel @Inject constructor(
     private fun handleState(state: BackupDownloadRequestState) {
         when (state) {
             is NetworkUnavailable -> {
-                _errorEvents.postValue(Event(true))
+                _errorEvents.postValue(Event(BackupDownloadErrorTypes.NetworkUnavailable))
             }
             is RemoteRequestFailure -> {
-                _errorEvents.postValue(Event(true))
+                _errorEvents.postValue(Event(BackupDownloadErrorTypes.RemoteRequestFailure))
             }
             is Progress -> {
                 _uiState.value?.let { content ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/usecases/GetBackupDownloadStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/usecases/GetBackupDownloadStatusUseCase.kt
@@ -20,13 +20,13 @@ class GetBackupDownloadStatusUseCase @Inject constructor(
     private val activityLogStore: ActivityLogStore
 ) {
     suspend fun getBackupDownloadStatus(site: SiteModel, downloadId: Long) = flow {
-        if (!networkUtilsWrapper.isNetworkAvailable()) {
-            emit(NetworkUnavailable)
-            return@flow
-        }
-
         var result: OnBackupDownloadStatusFetched?
         while (true) {
+            if (!networkUtilsWrapper.isNetworkAvailable()) {
+                emit(NetworkUnavailable)
+                return@flow
+            }
+
             val downloadStatusForSite = activityLogStore.getBackupDownloadStatusForSite(site)
             if (downloadStatusForSite != null && downloadStatusForSite.downloadId == downloadId) {
                 if (downloadStatusForSite.progress == null && downloadId == downloadStatusForSite.downloadId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/usecases/GetBackupDownloadStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/usecases/GetBackupDownloadStatusUseCase.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.flow.flow
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchBackupDownloadStatePayload
-import org.wordpress.android.fluxc.store.ActivityLogStore.OnBackupDownloadStatusFetched
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState.Complete
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState.Failure.NetworkUnavailable
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState.Failure.RemoteRequestFailure

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/usecases/GetBackupDownloadStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/usecases/GetBackupDownloadStatusUseCase.kt
@@ -20,7 +20,6 @@ class GetBackupDownloadStatusUseCase @Inject constructor(
     private val activityLogStore: ActivityLogStore
 ) {
     suspend fun getBackupDownloadStatus(site: SiteModel, downloadId: Long) = flow {
-        var result: OnBackupDownloadStatusFetched?
         while (true) {
             if (!networkUtilsWrapper.isNetworkAvailable()) {
                 emit(NetworkUnavailable)
@@ -42,7 +41,7 @@ class GetBackupDownloadStatusUseCase @Inject constructor(
                     emit(Progress(downloadStatusForSite.rewindId, downloadStatusForSite.progress))
                 }
             }
-            result = activityLogStore.fetchBackupDownloadState(FetchBackupDownloadStatePayload(site))
+            val result = activityLogStore.fetchBackupDownloadState(FetchBackupDownloadStatePayload(site))
             if (result.isError) {
                 emit(RemoteRequestFailure)
                 return@flow

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3426,6 +3426,11 @@ translators: sample content for "Services" page template -->
     <string name="backup_download_complete_download_action_button_content_description">Download button</string>
     <string name="backup_download_complete_download_share_action_button_content_description">Share link button</string>
     <string name="backup_download_complete_info">We\'ve also emailed you a link to your file.</string>
+    <string name="backup_download_complete_failed_title">Download failed</string>
+    <string name="backup_download_complete_failed_description">We couldn\'t create your backup. Please try again later.</string>
+    <string name="backup_download_complete_failed_action_button">Done</string>
+    <string name="backup_download_complete_failed_action_button_content_description">Done button</string>
+    <string name="backup_download_complete_failed_icon_content_description">Cloud with X icon</string>
 
     <string name="jetpack_icon_content_description">icon</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadDetailsViewModelTest.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDe
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState
-import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.backup.download.usecases.PostBackupDownloadUseCase
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButtonState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.CheckboxState
@@ -61,7 +60,7 @@ class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, activityId, parentViewModel)
 
-        assertThat(uiStates[0]).isInstanceOf(Content::class.java)
+        assertThat(uiStates[0]).isInstanceOf(UiState::class.java)
     }
 
     @Test
@@ -70,9 +69,9 @@ class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, activityId, parentViewModel)
 
-        (((uiStates.last() as Content).items).first { it is CheckboxState } as CheckboxState).onClick.invoke()
+        ((uiStates.last().items).first { it is CheckboxState } as CheckboxState).onClick.invoke()
 
-        assertThat((((uiStates.last() as Content).items)
+        assertThat((((uiStates.last()).items)
             .first { it is CheckboxState } as CheckboxState).checked).isFalse
     }
 
@@ -82,10 +81,10 @@ class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, activityId, parentViewModel)
 
-        (((uiStates.last() as Content).items).first { it is CheckboxState } as CheckboxState).onClick.invoke()
-        (((uiStates.last() as Content).items).first { it is CheckboxState } as CheckboxState).onClick.invoke()
+        ((uiStates.last().items).first { it is CheckboxState } as CheckboxState).onClick.invoke()
+        ((uiStates.last().items).first { it is CheckboxState } as CheckboxState).onClick.invoke()
 
-        assertThat((((uiStates.last() as Content).items).first { it is CheckboxState } as CheckboxState).checked).isTrue
+        assertThat(((uiStates.last().items).first { it is CheckboxState } as CheckboxState).checked).isTrue
     }
 
     @Test
@@ -98,7 +97,7 @@ class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, activityId, parentViewModel)
 
-        (((uiStates.last() as Content).items).first { it is ActionButtonState } as ActionButtonState).onClick.invoke()
+        ((uiStates.last().items).first { it is ActionButtonState } as ActionButtonState).onClick.invoke()
 
         assertThat(msgs[0].peekContent().message).isEqualTo(UiStringRes(R.string.error_network_connection))
     }
@@ -113,7 +112,7 @@ class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, activityId, parentViewModel)
 
-        (((uiStates.last() as Content).items).first { it is ActionButtonState } as ActionButtonState).onClick.invoke()
+        ((uiStates.last().items).first { it is ActionButtonState } as ActionButtonState).onClick.invoke()
 
         assertThat(messages[0].peekContent().message).isEqualTo(UiStringRes(R.string.backup_download_generic_failure))
     }
@@ -128,7 +127,7 @@ class BackupDownloadDetailsViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, activityId, parentViewModel)
 
-        (((uiStates.last() as Content).items)
+        ((uiStates.last().items)
                 .first { it is ActionButtonState } as ActionButtonState).onClick.invoke()
 
         assertThat(messages[0].peekContent().message)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadProgressViewModelTest.kt
@@ -17,8 +17,6 @@ import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadP
 import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressViewModel
 import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressViewModel.UiState
 import org.wordpress.android.ui.jetpack.backup.download.usecases.GetBackupDownloadStatusUseCase
-import org.wordpress.android.ui.pages.SnackbarMessageHolder
-import org.wordpress.android.viewmodel.Event
 import java.util.Date
 
 @InternalCoroutinesApi
@@ -75,16 +73,12 @@ class BackupDownloadProgressViewModelTest : BaseUnitTest() {
         viewModel.uiState.observeForever {
             uiStates.add(it)
         }
-        val snackbarMessages = mutableListOf<Event<SnackbarMessageHolder>>()
-        viewModel.snackbarEvents.observeForever {
-            snackbarMessages.add(it)
-        }
-        return Observers(uiStates, snackbarMessages)
+
+        return Observers(uiStates)
     }
 
     private data class Observers(
-        val uiStates: List<UiState>,
-        val snackbarMessages: List<Event<SnackbarMessageHolder>>
+        val uiStates: List<UiState>
     )
 
     private val getStatusProgress = BackupDownloadRequestState.Progress(rewindId = "rewindId", progress = 0)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadProgressViewModelTest.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadListItemSt
 import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressStateListItemBuilder
 import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressViewModel
 import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressViewModel.UiState
-import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.backup.download.usecases.GetBackupDownloadStatusUseCase
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -60,7 +59,7 @@ class BackupDownloadProgressViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, backupDownloadState, parentViewModel)
 
-        assertThat(uiStates[0]).isInstanceOf(Content::class.java)
+        assertThat(uiStates[0]).isInstanceOf(UiState::class.java)
     }
 
     @Test
@@ -69,7 +68,7 @@ class BackupDownloadProgressViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, backupDownloadState, parentViewModel)
 
-        assertThat((((uiStates[0] as Content).items).first { it is ProgressState } as ProgressState).progress)
+        assertThat(((uiStates[0].items).first { it is ProgressState } as ProgressState).progress)
                 .isEqualTo(0)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadProgressViewModelTest.kt
@@ -9,7 +9,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.R.string
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.test
@@ -19,7 +18,6 @@ import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadP
 import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressViewModel.UiState
 import org.wordpress.android.ui.jetpack.backup.download.usecases.GetBackupDownloadStatusUseCase
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
-import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.viewmodel.Event
 import java.util.Date
 
@@ -72,30 +70,6 @@ class BackupDownloadProgressViewModelTest : BaseUnitTest() {
                 .isEqualTo(0)
     }
 
-    @Test
-    fun `snackbar message is shown when request encounters a network connection issue`() = test {
-        whenever(backupDownloadStatusUseCase.getBackupDownloadStatus(anyOrNull(), anyOrNull()))
-                .thenReturn(flow { emit(getStatusNetworkError) })
-
-        val msgs = initObservers().snackbarMessages
-
-        viewModel.start(site, backupDownloadState, parentViewModel)
-
-        assertThat(msgs[0].peekContent().message).isEqualTo(UiStringRes(string.error_network_connection))
-    }
-
-    @Test
-    fun `snackbar message is shown when request encounters a request issue`() = test {
-        whenever(backupDownloadStatusUseCase.getBackupDownloadStatus(anyOrNull(), anyOrNull()))
-                .thenReturn(flow { emit(getStatusRemoteRequestError) })
-
-        val msgs = initObservers().snackbarMessages
-
-        viewModel.start(site, backupDownloadState, parentViewModel)
-
-        assertThat(msgs[0].peekContent().message).isEqualTo(UiStringRes(string.backup_download_generic_failure))
-    }
-
     private fun initObservers(): Observers {
         val uiStates = mutableListOf<UiState>()
         viewModel.uiState.observeForever {
@@ -113,7 +87,5 @@ class BackupDownloadProgressViewModelTest : BaseUnitTest() {
         val snackbarMessages: List<Event<SnackbarMessageHolder>>
     )
 
-    private val getStatusNetworkError = BackupDownloadRequestState.Failure.NetworkUnavailable
-    private val getStatusRemoteRequestError = BackupDownloadRequestState.Failure.RemoteRequestFailure
     private val getStatusProgress = BackupDownloadRequestState.Progress(rewindId = "rewindId", progress = 0)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.CompleteToolbarState
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.DetailsToolbarState
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.ErrorToolbarState
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.ProgressToolbarState
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -193,6 +194,16 @@ class BackupDownloadViewModelTest : BaseUnitTest() {
         viewModel.setToolbarState(ProgressToolbarState())
 
         assertThat(toolbarStates.last()).isInstanceOf(ProgressToolbarState::class.java)
+    }
+
+    @Test
+    fun `given in complete error step, when setToolbarState is invoked, then toolbar state is updated`() {
+        val toolbarStates = initObservers().toolbarState
+        viewModel.start(null)
+
+        viewModel.setToolbarState(ErrorToolbarState())
+
+        assertThat(toolbarStates.last()).isInstanceOf(ErrorToolbarState::class.java)
     }
 
     @Test


### PR DESCRIPTION
Parent #13329 

This PR adds logic to use the last step of the wizard "Complete" in both complete and error capacities.
- Removed "Error" UiState and refactored"Content" UiState in the viewmodels, as only one state is needed since everything is a list of items
- Updated `BackupDownloadCompleteStateListItemBuilder` to include building out a JetpackItemList for error
- Updated `GetBackupDownloadStatusUseCase` to check for network connectivity after each delay to fix a potential never ending loop issue.
- Send errors to Complete view as outlined in the following image

<img src="https://user-images.githubusercontent.com/506707/104215898-69b66f00-5407-11eb-86a2-fee981fb475c.png" width="300" alt="Screenshot">

**Notes**
- Please pay no attention to styles
- Complete success buttons are not hooked up yet

**To test:**
- Launch the app with BackupDownloadConfig flag on
- Navigate to ActivityLog
- Tap the More menu
- Tap Download Backup menu item
- Tap the Create downloadable file button
- When the view changes to progress, quickly turn on airplane mode
- Note that the view changes to "Download Failed"
- Click the Done button to close the wizard
- Don't forget to turn airplane mode back on after the test is over

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
