### PR TITLE
Fixing P2 and A8C tab shown traking in reader.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2499,10 +2499,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
             stat = Stat.READER_TAG_LOADED;
         } else if (tag.isListTopic()) {
             stat = Stat.READER_LIST_LOADED;
-        } else if (tag.isP2()) {
-            stat = Stat.READER_P2_SHOWN;
-        } else if (tag.isA8C()) {
-            stat = Stat.READER_A8C_SHOWN;
         } else {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
@@ -1,17 +1,21 @@
 package org.wordpress.android.ui.reader.tracker
 
 import androidx.annotation.MainThread
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_A8C_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_CUSTOM_TAB_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_DISCOVER_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_FOLLOWING_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_LIKED_SHOWN
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_P2_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_SAVED_LIST_SHOWN
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.reader.tracker.ReaderTab.A8C
 import org.wordpress.android.ui.reader.tracker.ReaderTab.CUSTOM
 import org.wordpress.android.ui.reader.tracker.ReaderTab.DISCOVER
 import org.wordpress.android.ui.reader.tracker.ReaderTab.FOLLOWING
 import org.wordpress.android.ui.reader.tracker.ReaderTab.LIKED
+import org.wordpress.android.ui.reader.tracker.ReaderTab.P2
 import org.wordpress.android.ui.reader.tracker.ReaderTab.SAVED
 import org.wordpress.android.ui.reader.utils.DateProvider
 import org.wordpress.android.util.AppLog
@@ -84,6 +88,8 @@ class ReaderTracker @Inject constructor(
                 DISCOVER -> analyticsTrackerWrapper.track(READER_DISCOVER_SHOWN)
                 LIKED -> analyticsTrackerWrapper.track(READER_LIKED_SHOWN)
                 SAVED -> analyticsTrackerWrapper.track(READER_SAVED_LIST_SHOWN, mapOf("source" to "reader_filter"))
+                A8C -> analyticsTrackerWrapper.track(READER_A8C_SHOWN)
+                P2 -> analyticsTrackerWrapper.track(READER_P2_SHOWN)
                 CUSTOM -> analyticsTrackerWrapper.track(READER_CUSTOM_TAB_SHOWN)
             }
             appPrefsWrapper.setReaderActiveTab(readerTab)
@@ -100,7 +106,7 @@ class ReaderTracker @Inject constructor(
 }
 
 enum class ReaderTab(val id: Int) {
-    FOLLOWING(1), DISCOVER(2), LIKED(3), SAVED(4), CUSTOM(5);
+    FOLLOWING(1), DISCOVER(2), LIKED(3), SAVED(4), CUSTOM(5), A8C(6), P2(7);
 
     companion object {
         fun fromId(id: Int): ReaderTab {
@@ -109,6 +115,8 @@ enum class ReaderTab(val id: Int) {
                 DISCOVER.id -> DISCOVER
                 LIKED.id -> LIKED
                 SAVED.id -> SAVED
+                A8C.id -> A8C
+                P2.id -> P2
                 CUSTOM.id -> CUSTOM
                 else -> throw RuntimeException("Unexpected ReaderTab id")
             }
@@ -120,6 +128,8 @@ enum class ReaderTab(val id: Int) {
                 readerTag.isPostsILike -> LIKED
                 readerTag.isBookmarked -> SAVED
                 readerTag.isDiscover -> DISCOVER
+                readerTag.isA8C -> A8C
+                readerTag.isP2 -> P2
                 else -> CUSTOM
             }
         }


### PR DESCRIPTION
This PR aim to fix an issue in tracking the `READER_A8C_SHOWN` and `READER_P2_SHOWN` events. The goal of these 2 events should be to track when user swipe to or select the Automattic or Followed P2s tabs, whereas the way we were tracking was such that we were tracking when the tags related to those tabs were loaded, so checking the tracks in the logcat you could notice those 2 events were not fired every time you go to the related tabs but basically only at first load of the tabs.

### To test
- In logcat use the `Tracked: ` string as filter
- Swipe (or select) between all the available tabs 
- Check you get the track events related to `reader_a8c_shown` and `reader_p2_shown` every time you come to the relative tab
- Check you get `reader_following_shown`, `reader_discover_shown`, `reader_liked_shown`, `reader_saved_list_shown` when coming to the related tabs
- If you have custom lists in the reader you should get a single `reader_custom_tab_shown` until you change to a not generic custom tab

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
