### PR TITLE
Reader: add a source property when following a topic

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -346,7 +346,11 @@ public class ReaderSubsActivity extends LocaleAwareActivity
                     showInfoSnackbar(getString(R.string.reader_label_added_tag, tag.getLabel()));
                     mLastAddedTagName = tag.getTagSlug();
                     AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_FOLLOWED,
-                            new HashMap<String, String>() { { put("tag", mLastAddedTagName); }});
+                            new HashMap<String, String>() {
+                                {
+                                    put("tag", mLastAddedTagName);
+                                }
+                            });
                 } else {
                     showInfoSnackbar(getString(R.string.reader_toast_err_add_tag));
                     mLastAddedTagName = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -349,6 +349,7 @@ public class ReaderSubsActivity extends LocaleAwareActivity
                             new HashMap<String, String>() {
                                 {
                                     put("tag", mLastAddedTagName);
+                                    put("source", "unknown");
                                 }
                             });
                 } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -319,7 +319,11 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             } else {
                 if (isAskingToFollow) {
                     AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_FOLLOWED,
-                        new HashMap<String, String>() { { put("tag", slugForTracking); }});
+                            new HashMap<String, String>() {
+                                {
+                                    put("tag", slugForTracking);
+                                }
+                            });
                 } else {
                     AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_UNFOLLOWED,
                         new HashMap<String, String>() { { put("tag", slugForTracking); }});

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -322,6 +322,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                             new HashMap<String, String>() {
                                 {
                                     put("tag", slugForTracking);
+                                    put("source", "unknown");
                                 }
                             });
                 } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -196,7 +196,12 @@ class ReaderInterestsViewModel @Inject constructor(
 
     private fun trackInterests(tags: List<ReaderTag>) {
         tags.forEach { it ->
-            trackerWrapper.track(READER_TAG_FOLLOWED, mapOf("tag" to it.tagSlug))
+            trackerWrapper.track(
+                    READER_TAG_FOLLOWED,
+                    mapOf(
+                            "tag" to it.tagSlug
+                    )
+            )
         }
         trackerWrapper.track(SELECT_INTERESTS_PICKED, mapOf("quantity" to tags.size))
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -199,7 +199,8 @@ class ReaderInterestsViewModel @Inject constructor(
             trackerWrapper.track(
                     READER_TAG_FOLLOWED,
                     mapOf(
-                            "tag" to it.tagSlug
+                            "tag" to it.tagSlug,
+                            "source" to "discover"
                     )
             )
         }


### PR DESCRIPTION
Fixes #13763
Related [WordPress-iOS#15660](https://github.com/wordpress-mobile/WordPress-iOS/pull/15660)

⚠️ This PR targets a release branch, the `release/16.5`. 

Merge instruction:
- ~~Verify with Platform team that this release branch can be used as a target branch~~ ✅ ,
- ~~Remove `[Status] Not Ready for Merge` label~~ ✅ , and
- Merge as normal.

To test:
- Following from `DISCOVER` tab:
  1) Remove ALL the followed topics you might have,
  1) Go to `Reader` -> `Discover` tab,
  1) Select a few topics and tap `Done`, and
  1) Check that `reader_reader_tag_followed` analytics event is fired with a `source: discover` property.
- Following from `Manage Topics & Sites` settings screen:
  1) Go to `Reader`,
  1) Tap the ⚙️  icon (see navigation bar on the right side),
  1) Add a topic, and
  1) Check that  `reader_reader_tag_followed` analytics event is fired with a `source: unknown` property.
- Following from `Topic` screen:
  1) Find ANY post with ANY number of topics,
  1) Go to `Reader` -> `FOLLOWING` tab (or any tab for that matter),
  1) Select a post with topics,
  1) Select ANY topic,
  1) Click `Follow` to follow the topic (if not following it already), and
  1) Check that  `reader_reader_tag_followed` analytics event is fired with a `source: unknown` property.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
