### PR TITLE
Issue/13326 fix threat from threat details

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -128,10 +128,11 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         if (requestCode == RequestCodes.SHOW_THREAT_DETAILS) {
             data?.let {
                 val threatId = it.getLongExtra(ThreatDetailsFragment.REQUEST_FIX_STATE, 0L)
+                val messageRes = it.getIntExtra(ThreatDetailsFragment.REQUEST_SCAN_STATE, 0)
                 if (threatId > 0L) {
                     viewModel.onFixStateRequested(threatId)
-                } else if (it.getBooleanExtra(ThreatDetailsFragment.REQUEST_SCAN_STATE, false)) {
-                    viewModel.onScanStateRequested()
+                } else {
+                    viewModel.onScanStateRequestedWithMessage(messageRes)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -131,7 +131,7 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
                 val messageRes = it.getIntExtra(ThreatDetailsFragment.REQUEST_SCAN_STATE, 0)
                 if (threatId > 0L) {
                     viewModel.onFixStateRequested(threatId)
-                } else {
+                } else if (messageRes > 0) {
                     viewModel.onScanStateRequestedWithMessage(messageRes)
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -125,10 +125,15 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == RequestCodes.SHOW_THREAT_DETAILS &&
-            data?.getBooleanExtra(ThreatDetailsFragment.REQUEST_SCAN_STATE, false) == true
-        ) {
-            viewModel.onScanStateRequested()
+        if (requestCode == RequestCodes.SHOW_THREAT_DETAILS) {
+            data?.let {
+                val threatId = it.getLongExtra(ThreatDetailsFragment.REQUEST_FIX_STATE, 0L)
+                if (threatId > 0L) {
+                    viewModel.onFixStateRequested(threatId)
+                } else if (it.getBooleanExtra(ThreatDetailsFragment.REQUEST_SCAN_STATE, false)) {
+                    viewModel.onScanStateRequested()
+                }
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -103,7 +103,7 @@ class ScanViewModel @Inject constructor(
             when (fixThreatsUseCase.fixThreats(remoteSiteId = site.siteId, fixableThreatIds = fixableThreatIds)) {
                 is FixThreatsState.Success -> {
                     updateSnackbarMessageEvent(UiStringRes(R.string.threat_fix_all_started_message))
-                    fetchFixThreatsStatus()
+                    fetchFixThreatsStatus(fixableThreatIds = fixableThreatIds)
                 }
                 is FixThreatsState.Failure.NetworkUnavailable -> {
                     updateActionButtons(isEnabled = true)
@@ -117,7 +117,7 @@ class ScanViewModel @Inject constructor(
         }
     }
 
-    private fun fetchFixThreatsStatus() {
+    private fun fetchFixThreatsStatus(fixableThreatIds: List<Long>) {
         launch {
             @StringRes var messageRes: Int? = null
             var isFixing: Boolean
@@ -175,6 +175,10 @@ class ScanViewModel @Inject constructor(
 
     fun onScanStateRequested() {
         fetchScanState()
+    }
+
+    fun onFixStateRequested(threatId: Long) {
+        fetchFixThreatsStatus(listOf(threatId))
     }
 
     private fun updateActionButtons(isEnabled: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -173,7 +173,8 @@ class ScanViewModel @Inject constructor(
         _navigationEvents.value = Event(ShowThreatDetails(threatId))
     }
 
-    fun onScanStateRequested() {
+    fun onScanStateRequestedWithMessage(@StringRes messageRes: Int) {
+        updateSnackbarMessageEvent(UiStringRes(messageRes))
         fetchScanState()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -13,7 +13,7 @@ import kotlinx.android.synthetic.main.threat_details_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.jetpack.scan.ScanFragment.Companion.ARG_THREAT_ID
-import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.OpenIgnoreThreatActionDialog
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.OpenThreatActionDialog
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedScanState
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.scan.details.adapters.ThreatDetailsAdapter
@@ -69,7 +69,7 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
             {
                 it.applyIfNotHandled {
                     when (this) {
-                        is OpenIgnoreThreatActionDialog -> showThreatActionDialog(this)
+                        is OpenThreatActionDialog -> showThreatActionDialog(this)
 
                         is ShowUpdatedScanState -> {
                             val intent = Intent().putExtra(REQUEST_SCAN_STATE, true)
@@ -95,7 +95,7 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
         snackbar.show()
     }
 
-    private fun showThreatActionDialog(holder: OpenIgnoreThreatActionDialog) {
+    private fun showThreatActionDialog(holder: OpenThreatActionDialog) {
         threatActionDialog = MaterialAlertDialogBuilder(requireActivity())
             .setTitle(uiHelpers.getTextOfUiString(requireContext(), holder.title))
             .setMessage(uiHelpers.getTextOfUiString(requireContext(), holder.message))

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.ui.jetpack.scan.ScanFragment.Companion.ARG_THREAT_ID
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.OpenThreatActionDialog
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedFixState
-import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedScanState
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedScanStateWithMessage
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.scan.details.adapters.ThreatDetailsAdapter
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
@@ -72,8 +72,8 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
                     when (this) {
                         is OpenThreatActionDialog -> showThreatActionDialog(this)
 
-                        is ShowUpdatedScanState -> {
-                            val intent = Intent().putExtra(REQUEST_SCAN_STATE, true)
+                        is ShowUpdatedScanStateWithMessage -> {
+                            val intent = Intent().putExtra(REQUEST_SCAN_STATE, this.messageRes)
                             activity?.setResult(Activity.RESULT_OK, intent)
                             activity?.finish()
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.jetpack.scan.ScanFragment.Companion.ARG_THREAT_ID
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.OpenThreatActionDialog
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedFixState
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedScanState
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.scan.details.adapters.ThreatDetailsAdapter
@@ -76,6 +77,12 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
                             activity?.setResult(Activity.RESULT_OK, intent)
                             activity?.finish()
                         }
+
+                        is ShowUpdatedFixState -> {
+                            val intent = Intent().putExtra(REQUEST_FIX_STATE, this.threatId)
+                            activity?.setResult(Activity.RESULT_OK, intent)
+                            activity?.finish()
+                        }
                     }
                 }
             }
@@ -113,5 +120,6 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
 
     companion object {
         const val REQUEST_SCAN_STATE = "request_scan_state"
+        const val REQUEST_FIX_STATE = "request_fix_state"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsListItemsBuilder.kt
@@ -184,7 +184,7 @@ class ThreatDetailsListItemsBuilder @Inject constructor(
     private fun buildFixDescription(fixable: Fixable?) = fixable?.let { buildFixableThreatDescription(it) }
         ?: buildNotFixableThreatDescription()
 
-    private fun buildFixableThreatDescription(fixable: Fixable) = DescriptionState(
+    fun buildFixableThreatDescription(fixable: Fixable) = DescriptionState(
         when (fixable.fixer) {
             FixType.REPLACE -> UiStringRes(R.string.threat_fix_fixable_replace)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsNavigationEvents.kt
@@ -15,4 +15,6 @@ sealed class ThreatDetailsNavigationEvents {
     }
 
     object ShowUpdatedScanState : ThreatDetailsNavigationEvents()
+
+    data class ShowUpdatedFixState(val threatId: Long) : ThreatDetailsNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsNavigationEvents.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.utils.UiString
 
 sealed class ThreatDetailsNavigationEvents {
-    class OpenIgnoreThreatActionDialog(
+    class OpenThreatActionDialog(
         val title: UiString,
         val message: UiString,
         val okButtonAction: () -> Unit

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsNavigationEvents.kt
@@ -14,7 +14,7 @@ sealed class ThreatDetailsNavigationEvents {
         @StringRes val negativeButtonLabel: Int = R.string.dialog_button_cancel
     }
 
-    object ShowUpdatedScanState : ThreatDetailsNavigationEvents()
+    data class ShowUpdatedScanStateWithMessage(@StringRes val messageRes: Int) : ThreatDetailsNavigationEvents()
 
     data class ShowUpdatedFixState(val threatId: Long) : ThreatDetailsNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModel.kt
@@ -6,9 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
@@ -17,7 +15,7 @@ import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButtonState
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.OpenThreatActionDialog
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedFixState
-import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedScanState
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedScanStateWithMessage
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.scan.details.usecases.GetThreatModelUseCase
 import org.wordpress.android.ui.jetpack.scan.details.usecases.IgnoreThreatUseCase
@@ -100,13 +98,9 @@ class ThreatDetailsViewModel @Inject constructor(
         viewModelScope.launch {
             updateThreatActionButtons(isEnabled = false)
             when (ignoreThreatUseCase.ignoreThreat(site.siteId, threatModel.baseThreatModel.id)) {
-                is IgnoreThreatState.Success -> {
-                    // TODO ashiagr consider showing success message in the scan state screen
-                    updateSnackbarMessageEvent(UiStringRes(R.string.threat_ignore_success_message))
-
-                    withContext(bgDispatcher) { delay(DELAY_MILLIS) }
-                    updateNavigationEvent(ShowUpdatedScanState)
-                }
+                is IgnoreThreatState.Success -> updateNavigationEvent(
+                    ShowUpdatedScanStateWithMessage(R.string.threat_ignore_success_message)
+                )
 
                 is IgnoreThreatState.Failure.NetworkUnavailable -> {
                     updateThreatActionButtons(isEnabled = true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModel.kt
@@ -72,6 +72,9 @@ class ThreatDetailsViewModel @Inject constructor(
         }
     }
 
+    private fun fixThreat() { // TODO ashiagr to be implemented
+    }
+
     private fun ignoreThreat() {
         viewModelScope.launch {
             updateThreatActionButtons(isEnabled = false)
@@ -97,7 +100,15 @@ class ThreatDetailsViewModel @Inject constructor(
         }
     }
 
-    private fun onFixThreatButtonClicked() { // TODO ashiagr to be implemented
+    private fun onFixThreatButtonClicked() {
+        val fixable = requireNotNull(threatModel.baseThreatModel.fixable)
+        updateNavigationEvent(
+            OpenThreatActionDialog(
+                title = UiStringRes(R.string.threat_fix),
+                message = builder.buildFixableThreatDescription(fixable).text,
+                okButtonAction = this@ThreatDetailsViewModel::fixThreat
+            )
+        )
     }
 
     private fun onIgnoreThreatButtonClicked() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModel.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButtonState
-import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.OpenIgnoreThreatActionDialog
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.OpenThreatActionDialog
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedScanState
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.scan.details.usecases.GetThreatModelUseCase
@@ -102,7 +102,7 @@ class ThreatDetailsViewModel @Inject constructor(
 
     private fun onIgnoreThreatButtonClicked() {
         updateNavigationEvent(
-            OpenIgnoreThreatActionDialog(
+            OpenThreatActionDialog(
                 title = UiStringRes(R.string.threat_ignore),
                 message = UiStringText(
                     htmlMessageUtils

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1122,6 +1122,7 @@
     <string name="threat_ignore">Ignore threat</string>
     <string name="threat_get_free_estimate">Get a free estimate</string>
     <!-- threat alert messages -->
+    <string name="threat_fix_error_message">Error fixing threat. Please contact our support.</string>
     <string name="threat_ignore_warning">You shouldn\’t ignore a security unless you are absolute sure it\’s harmless. If you choose to ignore this threat, it will remain on your site &lt;b&gt;%s&lt;/b&gt;.</string>
     <string name="threat_ignore_success_message">Threat ignored.</string>
     <string name="threat_ignore_error_message">Error ignoring threat. Please contact support.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -177,7 +177,7 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when request to fix threats succeeds, then fix started message is shown`() = test {
+    fun `given success response, when fix threats is triggered, then fix started message is shown`() = test {
         whenever(fixThreatsUseCase.fixThreats(any(), any())).thenReturn(FixThreatsState.Success)
         val observers = init()
 
@@ -188,15 +188,17 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when request to fix threats fails, then fix threats error message is shown`() = test {
-        whenever(fixThreatsUseCase.fixThreats(any(), any())).thenReturn(FixThreatsState.Failure.RemoteRequestFailure)
-        val observers = init()
+    fun `given invalid response, when fix threats action is triggered, then fix threats error message is shown`() =
+        test {
+            whenever(fixThreatsUseCase.fixThreats(any(), any()))
+                .thenReturn(FixThreatsState.Failure.RemoteRequestFailure)
+            val observers = init()
 
-        triggerFixThreatsAction(observers)
+            triggerFixThreatsAction(observers)
 
-        val snackBarMsg = observers.snackBarMsgs.last().peekContent()
-        assertThat(snackBarMsg).isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.threat_fix_all_error_message)))
-    }
+            val snackBarMsg = observers.snackBarMsgs.last().peekContent()
+            assertThat(snackBarMsg).isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.threat_fix_all_error_message)))
+        }
 
     @Test
     fun `when ok button on fix threats action confirmation dialog is clicked, then action buttons are disabled`() =
@@ -211,7 +213,7 @@ class ScanViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when request to fix threats fails, then action buttons are enabled`() = test {
+    fun `given invalid response, when fix threats action is triggered, then action buttons are enabled`() = test {
         whenever(fixThreatsUseCase.fixThreats(any(), any())).thenReturn(FixThreatsState.Failure.RemoteRequestFailure)
         val observers = init()
 
@@ -223,11 +225,8 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given threats are fixed successfully, when threats fix status is checked, then success message is shown`() =
+    fun `given threats are fixed, when threats fix status is checked, then success message is shown`() =
         test {
-            val expectedSuccessSnackBarMsg = SnackbarMessageHolder(
-                UiStringRes(R.string.threat_fix_all_status_success_message)
-            )
             whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
                 flowOf(FetchFixThreatsState.Complete)
             )
@@ -236,12 +235,13 @@ class ScanViewModelTest : BaseUnitTest() {
             fetchFixThreatsStatus(observers)
 
             val snackBarMsg = observers.snackBarMsgs.last().peekContent()
-            assertThat(snackBarMsg).isEqualTo(expectedSuccessSnackBarMsg)
+            assertThat(snackBarMsg).isEqualTo(
+                SnackbarMessageHolder(UiStringRes(R.string.threat_fix_all_status_success_message))
+            )
         }
 
     @Test
     fun `given no network, when threats fix status is checked, then network error message is shown`() = test {
-        val expectedFailureSnackBarMsg = SnackbarMessageHolder(UiStringRes(R.string.error_generic_network))
         whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
             flowOf(FetchFixThreatsState.Failure.NetworkUnavailable)
         )
@@ -250,14 +250,11 @@ class ScanViewModelTest : BaseUnitTest() {
         fetchFixThreatsStatus(observers)
 
         val snackBarMsg = observers.snackBarMsgs.last().peekContent()
-        assertThat(snackBarMsg).isEqualTo(expectedFailureSnackBarMsg)
+        assertThat(snackBarMsg).isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.error_generic_network)))
     }
 
     @Test
     fun `given server is unavailable, when threats fix status is checked, then error message is shown`() = test {
-        val expectedFailureSnackBarMsg = SnackbarMessageHolder(
-            UiStringRes(R.string.threat_fix_all_status_error_message)
-        )
         whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
             flowOf(FetchFixThreatsState.Failure.RemoteRequestFailure)
         )
@@ -266,15 +263,14 @@ class ScanViewModelTest : BaseUnitTest() {
         fetchFixThreatsStatus(observers)
 
         val snackBarMsg = observers.snackBarMsgs.last().peekContent()
-        assertThat(snackBarMsg).isEqualTo(expectedFailureSnackBarMsg)
+        assertThat(snackBarMsg).isEqualTo(
+            SnackbarMessageHolder(UiStringRes(R.string.threat_fix_all_status_error_message))
+        )
     }
 
     @Test
     fun `given a threat not fixed, when threats fix status checked, then some threats not fixed error message shown`() =
         test {
-            val expectedFailureSnackBarMsg = SnackbarMessageHolder(
-                UiStringRes(R.string.threat_fix_all_status_some_threats_not_fixed_error_message)
-            )
             whenever(fixThreatsUseCase.fixThreats(any(), any())).thenReturn(FixThreatsState.Success)
             whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
                 flowOf(FetchFixThreatsState.Failure.FixFailure)
@@ -284,7 +280,9 @@ class ScanViewModelTest : BaseUnitTest() {
             triggerFixThreatsAction(observers)
 
             val snackBarMsg = observers.snackBarMsgs.last().peekContent()
-            assertThat(snackBarMsg).isEqualTo(expectedFailureSnackBarMsg)
+            assertThat(snackBarMsg).isEqualTo(
+                SnackbarMessageHolder(UiStringRes(R.string.threat_fix_all_status_some_threats_not_fixed_error_message))
+            )
         }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -321,6 +321,42 @@ class ScanViewModelTest : BaseUnitTest() {
             assertThat(indeterminateProgressBars.isEmpty()).isTrue
         }
 
+    @Test
+    fun `given activity result fix threat status data, when fix status is requested, then fix status is fetched`() =
+        test {
+            whenever(site.siteId).thenReturn(1L)
+            viewModel.start(site)
+
+            viewModel.onFixStateRequested(threatId = 11L)
+
+            verify(fetchFixThreatsStatusUseCase).fetchFixThreatsStatus(
+                remoteSiteId = 1L,
+                fixableThreatIds = listOf(11L)
+            )
+        }
+
+    @Test
+    fun `given activity result request scan state data, when scan state is requested, then snackbar msg is shown`() =
+        test {
+            val observers = init()
+
+            viewModel.onScanStateRequestedWithMessage(R.string.threat_ignore_success_message)
+
+            val snackBarMsg = observers.snackBarMsgs.last().peekContent()
+            assertThat(snackBarMsg)
+                .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.threat_ignore_success_message)))
+        }
+
+    @Test
+    fun `given activity result request scan state data, when scan state is requested, then scan state is fetched`() =
+        test {
+            viewModel.start(site)
+
+            viewModel.onScanStateRequestedWithMessage(R.string.threat_ignore_success_message)
+
+            verify(fetchScanStateUseCase, times(2)).fetchScanState(site)
+        }
+
     private fun triggerFixThreatsAction(observers: Observers) {
         (observers.uiStates.last() as Content).items.filterIsInstance<ActionButtonState>().last().onClick.invoke()
         (observers.navigation.last().peekContent() as OpenFixThreatsConfirmationDialog).okButtonAction.invoke()

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModelTest.kt
@@ -20,7 +20,7 @@ import org.wordpress.android.ui.jetpack.common.JetpackListItemState.DescriptionS
 import org.wordpress.android.ui.jetpack.scan.ThreatTestData
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.OpenThreatActionDialog
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedFixState
-import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedScanState
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedScanStateWithMessage
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel.UiState
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.scan.details.usecases.GetThreatModelUseCase
@@ -225,17 +225,6 @@ class ThreatDetailsViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given success response, when ignore threat is triggered, then success message is shown`() = test {
-        whenever(ignoreThreatUseCase.ignoreThreat(any(), any())).thenReturn(Success)
-        val observers = init()
-
-        triggerIgnoreThreatAction(observers)
-
-        val snackBarMsg = observers.snackBarMsgs.last().peekContent()
-        assertThat(snackBarMsg).isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.threat_ignore_success_message)))
-    }
-
-    @Test
     fun `given server unavailable, when ignore threat action is triggered, then ignore threat error msg is shown`() =
         test {
             whenever(ignoreThreatUseCase.ignoreThreat(any(), any())).thenReturn(Failure.RemoteRequestFailure)
@@ -289,7 +278,8 @@ class ThreatDetailsViewModelTest : BaseUnitTest() {
 
             triggerIgnoreThreatAction(observers)
 
-            assertThat(observers.navigation.last().peekContent()).isEqualTo(ShowUpdatedScanState)
+            assertThat(observers.navigation.last().peekContent())
+                .isEqualTo(ShowUpdatedScanStateWithMessage(R.string.threat_ignore_success_message))
         }
 
     private fun triggerIgnoreThreatAction(observers: Observers) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModelTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.test
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButtonState
-import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.OpenIgnoreThreatActionDialog
+import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.OpenThreatActionDialog
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedScanState
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel.UiState
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel.UiState.Content
@@ -92,7 +92,7 @@ class ThreatDetailsViewModelTest : BaseUnitTest() {
                 .first().onClick.invoke()
 
             assertThat(observers.navigation.last().peekContent())
-                .isInstanceOf(OpenIgnoreThreatActionDialog::class.java)
+                .isInstanceOf(OpenThreatActionDialog::class.java)
         }
 
     @Test
@@ -103,7 +103,7 @@ class ThreatDetailsViewModelTest : BaseUnitTest() {
             (observers.uiStates.last() as Content).items.filterIsInstance<ActionButtonState>()
                 .first().onClick.invoke()
 
-            val confirmationDialog = observers.navigation.last().peekContent() as OpenIgnoreThreatActionDialog
+            val confirmationDialog = observers.navigation.last().peekContent() as OpenThreatActionDialog
             with(confirmationDialog) {
                 assertThat(title).isEqualTo(UiStringRes(R.string.threat_ignore))
                 assertThat(message).isEqualTo(
@@ -189,7 +189,7 @@ class ThreatDetailsViewModelTest : BaseUnitTest() {
 
     private fun triggerIgnoreThreatAction(observers: Observers) {
         (observers.uiStates.last() as Content).items.filterIsInstance<ActionButtonState>().first().onClick.invoke()
-        (observers.navigation.last().peekContent() as OpenIgnoreThreatActionDialog).okButtonAction.invoke()
+        (observers.navigation.last().peekContent() as OpenThreatActionDialog).okButtonAction.invoke()
     }
 
     private fun createDummyThreatDetailsListItems(


### PR DESCRIPTION
Parent #13326

This PR
- Reuses `FixThreatsUsecase` for fix threat action on the threat details screen.
- When fix request succeeds, navigates back to the scan state screen and fetches fix status by reusing existing logic for fix threats status.
- Moves ignore threat success message to the scan state screen as per https://github.com/wordpress-mobile/WordPress-Android/pull/13768#discussion_r559502715.

https://user-images.githubusercontent.com/1405144/105171373-26b17580-5b44-11eb-9374-8db7ec513e17.mov


https://user-images.githubusercontent.com/1405144/105170568-1e0c6f80-5b43-11eb-9994-42c1744acb33.mov

To test:

Prerequisite:

- Make sure both Scan feature flag and MySiteImprovements flag are set to on in the App settings.
- You have access to WP.com account with a site having scan capability and threats (e.g. https://pressable-jetpack-daily-scan.mystagingwebsite.com). Server credentials should be set on the site.
- A threat is added to the site. In case you run out of threats, re-install bad calendar plugin from [here](https://jetpackp2.files.wordpress.com/2020/05/calendar-1.zip) and re-run scan.

1. Login to the app using above WP.com account and select the site on the My Site tab
2. Click scan menu item on My Site
3. Click a threat on scan state screen
4. Click fix threat button on the threat details screen
5. Notice that a confirmation dialog is shown (see video)
6. Click ok in the confirmation dialog
7. Notice that app navigates back to scan state screen and fix status is shown

Repeat above steps and enable airplane mode after step 6. Notice that an error message is displayed and actions buttons are re-enabled.

Also test that when ignore threat action succeeds, ignore threat success message is shown on the scan state screen. 

(Tests included in `ThreatDetailsViewModelTest` , `ScanViewModelTest`)

Notes:
1. Ignore all styling
2. Server credentials check is not handled
3. Fix status fine-tuning will be done separately
4. Task for pluralisation of messages (threat vs threats based on threat count) is added to backlog

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
