### PR TITLE
Issue/13328 restore skeleton

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -686,6 +686,12 @@
             android:label="@string/backup_download"
             android:theme="@style/WordPress.NoActionBar"/>
 
+        <!-- Jetpack restore -->
+        <activity
+            android:name=".ui.jetpack.restore.RestoreActivity"
+            android:label="@string/restore"
+            android:theme="@style/WordPress.NoActionBar"/>
+
         <!-- Services -->
         <service
             android:name=".ui.uploads.UploadService"

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -49,6 +49,8 @@ import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadActivity;
 import org.wordpress.android.ui.jetpack.backup.download.complete.BackupDownloadCompleteFragment;
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsFragment;
 import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressFragment;
+import org.wordpress.android.ui.jetpack.restore.RestoreActivity;
+import org.wordpress.android.ui.jetpack.restore.details.RestoreDetailsFragment;
 import org.wordpress.android.ui.jetpack.scan.ScanFragment;
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsFragment;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryFragment;
@@ -639,6 +641,10 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(BackupDownloadProgressFragment object);
 
     void inject(BackupDownloadCompleteFragment object);
+
+    void inject(RestoreActivity object);
+
+    void inject(RestoreDetailsFragment object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -17,6 +17,8 @@ import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment.Countr
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment.StatePickerDialogFragment;
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStep;
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadStepsProvider;
+import org.wordpress.android.ui.jetpack.restore.RestoreStep;
+import org.wordpress.android.ui.jetpack.restore.RestoreStepsProvider;
 import org.wordpress.android.ui.mediapicker.loader.TenorGifClient;
 import org.wordpress.android.ui.posts.BasicDialog;
 import org.wordpress.android.ui.reader.ReaderPostWebViewCachingFragment;
@@ -138,6 +140,12 @@ public abstract class ApplicationModule {
     @Provides
     public static WizardManager<BackupDownloadStep> provideBackupDownloadWizardManager(
             BackupDownloadStepsProvider stepsProvider) {
+        return new WizardManager<>(stepsProvider.getSteps());
+    }
+
+    @Provides
+    public static WizardManager<RestoreStep> provideRestoreWizardManager(
+            RestoreStepsProvider stepsProvider) {
         return new WizardManager<>(stepsProvider.getSteps());
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -10,6 +10,8 @@ import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel;
 import org.wordpress.android.ui.jetpack.backup.download.complete.BackupDownloadCompleteViewModel;
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel;
 import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressViewModel;
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel;
+import org.wordpress.android.ui.jetpack.restore.details.RestoreDetailsViewModel;
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel;
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel;
@@ -479,6 +481,16 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(BackupDownloadCompleteViewModel.class)
     abstract ViewModel backupDownloadCompleteViewModel(BackupDownloadCompleteViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(RestoreViewModel.class)
+    abstract ViewModel restoreViewModel(RestoreViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(RestoreDetailsViewModel.class)
+    abstract ViewModel restoreDetailsViewModel(RestoreDetailsViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -48,6 +48,8 @@ import org.wordpress.android.ui.history.HistoryDetailActivity;
 import org.wordpress.android.ui.history.HistoryDetailContainerFragment;
 import org.wordpress.android.ui.history.HistoryListItem.Revision;
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadActivity;
+import org.wordpress.android.ui.jetpack.restore.RestoreActivity;
+import org.wordpress.android.ui.jetpack.scan.ScanActivity;
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsActivity;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryActivity;
 import org.wordpress.android.ui.main.MeActivity;
@@ -76,7 +78,6 @@ import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
 import org.wordpress.android.ui.prefs.MyProfileActivity;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsActivity;
 import org.wordpress.android.ui.publicize.PublicizeListActivity;
-import org.wordpress.android.ui.jetpack.scan.ScanActivity;
 import org.wordpress.android.ui.sitecreation.SiteCreationActivity;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
 import org.wordpress.android.ui.stats.StatsConstants;
@@ -117,6 +118,7 @@ import static org.wordpress.android.imageeditor.preview.PreviewImageFragment.ARG
 import static org.wordpress.android.login.LoginMode.WPCOM_LOGIN_ONLY;
 import static org.wordpress.android.ui.WPWebViewActivity.ENCODING_UTF8;
 import static org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModelKt.KEY_BACKUP_DOWNLOAD_ACTIVITY_ID_KEY;
+import static org.wordpress.android.ui.jetpack.restore.RestoreViewModelKt.KEY_RESTORE_ACTIVITY_ID_KEY;
 import static org.wordpress.android.ui.jetpack.scan.ScanFragment.ARG_THREAT_ID;
 import static org.wordpress.android.ui.media.MediaBrowserActivity.ARG_BROWSER_TYPE;
 import static org.wordpress.android.ui.pages.PagesActivityKt.EXTRA_PAGE_REMOTE_ID_KEY;
@@ -1375,5 +1377,13 @@ public class ActivityLauncher {
     public static void downloadBackupDownloadFile(Context context, String url) {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         context.startActivity(intent);
+    }
+
+    public static void showRestoreForResult(Activity activity, @NonNull SiteModel site, String activityId,
+                                                   int resultCode) {
+        Intent intent = new Intent(activity, RestoreActivity.class);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(KEY_RESTORE_ACTIVITY_ID_KEY, activityId);
+        activity.startActivityForResult(intent, resultCode);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/ActivityLogNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/ActivityLogNavigationEvents.kt
@@ -5,4 +5,5 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
 sealed class ActivityLogNavigationEvents {
     data class ShowBackupDownload(val event: ActivityLogListItem.Event) : ActivityLogNavigationEvents()
     data class ShowRestore(val event: ActivityLogListItem.Event) : ActivityLogNavigationEvents()
+    data class ShowRewindDialog(val event: ActivityLogListItem.Event) : ActivityLogNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -40,6 +40,7 @@ import javax.inject.Inject
 private const val ACTIVITY_TYPE_FILTER_TAG = "activity_log_type_filter_tag"
 private const val DATE_PICKER_TAG = "activity_log_date_picker_tag"
 private const val BACKUP_DOWNLOAD_REQUEST_CODE = 1710
+private const val RESTORE_REQUEST_CODE = 1720
 
 class ActivityLogListFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -160,7 +161,16 @@ class ActivityLogListFragment : Fragment() {
 
         viewModel.showRewindDialog.observe(viewLifecycleOwner, {
             if (it is ActivityLogListItem.Event) {
-                displayRewindDialog(it)
+                if (it.launchRestoreWizard) {
+                    ActivityLauncher.showRestoreForResult(
+                            requireActivity(),
+                            viewModel.site,
+                            it.activityId,
+                            RESTORE_REQUEST_CODE
+                    )
+                } else {
+                    displayRewindDialog(it)
+                }
             }
         })
 
@@ -183,10 +193,21 @@ class ActivityLogListFragment : Fragment() {
                             viewModel.site,
                             event.activityId,
                             BACKUP_DOWNLOAD_REQUEST_CODE)
-                    // todo: annmarie replace with the ActivityLauncher for showing restore details
-                    is ShowRestore -> displayRewindDialog(event) }
+                    is ShowRestore -> {
+                        if (event.launchRestoreWizard) {
+                            ActivityLauncher.showRestoreForResult(
+                                    requireActivity(),
+                                    viewModel.site,
+                                    event.activityId,
+                                    RESTORE_REQUEST_CODE
+                            )
+                        } else {
+                            displayRewindDialog(event)
+                        }
+                    }
                 }
-            })
+            }
+        })
     }
 
     private fun displayRewindDialog(item: ActivityLogListItem.Event) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowBackupDownload
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRestore
+import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRewindDialog
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterFragment
 import org.wordpress.android.ui.posts.BasicFragmentDialog
 import org.wordpress.android.ui.utils.UiHelpers
@@ -159,21 +160,6 @@ class ActivityLogListFragment : Fragment() {
             }
         })
 
