### PR TITLE
Show postcard menu when site filter is active.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -254,7 +254,7 @@ class SubFilterViewModel @Inject constructor(
 
                 _readerModeInfo.value = (ReaderModeInfo(
                         null,
-                        ReaderPostListType.BLOG_PREVIEW,
+                        ReaderPostListType.TAG_FOLLOWED,
                         currentBlogId,
                         currentFeedId,
                         requestNewerPosts,

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
@@ -409,7 +409,7 @@ class SubFilterViewModelTest {
         viewModel.onSubfilterSelected(filter)
 
         requireNotNull(readerModeInfo).let {
-            assertThat(it.listType).isEqualTo(ReaderPostListType.BLOG_PREVIEW)
+            assertThat(it.listType).isEqualTo(ReaderPostListType.TAG_FOLLOWED)
             assertThat(it.isFiltered).isEqualTo(true)
         }
     }


### PR DESCRIPTION
Fixes #13821 

When selecting a followed site from site filter, were were showing it's post as posts from Blog Preview, which does not have a menu button. This PR changes this, so the posts from followed sites will be treated in the same way as the unfiltered feed.

[![Image from Gyazo](https://i.gyazo.com/f029fc62eb0b2435d97b046079870a75.gif)](https://gyazo.com/f029fc62eb0b2435d97b046079870a75)

To test:
- Using any Reader's tab that has a filter, open it and select an individual site.
- Confirm that the menu button is visible and works as expected.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
