### PR TITLE
Removes segmentId value from site creation call when a design is selected

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -162,8 +162,11 @@ class SitePreviewViewModel @Inject constructor(
     private fun startCreateSiteService(previousState: SiteCreationServiceState? = null) {
         if (networkUtils.isNetworkAvailable()) {
             siteCreationState.apply {
+                // A non-null [segmentId] may invalidate the [siteDesign] selection
+                // https://github.com/wordpress-mobile/WordPress-Android/issues/13749
+                val segmentIdentifier = if (siteDesign != null) null else segmentId
                 val serviceData = SiteCreationServiceData(
-                        segmentId,
+                        segmentIdentifier,
                         siteDesign,
                         urlWithoutScheme
                 )


### PR DESCRIPTION
**Fixes** #13749

## Description

Removes segmentId value from site creation call when a design is selected

### Note

I chose to remove the `segment_id` only in the site creation flow since removing it completely will also have an effect on the domain search (will always return **wordpress.com** domains as described in https://github.com/wordpress-mobile/WordPress-Android/issues/13653)

## To test

1. Start the site creation flow (e.g. Choose site > Add button)
1. Select the Create WordPress.com site option
1. Select the Overton design
1. Press Choose
1. Search and select a domain
1. Select create site
1. Verify that the created site has the Overton design applied

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
