### PR TITLE
Issue/13812 fix site notifications on following tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTableWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTableWrapper.kt
@@ -1,10 +1,11 @@
 package org.wordpress.android.datasets
 
 import org.wordpress.android.models.ReaderBlog
+import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import javax.inject.Inject
 
 class ReaderBlogTableWrapper
-@Inject constructor() {
+@Inject constructor(private val readerUtilsWrapper: ReaderUtilsWrapper) {
     fun getFollowedBlogs(): List<ReaderBlog> = ReaderBlogTable.getFollowedBlogs()!!
     fun getBlogInfo(blogId: Long): ReaderBlog? = ReaderBlogTable.getBlogInfo(blogId)
     fun getFeedInfo(feedId: Long): ReaderBlog? = ReaderBlogTable.getFeedInfo(feedId)
@@ -13,7 +14,7 @@ class ReaderBlogTableWrapper
             ReaderBlogTable.setNotificationsEnabledByBlogId(blogId, isEnabled)
 
     fun getReaderBlog(blogId: Long, feedId: Long): ReaderBlog? {
-        return if (feedId != 0L) {
+        return if (readerUtilsWrapper.isExternalFeed(blogId, feedId)) {
             ReaderBlogTable.getFeedInfo(feedId)
         } else {
             ReaderBlogTable.getBlogInfo(blogId)
@@ -21,7 +22,7 @@ class ReaderBlogTableWrapper
     }
 
     fun isSiteFollowed(blogId: Long, feedId: Long): Boolean {
-        return if (feedId != 0L) {
+        return if (readerUtilsWrapper.isExternalFeed(blogId, feedId)) {
             ReaderBlogTable.isFollowedFeed(feedId)
         } else {
             ReaderBlogTable.isFollowedBlog(blogId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -234,7 +234,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
                             Event(SnackbarMessageHolder((UiStringRes(R.string.reader_error_request_failed_title))))
                     )
                 }
-                is FollowSiteState.Success -> Unit // Do nothing
+                is FollowSiteState.AlreadyRunning, FollowSiteState.Success -> Unit // Do nothing
                 is FollowStatusChanged -> {
                     _followStatusUpdated.postValue(it)
                     siteNotificationsUseCase.fetchSubscriptions()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderSiteFollowUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderSiteFollowUseCase.kt
@@ -28,7 +28,7 @@ class ReaderSiteFollowUseCase @Inject constructor(
 ) {
     private val continuations: MutableMap<Param, Continuation<Boolean>?> = mutableMapOf()
 
-    suspend fun toggleFollow(param: Param) = flow<FollowSiteState> {
+    suspend fun toggleFollow(param: Param) = flow {
         val (blogId, feedId) = param
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             emit(NoNetwork)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderSiteFollowUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderSiteFollowUseCase.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.flow
 import org.wordpress.android.datasets.ReaderBlogTableWrapper
 import org.wordpress.android.ui.reader.actions.ReaderActions.ActionListener
 import org.wordpress.android.ui.reader.actions.ReaderBlogActionsWrapper
+import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.AlreadyRunning
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.Failed.NoNetwork
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.Failed.RequestFailed
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.FollowStatusChanged
@@ -25,36 +26,37 @@ class ReaderSiteFollowUseCase @Inject constructor(
     private val readerBlogTableWrapper: ReaderBlogTableWrapper,
     private val readerUtilsWrapper: ReaderUtilsWrapper
 ) {
-    private var continuation: Continuation<Boolean>? = null
+    private val continuations: MutableMap<Param, Continuation<Boolean>?> = mutableMapOf()
 
     suspend fun toggleFollow(param: Param) = flow<FollowSiteState> {
         val (blogId, feedId) = param
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             emit(NoNetwork)
         } else {
+            // There is already an action running for this request
+            if (continuations[param] != null) {
+                emit(AlreadyRunning)
+                return@flow
+            }
             val isAskingToFollow = !readerBlogTableWrapper.isSiteFollowed(blogId, feedId)
             val showEnableNotification = !readerUtilsWrapper.isExternalFeed(blogId, feedId) && isAskingToFollow
 
             emit(FollowStatusChanged(blogId, isAskingToFollow, showEnableNotification))
-            performAction(blogId, feedId, isAskingToFollow)
+            performAction(param, isAskingToFollow)
         }
     }
 
-    private suspend fun FlowCollector<FollowSiteState>.performAction(
-        blogId: Long,
-        feedId: Long,
-        isAskingToFollow: Boolean
-    ) {
-        val succeeded = followSiteAndWaitForResult(blogId, feedId, isAskingToFollow)
+    private suspend fun FlowCollector<FollowSiteState>.performAction(param: Param, isAskingToFollow: Boolean) {
+        val succeeded = followSiteAndWaitForResult(param, isAskingToFollow)
         if (!succeeded) {
-            emit(FollowStatusChanged(blogId, !isAskingToFollow))
+            emit(FollowStatusChanged(param.blogId, !isAskingToFollow))
             emit(RequestFailed)
         } else {
-            val deleteNotificationSubscription = !readerUtilsWrapper.isExternalFeed(blogId, feedId) &&
+            val deleteNotificationSubscription = !readerUtilsWrapper.isExternalFeed(param.blogId, param.feedId) &&
                     !isAskingToFollow
             emit(
                     FollowStatusChanged(
-                            blogId,
+                            param.blogId,
                             isAskingToFollow,
                             deleteNotificationSubscription = deleteNotificationSubscription
                     )
@@ -63,15 +65,15 @@ class ReaderSiteFollowUseCase @Inject constructor(
         }
     }
 
-    private suspend fun followSiteAndWaitForResult(blogId: Long, feedId: Long, isAskingToFollow: Boolean): Boolean {
+    private suspend fun followSiteAndWaitForResult(param: Param, isAskingToFollow: Boolean): Boolean {
         val actionListener = ActionListener { succeeded ->
-            continuation?.resume(succeeded)
-            continuation = null
+            continuations[param]?.resume(succeeded)
+            continuations[param] = null
         }
 
         return suspendCoroutine { cont ->
-            continuation = cont
-            readerBlogActionsWrapper.followBlog(blogId, feedId, isAskingToFollow, actionListener)
+            continuations[param] = cont
+            readerBlogActionsWrapper.followBlog(param.blogId, param.feedId, isAskingToFollow, actionListener)
         }
     }
 
@@ -84,6 +86,7 @@ class ReaderSiteFollowUseCase @Inject constructor(
         ) : FollowSiteState()
 
         object Success : FollowSiteState()
+        object AlreadyRunning : FollowSiteState()
         sealed class Failed : FollowSiteState() {
             object NoNetwork : Failed()
             object RequestFailed : Failed()

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'a12683c2102bd4ee689b8eb0dc8e1fc099b37dd4'
+    fluxCVersion = '1.9.0-beta-9'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.9.0-beta-8'
+    fluxCVersion = 'a12683c2102bd4ee689b8eb0dc8e1fc099b37dd4'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'


### PR DESCRIPTION
Fixes #13812

This PR checks if the blog is an external feed [here](https://github.com/wordpress-mobile/WordPress-Android/blob/b7a62482dd80bc50c227d52be059c65b552999b3/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTableWrapper.kt#L15-L29), when site follow status is checked in the db. This resolves an occasional follow blog issue occurring when a blog is followed by url and feed id gets generated for it. 

It also fixes `SQLiteConstraintException: UNIQUE constraint failed` exception seen in the logs when site notifications are subscribed.

Details below:

To test:

1. Follow a simple WP.com site using the site url on Reader -> gear icon -> Manage Topics & Sites

2. Notice that the user's followed sites response does not contain `feed_id`. Details are updated in `tbl_blog_info` with `feed_id` = 0.
    Eg: [read-following-mine_meta=site%2Cfeed.txt](https://github.com/wordpress-mobile/WordPress-Android/files/5854302/read-following-mine_meta.site.2Cfeed.txt)

3. Return from "Manage Topics & Sites" to the following tab. Notice that followed site posts contains feed id and are inserted into `tbl_posts` with `feed_id` set.
    Eg: [read-following_number=20&meta=site,likes.txt](https://github.com/wordpress-mobile/WordPress-Android/files/5854296/read-following_number.20.meta.site.likes.txt)

4. Toggle follow site menu few times. Also toggle follow button on the post details screen.

5. Notice that site is followed/ unfollowed properly.
    
    With the external feed check in the `ReaderBlogTableWrapper` class, site is now retrieved from the `tbl_blog_info` using the `blog_id` instead of the `feed_id`. Earlier it wasn't found in the `tbl_blog_info` since `feed_id` was not set at step 2 and returned wrong followed status, sending incorrect follow request. 

https://user-images.githubusercontent.com/1405144/105350203-cd634800-5c10-11eb-80b7-2f9bf546e89a.mp4 

https://user-images.githubusercontent.com/1405144/105350250-deac5480-5c10-11eb-984f-2dbf6ae226f3.mp4

Also `AlreadyRunning` state is added when request to follow blog is running and `updateSubscription` method in FluxC is synchronised. This fixes `SQLiteConstraintException: UNIQUE constraint failed:` exception in the logs. Issue existed even before reader refactoring, occurred on trying to follow/ unfollow blog/ site in quick succession, resulting in desynchronisation while updating user's subscriptions [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/a097f94c384cc146c9a187144ea73eb1ab64c893/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/AccountSqlUtils.java#L145-L148).

Merge instructions:
- ~~Review, merge https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1851 and create a FluxC tag~~ Done
- ~~Replace FluxC commit hash with tag on develop~~ Done
- Remove 'Not Ready for Merge' label
- Merge this PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
