### PR TITLE
Contact Info Enabled in Production

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+16.6
+-----
+* [**] Block Editor: Added Contact Info block to sites on WPcom or with Jetpack version > 9.1.
+
 16.5
 -----
 [***] Block Editor: Cross-post suggestions are now available by typing the + character (or long-pressing the toolbar button labelled with an @-symbol) in a post on a P2 site [https://github.com/wordpress-mobile/WordPress-Android/pull/13184]

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2342,6 +2342,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         boolean unsupportedBlockEditorSwitch = !mIsJetpackSsoEnabled && "gutenberg".equals(mSite.getWebEditor());
 
         return new GutenbergPropsBuilder(
+                SiteUtils.supportsContactInfoFeature(mSite),
                 mWPStoriesFeatureConfig.isEnabled() && SiteUtils.supportsStoriesFeature(mSite),
                 enableMentions,
                 enableXPosts,

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -33,6 +33,7 @@ public class SiteUtils {
     public static final String AZTEC_EDITOR_NAME = "aztec";
     public static final String WP_STORIES_CREATOR_NAME = "wp_stories_creator";
     public static final String WP_STORIES_JETPACK_VERSION = "9.1";
+    public static final String WP_CONTACT_INFO_JETPACK_VERSION = "9.1";
     private static final int GB_ROLLOUT_PERCENTAGE_PHASE_1 = 100;
     private static final int GB_ROLLOUT_PERCENTAGE_PHASE_2 = 100;
 
@@ -339,6 +340,10 @@ public class SiteUtils {
 
     public static boolean supportsStoriesFeature(SiteModel site) {
         return site != null && (site.isWPCom() || checkMinimalJetpackVersion(site, WP_STORIES_JETPACK_VERSION));
+    }
+
+    public static boolean supportsContactInfoFeature(SiteModel site) {
+        return site != null & (site.isWPCom() || checkMinimalJetpackVersion(site, WP_CONTACT_INFO_JETPACK_VERSION));
     }
 
     public static boolean isNonAtomicBusinessPlanSite(@Nullable SiteModel site) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergPropsBuilder.kt
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergPropsBuilder.kt
@@ -8,6 +8,7 @@ import org.wordpress.mobile.WPAndroidGlue.GutenbergProps
 
 @Parcelize
 data class GutenbergPropsBuilder(
+    private val enableContactInfoBlock: Boolean,
     private val enableMediaFilesCollectionBlocks: Boolean,
     private val enableMentions: Boolean,
     private val enableXPosts: Boolean,
@@ -20,6 +21,7 @@ data class GutenbergPropsBuilder(
     private val editorTheme: Bundle?
 ) : Parcelable {
     fun build(activity: Activity, isHtmlModeEnabled: Boolean) = GutenbergProps(
+            enableContactInfoBlock = enableContactInfoBlock,
             enableMediaFilesCollectionBlocks = enableMediaFilesCollectionBlocks,
             enableMentions = enableMentions,
             enableXPosts = enableXPosts,


### PR DESCRIPTION
## Description
Added capabilities in order to determine whether contact info should be shown or not.

#### Notes: 
* @mzorz I believe I need help to figure out the `Feature` flag. Not familiar enough with Android to decide on which parts I need to add as I believe you're using more of it for the Story Post as well.

See further descriptions in linked PRs:
* `gutenberg-mobile`: [#3001](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3001)
* `gutenberg`: [#28168](https://github.com/WordPress/gutenberg/pull/28168)
* `WPiOS`: [#15634](https://github.com/wordpress-mobile/WordPress-iOS/pull/15634)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
