### PR TITLE
Adjust states, context and others

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
@@ -14,8 +14,6 @@ class BackupDownloadActivity : LocaleAwareActivity() {
         setContentView(R.layout.backup_download_activity)
 
         setSupportActionBar(toolbar_main)
-        supportActionBar?.setHomeButtonEnabled(true)
-        supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
@@ -77,8 +77,7 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
     }
 
     private fun initViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(BackupDownloadViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(BackupDownloadViewModel::class.java)
 
         val (site, activityId) = when {
             requireActivity().intent?.extras != null -> {
@@ -146,6 +145,8 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
     private fun updateToolbar(toolbarState: ToolbarState) {
         val activity = requireActivity() as? AppCompatActivity
         activity?.supportActionBar?.let {
+            it.setHomeButtonEnabled(true)
+            it.setDisplayHomeAsUpEnabled(true)
             it.title = getString(toolbarState.title)
             it.setHomeAsUpIndicator(toolbarState.icon)
         }
@@ -175,12 +176,5 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
     override fun onSaveInstanceState(outState: Bundle) {
         viewModel.writeToBundle(outState)
         super.onSaveInstanceState(outState)
-    }
-
-    companion object {
-        const val TAG = "BACKUP_DOWNLOAD_FRAGMENT"
-        fun newInstance(bundle: Bundle?): BackupDownloadFragment {
-            return BackupDownloadFragment().apply { arguments = bundle }
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadStates.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadStates.kt
@@ -20,7 +20,7 @@ abstract class BackupDownloadUiState(open val type: StateType) {
 
     data class ErrorState(
         val errorType: BackupDownloadErrorTypes,
-        override val items: List<JetpackListItemState>,
+        override val items: List<JetpackListItemState>
     ) : BackupDownloadUiState(ERROR) {
         override val toolbarState: ToolbarState = ErrorToolbarState
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadStates.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadStates.kt
@@ -8,6 +8,10 @@ import org.wordpress.android.ui.jetpack.backup.download.StateType.COMPLETE
 import org.wordpress.android.ui.jetpack.backup.download.StateType.DETAILS
 import org.wordpress.android.ui.jetpack.backup.download.StateType.ERROR
 import org.wordpress.android.ui.jetpack.backup.download.StateType.PROGRESS
+import org.wordpress.android.ui.jetpack.backup.download.ToolbarState.CompleteToolbarState
+import org.wordpress.android.ui.jetpack.backup.download.ToolbarState.DetailsToolbarState
+import org.wordpress.android.ui.jetpack.backup.download.ToolbarState.ErrorToolbarState
+import org.wordpress.android.ui.jetpack.backup.download.ToolbarState.ProgressToolbarState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 
 abstract class BackupDownloadUiState(open val type: StateType) {
@@ -17,28 +21,32 @@ abstract class BackupDownloadUiState(open val type: StateType) {
     data class ErrorState(
         val errorType: BackupDownloadErrorTypes,
         override val items: List<JetpackListItemState>,
-        override val toolbarState: ToolbarState
-    ) : BackupDownloadUiState(ERROR)
+    ) : BackupDownloadUiState(ERROR) {
+        override val toolbarState: ToolbarState = ErrorToolbarState
+    }
 
     sealed class ContentState(override val type: StateType) : BackupDownloadUiState(type) {
         data class DetailsState(
             val activityLogModel: ActivityLogModel,
             override val items: List<JetpackListItemState>,
-            override val toolbarState: ToolbarState,
             override val type: StateType
-        ) : ContentState(DETAILS)
+        ) : ContentState(DETAILS) {
+            override val toolbarState: ToolbarState = DetailsToolbarState
+        }
 
         data class ProgressState(
             override val items: List<JetpackListItemState>,
-            override val toolbarState: ToolbarState,
             override val type: StateType
-        ) : ContentState(PROGRESS)
+        ) : ContentState(PROGRESS) {
+            override val toolbarState: ToolbarState = ProgressToolbarState
+        }
 
         data class CompleteState(
             override val items: List<JetpackListItemState>,
-            override val toolbarState: ToolbarState,
             override val type: StateType
-        ) : ContentState(COMPLETE)
+        ) : ContentState(COMPLETE) {
+            override val toolbarState: ToolbarState = CompleteToolbarState
+        }
     }
 }
 
@@ -51,27 +59,23 @@ enum class StateType(val id: Int) {
 
 sealed class ToolbarState {
     abstract val title: Int
-    abstract val icon: Int
+    @DrawableRes val icon: Int = R.drawable.ic_arrow_back
 
-    data class DetailsToolbarState(
-        @StringRes override val title: Int = R.string.backup_download_details_page_title,
-        @DrawableRes override val icon: Int = R.drawable.ic_arrow_back
-    ) : ToolbarState()
+    object DetailsToolbarState : ToolbarState() {
+        @StringRes override val title: Int = R.string.backup_download_details_page_title
+    }
 
-    data class ProgressToolbarState(
-        @StringRes override val title: Int = R.string.backup_download_progress_page_title,
-        @DrawableRes override val icon: Int = R.drawable.ic_close_24px
-    ) : ToolbarState()
+    object ProgressToolbarState : ToolbarState() {
+        @StringRes override val title: Int = R.string.backup_download_progress_page_title
+    }
 
-    data class CompleteToolbarState(
-        @StringRes override val title: Int = R.string.backup_download_complete_page_title,
-        @DrawableRes override val icon: Int = R.drawable.ic_close_24px
-    ) : ToolbarState()
+    object CompleteToolbarState : ToolbarState() {
+        @StringRes override val title: Int = R.string.backup_download_complete_page_title
+    }
 
-    data class ErrorToolbarState(
-        @StringRes override val title: Int = R.string.backup_download_complete_failed_title,
-        @DrawableRes override val icon: Int = R.drawable.ic_close_24px
-    ) : ToolbarState()
+    object ErrorToolbarState : ToolbarState() {
+        @StringRes override val title: Int = R.string.backup_download_complete_failed_title
+    }
 }
 
 sealed class BackupDownloadRequestState {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadStates.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadStates.kt
@@ -59,7 +59,7 @@ enum class StateType(val id: Int) {
 
 sealed class ToolbarState {
     abstract val title: Int
-    @DrawableRes val icon: Int = R.drawable.ic_arrow_back
+    @DrawableRes val icon: Int = R.drawable.ic_close_24px
 
     object DetailsToolbarState : ToolbarState() {
         @StringRes override val title: Int = R.string.backup_download_details_page_title

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -37,10 +37,6 @@ import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadUiState.Er
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.BackupDownloadWizardState.BackupDownloadCanceled
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.BackupDownloadWizardState.BackupDownloadCompleted
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadViewModel.BackupDownloadWizardState.BackupDownloadInProgress
-import org.wordpress.android.ui.jetpack.backup.download.ToolbarState.CompleteToolbarState
-import org.wordpress.android.ui.jetpack.backup.download.ToolbarState.DetailsToolbarState
-import org.wordpress.android.ui.jetpack.backup.download.ToolbarState.ErrorToolbarState
-import org.wordpress.android.ui.jetpack.backup.download.ToolbarState.ProgressToolbarState
 import org.wordpress.android.ui.jetpack.backup.download.builders.BackupDownloadStateListItemBuilder
 import org.wordpress.android.ui.jetpack.backup.download.usecases.GetBackupDownloadStatusUseCase
 import org.wordpress.android.ui.jetpack.backup.download.usecases.PostBackupDownloadUseCase
@@ -103,6 +99,7 @@ class BackupDownloadViewModel @Inject constructor(
     private lateinit var activityId: String
 
     private lateinit var backupDownloadState: BackupDownloadState
+    private val progressStart = 0
 
     private val _wizardFinishedObservable = MutableLiveData<Event<BackupDownloadWizardState>>()
     val wizardFinishedObservable: LiveData<Event<BackupDownloadWizardState>> = _wizardFinishedObservable
@@ -145,9 +142,7 @@ class BackupDownloadViewModel @Inject constructor(
 
     fun onBackPressed() {
         when (wizardManager.currentStep) {
-            DETAILS.id -> {
-                _wizardFinishedObservable.value = Event(BackupDownloadCanceled)
-            }
+            DETAILS.id -> { _wizardFinishedObservable.value = Event(BackupDownloadCanceled) }
             PROGRESS.id -> {
                 _wizardFinishedObservable.value = if (backupDownloadState.downloadId != null) {
                     Event(BackupDownloadInProgress(backupDownloadState.downloadId as Long))
@@ -155,9 +150,8 @@ class BackupDownloadViewModel @Inject constructor(
                     Event(BackupDownloadCanceled)
                 }
             }
-            COMPLETE.id -> {
-                _wizardFinishedObservable.value = Event(BackupDownloadCompleted)
-            }
+            COMPLETE.id -> { _wizardFinishedObservable.value = Event(BackupDownloadCompleted) }
+            ERROR.id -> { _wizardFinishedObservable.value = Event(BackupDownloadCanceled) }
         }
     }
 
@@ -173,7 +167,6 @@ class BackupDownloadViewModel @Inject constructor(
             if (activityLogModel != null) {
                 _uiState.value = DetailsState(
                         activityLogModel = activityLogModel,
-                        toolbarState = DetailsToolbarState(),
                         items = stateListItemBuilder.buildDetailsListStateItems(
                                 availableItems = availableItems,
                                 published = activityLogModel.published,
@@ -190,9 +183,8 @@ class BackupDownloadViewModel @Inject constructor(
 
     private fun buildProgress() {
         _uiState.value = ProgressState(
-                toolbarState = ProgressToolbarState(),
                 items = stateListItemBuilder.buildProgressListStateItems(
-                        progress = 0,
+                        progress = progressStart,
                         published = backupDownloadState.published as Date,
                         onNotifyMeClick = this@BackupDownloadViewModel::onNotifyMeClick
                 ),
@@ -203,7 +195,6 @@ class BackupDownloadViewModel @Inject constructor(
 
     private fun buildComplete() {
         _uiState.value = CompleteState(
-                toolbarState = CompleteToolbarState(),
                 items = stateListItemBuilder.buildCompleteListStateItems(
                         published = backupDownloadState.published as Date,
                         onDownloadFileClick = this@BackupDownloadViewModel::onDownloadFileClick,
@@ -213,7 +204,6 @@ class BackupDownloadViewModel @Inject constructor(
 
     private fun buildError(errorType: BackupDownloadErrorTypes) {
         _uiState.value = ErrorState(
-                toolbarState = ErrorToolbarState(),
                 errorType = errorType,
                 items = stateListItemBuilder.buildCompleteListStateErrorItems(
                         onDoneClick = this@BackupDownloadViewModel::onDoneClick


### PR DESCRIPTION
Parent #13329 

This PR make minor enhancements to the Backup Download code base.  

Included in this PR are the following:
- Use fragment context instead of activity for viewmodel providers
- Remove newInstance - it’s not being used, entry is only through activity
- Move toolbar handling for home button and display home from activity to fragment
- Use val for starting progress value
- Tidy up toolbarState by making title a regular field and moving icon to parent
- Tidy up uiState by moving toolbar to a regular field
- Update onBackPressed when conditional to include “error” 

**To test:**
- Run the backup download process from start to end. 
- Note that the process works identically to the way it did before.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
