### PR TITLE
Fix stories `alt` tags

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -45,7 +45,7 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
 
     private fun buildMediaFileData(mediaFile: MediaFile): StoryMediaFileData {
         return StoryMediaFileData(
-                alt = "",
+                alt = mediaFile.alt,
                 id = mediaFile.id.toString(),
                 link = StringUtils.notNullStr(mediaFile.fileURL),
                 type = if (mediaFile.isVideo) "video" else "image",
@@ -57,7 +57,7 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
 
     fun buildMediaFileDataWithTemporaryId(mediaFile: MediaFile, temporaryId: String): StoryMediaFileData {
         return StoryMediaFileData(
-                alt = "",
+                alt = mediaFile.alt,
                 id = temporaryId, // mediaFile.id,
                 link = StringUtils.notNullStr(mediaFile.fileURL),
                 type = if (mediaFile.isVideo) "video" else "image",

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -177,6 +177,18 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
         }
     }
 
+    fun assignAltOnEachMediaFile(
+        frames: List<StoryFrameItem>,
+        mediaFiles: ArrayList<MediaFile>
+    ): List<MediaFile> {
+        return mediaFiles.mapIndexed { index, mediaFile -> run {
+            mediaFile.alt = StoryFrameItem.getAltTextFromFrameAddedViews(frames[index])
+            mediaFile
+        }
+            mediaFile
+        }
+    }
+
     private fun createGBStoryBlockStringFromJson(storyBlock: StoryBlockData): String {
         val gson = Gson()
         return HEADING_START + gson.toJson(storyBlock) + HEADING_END + DIV_PART + CLOSING_TAG

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -499,6 +499,10 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                 }
             }
 
+            viewModel.onStorySaved()
+            // TODO add tracks
+            processStorySaving()
+
             val savedContentIntent = Intent()
             val blockId = intent.extras?.getString(ARG_STORY_BLOCK_ID)
             savedContentIntent.putExtra(ARG_STORY_BLOCK_ID, blockId)
@@ -509,6 +513,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                 // if not, let's use the current Story
                 storyIndex = storyRepositoryWrapper.getCurrentStoryIndex()
             }
+
             // if we are editing this Story Block, then the id is assured to be a remote media file id, but
             // the frame no longer points to such media Id on the site given we are just about to save a
             // new flattened media. Hence, we need to set a new temporary Id we can use to identify
@@ -523,12 +528,6 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
 
             savedContentIntent.putExtra(ARG_STORY_BLOCK_UPDATED_CONTENT, updatedStoryBlock)
             setResult(Activity.RESULT_OK, savedContentIntent)
