### PR TITLE
Issue/13326 update tabs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -99,7 +99,7 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
     ) : FragmentStateAdapter(parent) {
         override fun getItemCount(): Int = items.count()
 
-        override fun createFragment(position: Int): Fragment = ScanHistoryListFragment()
+        override fun createFragment(position: Int): Fragment = ScanHistoryListFragment.newInstance(items[position].type)
     }
 
     override fun onScrollableViewInitialized(viewId: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -13,31 +13,25 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ScrollableViewInitializedListener
+import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.TabUiState
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.LocaleManagerWrapper
 import javax.inject.Inject
 
 class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), ScrollableViewInitializedListener {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var uiHelpers: UiHelpers
+    @Inject lateinit var localeManagerWrapper: LocaleManagerWrapper
     private lateinit var viewModel: ScanHistoryViewModel
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initDagger()
         initViewModel(getSite(savedInstanceState))
-        // TODO malinjir use vm
-        updateTabs()
     }
 
     private fun initDagger() {
         (requireActivity().application as WordPress).component()?.inject(this)
-    }
-
-    private fun updateTabs() {
-        val adapter = ScanHistoryTabAdapter(this)
-        view_pager.adapter = adapter
-
-        TabLayoutMediator(tab_layout, view_pager) { tab, position ->
-            tab.text = "Tab $position"
-        }.attach()
     }
 
     private fun initViewModel(site: SiteModel) {
@@ -47,6 +41,20 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
     }
 
     private fun setupObservers() {
+        viewModel.tabs.observe(viewLifecycleOwner, {
+            updateTabs(it)
+        })
+    }
+
+    private fun updateTabs(list: List<TabUiState>) {
+        val adapter = ScanHistoryTabAdapter(list, this)
+        view_pager.adapter = adapter
+
+        TabLayoutMediator(tab_layout, view_pager) { tab, position ->
+            tab.text = uiHelpers.getTextOfUiString(requireContext(), list[position].label)
+                    .toString()
+                    .toUpperCase(localeManagerWrapper.getLocale())
+        }.attach()
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
@@ -86,9 +94,10 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
         return super.onOptionsItemSelected(item)
     }
 
-    // todo malinjir create real tabs
-    private class ScanHistoryTabAdapter(parent: Fragment) : FragmentStateAdapter(parent) {
-        override fun getItemCount(): Int = 3
+    private class ScanHistoryTabAdapter(
+        private val items: List<TabUiState>, parent: Fragment
+    ) : FragmentStateAdapter(parent) {
+        override fun getItemCount(): Int = items.count()
 
         override fun createFragment(position: Int): Fragment = ScanHistoryListFragment()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -95,7 +95,8 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
     }
 
     private class ScanHistoryTabAdapter(
-        private val items: List<TabUiState>, parent: Fragment
+        private val items: List<TabUiState>,
+        parent: Fragment
     ) : FragmentStateAdapter(parent) {
         override fun getItemCount(): Int = items.count()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -28,7 +28,7 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
         super.onViewCreated(view, savedInstanceState)
         initDagger()
         initRecyclerView()
-        initViewModel(getSite(savedInstanceState))
+        initViewModel(getSite(savedInstanceState), getTabType())
     }
 
     private fun initDagger() {
@@ -44,12 +44,12 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
         recycler_view.itemAnimator = null
     }
 
-    private fun initViewModel(site: SiteModel) {
+    private fun initViewModel(site: SiteModel, tabType: ScanHistoryTabType) {
         viewModel = ViewModelProvider(this, viewModelFactory).get(ScanHistoryListViewModel::class.java)
         parentViewModel = ViewModelProvider(parentFragment as ViewModelStoreOwner, viewModelFactory).get(
                 ScanHistoryViewModel::class.java
         )
-        viewModel.start(site, parentViewModel)
+        viewModel.start(tabType, site, parentViewModel)
         setupObservers()
     }
 
@@ -68,6 +68,9 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
             savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
         }
     }
+
+    private fun getTabType(): ScanHistoryTabType =
+            requireNotNull(arguments?.getParcelable(ARG_TAB_TYPE))
 
     override fun getScrollableViewForUniqueIdProvision(): View? = recycler_view
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ViewPagerFragment
 import org.wordpress.android.ui.jetpack.scan.ScanListItemState
 import org.wordpress.android.ui.jetpack.scan.adapters.ScanAdapter
+import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
@@ -73,5 +74,16 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putSerializable(WordPress.SITE, viewModel.site)
         super.onSaveInstanceState(outState)
+    }
+
+    companion object {
+        private const val ARG_TAB_TYPE = "arg_tab_type"
+
+        fun newInstance(tabType: ScanHistoryTabType): ScanHistoryListFragment {
+            val newBundle = Bundle().apply {
+                putParcelable(ARG_TAB_TYPE, tabType)
+            }
+            return ScanHistoryListFragment().apply { arguments = newBundle }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -69,8 +69,7 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
         }
     }
 
