### PR TITLE
Save Stories composer from crashing when Post cannot be obtained

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -79,6 +79,8 @@ import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.helpers.MediaFile
+import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.widgets.WPSnackbar
 import java.util.Objects
@@ -180,13 +182,19 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                 .get(StoryComposerViewModel::class.java)
 
         site?.let {
-            viewModel.start(
+            val postInitialized = viewModel.start(
                     it,
                     editPostRepository,
                     LocalId(localPostId),
                     postEditorAnalyticsSession,
                     notificationType
             )
+
+            // Ensure we have a valid post
+            if (!postInitialized) {
+                showErrorAndFinish(R.string.post_not_found)
+                return@let
+            }
         }
 
         storyEditorMedia.start(requireNotNull(site), this)
@@ -247,6 +255,15 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                 }
             }
         })
+    }
+
+    private fun showErrorAndFinish(errorMessageId: Int) {
+        ToastUtils.showToast(
+                this,
+                errorMessageId,
+                ToastUtils.Duration.LONG
+        )
+        finish()
     }
 
     override fun onLoadFromIntent(intent: Intent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -26,6 +26,8 @@ import org.wordpress.android.ui.posts.PostEditorAnalyticsSession.Outcome.SAVE
 import org.wordpress.android.ui.posts.PostEditorAnalyticsSessionWrapper
 import org.wordpress.android.ui.posts.SavePostToDbUseCase
 import org.wordpress.android.ui.stories.usecase.SetUntitledStoryTitleIfTitleEmptyUseCase
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
@@ -84,6 +86,7 @@ class StoryComposerViewModel @Inject constructor(
 
         // Ensure we have a valid post
         if (!editPostRepository.hasPost()) {
+            AppLog.e(T.EDITOR, "StoryComposerViewModel's EditPostRepository has no Post loaded: " + postId.value)
             return false
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -69,7 +69,7 @@ class StoryComposerViewModel @Inject constructor(
         postId: LocalId,
         postEditorAnalyticsSession: PostEditorAnalyticsSession?,
         notificationType: NotificationType?
-    ) {
+    ): Boolean {
         this.editPostRepository = editPostRepository
         this.site = site
 
@@ -82,6 +82,11 @@ class StoryComposerViewModel @Inject constructor(
             editPostRepository.loadPostByLocalPostId(postId.value)
         }
 
+        // Ensure we have a valid post
+        if (!editPostRepository.hasPost()) {
+            return false
+        }
+
         setupPostEditorAnalyticsSession(postEditorAnalyticsSession)
 
         notificationType?.let {
@@ -90,6 +95,8 @@ class StoryComposerViewModel @Inject constructor(
 
         lifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.STARTED
         updateStoryPostWithChanges()
+
+        return true
     }
 
     private fun setupPostEditorAnalyticsSession(postEditorAnalyticsSession: PostEditorAnalyticsSession?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -75,6 +75,10 @@ class StoryComposerViewModel @Inject constructor(
         this.editPostRepository = editPostRepository
         this.site = site
 
+        notificationType?.let {
+            systemNotificationsTracker.trackTappedNotification(it)
+        }
+
         if (postId.value == 0) {
             // Create a new post
             saveInitialPostUseCase.saveInitialPost(editPostRepository, site)
@@ -91,10 +95,6 @@ class StoryComposerViewModel @Inject constructor(
         }
 
         setupPostEditorAnalyticsSession(postEditorAnalyticsSession)
-
-        notificationType?.let {
-            systemNotificationsTracker.trackTappedNotification(it)
-        }
 
         lifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.STARTED
         updateStoryPostWithChanges()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -45,7 +45,7 @@ class StoryComposerViewModel @Inject constructor(
 
     private lateinit var editPostRepository: EditPostRepository
     private lateinit var site: SiteModel
-    private lateinit var postEditorAnalyticsSession: PostEditorAnalyticsSession
+    private var postEditorAnalyticsSession: PostEditorAnalyticsSession? = null
 
     private val _mediaFilesUris = MutableLiveData<List<Uri>>()
     val mediaFilesUris: LiveData<List<Uri>> = _mediaFilesUris
@@ -104,7 +104,7 @@ class StoryComposerViewModel @Inject constructor(
                 editPostRepository.getPost(),
                 site
         )
-        this.postEditorAnalyticsSession.start(null)
+        this.postEditorAnalyticsSession?.start(null)
     }
 
     private fun createPostEditorAnalyticsSessionTracker(
@@ -124,7 +124,7 @@ class StoryComposerViewModel @Inject constructor(
     }
 
     fun onStorySaved() {
-        postEditorAnalyticsSession.setOutcome(SAVE)
+        postEditorAnalyticsSession?.setOutcome(SAVE)
     }
 
     fun onStoryDiscarded(deleteDiscardedPost: Boolean) {
@@ -132,7 +132,7 @@ class StoryComposerViewModel @Inject constructor(
             // delete empty post from database
             dispatcher.dispatch(PostActionBuilder.newRemovePostAction(editPostRepository.getEditablePost()))
         }
-        postEditorAnalyticsSession.setOutcome(CANCEL)
+        postEditorAnalyticsSession?.setOutcome(CANCEL)
     }
 
     private fun updateStoryPostWithChanges() {
@@ -161,13 +161,13 @@ class StoryComposerViewModel @Inject constructor(
 
     fun onSubmitButtonClicked() {
         setUntitledStoryTitleIfTitleEmptyUseCase.setUntitledStoryTitleIfTitleEmpty(editPostRepository)
-        postEditorAnalyticsSession.setOutcome(PUBLISH)
+        postEditorAnalyticsSession?.setOutcome(PUBLISH)
         _submitButtonClicked.postValue(Event(Unit))
     }
 
     override fun onCleared() {
         super.onCleared()
         lifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
-        postEditorAnalyticsSession.end()
+        postEditorAnalyticsSession?.end()
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/StoryComposerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/StoryComposerViewModelTest.kt
@@ -17,7 +17,6 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
-import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/StoryComposerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/StoryComposerViewModelTest.kt
@@ -249,4 +249,32 @@ class StoryComposerViewModelTest : BaseUnitTest() {
         // assert
         assertThat(viewModel.mediaFilesUris).isNotNull
     }
+
+    @Test
+    fun `if editPostRepository does not have a post then vm start() returns false`() {
+        // arrange
+        whenever(
+                postStore.getPostByLocalPostId(any())
+        ).thenReturn(null)
+
+        // act
+        val result = viewModel.start(site, editPostRepository, LocalId(2), mock(), mock())
+
+        // assert
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `if editPostRepository does have a post then vm start() returns true`() {
+        // arrange
+        whenever(
+                postStore.getPostByLocalPostId(any())
+        ).thenReturn(mock())
+
+        // act
+        val result = viewModel.start(site, editPostRepository, LocalId(2), mock(), mock())
+
+        // assert
+        assertThat(result).isTrue()
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/StoryComposerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/StoryComposerViewModelTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore
@@ -109,16 +110,20 @@ class StoryComposerViewModelTest : BaseUnitTest() {
         // arrange
         val postEditorAnalyticsSession: PostEditorAnalyticsSession? = null
         whenever(
+                postStore.getPostByLocalPostId(any())
+        ).thenReturn(mock())
+
+        whenever(
                 postEditorAnalyticsSessionWrapper.getNewPostEditorAnalyticsSession(
                         any(),
-                        anyOrNull(),
+                        any(),
                         anyOrNull(),
                         any()
                 )
         ).thenReturn(mock())
 
         // act
-        viewModel.start(site, editPostRepository, LocalId(0), postEditorAnalyticsSession, mock())
+        viewModel.start(site, editPostRepository, LocalId(1), postEditorAnalyticsSession, mock())
 
         // assert
         verify(postEditorAnalyticsSessionWrapper, times(1)).getNewPostEditorAnalyticsSession(


### PR DESCRIPTION
Fixes #13681 

As said in the comment [here](https://github.com/wordpress-mobile/WordPress-Android/issues/13681#issuecomment-758168432), I wanted to understand the root cause of this.

Been trying a number of things or cases where this would be possible, but I couldn't find a way to reproduce. There are 2 ways to access the StoryComposer from the Editor, and these are:
1. opening a Post that contains a Story block, then tapping on the Story block's tool icon to edit
2. opening a Post, adding a Story block, adding media to it to open the Story block

In both cases, a Post needs to exist (because we're on the Editor in the first place anyway!) so the only possibilities left that I can think of are that the actual Post Id is indeed being passed, but somehow the Post can't be loaded by FluxC. I have seen low memory indicators in one of the Sentry issues reported there, so I'm thinking this could be a possibility, but the other report doesn't show low memory signals. I still can't find a way to reproduce.

Another (more awkward) scenario I thought of was what if the Post could be loaded in the Editor, but then we trashed it away? I tried combinations of tapping on the "trash" option in the Posts list and rapidly tapping the post item to open it in the editor (it actually worked a few times for me!) but the Post is not really deleted (only marked as Trashed) so, it is always the case that the actual Post object can be found and should be loaded.

Given all of this, I've decided to follow along the way things are handled in [EditPostActivity in this regard](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L612-L616) where we just validate we have an actual loaded valid Post object before continuing, and therefore I've written this small PR that prevents the app from crashing for this specific cause of not having been able to load a Post in the internal EditPostRepository instance used in the StoryComposer - hoping that letting the user retry once more will fix it, and logging it so we can monitor how things go.

To test:
Given I haven't found a way to reproduce, you should be able to test the code flow using the following steps:
1. modify [this line here](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/13681-stories-post-null?expand=1#diff-a7bfc0b68b2b746ebe42c6aff3aa0b3eab23492eca2d6b606fa0651a4d526873R84) with some random, inexistent postId you know doesn't exist in the local database. For example I used: `editPostRepository.loadPostByLocalPostId(1231231213)`
2. run WPAndroid
3. create a Story post and publish it
4. go to your published Posts list
5. tap on the recently created Post to open it in the editor
6. once the content is rendered, tap on the Story block to select it, then tap on the tools icon to open the Story composer
7. observe the Toast appears on the device screen, and the following entry shows a line like the following: `2021-01-12 13:36:17.592 21497-21497/org.wordpress.android E/WordPress-EDITOR: StoryComposerViewModel's EditPostRepository has no Post loaded: 43`

![toast_composer_no_post](https://user-images.githubusercontent.com/6597771/104344274-b7041080-54db-11eb-97bb-627183e0c58c.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
