### PR TITLE
Set secondary buttons

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
@@ -40,9 +40,9 @@ class BackupDownloadStateListItemBuilder @Inject constructor() {
                 buildHeaderState(R.string.backup_download_details_header),
                 buildDescriptionState(published, R.string.backup_download_details_description_with_two_parameters),
                 buildActionButtonState(
-                        R.string.backup_download_details_action_button,
-                        R.string.backup_download_details_action_button_content_description,
-                        onCreateDownloadClick),
+                        titleRes = R.string.backup_download_details_action_button,
+                        contentDescRes = R.string.backup_download_details_action_button_content_description,
+                        onClick = onCreateDownloadClick),
                 buildSubHeaderState()
         )
 
@@ -72,9 +72,9 @@ class BackupDownloadStateListItemBuilder @Inject constructor() {
                 buildDescriptionState(published, R.string.backup_download_progress_description_with_two_parameters),
                 buildProgressState(progress),
                 buildActionButtonState(
-                        R.string.backup_download_progress_action_button,
-                        R.string.backup_download_progress_action_button_content_description,
-                        onNotifyMeClick),
+                        titleRes = R.string.backup_download_progress_action_button,
+                        contentDescRes = R.string.backup_download_progress_action_button_content_description,
+                        onClick = onNotifyMeClick),
                 buildAdditionalInformationState(R.string.backup_download_progress_additional_info)
         )
     }
@@ -92,13 +92,16 @@ class BackupDownloadStateListItemBuilder @Inject constructor() {
                 buildHeaderState(R.string.backup_download_complete_header),
                 buildDescriptionState(published, R.string.backup_download_complete_description_with_two_parameters),
                 buildActionButtonState(
-                        R.string.backup_download_complete_download_action_button,
-                        R.string.backup_download_complete_download_action_button_content_description,
-                        onDownloadFileClick),
+                        titleRes = R.string.backup_download_complete_download_action_button,
+                        contentDescRes = R.string.backup_download_complete_download_action_button_content_description,
+                        onClick = onDownloadFileClick),
                 buildActionButtonState(
-                        R.string.backup_download_complete_download_share_action_button,
-                        R.string.backup_download_complete_download_share_action_button_content_description,
-                        onShareLinkClick),
+                        titleRes = R.string.backup_download_complete_download_share_action_button,
+                        contentDescRes =
+                            R.string.backup_download_complete_download_share_action_button_content_description,
+                        isSecondary = true,
+                        iconRes = R.drawable.ic_share_white_24dp,
+                        onClick = onShareLinkClick),
                 buildAdditionalInformationState(R.string.backup_download_complete_info)
         )
     }
