### PR TITLE
Issue/13812 site notifications discover

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActionsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActionsWrapper.kt
@@ -1,10 +1,14 @@
 package org.wordpress.android.ui.reader.actions
 
 import org.wordpress.android.ui.reader.actions.ReaderActions.ActionListener
+import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateBlogInfoListener
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions.BlockedBlogResult
+import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import javax.inject.Inject
 
-class ReaderBlogActionsWrapper @Inject constructor() {
+class ReaderBlogActionsWrapper @Inject constructor(
+    private val readerUtilsWrapper: ReaderUtilsWrapper
+) {
     fun blockBlogFromReaderLocal(blogId: Long): BlockedBlogResult = ReaderBlogActions.blockBlogFromReaderLocal(blogId)
 
     fun blockBlogFromReaderRemote(blockedBlogResult: BlockedBlogResult, actionListener: ActionListener?): Unit =
@@ -14,4 +18,11 @@ class ReaderBlogActionsWrapper @Inject constructor() {
 
     fun followBlog(blogId: Long, feedId: Long, isAskingToFollow: Boolean, actionListener: ActionListener) =
             ReaderBlogActions.followBlog(blogId, feedId, isAskingToFollow, actionListener)
+
+    fun updateBlogInfo(blogId: Long, feedId: Long, blogUrl: String?, infoListener: UpdateBlogInfoListener) =
+            if (readerUtilsWrapper.isExternalFeed(blogId, feedId)) {
+                ReaderBlogActions.updateFeedInfo(blogId, blogUrl, infoListener)
+            } else {
+                ReaderBlogActions.updateBlogInfo(blogId, blogUrl, infoListener)
+            }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderFetchSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderFetchSiteUseCase.kt
@@ -1,0 +1,73 @@
+package org.wordpress.android.ui.reader.usecases
+
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import org.wordpress.android.models.ReaderBlog
+import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateBlogInfoListener
+import org.wordpress.android.ui.reader.actions.ReaderBlogActionsWrapper
+import org.wordpress.android.ui.reader.usecases.ReaderFetchSiteUseCase.FetchSiteState.AlreadyRunning
+import org.wordpress.android.ui.reader.usecases.ReaderFetchSiteUseCase.FetchSiteState.Failed.NoNetwork
+import org.wordpress.android.ui.reader.usecases.ReaderFetchSiteUseCase.FetchSiteState.Failed.RequestFailed
+import org.wordpress.android.ui.reader.usecases.ReaderFetchSiteUseCase.FetchSiteState.Success
+import org.wordpress.android.util.NetworkUtilsWrapper
+import javax.inject.Inject
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+class ReaderFetchSiteUseCase @Inject constructor(
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val readerBlogActionsWrapper: ReaderBlogActionsWrapper
+) {
+    private val continuations: MutableMap<FetchSiteRequestParams, Continuation<ReaderBlog?>?> = mutableMapOf()
+
+    suspend fun fetchSite(blogId: Long, feedId: Long, blogUrl: String? = null) = flow {
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+            emit(NoNetwork)
+        } else {
+            val requestParams = FetchSiteRequestParams(blogId, feedId, blogUrl)
+            // There is already an action running for this request
+            if (continuations[requestParams] != null) {
+                emit(AlreadyRunning)
+                return@flow
+            }
+            performAction(requestParams)
+        }
+    }
+
+    private suspend fun FlowCollector<FetchSiteState>.performAction(requestParams: FetchSiteRequestParams) {
+        fetchSiteAndWaitForResult(requestParams)?.let { emit(Success) } ?: emit(RequestFailed)
+    }
+
+    private suspend fun fetchSiteAndWaitForResult(requestParams: FetchSiteRequestParams): ReaderBlog? {
+        val actionListener = UpdateBlogInfoListener { readerBlog ->
+            continuations[requestParams]?.resume(readerBlog)
+            continuations[requestParams] = null
+        }
+
+        return suspendCoroutine { cont ->
+            continuations[requestParams] = cont
+            readerBlogActionsWrapper.updateBlogInfo(
+                requestParams.blogId,
+                requestParams.feedId,
+                requestParams.blogUrl,
+                actionListener
+            )
+        }
+    }
+
+    sealed class FetchSiteState {
+        object Success : FetchSiteState()
+        object AlreadyRunning : FetchSiteState()
+        sealed class Failed : FetchSiteState() {
+            object NoNetwork : Failed()
+            object RequestFailed : Failed()
+        }
+    }
+
+    data class FetchSiteRequestParams(
+        val blogId: Long,
+        val feedId: Long,
+        val blogUrl: String?
+    )
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.ui.reader.discover
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -20,6 +22,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.TEST_SCOPE
+import org.wordpress.android.datasets.ReaderBlogTableWrapper
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.store.AccountStore.AddOrDeleteSubscriptionPayload.SubscriptionAction
 import org.wordpress.android.models.ReaderPost
@@ -35,10 +38,10 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookm
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowNoSitesToReblog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostDetail
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReportPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
-import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReportPost
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.COMMENTS
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
@@ -61,9 +64,12 @@ import org.wordpress.android.ui.reader.repository.usecases.PostLikeUseCase.PostL
 import org.wordpress.android.ui.reader.repository.usecases.UndoBlockBlogUseCase
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.Success
+import org.wordpress.android.ui.reader.usecases.ReaderFetchSiteUseCase
+import org.wordpress.android.ui.reader.usecases.ReaderFetchSiteUseCase.FetchSiteState
 import org.wordpress.android.ui.reader.usecases.ReaderPostBookmarkUseCase
 import org.wordpress.android.ui.reader.usecases.ReaderSeenStatusToggleUseCase
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase
+import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.Failed.NoNetwork
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.Failed.RequestFailed
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.FollowStatusChanged
@@ -89,13 +95,15 @@ class ReaderPostCardActionsHandlerTest {
     @Mock private lateinit var siteNotificationsUseCase: ReaderSiteNotificationsUseCase
     @Mock private lateinit var seenStatusToggleUseCase: ReaderSeenStatusToggleUseCase
     @Mock private lateinit var undoBlockBlogUseCase: UndoBlockBlogUseCase
+    @Mock private lateinit var fetchSiteUseCase: ReaderFetchSiteUseCase
     @Mock private lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock private lateinit var readerBlogTableWrapper: ReaderBlogTableWrapper
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var resourceProvider: ResourceProvider
     @Mock private lateinit var htmlMessageUtils: HtmlMessageUtils
 
     @Before
-    fun setUp() {
+    fun setUp() = test {
         actionHandler = ReaderPostCardActionsHandler(
                 analyticsTrackerWrapper,
                 reblogUseCase,
@@ -105,18 +113,21 @@ class ReaderPostCardActionsHandlerTest {
                 likeUseCase,
                 siteNotificationsUseCase,
                 undoBlockBlogUseCase,
+                fetchSiteUseCase,
                 appPrefsWrapper,
                 dispatcher,
                 resourceProvider,
                 htmlMessageUtils,
                 mock(),
                 seenStatusToggleUseCase,
+                readerBlogTableWrapper,
                 TEST_DISPATCHER,
                 TEST_SCOPE,
                 TEST_SCOPE
         )
         whenever(appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog()).thenReturn(false)
         whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), anyOrNull())).thenReturn(mock())
+        whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(mock())
     }
 
     /** BOOKMARK ACTION begin **/
@@ -307,6 +318,61 @@ class ReaderPostCardActionsHandlerTest {
         // Assert
         assertThat(observedValues.snackbarMsgs.size).isEqualTo(1)
     }
+
+    @Test
+    fun `given site present in db, when follow action is requested, follow site is triggered`() = test {
+        // Arrange
+        whenever(followUseCase.toggleFollow(anyOrNull())).thenReturn(flowOf(FollowSiteState.Success))
+
+        // Act
+        actionHandler.onAction(dummyReaderPostModel(), FOLLOW, false)
+
+        // Assert
+        verify(followUseCase, times(1)).toggleFollow(any())
+    }
+
+    @Test
+    fun `given site not present in db, when follow action is requested, fetch site is triggered`() = test {
+        // Arrange
+        whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
+        whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(flowOf(FetchSiteState.Success))
+        whenever(followUseCase.toggleFollow(anyOrNull())).thenReturn(flowOf(FollowSiteState.Success))
+
+        // Act
+        actionHandler.onAction(dummyReaderPostModel(), FOLLOW, false)
+
+        // Assert
+        verify(fetchSiteUseCase, times(1)).fetchSite(any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun `given fetch site request fails, when follow action is requested, error snackbar is shown`() = test {
+        // Arrange
+        whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
+        whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull()))
+                .thenReturn(flowOf(FetchSiteState.Failed.RequestFailed))
+        val observedValues = startObserving()
+
+        // Act
+        actionHandler.onAction(dummyReaderPostModel(), FOLLOW, false)
+
+        // Assert
+        assertThat(observedValues.snackbarMsgs.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `given fetch site request succeeds, when follow action is requested, follow site is triggered`() = test {
+        // Arrange
+        whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
+        whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(flowOf(FetchSiteState.Success))
+        whenever(followUseCase.toggleFollow(anyOrNull())).thenReturn(flowOf(FollowSiteState.Success))
+
+        // Act
+        actionHandler.onAction(dummyReaderPostModel(), FOLLOW, false)
+
+        // Assert
+        verify(followUseCase, times(1)).toggleFollow(any())
+    }
     /** FOLLOW ACTION end **/
 
     /** SITE NOTIFICATIONS ACTION Begin **/
@@ -362,6 +428,64 @@ class ReaderPostCardActionsHandlerTest {
         // Assert
         assertThat(observedValues.snackbarMsgs).isEmpty()
     }
+
+    @Test
+    fun `given site present in db, when site notifications action is requested, toggle notifications is triggered`() =
+        test {
+            // Arrange
+            whenever(siteNotificationsUseCase.toggleNotification(anyLong())).thenReturn(SiteNotificationState.Success)
+
+            // Act
+            actionHandler.onAction(dummyReaderPostModel(), SITE_NOTIFICATIONS, false)
+
+            // Assert
+            verify(siteNotificationsUseCase, times(1)).toggleNotification(any())
+        }
+
+    @Test
+    fun `given site not present in db, when site notifications action is requested, fetch site is triggered`() = test {
+        // Arrange
+        whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
+        whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(flowOf(FetchSiteState.Success))
+        whenever(siteNotificationsUseCase.toggleNotification(anyLong())).thenReturn(SiteNotificationState.Success)
+
+        // Act
+        actionHandler.onAction(dummyReaderPostModel(), SITE_NOTIFICATIONS, false)
+
+        // Assert
+        verify(fetchSiteUseCase, times(1)).fetchSite(any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun `given fetch site request fails, when site notifications action is requested, error snackbar is shown`() =
+        test {
+            // Arrange
+            whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
+            whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull()))
+                    .thenReturn(flowOf(FetchSiteState.Failed.RequestFailed))
+            val observedValues = startObserving()
+
+            // Act
+            actionHandler.onAction(dummyReaderPostModel(), SITE_NOTIFICATIONS, false)
+
+            // Assert
+            assertThat(observedValues.snackbarMsgs.size).isEqualTo(1)
+        }
+
+    @Test
+    fun `given fetch site request succeeds, when site notifications is requested, toggle notifications is triggered`() =
+        test {
+            // Arrange
+            whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
+            whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(flowOf(FetchSiteState.Success))
+            whenever(siteNotificationsUseCase.toggleNotification(anyLong())).thenReturn(SiteNotificationState.Success)
+
+            // Act
+            actionHandler.onAction(dummyReaderPostModel(), SITE_NOTIFICATIONS, false)
+
+            // Assert
+            verify(siteNotificationsUseCase, times(1)).toggleNotification(any())
+        }
     /** SITE NOTIFICATIONS ACTION end **/
 
     /** SHARE ACTION Begin **/

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
@@ -335,7 +335,7 @@ class ReaderPostCardActionsHandlerTest {
     fun `given site not present in db, when follow action is requested, fetch site is triggered`() = test {
         // Arrange
         whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
-        whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(flowOf(FetchSiteState.Success))
+        whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(FetchSiteState.Success)
         whenever(followUseCase.toggleFollow(anyOrNull())).thenReturn(flowOf(FollowSiteState.Success))
 
         // Act
@@ -350,7 +350,7 @@ class ReaderPostCardActionsHandlerTest {
         // Arrange
         whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
         whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull()))
-                .thenReturn(flowOf(FetchSiteState.Failed.RequestFailed))
+                .thenReturn(FetchSiteState.Failed.RequestFailed)
         val observedValues = startObserving()
 
         // Act
@@ -364,7 +364,7 @@ class ReaderPostCardActionsHandlerTest {
     fun `given fetch site request succeeds, when follow action is requested, follow site is triggered`() = test {
         // Arrange
         whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
-        whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(flowOf(FetchSiteState.Success))
+        whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(FetchSiteState.Success)
         whenever(followUseCase.toggleFollow(anyOrNull())).thenReturn(flowOf(FollowSiteState.Success))
 
         // Act
@@ -446,7 +446,7 @@ class ReaderPostCardActionsHandlerTest {
     fun `given site not present in db, when site notifications action is requested, fetch site is triggered`() = test {
         // Arrange
         whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
-        whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(flowOf(FetchSiteState.Success))
+        whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(FetchSiteState.Success)
         whenever(siteNotificationsUseCase.toggleNotification(anyLong())).thenReturn(SiteNotificationState.Success)
 
         // Act
@@ -462,7 +462,7 @@ class ReaderPostCardActionsHandlerTest {
             // Arrange
             whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
             whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull()))
-                    .thenReturn(flowOf(FetchSiteState.Failed.RequestFailed))
+                    .thenReturn(FetchSiteState.Failed.RequestFailed)
             val observedValues = startObserving()
 
             // Act
@@ -477,7 +477,7 @@ class ReaderPostCardActionsHandlerTest {
         test {
             // Arrange
             whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(null)
-            whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(flowOf(FetchSiteState.Success))
+            whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull())).thenReturn(FetchSiteState.Success)
             whenever(siteNotificationsUseCase.toggleNotification(anyLong())).thenReturn(SiteNotificationState.Success)
 
             // Act


### PR DESCRIPTION
This PR fixes sites notifications issue on the discover tab as part of #13812.
It prefetches the site if not available in db before the toggle follow and toggle notifications actions are performed.

To test:
- Fresh install the app and perform toggle (site, notification) actions on a discover tab post few times
- Verify that the post is appropriately followed/ unfollowed,  notifications are subscribed/ unsubscribed

Merge Instructions:

- Review and merge #13838
- Remove 'Not Ready for Merge' label
- Merge this PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
