### PR TITLE
Adding more unit test coverage to SubfilterViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -214,7 +214,9 @@ class SubFilterViewModel @Inject constructor(
                 UpdateTask.FOLLOWED_BLOGS
         ))
         _bottomSheetUiState.value = Event(BottomSheetVisible(
-                mTagFragmentStartedWith?.let { UiStringText(it.label) } ?: UiStringRes(R.string.reader_filter_main_title),
+                mTagFragmentStartedWith?.let {
+                    UiStringText(it.label)
+                } ?: UiStringRes(R.string.reader_filter_main_title),
                 if (mTagFragmentStartedWith?.organization == NO_ORGANIZATION) listOf(SITES, TAGS) else listOf(SITES)
         ))
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -361,9 +361,9 @@ class SubFilterViewModel @Inject constructor(
     }
 
     override fun onCleared() {
-    super.onCleared()
-    eventBusWrapper.unregister(this)
-}
+        super.onCleared()
+        eventBusWrapper.unregister(this)
+    }
 
     companion object {
         const val SUBFILTER_VM_BASE_KEY = "SUBFILTER_VIEW_MODEL_BASE_KEY"

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
@@ -3,6 +3,9 @@ package org.wordpress.android.ui.reader.subfilter
 import android.os.Bundle
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -22,16 +25,26 @@ import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType.BOOKMARKED
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.ReaderSubsActivity
+import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
+import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask
 import org.wordpress.android.ui.reader.subfilter.ActionType.OpenLoginPage
 import org.wordpress.android.ui.reader.subfilter.ActionType.OpenSubsAtPage
 import org.wordpress.android.ui.reader.subfilter.BottomSheetUiState.BottomSheetHidden
+import org.wordpress.android.ui.reader.subfilter.BottomSheetUiState.BottomSheetVisible
+import org.wordpress.android.ui.reader.subfilter.SubFilterViewModel.Companion
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.SITES
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.TAGS
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SITE
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.SITE_ALL
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.ItemType.TAG
+import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Site
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.SiteAll
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.tracker.ReaderTrackerType
+import org.wordpress.android.ui.reader.viewmodels.ReaderModeInfo
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.EventBusWrapper
 import java.util.EnumSet
 
@@ -52,18 +65,15 @@ class SubFilterViewModelTest {
     @Mock private lateinit var eventBusWrapper: EventBusWrapper
     @Mock private lateinit var accountStore: AccountStore
     @Mock private lateinit var readerTracker: ReaderTracker
-    @Mock private lateinit var siteStore: SiteStore
+    @Mock private lateinit var savedState: Bundle
+    @Mock private lateinit var filter: SubfilterListItem
 
     private lateinit var viewModel: SubFilterViewModel
 
     @Before
     fun setUp() {
+        whenever(initialTag.label).thenReturn("tag-label")
         whenever(savedTag.tagTitle).thenReturn("tag-title")
-        val tag = Tag(
-                tag = savedTag,
-                onClickAction = ::onClickActionDummy
-        )
-        val json = "{\"blogId\":0,\"feedId\":0,\"tagSlug\":\"news\",\"tagType\":1,\"type\":4}"
 
         viewModel = SubFilterViewModel(
                 TEST_DISPATCHER,
@@ -75,22 +85,63 @@ class SubFilterViewModelTest {
                 readerTracker
         )
 
-        val bundle = Bundle()
-        bundle.putString(SubFilterViewModel.ARG_CURRENT_SUBFILTER_JSON, json)
-        bundle.putBoolean(SubFilterViewModel.ARG_IS_FIRST_LOAD, false)
-
-        viewModel.start(initialTag, any(), bundle)
+        viewModel.start(initialTag, savedTag, savedState)
     }
 
     @Test
-    fun `view model tracks subfiltered list if filter is a tracked item`() {
-        viewModel.setSubfilterFromTag(savedTag)
-        viewModel.initSubfiltersTracking(true)
+    fun `current subfilter is set back when we have a previous intance state`() {
+        val json = "{\"blogId\":0,\"feedId\":0,\"tagSlug\":\"news\",\"tagType\":1,\"type\":4}"
 
+        whenever(savedState.getString(SubFilterViewModel.ARG_CURRENT_SUBFILTER_JSON)).thenReturn(json)
+        whenever(subfilterListItemMapper.fromJson(eq(json), any(), any())).thenReturn(filter)
+
+        viewModel = SubFilterViewModel(
+                TEST_DISPATCHER,
+                TEST_DISPATCHER,
+                appPrefsWrapper,
+                subfilterListItemMapper,
+                eventBusWrapper,
+                accountStore,
+                readerTracker
+        )
+
+        viewModel.start(initialTag, savedTag, savedState)
+
+        assertThat(viewModel.getCurrentSubfilterValue()).isEqualTo(filter)
+    }
+
+    @Test
+    fun `view model start and stop tracking subfiltered list if filter is a tracked item`() {
+        viewModel.setSubfilterFromTag(savedTag)
+
+        // this is done to focus this unit test only on effects of initSubfiltersTracking
+        // usually it's not considered great to use this function but here it seemed
+        // fair enough for the scope
+        // (see https://javadoc.io/static/org.mockito/mockito-core/3.7.7/org/mockito/Mockito.html#resetting_mocks)
+        reset(readerTracker)
+
+        viewModel.initSubfiltersTracking(true)
         viewModel.initSubfiltersTracking(false)
 
-        verify(readerTracker, times(2)).start(ReaderTrackerType.SUBFILTERED_LIST)
+        verify(readerTracker, times(1)).start(ReaderTrackerType.SUBFILTERED_LIST)
         verify(readerTracker, times(1)).stop(ReaderTrackerType.SUBFILTERED_LIST)
+    }
+
+    @Test
+    fun `view model doesn't start tracking subfiltered list if filter is a not tracked item`() {
+        viewModel.setDefaultSubfilter()
+
+        // this is done to focus this unit test only on effects of initSubfiltersTracking
+        // usually it's not considered great to use this function but here it seemed
+        // fair enough for the scope
+        // (see https://javadoc.io/static/org.mockito/mockito-core/3.7.7/org/mockito/Mockito.html#resetting_mocks)
+        reset(readerTracker)
+
+        viewModel.initSubfiltersTracking(true)
+        viewModel.initSubfiltersTracking(false)
+
+        verify(readerTracker, times(0)).start(ReaderTrackerType.SUBFILTERED_LIST)
+        verify(readerTracker, times(2)).stop(ReaderTrackerType.SUBFILTERED_LIST)
     }
 
     @Test
@@ -102,6 +153,7 @@ class SubFilterViewModelTest {
     fun `view model is able to set requested subfilter given a tag`() {
         val tag = ReaderTag("", "", "", "", BOOKMARKED)
         var item: SubfilterListItem? = null
+
         viewModel.setSubfilterFromTag(tag)
 
         viewModel.currentSubFilter.observeForever { item = it }
@@ -221,8 +273,7 @@ class SubFilterViewModelTest {
 
         assertThat(viewModel.updateTagsAndSites.value).isEqualTo(null)
 
-        // we didn't call start so noone should have changed the value
-        assertThat(viewModel.currentSubFilter.value).isEqualTo(null)
+        assertThat(viewModel.currentSubFilter.value).isInstanceOf(SiteAll::class.java)
     }
 
     @Test
@@ -238,11 +289,147 @@ class SubFilterViewModelTest {
 
         assertThat(viewModel.updateTagsAndSites.value).isEqualTo(null)
 
-        // we didn't call start so noone should have changed the value
-        assertThat(viewModel.currentSubFilter.value).isEqualTo(null)
+        assertThat(viewModel.currentSubFilter.value).isInstanceOf(SiteAll::class.java)
     }
 
-    private fun onClickActionDummy(filter: SubfilterListItem) {
-        return
+    @Test
+    fun `view model updates the tags and sites and asks to show the bottom sheet when filters button is tapped`() {
+        var updateTasks: EnumSet<ReaderUpdateLogic.UpdateTask>? = null
+        var uiState: BottomSheetUiState? = null
+
+        viewModel.updateTagsAndSites.observeForever { updateTasks = it.peekContent() }
+        viewModel.bottomSheetUiState.observeForever { uiState = it.peekContent() }
+
+        viewModel.onSubFiltersListButtonClicked()
+
+        assertThat(updateTasks).isEqualTo(EnumSet.of(
+                UpdateTask.TAGS,
+                UpdateTask.FOLLOWED_BLOGS
+        ))
+
+        assertThat(uiState).isInstanceOf(BottomSheetVisible::class.java)
+    }
+
+    @Test
+    fun `view model hides the bottom sheet when it is cancelled`() {
+        var uiState: BottomSheetUiState? = null
+
+        viewModel.bottomSheetUiState.observeForever { uiState = it.peekContent() }
+
+        viewModel.onBottomSheetCancelled()
+
+        assertThat(uiState).isInstanceOf(BottomSheetHidden::class.java)
+    }
+
+    @Test
+    fun `bottom sheet is hidden when a filter is tapped on`() {
+        var uiState: BottomSheetUiState? = null
+        val filter: SubfilterListItem = mock()
+
+        viewModel.setSubfilterFromTag(savedTag)
+
+        viewModel.bottomSheetUiState.observeForever { uiState = it.peekContent() }
+
+        viewModel.getCurrentSubfilterValue().onClickAction!!.invoke(filter)
+
+        assertThat(uiState).isInstanceOf(BottomSheetHidden::class.java)
+    }
+
+    @Test
+    fun `onSaveInstanceState puts expected parameters in the bundle`() {
+        val outState: Bundle = mock()
+        whenever(subfilterListItemMapper.toJson(any())).thenReturn("test-json")
+
+        viewModel.onSaveInstanceState(outState)
+
+        verify(outState, times(1)).putString(eq(Companion.ARG_CURRENT_SUBFILTER_JSON), any())
+        verify(outState, times(1)).putBoolean(eq(Companion.ARG_IS_FIRST_LOAD), any())
+    }
+
+    @Test
+    fun `view model start register event bus`() {
+        verify(eventBusWrapper, times(1)).register(viewModel)
+    }
+
+    @Test
+    fun `onSubfilterSelected requests newer posts`() {
+        val filter: SubfilterListItem = mock()
+        var readerModeInfo: ReaderModeInfo? = null
+
+        whenever(filter.type).thenReturn(SITE_ALL)
+        whenever(filter.label).thenReturn(UiStringText("test-label"))
+
+        viewModel.readerModeInfo.observeForever { readerModeInfo = it }
+
+        viewModel.onSubfilterSelected(filter)
+
+        assertThat(readerModeInfo!!.requestNewerPosts).isTrue()
+    }
+
+    @Test
+    fun `onSubfilterReselected does not request newer posts`() {
+        var readerModeInfo: ReaderModeInfo? = null
+
+        viewModel.readerModeInfo.observeForever { readerModeInfo = it }
+
+        viewModel.onSubfilterReselected()
+        assertThat(readerModeInfo!!.requestNewerPosts).isFalse()
+    }
+
+    @Test
+    fun `onSubfilterSelected set expected readerModeInfo when filters are removed`() {
+        val filter: SubfilterListItem = mock()
+        var readerModeInfo: ReaderModeInfo? = null
+
+        whenever(filter.type).thenReturn(SITE_ALL)
+        whenever(filter.label).thenReturn(UiStringText("test-label"))
+
+        viewModel.readerModeInfo.observeForever { readerModeInfo = it }
+
+        viewModel.onSubfilterSelected(filter)
+
+        requireNotNull(readerModeInfo).let {
+            assertThat(it.listType).isEqualTo(ReaderPostListType.TAG_FOLLOWED)
+            assertThat(it.blogId).isEqualTo(0L)
+            assertThat(it.feedId).isEqualTo(0L)
+            assertThat(it.isFiltered).isEqualTo(false)
+        }
+    }
+
+    @Test
+    fun `onSubfilterSelected set expected readerModeInfo when a site filter was tapped`() {
+        val filter: Site = mock()
+        var readerModeInfo: ReaderModeInfo? = null
+
+        whenever(filter.type).thenReturn(SITE)
+        whenever(filter.label).thenReturn(UiStringText("test-label"))
+        whenever(filter.blog).thenReturn(mock())
+
+        viewModel.readerModeInfo.observeForever { readerModeInfo = it }
+
+        viewModel.onSubfilterSelected(filter)
+
+        requireNotNull(readerModeInfo).let {
+            assertThat(it.listType).isEqualTo(ReaderPostListType.BLOG_PREVIEW)
+            assertThat(it.isFiltered).isEqualTo(true)
+        }
+    }
+
+    @Test
+    fun `onSubfilterSelected set expected readerModeInfo when a tag filter was tapped`() {
+        val filter: Tag = mock()
+        var readerModeInfo: ReaderModeInfo? = null
+
+        whenever(filter.type).thenReturn(TAG)
+        whenever(filter.label).thenReturn(UiStringText("test-label"))
+
+        viewModel.readerModeInfo.observeForever { readerModeInfo = it }
+
+        viewModel.onSubfilterSelected(filter)
+
+        requireNotNull(readerModeInfo).let {
+            assertThat(it.listType).isEqualTo(ReaderPostListType.TAG_FOLLOWED)
+            assertThat(it.isFiltered).isEqualTo(true)
+        }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
@@ -20,7 +20,6 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType.BOOKMARKED
 import org.wordpress.android.ui.prefs.AppPrefsWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
@@ -351,7 +351,7 @@ class SubFilterViewModelTest {
     }
 
     @Test
-    fun `onSubfilterSelected requests newer posts`() {
+    fun `onSubfilterSelected requests newer posts when new filter is selected`() {
         val filter: SubfilterListItem = mock()
         var readerModeInfo: ReaderModeInfo? = null
 
@@ -366,7 +366,7 @@ class SubFilterViewModelTest {
     }
 
     @Test
-    fun `onSubfilterReselected does not request newer posts`() {
+    fun `onSubfilterReselected does not request newer posts when already selected filter is re-selected`() {
         var readerModeInfo: ReaderModeInfo? = null
 
         viewModel.readerModeInfo.observeForever { readerModeInfo = it }


### PR DESCRIPTION
This PR is a follow up to the #13766 and adds more unit testing coverage to the `SubfilterViewModel`

## To test
Should be enough to check the CI pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
