### PR TITLE
Mark reference strings as non translatable.

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1115,7 +1115,7 @@
     <!-- threat fix -->
     <string name="threat_fix_default_header">How will we fix it?</string>
     <string name="threat_fix_fixed_header">How did Jetpack fix it?</string>
-    <string name="threat_fix_current_fixable_header">@string/threat_fix_default_header</string>
+    <string name="threat_fix_current_fixable_header" translatable="false">@string/threat_fix_default_header</string>
     <string name="threat_fix_current_not_fixable_header">Resolving the threat</string>
     <string name="threat_fix_current_not_fixable_description">Jetpack Scan cannot automatically fix this threat.
         We suggest that you resolve the threat manually: ensure that WordPress, your theme, and all of your plugins are up to date, and remove the offending code, theme, or plugin from your site. \n \n
@@ -2037,7 +2037,7 @@
     <string name="support_contact_email_not_set">Not set</string>
     <string name="support_push_notification_title">WordPress</string>
     <string name="support_push_notification_message">New message from \'Help &amp; Support\'</string>
-    <string name="contact_fragment_title">@string/contact_support</string>
+    <string name="contact_fragment_title" translatable="false">@string/contact_support</string>
 
     <!--My Site-->
     <string name="my_site_header_external">External</string>


### PR DESCRIPTION
@designsimply reported an issue where title of Contact Support screen is broken for some non-english locales.

[![Image from Gyazo](https://i.gyazo.com/4cc67e6a5e58b5656455f18c59581882.png)](https://gyazo.com/4cc67e6a5e58b5656455f18c59581882)

I turned out that `contact_fragment_title` string referenced `@string/contact_support` but was not marked as `translatable="false"`, and GlotPress escaped the `@` character as a result (like [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/res/values-es/strings.xml#L278))

@loremattei If I understand the issue correctly, this PR should hopefully fix this, and the offending string should be removed from the translated resources.

To test:
- There are no immediate changes.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
