### PR TITLE
Issue/13328 progress labels

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -341,7 +341,11 @@ class RestoreViewModel @Inject constructor(
                                         } else {
                                             null
                                         },
-                                    progressStateLabel = UiStringText("${restoreStatus.message}"),
+                                    progressStateLabel = if (restoreStatus.message != null) {
+                                        UiStringText("${restoreStatus.message}")
+                                    } else {
+                                        null
+                                    },
                                     isIndeterminate = (restoreStatus.progress ?: 0) <= 0
                             )
                         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -199,6 +199,7 @@ class RestoreViewModel @Inject constructor(
                 items = stateListItemBuilder.buildProgressListStateItems(
                         progress = progressStart,
                         published = restoreState.published as Date,
+                        isIndeterminate = true,
                         onNotifyMeClick = this@RestoreViewModel::onNotifyMeClick
                 ),
                 type = StateType.PROGRESS
@@ -335,11 +336,13 @@ class RestoreViewModel @Inject constructor(
                                             R.string.restore_progress_label,
                                             listOf(UiStringText(restoreStatus.progress?.toString() ?: "0"))
                                     ),
-                                    progressStateLabel = if (restoreStatus.currentEntry != null) {
-                                                UiStringText("${restoreStatus.currentEntry}")
-                                            } else {
-                                                UiStringText("Restoring your site") },
-                                    progressInfoLabel = UiStringRes(R.string.restore_progress_current_entry)
+                                    progressInfoLabel = if (restoreStatus.currentEntry != null) {
+                                            UiStringText("${restoreStatus.currentEntry}") }
+                                        else {
+                                            null
+                                        },
+                                    progressStateLabel = UiStringText("${restoreStatus.message}"),
+                                    isIndeterminate = (restoreStatus.progress ?: 0) <= 0
                             )
                         } else {
                             contentState

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
-import org.wordpress.android.R.string
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindRequestTypes
 import org.wordpress.android.modules.BG_THREAD
@@ -320,8 +320,8 @@ class RestoreViewModel @Inject constructor(
         }
     }
 
