### PR TITLE
Issue/13329 complete actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1352,4 +1352,17 @@ public class ActivityLauncher {
         intent.putExtra(KEY_BACKUP_DOWNLOAD_ACTIVITY_ID_KEY, activityId);
         activity.startActivityForResult(intent, resultCode);
     }
+
+    public static void shareBackupDownloadFileLink(Context context, String url) {
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TEXT, url);
+
+        context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_link)));
+    }
+
+    public static void downloadBackupDownloadFile(Context context, String url) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        context.startActivity(intent);
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
@@ -9,7 +9,10 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.backup_download_activity.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadNavigationEvents.DownloadFile
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadNavigationEvents.ShareLink
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep.COMPLETE
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep.DETAILS
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep.PROGRESS
@@ -100,6 +103,19 @@ class BackupDownloadActivity : LocaleAwareActivity() {
                 intent.putExtra(KEY_BACKUP_DOWNLOAD_DOWNLOAD_ID, downloadId)
                 setResult(if (backupDownloadCreated) RESULT_OK else RESULT_CANCELED, intent)
                 finish()
+            }
+        })
+
+        viewModel.navigationEvents.observe(this, {
+            it.applyIfNotHandled {
+                when (this) {
+                    is ShareLink -> {
+                        ActivityLauncher.shareBackupDownloadFileLink(this@BackupDownloadActivity, url)
+                    }
+                    is DownloadFile -> {
+                        ActivityLauncher.downloadBackupDownloadFile(this@BackupDownloadActivity, url)
+                    }
+                }
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadNavigationEvents.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.jetpack.backup.download
+
+sealed class BackupDownloadNavigationEvents {
+    data class ShareLink(val url: String) : BackupDownloadNavigationEvents()
+    data class DownloadFile(val url: String) : BackupDownloadNavigationEvents()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -73,6 +73,9 @@ class BackupDownloadViewModel @Inject constructor(
     private val _errorEvents = MediatorLiveData<Event<Boolean>>()
     val errorEvents: LiveData<Event<Boolean>> = _errorEvents
 
+    private val _navigationEvents = MediatorLiveData<Event<BackupDownloadNavigationEvents>>()
+    val navigationEvents: LiveData<Event<BackupDownloadNavigationEvents>> = _navigationEvents
+
     fun start(savedInstanceState: Bundle?) {
         if (isStarted) return
         isStarted = true
@@ -96,6 +99,12 @@ class BackupDownloadViewModel @Inject constructor(
     fun addErrorMessageSource(errorEvents: LiveData<Event<Boolean>>) {
         _errorEvents.addSource(errorEvents) { event ->
             _errorEvents.value = event
+        }
+    }
+
+    fun addNavigationEventSource(navigationEvent: LiveData<Event<BackupDownloadNavigationEvents>>) {
+        _navigationEvents.addSource(navigationEvent) { event ->
+            _navigationEvents.value = event
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/complete/BackupDownloadCompleteViewModel.kt
@@ -6,13 +6,15 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadNavigationEvents
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadNavigationEvents.DownloadFile
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadNavigationEvents.ShareLink
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadState
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.CompleteToolbarState
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.ErrorToolbarState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
-import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import java.util.Date
@@ -34,6 +36,9 @@ class BackupDownloadCompleteViewModel @Inject constructor(
     private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
     val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
+    private val _navigationEvents = MediatorLiveData<Event<BackupDownloadNavigationEvents>>()
+    val navigationEvents: LiveData<Event<BackupDownloadNavigationEvents>> = _navigationEvents
+
     fun start(
         site: SiteModel,
         backupDownloadState: BackupDownloadState,
@@ -52,6 +57,7 @@ class BackupDownloadCompleteViewModel @Inject constructor(
 
     private fun initSources() {
         parentViewModel.addSnackbarMessageSource(snackbarEvents)
+        parentViewModel.addNavigationEventSource(navigationEvents)
     }
 
     private fun initView() {
@@ -73,13 +79,11 @@ class BackupDownloadCompleteViewModel @Inject constructor(
     }
 
     private fun onDownloadFileClick() {
-        // todo: annmarie - implement the onDownloadFileClick
-        _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringText("Download clicked"))))
+        backupDownloadState.url?.let { _navigationEvents.postValue(Event(DownloadFile(it))) }
     }
 
     private fun onShareLinkClick() {
-        // todo: annmarie - implement the onShareLinkClick
-        _snackbarEvents.postValue(Event(SnackbarMessageHolder(UiStringText("Share clicked"))))
+        backupDownloadState.url?.let { _navigationEvents.postValue(Event(ShareLink(it))) }
     }
 
     private fun onDoneClick() {


### PR DESCRIPTION
Parent #13329 

This PR hooks up the following buttons on the **Your Backup** (a.k.a. backup is complete view)
- Share Link
- Download File

**Merge Instructions**
- Make sure #13743 has been merged
- Remove label
- Merge as normal

**Notes:**
- Ignore styling

**To test:**
- Launch the app with BackupDownloadConfig flag on
- Navigate to ActivityLog
- Tap the More menu
- Tap Download Backup menu item
- Tap the Create downloadable file button
- The view changes to progress
- Wait for the progress to finish
- The the view changes to _Your Backup_
- On tap of the download button, note you are directed to the browser to download the file
- On tap of the share link, note the share sheet is launched

PR submission checklist:
- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
