### PR TITLE
Update subheader and icon for threats in fixed and ignored status

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanListItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanListItemState.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.jetpack.scan
 
+import androidx.annotation.DrawableRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.ViewType
@@ -16,6 +17,8 @@ sealed class ScanListItemState(override val type: ViewType) : JetpackListItemSta
         val isFixable: Boolean = true,
         val header: UiString,
         val subHeader: UiString,
+        @DrawableRes val icon: Int,
+        @DrawableRes val iconBackground: Int,
         val onClick: () -> Unit
     ) : ScanListItemState(
         ViewType.THREAT_ITEM

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/adapters/viewholders/ThreatViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/adapters/viewholders/ThreatViewHolder.kt
@@ -18,6 +18,8 @@ class ThreatViewHolder(
             threat_header.text = getTextOfUiString(itemView.context, threatItemState.header)
             threat_sub_header.text = getTextOfUiString(itemView.context, threatItemState.subHeader)
         }
+        threat_icon.setImageResource(itemUiState.icon)
+        threat_icon.setBackgroundResource(itemUiState.iconBackground)
         itemView.setOnClickListener { threatItemState.onClick.invoke() }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.jetpack.scan.builders
 
+import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import dagger.Reusable
@@ -64,7 +65,7 @@ class ScanStateListItemsBuilder @Inject constructor(
     ): List<JetpackListItemState> {
         val items = mutableListOf<JetpackListItemState>()
 
-        val scanIcon = buildScanIcon(R.drawable.ic_scan_idle_threats_found)
+        val scanIcon = buildScanIcon(R.drawable.ic_shield_warning_white, R.color.error)
         val scanHeader = HeaderState(UiStringRes(R.string.scan_idle_threats_found_title))
         val scanDescription = buildThreatsFoundDescription(site, threats.size)
         val scanButton = buildScanButtonAction(titleRes = R.string.scan_again, onClick = onScanButtonClicked)
@@ -92,7 +93,7 @@ class ScanStateListItemsBuilder @Inject constructor(
     ): List<JetpackListItemState> {
         val items = mutableListOf<JetpackListItemState>()
 
-        val scanIcon = buildScanIcon(R.drawable.ic_scan_idle_threats_not_found)
+        val scanIcon = buildScanIcon(R.drawable.ic_shield_white, R.color.jetpack_green_40)
         val scanHeader = HeaderState(UiStringRes(R.string.scan_idle_no_threats_found_title))
         val scanDescription = scanStateModel.mostRecentStatus?.startDate?.time?.let {
             buildLastScanDescription(it)
@@ -110,7 +111,7 @@ class ScanStateListItemsBuilder @Inject constructor(
     private fun buildScanningStateItems(progress: Int): List<JetpackListItemState> {
         val items = mutableListOf<JetpackListItemState>()
 
-        val scanIcon = buildScanIcon(R.drawable.ic_scan_scanning)
+        val scanIcon = buildScanIcon(R.drawable.ic_scan_scanning, null)
         val scanTitleRes = if (progress == 0) R.string.scan_preparing_to_scan_title else R.string.scan_scanning_title
         val scanHeader = HeaderState(UiStringRes(scanTitleRes))
         val scanDescription = DescriptionState(UiStringRes(R.string.scan_scanning_description))
@@ -124,8 +125,9 @@ class ScanStateListItemsBuilder @Inject constructor(
         return items
     }
 
-    private fun buildScanIcon(@DrawableRes icon: Int) = IconState(
+    private fun buildScanIcon(@DrawableRes icon: Int, @ColorRes color: Int?) = IconState(
         icon = icon,
+        colorResId = color,
         contentDescription = UiStringRes(R.string.scan_state_icon)
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -115,7 +115,7 @@ class ThreatItemBuilder @Inject constructor() {
             when (threatModel.baseThreatModel.status) {
                 FIXED -> R.drawable.bg_oval_success_50
                 IGNORED -> R.drawable.bg_oval_neutral_30
-                IGNORED, UNKNOWN, CURRENT -> R.drawable.ic_notice_outline_white_24dp
+                UNKNOWN, CURRENT -> R.drawable.bg_oval_error_50
             }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -7,9 +7,12 @@ import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.CoreFileModific
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.DatabaseThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.FileThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.GenericThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.FIXED
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.IGNORED
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension.ExtensionType
 import org.wordpress.android.ui.jetpack.scan.ScanListItemState.ThreatItemState
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -63,27 +66,39 @@ class ThreatItemBuilder @Inject constructor() {
         is GenericThreatModel -> UiStringRes(R.string.threat_item_header_threat_found)
     }
 
-    fun buildThreatItemSubHeader(threatModel: ThreatModel) = when (threatModel) {
-        is CoreFileModificationThreatModel -> UiStringRes(R.string.threat_item_sub_header_core_file)
+    fun buildThreatItemSubHeader(threatModel: ThreatModel): UiString {
+        return when (threatModel.baseThreatModel.status) {
+            FIXED -> {
+                UiStringRes(R.string.threat_item_sub_header_status_fixed)
+            }
+            IGNORED -> {
+                UiStringRes(R.string.threat_item_sub_header_status_ignored)
+            }
+            else -> {
+                when (threatModel) {
+                    is CoreFileModificationThreatModel -> UiStringRes(R.string.threat_item_sub_header_core_file)
 
-        is DatabaseThreatModel -> UiStringText("")
+                    is DatabaseThreatModel -> UiStringText("")
 
-        is FileThreatModel -> UiStringResWithParams(
-            R.string.threat_item_sub_header_file_signature,
-            listOf(UiStringText(threatModel.baseThreatModel.signature))
-        )
+                    is FileThreatModel -> UiStringResWithParams(
+                            R.string.threat_item_sub_header_file_signature,
+                            listOf(UiStringText(threatModel.baseThreatModel.signature))
+                    )
 
-        is VulnerableExtensionThreatModel -> {
-            when (threatModel.extension.type) {
-                ExtensionType.PLUGIN -> UiStringRes(R.string.threat_item_sub_header_vulnerable_plugin)
-                ExtensionType.THEME -> UiStringRes(R.string.threat_item_sub_header_vulnerable_theme)
-                ExtensionType.UNKNOWN -> throw IllegalArgumentException(
-                    "$UNKNOWN_VULNERABLE_EXTENSION_TYPE in ${this::class.java.simpleName}"
-                )
+                    is VulnerableExtensionThreatModel -> {
+                        when (threatModel.extension.type) {
+                            ExtensionType.PLUGIN -> UiStringRes(R.string.threat_item_sub_header_vulnerable_plugin)
+                            ExtensionType.THEME -> UiStringRes(R.string.threat_item_sub_header_vulnerable_theme)
+                            ExtensionType.UNKNOWN -> throw IllegalArgumentException(
+                                    "$UNKNOWN_VULNERABLE_EXTENSION_TYPE in ${this::class.java.simpleName}"
+                            )
+                        }
+                    }
+
+                    is GenericThreatModel -> UiStringRes(R.string.threat_item_sub_header_misc_vulnerability)
+                }
             }
         }
-
-        is GenericThreatModel -> UiStringRes(R.string.threat_item_sub_header_misc_vulnerability)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -118,7 +118,6 @@ class ThreatItemBuilder @Inject constructor() {
                 UNKNOWN, CURRENT -> R.drawable.bg_oval_error_50
             }
 
-
     /**
      * Uses regex to remove the whole path except of the file name
      * e.g. "/var/www/html/jp-scan-daily/wp-admin/index.php" returns "index.php".

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -7,8 +7,10 @@ import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.CoreFileModific
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.DatabaseThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.FileThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.GenericThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.CURRENT
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.FIXED
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.IGNORED
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.UNKNOWN
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension.ExtensionType
 import org.wordpress.android.ui.jetpack.scan.ScanListItemState.ThreatItemState
@@ -103,9 +105,18 @@ class ThreatItemBuilder @Inject constructor() {
         }
     }
 
-    private fun buildThreatItemIcon(threatModel: ThreatModel): Int = R.drawable.ic_notice_outline_white_24dp
+    private fun buildThreatItemIcon(threatModel: ThreatModel): Int =
+            when (threatModel.baseThreatModel.status) {
+                FIXED -> R.drawable.ic_shield_white
+                IGNORED, UNKNOWN, CURRENT -> R.drawable.ic_notice_outline_white_24dp
+            }
 
-    private fun buildThreatItemIconBackground(threatModel: ThreatModel): Int = R.drawable.bg_oval_error_50
+    private fun buildThreatItemIconBackground(threatModel: ThreatModel): Int =
+            when (threatModel.baseThreatModel.status) {
+                FIXED -> R.drawable.bg_oval_success_50
+                IGNORED -> R.drawable.bg_oval_neutral_30
+                IGNORED, UNKNOWN, CURRENT -> R.drawable.ic_notice_outline_white_24dp
+            }
 
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -26,6 +26,8 @@ class ThreatItemBuilder @Inject constructor() {
             isFixable = threatModel.baseThreatModel.fixable != null,
             header = buildThreatItemHeader(threatModel),
             subHeader = buildThreatItemSubHeader(threatModel),
+            icon = buildThreatItemIcon(threatModel),
+            iconBackground = buildThreatItemIconBackground(threatModel),
             onClick = { onThreatItemClicked(threatModel.baseThreatModel.id) }
         )
 
@@ -100,6 +102,11 @@ class ThreatItemBuilder @Inject constructor() {
             }
         }
     }
+
+    private fun buildThreatItemIcon(threatModel: ThreatModel): Int = R.drawable.ic_notice_outline_white_24dp
+
+    private fun buildThreatItemIconBackground(threatModel: ThreatModel): Int = R.drawable.bg_oval_error_50
+
 
     /**
      * Uses regex to remove the whole path except of the file name

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilder.kt
@@ -121,7 +121,8 @@ class ThreatDetailsListItemsBuilder @Inject constructor(
     }
 
     private fun buildThreatDetailsIcon() = IconState(
-        icon = R.drawable.ic_scan_idle_threats_found,
+        icon = R.drawable.ic_shield_warning_white,
+        colorResId = R.color.error,
         contentDescription = UiStringRes(R.string.threat_details_icon)
     )
 

--- a/WordPress/src/main/res/drawable/ic_shield_warning_white.xml
+++ b/WordPress/src/main/res/drawable/ic_shield_warning_white.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="162">
   <path
       android:pathData="M69,8L12,33.046V70.614C12,105.364 36.32,137.861 69,145.75C101.68,137.861 126,105.364 126,70.614V33.046L69,8ZM62.667,45.568H75.333V83.136H62.667V45.568ZM62.667,95.659H75.333V108.182H62.667"
-      android:fillColor="#DC3232"/>
+      android:fillColor="#ffffff"/>
 </vector>

--- a/WordPress/src/main/res/drawable/ic_shield_warning_white.xml
+++ b/WordPress/src/main/res/drawable/ic_shield_warning_white.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="162">
   <path
       android:pathData="M69,8L12,33.046V70.614C12,105.364 36.32,137.861 69,145.75C101.68,137.861 126,105.364 126,70.614V33.046L69,8ZM62.667,45.568H75.333V83.136H62.667V45.568ZM62.667,95.659H75.333V108.182H62.667"
-      android:fillColor="#ffffff"/>
+      android:fillColor="@android:color/white"/>
 </vector>

--- a/WordPress/src/main/res/drawable/ic_shield_white.xml
+++ b/WordPress/src/main/res/drawable/ic_shield_white.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="162">
   <path
       android:pathData="M56.333,108.063L31,83.047L39.93,74.229L56.333,90.364L98.07,49.151L107,58.031L56.333,108.063ZM69,8L12,33.016V70.539C12,105.248 36.32,137.706 69,145.586C101.68,137.706 126,105.248 126,70.539V33.016L69,8Z"
-      android:fillColor="#ffffff"/>
+      android:fillColor="@android:color/white"/>
 </vector>

--- a/WordPress/src/main/res/drawable/ic_shield_white.xml
+++ b/WordPress/src/main/res/drawable/ic_shield_white.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="138dp"
-    android:height="162dp"
+    android:width="24dp"
+    android:height="29dp"
     android:viewportWidth="138"
     android:viewportHeight="162">
   <path

--- a/WordPress/src/main/res/drawable/ic_shield_white.xml
+++ b/WordPress/src/main/res/drawable/ic_shield_white.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="162">
   <path
       android:pathData="M56.333,108.063L31,83.047L39.93,74.229L56.333,90.364L98.07,49.151L107,58.031L56.333,108.063ZM69,8L12,33.016V70.539C12,105.248 36.32,137.706 69,145.586C101.68,137.706 126,105.248 126,70.539V33.016L69,8Z"
-      android:fillColor="#069E08"/>
+      android:fillColor="#ffffff"/>
 </vector>

--- a/WordPress/src/main/res/values/scan_styles.xml
+++ b/WordPress/src/main/res/values/scan_styles.xml
@@ -27,8 +27,6 @@
         <item name="android:layout_marginEnd">@dimen/margin_extra_large</item>
         <item name="android:importantForAccessibility">no</item>
         <item name="android:padding">@dimen/margin_medium</item>
-        <item name="android:background">@drawable/bg_oval_error_50</item>
-        <item name="android:src">@drawable/ic_notice_outline_white_24dp</item>
     </style>
 
     <style name="Scan.Threat.Header" parent="Scan.TextView">

--- a/WordPress/src/main/res/values/scan_styles.xml
+++ b/WordPress/src/main/res/values/scan_styles.xml
@@ -21,12 +21,12 @@
 
     <!--Threat List Item-->
     <style name="Scan.Threat.Icon" parent="">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_width">32dp</item>
+        <item name="android:layout_height">32dp</item>
         <item name="android:layout_marginStart">@dimen/margin_extra_large</item>
         <item name="android:layout_marginEnd">@dimen/margin_extra_large</item>
         <item name="android:importantForAccessibility">no</item>
-        <item name="android:padding">@dimen/margin_medium</item>
+        <item name="android:padding">@dimen/margin_small_medium</item>
     </style>
 
     <style name="Scan.Threat.Header" parent="Scan.TextView">

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1094,6 +1094,8 @@
     <string name="threat_item_sub_header_file_signature">Threat found %s</string>
     <string name="threat_item_sub_header_vulnerable_plugin">Vulnerability found in plugin</string>
     <string name="threat_item_sub_header_vulnerable_theme">Vulnerability found in theme</string>
+    <string name="threat_item_sub_header_status_fixed">Threat fixed</string>
+    <string name="threat_item_sub_header_status_ignored">Threat ignored</string>
 
     <!-- threat details -->
     <string name="threat_details">Threat Details</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -56,7 +56,6 @@ class ScanViewModelTest : BaseUnitTest() {
     private val fakeIconId = 1
     private val fakeIconBackgroundId = 1
 
-
     @Before
     fun setUp() = test {
         viewModel = ScanViewModel(

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -53,6 +53,9 @@ class ScanViewModelTest : BaseUnitTest() {
     private val fakeScanStateModel = ScanStateModel(state = ScanStateModel.State.IDLE, hasCloud = true)
     private val fakeUiStringText = UiStringText("")
     private val fakeThreatId = 1L
+    private val fakeIconId = 1
+    private val fakeIconBackgroundId = 1
+
 
     @Before
     fun setUp() = test {
@@ -243,7 +246,9 @@ class ScanViewModelTest : BaseUnitTest() {
             threatId = fakeThreatId,
             isFixable = true,
             header = fakeUiStringText,
-            subHeader = fakeUiStringText
+            subHeader = fakeUiStringText,
+            icon = fakeIconId,
+            iconBackground = fakeIconBackgroundId
         ) { onThreatItemClicked(fakeThreatId) }
     )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
@@ -9,6 +9,9 @@ import org.junit.Test
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.GenericThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.FIXED
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.IGNORED
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension.ExtensionType
 import org.wordpress.android.test
 import org.wordpress.android.ui.jetpack.scan.builders.ThreatItemBuilder
@@ -23,6 +26,28 @@ class ThreatItemBuilderTest : BaseUnitTest() {
     @Before
     fun setUp() {
         builder = ThreatItemBuilder()
+    }
+
+    @Test
+    fun `builds threat sub header correctly for fixed threat`() {
+        // Arrange
+        val expectedSubHeader = UiStringRes(R.string.threat_item_sub_header_status_fixed)
+        val threatModel = GenericThreatModel(ThreatTestData.baseThreatModel.copy(status = FIXED))
+        // Act
+        val threatItem = buildThreatItem(threatModel)
+        // Assert
+        assertThat(threatItem.subHeader).isEqualTo(expectedSubHeader)
+    }
+
+    @Test
+    fun `builds threat sub header correctly for ignored threat`() {
+        // Arrange
+        val expectedSubHeader = UiStringRes(R.string.threat_item_sub_header_status_ignored)
+        val threatModel = GenericThreatModel(ThreatTestData.baseThreatModel.copy(status = IGNORED))
+        // Act
+        val threatItem = buildThreatItem(threatModel)
+        // Assert
+        assertThat(threatItem.subHeader).isEqualTo(expectedSubHeader)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.GenericThreatModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.CURRENT
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.FIXED
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.IGNORED
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension.ExtensionType
@@ -205,6 +206,39 @@ class ThreatItemBuilderTest : BaseUnitTest() {
         threatItem.onClick.invoke()
         // Assert
         verify(onThreatItemClicked).invoke(ThreatTestData.genericThreatModel.baseThreatModel.id)
+    }
+
+    @Test
+    fun `Shield icon and green background is used for fixed threat`() {
+        // Arrange
+        val threatModel = GenericThreatModel(ThreatTestData.genericThreatModel.baseThreatModel.copy(status = FIXED))
+        // Act
+        val threatItem = buildThreatItem(threatModel)
+        // Assert
+        assertThat(threatItem.icon).isEqualTo(R.drawable.ic_shield_white)
+        assertThat(threatItem.iconBackground).isEqualTo(R.drawable.bg_oval_success_50)
+    }
+
+    @Test
+    fun `Notice icon and grey background is used for ignored threat`() {
+        // Arrange
+        val threatModel = GenericThreatModel(ThreatTestData.genericThreatModel.baseThreatModel.copy(status = IGNORED))
+        // Act
+        val threatItem = buildThreatItem(threatModel)
+        // Assert
+        assertThat(threatItem.icon).isEqualTo(R.drawable.ic_notice_outline_white_24dp)
+        assertThat(threatItem.iconBackground).isEqualTo(R.drawable.bg_oval_neutral_30)
+    }
+
+    @Test
+    fun `Notice icon and red background is used for current threat`() {
+        // Arrange
+        val threatModel = GenericThreatModel(ThreatTestData.genericThreatModel.baseThreatModel.copy(status = CURRENT))
+        // Act
+        val threatItem = buildThreatItem(threatModel)
+        // Assert
+        assertThat(threatItem.icon).isEqualTo(R.drawable.ic_notice_outline_white_24dp)
+        assertThat(threatItem.iconBackground).isEqualTo(R.drawable.bg_oval_error_50)
     }
 
     private fun buildThreatItem(threatModel: ThreatModel, onThreatItemClicked: ((Long) -> Unit) = mock()) =

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatTestData.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatTestData.kt
@@ -11,8 +11,6 @@ import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.Fixable
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.Fixable.FixType
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.GenericThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus
-import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.FIXED
-import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.IGNORED
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension.ExtensionType

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatTestData.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatTestData.kt
@@ -11,6 +11,8 @@ import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.Fixable
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.Fixable.FixType
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.GenericThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.FIXED
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.IGNORED
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension.ExtensionType
@@ -43,7 +45,7 @@ object ThreatTestData {
         id = 1L,
         signature = TEST_SIGNATURE,
         description = TEST_DESCRIPTION,
-        status = ThreatStatus.FIXED,
+        status = ThreatStatus.CURRENT,
         firstDetected = Date(0)
     )
     val genericThreatModel = GenericThreatModel(

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilderTest.kt
@@ -81,7 +81,8 @@ class ThreatDetailsListItemsBuilderTest : BaseUnitTest() {
         // Arrange
         val threatModel = GenericThreatModel(ThreatTestData.genericThreatModel.baseThreatModel.copy(status = FIXED))
         val expectedIconItem = IconState(
-            icon = R.drawable.ic_scan_idle_threats_found,
+            icon = R.drawable.ic_shield_warning_white,
+            colorResId = R.color.error,
             contentDescription = UiStringRes(R.string.threat_details_icon)
         )
         val expectedThreatItemHeader = HeaderState(

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilderTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.Fixable
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.GenericThreatModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.FIXED
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButtonState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.DescriptionState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.HeaderState
@@ -78,24 +79,25 @@ class ThreatDetailsListItemsBuilderTest : BaseUnitTest() {
     @Test
     fun `builds basic list items correctly for a ThreatModel`() {
         // Arrange
+        val threatModel = GenericThreatModel(ThreatTestData.genericThreatModel.baseThreatModel.copy(status = FIXED))
         val expectedIconItem = IconState(
             icon = R.drawable.ic_scan_idle_threats_found,
             contentDescription = UiStringRes(R.string.threat_details_icon)
         )
         val expectedThreatItemHeader = HeaderState(
-            text = threatItemBuilder.buildThreatItemHeader(ThreatTestData.genericThreatModel),
+            text = threatItemBuilder.buildThreatItemHeader(threatModel),
             textColorRes = R.attr.colorError
         )
         val expectedThreatItemSubHeader = DescriptionState(
-            threatItemBuilder.buildThreatItemSubHeader(ThreatTestData.genericThreatModel)
+            threatItemBuilder.buildThreatItemSubHeader(threatModel)
         )
         val expectedProblemHeader = HeaderState(UiStringRes(R.string.threat_problem_header))
         val expectedProblemDescription = DescriptionState(
-            UiStringText(ThreatTestData.genericThreatModel.baseThreatModel.description)
+            UiStringText(threatModel.baseThreatModel.description)
         )
 
         // Act
-        val threatItems = buildThreatDetailsListItems(ThreatTestData.genericThreatModel)
+        val threatItems = buildThreatDetailsListItems(threatModel)
 
         // Assert
         Assertions.assertThat(threatItems).size().isEqualTo(5)


### PR DESCRIPTION
Parent issue #13326

This PR updates icon and subheader of Threat list items in Fixed and Ignored state.

I made two other changes
1. Changed default ThreatStatus for dummy object used for testing to CURRENT
2. Removed colors from related vector drawable resources and use tint to set the color programatically

Note: The UI is not polished, I made just necessary changes so the UI doesn't look completely broken (eg. vector dimensions).
Note2: Review by commits might be easier to follow.

To Test
1. Open Scan
2. Notice current threat has red background and "i"(notice) icon
3. Open History
4. Notice fixed threat has red background and shield icon with a checkmark
5. Notice ignored threat has grey background and "i"(notice) icon

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