-    private fun handleQueryStatus(state: RestoreRequestState) {
-        when (state) {
+    private fun handleQueryStatus(restoreStatus: RestoreRequestState) {
+        when (restoreStatus) {
             is NetworkUnavailable -> { transitionToError(RestoreErrorTypes.NetworkUnavailable) }
             is RemoteRequestFailure -> { transitionToError(RestoreErrorTypes.RemoteRequestFailure) }
             is Progress -> {
@@ -330,11 +330,16 @@ class RestoreViewModel @Inject constructor(
                         if (contentState.type == ViewType.PROGRESS) {
                             contentState as JetpackListItemState.ProgressState
                             contentState.copy(
-                                    progress = state.progress ?: 0,
+                                    progress = restoreStatus.progress ?: 0,
                                     progressLabel = UiStringResWithParams(
-                                            string.restore_progress_label,
-                                            listOf(UiStringText(state.progress?.toString() ?: "0"))
-                                    )
+                                            R.string.restore_progress_label,
+                                            listOf(UiStringText(restoreStatus.progress?.toString() ?: "0"))
+                                    ),
+                                    progressStateLabel = if (restoreStatus.currentEntry != null) {
+                                                UiStringText("${restoreStatus.currentEntry}")
+                                            } else {
+                                                UiStringText("Restoring your site") },
+                                    progressInfoLabel = UiStringRes(R.string.restore_progress_current_entry)
                             )
                         } else {
                             contentState
@@ -432,9 +437,9 @@ class RestoreViewModel @Inject constructor(
     }
 
     companion object {
-        private val NetworkUnavailableMsg = SnackbarMessageHolder(UiStringRes(string.error_network_connection))
-        private val GenericFailureMsg = SnackbarMessageHolder(UiStringRes(string.rewind_generic_failure))
-        private val OtherRequestRunningMsg = SnackbarMessageHolder(UiStringRes(string.rewind_another_process_running))
+        private val NetworkUnavailableMsg = SnackbarMessageHolder(UiStringRes(R.string.error_network_connection))
+        private val GenericFailureMsg = SnackbarMessageHolder(UiStringRes(R.string.rewind_generic_failure))
+        private val OtherRequestRunningMsg = SnackbarMessageHolder(UiStringRes(R.string.rewind_another_process_running))
     }
 
     sealed class RestoreWizardState : Parcelable {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -337,8 +337,8 @@ class RestoreViewModel @Inject constructor(
                                             listOf(UiStringText(restoreStatus.progress?.toString() ?: "0"))
                                     ),
                                     progressInfoLabel = if (restoreStatus.currentEntry != null) {
-                                            UiStringText("${restoreStatus.currentEntry}") }
-                                        else {
+                                            UiStringText("${restoreStatus.currentEntry}")
+                                        } else {
                                             null
                                         },
                                     progressStateLabel = UiStringText("${restoreStatus.message}"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
@@ -83,6 +83,7 @@ class RestoreStateListItemBuilder @Inject constructor() {
     fun buildProgressListStateItems(
         progress: Int = 0,
         published: Date,
+        isIndeterminate: Boolean = false,
         onNotifyMeClick: () -> Unit
     ): List<JetpackListItemState> {
         return mutableListOf(
@@ -92,7 +93,7 @@ class RestoreStateListItemBuilder @Inject constructor() {
                         R.color.success_50),
                 buildHeaderState(R.string.restore_progress_header),
                 buildDescriptionState(published, R.string.restore_progress_description_with_two_parameters),
-                buildProgressState(progress),
+                buildProgressState(progress, isIndeterminate),
                 buildActionButtonState(
                         titleRes = R.string.restore_progress_action_button,
                         contentDescRes = R.string.restore_progress_action_button_content_description,
@@ -180,8 +181,9 @@ class RestoreStateListItemBuilder @Inject constructor() {
             UiStringRes(textRes)
     )
 
-    private fun buildProgressState(progress: Int) = ProgressState(
+    private fun buildProgressState(progress: Int, isIndeterminate: Boolean = false) = ProgressState(
             progress = progress,
+            isIndeterminate = true,
             progressLabel = UiStringResWithParams(
                     R.string.restore_progress_label, listOf(UiStringText(progress.toString()))
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
@@ -183,7 +183,7 @@ class RestoreStateListItemBuilder @Inject constructor() {
 
     private fun buildProgressState(progress: Int, isIndeterminate: Boolean = false) = ProgressState(
             progress = progress,
-            isIndeterminate = true,
+            isIndeterminate = isIndeterminate,
             progressLabel = UiStringResWithParams(
                     R.string.restore_progress_label, listOf(UiStringText(progress.toString()))
             )

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3417,8 +3417,6 @@
     <string name="restore_progress_action_button_content_description">@string/backup_download_progress_action_button_content_description</string>
     <string name="restore_progress_additional_info">No need to wait around. We\'ll notify you when your site has been restored.</string>
     <string name="restore_progress_label">%1$s%%</string>
-    <string name="restore_progress_current_entry">Restoring your site</string>
-
 
     <string name="restore_complete_page_title">@string/restore</string>
     <string name="restore_complete_header">Your site has been restored</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3417,6 +3417,8 @@
     <string name="restore_progress_action_button_content_description">@string/backup_download_progress_action_button_content_description</string>
     <string name="restore_progress_additional_info">No need to wait around. We\'ll notify you when your site has been restored.</string>
     <string name="restore_progress_label">%1$s%%</string>
+    <string name="restore_progress_current_entry">Restoring your site</string>
+
 
     <string name="restore_complete_page_title">@string/restore</string>
     <string name="restore_complete_header">Your site has been restored</string>


### PR DESCRIPTION
Parent #13228

This PR enhances the Restore progress view by:
1. Updating the labels using the API message value and current entry.  (Note that current entry is not yet returning data, but when it does it will be shown under the progress bar)
2. Uses a indeterminate progress bar until the progress value is > 0
Also this PR adds back the "R.string" in `RestoreViewModel` I don't know why AS keeps dropping it. 

**Notes**
- View copy will be updated in the separate PR

|on submit|starting|in progress
|---|---|---|
|![on submit](https://user-images.githubusercontent.com/506707/106075050-e79e9980-60da-11eb-9aba-66263460ce07.png)|![starting](https://user-images.githubusercontent.com/506707/106075103-fd13c380-60da-11eb-90fe-4389c05f6b00.png)|![progress](https://user-images.githubusercontent.com/506707/106075143-1288ed80-60db-11eb-890f-7645db3ec7fa.png)


**To test:**
- Run the Restore Process from start to finish
- Take note that Progress view
-- Shows an indeterminate progress bar until progress > 0
-- Shows a message on the right hand side of the screen - this message is straight from the API

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