-    private fun getTabType(): ScanHistoryTabType =
-            requireNotNull(arguments?.getParcelable(ARG_TAB_TYPE))
+    private fun getTabType(): ScanHistoryTabType = requireNotNull(arguments?.getParcelable(ARG_TAB_TYPE))
 
     override fun getScrollableViewForUniqueIdProvision(): View? = recycler_view
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModel.kt
@@ -33,11 +33,8 @@ class ScanHistoryListViewModel @Inject constructor(
         uiState = parentViewModel
                 .threats
                 .map { threats ->
-                    threats
-                            .filter { mapTabTypeToThreatStatuses(tabType).contains(it.baseThreatModel.status) }
-                            .map {
-                                scanThreatItemBuilder.buildThreatItem(it, this::onItemClicked)
-                            }
+                    threats.filter { mapTabTypeToThreatStatuses(tabType).contains(it.baseThreatModel.status) }
+                            .map { scanThreatItemBuilder.buildThreatItem(it, this::onItemClicked) }
                 }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModel.kt
@@ -4,9 +4,14 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.jetpack.scan.ScanListItemState
 import org.wordpress.android.ui.jetpack.scan.builders.ThreatItemBuilder
+import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType
+import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType.ALL
+import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType.FIXED
+import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType.IGNORED
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -21,18 +26,28 @@ class ScanHistoryListViewModel @Inject constructor(
 
     lateinit var site: SiteModel
 
-    fun start(site: SiteModel, parentViewModel: ScanHistoryViewModel) {
+    fun start(tabType: ScanHistoryTabType, site: SiteModel, parentViewModel: ScanHistoryViewModel) {
         if (isStarted) return
         isStarted = true
         this.site = site
-        uiState = parentViewModel.threats.map { threats ->
-            // TODO malinjir filter by tab
-            threats.map {
-                scanThreatItemBuilder.buildThreatItem(it, this::onItemClicked)
-            }
-        }
+        uiState = parentViewModel
+                .threats
+                .map { threats ->
+                    threats
+                            .filter { mapTabTypeToThreatStatuses(tabType).contains(it.baseThreatModel.status) }
+                            .map {
+                                scanThreatItemBuilder.buildThreatItem(it, this::onItemClicked)
+                            }
+                }
     }
 
     private fun onItemClicked(threatId: Long) {
     }
+
+    private fun mapTabTypeToThreatStatuses(tabType: ScanHistoryTabType): List<ThreatStatus> =
+            when (tabType) {
+                ALL -> listOf(ThreatStatus.FIXED, ThreatStatus.IGNORED)
+                FIXED -> listOf(ThreatStatus.FIXED)
+                IGNORED -> listOf(ThreatStatus.IGNORED)
+            }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
@@ -4,11 +4,17 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
 import org.wordpress.android.fluxc.store.ScanStore
 import org.wordpress.android.fluxc.store.ScanStore.FetchScanHistoryPayload
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType.ALL
+import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType.FIXED
+import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType.IGNORED
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -21,6 +27,14 @@ class ScanHistoryViewModel @Inject constructor(
 
     private val _threats = MutableLiveData<List<ThreatModel>>()
     val threats: LiveData<List<ThreatModel>> = _threats
+
+    val tabs: LiveData<List<TabUiState>> = MutableLiveData(
+                    listOf(
+                            TabUiState(UiStringRes(R.string.scan_history_all_threats_tab), ALL),
+                            TabUiState(UiStringRes(R.string.scan_history_fixed_threats_tab), FIXED),
+                            TabUiState(UiStringRes(R.string.scan_history_ignored_threats_tab), IGNORED)
+                    )
+    )
 
     lateinit var site: SiteModel
 
@@ -40,5 +54,10 @@ class ScanHistoryViewModel @Inject constructor(
                 _threats.value = scanStore.getScanHistoryForSite(site)
             }
         }
+    }
+
+    data class TabUiState(val label: UiString, val type: ScanHistoryTabType)
+    enum class ScanHistoryTabType {
+        ALL, FIXED, IGNORED
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
@@ -60,7 +60,7 @@ class ScanHistoryViewModel @Inject constructor(
 
     data class TabUiState(val label: UiString, val type: ScanHistoryTabType)
     @Parcelize
-    enum class ScanHistoryTabType: Parcelable {
+    enum class ScanHistoryTabType : Parcelable {
         ALL, FIXED, IGNORED
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
@@ -31,11 +31,11 @@ class ScanHistoryViewModel @Inject constructor(
     val threats: LiveData<List<ThreatModel>> = _threats
 
     val tabs: LiveData<List<TabUiState>> = MutableLiveData(
-                    listOf(
-                            TabUiState(UiStringRes(R.string.scan_history_all_threats_tab), ALL),
-                            TabUiState(UiStringRes(R.string.scan_history_fixed_threats_tab), FIXED),
-                            TabUiState(UiStringRes(R.string.scan_history_ignored_threats_tab), IGNORED)
-                    )
+            listOf(
+                    TabUiState(UiStringRes(R.string.scan_history_all_threats_tab), ALL),
+                    TabUiState(UiStringRes(R.string.scan_history_fixed_threats_tab), FIXED),
+                    TabUiState(UiStringRes(R.string.scan_history_ignored_threats_tab), IGNORED)
+            )
     )
 
     lateinit var site: SiteModel
@@ -59,6 +59,7 @@ class ScanHistoryViewModel @Inject constructor(
     }
 
     data class TabUiState(val label: UiString, val type: ScanHistoryTabType)
+
     @Parcelize
     enum class ScanHistoryTabType : Parcelable {
         ALL, FIXED, IGNORED

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.ui.jetpack.scan.history
 
+import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import kotlinx.android.parcel.Parcelize
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
@@ -57,7 +59,8 @@ class ScanHistoryViewModel @Inject constructor(
     }
 
     data class TabUiState(val label: UiString, val type: ScanHistoryTabType)
-    enum class ScanHistoryTabType {
+    @Parcelize
+    enum class ScanHistoryTabType: Parcelable {
         ALL, FIXED, IGNORED
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1076,6 +1076,11 @@
     <string name="scan_in_minutes_ago">%s minutes ago</string>
     <string name="scan_in_few_seconds">in a few seconds</string>
 
+    <!-- scan history -->
+    <string name="scan_history_all_threats_tab">All</string>
+    <string name="scan_history_fixed_threats_tab">Fixed</string>
+    <string name="scan_history_ignored_threats_tab">Ignored</string>
+
     <!-- threats -->
     <string name="threats_fix_num_of_threats">Fix %s threats</string>
     <string name="threats_found">Threats found</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModelTest.kt
@@ -43,18 +43,15 @@ class ScanHistoryListViewModelTest {
     @Before
     fun setUp() = test {
         viewModel = ScanHistoryListViewModel(scanThreatItemBuilder, TEST_DISPATCHER)
-        whenever(scanHistoryViewModel.threats).thenReturn(
-                MutableLiveData(
-                        listOf(
-                                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.FIXED)),
-                                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.UNKNOWN)),
-                                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.FIXED)),
-                                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.IGNORED)),
-                                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.FIXED)),
-                                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.CURRENT))
-                        )
-                )
+        val threats = listOf(
+                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.FIXED)),
+                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.UNKNOWN)),
+                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.FIXED)),
+                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.IGNORED)),
+                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.FIXED)),
+                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.CURRENT))
         )