-        viewModel.showRewindDialog.observe(viewLifecycleOwner, {
-            if (it is ActivityLogListItem.Event) {
-                if (it.launchRestoreWizard) {
-                    ActivityLauncher.showRestoreForResult(
-                            requireActivity(),
-                            viewModel.site,
-                            it.activityId,
-                            RESTORE_REQUEST_CODE
-                    )
-                } else {
-                    displayRewindDialog(it)
-                }
-            }
-        })
-
         viewModel.showSnackbarMessage.observe(viewLifecycleOwner, { message ->
             val parent: View? = activity?.findViewById(android.R.id.content)
             if (message != null && parent != null) {
@@ -193,18 +179,12 @@ class ActivityLogListFragment : Fragment() {
                             viewModel.site,
                             event.activityId,
                             BACKUP_DOWNLOAD_REQUEST_CODE)
-                    is ShowRestore -> {
-                        if (event.launchRestoreWizard) {
-                            ActivityLauncher.showRestoreForResult(
-                                    requireActivity(),
-                                    viewModel.site,
-                                    event.activityId,
-                                    RESTORE_REQUEST_CODE
-                            )
-                        } else {
-                            displayRewindDialog(event)
-                        }
-                    }
+                    is ShowRestore -> ActivityLauncher.showRestoreForResult(
+                            requireActivity(),
+                            viewModel.site,
+                            event.activityId,
+                            RESTORE_REQUEST_CODE)
+                    is ShowRewindDialog -> displayRewindDialog(event)
                 }
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItem.kt
@@ -33,14 +33,20 @@ sealed class ActivityLogListItem(val type: ViewType) {
         override val isButtonVisible: Boolean,
         val buttonIcon: Icon,
         val isProgressBarVisible: Boolean = false,
-        val showMoreMenu: Boolean = false
+        val showMoreMenu: Boolean = false,
+        val launchRestoreWizard: Boolean = false
     ) : ActivityLogListItem(EVENT), IActionableItem {
         val formattedDate: String = date.toFormattedDateString()
         val formattedTime: String = date.toFormattedTimeString()
         val icon = Icon.fromValue(gridIcon)
         val status = Status.fromValue(eventStatus)
 
-        constructor(model: ActivityLogModel, rewindDisabled: Boolean = false, backupFeatureEnabled: Boolean) : this(
+        constructor(
+            model: ActivityLogModel,
+            rewindDisabled: Boolean = false,
+            backupFeatureEnabled: Boolean,
+            restoreFeatureEnabled: Boolean
+        ) : this(
                 model.activityID,
                 model.summary,
                 model.content?.text ?: "",
@@ -51,7 +57,8 @@ sealed class ActivityLogListItem(val type: ViewType) {
                 model.published,
                 isButtonVisible = !rewindDisabled && model.rewindable ?: false,
                 buttonIcon = if (backupFeatureEnabled) MORE else HISTORY,
-                showMoreMenu = backupFeatureEnabled
+                showMoreMenu = backupFeatureEnabled,
+                launchRestoreWizard = restoreFeatureEnabled
         )
 
         override fun longId(): Long = activityId.hashCode().toLong()

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
@@ -1,0 +1,160 @@
+package org.wordpress.android.ui.jetpack.restore
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.android.synthetic.main.restore_activity.*
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.ui.jetpack.restore.RestoreNavigationEvents.VisitSite
+import org.wordpress.android.ui.jetpack.restore.RestoreStep.COMPLETE
+import org.wordpress.android.ui.jetpack.restore.RestoreStep.DETAILS
+import org.wordpress.android.ui.jetpack.restore.RestoreStep.PROGRESS
+import org.wordpress.android.ui.jetpack.restore.RestoreStep.WARNING
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCanceled
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCompleted
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreInProgress
+import org.wordpress.android.ui.jetpack.restore.details.RestoreDetailsFragment
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.wizard.WizardNavigationTarget
+import org.wordpress.android.widgets.WPSnackbar
+import javax.inject.Inject
+
+const val KEY_RESTORE_RESTORE_ID = "key_restore_restore_id"
+
+class RestoreActivity : LocaleAwareActivity() {
+    @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject internal lateinit var uiHelpers: UiHelpers
+    private lateinit var viewModel: RestoreViewModel
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (application as WordPress).component().inject(this)
+        setContentView(R.layout.restore_activity)
+
+        setSupportActionBar(toolbar_main)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        initViewModel(savedInstanceState)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressed()
+            return true
+        }
+        return false
+    }
+
+    override fun onBackPressed() {
+        viewModel.onBackPressed()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        viewModel.writeToBundle(outState)
+    }
+
+    private fun initViewModel(savedInstanceState: Bundle?) {
+        viewModel = ViewModelProvider(this, viewModelFactory)
+                .get(RestoreViewModel::class.java)
+
+        viewModel.navigationTargetObservable.observe(this, { target ->
+            target?.let {
+                showStep(target)
+            }
+        })
+
+        viewModel.toolbarStateObservable.observe(this, { state ->
+            supportActionBar?.title = getString(state.title)
+            supportActionBar?.setHomeAsUpIndicator(state.icon)
+            // Change the activity title for accessibility purposes
+            this.title = getString(state.title)
+        })
+
+        viewModel.snackbarEvents.observe(this, {
+            it?.applyIfNotHandled {
+                showSnackbar()
+            }
+        })
+
+        viewModel.errorEvents.observe(this, {
+            it?.applyIfNotHandled {
+                viewModel.transitionToError(this)
+            }
+        })
+
+        viewModel.wizardFinishedObservable.observe(this, {
+            it.applyIfNotHandled {
+                val intent = Intent()
+                val (restoreCreated, restoreId) = when (this) {
+                    is RestoreCanceled -> Pair(false, null)
+                    is RestoreInProgress -> Pair(true, restoreId)
+                    is RestoreCompleted -> Pair(true, null)
+                }
+                intent.putExtra(KEY_RESTORE_RESTORE_ID, restoreId)
+                setResult(if (restoreCreated) RESULT_OK else RESULT_CANCELED, intent)
+                finish()
+            }
+        })
+
+        viewModel.navigationEvents.observe(this, {
+            it.applyIfNotHandled {
+                when (this) {
+                    is VisitSite -> {
+                        // todo annmarie add to ActivityLauncher
+                    }
+                }
+            }
+        })
+
+        viewModel.start(savedInstanceState)
+    }
+
+    private fun SnackbarMessageHolder.showSnackbar() {
+        val snackbar = WPSnackbar.make(
+                coordinator_layout,
+                uiHelpers.getTextOfUiString(this@RestoreActivity, message),
+                Snackbar.LENGTH_LONG
+        )
+        if (buttonTitle != null) {
+            snackbar.setAction(
+                    uiHelpers.getTextOfUiString(this@RestoreActivity, buttonTitle)
+            ) {
+                buttonAction.invoke()
+            }
+        }
+        snackbar.show()
+    }
+
+    private fun showStep(target: WizardNavigationTarget<RestoreStep, RestoreState>) {
+        val fragment = when (target.wizardStep) {
+            DETAILS -> RestoreDetailsFragment.newInstance(intent?.extras)
+            // todo: annmarie add fragments as they become available
+            WARNING -> RestoreDetailsFragment.newInstance(intent?.extras)
+            PROGRESS -> RestoreDetailsFragment.newInstance(intent?.extras)
+            COMPLETE -> RestoreDetailsFragment.newInstance(intent?.extras)
+        }
+
+        slideInFragment(fragment, target.wizardStep.toString())
+    }
+
+    private fun slideInFragment(fragment: Fragment, tag: String) {
+        val transaction = supportFragmentManager.beginTransaction()
+        if (supportFragmentManager.findFragmentById(R.id.fragment_container) != null) {
+            transaction.addToBackStack(null).setCustomAnimations(
+                    R.anim.activity_slide_in_from_right,
+                    R.anim.activity_slide_out_to_left,
+                    R.anim.activity_slide_in_from_left,
+                    R.anim.activity_slide_out_to_right
+            )
+        }
+        transaction.replace(R.id.fragment_container, fragment, tag)
+        transaction.commit()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreErrorTypes.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreErrorTypes.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.ui.jetpack.restore
+
+enum class RestoreErrorTypes(val id: Int) {
+    NetworkUnavailable(0), RemoteRequestFailure(1), GenericFailure(2);
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreNavigationEvents.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.ui.jetpack.restore
+
+sealed class RestoreNavigationEvents {
+    data class VisitSite(val url: String) : RestoreNavigationEvents()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreStep.kt
@@ -1,0 +1,31 @@
+package org.wordpress.android.ui.jetpack.restore
+
+import org.wordpress.android.util.wizard.WizardStep
+import javax.inject.Inject
+import javax.inject.Singleton
+
+enum class RestoreStep(val id: Int) : WizardStep {
+    DETAILS(0), WARNING(1), PROGRESS(1), COMPLETE(2);
+
+    companion object {
+        fun fromString(input: String): RestoreStep = when (input) {
+            "restore_details" -> DETAILS
+            "restore_warning" -> WARNING
+            "restore_progress" -> PROGRESS
+            "restore_complete" -> COMPLETE
+            else -> throw IllegalArgumentException("RestoreStep not recognized: \$input")
+        }
+
+        fun indexForErrorTransition(): Int = PROGRESS.id
+    }
+}
+
+@Singleton
+class RestoreStepsProvider @Inject constructor() {
+    fun getSteps() = listOf(
+            RestoreStep.fromString("restore_details"),
+            RestoreStep.fromString("restore_warning"),
+            RestoreStep.fromString("restore_progress"),
+            RestoreStep.fromString("restore_complete")
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -1,0 +1,172 @@
+package org.wordpress.android.ui.jetpack.restore
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Transformations
+import androidx.lifecycle.ViewModel
+import kotlinx.android.parcel.Parcelize
+import org.wordpress.android.R
+import org.wordpress.android.ui.jetpack.restore.RestoreStep.DETAILS
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCanceled
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.util.wizard.WizardManager
+import org.wordpress.android.util.wizard.WizardNavigationTarget
+import org.wordpress.android.util.wizard.WizardState
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.SingleEventObservable
+import java.util.Date
+import javax.inject.Inject
+
+const val KEY_RESTORE_ACTIVITY_ID_KEY = "key_restore_activity_id_key"
+const val KEY_RESTORE_CURRENT_STEP = "key_restore_current_step"
+const val KEY_RESTORE_STATE = "key_restore_state"
+
+@Parcelize
+@SuppressLint("ParcelCreator")
+data class RestoreState(
+    val siteId: Long? = null,
+    val activityId: String? = null,
+    val rewindId: String? = null,
+    val restoreId: Long? = null,
+    val published: Date? = null,
+    val url: String? = null,
+    val errorType: Int? = null
+) : WizardState, Parcelable
+
+typealias NavigationTarget = WizardNavigationTarget<RestoreStep, RestoreState>
+
+class RestoreViewModel @Inject constructor(
+    private val wizardManager: WizardManager<RestoreStep>
+) : ViewModel() {
+    private var isStarted = false
+
+    private lateinit var restoreState: RestoreState
+
+    val navigationTargetObservable: SingleEventObservable<NavigationTarget> by lazy {
+        SingleEventObservable(
+                Transformations.map(wizardManager.navigatorLiveData) {
+                    clearOldRestoreState(it)
+                    WizardNavigationTarget(it, restoreState)
+                }
+        )
+    }
+
+    private val _wizardFinishedObservable = MutableLiveData<Event<RestoreWizardState>>()
+    val wizardFinishedObservable: LiveData<Event<RestoreWizardState>> = _wizardFinishedObservable
+
+    private val _toolbarStateObservable = MutableLiveData<ToolbarState>()
+    val toolbarStateObservable: LiveData<ToolbarState> = _toolbarStateObservable
+
+    private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
+    val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
+
+    private val _errorEvents = MediatorLiveData<Event<RestoreErrorTypes>>()
+    val errorEvents: LiveData<Event<RestoreErrorTypes>> = _errorEvents
+
+    private val _navigationEvents = MediatorLiveData<Event<RestoreNavigationEvents>>()
+    val navigationEvents: LiveData<Event<RestoreNavigationEvents>> = _navigationEvents
+
+    fun start(savedInstanceState: Bundle?) {
+        if (isStarted) return
+        isStarted = true
+        if (savedInstanceState == null) {
+            restoreState = RestoreState()
+            // Show the next step only if it's a fresh activity so we can handle the navigation
+            wizardManager.showNextStep()
+        } else {
+            restoreState = requireNotNull(savedInstanceState.getParcelable(KEY_RESTORE_STATE))
+            val currentStepIndex = savedInstanceState.getInt(KEY_RESTORE_CURRENT_STEP)
+            wizardManager.setCurrentStepIndex(currentStepIndex)
+        }
+    }
+
+    fun addSnackbarMessageSource(snackbarEvents: LiveData<Event<SnackbarMessageHolder>>) {
+        _snackbarEvents.addSource(snackbarEvents) { event ->
+            _snackbarEvents.value = event
+        }
+    }
+
+    fun addErrorMessageSource(errorEvents: LiveData<Event<RestoreErrorTypes>>) {
+        _errorEvents.addSource(errorEvents) { event ->
+            _errorEvents.value = event
+        }
+    }
+
+    fun writeToBundle(outState: Bundle) {
+        outState.putInt(KEY_RESTORE_CURRENT_STEP, wizardManager.currentStep)
+        outState.putParcelable(KEY_RESTORE_STATE, restoreState)
+    }
+
+    fun onBackPressed() {
+        when (wizardManager.currentStep) {
+            DETAILS.id -> {
+                _wizardFinishedObservable.value = Event(RestoreCanceled)
+            }
+        }
+    }
+
+    private fun clearOldRestoreState(wizardStep: RestoreStep) {
+        if (wizardStep == DETAILS) {
+            restoreState = restoreState.copy(
+                    rewindId = null,
+                    restoreId = null,
+                    url = null,
+                    errorType = null
+            )
+        }
+    }
+
+    fun onRestoreDetailsFinished(rewindId: String?, restoreId: Long?, published: Date) {
+        restoreState = restoreState.copy(
+                rewindId = rewindId,
+                restoreId = restoreId,
+                published = published)
+        wizardManager.showNextStep()
+    }
+
+    fun onRestoreCanceled() {
+        _wizardFinishedObservable.value = Event(RestoreCanceled)
+    }
+
+    fun onRestoreProgressFinished(url: String?) {
+        restoreState = restoreState.copy(url = url)
+        wizardManager.showNextStep()
+    }
+
+    fun setToolbarState(toolbarState: ToolbarState) {
+        _toolbarStateObservable.value = toolbarState
+    }
+
+    fun transitionToError(errorType: RestoreErrorTypes) {
+        restoreState = restoreState.copy(errorType = errorType.id)
+        wizardManager.setCurrentStepIndex(RestoreStep.indexForErrorTransition())
+        wizardManager.showNextStep()
+    }
+
+    sealed class RestoreWizardState : Parcelable {
+        @Parcelize
+        object RestoreCanceled : RestoreWizardState()
+
+        @Parcelize
+        data class RestoreInProgress(val restoreId: Long) : RestoreWizardState()
+
+        @Parcelize
+        object RestoreCompleted : RestoreWizardState()
+    }
+
+    sealed class ToolbarState {
+        abstract val title: Int
+        abstract val icon: Int
+
+        data class DetailsToolbarState(
+            @StringRes override val title: Int = R.string.restore_details_page_title,
+            @DrawableRes override val icon: Int = R.drawable.ic_arrow_back
+        ) : ToolbarState()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/details/RestoreDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/details/RestoreDetailsFragment.kt
@@ -1,0 +1,50 @@
+package org.wordpress.android.ui.jetpack.restore.details
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel
+import javax.inject.Inject
+
+class RestoreDetailsFragment : Fragment() {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var parentViewModel: RestoreViewModel
+    private lateinit var viewModel: RestoreDetailsViewModel
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.restore_details_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initDagger()
+        initViewModel()
+    }
+
+    private fun initDagger() {
+        (requireActivity().application as WordPress).component().inject(this)
+    }
+
+    private fun initViewModel() {
+        parentViewModel = ViewModelProvider(requireActivity(), viewModelFactory)
+                .get(RestoreViewModel::class.java)
+
+        viewModel = ViewModelProvider(this, viewModelFactory)
+                .get(RestoreDetailsViewModel::class.java)
+    }
+
+    companion object {
+        const val TAG = "RESTORE_DETAILS_FRAGMENT"
+        fun newInstance(bundle: Bundle?): RestoreDetailsFragment {
+            return RestoreDetailsFragment().apply { arguments = bundle }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/details/RestoreDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/details/RestoreDetailsViewModel.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.ui.jetpack.restore.details
+
+import androidx.lifecycle.ViewModel
+import javax.inject.Inject
+
+class RestoreDetailsViewModel @Inject constructor() : ViewModel() {
+    private var isStarted: Boolean = false
+
+    fun start() {
+        if (isStarted) return
+        isStarted = true
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowBackupDownload
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRestore
+import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRewindDialog
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Footer
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Header
@@ -97,10 +98,6 @@ class ActivityLogViewModel @Inject constructor(
 
     private val _emptyUiState = MutableLiveData<EmptyUiState>(EmptyUiState.EmptyFilters)
     val emptyUiState: LiveData<EmptyUiState> = _emptyUiState
-
-    private val _showRewindDialog = SingleLiveEvent<ActivityLogListItem>()
-    val showRewindDialog: LiveData<ActivityLogListItem>
-        get() = _showRewindDialog
 
     private val _showActivityTypeFilterDialog = SingleLiveEvent<ShowActivityTypePicker>()
     val showActivityTypeFilterDialog: LiveData<ShowActivityTypePicker>
@@ -283,7 +280,12 @@ class ActivityLogViewModel @Inject constructor(
     // todo: annmarie - Remove once the feature exclusively uses the more menu
     fun onActionButtonClicked(item: ActivityLogListItem) {
         if (item is ActivityLogListItem.Event) {
-            _showRewindDialog.value = item
+            val navigationEvent = if (item.launchRestoreWizard) {
+                ShowRestore(item)
+            } else {
+                ShowRewindDialog(item)
+            }
+            _navigationEvents.value = Event(navigationEvent)
         }
     }
 
@@ -294,7 +296,11 @@ class ActivityLogViewModel @Inject constructor(
         if (item is ActivityLogListItem.Event) {
             val navigationEvent = when (secondaryAction) {
                 RESTORE -> {
-                    ShowRestore(item)
+                    if (item.launchRestoreWizard) {
+                        ShowRestore(item)
+                    } else {
+                        ShowRewindDialog(item)
+                    }
                 }
                 DOWNLOAD_BACKUP -> {
                     ShowBackupDownload(item)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.BackupFeatureConfig
+import org.wordpress.android.util.RestoreFeatureConfig
 import org.wordpress.android.util.analytics.ActivityLogTracker
 import org.wordpress.android.util.config.ActivityLogFiltersFeatureConfig
 import org.wordpress.android.viewmodel.Event
@@ -70,6 +71,7 @@ class ActivityLogViewModel @Inject constructor(
     private val dateUtils: DateUtils,
     private val activityLogTracker: ActivityLogTracker,
     private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase,
+    private val restoreFeatureConfig: RestoreFeatureConfig,
     @param:Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(uiDispatcher) {
     enum class ActivityLogListStatus {
@@ -383,7 +385,11 @@ class ActivityLogViewModel @Inject constructor(
             moveToTop = eventListStatus.value != LOADING_MORE
         }
         eventList.forEach { model ->
-            val currentItem = ActivityLogListItem.Event(model, disableActions, backupFeatureConfig.isEnabled())
+            val currentItem = ActivityLogListItem.Event(
+                    model,
+                    disableActions,
+                    backupFeatureConfig.isEnabled(),
+                    restoreFeatureConfig.isEnabled())
             val lastItem = items.lastOrNull() as? ActivityLogListItem.Event
             if (lastItem == null || lastItem.formattedDate != currentItem.formattedDate) {
                 items.add(Header(currentItem.formattedDate))
@@ -415,7 +421,8 @@ class ActivityLogViewModel @Inject constructor(
         return activityLogModel?.let {
             val rewoundEvent = ActivityLogListItem.Event(
                     model = it,
-                    backupFeatureEnabled = backupFeatureConfig.isEnabled()
+                    backupFeatureEnabled = backupFeatureConfig.isEnabled(),
+                    restoreFeatureEnabled = restoreFeatureConfig.isEnabled()
             )
             ActivityLogListItem.Progress(
                     resourceProvider.getString(R.string.activity_log_currently_restoring_title),
@@ -458,7 +465,10 @@ class ActivityLogViewModel @Inject constructor(
 
     private fun showRewindStartedMessage() {
         rewindStatusService.rewindingActivity?.let {
-            val event = ActivityLogListItem.Event(model = it, backupFeatureEnabled = backupFeatureConfig.isEnabled())
+            val event = ActivityLogListItem.Event(
+                    model = it,
+                    backupFeatureEnabled = backupFeatureConfig.isEnabled(),
+                    restoreFeatureEnabled = restoreFeatureConfig.isEnabled())
             _showSnackbarMessage.value = resourceProvider.getString(
                     R.string.activity_log_rewind_started_snackbar_message,
                     event.formattedDate,
@@ -470,7 +480,10 @@ class ActivityLogViewModel @Inject constructor(
     private fun showRewindFinishedMessage() {
         val item = rewindStatusService.rewindingActivity
         if (item != null) {
-            val event = ActivityLogListItem.Event(model = item, backupFeatureEnabled = backupFeatureConfig.isEnabled())
+            val event = ActivityLogListItem.Event(
+                    model = item,
+                    backupFeatureEnabled = backupFeatureConfig.isEnabled(),
+                    restoreFeatureEnabled = restoreFeatureConfig.isEnabled())
             _showSnackbarMessage.value =
                     resourceProvider.getString(
                             R.string.activity_log_rewind_finished_snackbar_message,

--- a/WordPress/src/main/res/layout/restore_activity.xml
+++ b/WordPress/src/main/res/layout/restore_activity.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+    </FrameLayout>
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar"
+            app:layout_scrollFlags="scroll|enterAlways"/>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/restore_details_fragment.xml
+++ b/WordPress/src/main/res/layout/restore_details_fragment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3442,4 +3442,8 @@ translators: sample content for "Services" page template -->
     <string name="jetpack_icon_content_description">icon</string>
     <string name="label_control_upload">Upload</string>
 
+    <!-- Jetpack restore -->
+    <string name="restore">Restore</string>
+    <string name="restore_details_page_title">@string/restore</string>
+
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreDetailsViewModelTest.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.jetpack.restore
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.jetpack.restore.details.RestoreDetailsViewModel
+
+@RunWith(MockitoJUnitRunner::class)
+class RestoreDetailsViewModelTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    private lateinit var viewModel: RestoreDetailsViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = RestoreDetailsViewModel()
+    }
+
+    @Test
+    fun `sample test`() {
+    } // TODO:
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.jetpack.restore
+
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.util.wizard.WizardManager
+
+@InternalCoroutinesApi
+class RestoreViewModelTest : BaseUnitTest() {
+    @Mock lateinit var wizardManager: WizardManager<RestoreStep>
+
+    private lateinit var viewModel: RestoreViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = RestoreViewModel(wizardManager)
+    }
+
+    @Test
+    fun `sample test`() {
+    } // TODO:
+}

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -44,6 +44,7 @@ import org.wordpress.android.test
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowBackupDownload
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRestore
+import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRewindDialog
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService.RewindProgress
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
@@ -97,7 +98,6 @@ class ActivityLogViewModelTest {
 
     private var events: MutableList<List<ActivityLogListItem>?> = mutableListOf()
     private var itemDetails: MutableList<ActivityLogListItem?> = mutableListOf()
-    private var rewindDialogs: MutableList<ActivityLogListItem?> = mutableListOf()
     private var eventListStatuses: MutableList<ActivityLogListStatus?> = mutableListOf()
     private var snackbarMessages: MutableList<String?> = mutableListOf()
     private var moveToTopEvents: MutableList<Unit?> = mutableListOf()
@@ -346,11 +346,9 @@ class ActivityLogViewModelTest {
 
     @Test
     fun onActionButtonClickShowsRewindDialog() {
-        assertTrue(rewindDialogs.isEmpty())
-
         viewModel.onActionButtonClicked(event)
 
-        assertEquals(rewindDialogs.firstOrNull(), event)
+        Assertions.assertThat(navigationEvents.last().peekContent()).isInstanceOf(ShowRewindDialog::class.java)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -488,10 +488,10 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun onSecondaryActionClickRestoreNavigationEventIsShowRestore() {
+    fun onSecondaryActionClickRestoreNavigationEventIsShowRewindDialog() {
         viewModel.onSecondaryActionClicked(RESTORE, event)
 
-        Assertions.assertThat(navigationEvents.last().peekContent()).isInstanceOf(ShowRestore::class.java)
+        Assertions.assertThat(navigationEvents.last().peekContent()).isInstanceOf(ShowRewindDialog::class.java)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -60,6 +60,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.BackupFeatureConfig
+import org.wordpress.android.util.RestoreFeatureConfig
 import org.wordpress.android.util.analytics.ActivityLogTracker
 import org.wordpress.android.util.config.ActivityLogFiltersFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -90,6 +91,7 @@ class ActivityLogViewModelTest {
     @Mock private lateinit var dateUtils: DateUtils
     @Mock private lateinit var activityLogTracker: ActivityLogTracker
     @Mock private lateinit var jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase
+    @Mock private lateinit var restoreFeatureConfig: RestoreFeatureConfig
     private lateinit var fetchActivityLogCaptor: KArgumentCaptor<FetchActivityLogPayload>
     private lateinit var formatDateRangeTimezoneCaptor: KArgumentCaptor<String>
 
@@ -154,6 +156,7 @@ class ActivityLogViewModelTest {
                 dateUtils,
                 activityLogTracker,
                 jetpackCapabilitiesUseCase,
+                restoreFeatureConfig,
                 Dispatchers.Unconfined
         )
         viewModel.site = site
@@ -269,9 +272,9 @@ class ActivityLogViewModelTest {
     private fun expectedActivityList(isLastPageAndFreeSite: Boolean = false, canLoadMore: Boolean = false):
             List<ActivityLogListItem> {
         val activityLogListItems = mutableListOf<ActivityLogListItem>()
-        val first = Event(activityLogList[0], true, false)
-        val second = Event(activityLogList[1], true, false)
-        val third = Event(activityLogList[2], true, false)
+        val first = Event(activityLogList[0], true, false, false)
+        val second = Event(activityLogList[1], true, false, false)
+        val third = Event(activityLogList[2], true, false, false)
         activityLogListItems.add(Header(first.formattedDate))
         activityLogListItems.add(first)
         activityLogListItems.add(second)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -163,7 +163,6 @@ class ActivityLogViewModelTest {
         viewModel.events.observeForever { events.add(it) }
         viewModel.eventListStatus.observeForever { eventListStatuses.add(it) }
         viewModel.showItemDetail.observeForever { itemDetails.add(it) }
-        viewModel.showRewindDialog.observeForever { rewindDialogs.add(it) }
         viewModel.showSnackbarMessage.observeForever { snackbarMessages.add(it) }
         viewModel.moveToTop.observeForever { moveToTopEvents.add(it) }
         viewModel.navigationEvents.observeForever { navigationEvents.add(it) }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -43,7 +43,6 @@ import org.wordpress.android.fluxc.store.ActivityLogStore.OnActivityLogFetched
 import org.wordpress.android.test
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowBackupDownload
-import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRestore
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRewindDialog
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService.RewindProgress


### PR DESCRIPTION
Parent #13328 

This PR introduces the "Restore" feature as accessed via the activity log list. This is prep PR.
 
`RestoreActivity`, `RestoreViewModel` are copies of the `BackupDownloadActivity` and `BackupDownloadViewModel` and functionality for observables and the wizard remain the same. Differences include supporting class renames, as well as function name changes. I have left //todo's to fill in particulars for each step as I include them.

`RestoreDetailsFragment` and `RestoreDetailsViewModel` are mere skeletons because it would have been too much to review. 

I did not use the `Rewind` package, but created a new one for `Restore`. I didn't rename because the current classes in `Rewind` are used by the ActivityLog. These `rewind` classes may be removed in the future and if so, this package will be deleted in its entirety.

This PR is a bit larger than normal, but to show that it works I had to go all the way to presenting the details view. It's best reviewed by commits which I have broken down as follows:

- Dagger & App Housekeeping: 9e4ad1b 
- Feature Flag in ActivityLog: ad0cc55
-- Adds support for showing the new restore wizard when the `RestoreFeatureConfig` is enabled. This will work with or without the BackupFeatureConfig flag.
- Restore Activity/Details: 723852c
-- This includes the cloned classes from BackupDownload feature
- Skeleton Unit Tests: 4f9d98b

**Merge Instructions**
- <del>Make sure #13759 has been merged<del> ✅
- <del>Remove Not Ready For Merge Label<del> ✅
- Merge as normal

**To test:**
- Launch the app with RestoreFeatureConfig flag on and the BackupFeatureFlag off
- Navigate to ActivityLog
- Tap the rewind icon for an item
- Note that an empty screen with the "Restore" title is shown

- Launch the app with RestoreFeatureConfig flag on and the BackupFeatureFlag on
- Navigate to ActivityLog
- Tap the More menu
- Tap Restore to this point menu item
- Note that an empty screen with the "Restore" title is shown

- Launch the app with RestoreFeatureConfig flag off and the BackupFeatureFlag off
- Navigate to ActivityLog
- Tap the rewind icon for an item
- Note that the restore dialog box is shown

PR submission checklist:
- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
