### PR TITLE
Fix strings in release/16.6

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1082,8 +1082,8 @@
     <string name="scan_history_fixed_threats_tab">Fixed</string>
     <string name="scan_history_no_threats_found">No items found</string>
     <string name="scan_history_ignored_threats_tab">Ignored</string>
-    <string name="scan_history_no_connection">@string/no_network_message</string>
-    <string name="scan_history_request_failed">@string/request_failed_message</string>
+    <string name="scan_history_no_connection" translatable="false">@string/no_network_message</string>
+    <string name="scan_history_request_failed" translatable="false">@string/request_failed_message</string>
 
     <!-- threats -->
     <string name="threats_fix_num_of_threats">Fix %s threats</string>
@@ -3394,7 +3394,7 @@
 
     <!-- Jetpack restore -->
     <string name="restore">Restore</string>
-    <string name="restore_details_page_title">@string/restore</string>
+    <string name="restore_details_page_title" translatable="false">@string/restore</string>
     <string name="restore_details_choose_items_header">Choose the items to restore:</string>
     <string name="restore_details_header">Restore Site</string>
     <string name="restore_details_description_with_two_parameters">%1$s %2$s is the selected point for your restore.</string>
@@ -3402,7 +3402,7 @@
     <string name="restore_details_icon_content_description">Restore icon</string>
     <string name="restore_details_action_button_content_description">Restore site button</string>
 
-    <string name="restore_warning_page_title">@string/restore</string>
+    <string name="restore_warning_page_title" translatable="false">@string/restore</string>
     <string name="restore_warning_header">Warning</string>
     <string name="restore_warning_description_with_two_parameters">Are you sure you want to rewind your site back to %1$s at %2$s?
         This will remove all content and options created or changed since then.</string>
@@ -3410,19 +3410,19 @@
     <string name="restore_warning_icon_content_description">Red circle image with exclamation point</string>
     <string name="restore_warning_action_button_content_description">Confirm restore site button</string>
 
-    <string name="restore_progress_page_title">@string/restore</string>
+    <string name="restore_progress_page_title" translatable="false">@string/restore</string>
     <string name="restore_progress_header">Currently restoring site</string>
     <string name="restore_progress_description_with_two_parameters">We\'re restoring your site back to %1$s %2$s.</string>
-    <string name="restore_progress_action_button">@string/backup_download_progress_action_button</string>
+    <string name="restore_progress_action_button" translatable="false">@string/backup_download_progress_action_button</string>
     <string name="restore_progress_icon_content_description">Restore site icon</string>
-    <string name="restore_progress_action_button_content_description">@string/backup_download_progress_action_button_content_description</string>
+    <string name="restore_progress_action_button_content_description" translatable="false">@string/backup_download_progress_action_button_content_description</string>
     <string name="restore_progress_additional_info">No need to wait around. We\'ll notify you when your site has been restored.</string>
     <string name="restore_progress_label">%1$s%%</string>
 
-    <string name="restore_complete_page_title">@string/restore</string>
+    <string name="restore_complete_page_title" translatable="false">@string/restore</string>
     <string name="restore_complete_header">Your site has been restored</string>
     <string name="restore_complete_description_with_two_parameters">All of your selected items are now restored back to %1$s %2$s.</string>
-    <string name="restore_complete_done_action_button">@string/label_done_button</string>
+    <string name="restore_complete_done_action_button" translatable="false">@string/label_done_button</string>
     <string name="restore_complete_visit_site_action_button">Visit site</string>
     <string name="restore_complete_icon_content_description">Restore icon</string>
     <string name="restore_complete_done_button_content_description">Done button</string>
@@ -3430,11 +3430,11 @@
 
     <string name="restore_complete_failed_title">Restore failed</string>
     <string name="restore_complete_failed_description">We couldn\'t restore your site. Please try again later.</string>
-    <string name="restore_complete_failed_action_button">@string/label_done_button</string>
+    <string name="restore_complete_failed_action_button" translatable="false">@string/label_done_button</string>
     <string name="restore_complete_failed_action_button_content_description">Done button</string>
     <string name="restore_complete_failed_icon_content_description">Error icon</string>
 
-    <string name="rewind_generic_failure">@string/backup_download_generic_failure</string>
+    <string name="rewind_generic_failure" translatable="false">@string/backup_download_generic_failure</string>
     <string name="rewind_another_process_running">There is another restore running.</string>
 
 </resources>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1082,8 +1082,8 @@
     <string name="scan_history_fixed_threats_tab">Fixed</string>
     <string name="scan_history_no_threats_found">No items found</string>
     <string name="scan_history_ignored_threats_tab">Ignored</string>
