### PR TITLE
Issue/13328 restore complete

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -50,6 +50,7 @@ import org.wordpress.android.ui.jetpack.backup.download.complete.BackupDownloadC
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsFragment;
 import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressFragment;
 import org.wordpress.android.ui.jetpack.restore.RestoreActivity;
+import org.wordpress.android.ui.jetpack.restore.complete.RestoreCompleteFragment;
 import org.wordpress.android.ui.jetpack.restore.details.RestoreDetailsFragment;
 import org.wordpress.android.ui.jetpack.restore.progress.RestoreProgressFragment;
 import org.wordpress.android.ui.jetpack.restore.warning.RestoreWarningFragment;
@@ -651,6 +652,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(RestoreWarningFragment object);
 
     void inject(RestoreProgressFragment object);
+
+    void inject(RestoreCompleteFragment object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -11,6 +11,7 @@ import org.wordpress.android.ui.jetpack.backup.download.complete.BackupDownloadC
 import org.wordpress.android.ui.jetpack.backup.download.details.BackupDownloadDetailsViewModel;
 import org.wordpress.android.ui.jetpack.backup.download.progress.BackupDownloadProgressViewModel;
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel;
+import org.wordpress.android.ui.jetpack.restore.complete.RestoreCompleteViewModel;
 import org.wordpress.android.ui.jetpack.restore.details.RestoreDetailsViewModel;
 import org.wordpress.android.ui.jetpack.restore.progress.RestoreProgressViewModel;
 import org.wordpress.android.ui.jetpack.restore.warning.RestoreWarningViewModel;
@@ -503,6 +504,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(RestoreProgressViewModel.class)
     abstract ViewModel restoreProgressViewModel(RestoreProgressViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(RestoreCompleteViewModel.class)
+    abstract ViewModel restoreCompleteViewModel(RestoreCompleteViewModel viewModel);
 
     @Binds
     abstract ViewModelProvider.Factory provideViewModelFactory(ViewModelFactory viewModelFactory);

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
@@ -110,9 +110,7 @@ class RestoreActivity : LocaleAwareActivity() {
         viewModel.navigationEvents.observe(this, {
             it.applyIfNotHandled {
                 when (this) {
-                    is VisitSite -> {
-                        ActivityLauncher.openUrlExternal(this@RestoreActivity, url)
-                    }
+                    is VisitSite -> ActivityLauncher.openUrlExternal(this@RestoreActivity, url)
                 }
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
@@ -9,6 +9,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.restore_activity.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.jetpack.restore.RestoreNavigationEvents.VisitSite
 import org.wordpress.android.ui.jetpack.restore.RestoreStep.COMPLETE
@@ -18,12 +19,12 @@ import org.wordpress.android.ui.jetpack.restore.RestoreStep.WARNING
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCanceled
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCompleted
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreInProgress
+import org.wordpress.android.ui.jetpack.restore.complete.RestoreCompleteFragment
 import org.wordpress.android.ui.jetpack.restore.details.RestoreDetailsFragment
 import org.wordpress.android.ui.jetpack.restore.progress.RestoreProgressFragment
 import org.wordpress.android.ui.jetpack.restore.warning.RestoreWarningFragment
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.wizard.WizardNavigationTarget
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
@@ -88,10 +89,7 @@ class RestoreActivity : LocaleAwareActivity() {
 
         viewModel.errorEvents.observe(this, {
             it?.applyIfNotHandled {
-                // todo: annmarie uncomment when complete step has been added & remove other
-                // viewModel.transitionToError(this)
-                ToastUtils.showToast(this@RestoreActivity, "Error - closing wizard")
-                finish()
+                viewModel.transitionToError(this)
             }
         })
 
@@ -113,7 +111,7 @@ class RestoreActivity : LocaleAwareActivity() {
             it.applyIfNotHandled {
                 when (this) {
                     is VisitSite -> {
-                        // todo annmarie add to ActivityLauncher
+                        ActivityLauncher.openUrlExternal(this@RestoreActivity, url)
                     }
                 }
             }
@@ -147,8 +145,7 @@ class RestoreActivity : LocaleAwareActivity() {
             DETAILS -> RestoreDetailsFragment.newInstance(intent?.extras, target.wizardState)
             WARNING -> RestoreWarningFragment.newInstance(intent?.extras, target.wizardState)
             PROGRESS -> RestoreProgressFragment.newInstance(intent?.extras, target.wizardState)
-            // todo: annmarie add fragments as they become available
-            COMPLETE -> RestoreDetailsFragment.newInstance(intent?.extras, target.wizardState)
+            COMPLETE -> RestoreCompleteFragment.newInstance(intent?.extras, target.wizardState)
         }
 
         slideInFragment(fragment, target.wizardStep.toString())

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.jetpack.restore.RestoreStep.DETAILS
 import org.wordpress.android.ui.jetpack.restore.RestoreStep.WARNING
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCanceled
-import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCompleted
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreInProgress
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.util.wizard.WizardManager
@@ -104,6 +103,12 @@ class RestoreViewModel @Inject constructor(
         }
     }
 
+    fun addNavigationEventSource(navigationEvent: LiveData<Event<RestoreNavigationEvents>>) {
+        _navigationEvents.addSource(navigationEvent) { event ->
+            _navigationEvents.value = event
+        }
+    }
+
     fun writeToBundle(outState: Bundle) {
         outState.putInt(KEY_RESTORE_CURRENT_STEP, wizardManager.currentStep)
         outState.putParcelable(KEY_RESTORE_STATE, restoreState)
@@ -161,9 +166,7 @@ class RestoreViewModel @Inject constructor(
     }
 
     fun onRestoreProgressFinished() {
-        // todo: annmarie remove first line & uncomment nextStep
-        _wizardFinishedObservable.value = Event(RestoreCompleted)
-        // wizardManager.showNextStep()
+        wizardManager.showNextStep()
     }
 
     fun setToolbarState(toolbarState: ToolbarState) {
@@ -203,6 +206,16 @@ class RestoreViewModel @Inject constructor(
 
         data class ProgressToolbarState(
             @StringRes override val title: Int = R.string.restore_progress_page_title,
+            @DrawableRes override val icon: Int = R.drawable.ic_close_24px
+        ) : ToolbarState()
+
+        data class CompleteToolbarState(
+            @StringRes override val title: Int = R.string.restore_complete_page_title,
+            @DrawableRes override val icon: Int = R.drawable.ic_close_24px
+        ) : ToolbarState()
+
+        data class ErrorToolbarState(
+            @StringRes override val title: Int = R.string.restore_complete_failed_title,
             @DrawableRes override val icon: Int = R.drawable.ic_close_24px
         ) : ToolbarState()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -12,9 +12,11 @@ import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.R
+import org.wordpress.android.ui.jetpack.restore.RestoreStep.COMPLETE
 import org.wordpress.android.ui.jetpack.restore.RestoreStep.DETAILS
 import org.wordpress.android.ui.jetpack.restore.RestoreStep.WARNING
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCanceled
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCompleted
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreInProgress
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.util.wizard.WizardManager
@@ -122,6 +124,9 @@ class RestoreViewModel @Inject constructor(
             WARNING.id -> {
                 wizardManager.onBackPressed()
                 _onBackPressedObservable.value = Unit
+            }
+            COMPLETE.id -> {
+                _wizardFinishedObservable.value = Event(RestoreCompleted)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/complete/RestoreCompleteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/complete/RestoreCompleteAdapter.kt
@@ -1,0 +1,91 @@
+package org.wordpress.android.ui.jetpack.restore.complete
+
+import android.view.ViewGroup
+import androidx.annotation.MainThread
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState
+import org.wordpress.android.ui.jetpack.common.ViewType
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackButtonViewHolder
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackDescriptionViewHolder
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackHeaderViewHolder
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackIconViewHolder
+import org.wordpress.android.ui.jetpack.common.viewholders.JetpackViewHolder
+import org.wordpress.android.ui.jetpack.restore.viewholders.RestoreAdditionalInformationViewHolder
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.image.ImageManager
+
+class RestoreCompleteAdapter(
+    private val imageManager: ImageManager,
+    private val uiHelpers: UiHelpers
+) : RecyclerView.Adapter<JetpackViewHolder>() {
+    private val items = mutableListOf<JetpackListItemState>()
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): JetpackViewHolder {
+        return when (viewType) {
+            ViewType.ICON.id -> JetpackIconViewHolder(imageManager, parent)
+            ViewType.HEADER.id -> JetpackHeaderViewHolder(uiHelpers, parent)
+            ViewType.DESCRIPTION.id -> JetpackDescriptionViewHolder(uiHelpers, parent)
+            ViewType.ACTION_BUTTON.id -> JetpackButtonViewHolder(uiHelpers, parent)
+            ViewType.RESTORE_ADDITIONAL_INFORMATION.id ->
+                RestoreAdditionalInformationViewHolder(uiHelpers, parent)
+            else -> throw IllegalArgumentException("Unexpected view type in ${this::class.java.simpleName}")
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun getItemId(position: Int): Long {
+        return position.toLong()
+    }
+
+    override fun onBindViewHolder(holder: JetpackViewHolder, position: Int) {
+        holder.onBind(items[position])
+    }
+
+    override fun getItemViewType(position: Int) = items[position].type.id
+
+    @MainThread
+    fun update(newItems: List<JetpackListItemState>) {
+        val diffResult = DiffUtil.calculateDiff(
+                RestoreCompleteListDiffUtils(
+                        items.toList(),
+                        newItems
+                )
+        )
+        items.clear()
+        items.addAll(newItems)
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    private class RestoreCompleteListDiffUtils(
+        val oldItems: List<JetpackListItemState>,
+        val newItems: List<JetpackListItemState>
+    ) : DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = oldItems[oldItemPosition]
+            val newItem = newItems[newItemPosition]
+            if (oldItem::class != newItem::class) {
+                return false
+            }
+
+            // todo: annmarie - adjust this
+            return oldItem.longId() == newItem.longId()
+        }
+
+        override fun getOldListSize(): Int = oldItems.size
+
+        override fun getNewListSize(): Int = newItems.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return oldItems[oldItemPosition] == newItems[newItemPosition]
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/complete/RestoreCompleteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/complete/RestoreCompleteFragment.kt
@@ -1,0 +1,91 @@
+package org.wordpress.android.ui.jetpack.restore.complete
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.restore_complete_fragment.*
+import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.jetpack.restore.RestoreState
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel
+import org.wordpress.android.ui.jetpack.restore.complete.RestoreCompleteViewModel.UiState
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.image.ImageManager
+import javax.inject.Inject
+
+private const val ARG_DATA = "arg_restore_complete_data"
+
+class RestoreCompleteFragment : Fragment(R.layout.restore_complete_fragment) {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var uiHelpers: UiHelpers
+    @Inject lateinit var imageManager: ImageManager
+    private lateinit var parentViewModel: RestoreViewModel
+    private lateinit var viewModel: RestoreCompleteViewModel
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initDagger()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initRecyclerView()
+        initViewModel()
+    }
+
+    private fun initDagger() {
+        (requireActivity().application as WordPress).component().inject(this)
+    }
+
+    private fun initRecyclerView() {
+        recycler_view.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+        initAdapter()
+    }
+
+    private fun initAdapter() {
+        recycler_view.adapter = RestoreCompleteAdapter(imageManager, uiHelpers)
+    }
+
+    private fun initViewModel() {
+        parentViewModel = ViewModelProvider(requireActivity(), viewModelFactory)
+                .get(RestoreViewModel::class.java)
+
+        viewModel = ViewModelProvider(this, viewModelFactory)
+                .get(RestoreCompleteViewModel::class.java)
+
+        viewModel.uiState.observe(viewLifecycleOwner, { showView(it) })
+
+        val (site, state) = when {
+            arguments != null -> {
+                val site = requireNotNull(arguments).getSerializable(WordPress.SITE) as SiteModel
+                val state = requireNotNull(arguments)
+                        .getParcelable<RestoreState>(ARG_DATA) as RestoreState
+                site to state
+            }
+            else -> throw Throwable("Couldn't initialize ${javaClass.simpleName} view model")
+        }
+
+        viewModel.start(site, state, parentViewModel)
+    }
+
+    private fun showView(uiState: UiState) {
+        ((recycler_view.adapter) as RestoreCompleteAdapter).update(uiState.items)
+    }
+
+    companion object {
+        fun newInstance(
+            bundle: Bundle? = null,
+            restoreState: RestoreState
+        ): RestoreCompleteFragment {
+            val newBundle = Bundle().apply {
+                putParcelable(ARG_DATA, restoreState)
+            }
+            bundle?.let { newBundle.putAll(bundle) }
+            return RestoreCompleteFragment().apply { arguments = newBundle }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/complete/RestoreCompleteStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/complete/RestoreCompleteStateListItemBuilder.kt
@@ -64,8 +64,8 @@ class RestoreCompleteStateListItemBuilder @Inject constructor() {
     )
 
     fun buildCompleteListStateErrorItems(onDoneClick: () -> Unit) = listOf(
-                buildErrorIconState(),
-                buildErrorDescriptionState(),
+            buildErrorIconState(),
+            buildErrorDescriptionState(),
             buildErrorDoneActionState(onDoneClick)
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/complete/RestoreCompleteStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/complete/RestoreCompleteStateListItemBuilder.kt
@@ -1,0 +1,88 @@
+package org.wordpress.android.ui.jetpack.restore.complete
+
+import dagger.Reusable
+import org.wordpress.android.R
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButtonState
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.DescriptionState
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.HeaderState
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.IconState
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
+import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.toFormattedDateString
+import org.wordpress.android.util.toFormattedTimeString
+import java.util.Date
+import javax.inject.Inject
+
+@Reusable
+class RestoreCompleteStateListItemBuilder @Inject constructor() {
+    fun buildCompleteListStateItems(
+        published: Date,
+        onDoneClick: () -> Unit,
+        onVisitSiteClick: () -> Unit
+    ): List<JetpackListItemState> {
+        return listOf(
+                buildIconState(),
+                buildHeaderState(),
+                buildDescriptionState(published),
+                buildDoneActionState(onDoneClick),
+                buildVisitSiteActionState(onVisitSiteClick)
+        )
+    }
+
+    private fun buildIconState() = IconState(
+            icon = R.drawable.ic_history_white_24dp,
+            contentDescription = UiStringRes(R.string.restore_complete_icon_content_description),
+            colorResId = R.color.success_50 // todo: annmarie make correct when doing design cleanup
+    )
+
+    private fun buildHeaderState() = HeaderState(
+            UiStringRes(R.string.restore_complete_header)
+    )
+
+    private fun buildDescriptionState(published: Date) = DescriptionState(
+            UiStringResWithParams(
+                    R.string.restore_complete_description_with_two_parameters,
+                    listOf(
+                            UiStringText(published.toFormattedDateString()),
+                            UiStringText(published.toFormattedTimeString())
+                    )
+            )
+    )
+
+    private fun buildVisitSiteActionState(onClick: () -> Unit) = ActionButtonState(
+            text = UiStringRes(R.string.restore_complete_visit_site_action_button),
+            contentDescription = UiStringRes(R.string.restore_complete_done_button_content_description),
+            onClick = onClick
+    )
+
+    private fun buildDoneActionState(onClick: () -> Unit) = ActionButtonState(
+            text = UiStringRes(R.string.restore_complete_done_action_button),
+            contentDescription = UiStringRes(R.string.restore_complete_visit_site_button_content_description),
+            onClick = onClick
+    )
+
+    fun buildCompleteListStateErrorItems(onDoneClick: () -> Unit) = listOf(
+                buildErrorIconState(),
+                buildErrorDescriptionState(),
+            buildErrorDoneActionState(onDoneClick)
+    )
+
+    private fun buildErrorIconState() = IconState(
+            icon = R.drawable.ic_get_app_24dp, // todo: annmarie replace with error icon
+            contentDescription = UiStringRes(R.string.restore_complete_failed_icon_content_description),
+            colorResId = R.color.error_50 // todo: annmarie make correct when doing design cleanup
+    )
+
+    private fun buildErrorDescriptionState() = DescriptionState(
+            UiStringRes(R.string.restore_complete_failed_description)
+    )
+
+    private fun buildErrorDoneActionState(onClick: () -> Unit) = ActionButtonState(
+            text = UiStringRes(R.string.restore_complete_failed_action_button),
+            contentDescription =
+            UiStringRes(R.string.restore_complete_failed_action_button_content_description),
+            onClick = onClick
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/complete/RestoreCompleteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/complete/RestoreCompleteViewModel.kt
@@ -1,0 +1,86 @@
+package org.wordpress.android.ui.jetpack.restore.complete
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState
+import org.wordpress.android.ui.jetpack.restore.RestoreNavigationEvents
+import org.wordpress.android.ui.jetpack.restore.RestoreNavigationEvents.VisitSite
+import org.wordpress.android.ui.jetpack.restore.RestoreState
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState.CompleteToolbarState
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState.ErrorToolbarState
+import org.wordpress.android.viewmodel.Event
+import org.wordpress.android.viewmodel.ScopedViewModel
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Named
+
+class RestoreCompleteViewModel @Inject constructor(
+    private val stateListItemBuilder: RestoreCompleteStateListItemBuilder,
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
+) : ScopedViewModel(mainDispatcher) {
+    private lateinit var site: SiteModel
+    private lateinit var restoreState: RestoreState
+    private lateinit var parentViewModel: RestoreViewModel
+    private var isStarted = false
+
+    private val _uiState = MutableLiveData<UiState>()
+    val uiState: LiveData<UiState> = _uiState
+
+    private val _navigationEvents = MediatorLiveData<Event<RestoreNavigationEvents>>()
+    val navigationEvents: LiveData<Event<RestoreNavigationEvents>> = _navigationEvents
+
+    fun start(
+        site: SiteModel,
+        restoreState: RestoreState,
+        parentViewModel: RestoreViewModel
+    ) {
+        if (isStarted) return
+        isStarted = true
+
+        this.site = site
+        this.restoreState = restoreState
+        this.parentViewModel = parentViewModel
+
+        initSources()
+        initView()
+    }
+
+    private fun initSources() {
+        parentViewModel.addNavigationEventSource(navigationEvents)
+    }
+
+    private fun initView() {
+        if (restoreState.errorType != null) {
+            parentViewModel.setToolbarState(ErrorToolbarState())
+            _uiState.value = UiState(
+                items = stateListItemBuilder.buildCompleteListStateErrorItems(
+                        onDoneClick = this@RestoreCompleteViewModel::onDoneClick
+                ))
+        } else {
+            parentViewModel.setToolbarState(CompleteToolbarState())
+            _uiState.value = UiState(
+                items = stateListItemBuilder.buildCompleteListStateItems(
+                published = restoreState.published as Date,
+                onDoneClick = this@RestoreCompleteViewModel::onDoneClick,
+                onVisitSiteClick = this@RestoreCompleteViewModel::onVisitSiteClick
+            ))
+        }
+    }
+
+    private fun onVisitSiteClick() {
+        site.url?.let { _navigationEvents.postValue(Event(VisitSite(site.url))) }
+    }
+
+    private fun onDoneClick() {
+        parentViewModel.onRestoreCanceled()
+    }
+
+    data class UiState(
+        val items: List<JetpackListItemState>
+    )
+}

--- a/WordPress/src/main/res/layout/restore_complete_fragment.xml
+++ b/WordPress/src/main/res/layout/restore_complete_fragment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3472,4 +3472,20 @@ translators: sample content for "Services" page template -->
     <string name="restore_progress_action_button_content_description">@string/backup_download_progress_action_button_content_description</string>
     <string name="restore_progress_additional_info">No need to wait around. We\'ll notify you when your site has been restored.</string>
     <string name="restore_progress_label">%1$s%%</string>
+
+    <string name="restore_complete_page_title">@string/restore</string>
+    <string name="restore_complete_header">Your site has been restored</string>
+    <string name="restore_complete_description_with_two_parameters">All of your selected items are now restored back to %1$s %2$s.</string>
+    <string name="restore_complete_done_action_button">@string/label_done_button</string>
+    <string name="restore_complete_visit_site_action_button">Visit site</string>
+    <string name="restore_complete_icon_content_description">Restore icon</string>
+    <string name="restore_complete_done_button_content_description">Done button</string>
+    <string name="restore_complete_visit_site_button_content_description">Visit site button</string>
+
+    <string name="restore_complete_failed_title">Restore failed</string>
+    <string name="restore_complete_failed_description">We couldn\'t restore your site. Please try again later.</string>
+    <string name="restore_complete_failed_action_button">@string/label_done_button</string>
+    <string name="restore_complete_failed_action_button_content_description">Done button</string>
+    <string name="restore_complete_failed_icon_content_description">Error icon</string>
+
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreCompleteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreCompleteViewModelTest.kt
@@ -51,10 +51,9 @@ class RestoreCompleteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given visit site is clicked, then a navigationEvent is posted`() = test {
+    fun `when visit site is clicked, then a navigationEvent is posted`() = test {
         val uiStates = initObservers().uiStates
         val navigationEvents = initObservers().navigationEvents
-        whenever(site.url).thenReturn("www.google.com")
 
         viewModel.start(site, restoreState, parentViewModel)
         whenever(site.url).thenReturn("www.google.com")

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreCompleteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreCompleteViewModelTest.kt
@@ -1,0 +1,81 @@
+package org.wordpress.android.ui.jetpack.restore
+
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.test
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButtonState
+import org.wordpress.android.ui.jetpack.restore.RestoreNavigationEvents.VisitSite
+import org.wordpress.android.ui.jetpack.restore.complete.RestoreCompleteStateListItemBuilder
+import org.wordpress.android.ui.jetpack.restore.complete.RestoreCompleteViewModel
+import org.wordpress.android.ui.jetpack.restore.complete.RestoreCompleteViewModel.UiState
+import java.util.Date
+
+@InternalCoroutinesApi
+class RestoreCompleteViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: RestoreCompleteViewModel
+    @Mock private lateinit var parentViewModel: RestoreViewModel
+    @Mock private lateinit var site: SiteModel
+    private lateinit var stateListItemBuilder: RestoreCompleteStateListItemBuilder
+
+    private val restoreState = RestoreState(
+            activityId = "activityId",
+            rewindId = "rewindId",
+            restoreId = 100L,
+            siteId = 200L,
+            published = Date(1609690147756)
+    )
+
+    @Before
+    fun setUp() = test {
+        stateListItemBuilder = RestoreCompleteStateListItemBuilder()
+        viewModel = RestoreCompleteViewModel(
+                stateListItemBuilder,
+                TEST_DISPATCHER
+        )
+    }
+
+    @Test
+    fun `when started, the content view is shown`() = test {
+        val uiStates = initObservers().uiStates
+
+        viewModel.start(site, restoreState, parentViewModel)
+
+        Assertions.assertThat(uiStates[0]).isInstanceOf(UiState::class.java)
+    }
+
+    @Test
+    fun `given visit site is clicked, then a navigationEvent is posted`() = test {
+        val uiStates = initObservers().uiStates
+        val navigationEvents = initObservers().navigationEvents
+        whenever(site.url).thenReturn("www.google.com")
+
+        viewModel.start(site, restoreState, parentViewModel)
+        whenever(site.url).thenReturn("www.google.com")
+
+        ((uiStates.last().items).last { it is ActionButtonState } as ActionButtonState).onClick.invoke()
+
+        Assertions.assertThat(navigationEvents.last()).isInstanceOf(VisitSite::class.java)
+    }
+
+    private fun initObservers(): Observers {
+        val uiStates = mutableListOf<UiState>()
+        viewModel.uiState.observeForever { uiStates.add(it) }
+
+        val navigationEvents = mutableListOf<RestoreNavigationEvents>()
+        viewModel.navigationEvents.observeForever { navigationEvents.add(it.peekContent()) }
+
+        return Observers(uiStates, navigationEvents)
+    }
+
+    private data class Observers(
+        val uiStates: List<UiState>,
+        val navigationEvents: List<RestoreNavigationEvents>
+    )
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreCompleteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreCompleteViewModelTest.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.jetpack.restore
 
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -47,7 +47,7 @@ class RestoreCompleteViewModelTest : BaseUnitTest() {
 
         viewModel.start(site, restoreState, parentViewModel)
 
-        Assertions.assertThat(uiStates[0]).isInstanceOf(UiState::class.java)
+        assertThat(uiStates[0]).isInstanceOf(UiState::class.java)
     }
 
     @Test
@@ -61,7 +61,7 @@ class RestoreCompleteViewModelTest : BaseUnitTest() {
 
         ((uiStates.last().items).last { it is ActionButtonState } as ActionButtonState).onClick.invoke()
 
-        Assertions.assertThat(navigationEvents.last()).isInstanceOf(VisitSite::class.java)
+        assertThat(navigationEvents.last()).isInstanceOf(VisitSite::class.java)
     }
 
     private fun initObservers(): Observers {

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
@@ -134,6 +134,15 @@ class RestoreViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given in progress step, when finished, then process moves to next step`() {
+        viewModel.start(null)
+        Mockito.clearInvocations(wizardManager)
+
+        viewModel.onRestoreProgressFinished()
+        Mockito.verify(wizardManager).showNextStep()
+    }
+
+    @Test
     fun `given in progress step, when onBackPressed, then invokes wizard finished with RestoreInProgress`() {
         val wizardFinishedObserver = initObservers().wizardFinishedObserver
         viewModel.start(null)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
@@ -11,7 +11,6 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.ErrorToolbarState
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType.CONTENTS
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType.MEDIA_UPLOADS
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType.PLUGINS
@@ -25,6 +24,7 @@ import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardSt
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState.CompleteToolbarState
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState.DetailsToolbarState
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState.ErrorToolbarState
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState.ProgressToolbarState
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState.WarningToolbarState
 import org.wordpress.android.util.wizard.WizardManager
@@ -235,7 +235,7 @@ class RestoreViewModelTest : BaseUnitTest() {
         val toolbarStates = initObservers().toolbarState
         viewModel.start(null)
 
-        viewModel.setToolbarState(ToolbarState.ErrorToolbarState())
+        viewModel.setToolbarState(ErrorToolbarState())
 
         Assertions.assertThat(toolbarStates.last()).isInstanceOf(ErrorToolbarState::class.java)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
@@ -11,6 +11,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.ToolbarState.ErrorToolbarState
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType.CONTENTS
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType.MEDIA_UPLOADS
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType.PLUGINS
@@ -19,8 +20,10 @@ import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsPr
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType.THEMES
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCanceled
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCompleted
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreInProgress
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState
+import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState.CompleteToolbarState
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState.DetailsToolbarState
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState.ProgressToolbarState
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.ToolbarState.WarningToolbarState
@@ -153,6 +156,18 @@ class RestoreViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given in complete step, when onBackPressed, then invokes wizard finished with BackupDownloadCompleted`() {
+        val wizardFinishedObserver = initObservers().wizardFinishedObserver
+        viewModel.start(null)
+        Mockito.clearInvocations(wizardManager)
+
+        whenever(wizardManager.currentStep).thenReturn(RestoreStep.COMPLETE.id)
+        viewModel.onBackPressed()
+
+        Assertions.assertThat(wizardFinishedObserver.last()).isInstanceOf(RestoreCompleted::class.java)
+    }
+
+    @Test
     fun `given viewModel, when starts, toolbarState contains no entries`() {
         val toolbarStates = initObservers().toolbarState
 
@@ -202,6 +217,27 @@ class RestoreViewModelTest : BaseUnitTest() {
         viewModel.setToolbarState(ProgressToolbarState())
 
         Assertions.assertThat(toolbarStates.last()).isInstanceOf(ProgressToolbarState::class.java)
+    }
+
+    @Test
+    fun `given in complete step, when setToolbarState is invoked, then toolbar state is updated`() {
+        val toolbarStates = initObservers().toolbarState
+
+        viewModel.start(null)
+
+        viewModel.setToolbarState(CompleteToolbarState())
+
+        Assertions.assertThat(toolbarStates.last()).isInstanceOf(CompleteToolbarState::class.java)
+    }
+
+    @Test
+    fun `given in complete error step, when setToolbarState is invoked, then toolbar state is updated`() {
+        val toolbarStates = initObservers().toolbarState
+        viewModel.start(null)
+
+        viewModel.setToolbarState(ToolbarState.ErrorToolbarState())
+
+        Assertions.assertThat(toolbarStates.last()).isInstanceOf(ErrorToolbarState::class.java)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
@@ -156,7 +156,7 @@ class RestoreViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given in complete step, when onBackPressed, then invokes wizard finished with BackupDownloadCompleted`() {
+    fun `given in complete step, when onBackPressed, then invokes wizard finished with RestoreCompleted`() {
         val wizardFinishedObserver = initObservers().wizardFinishedObserver
         viewModel.start(null)
         Mockito.clearInvocations(wizardManager)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
@@ -137,10 +137,10 @@ class RestoreViewModelTest : BaseUnitTest() {
     @Test
     fun `given in progress step, when finished, then process moves to next step`() {
         viewModel.start(null)
-        Mockito.clearInvocations(wizardManager)
+        clearInvocations(wizardManager)
 
         viewModel.onRestoreProgressFinished()
-        Mockito.verify(wizardManager).showNextStep()
+        verify(wizardManager).showNextStep()
     }
 
     @Test
@@ -160,12 +160,12 @@ class RestoreViewModelTest : BaseUnitTest() {
     fun `given in complete step, when onBackPressed, then invokes wizard finished with RestoreCompleted`() {
         val wizardFinishedObserver = initObservers().wizardFinishedObserver
         viewModel.start(null)
-        Mockito.clearInvocations(wizardManager)
+        clearInvocations(wizardManager)
 
         whenever(wizardManager.currentStep).thenReturn(RestoreStep.COMPLETE.id)
         viewModel.onBackPressed()
 
-        Assertions.assertThat(wizardFinishedObserver.last()).isInstanceOf(RestoreCompleted::class.java)
+        assertThat(wizardFinishedObserver.last()).isInstanceOf(RestoreCompleted::class.java)
     }
 
     @Test
@@ -228,7 +228,7 @@ class RestoreViewModelTest : BaseUnitTest() {
 
         viewModel.setToolbarState(CompleteToolbarState())
 
-        Assertions.assertThat(toolbarStates.last()).isInstanceOf(CompleteToolbarState::class.java)
+        assertThat(toolbarStates.last()).isInstanceOf(CompleteToolbarState::class.java)
     }
 
     @Test
@@ -238,7 +238,7 @@ class RestoreViewModelTest : BaseUnitTest() {
 
         viewModel.setToolbarState(ErrorToolbarState())
 
-        Assertions.assertThat(toolbarStates.last()).isInstanceOf(ErrorToolbarState::class.java)
+        assertThat(toolbarStates.last()).isInstanceOf(ErrorToolbarState::class.java)
     }
 
     @Test


### PR DESCRIPTION
Parent #13328

This PR implements the "complete" wizard step/view for the restore request and is mostly a clone of Backup Download complete. This PR also undoes the temporary navigations actions implemented in the progress PR #13778 .

**Merge Instructions**
- Make sure #13773, #13775 & #13778 have been merged (sorry, but they need to build upon each other)
- Remove Not Ready For Merge Label
- Merge as normal

**Cloned Classes**
RestoreCompleteAdapter
RestoreCompleteFragment
RestoreCompleteStateListItemBuilder
RestoreCompleteViewModel

**Notes**:
- Ignore styling - this is being handled separately 
- Ignore unit test placement in packages - this is being handled separately 
- RestoreActivity & RestoreViewModel (+unit tests) will continue to get updated as I move throughout the steps of the wizard

**To test:**
**Warning**: The Restore site button is hooked up, so if you press it your site will be backed up!
- Launch the app with RestoreFeatureConfig flag on and the BackupFeatureFlag on
- Navigate to ActivityLog
- Tap the more menu
- Select the restore option
- Tap the Restore Site button on the Details View
- Tap the Confirm restore site on the Warning View
- The Progress view will do it's thing - don't cancel out
Verify
- (1) The complete view is shown when the restore is finished
- (2) Tapping the Visit Site button to launch the site url in an external browser
- (3) Tap the Done button to close the wizard

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

