### PR TITLE
Reader: Changes the label of the follow conversation button

### DIFF
--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -155,7 +155,7 @@
 
     <!-- reader follow unfollow comments dimensions -->
     <dimen name="reader_follow_button_min_height">32dp</dimen>
-    <dimen name="reader_follow_button_skeleton_width">165dp</dimen>
+    <dimen name="reader_follow_button_skeleton_width">200dp</dimen>
     <dimen name="reader_follow_button_skeleton_icon_size">14dp</dimen>
     <dimen name="reader_follow_button_skeleton_icon_text_margin">4dp</dimen>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1863,8 +1863,8 @@
     <string name="reader_btn_notifications_on">Turn on site notifications</string>
     <string name="reader_btn_select_few_interests">Select a few to continue</string>
     <string name="reader_btn_done">Done</string>
-    <string name="reader_btn_follow_comments">Follow conversation</string>
-    <string name="reader_btn_following_comments">Following conversation</string>
+    <string name="reader_btn_follow_comments">Follow conversation by email</string>
+    <string name="reader_btn_following_comments">Following conversation by email</string>
 
     <!-- accessibility content desciptions -->
     <string name="reader_btn_remove_filter_content_description">Remove the current filter</string>


### PR DESCRIPTION
Refs pbArwn-1zZ-p2

This PR updates the text of the follow conversation button to read "Follow conversation by email" or "Following conversation by email"

To test:
Launch the app and confirm the text change.

![Screenshot_1611335019](https://user-images.githubusercontent.com/1435271/105522150-7dcd5c80-5ca2-11eb-80d8-76fb0f7aa0a9.png)
![Screenshot_1611335026](https://user-images.githubusercontent.com/1435271/105522157-7e65f300-5ca2-11eb-9115-984f6ff7bdfe.png)



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