-    <string name="scan_history_no_connection">@string/no_network_message</string>
-    <string name="scan_history_request_failed">@string/request_failed_message</string>
+    <string name="scan_history_no_connection" translatable="false">@string/no_network_message</string>
+    <string name="scan_history_request_failed" translatable="false">@string/request_failed_message</string>
 
     <!-- threats -->
     <string name="threats_fix_num_of_threats">Fix %s threats</string>
@@ -3394,7 +3394,7 @@
 
     <!-- Jetpack restore -->
     <string name="restore">Restore</string>
-    <string name="restore_details_page_title">@string/restore</string>
+    <string name="restore_details_page_title" translatable="false">@string/restore</string>
     <string name="restore_details_choose_items_header">Choose the items to restore:</string>
     <string name="restore_details_header">Restore Site</string>
     <string name="restore_details_description_with_two_parameters">%1$s %2$s is the selected point for your restore.</string>
@@ -3402,7 +3402,7 @@
     <string name="restore_details_icon_content_description">Restore icon</string>
     <string name="restore_details_action_button_content_description">Restore site button</string>
 
-    <string name="restore_warning_page_title">@string/restore</string>
+    <string name="restore_warning_page_title" translatable="false">@string/restore</string>
     <string name="restore_warning_header">Warning</string>
     <string name="restore_warning_description_with_two_parameters">Are you sure you want to rewind your site back to %1$s at %2$s?
         This will remove all content and options created or changed since then.</string>
@@ -3410,19 +3410,19 @@
     <string name="restore_warning_icon_content_description">Red circle image with exclamation point</string>
     <string name="restore_warning_action_button_content_description">Confirm restore site button</string>
 
-    <string name="restore_progress_page_title">@string/restore</string>
+    <string name="restore_progress_page_title" translatable="false">@string/restore</string>
     <string name="restore_progress_header">Currently restoring site</string>
     <string name="restore_progress_description_with_two_parameters">We\'re restoring your site back to %1$s %2$s.</string>
-    <string name="restore_progress_action_button">@string/backup_download_progress_action_button</string>
+    <string name="restore_progress_action_button" translatable="false">@string/backup_download_progress_action_button</string>
     <string name="restore_progress_icon_content_description">Restore site icon</string>
-    <string name="restore_progress_action_button_content_description">@string/backup_download_progress_action_button_content_description</string>
+    <string name="restore_progress_action_button_content_description" translatable="false">@string/backup_download_progress_action_button_content_description</string>
     <string name="restore_progress_additional_info">No need to wait around. We\'ll notify you when your site has been restored.</string>
     <string name="restore_progress_label">%1$s%%</string>
 
-    <string name="restore_complete_page_title">@string/restore</string>
+    <string name="restore_complete_page_title" translatable="false">@string/restore</string>
     <string name="restore_complete_header">Your site has been restored</string>
     <string name="restore_complete_description_with_two_parameters">All of your selected items are now restored back to %1$s %2$s.</string>
-    <string name="restore_complete_done_action_button">@string/label_done_button</string>
+    <string name="restore_complete_done_action_button" translatable="false">@string/label_done_button</string>
     <string name="restore_complete_visit_site_action_button">Visit site</string>
     <string name="restore_complete_icon_content_description">Restore icon</string>
     <string name="restore_complete_done_button_content_description">Done button</string>
@@ -3430,11 +3430,11 @@
 
     <string name="restore_complete_failed_title">Restore failed</string>
     <string name="restore_complete_failed_description">We couldn\'t restore your site. Please try again later.</string>
-    <string name="restore_complete_failed_action_button">@string/label_done_button</string>
+    <string name="restore_complete_failed_action_button" translatable="false">@string/label_done_button</string>
     <string name="restore_complete_failed_action_button_content_description">Done button</string>
     <string name="restore_complete_failed_icon_content_description">Error icon</string>
 
-    <string name="rewind_generic_failure">@string/backup_download_generic_failure</string>
+    <string name="rewind_generic_failure" translatable="false">@string/backup_download_generic_failure</string>
     <string name="rewind_another_process_running">There is another restore running.</string>
 
 </resources>


### PR DESCRIPTION
Translators noticed that some strings which reference other strings resources have been sent to GlotPress. 
I think the only issue with those is that they miss the `translatable=false` attribute, so this PR adds it. 

Adding @zwarm and @malinajirka as reviewers to make sure this is the expected behaviour.

After this PR is merged, we'll need to merge the release branch into `develop` to update GlotPress.

cc @JavonDavis.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
