### PR TITLE
[Gutenberg] Add Cover block media settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3332,6 +3332,14 @@ public class EditPostActivity extends LocaleAwareActivity implements
         ActivityLauncher.viewSuggestionsForResult(this, mSite, type);
     }
 
+    @Override public void onGutenbergEditorSetFocalPointPickerTooltipShown(boolean tooltipShown) {
+        AppPrefs.setGutenbergFocalPointPickerTooltipShown(tooltipShown);
+    }
+
+    @Override public boolean onGutenbergEditorRequestFocalPointPickerTooltipShown() {
+        return AppPrefs.getGutenbergFocalPointPickerTooltipShown();
+    }
+
     @Override
     public void onHtmlModeToggledInToolbar() {
         toggleHtmlModeOnMenu();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -130,6 +130,7 @@ public class AppPrefs {
         SHOULD_AUTO_ENABLE_GUTENBERG_FOR_THE_NEW_POSTS,
         SHOULD_AUTO_ENABLE_GUTENBERG_FOR_THE_NEW_POSTS_PHASE_2,
         GUTENBERG_OPT_IN_DIALOG_SHOWN,
+        GUTENBERG_FOCAL_POINT_PICKER_TOOLTIP_SHOWN,
 
         IS_QUICK_START_NOTICE_REQUIRED,
         LAST_SKIPPED_QUICK_START_TASK,
@@ -887,6 +888,14 @@ public class AppPrefs {
 
     public static void removeSupportName() {
         remove(DeletablePrefKey.SUPPORT_NAME);
+    }
+
+    public static void setGutenbergFocalPointPickerTooltipShown(boolean tooltipShown) {
+        setBoolean(DeletablePrefKey.GUTENBERG_FOCAL_POINT_PICKER_TOOLTIP_SHOWN, tooltipShown);
+    }
+
+    public static boolean getGutenbergFocalPointPickerTooltipShown() {
+        return getBoolean(DeletablePrefKey.GUTENBERG_FOCAL_POINT_PICKER_TOOLTIP_SHOWN, false);
     }
 
     /*

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -208,6 +208,8 @@ public abstract class EditorFragmentAbstract extends Fragment {
         void onGutenbergEditorSessionTemplatePreviewTracked(String template);
         void showUserSuggestions(Consumer<String> onResult);
         void showXpostSuggestions(Consumer<String> onResult);
+        void onGutenbergEditorSetFocalPointPickerTooltipShown(boolean tooltipShown);
+        boolean onGutenbergEditorRequestFocalPointPickerTooltipShown();
         String getErrorMessageFromMedia(int mediaId);
         void showJetpackSettings();
         void onStoryComposerLoadRequested(ArrayList<Object> mediaFiles, String blockId);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -26,6 +26,7 @@ import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnImageFullscreenPre
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnLogGutenbergUserEventListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnReattachMediaSavingQueryListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnReattachMediaUploadQueryListener;
+import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnFocalPointPickerTooltipShownEventListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaEditorListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaLibraryButtonListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaFilesCollectionBasedBlockEditorListener;
@@ -70,6 +71,7 @@ public class GutenbergContainerFragment extends Fragment {
                                   ShowSuggestionsUtil showSuggestionsUtil,
                                   OnMediaFilesCollectionBasedBlockEditorListener
                                           onMediaFilesCollectionBasedBlockEditorListener,
+                                  OnFocalPointPickerTooltipShownEventListener onFPPTooltipShownEventListener,
                                   boolean isDarkMode) {
             mWPAndroidGlueCode.attachToContainer(
                     viewGroup,
@@ -87,6 +89,7 @@ public class GutenbergContainerFragment extends Fragment {
                     onGutenbergDidSendButtonPressedActionListener,
                     showSuggestionsUtil,
                     onMediaFilesCollectionBasedBlockEditorListener,
+                    onFPPTooltipShownEventListener,
                     isDarkMode);
     }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -67,6 +67,7 @@ import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGutenbergDidSendBu
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnLogGutenbergUserEventListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnReattachMediaSavingQueryListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnReattachMediaUploadQueryListener;
+import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnFocalPointPickerTooltipShownEventListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaLibraryButtonListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaFilesCollectionBasedBlockEditorListener;
 
@@ -455,6 +456,17 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                                 // other than the one that was actually edited. Just skip it.
                             }
                         }
+                    }
+                },
+                new OnFocalPointPickerTooltipShownEventListener() {
+                    @Override
+                    public void onSetFocalPointPickerTooltipShown(boolean tooltipShown) {
+                        mEditorFragmentListener.onGutenbergEditorSetFocalPointPickerTooltipShown(tooltipShown);
+                    }
+
+                    @Override
+                    public boolean onRequestFocalPointPickerTooltipShown() {
+                        return mEditorFragmentListener.onGutenbergEditorRequestFocalPointPickerTooltipShown();
                     }
                 },
                 GutenbergUtils.isDarkMode(getActivity()));


### PR DESCRIPTION
Fixes wordpress-mobile/gutenberg-mobile#1741

- **Guntenberg**: wordpress/gutenberg#25810
- **Gutenberg Mobile:** wordpress-mobile/gutenberg-mobile#3028
- **WordPress iOS:** wordpress-mobile/WordPress-iOS#15665

To test: Test plan in Gutenberg PR description.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.