### PR TITLE
Add icon and rename existing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItemMenuAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListItemMenuAdapter.kt
@@ -54,7 +54,7 @@ class ActivityLogListItemMenuAdapter(
             }
             DOWNLOAD_BACKUP -> {
                 textRes = R.string.activity_log_item_menu_download_backup_label
-                iconRes = R.drawable.ic_get_app_24dp
+                iconRes = R.drawable.ic_get_app_white_24dp
             }
         }
         holder.text.setText(textRes)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
@@ -34,7 +34,7 @@ class BackupDownloadStateListItemBuilder @Inject constructor() {
     ): List<JetpackListItemState> {
         val items = mutableListOf(
                 buildIconState(
-                        R.drawable.ic_get_app_24dp,
+                        R.drawable.ic_get_app_white_24dp,
                         R.string.backup_download_details_icon_content_description,
                         R.color.success_50),
                 buildHeaderState(R.string.backup_download_details_header),
@@ -65,7 +65,7 @@ class BackupDownloadStateListItemBuilder @Inject constructor() {
     ): List<JetpackListItemState> {
         return mutableListOf(
                 buildIconState(
-                        R.drawable.ic_get_app_24dp,
+                        R.drawable.ic_get_app_white_24dp,
                         R.string.backup_download_progress_icon_content_description,
                         R.color.success_50),
                 buildHeaderState(R.string.backup_download_progress_header),
@@ -86,7 +86,7 @@ class BackupDownloadStateListItemBuilder @Inject constructor() {
     ): List<JetpackListItemState> {
         return listOf(
                 buildIconState(
-                        R.drawable.ic_get_app_24dp,
+                        R.drawable.ic_cloud_done_white_24dp,
                         R.string.backup_download_complete_icon_content_description,
                         R.color.success_50),
                 buildHeaderState(R.string.backup_download_complete_header),
@@ -105,7 +105,7 @@ class BackupDownloadStateListItemBuilder @Inject constructor() {
 
     fun buildCompleteListStateErrorItems(onDoneClick: () -> Unit) = listOf(
             buildIconState(
-                    R.drawable.ic_get_app_24dp,
+                    R.drawable.ic_notice_white_24dp,
                     R.string.backup_download_complete_failed_icon_content_description,
                     R.color.error_50),
             buildDescriptionState(R.string.backup_download_complete_failed_description),

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
@@ -63,9 +63,9 @@ class RestoreStateListItemBuilder @Inject constructor() {
         onConfirmRestoreClick: () -> Unit
     ): List<JetpackListItemState> = listOf(
             buildIconState(
-                    R.drawable.ic_trophy_white_24dp,
+                    R.drawable.ic_notice_white_24dp,
                     R.string.restore_warning_icon_content_description,
-                    R.color.success_50),
+                    R.color.error_50),
             buildHeaderState(R.string.restore_warning_header),
             buildDescriptionState(published, R.string.restore_warning_description_with_two_parameters),
             buildActionButtonState(
@@ -120,7 +120,7 @@ class RestoreStateListItemBuilder @Inject constructor() {
 
     fun buildCompleteListStateErrorItems(onDoneClick: () -> Unit) = listOf(
             buildIconState(
-                    R.drawable.ic_get_app_24dp,
+                    R.drawable.ic_notice_white_24dp,
                     R.string.restore_complete_failed_icon_content_description,
                     R.color.error_50),
             buildDescriptionState(R.string.restore_complete_failed_description),

--- a/WordPress/src/main/res/drawable/ic_cloud_done_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_cloud_done_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM10,17l-3.5,-3.5 1.41,-1.41L10,14.17 15.18,9l1.41,1.41L10,17z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/WordPress/src/main/res/drawable/ic_get_app_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_get_app_white_24dp.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-      android:fillColor="#FF000000"
+      android:fillColor="@android:color/white"
       android:pathData="M19,9h-4V3H9v6H5l7,7 7,-7zM5,18v2h14v-2H5z"/>
 </vector>

--- a/WordPress/src/main/res/layout/jetpack_backup_restore_fragment.xml
+++ b/WordPress/src/main/res/layout/jetpack_backup_restore_fragment.xml
@@ -2,13 +2,16 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="@dimen/margin_medium_large">
+    android:layout_height="match_parent">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_marginBottom="@dimen/margin_extra_large"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/WordPress/src/main/res/layout/jetpack_backup_restore_fragment.xml
+++ b/WordPress/src/main/res/layout/jetpack_backup_restore_fragment.xml
@@ -8,10 +8,7 @@
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_extra_large"
-        android:layout_marginEnd="@dimen/margin_extra_large"
-        android:layout_marginTop="@dimen/margin_extra_large"
-        android:layout_marginBottom="@dimen/margin_extra_large"
+        android:layout_margin="@dimen/margin_extra_large"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/WordPress/src/main/res/layout/jetpack_list_icon_item.xml
+++ b/WordPress/src/main/res/layout/jetpack_list_icon_item.xml
@@ -13,6 +13,6 @@
         android:contentDescription="@string/jetpack_icon_content_description"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:src="@drawable/ic_get_app_24dp" />
+        tools:src="@drawable/ic_get_app_white_24dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Parent #13328

Included in this PR:
(1) Added new icon for backup download complete view `ic_cloud_done_white_24dp.xml`
(2) Change icon color to white and rename `ic_get_app_24dp.xml`  to `ic_get_app_white_24dp.xml`
(3) Moved margin start/end to recycler_view
(4) Changed error and warning icon to red round circle with exclamation point

**To test:**
- Launch the app with feature backupDownload on
- Navigate to Activity Log
- Tap more menu
- Select Backup Download
- Follow process to create a downloadable file
- Note on the final view, the icon is a green cloud with a white arrow
--------------

- Launch the app with feature restore on
- Navigate to Activity Log
- Tap more menu
- Tap Restore to this point
- Tap the Restore Site button
- Note on the warning view, the icon is a round red circle with an exclamation point

**Note:**
No other styles have changed in this PR

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
