### PR TITLE
Update Zendesk to 5.0.2

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -340,7 +340,7 @@ dependencies {
         exclude group: 'org.wordpress', module: 'utils' 
     }
 
-    implementation (group: 'com.zendesk', name: 'support', version: '5.0.1') {
+    implementation (group: 'com.zendesk', name: 'support', version: '5.0.2') {
         exclude group: 'com.google.dagger'
         exclude group: 'com.android.support', module: 'support-annotations'
     }


### PR DESCRIPTION
Fixes #13861 

This PR updates the Zendesk support library from 5.0.1 to 5.0.2.

It fixes an issue where the push notification is not received on the first message sent to a user. According to the Zendesk [release log](https://developer.zendesk.com/embeddables/docs/android-support-sdk/release_notes) this is the only change in the update. 

