### PR TITLE
Quick Start: Cancel Edit homepage when homepage is removed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -71,6 +71,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.JetpackCapability.SCAN
 import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteHomepageSettings.ShowOnFront
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.MediaStore
@@ -148,6 +149,7 @@ import org.wordpress.android.util.MediaUtils
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.PhotonUtils
 import org.wordpress.android.util.PhotonUtils.Quality.HIGH
+import org.wordpress.android.util.QuickStartUtils
 import org.wordpress.android.util.QuickStartUtils.Companion.addQuickStartFocusPointAboveTheView
 import org.wordpress.android.util.QuickStartUtils.Companion.completeTaskAndRemindNextOne
 import org.wordpress.android.util.QuickStartUtils.Companion.getNextUncompletedQuickStartTask
@@ -250,7 +252,7 @@ class MySiteFragment : Fragment(),
     override fun onResume() {
         super.onResume()
         updateSiteSettingsIfNecessary()
-
+        completeQuickStartStepsIfNeeded()
         // Site details may have changed (e.g. via Settings and returning to this Fragment) so update the UI
         refreshSelectedSiteDetails(selectedSite)
         selectedSite?.let { site ->
@@ -292,6 +294,18 @@ class MySiteFragment : Fragment(),
         }
     }
 
+    private fun completeQuickStartStepsIfNeeded() {
+        selectedSite?.let {
+            if (it.showOnFront == ShowOnFront.POSTS.value) {
+                completeTaskAndRemindNextOne(quickStartStore,
+                        EDIT_HOMEPAGE,
+                        dispatcher,
+                        it,
+                        null,
+                        requireContext())
+            }
+        }
+    }
     private fun showQuickStartNoticeIfNecessary() {
         if (!isQuickStartInProgress(quickStartStore) || !AppPrefs.isQuickStartNoticeRequired()) {
             return

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -149,7 +149,6 @@ import org.wordpress.android.util.MediaUtils
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.PhotonUtils
 import org.wordpress.android.util.PhotonUtils.Quality.HIGH
-import org.wordpress.android.util.QuickStartUtils
 import org.wordpress.android.util.QuickStartUtils.Companion.addQuickStartFocusPointAboveTheView
 import org.wordpress.android.util.QuickStartUtils.Companion.completeTaskAndRemindNextOne
 import org.wordpress.android.util.QuickStartUtils.Companion.getNextUncompletedQuickStartTask

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -133,7 +133,7 @@ class PageListFragment : ViewPagerFragment() {
         val adapter: PageListAdapter
         if (recyclerView.adapter == null) {
             adapter = PageListAdapter(
-                    { action, page -> viewModel.onMenuAction(action, page) },
+                    { action, page -> viewModel.onMenuAction(action, page, requireContext()) },
                     { page -> viewModel.onItemTapped(page, requireContext()) },
                     { viewModel.onEmptyListNewPageButtonTapped() },
                     isSitePhotonCapable,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -154,23 +154,29 @@ class PageListViewModel @Inject constructor(
         dispatcher.unregister(this)
     }
 
-    fun onMenuAction(action: Action, pageItem: Page): Boolean {
+    fun onMenuAction(action: Action, pageItem: Page, context: Context): Boolean {
+        completeEditHomePageTour(pageItem, context)
         return pagesViewModel.onMenuAction(action, pageItem)
     }
 
     fun onItemTapped(pageItem: Page, context: Context) {
+        completeEditHomePageTour(pageItem, context)
+        _quickStartEvent.postValue(null)
+        if (pageItem.tapActionEnabled) {
+            pagesViewModel.onItemTapped(pageItem)
+        }
+    }
+
+    private fun completeEditHomePageTour(pageItem: Page, context: Context) {
         if (isHomepage(pageItem)) {
-            QuickStartUtils.completeTaskAndRemindNextOne(quickStartStore,
+            QuickStartUtils.completeTaskAndRemindNextOne(
+                    quickStartStore,
                     EDIT_HOMEPAGE,
                     dispatcher,
                     pagesViewModel.site,
                     _quickStartEvent.value,
-                    context)
-        }
-
-        _quickStartEvent.postValue(null)
-        if (pageItem.tapActionEnabled) {
-            pagesViewModel.onItemTapped(pageItem)
+                    context
+            )
         }
     }
 


### PR DESCRIPTION
Fixes this report from the 16.6 testing

> I got stuck on “Select Homepage” step on the Pages screen, since I had no homepage. I wasn’t able to dismiss the prompt, and it obstructed some of the actions on that page. If you don’t have a Homepage and create one using “Home” layout it will not be recognized by Quick Start logic.

## To test:
### Remove Homepage
1. Create a site. 
2. Select "Yes, Help Me" in the quick start prompt
3. Remove your homepage. You can do this by:
    - Going to Pages and deleting your homepage (I'll create an issue for this because Web blocks you from deleting your HomePage)
-or-
    - Going to Site Settings > Homepage Settings and select Classic Blog
4. Return to Quick Start 
5. **Expect** Edit Your homepage to be marked as completed

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
