### PR TITLE
Jetpack Section: Restore - Fix Dark Theme for Rewind Progress Row

### DIFF
--- a/WordPress/src/main/res/layout/activity_log_list_progress_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_progress_item.xml
@@ -11,6 +11,25 @@
     android:minHeight="?attr/listPreferredItemHeight"
     tools:layout_height="?attr/listPreferredItemHeightLarge">
 
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/activity_progress_bar_height"
+        android:layout_alignParentBottom="true">
+
+        <ProgressBar
+            android:id="@+id/rewind_progress_bar"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center_vertical"
+            android:layout_marginBottom="@dimen/activity_progress_bar_margin_vertical"
+            android:layout_marginTop="@dimen/activity_progress_bar_margin_vertical"
+            android:background="@color/neutral_10"
+            android:indeterminate="true"
+            android:theme="@style/LinearProgress" />
+
+    </FrameLayout>
+
     <ImageView
         android:id="@+id/action_icon"
         android:layout_width="@dimen/activity_log_icon_size"
@@ -60,24 +79,5 @@
         android:layout_height="@dimen/list_divider_height"
         android:layout_alignParentBottom="true"
         android:background="?android:attr/listDivider" />
-
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/activity_progress_bar_height"
-        android:layout_alignParentBottom="true">
-
-        <ProgressBar
-            android:id="@+id/rewind_progress_bar"
-            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center_vertical"
-            android:layout_marginBottom="@dimen/activity_progress_bar_margin_vertical"
-            android:layout_marginTop="@dimen/activity_progress_bar_margin_vertical"
-            android:background="@color/neutral_10"
-            android:indeterminate="true"
-            android:theme="@style/LinearProgress" />
-
-    </FrameLayout>
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/activity_log_list_progress_item.xml
+++ b/WordPress/src/main/res/layout/activity_log_list_progress_item.xml
@@ -1,90 +1,83 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/activity_content_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@android:color/white"
+    android:background="?attr/selectableItemBackground"
     android:clickable="true"
     android:focusable="true"
     android:minHeight="?attr/listPreferredItemHeight"
     tools:layout_height="?attr/listPreferredItemHeightLarge">
 
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="?attr/selectableItemBackground">
+    <ImageView
+        android:id="@+id/action_icon"
+        android:layout_width="@dimen/activity_log_icon_size"
+        android:layout_height="@dimen/activity_log_icon_size"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:layout_margin="@dimen/activity_log_icon_margin"
+        android:background="@drawable/bg_oval_primary_50"
+        android:contentDescription="@string/activity_log_icon"
+        android:padding="@dimen/margin_medium"
+        android:src="@drawable/ic_notice_outline_white_24dp" />
 
-        <ImageView
-            android:id="@+id/action_icon"
-            android:layout_width="@dimen/activity_log_icon_size"
-            android:layout_height="@dimen/activity_log_icon_size"
-            android:layout_alignParentStart="true"
-            android:layout_centerVertical="true"
-            android:layout_margin="@dimen/activity_log_icon_margin"
-            android:background="@drawable/bg_oval_primary_50"
-            android:contentDescription="@string/activity_log_icon"
-            android:padding="@dimen/margin_medium"
-            android:src="@drawable/ic_notice_outline_white_24dp" />
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_gravity="center_vertical"
+        android:layout_marginEnd="@dimen/activity_log_icon_margin"
+        android:layout_toEndOf="@id/action_icon"
+        android:orientation="vertical">
 
-        <LinearLayout
-            android:layout_width="fill_parent"
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/action_text"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
+            android:ellipsize="end"
+            android:gravity="start"
+            android:singleLine="true"
+            android:textAlignment="viewStart"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            tools:text="Rewinding to June 1 2018 12:22PM" />
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/action_summary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textAppearance="@style/Base.TextAppearance.AppCompat.Body1"
+            android:textColor="?attr/wpColorOnSurfaceMedium"
+            tools:text="Rewind in progress" />
+
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/list_divider_height"
+        android:layout_alignParentBottom="true"
+        android:background="?android:attr/listDivider" />
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/activity_progress_bar_height"
+        android:layout_alignParentBottom="true">
+
+        <ProgressBar
+            android:id="@+id/rewind_progress_bar"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:layout_gravity="center_vertical"
-            android:layout_marginEnd="@dimen/activity_log_icon_margin"
-            android:layout_toEndOf="@id/action_icon"
-            android:orientation="vertical">
+            android:layout_marginBottom="@dimen/activity_progress_bar_margin_vertical"
+            android:layout_marginTop="@dimen/activity_progress_bar_margin_vertical"
+            android:background="@color/neutral_10"
+            android:indeterminate="true"
+            android:theme="@style/LinearProgress" />
 
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/action_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:gravity="start"
-                android:singleLine="true"
-                android:textAlignment="viewStart"
-                android:textAppearance="?attr/textAppearanceSubtitle1"
-                tools:text="Rewinding to June 1 2018 12:22PM" />
+    </FrameLayout>
 
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/action_summary"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:singleLine="true"
-                android:textAppearance="@style/Base.TextAppearance.AppCompat.Body1"
-                android:textColor="?attr/wpColorOnSurfaceMedium"
-                tools:text="Rewind in progress" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/list_divider_height"
-            android:layout_alignParentBottom="true"
-            android:background="?android:attr/listDivider" />
-
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/activity_progress_bar_height"
-            android:layout_alignParentBottom="true">
-
-            <ProgressBar
-                android:id="@+id/rewind_progress_bar"
-                style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_gravity="center_vertical"
-                android:layout_marginTop="@dimen/activity_progress_bar_margin_vertical"
-                android:layout_marginBottom="@dimen/activity_progress_bar_margin_vertical"
-                android:background="@color/neutral_10"
-                android:indeterminate="true"
-                android:theme="@style/LinearProgress" />
-
-        </FrameLayout>
-
-    </RelativeLayout>
-
-</FrameLayout>
+</RelativeLayout>


### PR DESCRIPTION
Parent #13328

This PR fixes an issue with the activity log rewind progress row UI now showing as should for dark theme.

Before | After
-------|------
<img width="250" height="500" alt="before" src="https://user-images.githubusercontent.com/9729923/105705145-72836680-5f18-11eb-8496-51b5fb611699.png"> | <img width="250" height="500" alt="after" src="https://user-images.githubusercontent.com/9729923/105705188-86c76380-5f18-11eb-90a6-64b1d8563973.png">

To test:
- Launch app and go to `My Site` tab.
- Click the `Activity` menu item to launch the activity log screen.
- Pick a rewindable item (an item that can be restored), and click on it. This will launch the activity log details screen.
- Click the `RESTORE` button. This will launch a `Restore Site` dialog.
- Click the `RESTORE SITE` confirmation button. You will be automatically navigated back to the `activity log` screen.
- Verify that the `Restoring to Data` rewind progress row is showing as expected for both dark and light theme.

PS: As always, I suggest doing a commit-by-commit review as this will make it much easier for you to review the overall solution.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