+        whenever(scanHistoryViewModel.threats).thenReturn(MutableLiveData(threats))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModelTest.kt
@@ -51,7 +51,7 @@ class ScanHistoryListViewModelTest {
                                 GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.FIXED)),
                                 GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.IGNORED)),
                                 GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.FIXED)),
-                                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.CURRENT)),
+                                GenericThreatModel(genericThreatModel.baseThreatModel.copy(status = ThreatStatus.CURRENT))
                         )
                 )
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModelTest.kt
@@ -4,8 +4,8 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.atLeast
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -67,7 +67,7 @@ class ScanHistoryListViewModelTest {
         viewModel.start(ScanHistoryTabType.FIXED, site, scanHistoryViewModel)
         viewModel.uiState.observeForever(mock())
 
-        verify(scanThreatItemBuilder, atLeast(1)).buildThreatItem(captor.capture(), anyOrNull())
+        verify(scanThreatItemBuilder, times(3)).buildThreatItem(captor.capture(), anyOrNull())
         assertThat(captor.allValues).allMatch { it.baseThreatModel.status == ThreatStatus.FIXED }
     }
 
@@ -76,7 +76,7 @@ class ScanHistoryListViewModelTest {
         viewModel.start(ScanHistoryTabType.IGNORED, site, scanHistoryViewModel)
         viewModel.uiState.observeForever(mock())
 
-        verify(scanThreatItemBuilder, atLeast(1)).buildThreatItem(captor.capture(), anyOrNull())
+        verify(scanThreatItemBuilder, times(1)).buildThreatItem(captor.capture(), anyOrNull())
         assertThat(captor.allValues).allMatch { it.baseThreatModel.status == ThreatStatus.IGNORED }
     }
 
@@ -85,7 +85,7 @@ class ScanHistoryListViewModelTest {
         viewModel.start(ScanHistoryTabType.ALL, site, scanHistoryViewModel)
         viewModel.uiState.observeForever(mock())
 
-        verify(scanThreatItemBuilder, atLeast(1)).buildThreatItem(captor.capture(), anyOrNull())
+        verify(scanThreatItemBuilder, times(4)).buildThreatItem(captor.capture(), anyOrNull())
         assertThat(captor.allValues).allMatch {
             it.baseThreatModel.status == ThreatStatus.FIXED || it.baseThreatModel.status == ThreatStatus.IGNORED
         }


### PR DESCRIPTION
Parent issue #13326

This PR updates labels of tabs on Scan History screen and implements filtering by ThreatStatus type.

Merge instructions:
1. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/13824 is merged
2. Remove Not Ready for Merge label
3. Merge this PR

To test:
1. Make sure Scan feature flag is enabled
2. Click on Scan menu item on MySite screen
3. Click on History action in the toolbar
5. Notice labels of the tabs are "ALL, FIXED, IGNORED"
4. Wait until a request finishes (there is no progress and it sometime takes 30s)
6. Verify the filtering works

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
