### PR TITLE
Issue/13329 backup download use case

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/usecases/PostBackupDownloadUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/usecases/PostBackupDownloadUseCase.kt
@@ -27,7 +27,7 @@ class PostBackupDownloadUseCase @Inject constructor(
         types: BackupDownloadRequestTypes
     ): BackupDownloadRequestState = withContext(ioDispatcher) {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
-            NetworkUnavailable
+            return@withContext NetworkUnavailable
         }
 
         val result = activityLogStore.backupDownload(BackupDownloadPayload(site, rewindId, types))

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/usecases/PostBackupDownloadUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/usecases/PostBackupDownloadUseCaseTest.kt
@@ -1,0 +1,143 @@
+package org.wordpress.android.ui.jetpack.backup.download.usecases
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.fluxc.action.ActivityLogAction.BACKUP_DOWNLOAD
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.activity.BackupDownloadStatusModel
+import org.wordpress.android.fluxc.store.ActivityLogStore
+import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadError
+import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadErrorType.API_ERROR
+import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadErrorType.INVALID_RESPONSE
+import org.wordpress.android.fluxc.store.ActivityLogStore.BackupDownloadRequestTypes
+import org.wordpress.android.fluxc.store.ActivityLogStore.OnBackupDownload
+import org.wordpress.android.test
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState.Failure.NetworkUnavailable
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState.Failure.OtherRequestRunning
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState.Failure.RemoteRequestFailure
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadRequestState.Success
+import org.wordpress.android.util.NetworkUtilsWrapper
+import java.util.Date
+
+@InternalCoroutinesApi
+class PostBackupDownloadUseCaseTest : BaseUnitTest() {
+    private lateinit var useCase: PostBackupDownloadUseCase
+    @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    @Mock lateinit var activityLogStore: ActivityLogStore
+    @Mock lateinit var siteModel: SiteModel
+
+    @Before
+    fun setup() = test {
+        useCase = PostBackupDownloadUseCase(networkUtilsWrapper, activityLogStore, TEST_DISPATCHER)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+    }
+
+    @Test
+    fun `given no network, when download is triggered, then NetworkUnavailable is returned`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        val result = useCase.postBackupDownloadRequest(rewindId, siteModel, types)
+
+        assertThat(result).isEqualTo(NetworkUnavailable)
+    }
+
+    @Test
+    fun `given invalid response, when download is triggered, then RemoteRequestFailure is returned`() = test {
+        whenever(activityLogStore.backupDownload(any())).thenReturn(OnBackupDownload(rewindId, BackupDownloadError(
+                INVALID_RESPONSE
+        ), BACKUP_DOWNLOAD))
+
+        val result = useCase.postBackupDownloadRequest(rewindId, siteModel, types)
+
+        assertThat(result).isEqualTo(RemoteRequestFailure)
+    }
+
+    @Test
+    fun `given generic error response, when download is triggered, then RemoteRequestFailure is returned`() = test {
+        whenever(activityLogStore.backupDownload(any())).thenReturn(OnBackupDownload(rewindId, BackupDownloadError(
+                GENERIC_ERROR
+        ), BACKUP_DOWNLOAD))
+
+        val result = useCase.postBackupDownloadRequest(rewindId, siteModel, types)
+
+        assertThat(result).isEqualTo(RemoteRequestFailure)
+    }
+
+    @Test
+    fun `given api error response, when download is triggered, then RemoteRequestFailure is returned`() = test {
+        whenever(activityLogStore.backupDownload(any())).thenReturn(OnBackupDownload(rewindId, BackupDownloadError(
+                API_ERROR
+        ), BACKUP_DOWNLOAD))
+
+        val result = useCase.postBackupDownloadRequest(rewindId, siteModel, types)
+
+        assertThat(result).isEqualTo(RemoteRequestFailure)
+    }
+
+    @Test
+    fun `when download is triggered successfully, then Success is returned`() = test {
+        whenever(activityLogStore.backupDownload(any())).thenReturn(OnBackupDownload(
+                rewindId = rewindId,
+                downloadId = downloadId,
+                causeOfChange = BACKUP_DOWNLOAD))
+
+        val result = useCase.postBackupDownloadRequest(rewindId, siteModel, types)
+
+        assertThat(result).isEqualTo(Success(requestRewindId = rewindId, rewindId= rewindId, downloadId=downloadId))
+    }
+
+    @Test
+    fun `given download success, when downloadId is null, then RemoteRequestFailure is returned`() = test {
+        whenever(activityLogStore.backupDownload(any())).thenReturn(OnBackupDownload(
+                rewindId = rewindId,
+                downloadId = null,
+                causeOfChange = BACKUP_DOWNLOAD))
+
+        val result = useCase.postBackupDownloadRequest(rewindId, siteModel, types)
+
+        assertThat(result).isEqualTo(RemoteRequestFailure)
+    }
+
+    @Test
+    fun `given download success, when unmatched rewindIds, then OtherRequestRunning is returned`() = test {
+        whenever(activityLogStore.backupDownload(any())).thenReturn(OnBackupDownload(
+                rewindId = "unmatchedRewindId",
+                downloadId = downloadId,
+                causeOfChange = BACKUP_DOWNLOAD))
+
+        val result = useCase.postBackupDownloadRequest(rewindId, siteModel, types)
+
+        assertThat(result).isEqualTo(OtherRequestRunning)
+    }
+
+    private val rewindId = "rewindId"
+    private val downloadId = 100L
+
+    private val types: BackupDownloadRequestTypes = BackupDownloadRequestTypes(
+            themes = true,
+            plugins = true,
+            uploads = true,
+            sqls = true,
+            roots = true,
+            contents = true
+    )
+
+    private val statusModel = BackupDownloadStatusModel(
+            downloadId = downloadId,
+            rewindId = rewindId,
+            backupPoint = Date(1609690147756),
+            startedAt = Date(1609690147756),
+            progress = null,
+            downloadCount = 0,
+            validUntil = Date(1609690147756),
+            url = "www.wordpress.com"
+    )
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/usecases/PostBackupDownloadUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/usecases/PostBackupDownloadUseCaseTest.kt
@@ -91,7 +91,7 @@ class PostBackupDownloadUseCaseTest : BaseUnitTest() {
 
         val result = useCase.postBackupDownloadRequest(rewindId, siteModel, types)
 
-        assertThat(result).isEqualTo(Success(requestRewindId = rewindId, rewindId= rewindId, downloadId=downloadId))
+        assertThat(result).isEqualTo(Success(requestRewindId = rewindId, rewindId = rewindId, downloadId = downloadId))
     }
 
     @Test


### PR DESCRIPTION
Parent #13329

This PR
1 -  Updates the GetBackupDownloadUseCase to short circuit the Network Error if branch
2 - Add tests for the use case

To test:
- Launch the app with BackupDownloadFeatureConfig flag on
- Navigate to ActivityLog 
- Tap the more menu (note the date of the item)
- Select the backup option
- Leave the app open on the backup download details view
- Log on to the web
- Navigate to activity log and kick off a download for a different date
- Go back to the app & tap the create download button
- Note that you are shown a snackbar for other request running

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
