### PR TITLE
Do not log default design when design selection is skipped

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.sitecreation.misc
 
 import org.wordpress.android.analytics.AnalyticsTracker
-import org.wordpress.android.ui.sitecreation.theme.defaultTemplateSlug
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Locale
 import javax.inject.Inject
@@ -14,6 +13,8 @@ enum class SiteCreationErrorType {
 
 @Singleton
 class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapper) {
+    private var designSelectionSkipped: Boolean = false
+
     fun trackSiteCreationAccessed() {
         tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_ACCESSED)
     }
@@ -47,7 +48,7 @@ class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapp
     }
 
     fun trackPreviewLoading(template: String?) {
-        if (template == null || template == defaultTemplateSlug) {
+        if (template == null || designSelectionSkipped) {
             tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_SUCCESS_LOADING)
         } else {
             tracker.track(
@@ -58,7 +59,7 @@ class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapp
     }
 
     fun trackPreviewWebviewShown(template: String?) {
-        if (template == null || template == defaultTemplateSlug) {
+        if (template == null || designSelectionSkipped) {
             tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_SUCCESS_PREVIEW_VIEWED)
         } else {
             tracker.track(
@@ -69,7 +70,7 @@ class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapp
     }
 
     fun trackPreviewWebviewFullyLoaded(template: String?) {
-        if (template == null || template == defaultTemplateSlug) {
+        if (template == null || designSelectionSkipped) {
             tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_SUCCESS_PREVIEW_LOADED)
         } else {
             tracker.track(
@@ -88,7 +89,7 @@ class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapp
      * making ANY modification to this stat please refer to: p4qSXL-35X-p2
      */
     fun trackSiteCreated(template: String?) {
-        if (template == null || template == defaultTemplateSlug) {
+        if (template == null || designSelectionSkipped) {
             tracker.track(AnalyticsTracker.Stat.SITE_CREATED)
         } else {
             tracker.track(AnalyticsTracker.Stat.SITE_CREATED, mapOf("template" to template))
@@ -121,10 +122,12 @@ class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapp
     }
 
     fun trackSiteDesignSkipped() {
+        designSelectionSkipped = true
         tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_SITE_DESIGN_SKIPPED)
     }
 
     fun trackSiteDesignSelected(template: String) {
+        designSelectionSkipped = false
         tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_SITE_DESIGN_SELECTED, mapOf("template" to template))
     }
 


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-Android/issues/13801

## Description
This PR prevents logging the template only when the user chooses the **Skip** option and allows logging of the `Default` design selection

## To test:

<details>
<summary><strong>To start the Home Page Picker screen</strong></summary>

1. Start the site creation flow (e.g. *Choose site > Add button*)
1. Select the *Create WordPress.com site* option
</details>

#### Note
An easy way to test for these analytics is to debug the app and filter Logcat to look for the string `🔵 Tracked:`

### Skip
1. Start the Home Page Picker
1. Select press **Skip**
1. Select a domain and create the site
1. **Verify** that the `🔵 Tracked: site_created` event is emitted without a template value (null)

### Default template
1. Start the Home Page Picker
1. Select the **default design** (check screenshot below)
1. Press **Choose**
1. Select a domain and create the site
1. **Verify** that the `🔵 Tracked: site_created, Properties: {"template":"default"}` event is emitted

### Default template and preview
1. Start the Home Page Picker
1. Select the **default design** (check screenshot below)
1. Press **Preview**
1. Press **Choose**
1. Select a domain and create the site
1. **Verify** that the `🔵 Tracked: site_created, Properties: {"template":"default"}` event is emitted

### Other template
1. Start the Home Page Picker
1. Select the **another design** (not the default)
1. Press **Choose**
1. Select a domain and create the site
1. **Verify** that the `🔵 Tracked: site_created, Properties: {"template":"bowen"}` event is emitted (where `bowen` your selected template)

## Screenshots
<image width="380" src="https://user-images.githubusercontent.com/304044/104914039-32ac0480-5997-11eb-8b7a-3a2c19606f49.png"/>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