@@ -110,9 +113,9 @@ class BackupDownloadStateListItemBuilder @Inject constructor() {
                     R.color.error_50),
             buildDescriptionState(R.string.backup_download_complete_failed_description),
             buildActionButtonState(
-                    R.string.backup_download_complete_failed_action_button,
-                    R.string.backup_download_complete_failed_action_button_content_description,
-                    onDoneClick)
+                    titleRes = R.string.backup_download_complete_failed_action_button,
+                    contentDescRes = R.string.backup_download_complete_failed_action_button_content_description,
+                    onClick = onDoneClick)
     )
 
     private fun buildIconState(
@@ -142,10 +145,14 @@ class BackupDownloadStateListItemBuilder @Inject constructor() {
     private fun buildActionButtonState(
         @StringRes titleRes: Int,
         @StringRes contentDescRes: Int,
+        isSecondary: Boolean = false,
+        @DrawableRes iconRes: Int? = null,
         onClick: () -> Unit
     ) = ActionButtonState(
         text = UiStringRes(titleRes),
         contentDescription = UiStringRes(contentDescRes),
+        isSecondary = isSecondary,
+        iconRes = iconRes,
         onClick = onClick
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/JetpackListItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/JetpackListItemState.kt
@@ -31,6 +31,7 @@ abstract class JetpackListItemState(open val type: ViewType) {
         val isSecondary: Boolean = false,
         val isEnabled: Boolean = true,
         val isVisible: Boolean = true,
+        @DrawableRes val iconRes: Int? = null,
         val onClick: () -> Unit
     ) : JetpackListItemState(if (isSecondary) ViewType.SECONDARY_ACTION_BUTTON else ViewType.PRIMARY_ACTION_BUTTON)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/viewholders/JetpackButtonViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/viewholders/JetpackButtonViewHolder.kt
@@ -39,7 +39,7 @@ sealed class JetpackButtonViewHolder(@LayoutRes layout: Int, parent: ViewGroup) 
         setOnClickListener { buttonState.onClick.invoke() }
         buttonState.iconRes?.let {
             iconGravity = MaterialButton.ICON_GRAVITY_TEXT_START
-            icon = this.context.getDrawable(it)
+            icon = context.getDrawable(it)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/viewholders/JetpackButtonViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/viewholders/JetpackButtonViewHolder.kt
@@ -2,9 +2,9 @@ package org.wordpress.android.ui.jetpack.common.viewholders
 
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
-import android.widget.Button
 import androidx.annotation.LayoutRes
 import androidx.constraintlayout.widget.ConstraintLayout
+import com.google.android.material.button.MaterialButton
 import org.wordpress.android.R
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButtonState
@@ -13,7 +13,10 @@ import org.wordpress.android.util.setVisible
 import kotlinx.android.synthetic.main.jetpack_list_button_primary_item.button as primaryButton
 import kotlinx.android.synthetic.main.jetpack_list_button_secondary_item.button as secondaryButton
 
-sealed class JetpackButtonViewHolder(@LayoutRes layout: Int, parent: ViewGroup) : JetpackViewHolder(layout, parent) {
+sealed class JetpackButtonViewHolder(@LayoutRes layout: Int, parent: ViewGroup) : JetpackViewHolder(
+        layout,
+        parent
+) {
     class Primary(
         private val uiHelpers: UiHelpers,
         parent: ViewGroup
@@ -32,11 +35,15 @@ sealed class JetpackButtonViewHolder(@LayoutRes layout: Int, parent: ViewGroup) 
         }
     }
 
-    internal fun Button.updateState(buttonState: ActionButtonState, uiHelpers: UiHelpers) {
+    internal fun MaterialButton.updateState(buttonState: ActionButtonState, uiHelpers: UiHelpers) {
         updateItemViewVisibility(buttonState.isVisible)
         uiHelpers.setTextOrHide(this, buttonState.text)
         isEnabled = buttonState.isEnabled
         setOnClickListener { buttonState.onClick.invoke() }
+        buttonState.iconRes?.let {
+            iconGravity = MaterialButton.ICON_GRAVITY_TEXT_START
+            icon = this.context.getDrawable(it)
+        }
     }
 
     private fun updateItemViewVisibility(isVisible: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/viewholders/JetpackButtonViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/viewholders/JetpackButtonViewHolder.kt
@@ -13,10 +13,7 @@ import org.wordpress.android.util.setVisible
 import kotlinx.android.synthetic.main.jetpack_list_button_primary_item.button as primaryButton
 import kotlinx.android.synthetic.main.jetpack_list_button_secondary_item.button as secondaryButton
 
-sealed class JetpackButtonViewHolder(@LayoutRes layout: Int, parent: ViewGroup) : JetpackViewHolder(
-        layout,
-        parent
-) {
+sealed class JetpackButtonViewHolder(@LayoutRes layout: Int, parent: ViewGroup) : JetpackViewHolder(layout, parent) {
     class Primary(
         private val uiHelpers: UiHelpers,
         parent: ViewGroup

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
@@ -40,9 +40,9 @@ class RestoreStateListItemBuilder @Inject constructor() {
                 buildHeaderState(R.string.restore_details_header),
                 buildDescriptionState(published, R.string.restore_details_description_with_two_parameters),
                 buildActionButtonState(
-                        R.string.restore_details_action_button,
-                        R.string.restore_details_action_button_content_description,
-                        onCreateDownloadClick),
+                        titleRes = R.string.restore_details_action_button,
+                        contentDescRes = R.string.restore_details_action_button_content_description,
+                        onClick = onCreateDownloadClick),
                 buildSubHeaderState()
         )
 
@@ -70,13 +70,14 @@ class RestoreStateListItemBuilder @Inject constructor() {
             buildHeaderState(R.string.restore_warning_header),
             buildDescriptionState(published, R.string.restore_warning_description_with_two_parameters),
             buildActionButtonState(
-                    R.string.restore_warning_action_button,
-                    R.string.restore_warning_action_button_content_description,
-                    onConfirmRestoreClick),
+                    titleRes = R.string.restore_warning_action_button,
+                    contentDescRes = R.string.restore_warning_action_button_content_description,
+                    onClick = onConfirmRestoreClick),
             buildActionButtonState(
-                    R.string.cancel,
-                    R.string.cancel,
-                    onCancelClick)
+                    titleRes = R.string.cancel,
+                    contentDescRes = R.string.cancel,
+                    isSecondary = true,
+                    onClick = onCancelClick)
     )
 
     fun buildProgressListStateItems(
@@ -93,9 +94,9 @@ class RestoreStateListItemBuilder @Inject constructor() {
                 buildDescriptionState(published, R.string.restore_progress_description_with_two_parameters),
                 buildProgressState(progress),
                 buildActionButtonState(
-                        R.string.restore_progress_action_button,
-                        R.string.restore_progress_action_button_content_description,
-                        onNotifyMeClick),
+                        titleRes = R.string.restore_progress_action_button,
+                        contentDescRes = R.string.restore_progress_action_button_content_description,
+                        onClick = onNotifyMeClick),
                 buildAdditionalInformationState(R.string.restore_progress_additional_info)
         )
     }
@@ -113,13 +114,14 @@ class RestoreStateListItemBuilder @Inject constructor() {
                 buildHeaderState(R.string.restore_complete_header),
                 buildDescriptionState(published, R.string.restore_complete_description_with_two_parameters),
                 buildActionButtonState(
-                        R.string.restore_complete_done_action_button,
-                        R.string.restore_complete_done_button_content_description,
-                        onDoneClick),
+                        titleRes = R.string.restore_complete_done_action_button,
+                        contentDescRes = R.string.restore_complete_done_button_content_description,
+                        onClick = onDoneClick),
                 buildActionButtonState(
-                        R.string.restore_complete_visit_site_action_button,
-                        R.string.restore_complete_visit_site_button_content_description,
-                        onVisitSiteClick)
+                        titleRes = R.string.restore_complete_visit_site_action_button,
+                        contentDescRes = R.string.restore_complete_visit_site_button_content_description,
+                        isSecondary = true,
+                        onClick = onVisitSiteClick)
         )
     }
 
@@ -130,9 +132,9 @@ class RestoreStateListItemBuilder @Inject constructor() {
                     R.color.error_50),
             buildDescriptionState(R.string.restore_complete_failed_description),
             buildActionButtonState(
-                    R.string.restore_complete_failed_action_button,
-                    R.string.restore_complete_failed_action_button_content_description,
-                    onDoneClick)
+                    titleRes = R.string.restore_complete_failed_action_button,
+                    contentDescRes = R.string.restore_complete_failed_action_button_content_description,
+                    onClick = onDoneClick)
     )
 
     private fun buildIconState(
@@ -162,10 +164,12 @@ class RestoreStateListItemBuilder @Inject constructor() {
     private fun buildActionButtonState(
         @StringRes titleRes: Int,
         @StringRes contentDescRes: Int,
+        isSecondary: Boolean = false,
         onClick: () -> Unit
     ) = ActionButtonState(
         text = UiStringRes(titleRes),
         contentDescription = UiStringRes(contentDescRes),
+        isSecondary = isSecondary,
         onClick = onClick
     )
 


### PR DESCRIPTION
Parent #13328 and #13329

This PR includes:
- Setting secondary button styles for:
  -- Backup Download Complete Share Link
  -- Restore Warning Cancel
  -- Restore Complete Visit Site
- Added iconRes to `JetpackListItemState` to support icons in secondary buttons
- Change `Button` to `MaterialButton` in `updateState` to expose icon and iconGravity
- Add share icon link to Backup Download Complete Share Link

**To test:**
- Run the backup download process to the end.
- Note that the Share Link button is not pink and includes the `Share` icon
----------------
- Run the restore process to the end.
- Note that the Warning view Cancel button is not pink
- Note that the Complete Visit Site button is not pink

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
