### PR TITLE
Issue/13326 fetch fix threats status usecase

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCase.kt
@@ -1,0 +1,81 @@
+package org.wordpress.android.ui.jetpack.scan.usecases
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import org.wordpress.android.fluxc.model.scan.threat.FixThreatStatusModel
+import org.wordpress.android.fluxc.model.scan.threat.FixThreatStatusModel.FixStatus
+import org.wordpress.android.fluxc.store.ScanStore
+import org.wordpress.android.fluxc.store.ScanStore.FetchFixThreatsStatusPayload
+import org.wordpress.android.modules.IO_THREAD
+import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.Complete
+import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.Failure
+import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.InProgress
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.NetworkUtilsWrapper
+import javax.inject.Inject
+import javax.inject.Named
+
+private const val FETCH_FIX_THREATS_STATUS_DELAY_MILLIS = 5000L
+
+class FetchFixThreatsStatusUseCase @Inject constructor(
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val scanStore: ScanStore,
+    @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
+) {
+    suspend fun fetchFixThreatsStatus(
+        remoteSiteId: Long,
+        fixableThreatIds: List<Long>,
+        delayInMs: Long = FETCH_FIX_THREATS_STATUS_DELAY_MILLIS
+    ): Flow<FetchFixThreatsState> = flow {
+        while (true) {
+            if (!networkUtilsWrapper.isNetworkAvailable()) {
+                emit(Failure.NetworkUnavailable)
+                return@flow
+            }
+
+            val result = scanStore.fetchFixThreatsStatus(FetchFixThreatsStatusPayload(remoteSiteId, fixableThreatIds))
+            if (result.isError) {
+                emit(Failure.RemoteRequestFailure)
+                return@flow
+            } else {
+                val fixState = mapToFixState(result.fixThreatStatusModels, fixableThreatIds)
+                emit(fixState)
+                if (fixState == InProgress) {
+                    delay(delayInMs)
+                } else {
+                    return@flow
+                }
+            }
+        }
+    }.flowOn(ioDispatcher)
+
+    private fun mapToFixState(models: List<FixThreatStatusModel>, fixableThreatIds: List<Long>): FetchFixThreatsState {
+        val isFixing = models.any { it.status == FixStatus.IN_PROGRESS }
+        val isFixingComplete = models.filter { it.status == FixStatus.FIXED }.size == fixableThreatIds.size
+        val containsError = models.any { it.error != null }
+
+        return when {
+            isFixing -> InProgress
+            isFixingComplete -> Complete
+            else -> {
+                // TODO ashiagr replace AppLog tag
+                if (containsError) AppLog.e(T.API, models.filter { it.error != null }.toString())
+                Failure.FixFailure
+            }
+        }
+    }
+
+    sealed class FetchFixThreatsState {
+        object InProgress : FetchFixThreatsState()
+        object Complete : FetchFixThreatsState()
+        sealed class Failure : FetchFixThreatsState() {
+            object NetworkUnavailable : Failure()
+            object RemoteRequestFailure : Failure()
+            object FixFailure : Failure()
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
@@ -106,7 +106,7 @@ class FetchFixThreatsStatusUseCaseTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when threats fix status is fetched, then FixFailure is returned if result model contains error`() = test {
+    fun `given result model contains error, when threats fix status is fetched, then FixFailure is returned`() = test {
         val storeResultWithErrorFixStatusModel = OnFixThreatsStatusFetched(
             fakeSiteId,
             listOf(fakeFixThreatsStatusModel.copy(status = FixStatus.UNKNOWN, error = "not_found")),

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
@@ -1,0 +1,123 @@
+package org.wordpress.android.ui.jetpack.scan.usecases
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.action.ScanAction.FETCH_FIX_THREATS_STATUS
+import org.wordpress.android.fluxc.model.scan.threat.FixThreatStatusModel
+import org.wordpress.android.fluxc.model.scan.threat.FixThreatStatusModel.FixStatus
+import org.wordpress.android.fluxc.store.ScanStore
+import org.wordpress.android.fluxc.store.ScanStore.FixThreatsStatusError
+import org.wordpress.android.fluxc.store.ScanStore.FixThreatsStatusErrorType
+import org.wordpress.android.fluxc.store.ScanStore.OnFixThreatsStatusFetched
+import org.wordpress.android.test
+import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.Complete
+import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.Failure
+import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.InProgress
+import org.wordpress.android.util.NetworkUtilsWrapper
+
+@InternalCoroutinesApi
+class FetchFixThreatsStatusUseCaseTest : BaseUnitTest() {
+    private lateinit var useCase: FetchFixThreatsStatusUseCase
+    @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    @Mock lateinit var scanStore: ScanStore
+
+    private val delayInMs = 0L
+    private val fakeSiteId = 1L
+    private val fakeThreatId = 11L
+    private val fakeFixThreatsStatusModel = FixThreatStatusModel(fakeThreatId, FixStatus.IN_PROGRESS)
+
+    private val storeResultWithInProgressFixStatusModel = OnFixThreatsStatusFetched(
+        fakeSiteId,
+        listOf(fakeFixThreatsStatusModel),
+        FETCH_FIX_THREATS_STATUS
+    )
+
+    private val storeResultWithFixedFixStatusModel = storeResultWithInProgressFixStatusModel.copy(
+        fixThreatStatusModels = listOf(fakeFixThreatsStatusModel.copy(status = FixStatus.FIXED))
+    )
+
+    @Before
+    fun setup() {
+        useCase = FetchFixThreatsStatusUseCase(networkUtilsWrapper, scanStore, TEST_DISPATCHER)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+    }
+
+    @Test
+    fun `given no network, when threats fix status is fetched, then NetworkUnavailable is returned`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(fakeThreatId))
+            .toList(mutableListOf())
+            .last()
+
+        assertThat(useCaseResult).isEqualTo(Failure.NetworkUnavailable)
+    }
+
+    @Test
+    fun `when in progress threats fix status is fetched, then polling occurs until in progress status changes`() =
+        test {
+            whenever(scanStore.fetchFixThreatsStatus(any()))
+                .thenReturn(storeResultWithInProgressFixStatusModel)
+                .thenReturn(storeResultWithInProgressFixStatusModel)
+                .thenReturn(storeResultWithFixedFixStatusModel)
+
+            val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(fakeThreatId), delayInMs)
+                .toList(mutableListOf())
+
+            verify(scanStore, times(3)).fetchFixThreatsStatus(any())
+            assertThat(useCaseResult).containsSequence(InProgress, InProgress, Complete)
+        }
+
+    @Test
+    fun `given threats fixed successfully, when threats fix status is fetched, then Complete is returned`() = test {
+        whenever(scanStore.fetchFixThreatsStatus(any())).thenReturn(storeResultWithFixedFixStatusModel)
+
+        val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(fakeThreatId))
+            .toList(mutableListOf())
+            .last()
+
+        assertThat(useCaseResult).isEqualTo(Complete)
+    }
+
+    @Test
+    fun `given invalid response, when threats fix status is fetched, then RemoteRequestFailure is returned`() = test {
+        val storeResultWithGenericError = OnFixThreatsStatusFetched(
+            fakeSiteId,
+            FixThreatsStatusError(FixThreatsStatusErrorType.INVALID_RESPONSE),
+            FETCH_FIX_THREATS_STATUS
+        )
+        whenever(scanStore.fetchFixThreatsStatus(any())).thenReturn(storeResultWithGenericError)
+
+        val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(fakeThreatId))
+            .toList(mutableListOf())
+            .last()
+
+        assertThat(useCaseResult).isEqualTo(Failure.RemoteRequestFailure)
+    }
+
+    @Test
+    fun `when threats fix status is fetched, then FixFailure is returned if result model contains error`() = test {
+        val storeResultWithErrorFixStatusModel = OnFixThreatsStatusFetched(
+            fakeSiteId,
+            listOf(fakeFixThreatsStatusModel.copy(status = FixStatus.UNKNOWN, error = "not_found")),
+            FETCH_FIX_THREATS_STATUS
+        )
+        whenever(scanStore.fetchFixThreatsStatus(any())).thenReturn(storeResultWithErrorFixStatusModel)
+
+        val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(fakeThreatId))
+            .toList(mutableListOf())
+            .last()
+
+        assertThat(useCaseResult).isEqualTo(Failure.FixFailure)
+    }
+}


### PR DESCRIPTION
Parent #13798
This PR adds use case to fetch fix threats status.

To test:
That `FetchFixThreatsStatusUseCaseTest` tests run fine and cover action results.

Merge Instructions

1. Make sure child PR #13795 is merged to develop
2. Remove the "Not Ready for Merge label"
3. Merge this PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
