### PR TITLE
Fixes broken test due to missing fields in StarterDesignModel

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModelTest.kt
@@ -75,7 +75,9 @@ class HomePagePickerViewModelTest {
                                 mockedDesignDemoUrl,
                                 "theme",
                                 mockedDesignSegmentId,
-                                "image"
+                                "desktopThumbnail",
+                                "mobileThumbnail",
+                                "tabletThumbnail"
                         )
                 ),
                 null

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.9.0-beta-4'
+    fluxCVersion = '1.9.0-beta-6'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'


### PR DESCRIPTION
Relates to https://github.com/wordpress-mobile/gutenberg-mobile/issues/2978

**Description**

Fixes broken tests due to missing fields in StarterDesignModel. This was caused by merging https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1837 before https://github.com/wordpress-mobile/WordPress-Android/pull/13674

To test:

Confirm that tests can be compiled

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
