### PR TITLE
Remove unneeded quotes from string resources

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2408,12 +2408,12 @@
     <string name="edit">Edit</string>
     <string name="tap_to_try_again">Tap to try again!</string>
     <string name="add_media_progress">Adding media</string>
-    <string name="suggestion_invalid">"%s is not a valid %s"</string>
-    <string name="suggestion_selection_needed">"Please type to filter the list of suggestions."</string>
-    <string name="suggestion_none">"No %s suggestions available."</string>
-    <string name="suggestion_problem">"There was a problem loading suggestions."</string>
-    <string name="suggestion_no_matching">"No matching %s."</string>
-    <string name="suggestion_no_connection">"No internet connection.\nSuggestions are unavailable."</string>
+    <string name="suggestion_invalid">%s is not a valid %s</string>
+    <string name="suggestion_selection_needed">Please type to filter the list of suggestions.</string>
+    <string name="suggestion_none">No %s suggestions available.</string>
+    <string name="suggestion_problem">There was a problem loading suggestions.</string>
+    <string name="suggestion_no_matching">No matching %s.</string>
+    <string name="suggestion_no_connection">No internet connection.\nSuggestions are unavailable.</string>
     <string name="suggestion_user">user</string>
     <string name="suggestion_xpost">crosspost</string>
 


### PR DESCRIPTION
Remove unnecessary quotes from strings used for the suggestions UI. I don't know why I added these initially.

This came up in the [WordPress Slack mobile channel](https://wordpress.slack.com/archives/C02RQC4LY/p1610468030166600) because the translators were uncertain if the quote should be changed as part of the translation.

To test:

1. Clear the device data
2. Open the app and select a p2 site
3. Turn on airplane mode
4. Edit a new post using gutenberg
5. open the suggestions UI (i.e., type an @ or + character at the beginning of a paragraph)
6. Observe the "No internet connection. Suggestions are unavailable." message
7. Exit the suggestions UI
8. Turn on airplane mode
9. Reopen the suggestions UI
10. If there are no suggestions available, you will see the "No [crosspost/user] suggestions available" message. Otherwise, you should see the list of suggestions. 
11. Immediately tap the submit checkmark _without typing anything_
11. Observe a toast stating "Please type to filter the list of suggestions"
12. If there are suggestions available, type until there are no matching users
13. Observe that the "No matching user" message is presented.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
