### PR TITLE
Add Stock photo caption and include it when uploading a photo

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
@@ -37,7 +37,8 @@ data class MediaItem(
         data class StockMediaIdentifier(
             val url: String?,
             val name: String?,
-            val title: String?
+            val title: String?,
+            val caption: String?
         ) : Identifier(STOCK_MEDIA_IDENTIFIER)
 
         data class GifMediaIdentifier(
@@ -62,6 +63,7 @@ data class MediaItem(
                     parcel.writeString(this.url)
                     parcel.writeString(this.name)
                     parcel.writeString(this.title)
+                    parcel.writeString(this.caption)
                 }
                 is GifMediaIdentifier -> {
                     parcel.writeParcelable(this.largeImageUri.uri, flags)
@@ -93,7 +95,7 @@ data class MediaItem(
                             LocalId(parcel.readInt())
                         }
                         STOCK_MEDIA_IDENTIFIER -> {
-                            StockMediaIdentifier(parcel.readString(), parcel.readString(), parcel.readString())
+                            StockMediaIdentifier(parcel.readString(), parcel.readString(), parcel.readString(), parcel.readString())
                         }
                         GIF_MEDIA_IDENTIFIER -> {
                             GifMediaIdentifier(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaItem.kt
@@ -95,7 +95,12 @@ data class MediaItem(
                             LocalId(parcel.readInt())
                         }
                         STOCK_MEDIA_IDENTIFIER -> {
-                            StockMediaIdentifier(parcel.readString(), parcel.readString(), parcel.readString(), parcel.readString())
+                            StockMediaIdentifier(
+                                    parcel.readString(),
+                                    parcel.readString(),
+                                    parcel.readString(),
+                                    parcel.readString()
+                            )
                         }
                         GIF_MEDIA_IDENTIFIER -> {
                             GifMediaIdentifier(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/insert/StockMediaInsertUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/insert/StockMediaInsertUseCase.kt
@@ -27,7 +27,7 @@ class StockMediaInsertUseCase(
         emit(InsertModel.Progress(actionTitle))
         val result = stockMediaStore.performUploadStockMedia(site, identifiers.mapNotNull { identifier ->
             (identifier as? StockMediaIdentifier)?.let {
-                StockMediaUploadItem(it.name, it.title, it.url)
+                StockMediaUploadItem(it.name, it.title, it.url, it.caption)
             }
         })
         emit(when {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/StockMediaDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/StockMediaDataSource.kt
@@ -80,7 +80,7 @@ class StockMediaDataSource
                 .mapNotNull {
                     it.url?.let { url ->
                         MediaItem(
-                                StockMediaIdentifier(it.url, it.name, it.title),
+                                StockMediaIdentifier(it.url, it.name, it.title, it.caption),
                                 url,
                                 it.name,
                                 IMAGE,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/insert/StockMediaInsertUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/insert/StockMediaInsertUseCaseTest.kt
@@ -30,13 +30,15 @@ class StockMediaInsertUseCaseTest : BaseUnitTest() {
     private val title = "title"
     private val name = "name"
     private val thumbnail = "image.jpg"
+    private val caption = "caption"
     private val stockMediaItem = StockMediaItem(
             "id",
             name,
             title,
             url,
             "123",
-            thumbnail
+            thumbnail,
+            caption
     )
 
     @Before
@@ -46,7 +48,7 @@ class StockMediaInsertUseCaseTest : BaseUnitTest() {
 
     @Test
     fun `uploads media on insert`() = test {
-        val itemToInsert = Identifier.StockMediaIdentifier(url, name, title)
+        val itemToInsert = Identifier.StockMediaIdentifier(url, name, title, caption)
         val insertedMediaModel = MediaModel()
         val mediaId: Long = 10
         insertedMediaModel.mediaId = mediaId
@@ -60,6 +62,6 @@ class StockMediaInsertUseCaseTest : BaseUnitTest() {
         (result[1] as InsertModel.Success).apply {
             assertThat(this.identifiers).containsExactly(RemoteId(mediaId))
         }
-        verify(stockMediaStore).performUploadStockMedia(site, listOf(StockMediaUploadItem(name, title, url)))
+        verify(stockMediaStore).performUploadStockMedia(site, listOf(StockMediaUploadItem(name, title, url, caption)))
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/StockMediaDataSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/StockMediaDataSourceTest.kt
@@ -37,13 +37,15 @@ class StockMediaDataSourceTest : BaseUnitTest() {
     private val title = "title"
     private val name = "name"
     private val thumbnail = "image.jpg"
+    private val caption = "caption"
     private val stockMediaItem = StockMediaItem(
             "id",
             name,
             title,
             url,
             "123",
-            thumbnail
+            thumbnail,
+            caption
     )
 
     @Before
@@ -87,7 +89,7 @@ class StockMediaDataSourceTest : BaseUnitTest() {
             assertThat(this.data).hasSize(1)
             assertThat(this.data).containsExactly(
                     MediaItem(
-                            StockMediaIdentifier(url, name, title),
+                            StockMediaIdentifier(url, name, title, caption),
                             url,
                             name,
                             IMAGE,

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '14ddf035a43593b9185cda8e2abcc151d4ffd724'
+    fluxCVersion = '5d6f6ce247a0ca6a99fc2d069f6461a20d3c668d'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.9.0'
+    fluxCVersion = '14ddf035a43593b9185cda8e2abcc151d4ffd724'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'


### PR DESCRIPTION
**Issue**: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1609

### Related PRs
- [`gutenberg-mobile`](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3046)
- [`gutenberg`](https://github.com/WordPress/gutenberg/pull/28469)
- [`WordPress-iOS`](https://github.com/wordpress-mobile/WordPress-iOS/pull/15674)
- [`WordPress-FluxC-Android`](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1846)

## Description

Parse `caption` field from the response of Stock media search requests and add it to the Stock media model and item. This field is now also included in the payload when a photo is uploaded.

## Test

### WellSQL migrations

<details><summary><strong>Verify migrations</strong></summary>

### Steps

- Apply this version over current version of app
- Ensure the app still runs and activity log doesn't crash
- Apply this version as a fresh install
- Ensure the app still runs and activity log doesn't crash

</details>

### User flows

**Test scenarios - Site types:**
- **Regular WP.com site**: No issues ✅ 
- **Atomic WP.com site**: Issues ❌ 
    - **Caption value is not shown after uploading a stock photo**: For some reason the upload response is not returning the caption value, it's only shown after refreshing the items. This is also happening in the web version, on Android the value from the upload response is used as the caption of the Image block so it won't be included.
- **Self-hosted (without Jetpack)**: Free photo library (Stock photos) is not available ✅ 
- **Self-hosted (with Jetpack)**: Issues (same issue as Atomic WP.com, probably related to Jetpack) ❌ 

The changes can be tested in the following described flows:

<details><summary><strong>Media screen</strong></summary>

### Steps

1. Go to a site.
2. Tap on `Media` button.
3. Tap on `+` button.
4. Tap on `Choose from Free Photo Library`
5. Search any term.
6. Tap one or multiple photos.
7. Tap on ✔️ button.
8. Wait for the items to be uploaded.
9. [Back in the Media screen] Tap on any of the recently uploaded photos.
10. Check that `Caption` field has value.

_Note: It's possible that in some cases the item doesn't have a caption value with the credit/attribution of the photo. In this case try another one._

</details>

<details><summary><strong>Image block / Free Photo Library</strong></summary>

### Steps

1. Go to a site.
2. Open a post/page.
3. Tap on `+` button.
4. Tap on `Image` block.
5. Tap on `ADD IMAGE`.
6. Tap on `Choose from Free Photo Library`
7. Search any term.
8. Tap one photo.
9. Tap on ✔️ button.
10. Wait for the item to be uploaded.
11. Check that below the photo the caption field has a value.

_Note: It's possible that in some cases the item doesn't have a caption value with the credit/attribution of the photo. In this case try another one._

</details>

<details><summary><strong>Image block / Insert multiple images from Media library</strong></summary>

### Steps

1. Go to a site.
2. Tap on `Media` button.
3. Tap on `+` button.
4. Tap on `Choose from Free Photo Library`
5. Search any term.
6. Tap **multiple** photos.
7. Tap on ✔️ button.
8. Wait for the items to be uploaded.
9. Go to a post/page.
10. Tap on `+` button.
11. Tap on `Image` block.
12. Tap on `ADD IMAGE`.
13. Tap on `WordPress Media Library`
14. Tap on the photos previously uploaded.
15. An image block is created for each photo.
16. **Only the first image block has a caption value, the rest are empty** ❌ 

_Note: It's possible that in some cases the item doesn't have a caption value with the credit/attribution of the photo. In this case try another one._

</details>

## Screenshots

<details><summary><strong>Media screen</strong></summary>

https://user-images.githubusercontent.com/14905380/105982752-016abd00-6098-11eb-866a-45cf6832c58e.mp4

</details>

<details><summary><strong>Image block</strong></summary>

https://user-images.githubusercontent.com/14905380/105982766-06c80780-6098-11eb-90e9-6edae2d1a8c6.mp4

</details>

<details><summary><strong>Image block / Insert multiple images from Media library</strong></summary>

https://user-images.githubusercontent.com/14905380/105982771-09c2f800-6098-11eb-9afd-f2662f74c060.mp4

</details>

<hr>

**Merge Instructions:**
Only merge after [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1846) is merged and tagged, this PR will be updated with correct FluxC version and merged to develop.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