-
-            viewModel.onStorySaved()
-
-            // TODO add tracks
-            processStorySaving()
-
             finish()
         } else {
             // assume this is a new Post, and proceed to PrePublish bottom sheet
@@ -573,6 +572,8 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                             val mediaModel = mediaStore.getSiteMediaWithId(site, it.toLong())
                             val mediaFile = fluxCUtilsWrapper.mediaFileFromMediaModel(mediaModel)
                             mediaFile?.let { mediafile ->
+                                mediaFile.alt = StoryFrameItem.getAltTextFromFrameAddedViews(frame)
+                                mediaModel.alt = mediaFile.alt
                                 val storyMediaFileData =
                                         saveStoryGutenbergBlockUseCase.buildMediaFileDataWithTemporaryId(
                                                 mediaFile = mediafile,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
@@ -111,7 +111,7 @@ class StoryMediaSaveUploadBridge @Inject constructor(
             val localEditorMediaListener = object : EditorMediaListener {
                 override fun appendMediaFiles(mediaFiles: Map<String, MediaFile>) {
                     if (!isEditMode) {
-                        assignAltOnEachMediaFile(frames, ArrayList(mediaFiles.values))
+                        saveStoryGutenbergBlockUseCase.assignAltOnEachMediaFile(frames, ArrayList(mediaFiles.values))
                         saveStoryGutenbergBlockUseCase.buildJetpackStoryBlockInPost(
                                 editPostRepository,
                                 ArrayList(mediaFiles.values)
@@ -222,18 +222,6 @@ class StoryMediaSaveUploadBridge @Inject constructor(
 
     private fun cancelAddMediaToEditorActions() {
         job.cancel()
-    }
-
-    private fun assignAltOnEachMediaFile(
-        frames: List<StoryFrameItem>,
-        mediaFiles: ArrayList<MediaFile>
-    ): List<MediaFile> {
-        return mediaFiles.mapIndexed { index, mediaFile -> run {
-                mediaFile.alt = StoryFrameItem.getAltTextFromFrameAddedViews(frames[index])
-                mediaFile
-            }
-            mediaFile
-        }
     }
 
     @Subscribe(sticky = true, threadMode = MAIN)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
@@ -96,16 +96,22 @@ class StoryMediaSaveUploadBridge @Inject constructor(
     private fun addNewStoryFrameMediaItemsToPostAndUploadAsync(site: SiteModel, saveResult: StorySaveResult) {
         // let's invoke the UploadService and enqueue all the files that were saved by the FrameSaveService
         val frames = storyRepositoryWrapper.getStoryAtIndex(saveResult.storyIndex).frames
-        val uriList = frames.map { Uri.fromFile(it.composedFrameFile) }
-        addNewMediaItemsToPostAsync(site, uriList, saveResult.isEditMode)
+        addNewMediaItemsInStoryFramesToPostAsync(site, frames, saveResult.isEditMode)
     }
 
-    private fun addNewMediaItemsToPostAsync(site: SiteModel, uriList: List<Uri>, isEditMode: Boolean) {
+    private fun addNewMediaItemsInStoryFramesToPostAsync(
+        site: SiteModel,
+        frames: List<StoryFrameItem>,
+        isEditMode: Boolean
+    ) {
+        val uriList = frames.map { Uri.fromFile(it.composedFrameFile) }
+
         // this is similar to addNewMediaItemsToEditorAsync in EditorMedia
         launch {
             val localEditorMediaListener = object : EditorMediaListener {
                 override fun appendMediaFiles(mediaFiles: Map<String, MediaFile>) {
                     if (!isEditMode) {
+                        assignAltOnEachMediaFile(frames, ArrayList(mediaFiles.values))
                         saveStoryGutenbergBlockUseCase.buildJetpackStoryBlockInPost(
                                 editPostRepository,
                                 ArrayList(mediaFiles.values)
@@ -135,44 +141,42 @@ class StoryMediaSaveUploadBridge @Inject constructor(
 
                     // here we change the ids on the actual StoryFrameItems, and also update the flattened / composed image
                     // urls with the new URLs which may have been replaced after image optimization
-                    for (story in storyRepositoryWrapper.getImmutableStories()) {
-                        // find the MediaModel for a given Uri from composedFrameFile
-                        for (frame in story.frames) {
-                            // if the old URI in frame.composedFrameFile exists as a key in the passed map, then update that
-                            // value with the new (probably optimized) URL and also keep track of the new id.
-                            val oldUri = Uri.fromFile(frame.composedFrameFile)
-                            val mediaModel = oldUriToMediaFiles.get(oldUri)
-                            mediaModel?.let {
-                                val oldTemporaryId = frame.id ?: ""
-                                frame.id = it.id.toString()
+                    // find the MediaModel for a given Uri from composedFrameFile
+                    for (frame in frames) {
+                        // if the old URI in frame.composedFrameFile exists as a key in the passed map, then update that
+                        // value with the new (probably optimized) URL and also keep track of the new id.
+                        val oldUri = Uri.fromFile(frame.composedFrameFile)
+                        val mediaModel = oldUriToMediaFiles.get(oldUri)
+                        mediaModel?.let {
+                            val oldTemporaryId = frame.id ?: ""
+                            frame.id = it.id.toString()
 
-                                // if prefs has this Slide with the temporary key, replace it
-                                // if not, let's now save the new slide with the local key
-                                storiesPrefs.replaceTempMediaIdKeyedSlideWithLocalMediaIdKeyedSlide(
-                                        TempId(oldTemporaryId),
-                                        LocalId(it.id),
-                                        it.localSiteId.toLong()
-                                ) ?: storiesPrefs.saveSlideWithLocalId(
-                                        it.localSiteId.toLong(),
-                                        // use the local id to save the original, will be replaced later
-                                        // with mediaModel.mediaId after uploading to the remote site
-                                        LocalId(it.id),
-                                        frame
+                            // if prefs has this Slide with the temporary key, replace it
+                            // if not, let's now save the new slide with the local key
+                            storiesPrefs.replaceTempMediaIdKeyedSlideWithLocalMediaIdKeyedSlide(
+                                    TempId(oldTemporaryId),
+                                    LocalId(it.id),
+                                    it.localSiteId.toLong()
+                            ) ?: storiesPrefs.saveSlideWithLocalId(
+                                    it.localSiteId.toLong(),
+                                    // use the local id to save the original, will be replaced later
+                                    // with mediaModel.mediaId after uploading to the remote site
+                                    LocalId(it.id),
+                                    frame
+                            )
+
+                            // for editMode, we'll need to tell the Gutenberg Editor to replace their mediaFiles
+                            // ids with the new MediaModel local ids are created so, broadcasting the event.
+                            if (isEditMode) {
+                                // finally send the event that this frameId has changed
+                                EventBus.getDefault().post(
+                                        StoryFrameMediaModelCreatedEvent(
+                                                oldTemporaryId,
+                                                it.id,
+                                                oldUri.toString(),
+                                                frame
+                                        )
                                 )
-
-                                // for editMode, we'll need to tell the Gutenberg Editor to replace their mediaFiles
-                                // ids with the new MediaModel local ids are created so, broadcasting the event.
-                                if (isEditMode) {
-                                    // finally send the event that this frameId has changed
-                                    EventBus.getDefault().post(
-                                            StoryFrameMediaModelCreatedEvent(
-                                                    oldTemporaryId,
-                                                    it.id,
-                                                    oldUri.toString(),
-                                                    frame
-                                            )
-                                    )
-                                }
                             }
                         }
                     }
@@ -215,6 +219,18 @@ class StoryMediaSaveUploadBridge @Inject constructor(
 
     private fun cancelAddMediaToEditorActions() {
         job.cancel()
+    }
+
+    private fun assignAltOnEachMediaFile(
+        frames: List<StoryFrameItem>,
+        mediaFiles: ArrayList<MediaFile>
+    ): List<MediaFile> {
+        return mediaFiles.mapIndexed { index, mediaFile -> run {
+                mediaFile.alt = StoryFrameItem.getAltTextFromFrameAddedViews(frames[index])
+                mediaFile
+            }
+            mediaFile
+        }
     }
 
     @Subscribe(sticky = true, threadMode = MAIN)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
@@ -151,6 +151,9 @@ class StoryMediaSaveUploadBridge @Inject constructor(
                             val oldTemporaryId = frame.id ?: ""
                             frame.id = it.id.toString()
 
+                            // set alt text on MediaModel too
+                            mediaModel.alt = StoryFrameItem.getAltTextFromFrameAddedViews(frame)
+
                             // if prefs has this Slide with the temporary key, replace it
                             // if not, let's now save the new slide with the local key
                             storiesPrefs.replaceTempMediaIdKeyedSlideWithLocalMediaIdKeyedSlide(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
@@ -193,10 +193,12 @@ class SaveStoryGutenbergBlockUseCaseTest : BaseUnitTest() {
         whenever(mediaFile.id).thenReturn(TestContent.localMediaId.toInt())
         whenever(mediaFile.fileURL).thenReturn(TestContent.localImageUrl)
         whenever(mediaFile.mimeType).thenReturn(TestContent.storyMediaFileMimeTypeImage)
+        whenever(mediaFile.alt).thenReturn("")
 
         whenever(mediaFile2.id).thenReturn(TestContent.localMediaId2.toInt())
         whenever(mediaFile2.fileURL).thenReturn(TestContent.localImageUrl2)
         whenever(mediaFile2.mimeType).thenReturn(TestContent.storyMediaFileMimeTypeImage)
+        whenever(mediaFile2.alt).thenReturn("")
 
         val mediaFiles = ArrayList<MediaFile>()
         mediaFiles.add(mediaFile)
@@ -221,6 +223,7 @@ class SaveStoryGutenbergBlockUseCaseTest : BaseUnitTest() {
                     mediaFile.id = i
                     mediaFile.mediaId = (i + 1000).toString()
                     mediaFile.mimeType = "image/jpeg"
+                    mediaFile.alt = ""
                     mediaFile.fileURL = "https://testsite.files.wordpress.com/2020/10/wp-0000000.jpg"
                     mediaFiles.add(mediaFile)
                 }
@@ -234,6 +237,7 @@ class SaveStoryGutenbergBlockUseCaseTest : BaseUnitTest() {
         mediaFile.id = id
         mediaFile.mediaId = (id + 1000).toString()
         mediaFile.mimeType = "image/jpeg"
+        mediaFile.alt = ""
         mediaFile.fileURL = "https://testsite.files.wordpress.com/2020/10/wp-0000000.jpg"
         return mediaFile
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
     ext.buildGutenbergMobileJSBundle = 1
-    ext.wordPressUtilsVersion = '60-4c7dbb04b1442d87166fa7608957cbb52157e412' // '1.30.1'
+    ext.wordPressUtilsVersion = '1.30.2'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
     ext.buildGutenbergMobileJSBundle = 1
-    ext.wordPressUtilsVersion = '1.30.1'
+    ext.wordPressUtilsVersion = '60-4c7dbb04b1442d87166fa7608957cbb52157e412' // '1.30.1'
 
     repositories {
         google()


### PR DESCRIPTION
Fixes accessibility problems by setting the `alt` attribute on Media files properly, with the added text on Story frames images:
- we're setting the `alt` attribute on the Story block itself, for each media item composing a Story frame
- we're also setting the  `alt` attribute on the composed image that was uploaded to the Media section of the site, so in case it's used elsewhere the `alt` attribute will be set.

Related PRs:
- Stories library https://github.com/Automattic/stories-android/pull/631
- WordPressUtils https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/60

_**Note: once the WordPressUtils PR is merged, let's update the `build.gradle` reference in this PR with the latest  `versionName` given.**_

To test:
1.  create a story with one or more slides
2. add some text to each slide
3. verify the uploaded html contains the `alt` attribute populated with the text you entered in step 2.
4. verify the media item in the media section contains the Alternative text set properly.

Example
The following html corresponds to a Story post with one slide, which has the word "hello" as an added view:
```
<!-- wp:jetpack/story {"mediaFiles":[{"alt":"hello","caption":"","id":"1767","link":"https://testmzorz3.files.wordpress.com/2021/01/wp_story1610815157231_0.jpg","mime":"image/jpeg","type":"image","url":"https://testmzorz3.files.wordpress.com/2021/01/wp_story1610815157231_0.jpg"}]} -->
<div class="wp-block-jetpack-story wp-story"></div>
<!-- /wp:jetpack/story -->
```

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
