### PR TITLE
Reader Details app bar icon color fix (for Pixel 5)

### DIFF
--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -160,7 +160,7 @@
     <dimen name="reader_follow_button_skeleton_icon_text_margin">4dp</dimen>
 
     <!-- collapsing toolbar scrim visible height trigger -->
-    <dimen name="scrim_visible_height_trigger">100dp</dimen>
+    <dimen name="scrim_visible_height_trigger">150dp</dimen>
 
     <item name="expandable_chips_view_chip_alpha" format="float" type="dimen">
         @dimen/emphasis_extra_low


### PR DESCRIPTION
This PR increases the height that triggers app bar icon color changes on the reader details screen.

Reason:
For Pixel 5 device, this height was reported not enough to trigger color changes on the collapsed state toolbar.
Internal Ref: `p4a5px-2Gi`

To test:
Test that icons + text are shown in correct color on scrolling reader details screen on Pixel 5.

Note: 

I was not able to reproduce it on a custom Pixel 5 emulator that I created using Pixel 5 specs. Would appreciate if someone with Pixel 5 device can test it out.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
