### PR TITLE
Add restore feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -83,6 +83,7 @@ android {
         buildConfigField "boolean", "BACKUP_AVAILABLE", "false"
         buildConfigField "boolean", "FOLLOW_UNFOLLOW_COMMENTS", "false"
         buildConfigField "boolean", "UNREAD_POSTS_COUNT", "false"
+        buildConfigField "boolean", "RESTORE_AVAILABLE", "false"
     }
 
     // Gutenberg's dependency - react-native-video is using

--- a/WordPress/src/main/java/org/wordpress/android/util/RestoreFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/RestoreFeatureConfig.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.util
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.util.config.AppConfig
+import org.wordpress.android.util.config.FeatureConfig
+import javax.inject.Inject
+
+/**
+ * Configuration of the Jetpack Restore feature.
+ */
+@FeatureInDevelopment
+class RestoreFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.RESTORE_AVAILABLE
+)


### PR DESCRIPTION
Fixes #13328 

This PR add a local feature flag for the Jetpack Restore feature. This is the precursor step to using the feature flag during development.

There is nothing to test in this PR.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
