### PR TITLE
Issue/13629 show backup menu item

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -274,6 +274,8 @@ class MySiteFragment : Fragment(),
     }
 
     private fun updateScanAndBackupVisibility(site: SiteModel) {
+        row_scan.setVisible(false)
+        row_backup.setVisible(false)
         if (scanScreenFeatureConfig.isEnabled() || backupScreenFeatureConfig.isEnabled()) {
             uiScope.launch {
                 val itemsVisibility = jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -9,9 +9,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP
-import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP_DAILY
-import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP_REALTIME
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
@@ -198,11 +195,10 @@ class ActivityLogViewModel @Inject constructor(
             !site.hasFreePlan -> refreshFiltersUiState()
             else -> {
                 launch {
-                    jetpackCapabilitiesUseCase.getOrFetchJetpackCapabilities(site.siteId)
-                            .find { it == BACKUP || it == BACKUP_DAILY || it == BACKUP_REALTIME }
-                            ?.let {
-                                refreshFiltersUiState()
-                            }
+                    val purchasedProducts = jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId)
+                    if (purchasedProducts.backup) {
+                        refreshFiltersUiState()
+                    }
                 }
             }
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCaseTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.JetpackCapability
 import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP
+import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP_DAILY
 import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP_REALTIME
 import org.wordpress.android.fluxc.model.JetpackCapability.SCAN
 import org.wordpress.android.fluxc.store.SiteStore
@@ -106,9 +107,75 @@ class JetpackCapabilitiesUseCaseTest {
     fun `updates cache, when fetch finishes`() = test {
         whenever(dispatcher.dispatch(any())).then { useCase.onJetpackCapabilitiesFetched(event) }
 
-        val result = useCase.getOrFetchJetpackCapabilities(SITE_ID)
+        useCase.getOrFetchJetpackCapabilities(SITE_ID)
 
         verify(appPrefsWrapper).setSiteJetpackCapabilities(SITE_ID, event.capabilities!!)
+    }
+
+    @Test
+    fun `Scan enabled, when JetpackCapabilities contains SCAN`() = test {
+        whenever(dispatcher.dispatch(any())).then {
+            useCase.onJetpackCapabilitiesFetched(buildCapabilitiesFetchedEvent(listOf(SCAN)))
+        }
+
+        val result = useCase.getJetpackPurchasedProducts(SITE_ID)
+
+        assertThat(result.scan).isTrue
+    }
+
+    @Test
+    fun `Scan disabled, when JetpackCapabilities does NOT contain SCAN`() = test {
+        whenever(dispatcher.dispatch(any())).then {
+            useCase.onJetpackCapabilitiesFetched(buildCapabilitiesFetchedEvent(listOf()))
+        }
+
+        val result = useCase.getJetpackPurchasedProducts(SITE_ID)
+
+        assertThat(result.scan).isFalse
+    }
+
+    @Test
+    fun `Backup enabled, when JetpackCapabilities contains BACKUP`() = test {
+        whenever(dispatcher.dispatch(any())).then {
+            useCase.onJetpackCapabilitiesFetched(buildCapabilitiesFetchedEvent(listOf(BACKUP)))
+        }
+
+        val result = useCase.getJetpackPurchasedProducts(SITE_ID)
+
+        assertThat(result.backup).isTrue
+    }
+
+    @Test
+    fun `Backup enabled, when JetpackCapabilities contains BACKUP_REALTIME`() = test {
+        whenever(dispatcher.dispatch(any())).then {
+            useCase.onJetpackCapabilitiesFetched(buildCapabilitiesFetchedEvent(listOf(BACKUP_REALTIME)))
+        }
+
+        val result = useCase.getJetpackPurchasedProducts(SITE_ID)
+
+        assertThat(result.backup).isTrue
+    }
+
+    @Test
+    fun `Backup enabled, when JetpackCapabilities contains BACKUP_DAILY`() = test {
+        whenever(dispatcher.dispatch(any())).then {
+            useCase.onJetpackCapabilitiesFetched(buildCapabilitiesFetchedEvent(listOf(BACKUP_DAILY)))
+        }
+
+        val result = useCase.getJetpackPurchasedProducts(SITE_ID)
+
+        assertThat(result.backup).isTrue
+    }
+
+    @Test
+    fun `Backup disabled, when JetpackCapabilities does not contain any BACKUP capability`() = test {
+        whenever(dispatcher.dispatch(any())).then {
+            useCase.onJetpackCapabilitiesFetched(buildCapabilitiesFetchedEvent(listOf()))
+        }
+
+        val result = useCase.getJetpackPurchasedProducts(SITE_ID)
+
+        assertThat(result.backup).isFalse
     }
 
     private fun buildCapabilitiesFetchedEvent(capabilities: List<JetpackCapability>) =

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCaseTest.kt
@@ -15,6 +15,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.JetpackCapability
 import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP
 import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP_REALTIME
 import org.wordpress.android.fluxc.model.JetpackCapability.SCAN
@@ -48,7 +49,7 @@ class JetpackCapabilitiesUseCaseTest {
                 currentTimeProvider,
                 TEST_DISPATCHER
         )
-        event = OnJetpackCapabilitiesFetched(SITE_ID, listOf(BACKUP_REALTIME), null)
+        event = buildCapabilitiesFetchedEvent(listOf(BACKUP_REALTIME))
         whenever(appPrefsWrapper.getSiteJetpackCapabilitiesLastUpdated(anyLong())).thenReturn(0)
         whenever(currentTimeProvider.currentDate()).thenReturn(Date(99999999))
     }
@@ -109,4 +110,7 @@ class JetpackCapabilitiesUseCaseTest {
 
         verify(appPrefsWrapper).setSiteJetpackCapabilities(SITE_ID, event.capabilities!!)
     }
+
+    private fun buildCapabilitiesFetchedEvent(capabilities: List<JetpackCapability>) =
+        OnJetpackCapabilitiesFetched(SITE_ID, capabilities, null)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -24,13 +24,13 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMP
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_TAPPED
 import org.wordpress.android.fluxc.model.AccountModel
-import org.wordpress.android.fluxc.model.JetpackCapability
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
 import org.wordpress.android.test
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
+import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase.JetpackPurchasedProducts
 import org.wordpress.android.ui.mysite.ListItemAction.ACTIVITY_LOG
 import org.wordpress.android.ui.mysite.ListItemAction.ADMIN
 import org.wordpress.android.ui.mysite.ListItemAction.COMMENTS
@@ -143,7 +143,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(selectedSiteRepository.showSiteIconProgressBar).thenReturn(onShowSiteIconProgressBar)
         whenever(domainRegistrationHandler.isDomainCreditAvailable).thenReturn(isDomainCreditAvailable)
         whenever(quickStartRepository.quickStartModel).thenReturn(quickStartModel)
-        whenever(jetpackCapabilitiesUseCase.getOrFetchJetpackCapabilities(anyLong())).thenReturn(listOf())
         viewModel = MySiteViewModel(
                 networkUtilsWrapper,
                 TEST_DISPATCHER,
@@ -801,42 +800,79 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `jetpack capabilities requested, when selected site changes`() = test {
+    fun `jetpack menu visibility requested, when selected site changes and scanScreenFeatureFlag is enabled`() = test {
         whenever(scanScreenFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(anyLong())).thenReturn(
+                JetpackPurchasedProducts(scan = false, backup = false)
+        )
 
         onSiteChange.postValue(site)
 
-        verify(jetpackCapabilitiesUseCase).getOrFetchJetpackCapabilities(site.siteId)
+        verify(jetpackCapabilitiesUseCase).getJetpackPurchasedProducts(site.siteId)
     }
 
     @Test
-    fun `jetpack capabilities not requested, when scan screen feature flag is off`() = test {
-        whenever(scanScreenFeatureConfig.isEnabled()).thenReturn(false)
-
-        onSiteChange.postValue(site)
-
-        verify(jetpackCapabilitiesUseCase, never()).getOrFetchJetpackCapabilities(site.siteId)
-    }
-
-    @Test
-    fun `site items builder invoked with the selected site's backup screen availability`() {
+    fun `jetpack menu visibility requested, when selected site changes and backupScreenFeatureFlag is enabled`() =
+            test {
         whenever(backupScreenFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(anyLong())).thenReturn(
+                JetpackPurchasedProducts(scan = false, backup = false)
+        )
+
+        onSiteChange.postValue(site)
+
+        verify(jetpackCapabilitiesUseCase).getJetpackPurchasedProducts(site.siteId)
+    }
+
+    @Test
+    fun `jetpack menu visibility not requested, when scan and backup screen feature flags are off`() = test {
+        whenever(scanScreenFeatureConfig.isEnabled()).thenReturn(false)
+        whenever(backupScreenFeatureConfig.isEnabled()).thenReturn(false)
+
+        onSiteChange.postValue(site)
+
+        verify(jetpackCapabilitiesUseCase, never()).getJetpackPurchasedProducts(site.siteId)
+    }
+
+    @Test
+    fun `backup menu item is NOT visible, when getJetpackMenuItemsVisibility is false`() = test {
+        whenever(backupScreenFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(anyLong())).thenReturn(
+                JetpackPurchasedProducts(scan = false, backup = false)
+        )
 
         onSiteChange.postValue(site)
 
         verify(siteItemsBuilder, times(2)).buildSiteItems(
                 site = eq(site),
                 onClick = any(),
-                isBackupAvailable = eq(true),
+                isBackupAvailable = eq(false),
                 isScanAvailable = any()
         )
     }
 
     @Test
-    fun `scan menu item is visible, when jetpack capabilities contain JETPACK item`() = test {
+    fun `scan menu item is NOT visible, when getJetpackMenuItemsVisibility is false`() = test {
         whenever(scanScreenFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(jetpackCapabilitiesUseCase.getOrFetchJetpackCapabilities(anyLong())).thenReturn(
-                listOf(JetpackCapability.SCAN)
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(anyLong())).thenReturn(
+                JetpackPurchasedProducts(scan = false, backup = false)
+        )
+
+        onSiteChange.postValue(site)
+
+        verify(siteItemsBuilder, times(2)).buildSiteItems(
+                site = eq(site),
+                onClick = any(),
+                isBackupAvailable = any(),
+                isScanAvailable = eq(false)
+        )
+    }
+
+    @Test
+    fun `scan menu item is visible, when getJetpackMenuItemsVisibility is true`() = test {
+        whenever(scanScreenFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(anyLong())).thenReturn(
+                JetpackPurchasedProducts(scan = true, backup = false)
         )
 
         onSiteChange.postValue(site)
@@ -846,6 +882,23 @@ class MySiteViewModelTest : BaseUnitTest() {
                 onClick = any(),
                 isBackupAvailable = any(),
                 isScanAvailable = eq(true)
+        )
+    }
+
+    @Test
+    fun `backup menu item is visible, when getJetpackMenuItemsVisibility is true`() = test {
+        whenever(backupScreenFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(anyLong())).thenReturn(
+                JetpackPurchasedProducts(scan = false, backup = true)
+        )
+
+        onSiteChange.postValue(site)
+
+        verify(siteItemsBuilder).buildSiteItems(
+                site = eq(site),
+                onClick = any(),
+                isBackupAvailable = eq(true),
+                isScanAvailable = any()
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -28,9 +28,6 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_ACTIVITIES
-import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP
-import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP_DAILY
-import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP_REALTIME
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
@@ -53,6 +50,7 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Loading
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.RESTORE
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
+import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase.JetpackPurchasedProducts
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService.RewindProgress
 import org.wordpress.android.ui.stats.refresh.utils.DateUtils
@@ -180,8 +178,8 @@ class ActivityLogViewModelTest {
         whenever(store.fetchActivities(anyOrNull())).thenReturn(mock())
         whenever(site.hasFreePlan).thenReturn(false)
         whenever(site.siteId).thenReturn(SITE_ID)
-        whenever(jetpackCapabilitiesUseCase.getOrFetchJetpackCapabilities(anyLong()))
-                .thenReturn(listOf())
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(anyLong()))
+                .thenReturn(JetpackPurchasedProducts(scan = false, backup = false))
     }
 
     @Test
@@ -430,32 +428,8 @@ class ActivityLogViewModelTest {
     fun filtersAreVisibleWhenSiteOnFreePlanButHasPurchasedBackupProduct() = test {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
         whenever(site.hasFreePlan).thenReturn(true)
-        whenever(jetpackCapabilitiesUseCase.getOrFetchJetpackCapabilities(SITE_ID))
-                .thenReturn(listOf(BACKUP))
-
-        viewModel.start(site, rewindableOnly)
-
-        assertEquals(true, viewModel.filtersUiState.value!!.visibility)
-    }
-
-    @Test
-    fun filtersAreVisibleWhenSiteOnFreePlanButHasPurchasedBackupDailyProduct() = test {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(site.hasFreePlan).thenReturn(true)
-        whenever(jetpackCapabilitiesUseCase.getOrFetchJetpackCapabilities(anyLong()))
-                .thenReturn(listOf(BACKUP_DAILY))
-
-        viewModel.start(site, rewindableOnly)
-
-        assertEquals(true, viewModel.filtersUiState.value!!.visibility)
-    }
-
-    @Test
-    fun filtersAreVisibleWhenSiteOnFreePlanButHasPurchasedBackupRealtimeProduct() = test {
-        whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(site.hasFreePlan).thenReturn(true)
-        whenever(jetpackCapabilitiesUseCase.getOrFetchJetpackCapabilities(anyLong()))
-                .thenReturn(listOf(BACKUP_REALTIME))
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(SITE_ID))
+                .thenReturn(JetpackPurchasedProducts(scan = false, backup = true))
 
         viewModel.start(site, rewindableOnly)
 


### PR DESCRIPTION
Partially fixes  #13629

- Shows/hides Backup screen menu item based on Jetpack capabilities
- Extracts related logic into the JetpackCapabilitiesUseCase

To test:
1. `BackupScreenFeatureFlag = false`, `ScanScreenFeatureFlag = false`, `MySiteImprovementsFeatureFlag = false` 
2. Verify both Backup and Scan menu items are hidden for all types of sites
------------------
1. `BackupScreenFeatureFlag = true`, `ScanScreenFeatureFlag = false`, `MySiteImprovementsFeatureFlag = false` 
2. Verify Backup menu item is shown when the site has BACKUP/BACKUP_DAILY/BACKUP_REALTIME capability and it is not shown when it doesn't have any of the backup capabilities
------------------
1. `BackupScreenFeatureFlag = false`, `ScanScreenFeatureFlag = true`, `MySiteImprovementsFeatureFlag = false` 
2. Verify Scan menu item is shown when the site has SCAN capability and it is not shown when it doesn't have it
----------------
1. `BackupScreenFeatureFlag = true`, `ScanScreenFeatureFlag = false`, `MySiteImprovementsFeatureFlag = true`
2. Verify Backup menu item is shown when the site has BACKUP/BACKUP_DAILY/BACKUP_REALTIME capability and it is not shown when it doesn't have any of the backup capabilities
------------------
1. `BackupScreenFeatureFlag = false`, `ScanScreenFeatureFlag = true`, `MySiteImprovementsFeatureFlag = true` 
2. Verify Scan menu item is shown when the site has SCAN capability and it is not shown when it doesn't have it


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
