### PR TITLE
Adjust states, context and other minor changes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
@@ -76,8 +76,7 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
     }
 
     private fun initViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(RestoreViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(RestoreViewModel::class.java)
 
         val (site, activityId) = when {
             requireActivity().intent?.extras != null -> {
@@ -171,12 +170,5 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
     override fun onSaveInstanceState(outState: Bundle) {
         viewModel.writeToBundle(outState)
         super.onSaveInstanceState(outState)
-    }
-
-    companion object {
-        const val TAG = "RESTORE_FRAGMENT"
-        fun newInstance(bundle: Bundle?): RestoreFragment {
-            return RestoreFragment().apply { arguments = bundle }
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreStates.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreStates.kt
@@ -10,6 +10,11 @@ import org.wordpress.android.ui.jetpack.restore.StateType.WARNING
 import org.wordpress.android.ui.jetpack.restore.StateType.PROGRESS
 import org.wordpress.android.ui.jetpack.restore.StateType.COMPLETE
 import org.wordpress.android.ui.jetpack.restore.StateType.ERROR
+import org.wordpress.android.ui.jetpack.restore.ToolbarState.CompleteToolbarState
+import org.wordpress.android.ui.jetpack.restore.ToolbarState.DetailsToolbarState
+import org.wordpress.android.ui.jetpack.restore.ToolbarState.ErrorToolbarState
+import org.wordpress.android.ui.jetpack.restore.ToolbarState.ProgressToolbarState
+import org.wordpress.android.ui.jetpack.restore.ToolbarState.WarningToolbarState
 
 abstract class RestoreUiState(open val type: StateType) {
     abstract val items: List<JetpackListItemState>
@@ -17,35 +22,40 @@ abstract class RestoreUiState(open val type: StateType) {
 
     data class ErrorState(
         val errorType: RestoreErrorTypes,
-        override val items: List<JetpackListItemState>,
-        override val toolbarState: ToolbarState
-    ) : RestoreUiState(ERROR)
+        override val items: List<JetpackListItemState>
+    ) : RestoreUiState(ERROR) {
+        override val toolbarState: ToolbarState = ErrorToolbarState
+    }
 
     sealed class ContentState(override val type: StateType) : RestoreUiState(type) {
         data class DetailsState(
             val activityLogModel: ActivityLogModel,
             override val items: List<JetpackListItemState>,
-            override val toolbarState: ToolbarState,
             override val type: StateType
-        ) : ContentState(DETAILS)
+        ) : ContentState(DETAILS) {
+            override val toolbarState: ToolbarState = DetailsToolbarState
+        }
 
         data class WarningState(
             override val items: List<JetpackListItemState>,
-            override val toolbarState: ToolbarState,
             override val type: StateType
-        ) : ContentState(WARNING)
+        ) : ContentState(WARNING) {
+            override val toolbarState: ToolbarState = WarningToolbarState
+        }
 
         data class ProgressState(
             override val items: List<JetpackListItemState>,
-            override val toolbarState: ToolbarState,
             override val type: StateType
-        ) : ContentState(PROGRESS)
+        ) : ContentState(PROGRESS) {
+            override val toolbarState: ToolbarState = ProgressToolbarState
+        }
 
         data class CompleteState(
             override val items: List<JetpackListItemState>,
-            override val toolbarState: ToolbarState,
             override val type: StateType
-        ) : ContentState(COMPLETE)
+        ) : ContentState(COMPLETE) {
+            override val toolbarState: ToolbarState = CompleteToolbarState
+        }
     }
 }
 
@@ -61,25 +71,25 @@ sealed class ToolbarState {
     abstract val title: Int
     @DrawableRes val icon: Int = R.drawable.ic_close_24px
 
-    data class DetailsToolbarState(
+    object DetailsToolbarState : ToolbarState() {
         @StringRes override val title: Int = R.string.restore_details_page_title
-    ) : ToolbarState()
+    }
 
-    data class WarningToolbarState(
+    object WarningToolbarState : ToolbarState() {
         @StringRes override val title: Int = R.string.restore_warning_page_title
-    ) : ToolbarState()
+    }
 
-    data class ProgressToolbarState(
+    object ProgressToolbarState : ToolbarState() {
         @StringRes override val title: Int = R.string.restore_progress_page_title
-    ) : ToolbarState()
+    }
 
-    data class CompleteToolbarState(
+    object CompleteToolbarState : ToolbarState() {
         @StringRes override val title: Int = R.string.restore_complete_page_title
-    ) : ToolbarState()
+    }
 
-    data class ErrorToolbarState(
+    object ErrorToolbarState : ToolbarState() {
         @StringRes override val title: Int = R.string.restore_complete_failed_title
-    ) : ToolbarState()
+    }
 }
 
 sealed class RestoreRequestState {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -51,11 +51,6 @@ import org.wordpress.android.ui.jetpack.restore.RestoreUiState.ErrorState
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCanceled
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreCompleted
 import org.wordpress.android.ui.jetpack.restore.RestoreViewModel.RestoreWizardState.RestoreInProgress
-import org.wordpress.android.ui.jetpack.restore.ToolbarState.CompleteToolbarState
-import org.wordpress.android.ui.jetpack.restore.ToolbarState.DetailsToolbarState
-import org.wordpress.android.ui.jetpack.restore.ToolbarState.ErrorToolbarState
-import org.wordpress.android.ui.jetpack.restore.ToolbarState.ProgressToolbarState
-import org.wordpress.android.ui.jetpack.restore.ToolbarState.WarningToolbarState
 import org.wordpress.android.ui.jetpack.restore.builders.RestoreStateListItemBuilder
 import org.wordpress.android.ui.jetpack.restore.usecases.GetRestoreStatusUseCase
 import org.wordpress.android.ui.jetpack.restore.usecases.PostRestoreUseCase
@@ -174,7 +169,6 @@ class RestoreViewModel @Inject constructor(
             if (activityLogModel != null) {
                 _uiState.value = DetailsState(
                         activityLogModel = activityLogModel,
-                        toolbarState = DetailsToolbarState(),
                         items = stateListItemBuilder.buildDetailsListStateItems(
                                 availableItems = availableItems,
                                 published = activityLogModel.published,
@@ -191,7 +185,6 @@ class RestoreViewModel @Inject constructor(
 
     private fun buildWarning() {
         _uiState.value = WarningState(
-                toolbarState = WarningToolbarState(),
                 items = stateListItemBuilder.buildWarningListStateItems(
                         published = restoreState.published as Date,
                         onConfirmRestoreClick = this@RestoreViewModel::onConfirmRestoreClick,
@@ -203,7 +196,6 @@ class RestoreViewModel @Inject constructor(
 
     private fun buildProgress() {
         _uiState.value = ProgressState(
-                toolbarState = ProgressToolbarState(),
                 items = stateListItemBuilder.buildProgressListStateItems(
                         progress = progressStart,
                         published = restoreState.published as Date,
@@ -216,7 +208,6 @@ class RestoreViewModel @Inject constructor(
 
     private fun buildComplete() {
         _uiState.value = CompleteState(
-                toolbarState = CompleteToolbarState(),
                 items = stateListItemBuilder.buildCompleteListStateItems(
                         published = restoreState.published as Date,
                         onDoneClick = this@RestoreViewModel::onDoneClick,
@@ -228,7 +219,6 @@ class RestoreViewModel @Inject constructor(
 
     private fun buildError(errorType: RestoreErrorTypes) {
         _uiState.value = ErrorState(
-                toolbarState = ErrorToolbarState(),
                 items = stateListItemBuilder.buildCompleteListStateErrorItems(
                         onDoneClick = this@RestoreViewModel::onDoneClick
                 ),


### PR DESCRIPTION
Parent #13329 

This PR make minor enhancements to the Restore flow.  

Included in this PR are the following:
- Use fragment context instead of activity for viewmodel providers
- Remove newInstance - it’s not being used, entry is only through activity
- Tidy up toolbarState by making title a regular field and moving icon to parent
- Tidy up uiState by moving toolbar to a regular field

**To test:**
- Run the restore process from start to end. 
- Note that the process works identically to the way it did before.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

