### PR TITLE
HPP: Prevents fetch when fetching already in progress

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
@@ -108,6 +108,7 @@ class HomePagePickerViewModel @Inject constructor(
     }
 
     private fun fetchLayouts() {
+        if (_uiState.value === UiState.Loading) return
         updateUiState(UiState.Loading)
         launch {
             val event = fetchHomePageLayoutsUseCase.fetchStarterDesigns()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
@@ -286,7 +286,9 @@ class HomePagePickerViewModel @Inject constructor(
     fun onThumbnailModeChanged(mode: PreviewMode) {
         if (_previewMode.value !== mode) {
             _previewMode.value = mode
-            loadLayouts()
+            if (uiState.value is UiState.Content) {
+                loadLayouts()
+            }
         }
     }
 


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-Android/issues/13814

## Description
This PR prevents a crash occurring when a fetch is requested while fetching is already in progress 

## To test:

## Skip and back
1. Open the App on a really **slow network** connection (e.g. [on an emulator with GPS and poor signal quality](https://user-images.githubusercontent.com/304044/105164706-20100780-5b1e-11eb-82f1-28d4a60c73b4.png))
1. Start the site creation flow (e.g. *Choose site > Add button*)
1. Select the *Create WordPress.com site* option
1. Quickly tap the **skip** button
1. Quickly tap the **back** button
1. Verify that the the screen is still in loading state (animating ghost thumbnail)
1. Verify that the thumbnails eventually load

## Thumbnail mode change
1. Open the App on a really **slow network** connection (e.g. [on an emulator with GPS and poor signal quality](https://user-images.githubusercontent.com/304044/105164706-20100780-5b1e-11eb-82f1-28d4a60c73b4.png))
1. Start the site creation flow (e.g. *Choose site > Add button*)
1. Select the *Create WordPress.com site* option
1. Quickly tap the **thumbnail mode** button (next to skip) and select another mode while the screen is still in loading state (animating ghost thumbnail)
1. Verify that the thumbnails eventually load in the last selected mode

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
