### PR TITLE
Remove symlinks to gutenberg-mobile submodule (#13747)

### DIFF
--- a/WordPress/src/main/assets/supported-blocks.json
+++ b/WordPress/src/main/assets/supported-blocks.json
@@ -1,1 +1,0 @@
-../../../../libs/gutenberg-mobile/src/block-support/supported-blocks.json

--- a/libs/editor/WordPressEditor/src/main/assets/unsupported-block-editor
+++ b/libs/editor/WordPressEditor/src/main/assets/unsupported-block-editor
@@ -1,1 +1,0 @@
-../../../../../gutenberg-mobile/resources/unsupported-block-editor/

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/WPGutenbergWebViewActivity.java
@@ -140,13 +140,13 @@ public class WPGutenbergWebViewActivity extends GutenbergWebViewActivity {
 
     @Override
     protected List<String> getOnGutenbergReadyExternalSources() {
-        String file = getFileContentFromAssets("unsupported-block-editor/remove-nux.js");
+        String file = getFileContentFromAssets("remove-nux.js");
         return Arrays.asList(file);
     }
 
     @Override protected List<String> getOnPageLoadExternalSources() {
         long userId = getIntent().getExtras().getLong(ARG_USER_ID, 0);
-        String file = getFileContentFromAssets("unsupported-block-editor/extra-localstorage-entries.js")
+        String file = getFileContentFromAssets("extra-localstorage-entries.js")
                 .replace("%@", Long.toString(userId));
         return Arrays.asList(file);
     }


### PR DESCRIPTION
Fixes #13747 by removing symlinks to files in the `gutenberg-mobile` submodule in favor of loading them from the `gutenberg-react-native-bridge` library.

### To test

For `supported-blocks.json`:

- Add a breakpoint to `SupportedBlocks.kt` line 12, where we load the file
- Debug the app
- Load the screen to create a new site page

You'll see the breakpoint being hit and you should be able to step over successfully.

For `unsupported-blocks/`:

- Add a breakpoint to `WPGutenbergWebViewActivity.kt` line 143 and/or 149, where files from that folder are loaded
- From WP.com, create a post (or a draft) with a block that is not supported yet. I used `jetpack/business-hours`
- Launch the app and go to Posts > Drafts
- Load the post with unsupported block(s)
- Select the unsupported block > "Edit using web editor"

You'll see the breakpoint(s) being hit and you should be able to step over successfully. 

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.