### PR TITLE
Issue/13326 threat list item

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanListItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanListItemState.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.jetpack.scan
 
+import androidx.annotation.AttrRes
 import androidx.annotation.DrawableRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
@@ -17,6 +18,7 @@ sealed class ScanListItemState(override val type: ViewType) : JetpackListItemSta
         val isFixable: Boolean = true,
         val header: UiString,
         val subHeader: UiString?,
+        @AttrRes val subHeaderColor: Int,
         @DrawableRes val icon: Int,
         @DrawableRes val iconBackground: Int,
         val onClick: () -> Unit

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/adapters/viewholders/ThreatViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/adapters/viewholders/ThreatViewHolder.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.viewholders.JetpackViewHolder
 import org.wordpress.android.ui.jetpack.scan.ScanListItemState.ThreatItemState
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.getColorFromAttribute
 
 class ThreatViewHolder(
     private val uiHelpers: UiHelpers,
@@ -18,6 +19,7 @@ class ThreatViewHolder(
             setTextOrHide(threat_header, threatItemState.header)
             setTextOrHide(threat_sub_header, threatItemState.subHeader)
         }
+        threat_sub_header.setTextColor(threat_sub_header.context.getColorFromAttribute(itemUiState.subHeaderColor))
         threat_icon.setImageResource(itemUiState.icon)
         threat_icon.setBackgroundResource(itemUiState.iconBackground)
         itemView.setOnClickListener { threatItemState.onClick.invoke() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -32,7 +32,7 @@ class ThreatItemBuilder @Inject constructor(
             isFixable = threatModel.baseThreatModel.fixable != null,
             header = buildThreatItemHeader(threatModel),
             subHeader = buildThreatItemSubHeader(threatModel),
-            subHeaderColor = buildThreatItemSubHeaderColor(threatModel) ,
+            subHeaderColor = buildThreatItemSubHeaderColor(threatModel),
             icon = buildThreatItemIcon(threatModel),
             iconBackground = buildThreatItemIconBackground(threatModel),
             onClick = { onThreatItemClicked(threatModel.baseThreatModel.id) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -32,6 +32,7 @@ class ThreatItemBuilder @Inject constructor(
             isFixable = threatModel.baseThreatModel.fixable != null,
             header = buildThreatItemHeader(threatModel),
             subHeader = buildThreatItemSubHeader(threatModel),
+            subHeaderColor = buildThreatItemSubHeaderColor(threatModel) ,
             icon = buildThreatItemIcon(threatModel),
             iconBackground = buildThreatItemIconBackground(threatModel),
             onClick = { onThreatItemClicked(threatModel.baseThreatModel.id) }
@@ -90,6 +91,14 @@ class ThreatItemBuilder @Inject constructor(
             }
         }
     }
+
+    fun buildThreatItemSubHeaderColor(threatModel: ThreatModel) =
+        if (threatModel.baseThreatModel.status == FIXED) {
+            R.attr.wpColorSuccess
+        } else {
+            R.attr.colorOnSurface
+        }
+
     fun buildThreatItemDescription(threatModel: ThreatModel): UiString? {
         return when (threatModel) {
             is CoreFileModificationThreatModel -> UiStringRes(R.string.threat_item_sub_header_core_file)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -92,7 +92,7 @@ class ThreatItemBuilder @Inject constructor(
         }
     }
 
-    fun buildThreatItemSubHeaderColor(threatModel: ThreatModel) =
+   private fun buildThreatItemSubHeaderColor(threatModel: ThreatModel) =
         if (threatModel.baseThreatModel.status == FIXED) {
             R.attr.wpColorSuccess
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -18,10 +18,14 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.DateFormatWrapper
+import java.util.Date
 import javax.inject.Inject
 
 @Reusable
-class ThreatItemBuilder @Inject constructor() {
+class ThreatItemBuilder @Inject constructor(
+    private val dateFormatWrapper: DateFormatWrapper
+) {
     fun buildThreatItem(threatModel: ThreatModel, onThreatItemClicked: (threatId: Long) -> Unit) =
         ThreatItemState(
             threatId = threatModel.baseThreatModel.id,
@@ -70,10 +74,13 @@ class ThreatItemBuilder @Inject constructor() {
         is GenericThreatModel -> UiStringRes(R.string.threat_item_header_threat_found)
     }
 
-    fun buildThreatItemSubHeader(threatModel: ThreatModel): UiString? {
+    private fun buildThreatItemSubHeader(threatModel: ThreatModel): UiString? {
         return when (threatModel.baseThreatModel.status) {
             FIXED -> {
-                UiStringRes(R.string.threat_item_sub_header_status_fixed)
+                UiStringResWithParams(
+                    R.string.threat_item_sub_header_status_fixed,
+                    listOf(getDateString(threatModel.baseThreatModel.fixedOn))
+                )
             }
             IGNORED -> {
                 UiStringRes(R.string.threat_item_sub_header_status_ignored)
@@ -120,6 +127,13 @@ class ThreatItemBuilder @Inject constructor() {
                 IGNORED -> R.drawable.bg_oval_neutral_30
                 UNKNOWN, CURRENT -> R.drawable.bg_oval_error_50
             }
+
+    private fun getDateString(date: Date?): UiStringText {
+        return date?.let {
+            val dateFormat = dateFormatWrapper.getLongDateFormat()
+            return UiStringText(dateFormat.format(date))
+        } ?: UiStringText("")
+    }
 
     /**
      * Uses regex to remove the whole path except of the file name

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -92,7 +92,7 @@ class ThreatItemBuilder @Inject constructor(
         }
     }
 
-   private fun buildThreatItemSubHeaderColor(threatModel: ThreatModel) =
+    private fun buildThreatItemSubHeaderColor(threatModel: ThreatModel) =
         if (threatModel.baseThreatModel.status == FIXED) {
             R.attr.wpColorSuccess
         } else {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1104,7 +1104,7 @@
     <string name="threat_item_sub_header_file_signature">Threat found %s</string>
     <string name="threat_item_sub_header_vulnerable_plugin">Vulnerability found in plugin</string>
     <string name="threat_item_sub_header_vulnerable_theme">Vulnerability found in theme</string>
-    <string name="threat_item_sub_header_status_fixed">Threat fixed</string>
+    <string name="threat_item_sub_header_status_fixed">Threat fixed on %s</string>
     <string name="threat_item_sub_header_status_ignored">Threat ignored</string>
 
     <!-- threat details -->

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -59,6 +59,7 @@ class ScanViewModelTest : BaseUnitTest() {
 
     private val fakeScanStateModel = ScanStateModel(state = ScanStateModel.State.IDLE, hasCloud = true)
     private val fakeUiStringText = UiStringText("")
+    private val fakeSubHeaderColor = 1
     private val fakeThreatId = 1L
     private val fakeIconId = 1
     private val fakeIconBackgroundId = 1
@@ -400,6 +401,7 @@ class ScanViewModelTest : BaseUnitTest() {
             isFixable = true,
             header = fakeUiStringText,
             subHeader = fakeUiStringText,
+            subHeaderColor = fakeSubHeaderColor,
             icon = fakeIconId,
             iconBackground = fakeIconBackgroundId
         ) { onThreatItemClicked(fakeThreatId) }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
@@ -254,6 +254,39 @@ class ThreatItemBuilderTest : BaseUnitTest() {
         assertThat(threatItem.iconBackground).isEqualTo(R.drawable.bg_oval_error_50)
     }
 
+    @Test
+    fun `Subheader for fixed threat has success color`() {
+        // Arrange
+        val expectedSubHeader = R.attr.wpColorSuccess
+        val threatModel = GenericThreatModel(ThreatTestData.baseThreatModel.copy(status = FIXED))
+        // Act
+        val threatItem = buildThreatItem(threatModel)
+        // Assert
+        assertThat(threatItem.subHeaderColor).isEqualTo(expectedSubHeader)
+    }
+
+    @Test
+    fun `sub header for current threat has onSurface color`() {
+        // Arrange
+        val expectedSubHeader = R.attr.colorOnSurface
+        val threatModel = GenericThreatModel(ThreatTestData.baseThreatModel.copy(status = CURRENT))
+        // Act
+        val threatItem = buildThreatItem(threatModel)
+        // Assert
+        assertThat(threatItem.subHeaderColor).isEqualTo(expectedSubHeader)
+    }
+
+    @Test
+    fun `sub header for ignored threat has onSurface color`() {
+        // Arrange
+        val expectedSubHeader = R.attr.colorOnSurface
+        val threatModel = GenericThreatModel(ThreatTestData.baseThreatModel.copy(status = IGNORED))
+        // Act
+        val threatItem = buildThreatItem(threatModel)
+        // Assert
+        assertThat(threatItem.subHeaderColor).isEqualTo(expectedSubHeader)
+    }
+
     private fun buildThreatItem(threatModel: ThreatModel, onThreatItemClicked: ((Long) -> Unit) = mock()) =
         builder.buildThreatItem(
             threatModel = threatModel,

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
@@ -2,10 +2,12 @@ package org.wordpress.android.ui.jetpack.scan
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
@@ -19,20 +21,33 @@ import org.wordpress.android.ui.jetpack.scan.builders.ThreatItemBuilder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.DateFormatWrapper
+import java.text.DateFormat
+
+private const val TEST_FIXED_ON_DATE = "2 January, 2020"
 
 @InternalCoroutinesApi
 class ThreatItemBuilderTest : BaseUnitTest() {
     private lateinit var builder: ThreatItemBuilder
 
+    @Mock private lateinit var dateFormatWrapper: DateFormatWrapper
+    @Mock private lateinit var dateFormat: DateFormat
+
     @Before
     fun setUp() {
-        builder = ThreatItemBuilder()
+        builder = ThreatItemBuilder(dateFormatWrapper)
+        whenever(dateFormatWrapper.getLongDateFormat()).thenReturn(dateFormat)
+        whenever(dateFormat.format(ThreatTestData.genericThreatModel.baseThreatModel.fixedOn))
+            .thenReturn(TEST_FIXED_ON_DATE)
     }
 
     @Test
     fun `builds threat sub header correctly for fixed threat`() {
         // Arrange
-        val expectedSubHeader = UiStringRes(R.string.threat_item_sub_header_status_fixed)
+        val expectedSubHeader = UiStringResWithParams(
+            R.string.threat_item_sub_header_status_fixed,
+            listOf(UiStringText(TEST_FIXED_ON_DATE))
+        )
         val threatModel = GenericThreatModel(ThreatTestData.baseThreatModel.copy(status = FIXED))
         // Act
         val threatItem = buildThreatItem(threatModel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModelTest.kt
@@ -61,7 +61,7 @@ class ScanHistoryListViewModelTest {
         )
         whenever(scanHistoryViewModel.threats).thenReturn(MutableLiveData(threats))
         whenever(scanThreatItemBuilder.buildThreatItem(anyOrNull(), anyOrNull())).thenAnswer {
-            ThreatItemState(1L, true, mock(), mock(), 0, 0) {
+            ThreatItemState(1L, true, mock(), mock(), 0, 0, 0) {
                 it.getArgument<(Long) -> Unit>(ON_ITEM_CLICKED_PARAM_POSITION)(1L)
             }
         }


### PR DESCRIPTION
Parent issue #13326

This PR updates subheader of fixed Threat items in Scan History.
- replaces "Threat fixed" with "Threat fixed on [Date]"
- updates color of the subheader for fixed threats to green

Merge instructions
1. Make sure https://github.com/wordpress-mobile/WordPress-Android/pull/13893 is merged
2. Remove Not Ready for Merge label
3. Merge this PR

To test:
1. Enable ScanScreen feature flag
2. Click on Scan menu item
3. Click on History action in the toolbar
4. Notice fixed threats have "Threat fixed on [Date]" green subheader
5. Check that the subheaders for current and ignored threats haven't changed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
