### PR TITLE
Try to get post with feed item id in reader post details

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -355,6 +355,15 @@ public class ReaderPostTable {
                        excludeTextColumn);
     }
 
+    public static ReaderPost getBlogPost(long blogId, long postId, boolean excludeTextColumn,
+                                         boolean tryIncludeFeedItemId) {
+        String sortingOptions = (tryIncludeFeedItemId) ? " ORDER BY feed_item_id DESC" : "";
+
+        return getPost("blog_id=? AND post_id=?" + sortingOptions,
+                new String[]{Long.toString(blogId), Long.toString(postId)},
+                excludeTextColumn);
+    }
+
     private static ReaderPost getPost(String where, String[] args, boolean excludeTextColumn) {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "*");
         String sql = "SELECT " + columns + " FROM tbl_posts WHERE " + where + " LIMIT 1";

--- a/WordPress/src/main/java/org/wordpress/android/datasets/wrappers/ReaderPostTableWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/wrappers/ReaderPostTableWrapper.kt
@@ -9,8 +9,13 @@ import javax.inject.Inject
 
 @Reusable
 class ReaderPostTableWrapper @Inject constructor() {
-    fun getBlogPost(blogId: Long, postId: Long, excludeTextColumn: Boolean): ReaderPost? =
-            ReaderPostTable.getBlogPost(blogId, postId, excludeTextColumn)
+    fun getBlogPost(
+        blogId: Long,
+        postId: Long,
+        excludeTextColumn: Boolean,
+        tryIncludeFeedItemId: Boolean = false
+    ): ReaderPost? =
+            ReaderPostTable.getBlogPost(blogId, postId, excludeTextColumn, tryIncludeFeedItemId)
 
     fun isPostFollowed(post: ReaderPost): Boolean = ReaderPostTable.isPostFollowed(post)
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/wrappers/ReaderPostTableWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/wrappers/ReaderPostTableWrapper.kt
@@ -12,6 +12,13 @@ class ReaderPostTableWrapper @Inject constructor() {
     fun getBlogPost(
         blogId: Long,
         postId: Long,
+        excludeTextColumn: Boolean
+    ): ReaderPost? =
+            ReaderPostTable.getBlogPost(blogId, postId, excludeTextColumn)
+
+    fun getBlogPost(
+        blogId: Long,
+        postId: Long,
         excludeTextColumn: Boolean,
         tryIncludeFeedItemId: Boolean = false
     ): ReaderPost? =

--- a/WordPress/src/main/java/org/wordpress/android/datasets/wrappers/ReaderPostTableWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/wrappers/ReaderPostTableWrapper.kt
@@ -9,11 +9,7 @@ import javax.inject.Inject
 
 @Reusable
 class ReaderPostTableWrapper @Inject constructor() {
-    fun getBlogPost(
-        blogId: Long,
-        postId: Long,
-        excludeTextColumn: Boolean
-    ): ReaderPost? =
+    fun getBlogPost(blogId: Long, postId: Long, excludeTextColumn: Boolean): ReaderPost? =
             ReaderPostTable.getBlogPost(blogId, postId, excludeTextColumn)
 
     fun getBlogPost(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -717,7 +717,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             if (isAdded && post != null) {
                 // if the post has changed, reload it from the db and update the like/comment counts
                 if (result.isNewOrChanged) {
-                    this.post = ReaderPostTable.getBlogPost(post.blogId, post.postId, false)
+                    this.post = ReaderPostTable.getBlogPost(post.blogId, post.postId, false, true)
                     this.post?.let {
                         viewModel.onUpdatePost(it)
                     }
@@ -1001,7 +1001,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             post = if (isFeed)
                 ReaderPostTable.getFeedPost(blogId, postId, false)
             else
-                ReaderPostTable.getBlogPost(blogId, postId, false)
+                ReaderPostTable.getBlogPost(blogId, postId, false, true)
             if (post == null) {
                 return false
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -183,7 +183,8 @@ class ReaderPostDetailViewModel @Inject constructor(
         return readerPostTableWrapper.getBlogPost(
                 blogId,
                 postId,
-                true
+                excludeTextColumn = true,
+                tryIncludeFeedItemId = true
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -99,6 +99,7 @@ class ReaderPostDetailViewModelTest {
         whenever(readerPostTableWrapper.getBlogPost(
                 anyOrNull(),
                 anyOrNull(),
+                anyOrNull(),
                 anyOrNull()
         )).thenReturn(readerPost)
 


### PR DESCRIPTION
Readers post can belong to multiple tags or streams, we sometimes have a multiple, almost identical versions of it at the same time - they only difference is additional data, like tag and feed item id. When opening a reader post details we use post and blog id to retrieve the post from DB, and because there are multiple posts that match give blog and post ID, we only take the first post from the set.

This PR changes the SQL query, so the posts with `feed_item_id` will appear at the top of the set and will get picked.
Reader logic is pretty complicated, so to avoid any potential complications I limited use of the the sorting to post details.

To test:
- Enable `UNREAD_POSTS_COUNT` feature.
- Pick a post in followed, a8c or or p2 streams. Confirm that is has a Mark as Seen/Unseen in postcard menu.
- Open post details and confirm that the Mark as Seen/Unseen is available in post menu (in top right corner).

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
