### PR TITLE
Jetpack Section: Restore - Replace Rewind Status Service with Restore Use Cases

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -129,7 +129,7 @@ class ActivityLogListFragment : Fragment() {
     }
 
     fun onRewindConfirmed(activityId: String) {
-        viewModel.onRewindConfirmed(activityId)
+        viewModel.onRestoreConfirmed(activityId)
     }
 
     private fun setupObservers() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreStates.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreStates.kt
@@ -105,13 +105,13 @@ sealed class RestoreRequestState {
         val progress: Int?,
         val message: String? = null,
         val currentEntry: String? = null,
-        val date: Date? = null
+        val published: Date? = null
     ) : RestoreRequestState()
 
     data class Complete(
         val rewindId: String,
         val restoreId: Long,
-        val date: Date? = null
+        val published: Date? = null
     ) : RestoreRequestState()
 
     sealed class Failure : RestoreRequestState() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreStates.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreStates.kt
@@ -5,16 +5,17 @@ import androidx.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
-import org.wordpress.android.ui.jetpack.restore.StateType.DETAILS
-import org.wordpress.android.ui.jetpack.restore.StateType.WARNING
-import org.wordpress.android.ui.jetpack.restore.StateType.PROGRESS
 import org.wordpress.android.ui.jetpack.restore.StateType.COMPLETE
+import org.wordpress.android.ui.jetpack.restore.StateType.DETAILS
 import org.wordpress.android.ui.jetpack.restore.StateType.ERROR
+import org.wordpress.android.ui.jetpack.restore.StateType.PROGRESS
+import org.wordpress.android.ui.jetpack.restore.StateType.WARNING
 import org.wordpress.android.ui.jetpack.restore.ToolbarState.CompleteToolbarState
 import org.wordpress.android.ui.jetpack.restore.ToolbarState.DetailsToolbarState
 import org.wordpress.android.ui.jetpack.restore.ToolbarState.ErrorToolbarState
 import org.wordpress.android.ui.jetpack.restore.ToolbarState.ProgressToolbarState
 import org.wordpress.android.ui.jetpack.restore.ToolbarState.WarningToolbarState
+import java.util.Date
 
 abstract class RestoreUiState(open val type: StateType) {
     abstract val items: List<JetpackListItemState>
@@ -103,10 +104,15 @@ sealed class RestoreRequestState {
         val rewindId: String,
         val progress: Int?,
         val message: String? = null,
-        val currentEntry: String? = null
+        val currentEntry: String? = null,
+        val date: Date? = null
     ) : RestoreRequestState()
 
-    data class Complete(val rewindId: String, val restoreId: Long) : RestoreRequestState()
+    data class Complete(
+        val rewindId: String,
+        val restoreId: Long,
+        val date: Date? = null
+    ) : RestoreRequestState()
 
     sealed class Failure : RestoreRequestState() {
         object NetworkUnavailable : Failure()

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -11,12 +11,10 @@ import androidx.lifecycle.Observer
 import kotlinx.android.parcel.Parcelize
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.ActivityLogStore.RewindRequestTypes
-import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.CheckboxState
@@ -93,8 +91,7 @@ class RestoreViewModel @Inject constructor(
     private val stateListItemBuilder: RestoreStateListItemBuilder,
     private val postRestoreUseCase: PostRestoreUseCase,
     private val getRestoreStatusUseCase: GetRestoreStatusUseCase,
-    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
-    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {
     private var isStarted = false
     private lateinit var site: SiteModel
@@ -316,7 +313,7 @@ class RestoreViewModel @Inject constructor(
     private fun queryStatus() {
         launch {
             getRestoreStatusUseCase.getRestoreStatus(site, restoreState.restoreId as Long)
-                    .flowOn(bgDispatcher).collect { state -> handleQueryStatus(state) }
+                    .collect { state -> handleQueryStatus(state) }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -30,6 +30,7 @@ class GetRestoreStatusUseCase @Inject constructor(
         restoreId: Long? = null
     ) = flow {
         if (restoreId == null) {
+            if (isNetworkUnavailable()) return@flow
             if (fetchActivitiesRewind(site)) return@flow
         }
         while (true) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -22,7 +22,10 @@ class GetRestoreStatusUseCase @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val activityLogStore: ActivityLogStore
 ) {
-    suspend fun getRestoreStatus(site: SiteModel, restoreId: Long) = flow {
+    suspend fun getRestoreStatus(
+        site: SiteModel,
+        restoreId: Long
+    ) = flow {
         while (true) {
             if (!networkUtilsWrapper.isNetworkAvailable()) {
                 emit(NetworkUnavailable)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -36,7 +36,7 @@ class GetRestoreStatusUseCase @Inject constructor(
     ) = flow {
         if (restoreId == null) {
             if (!isNetworkAvailable()) return@flow
-            if (!isFetchActivitiesRewindSuccessful(site)) return@flow
+            if (!fetchActivitiesRewind(site)) return@flow
         }
         while (true) {
             if (!isNetworkAvailable()) return@flow
@@ -58,7 +58,7 @@ class GetRestoreStatusUseCase @Inject constructor(
                 }
             }
 
-            if (!isFetchActivitiesRewindSuccessful(site)) return@flow
+            if (!fetchActivitiesRewind(site)) return@flow
 
             delay(DELAY_MILLIS)
         }
@@ -71,7 +71,7 @@ class GetRestoreStatusUseCase @Inject constructor(
         } else true
     }
 
-    private suspend fun FlowCollector<RestoreRequestState>.isFetchActivitiesRewindSuccessful(site: SiteModel): Boolean {
+    private suspend fun FlowCollector<RestoreRequestState>.fetchActivitiesRewind(site: SiteModel): Boolean {
         val result = activityLogStore.fetchActivitiesRewind(FetchRewindStatePayload(site))
         return if (result.isError) {
             emit(RemoteRequestFailure)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -50,12 +50,8 @@ class GetRestoreStatusUseCase @Inject constructor(
                         emitFailure()
                         return@flow
                     }
-                    RUNNING -> {
-                        emitProgress(rewind)
-                    }
-                    QUEUED -> {
-                        emitProgress(rewind)
-                    }
+                    RUNNING -> emitProgress(rewind)
+                    QUEUED -> emitProgress(rewind)
                 }
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -43,11 +43,7 @@ class GetRestoreStatusUseCase @Inject constructor(
                     (restoreId == null || rewind.restoreId == restoreId)) {
                 when (rewind.status) {
                     FINISHED -> {
-                        if (rewind.rewindId != null) {
-                            emitComplete(rewind)
-                        } else {
-                            emitFailure()
-                        }
+                        emitFinished(rewind)
                         return@flow
                     }
                     FAILED -> {
@@ -77,6 +73,9 @@ class GetRestoreStatusUseCase @Inject constructor(
         }
         return false
     }
+
+    private suspend fun FlowCollector<RestoreRequestState>.emitFinished(rewind: Rewind) =
+            if (rewind.rewindId != null) emitComplete(rewind) else emitFailure()
 
     private suspend fun FlowCollector<RestoreRequestState>.emitComplete(rewind: Rewind) {
         val rewindId = rewind.rewindId as String

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -33,10 +33,7 @@ class GetRestoreStatusUseCase @Inject constructor(
             if (fetchActivitiesRewind(site)) return@flow
         }
         while (true) {
-            if (!networkUtilsWrapper.isNetworkAvailable()) {
-                emit(NetworkUnavailable)
-                return@flow
-            }
+            if (isNetworkUnavailable()) return@flow
 
             val rewind = activityLogStore.getRewindStatusForSite(site)?.rewind
             if (rewind != null &&
@@ -59,6 +56,14 @@ class GetRestoreStatusUseCase @Inject constructor(
 
             delay(DELAY_MILLIS)
         }
+    }
+
+    private suspend fun FlowCollector<RestoreRequestState>.isNetworkUnavailable(): Boolean {
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+            emit(NetworkUnavailable)
+            return true
+        }
+        return false
     }
 
     private suspend fun FlowCollector<RestoreRequestState>.fetchActivitiesRewind(site: SiteModel): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -35,11 +35,11 @@ class GetRestoreStatusUseCase @Inject constructor(
         restoreId: Long? = null
     ) = flow {
         if (restoreId == null) {
-            if (isNetworkUnavailable()) return@flow
+            if (!isNetworkAvailable()) return@flow
             if (fetchActivitiesRewind(site)) return@flow
         }
         while (true) {
-            if (isNetworkUnavailable()) return@flow
+            if (!isNetworkAvailable()) return@flow
 
             val rewind = activityLogStore.getRewindStatusForSite(site)?.rewind
             if (rewind != null &&
@@ -64,12 +64,12 @@ class GetRestoreStatusUseCase @Inject constructor(
         }
     }.flowOn(bgDispatcher)
 
-    private suspend fun FlowCollector<RestoreRequestState>.isNetworkUnavailable(): Boolean {
+    private suspend fun FlowCollector<RestoreRequestState>.isNetworkAvailable(): Boolean {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             emit(NetworkUnavailable)
-            return true
+            return false
         }
-        return false
+        return true
     }
 
     private suspend fun FlowCollector<RestoreRequestState>.fetchActivitiesRewind(site: SiteModel): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -43,7 +43,9 @@ class GetRestoreStatusUseCase @Inject constructor(
                 when (rewind.status) {
                     FINISHED -> {
                         if (rewind.rewindId != null) {
-                            emit(Complete(rewind.rewindId as String, rewind.restoreId))
+                            val rewindId = rewind.rewindId as String
+                            val date = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
+                            emit(Complete(rewind.rewindId as String, rewind.restoreId, date))
                         } else {
                             emit(RemoteRequestFailure)
                         }
@@ -54,10 +56,14 @@ class GetRestoreStatusUseCase @Inject constructor(
                         return@flow
                     }
                     RUNNING -> {
-                        emit(Progress(rewind.rewindId as String, rewind.progress, rewind.message, rewind.currentEntry))
+                        val rewindId = rewind.rewindId as String
+                        val date = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
+                        emit(Progress(rewindId, rewind.progress, rewind.message, rewind.currentEntry, date))
                     }
                     QUEUED -> {
-                        emit(Progress(rewind.rewindId as String, rewind.progress, rewind.message, rewind.currentEntry))
+                        val rewindId = rewind.rewindId as String
+                        val date = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
+                        emit(Progress(rewindId, rewind.progress, rewind.message, rewind.currentEntry, date))
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.FAILED
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.FINISHED
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.QUEUED
@@ -56,14 +57,10 @@ class GetRestoreStatusUseCase @Inject constructor(
                         return@flow
                     }
                     RUNNING -> {
-                        val rewindId = rewind.rewindId as String
-                        val date = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
-                        emit(Progress(rewindId, rewind.progress, rewind.message, rewind.currentEntry, date))
+                        emitProgress(rewind)
                     }
                     QUEUED -> {
-                        val rewindId = rewind.rewindId as String
-                        val date = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
-                        emit(Progress(rewindId, rewind.progress, rewind.message, rewind.currentEntry, date))
+                        emitProgress(rewind)
                     }
                 }
             }
@@ -81,5 +78,11 @@ class GetRestoreStatusUseCase @Inject constructor(
             return true
         }
         return false
+    }
+
+    private suspend fun FlowCollector<RestoreRequestState>.emitProgress(rewind: Rewind) {
+        val rewindId = rewind.rewindId as String
+        val date = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
+        emit(Progress(rewindId, rewind.progress, rewind.message, rewind.currentEntry, date))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -36,7 +36,7 @@ class GetRestoreStatusUseCase @Inject constructor(
     ) = flow {
         if (restoreId == null) {
             if (!isNetworkAvailable()) return@flow
-            if (fetchActivitiesRewind(site)) return@flow
+            if (!isFetchActivitiesRewindSuccessful(site)) return@flow
         }
         while (true) {
             if (!isNetworkAvailable()) return@flow
@@ -58,7 +58,7 @@ class GetRestoreStatusUseCase @Inject constructor(
                 }
             }
 
-            if (fetchActivitiesRewind(site)) return@flow
+            if (!isFetchActivitiesRewindSuccessful(site)) return@flow
 
             delay(DELAY_MILLIS)
         }
@@ -71,12 +71,12 @@ class GetRestoreStatusUseCase @Inject constructor(
         } else true
     }
 
-    private suspend fun FlowCollector<RestoreRequestState>.fetchActivitiesRewind(site: SiteModel): Boolean {
+    private suspend fun FlowCollector<RestoreRequestState>.isFetchActivitiesRewindSuccessful(site: SiteModel): Boolean {
         val result = activityLogStore.fetchActivitiesRewind(FetchRewindStatePayload(site))
         return if (result.isError) {
             emit(RemoteRequestFailure)
-            true
-        } else false
+            false
+        } else true
     }
 
     private suspend fun FlowCollector<RestoreRequestState>.emitFinished(rewind: Rewind) =

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -86,15 +86,15 @@ class GetRestoreStatusUseCase @Inject constructor(
 
     private suspend fun FlowCollector<RestoreRequestState>.emitComplete(rewind: Rewind) {
         val rewindId = rewind.rewindId as String
-        val date = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
-        emit(Complete(rewind.rewindId as String, rewind.restoreId, date))
+        val published = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
+        emit(Complete(rewind.rewindId as String, rewind.restoreId, published))
     }
 
     private suspend fun FlowCollector<RestoreRequestState>.emitFailure() = emit(RemoteRequestFailure)
 
     private suspend fun FlowCollector<RestoreRequestState>.emitProgress(rewind: Rewind) {
         val rewindId = rewind.rewindId as String
-        val date = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
-        emit(Progress(rewindId, rewind.progress, rewind.message, rewind.currentEntry, date))
+        val published = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
+        emit(Progress(rewindId, rewind.progress, rewind.message, rewind.currentEntry, published))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -46,12 +46,12 @@ class GetRestoreStatusUseCase @Inject constructor(
                         if (rewind.rewindId != null) {
                             emitComplete(rewind)
                         } else {
-                            emit(RemoteRequestFailure)
+                            emitFailure()
                         }
                         return@flow
                     }
                     FAILED -> {
-                        emit(RemoteRequestFailure)
+                        emitFailure()
                         return@flow
                     }
                     RUNNING -> {
@@ -83,6 +83,8 @@ class GetRestoreStatusUseCase @Inject constructor(
         val date = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
         emit(Complete(rewind.rewindId as String, rewind.restoreId, date))
     }
+
+    private suspend fun FlowCollector<RestoreRequestState>.emitFailure() = emit(RemoteRequestFailure)
 
     private suspend fun FlowCollector<RestoreRequestState>.emitProgress(rewind: Rewind) {
         val rewindId = rewind.rewindId as String

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -44,9 +44,7 @@ class GetRestoreStatusUseCase @Inject constructor(
                 when (rewind.status) {
                     FINISHED -> {
                         if (rewind.rewindId != null) {
-                            val rewindId = rewind.rewindId as String
-                            val date = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
-                            emit(Complete(rewind.rewindId as String, rewind.restoreId, date))
+                            emitComplete(rewind)
                         } else {
                             emit(RemoteRequestFailure)
                         }
@@ -78,6 +76,12 @@ class GetRestoreStatusUseCase @Inject constructor(
             return true
         }
         return false
+    }
+
+    private suspend fun FlowCollector<RestoreRequestState>.emitComplete(rewind: Rewind) {
+        val rewindId = rewind.rewindId as String
+        val date = activityLogStore.getActivityLogItemByRewindId(rewindId)?.published
+        emit(Complete(rewind.rewindId as String, rewind.restoreId, date))
     }
 
     private suspend fun FlowCollector<RestoreRequestState>.emitProgress(rewind: Rewind) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -52,7 +52,7 @@ class GetRestoreStatusUseCase @Inject constructor(
                         emit(Progress(rewind.rewindId as String, rewind.progress, rewind.message, rewind.currentEntry))
                     }
                     QUEUED -> {
-                        // no op
+                        emit(Progress(rewind.rewindId as String, rewind.progress, rewind.message, rewind.currentEntry))
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -26,6 +26,13 @@ class GetRestoreStatusUseCase @Inject constructor(
         site: SiteModel,
         restoreId: Long? = null
     ) = flow {
+        if (restoreId == null) {
+            val result = activityLogStore.fetchActivitiesRewind(FetchRewindStatePayload(site))
+            if (result.isError) {
+                emit(RemoteRequestFailure)
+                return@flow
+            }
+        }
         while (true) {
             if (!networkUtilsWrapper.isNetworkAvailable()) {
                 emit(NetworkUnavailable)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -18,7 +18,7 @@ import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Progress
 import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
 
-const val DELAY_MILLIS = 10000L
+const val DELAY_MILLIS = 5000L
 
 class GetRestoreStatusUseCase @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -65,20 +65,18 @@ class GetRestoreStatusUseCase @Inject constructor(
     }.flowOn(bgDispatcher)
 
     private suspend fun FlowCollector<RestoreRequestState>.isNetworkAvailable(): Boolean {
-        if (!networkUtilsWrapper.isNetworkAvailable()) {
+        return if (!networkUtilsWrapper.isNetworkAvailable()) {
             emit(NetworkUnavailable)
-            return false
-        }
-        return true
+            false
+        } else true
     }
 
     private suspend fun FlowCollector<RestoreRequestState>.fetchActivitiesRewind(site: SiteModel): Boolean {
         val result = activityLogStore.fetchActivitiesRewind(FetchRewindStatePayload(site))
-        if (result.isError) {
+        return if (result.isError) {
             emit(RemoteRequestFailure)
-            return true
-        }
-        return false
+            true
+        } else false
     }
 
     private suspend fun FlowCollector<RestoreRequestState>.emitFinished(rewind: Rewind) =

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -24,7 +24,7 @@ class GetRestoreStatusUseCase @Inject constructor(
 ) {
     suspend fun getRestoreStatus(
         site: SiteModel,
-        restoreId: Long
+        restoreId: Long? = null
     ) = flow {
         while (true) {
             if (!networkUtilsWrapper.isNetworkAvailable()) {
@@ -33,7 +33,8 @@ class GetRestoreStatusUseCase @Inject constructor(
             }
 
             val rewind = activityLogStore.getRewindStatusForSite(site)?.rewind
-            if (rewind != null && rewind.restoreId == restoreId) {
+            if (rewind != null &&
+                    (restoreId == null || rewind.restoreId == restoreId)) {
                 when (rewind.status) {
                     FINISHED -> {
                         if (rewind.rewindId != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/PostRestoreUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/PostRestoreUseCase.kt
@@ -28,7 +28,7 @@ class PostRestoreUseCase @Inject constructor(
     suspend fun postRestoreRequest(
         rewindId: String,
         site: SiteModel,
-        types: RewindRequestTypes
+        types: RewindRequestTypes? = null
     ): RestoreRequestState = withContext(ioDispatcher) {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return@withContext NetworkUnavailable

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -437,7 +437,7 @@ class ActivityLogViewModel @Inject constructor(
             _moveToTop.call()
         }
         if (restoreEvent.isCompleted) {
-            showRewindFinishedMessage()
+            showRewindFinishedMessage(restoreEvent.date)
         }
     }
 
@@ -500,19 +500,13 @@ class ActivityLogViewModel @Inject constructor(
         }
     }
 
-    private fun showRewindFinishedMessage() {
-        val item = rewindStatusService.rewindingActivity
-        if (item != null) {
-            val event = ActivityLogListItem.Event(
-                    model = item,
-                    backupDownloadFeatureEnabled = backupDownloadFeatureConfig.isEnabled(),
-                    restoreFeatureEnabled = restoreFeatureConfig.isEnabled()
-            )
+    private fun showRewindFinishedMessage(date: Date?) {
+        if (date != null) {
             _showSnackbarMessage.value =
                     resourceProvider.getString(
                             R.string.activity_log_rewind_finished_snackbar_message,
-                            event.formattedDate,
-                            event.formattedTime
+                            date.toFormattedDateString(),
+                            date.toFormattedTimeString()
                     )
         } else {
             _showSnackbarMessage.value =

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -504,31 +504,6 @@ class ActivityLogViewModel @Inject constructor(
         }
     }
 
-    private fun showRewindStartedMessage(rewindId: String) {
-        activityLogStore.getActivityLogItemByRewindId(rewindId)?.published?.let {
-            _showSnackbarMessage.value = resourceProvider.getString(
-                    R.string.activity_log_rewind_started_snackbar_message,
-                    it.toFormattedDateString(),
-                    it.toFormattedTimeString()
-            )
-        }
-    }
-
-    private fun showRewindFinishedMessage(rewindId: String?, date: Date?) {
-        val rewindDate = date ?: rewindId?.let { activityLogStore.getActivityLogItemByRewindId(it)?.published }
-        if (rewindDate != null) {
-            _showSnackbarMessage.value =
-                    resourceProvider.getString(
-                            R.string.activity_log_rewind_finished_snackbar_message,
-                            rewindDate.toFormattedDateString(),
-                            rewindDate.toFormattedTimeString()
-                    )
-        } else {
-            _showSnackbarMessage.value =
-                    resourceProvider.getString(R.string.activity_log_rewind_finished_snackbar_message_no_dates)
-        }
-    }
-
     private fun onActivityLogFetched(
         event: OnActivityLogFetched,
         loadingMore: Boolean,
@@ -555,6 +530,31 @@ class ActivityLogViewModel @Inject constructor(
             _eventListStatus.value = ActivityLogListStatus.CAN_LOAD_MORE
         } else {
             _eventListStatus.value = ActivityLogListStatus.DONE
+        }
+    }
+
+    private fun showRewindStartedMessage(rewindId: String) {
+        activityLogStore.getActivityLogItemByRewindId(rewindId)?.published?.let {
+            _showSnackbarMessage.value = resourceProvider.getString(
+                    R.string.activity_log_rewind_started_snackbar_message,
+                    it.toFormattedDateString(),
+                    it.toFormattedTimeString()
+            )
+        }
+    }
+
+    private fun showRewindFinishedMessage(rewindId: String?, date: Date?) {
+        val rewindDate = date ?: rewindId?.let { activityLogStore.getActivityLogItemByRewindId(it)?.published }
+        if (rewindDate != null) {
+            _showSnackbarMessage.value =
+                    resourceProvider.getString(
+                            R.string.activity_log_rewind_finished_snackbar_message,
+                            rewindDate.toFormattedDateString(),
+                            rewindDate.toFormattedTimeString()
+                    )
+        } else {
+            _showSnackbarMessage.value =
+                    resourceProvider.getString(R.string.activity_log_rewind_finished_snackbar_message_no_dates)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -169,8 +169,6 @@ class ActivityLogViewModel @Inject constructor(
         rewindStatusService.rewindProgress.observeForever(rewindProgressObserver)
         rewindStatusService.rewindAvailable.observeForever(rewindAvailableObserver)
 
-        activityLogStore.getRewindStatusForSite(site)
-
         reloadEvents(done = true)
         requestEventsUpdate(false)
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -497,7 +497,7 @@ class ActivityLogViewModel @Inject constructor(
         requestEventsUpdate(false)
     }
 
-    fun onRewindConfirmed(rewindId: String) {
+    fun onRestoreConfirmed(rewindId: String) {
         viewModelScope.launch { handleRestoreRequest(postRestoreUseCase.postRestoreRequest(rewindId, site)) }
         showRewindStartedMessage(rewindId)
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -465,7 +465,10 @@ class ActivityLogViewModel @Inject constructor(
         )
     }
 
-    private fun requestEventsUpdate(loadMore: Boolean, restoreEvent: RestoreEvent = RestoreEvent(isRewindProgressItemShown)) {
+    private fun requestEventsUpdate(
+        loadMore: Boolean,
+        restoreEvent: RestoreEvent = RestoreEvent(isRewindProgressItemShown)
+    ) {
         val isLoadingMore = fetchActivitiesJob != null && eventListStatus.value == ActivityLogListStatus.LOADING_MORE
         val canLoadMore = eventListStatus.value == ActivityLogListStatus.CAN_LOAD_MORE
         if (loadMore && (isLoadingMore || !canLoadMore)) {
@@ -526,7 +529,11 @@ class ActivityLogViewModel @Inject constructor(
         }
     }
 
-    private fun onActivityLogFetched(event: OnActivityLogFetched, loadingMore: Boolean, restoreEvent: RestoreEvent) {
+    private fun onActivityLogFetched(
+        event: OnActivityLogFetched,
+        loadingMore: Boolean,
+        restoreEvent: RestoreEvent
+    ) {
         if (event.isError) {
             _eventListStatus.value = ActivityLogListStatus.ERROR
             AppLog.e(AppLog.T.ACTIVITY_LOG, "An error occurred while fetching the Activity log events")

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -127,7 +127,7 @@ class ActivityLogViewModel @Inject constructor(
     val navigationEvents: LiveData<Event<ActivityLogNavigationEvents>>
         get() = _navigationEvents
 
-    private val isRewindProgressItemShown: Boolean
+    private val isRestoreProgressItemShown: Boolean
         get() = events.value?.containsProgressItem() == true
 
     private val isDone: Boolean
@@ -376,7 +376,7 @@ class ActivityLogViewModel @Inject constructor(
 
     private fun handleRestoreStatus(state: RestoreRequestState) {
         when (state) {
-            is RestoreRequestState.Progress -> if (!isRewindProgressItemShown) {
+            is RestoreRequestState.Progress -> if (!isRestoreProgressItemShown) {
                 reloadEvents(
                         restoreEvent = RestoreEvent(
                                 displayProgress = true,
@@ -386,7 +386,7 @@ class ActivityLogViewModel @Inject constructor(
                         ),
                 )
             }
-            is RestoreRequestState.Complete -> if (isRewindProgressItemShown) {
+            is RestoreRequestState.Complete -> if (isRestoreProgressItemShown) {
                 requestEventsUpdate(
                         loadMore = false,
                         restoreEvent = RestoreEvent(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -225,6 +225,21 @@ class ActivityLogViewModel @Inject constructor(
         )
     }
 
+    private fun showRewindFinishedMessage(rewindId: String?, date: Date?) {
+        val rewindDate = date ?: rewindId?.let { activityLogStore.getActivityLogItemByRewindId(it)?.published }
+        if (rewindDate != null) {
+            _showSnackbarMessage.value =
+                    resourceProvider.getString(
+                            R.string.activity_log_rewind_finished_snackbar_message,
+                            rewindDate.toFormattedDateString(),
+                            rewindDate.toFormattedTimeString()
+                    )
+        } else {
+            _showSnackbarMessage.value =
+                    resourceProvider.getString(R.string.activity_log_rewind_finished_snackbar_message_no_dates)
+        }
+    }
+
     private fun requestEventsUpdate(
         loadMore: Boolean,
         restoreEvent: RestoreEvent = currentRestoreEvent
@@ -540,21 +555,6 @@ class ActivityLogViewModel @Inject constructor(
                     it.toFormattedDateString(),
                     it.toFormattedTimeString()
             )
-        }
-    }
-
-    private fun showRewindFinishedMessage(rewindId: String?, date: Date?) {
-        val rewindDate = date ?: rewindId?.let { activityLogStore.getActivityLogItemByRewindId(it)?.published }
-        if (rewindDate != null) {
-            _showSnackbarMessage.value =
-                    resourceProvider.getString(
-                            R.string.activity_log_rewind_finished_snackbar_message,
-                            rewindDate.toFormattedDateString(),
-                            rewindDate.toFormattedTimeString()
-                    )
-        } else {
-            _showSnackbarMessage.value =
-                    resourceProvider.getString(R.string.activity_log_rewind_finished_snackbar_message_no_dates)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -170,7 +170,7 @@ class ActivityLogViewModel @Inject constructor(
         val withRestoreProgressItem = restoreEvent.displayProgress && !restoreEvent.isCompleted
         if (withRestoreProgressItem) {
             items.add(ActivityLogListItem.Header(resourceProvider.getString(R.string.now)))
-            items.add(getRestoreProgressItem(restoreEvent.rewindId, restoreEvent.date))
+            items.add(getRestoreProgressItem(restoreEvent.rewindId, restoreEvent.published))
             moveToTop = eventListStatus.value != ActivityLogListStatus.LOADING_MORE
         }
         eventList.forEach { model ->
@@ -198,13 +198,13 @@ class ActivityLogViewModel @Inject constructor(
             _moveToTop.call()
         }
         if (restoreEvent.isCompleted) {
-            showRewindFinishedMessage(restoreEvent.rewindId, restoreEvent.date)
+            showRewindFinishedMessage(restoreEvent.rewindId, restoreEvent.published)
             currentRestoreEvent = RestoreEvent(false)
         }
     }
 
-    private fun getRestoreProgressItem(rewindId: String?, date: Date?): ActivityLogListItem.Progress {
-        val rewindDate = date ?: rewindId?.let { activityLogStore.getActivityLogItemByRewindId(it)?.published }
+    private fun getRestoreProgressItem(rewindId: String?, published: Date?): ActivityLogListItem.Progress {
+        val rewindDate = published ?: rewindId?.let { activityLogStore.getActivityLogItemByRewindId(it)?.published }
         return rewindDate?.let {
             ActivityLogListItem.Progress(
                     resourceProvider.getString(R.string.activity_log_currently_restoring_title),
@@ -220,8 +220,8 @@ class ActivityLogViewModel @Inject constructor(
         )
     }
 
-    private fun showRewindFinishedMessage(rewindId: String?, date: Date?) {
-        val rewindDate = date ?: rewindId?.let { activityLogStore.getActivityLogItemByRewindId(it)?.published }
+    private fun showRewindFinishedMessage(rewindId: String?, published: Date?) {
+        val rewindDate = published ?: rewindId?.let { activityLogStore.getActivityLogItemByRewindId(it)?.published }
         if (rewindDate != null) {
             _showSnackbarMessage.value =
                     resourceProvider.getString(
@@ -520,7 +520,7 @@ class ActivityLogViewModel @Inject constructor(
                                 displayProgress = true,
                                 isCompleted = false,
                                 rewindId = state.rewindId,
-                                date = state.date
+                                published = state.published
                         )
                 )
             }
@@ -531,7 +531,7 @@ class ActivityLogViewModel @Inject constructor(
                                 displayProgress = false,
                                 isCompleted = true,
                                 rewindId = state.rewindId,
-                                date = state.date
+                                published = state.published
                         )
                 )
             }
@@ -560,7 +560,7 @@ class ActivityLogViewModel @Inject constructor(
         val displayProgress: Boolean,
         val isCompleted: Boolean = false,
         val rewindId: String? = null,
-        val date: Date? = null
+        val published: Date? = null
     )
 
     sealed class FiltersUiState(val visibility: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -6,10 +6,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
@@ -18,7 +16,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityTypeModel
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.OnActivityLogFetched
-import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
@@ -44,7 +41,6 @@ import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.FiltersU
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.FiltersUiState.FiltersShown
 import java.util.Date
 import javax.inject.Inject
-import javax.inject.Named
 
 const val ACTIVITY_LOG_REWINDABLE_ONLY_KEY = "activity_log_rewindable_only"
 
@@ -74,8 +70,7 @@ class ActivityLogViewModel @Inject constructor(
     private val dateUtils: DateUtils,
     private val activityLogTracker: ActivityLogTracker,
     private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase,
-    private val restoreFeatureConfig: RestoreFeatureConfig,
-    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+    private val restoreFeatureConfig: RestoreFeatureConfig
 ) : ViewModel() {
     enum class ActivityLogListStatus {
         CAN_LOAD_MORE,
@@ -513,7 +508,7 @@ class ActivityLogViewModel @Inject constructor(
         restoreStatusJob?.cancel()
         restoreStatusJob = viewModelScope.launch {
             getRestoreStatusUseCase.getRestoreStatus(site, restoreId)
-                    .flowOn(bgDispatcher).collect { handleRestoreStatus(it) }
+                    .collect { handleRestoreStatus(it) }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -368,7 +368,7 @@ class ActivityLogViewModel @Inject constructor(
         activityLogTracker.trackActivityTypeFilterButtonClicked()
         _showActivityTypeFilterDialog.value = ShowActivityTypePicker(
                 RemoteId(site.siteId),
-                currentActivityTypeFilter.mapNotNull { it.key },
+                currentActivityTypeFilter.map { it.key },
                 currentDateRangeFilter
         )
     }
@@ -493,7 +493,7 @@ class ActivityLogViewModel @Inject constructor(
                 loadMore,
                 currentDateRangeFilter?.first?.let { Date(it) },
                 currentDateRangeFilter?.second?.let { Date(it) },
-                currentActivityTypeFilter.mapNotNull { it.key }
+                currentActivityTypeFilter.map { it.key }
         )
         fetchActivitiesJob = launch {
             val result = activityLogStore.fetchActivities(payload)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -13,8 +13,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.ActivityTypeModel
-import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status
-import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.RUNNING
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.OnActivityLogFetched
 import org.wordpress.android.modules.UI_THREAD
@@ -142,7 +141,7 @@ class ActivityLogViewModel @Inject constructor(
     private var areActionsEnabled: Boolean = true
 
     private var lastRewindActivityId: String? = null
-    private var lastRewindStatus: Status? = null
+    private var lastRewindStatus: Rewind.Status? = null
 
     private var currentDateRangeFilter: DateRange? = null
     private var currentActivityTypeFilter: List<ActivityTypeModel> = listOf()
@@ -393,11 +392,11 @@ class ActivityLogViewModel @Inject constructor(
         requestEventsUpdate(true)
     }
 
-    private fun updateRewindState(status: Status?) {
+    private fun updateRewindState(status: Rewind.Status?) {
         lastRewindStatus = status
-        if (status == RUNNING && !isRewindProgressItemShown) {
+        if (status == Rewind.Status.RUNNING && !isRewindProgressItemShown) {
             reloadEvents(disableActions = true, displayProgressItem = true)
-        } else if (status != RUNNING && isRewindProgressItemShown) {
+        } else if (status != Rewind.Status.RUNNING && isRewindProgressItemShown) {
             requestEventsUpdate(false)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -208,6 +208,23 @@ class ActivityLogViewModel @Inject constructor(
         }
     }
 
+    private fun getRewindProgressItem(rewindId: String?, date: Date?): ActivityLogListItem.Progress {
+        val rewindDate = date ?: rewindId?.let { activityLogStore.getActivityLogItemByRewindId(it)?.published }
+        return rewindDate?.let {
+            ActivityLogListItem.Progress(
+                    resourceProvider.getString(R.string.activity_log_currently_restoring_title),
+                    resourceProvider.getString(
+                            R.string.activity_log_currently_restoring_message,
+                            rewindDate.toFormattedDateString(),
+                            rewindDate.toFormattedTimeString()
+                    )
+            )
+        } ?: ActivityLogListItem.Progress(
+                resourceProvider.getString(R.string.activity_log_currently_restoring_title),
+                resourceProvider.getString(R.string.activity_log_currently_restoring_message_no_dates)
+        )
+    }
+
     private fun requestEventsUpdate(
         loadMore: Boolean,
         restoreEvent: RestoreEvent = currentRestoreEvent
@@ -514,23 +531,6 @@ class ActivityLogViewModel @Inject constructor(
 
     private fun List<ActivityLogListItem>.containsProgressItem(): Boolean {
         return this.find { it is ActivityLogListItem.Progress } != null
-    }
-
-    private fun getRewindProgressItem(rewindId: String?, date: Date?): ActivityLogListItem.Progress {
-        val rewindDate = date ?: rewindId?.let { activityLogStore.getActivityLogItemByRewindId(it)?.published }
-        return rewindDate?.let {
-            ActivityLogListItem.Progress(
-                    resourceProvider.getString(R.string.activity_log_currently_restoring_title),
-                    resourceProvider.getString(
-                            R.string.activity_log_currently_restoring_message,
-                            rewindDate.toFormattedDateString(),
-                            rewindDate.toFormattedTimeString()
-                    )
-            )
-        } ?: ActivityLogListItem.Progress(
-                resourceProvider.getString(R.string.activity_log_currently_restoring_title),
-                resourceProvider.getString(R.string.activity_log_currently_restoring_message_no_dates)
-        )
     }
 
     private fun showRewindStartedMessage(rewindId: String) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -45,9 +45,6 @@ import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
-import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.CAN_LOAD_MORE
-import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.DONE
-import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus.LOADING_MORE
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.FiltersUiState.FiltersHidden
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.FiltersUiState.FiltersShown
 import java.util.Date
@@ -138,7 +135,7 @@ class ActivityLogViewModel @Inject constructor(
         get() = _events.value?.containsProgressItem() == true
 
     private val isDone: Boolean
-        get() = eventListStatus.value == DONE
+        get() = eventListStatus.value == ActivityLogListStatus.DONE
 
     private var fetchActivitiesJob: Job? = null
 
@@ -422,7 +419,7 @@ class ActivityLogViewModel @Inject constructor(
             val activityLogModel = rewindStatusService.rewindProgress.value?.activityLogItem
             items.add(Header(resourceProvider.getString(R.string.now)))
             items.add(getRewindProgressItem(activityLogModel))
-            moveToTop = eventListStatus.value != LOADING_MORE
+            moveToTop = eventListStatus.value != ActivityLogListStatus.LOADING_MORE
         }
         eventList.forEach { model ->
             val currentItem = ActivityLogListItem.Event(
@@ -480,13 +477,13 @@ class ActivityLogViewModel @Inject constructor(
 
     private fun requestEventsUpdate(loadMore: Boolean) {
         val isLoadingMore = fetchActivitiesJob != null && _eventListStatus.value == ActivityLogListStatus.LOADING_MORE
-        val canLoadMore = _eventListStatus.value == CAN_LOAD_MORE
+        val canLoadMore = _eventListStatus.value == ActivityLogListStatus.CAN_LOAD_MORE
         if (loadMore && (isLoadingMore || !canLoadMore)) {
             // Ignore loadMore request when already loading more items or there are no more items to load
             return
         }
         fetchActivitiesJob?.cancel()
-        val newStatus = if (loadMore) LOADING_MORE else ActivityLogListStatus.FETCHING
+        val newStatus = if (loadMore) ActivityLogListStatus.LOADING_MORE else ActivityLogListStatus.FETCHING
         _eventListStatus.value = newStatus
         val payload = ActivityLogStore.FetchActivityLogPayload(
                 site,
@@ -561,7 +558,7 @@ class ActivityLogViewModel @Inject constructor(
         if (event.canLoadMore) {
             _eventListStatus.value = ActivityLogListStatus.CAN_LOAD_MORE
         } else {
-            _eventListStatus.value = DONE
+            _eventListStatus.value = ActivityLogListStatus.DONE
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -128,7 +128,7 @@ class ActivityLogViewModel @Inject constructor(
         get() = _navigationEvents
 
     private val isRestoreProgressItemShown: Boolean
-        get() = events.value?.containsProgressItem() == true
+        get() = events.value?.find { it is ActivityLogListItem.Progress } != null
 
     private val isDone: Boolean
         get() = eventListStatus.value == ActivityLogListStatus.DONE
@@ -542,10 +542,6 @@ class ActivityLogViewModel @Inject constructor(
 
     fun onScrolledToBottom() {
         requestEventsUpdate(true)
-    }
-
-    private fun List<ActivityLogListItem>.containsProgressItem(): Boolean {
-        return this.find { it is ActivityLogListItem.Progress } != null
     }
 
     private fun showRewindStartedMessage(rewindId: String) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -175,7 +175,7 @@ class ActivityLogViewModel @Inject constructor(
         val withRestoreProgressItem = restoreEvent.displayProgress && !restoreEvent.isCompleted
         if (withRestoreProgressItem) {
             items.add(ActivityLogListItem.Header(resourceProvider.getString(R.string.now)))
-            items.add(getRewindProgressItem(restoreEvent.rewindId, restoreEvent.date))
+            items.add(getRestoreProgressItem(restoreEvent.rewindId, restoreEvent.date))
             moveToTop = eventListStatus.value != ActivityLogListStatus.LOADING_MORE
         }
         eventList.forEach { model ->
@@ -208,7 +208,7 @@ class ActivityLogViewModel @Inject constructor(
         }
     }
 
-    private fun getRewindProgressItem(rewindId: String?, date: Date?): ActivityLogListItem.Progress {
+    private fun getRestoreProgressItem(rewindId: String?, date: Date?): ActivityLogListItem.Progress {
         val rewindDate = date ?: rewindId?.let { activityLogStore.getActivityLogItemByRewindId(it)?.published }
         return rewindDate?.let {
             ActivityLogListItem.Progress(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -403,6 +403,10 @@ class ActivityLogViewModel @Inject constructor(
         )
     }
 
+    fun onScrolledToBottom() {
+        requestEventsUpdate(true)
+    }
+
     fun onPullToRefresh() {
         requestEventsUpdate(false)
     }
@@ -538,10 +542,6 @@ class ActivityLogViewModel @Inject constructor(
             }
             else -> Unit // Do nothing
         }
-    }
-
-    fun onScrolledToBottom() {
-        requestEventsUpdate(true)
     }
 
     private fun showRewindStartedMessage(rewindId: String) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -283,7 +283,7 @@ class ActivityLogViewModel @Inject constructor(
         if (event.rowsAffected > 0) {
             reloadEvents(
                     done = !event.canLoadMore,
-                    restoreEvent = restoreEvent,
+                    restoreEvent = restoreEvent
             )
             if (!loadingMore) {
                 moveToTop.call()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -123,7 +123,7 @@ class ActivityLogViewModel @Inject constructor(
         get() = _navigationEvents
 
     private val isRewindProgressItemShown: Boolean
-        get() = _events.value?.containsProgressItem() == true
+        get() = events.value?.containsProgressItem() == true
 
     private val isDone: Boolean
         get() = eventListStatus.value == ActivityLogListStatus.DONE
@@ -465,8 +465,8 @@ class ActivityLogViewModel @Inject constructor(
     }
 
     private fun requestEventsUpdate(loadMore: Boolean) {
-        val isLoadingMore = fetchActivitiesJob != null && _eventListStatus.value == ActivityLogListStatus.LOADING_MORE
-        val canLoadMore = _eventListStatus.value == ActivityLogListStatus.CAN_LOAD_MORE
+        val isLoadingMore = fetchActivitiesJob != null && eventListStatus.value == ActivityLogListStatus.LOADING_MORE
+        val canLoadMore = eventListStatus.value == ActivityLogListStatus.CAN_LOAD_MORE
         if (loadMore && (isLoadingMore || !canLoadMore)) {
             // Ignore loadMore request when already loading more items or there are no more items to load
             return

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -499,7 +499,7 @@ class ActivityLogViewModel @Inject constructor(
 
     fun onRestoreConfirmed(rewindId: String) {
         viewModelScope.launch { handleRestoreRequest(postRestoreUseCase.postRestoreRequest(rewindId, site)) }
-        showRewindStartedMessage(rewindId)
+        showRestoreStartedMessage(rewindId)
     }
 
     private fun handleRestoreRequest(state: RestoreRequestState) {
@@ -544,7 +544,7 @@ class ActivityLogViewModel @Inject constructor(
         }
     }
 
-    private fun showRewindStartedMessage(rewindId: String) {
+    private fun showRestoreStartedMessage(rewindId: String) {
         activityLogStore.getActivityLogItemByRewindId(rewindId)?.published?.let {
             _showSnackbarMessage.value = resourceProvider.getString(
                     R.string.activity_log_rewind_started_snackbar_message,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -18,9 +18,6 @@ import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.OnActivityLogFetched
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents
-import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowBackupDownload
-import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRestore
-import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRewindDialog
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
@@ -302,9 +299,9 @@ class ActivityLogViewModel @Inject constructor(
     fun onActionButtonClicked(item: ActivityLogListItem) {
         if (item is ActivityLogListItem.Event) {
             val navigationEvent = if (item.launchRestoreWizard) {
-                ShowRestore(item)
+                ActivityLogNavigationEvents.ShowRestore(item)
             } else {
-                ShowRewindDialog(item)
+                ActivityLogNavigationEvents.ShowRewindDialog(item)
             }
             _navigationEvents.value = Event(navigationEvent)
         }
@@ -318,13 +315,13 @@ class ActivityLogViewModel @Inject constructor(
             val navigationEvent = when (secondaryAction) {
                 ActivityLogListItem.SecondaryAction.RESTORE -> {
                     if (item.launchRestoreWizard) {
-                        ShowRestore(item)
+                        ActivityLogNavigationEvents.ShowRestore(item)
                     } else {
-                        ShowRewindDialog(item)
+                        ActivityLogNavigationEvents.ShowRewindDialog(item)
                     }
                 }
                 ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP -> {
-                    ShowBackupDownload(item)
+                    ActivityLogNavigationEvents.ShowBackupDownload(item)
                 }
             }
             _navigationEvents.value = Event(navigationEvent)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -22,11 +22,6 @@ import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowBack
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRestore
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRewindDialog
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Footer
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Header
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Loading
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.RESTORE
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService.RewindProgress
@@ -321,14 +316,14 @@ class ActivityLogViewModel @Inject constructor(
     ): Boolean {
         if (item is ActivityLogListItem.Event) {
             val navigationEvent = when (secondaryAction) {
-                RESTORE -> {
+                ActivityLogListItem.SecondaryAction.RESTORE -> {
                     if (item.launchRestoreWizard) {
                         ShowRestore(item)
                     } else {
                         ShowRewindDialog(item)
                     }
                 }
-                DOWNLOAD_BACKUP -> {
+                ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP -> {
                     ShowBackupDownload(item)
                 }
             }
@@ -416,7 +411,7 @@ class ActivityLogViewModel @Inject constructor(
         val rewindFinished = isRewindProgressItemShown && !displayProgressItem
         if (displayProgressItem) {
             val activityLogModel = rewindStatusService.rewindProgress.value?.activityLogItem
-            items.add(Header(resourceProvider.getString(R.string.now)))
+            items.add(ActivityLogListItem.Header(resourceProvider.getString(R.string.now)))
             items.add(getRewindProgressItem(activityLogModel))
             moveToTop = eventListStatus.value != ActivityLogListStatus.LOADING_MORE
         }
@@ -429,15 +424,15 @@ class ActivityLogViewModel @Inject constructor(
             )
             val lastItem = items.lastOrNull() as? ActivityLogListItem.Event
             if (lastItem == null || lastItem.formattedDate != currentItem.formattedDate) {
-                items.add(Header(currentItem.formattedDate))
+                items.add(ActivityLogListItem.Header(currentItem.formattedDate))
             }
             items.add(currentItem)
         }
         if (eventList.isNotEmpty() && !done) {
-            items.add(Loading)
+            items.add(ActivityLogListItem.Loading)
         }
         if (eventList.isNotEmpty() && site.hasFreePlan && done) {
-            items.add(Footer)
+            items.add(ActivityLogListItem.Footer)
         }
         areActionsEnabled = !disableActions
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.viewmodel.activitylog
 
+import androidx.annotation.VisibleForTesting
 import androidx.core.util.Pair
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -391,7 +392,8 @@ class ActivityLogViewModel @Inject constructor(
         }
     }
 
-    private fun reloadEvents(
+    @VisibleForTesting
+    fun reloadEvents(
         disableActions: Boolean = areActionsEnabled,
         displayProgressItem: Boolean = isRewindProgressItemShown,
         done: Boolean = isDone

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -526,7 +526,7 @@ class ActivityLogViewModel @Inject constructor(
                                 isCompleted = false,
                                 rewindId = state.rewindId,
                                 date = state.date
-                        ),
+                        )
                 )
             }
             is RestoreRequestState.Complete -> if (isRestoreProgressItemShown) {
@@ -565,7 +565,7 @@ class ActivityLogViewModel @Inject constructor(
         val displayProgress: Boolean,
         val isCompleted: Boolean = false,
         val rewindId: String? = null,
-        val date: Date? = null,
+        val date: Date? = null
     )
 
     sealed class FiltersUiState(val visibility: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -377,7 +377,7 @@ class ActivityLogViewModel @Inject constructor(
 
     fun onRewindConfirmed(rewindId: String) {
         rewindStatusService.rewind(rewindId, site)
-        showRewindStartedMessage()
+        showRewindStartedMessage(rewindId)
     }
 
     fun onScrolledToBottom() {
@@ -490,17 +490,12 @@ class ActivityLogViewModel @Inject constructor(
         }
     }
 
-    private fun showRewindStartedMessage() {
-        rewindStatusService.rewindingActivity?.let {
-            val event = ActivityLogListItem.Event(
-                    model = it,
-                    backupDownloadFeatureEnabled = backupDownloadFeatureConfig.isEnabled(),
-                    restoreFeatureEnabled = restoreFeatureConfig.isEnabled()
-            )
+    private fun showRewindStartedMessage(rewindId: String) {
+        activityLogStore.getActivityLogItemByRewindId(rewindId)?.published?.let {
             _showSnackbarMessage.value = resourceProvider.getString(
                     R.string.activity_log_rewind_started_snackbar_message,
-                    event.formattedDate,
-                    event.formattedTime
+                    it.toFormattedDateString(),
+                    it.toFormattedTimeString()
             )
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
@@ -103,7 +103,6 @@ class RestoreViewModelTest : BaseUnitTest() {
                 stateListItemBuilder,
                 postRestoreUseCase,
                 restoreStatusUseCase,
-                TEST_DISPATCHER,
                 TEST_DISPATCHER
         )
         whenever(getActivityLogItemUseCase.get(anyOrNull())).thenReturn(fakeActivityLogModel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.jetpack.restore.usecases
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
@@ -13,6 +14,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.MainCoroutineScopeRule
+import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_REWIND_STATE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
@@ -38,6 +40,7 @@ private const val CURRENT_ENTRY = "current entry"
 
 private val DATE = Date()
 
+@InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class GetRestoreStatusUseCaseTest {
@@ -53,7 +56,7 @@ class GetRestoreStatusUseCaseTest {
 
     @Before
     fun setup() = test {
-        useCase = GetRestoreStatusUseCase(networkUtilsWrapper, activityLogStore)
+        useCase = GetRestoreStatusUseCase(networkUtilsWrapper, activityLogStore, TEST_DISPATCHER)
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
         whenever(activityLogStore.fetchActivitiesRewind(any())).thenReturn(OnRewindStatusFetched(FETCH_REWIND_STATE))
         whenever(activityLogStore.getActivityLogItemByRewindId(REWIND_ID)).thenReturn(activityLogModel())

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
@@ -38,7 +38,7 @@ private const val PROGRESS = 50
 private const val MESSAGE = "message"
 private const val CURRENT_ENTRY = "current entry"
 
-private val DATE = Date()
+private val PUBLISHED = Date()
 
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
@@ -107,7 +107,7 @@ class GetRestoreStatusUseCaseTest {
 
         val result = useCase.getRestoreStatus(site, null).toList()
 
-        assertThat(result).contains(Complete(REWIND_ID, RESTORE_ID, DATE))
+        assertThat(result).contains(Complete(REWIND_ID, RESTORE_ID, PUBLISHED))
     }
 
     @Test
@@ -117,7 +117,7 @@ class GetRestoreStatusUseCaseTest {
 
         val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
 
-        assertThat(result).contains(Complete(REWIND_ID, RESTORE_ID, DATE))
+        assertThat(result).contains(Complete(REWIND_ID, RESTORE_ID, PUBLISHED))
     }
 
     @Test
@@ -171,8 +171,8 @@ class GetRestoreStatusUseCaseTest {
                 advanceTimeBy(DELAY_MILLIS)
 
                 assertThat(result).contains(
-                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, DATE),
-                        Complete(REWIND_ID, RESTORE_ID, DATE)
+                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, PUBLISHED),
+                        Complete(REWIND_ID, RESTORE_ID, PUBLISHED)
                 )
             }
 
@@ -187,8 +187,8 @@ class GetRestoreStatusUseCaseTest {
                 advanceTimeBy(DELAY_MILLIS)
 
                 assertThat(result).contains(
-                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, DATE),
-                        Complete(REWIND_ID, RESTORE_ID, DATE)
+                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, PUBLISHED),
+                        Complete(REWIND_ID, RESTORE_ID, PUBLISHED)
                 )
             }
 
@@ -203,8 +203,8 @@ class GetRestoreStatusUseCaseTest {
                 advanceTimeBy(DELAY_MILLIS)
 
                 assertThat(result).contains(
-                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, DATE),
-                        Complete(REWIND_ID, RESTORE_ID, DATE)
+                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, PUBLISHED),
+                        Complete(REWIND_ID, RESTORE_ID, PUBLISHED)
                 )
             }
 
@@ -219,8 +219,8 @@ class GetRestoreStatusUseCaseTest {
                 advanceTimeBy(DELAY_MILLIS)
 
                 assertThat(result).contains(
-                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, DATE),
-                        Complete(REWIND_ID, RESTORE_ID, DATE)
+                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, PUBLISHED),
+                        Complete(REWIND_ID, RESTORE_ID, PUBLISHED)
                 )
             }
 
@@ -236,7 +236,7 @@ class GetRestoreStatusUseCaseTest {
             status = null,
             rewindable = null,
             rewindID = null,
-            published = DATE,
+            published = PUBLISHED,
             actor = null
     )
 
@@ -246,7 +246,7 @@ class GetRestoreStatusUseCaseTest {
     ) = RewindStatusModel(
             state = State.ACTIVE,
             reason = null,
-            lastUpdated = DATE,
+            lastUpdated = PUBLISHED,
             canAutoconfigure = null,
             credentials = null,
             rewind = rewind(rewindId, status)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
@@ -1,0 +1,264 @@
+package org.wordpress.android.ui.jetpack.restore.usecases
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.MainCoroutineScopeRule
+import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_REWIND_STATE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.activity.ActivityLogModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.State
+import org.wordpress.android.fluxc.store.ActivityLogStore
+import org.wordpress.android.fluxc.store.ActivityLogStore.OnRewindStatusFetched
+import org.wordpress.android.fluxc.store.ActivityLogStore.RewindStatusError
+import org.wordpress.android.fluxc.store.ActivityLogStore.RewindStatusErrorType.GENERIC_ERROR
+import org.wordpress.android.test
+import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Complete
+import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Failure
+import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Progress
+import org.wordpress.android.util.NetworkUtilsWrapper
+import java.util.Date
+
+private const val REWIND_ID = "rewindId"
+private const val RESTORE_ID = 123456789L
+private const val PROGRESS = 50
+private const val MESSAGE = "message"
+private const val CURRENT_ENTRY = "current entry"
+
+private val DATE = Date()
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class GetRestoreStatusUseCaseTest {
+    @ExperimentalCoroutinesApi
+    @Rule
+    @JvmField val coroutineScope = MainCoroutineScopeRule()
+
+    private lateinit var useCase: GetRestoreStatusUseCase
+
+    @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    @Mock lateinit var activityLogStore: ActivityLogStore
+    @Mock private lateinit var site: SiteModel
+
+    @Before
+    fun setup() = test {
+        useCase = GetRestoreStatusUseCase(networkUtilsWrapper, activityLogStore)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(activityLogStore.fetchActivitiesRewind(any())).thenReturn(OnRewindStatusFetched(FETCH_REWIND_STATE))
+        whenever(activityLogStore.getActivityLogItemByRewindId(REWIND_ID)).thenReturn(activityLogModel())
+    }
+
+    @Test
+    fun `given no network without restore id, when restore status triggers, then return network unavailable`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        val result = useCase.getRestoreStatus(site, null).toList()
+
+        assertThat(result).contains(Failure.NetworkUnavailable)
+    }
+
+    @Test
+    fun `given no network with restore id, when restore status triggers, then return network unavailable`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+
+        assertThat(result).contains(Failure.NetworkUnavailable)
+    }
+
+    @Test
+    fun `given failure without restore id, when restore status triggers, then return remote request failure`() = test {
+        whenever(activityLogStore.fetchActivitiesRewind(any()))
+                .thenReturn(OnRewindStatusFetched(RewindStatusError(GENERIC_ERROR), FETCH_REWIND_STATE))
+
+        val result = useCase.getRestoreStatus(site, null).toList()
+
+        assertThat(result).contains(Failure.RemoteRequestFailure)
+    }
+
+    @Test
+    fun `given failure with restore id, when restore status triggers, then return failure`() = test {
+        whenever(activityLogStore.fetchActivitiesRewind(any()))
+                .thenReturn(OnRewindStatusFetched(RewindStatusError(GENERIC_ERROR), FETCH_REWIND_STATE))
+
+        val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+
+        assertThat(result).contains(Failure.RemoteRequestFailure)
+    }
+
+    @Test
+    fun `given finished without restore id and rewind id, when restore status triggers, then return complete`() = test {
+        whenever(activityLogStore.getRewindStatusForSite(site))
+                .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FINISHED))
+
+        val result = useCase.getRestoreStatus(site, null).toList()
+
+        assertThat(result).contains(Complete(REWIND_ID, RESTORE_ID, DATE))
+    }
+
+    @Test
+    fun `given finished with restore id and rewind id, when restore status triggers, then return complete`() = test {
+        whenever(activityLogStore.getRewindStatusForSite(site))
+                .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FINISHED))
+
+        val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+
+        assertThat(result).contains(Complete(REWIND_ID, RESTORE_ID, DATE))
+    }
+
+    @Test
+    fun `given finished without restore id no rewind id, when restore status triggers, then return failure`() = test {
+        whenever(activityLogStore.getRewindStatusForSite(site))
+                .thenReturn(rewindStatusModel(null, Rewind.Status.FINISHED))
+
+        val result = useCase.getRestoreStatus(site, null).toList()
+
+        assertThat(result).contains(Failure.RemoteRequestFailure)
+    }
+
+    @Test
+    fun `given finished with restore id no rewind id, when restore status triggers, then return failure`() = test {
+        whenever(activityLogStore.getRewindStatusForSite(site))
+                .thenReturn(rewindStatusModel(null, Rewind.Status.FINISHED))
+
+        val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+
+        assertThat(result).contains(Failure.RemoteRequestFailure)
+    }
+
+    @Test
+    fun `given failed without restore id, when restore status triggers, then return failure`() = test {
+        whenever(activityLogStore.getRewindStatusForSite(site))
+                .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FAILED))
+
+        val result = useCase.getRestoreStatus(site, null).toList()
+
+        assertThat(result).contains(Failure.RemoteRequestFailure)
+    }
+
+    @Test
+    fun `given failed with restore id, when restore status triggers, then return failure`() = test {
+        whenever(activityLogStore.getRewindStatusForSite(site))
+                .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FAILED))
+
+        val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+
+        assertThat(result).contains(Failure.RemoteRequestFailure)
+    }
+
+    @Test
+    fun `given running without restore id, when restore status triggers, then return progress`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.getRewindStatusForSite(site))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.RUNNING))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FINISHED))
+
+                val result = useCase.getRestoreStatus(site, null).toList()
+                advanceTimeBy(DELAY_MILLIS)
+
+                assertThat(result).contains(
+                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, DATE),
+                        Complete(REWIND_ID, RESTORE_ID, DATE)
+                )
+            }
+
+    @Test
+    fun `given running with restore id, when restore status triggers, then return progress`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.getRewindStatusForSite(site))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.RUNNING))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FINISHED))
+
+                val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+                advanceTimeBy(DELAY_MILLIS)
+
+                assertThat(result).contains(
+                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, DATE),
+                        Complete(REWIND_ID, RESTORE_ID, DATE)
+                )
+            }
+
+    @Test
+    fun `given queued without restore id, when restore status triggers, then return progress`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.getRewindStatusForSite(site))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.QUEUED))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FINISHED))
+
+                val result = useCase.getRestoreStatus(site, null).toList()
+                advanceTimeBy(DELAY_MILLIS)
+
+                assertThat(result).contains(
+                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, DATE),
+                        Complete(REWIND_ID, RESTORE_ID, DATE)
+                )
+            }
+
+    @Test
+    fun `given queued with restore id, when restore status triggers, then return progress`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.getRewindStatusForSite(site))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.QUEUED))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FINISHED))
+
+                val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+                advanceTimeBy(DELAY_MILLIS)
+
+                assertThat(result).contains(
+                        Progress(REWIND_ID, PROGRESS, MESSAGE, CURRENT_ENTRY, DATE),
+                        Complete(REWIND_ID, RESTORE_ID, DATE)
+                )
+            }
+
+    /* PRIVATE */
+
+    private fun activityLogModel() = ActivityLogModel(
+            activityID = "activityID",
+            summary = "summary",
+            content = null,
+            name = null,
+            type = null,
+            gridicon = null,
+            status = null,
+            rewindable = null,
+            rewindID = null,
+            published = DATE,
+            actor = null
+    )
+
+    private fun rewindStatusModel(
+        rewindId: String?,
+        status: Rewind.Status
+    ) = RewindStatusModel(
+            state = State.ACTIVE,
+            reason = null,
+            lastUpdated = DATE,
+            canAutoconfigure = null,
+            credentials = null,
+            rewind = rewind(rewindId, status)
+    )
+
+    private fun rewind(
+        rewindId: String?,
+        status: Rewind.Status
+    ) = Rewind(
+            rewindId = rewindId,
+            restoreId = RESTORE_ID,
+            status = status,
+            progress = PROGRESS,
+            reason = null,
+            message = MESSAGE,
+            currentEntry = CURRENT_ENTRY
+    )
+}

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -736,7 +736,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun `given restore finished without date, when reloading events, then show restore finished message without date`() {
+    fun `given restore finished without date, when reloading events, then show restore finished msg without date`() {
         val date = null
         initProgressFinishedMocks(date, false)
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -72,7 +72,7 @@ private const val SITE_ID = 1L
 
 private const val NOW = "Now"
 private const val RESTORE_STARTED = "Your site is being restored\nRestoring to date time"
-private const val CURRENTLY_RESTORING = "Currently restoring your site"
+private const val RESTORING_CURRENTLY = "Currently restoring your site"
 private const val RESTORING_DATE_TIME = "Restoring to date time"
 private const val RESTORING_NO_DATE = "Restore in progress"
 private const val RESTORED_DATE_TIME = "Your site has been successfully restored\\nRestored to date time"
@@ -1026,9 +1026,9 @@ class ActivityLogViewModelTest {
         if (displayProgress) {
             list.add(ActivityLogListItem.Header(NOW))
             if (progressWithDate) {
-                list.add(ActivityLogListItem.Progress(CURRENTLY_RESTORING, RESTORING_DATE_TIME))
+                list.add(ActivityLogListItem.Progress(RESTORING_CURRENTLY, RESTORING_DATE_TIME))
             } else {
-                list.add(ActivityLogListItem.Progress(CURRENTLY_RESTORING, RESTORING_NO_DATE))
+                list.add(ActivityLogListItem.Progress(RESTORING_CURRENTLY, RESTORING_NO_DATE))
             }
         }
         if (!emptyList) {
@@ -1105,7 +1105,7 @@ class ActivityLogViewModelTest {
         }
         whenever(resourceProvider.getString(R.string.now)).thenReturn(NOW)
         whenever(resourceProvider.getString(R.string.activity_log_currently_restoring_title))
-                .thenReturn(CURRENTLY_RESTORING)
+                .thenReturn(RESTORING_CURRENTLY)
         if (displayProgressWithDate) {
             whenever(resourceProvider.getString(eq(R.string.activity_log_currently_restoring_message), any(), any()))
                     .thenReturn(RESTORING_DATE_TIME)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -49,6 +49,7 @@ import org.wordpress.android.util.analytics.ActivityLogTracker
 import org.wordpress.android.util.config.ActivityLogFiltersFeatureConfig
 import org.wordpress.android.util.config.BackupDownloadFeatureConfig
 import org.wordpress.android.util.config.RestoreFeatureConfig
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.ActivityLogListStatus
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel.EmptyUiState
@@ -86,8 +87,7 @@ class ActivityLogViewModelTest {
     private var eventListStatuses: MutableList<ActivityLogListStatus?> = mutableListOf()
     private var snackbarMessages: MutableList<String?> = mutableListOf()
     private var moveToTopEvents: MutableList<Unit?> = mutableListOf()
-    private var navigationEvents:
-            MutableList<org.wordpress.android.viewmodel.Event<ActivityLogNavigationEvents?>> = mutableListOf()
+    private var navigationEvents: MutableList<Event<ActivityLogNavigationEvents?>> = mutableListOf()
     private var showDateRangePickerEvents: MutableList<ShowDateRangePicker> = mutableListOf()
     private lateinit var activityLogList: List<ActivityLogModel>
     private lateinit var viewModel: ActivityLogViewModel

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -613,29 +613,15 @@ class ActivityLogViewModelTest {
     private fun expectedActivityList(isLastPageAndFreeSite: Boolean = false, canLoadMore: Boolean = false):
             List<ActivityLogListItem> {
         val activityLogListItems = mutableListOf<ActivityLogListItem>()
-        val first = ActivityLogListItem.Event(
-                model = activityLogList[0],
-                rewindDisabled = true,
-                backupDownloadFeatureEnabled = false,
-                restoreFeatureEnabled = false
-        )
-        val second = ActivityLogListItem.Event(
-                model = activityLogList[1],
-                rewindDisabled = true,
-                backupDownloadFeatureEnabled = false,
-                restoreFeatureEnabled = false
-        )
-        val third = ActivityLogListItem.Event(
-                model = activityLogList[2],
-                rewindDisabled = true,
-                backupDownloadFeatureEnabled = false,
-                restoreFeatureEnabled = false
-        )
-        activityLogListItems.add(ActivityLogListItem.Header(first.formattedDate))
-        activityLogListItems.add(first)
-        activityLogListItems.add(second)
-        activityLogListItems.add(ActivityLogListItem.Header(third.formattedDate))
-        activityLogListItems.add(third)
+        firstItem().let {
+            activityLogListItems.add(ActivityLogListItem.Header(it.formattedDate))
+            activityLogListItems.add(it)
+        }
+        activityLogListItems.add(secondItem())
+        thirdItem().let {
+            activityLogListItems.add(ActivityLogListItem.Header(it.formattedDate))
+            activityLogListItems.add(it)
+        }
         if (isLastPageAndFreeSite) {
             activityLogListItems.add(ActivityLogListItem.Footer)
         }
@@ -644,6 +630,27 @@ class ActivityLogViewModelTest {
         }
         return activityLogListItems
     }
+
+    private fun firstItem() = ActivityLogListItem.Event(
+            model = activityLogList[0],
+            rewindDisabled = true,
+            backupDownloadFeatureEnabled = false,
+            restoreFeatureEnabled = false
+    )
+
+    private fun secondItem() = ActivityLogListItem.Event(
+            model = activityLogList[1],
+            rewindDisabled = true,
+            backupDownloadFeatureEnabled = false,
+            restoreFeatureEnabled = false
+    )
+
+    private fun thirdItem() = ActivityLogListItem.Event(
+            model = activityLogList[2],
+            rewindDisabled = true,
+            backupDownloadFeatureEnabled = false,
+            restoreFeatureEnabled = false
+    )
 
     private suspend fun assertFetchEvents(canLoadMore: Boolean = false) {
         verify(store).fetchActivities(fetchActivityLogCaptor.capture())

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -43,7 +43,6 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase.JetpackPurchasedProducts
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
-import org.wordpress.android.ui.jetpack.rewind.RewindStatusService.RewindProgress
 import org.wordpress.android.ui.stats.refresh.utils.DateUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
@@ -94,7 +93,7 @@ class ActivityLogViewModelTest {
     private var showDateRangePickerEvents: MutableList<ShowDateRangePicker> = mutableListOf()
     private lateinit var activityLogList: List<ActivityLogModel>
     private lateinit var viewModel: ActivityLogViewModel
-    private var rewindProgress = MutableLiveData<RewindProgress>()
+    private var rewindProgress = MutableLiveData<RewindStatusService.RewindProgress>()
     private var rewindAvailable = MutableLiveData<Boolean>()
 
     private val rewindStatusModel = RewindStatusModel(

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -39,8 +39,6 @@ import org.wordpress.android.fluxc.store.ActivityLogStore.FetchActivityLogPayloa
 import org.wordpress.android.fluxc.store.ActivityLogStore.OnActivityLogFetched
 import org.wordpress.android.test
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents
-import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowBackupDownload
-import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRewindDialog
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase.JetpackPurchasedProducts
@@ -341,7 +339,8 @@ class ActivityLogViewModelTest {
     fun onActionButtonClickShowsRewindDialog() {
         viewModel.onActionButtonClicked(event)
 
-        assertThat(navigationEvents.last().peekContent()).isInstanceOf(ShowRewindDialog::class.java)
+        assertThat(navigationEvents.last().peekContent())
+                .isInstanceOf(ActivityLogNavigationEvents.ShowRewindDialog::class.java)
     }
 
     @Test
@@ -460,14 +459,16 @@ class ActivityLogViewModelTest {
     fun onSecondaryActionClickRestoreNavigationEventIsShowRewindDialog() {
         viewModel.onSecondaryActionClicked(ActivityLogListItem.SecondaryAction.RESTORE, event)
 
-        assertThat(navigationEvents.last().peekContent()).isInstanceOf(ShowRewindDialog::class.java)
+        assertThat(navigationEvents.last().peekContent())
+                .isInstanceOf(ActivityLogNavigationEvents.ShowRewindDialog::class.java)
     }
 
     @Test
     fun onSecondaryActionClickDownloadBackupNavigationEventIsShowBackupDownload() {
         viewModel.onSecondaryActionClicked(ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP, event)
 
-        assertThat(navigationEvents.last().peekContent()).isInstanceOf(ShowBackupDownload::class.java)
+        assertThat(navigationEvents.last().peekContent())
+                .isInstanceOf(ActivityLogNavigationEvents.ShowBackupDownload::class.java)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -32,8 +32,6 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.ActivityTypeModel
-import org.wordpress.android.fluxc.model.activity.RewindStatusModel
-import org.wordpress.android.fluxc.model.activity.RewindStatusModel.State
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchActivityLogPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.OnActivityLogFetched
@@ -95,15 +93,6 @@ class ActivityLogViewModelTest {
     private lateinit var viewModel: ActivityLogViewModel
     private var rewindProgress = MutableLiveData<RewindStatusService.RewindProgress>()
     private var rewindAvailable = MutableLiveData<Boolean>()
-
-    private val rewindStatusModel = RewindStatusModel(
-            State.ACTIVE,
-            null,
-            Date(),
-            true,
-            null,
-            null
-    )
 
     val event = ActivityLogListItem.Event(
             "activityId",

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -726,7 +726,7 @@ class ActivityLogViewModelTest {
                         displayProgress = false,
                         isCompleted = true,
                         rewindId = REWIND_ID,
-                        date = date
+                        published = date
                 )
         )
 
@@ -744,7 +744,7 @@ class ActivityLogViewModelTest {
                         displayProgress = false,
                         isCompleted = true,
                         rewindId = REWIND_ID,
-                        date = date
+                        published = date
                 )
         )
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -164,7 +164,6 @@ class ActivityLogViewModelTest {
 
         activityLogList = initializeActivityList()
         whenever(store.getActivityLogForSite(site, false, rewindableOnly)).thenReturn(activityLogList.toList())
-        whenever(store.getRewindStatusForSite(site)).thenReturn(rewindStatusModel)
         whenever(rewindStatusService.rewindProgress).thenReturn(rewindProgress)
         whenever(rewindStatusService.rewindAvailable).thenReturn(rewindAvailable)
         whenever(store.fetchActivities(anyOrNull())).thenReturn(mock())

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -42,13 +42,6 @@ import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowBackupDownload
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRewindDialog
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Event
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Footer
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Header
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Icon.DEFAULT
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.Loading
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP
-import org.wordpress.android.ui.activitylog.list.ActivityLogListItem.SecondaryAction.RESTORE
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase.JetpackPurchasedProducts
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
@@ -125,7 +118,7 @@ class ActivityLogViewModelTest {
             null,
             Date(),
             true,
-            DEFAULT,
+            ActivityLogListItem.Icon.DEFAULT,
             false
     )
     val activity = ActivityLogModel(
@@ -271,19 +264,19 @@ class ActivityLogViewModelTest {
     private fun expectedActivityList(isLastPageAndFreeSite: Boolean = false, canLoadMore: Boolean = false):
             List<ActivityLogListItem> {
         val activityLogListItems = mutableListOf<ActivityLogListItem>()
-        val first = Event(activityLogList[0], true, false, false)
-        val second = Event(activityLogList[1], true, false, false)
-        val third = Event(activityLogList[2], true, false, false)
-        activityLogListItems.add(Header(first.formattedDate))
+        val first = ActivityLogListItem.Event(activityLogList[0], true, false, false)
+        val second = ActivityLogListItem.Event(activityLogList[1], true, false, false)
+        val third = ActivityLogListItem.Event(activityLogList[2], true, false, false)
+        activityLogListItems.add(ActivityLogListItem.Header(first.formattedDate))
         activityLogListItems.add(first)
         activityLogListItems.add(second)
-        activityLogListItems.add(Header(third.formattedDate))
+        activityLogListItems.add(ActivityLogListItem.Header(third.formattedDate))
         activityLogListItems.add(third)
         if (isLastPageAndFreeSite) {
-            activityLogListItems.add(Footer)
+            activityLogListItems.add(ActivityLogListItem.Footer)
         }
         if (canLoadMore) {
-            activityLogListItems.add(Loading)
+            activityLogListItems.add(ActivityLogListItem.Loading)
         }
         return activityLogListItems
     }
@@ -331,8 +324,8 @@ class ActivityLogViewModelTest {
 
         viewModel.start(site, rewindableOnly)
 
-        assertTrue(events.last()?.get(0) is Header)
-        assertTrue(events.last()?.get(3) is Header)
+        assertTrue(events.last()?.get(0) is ActivityLogListItem.Header)
+        assertTrue(events.last()?.get(3) is ActivityLogListItem.Header)
     }
 
     @Test
@@ -465,14 +458,14 @@ class ActivityLogViewModelTest {
 
     @Test
     fun onSecondaryActionClickRestoreNavigationEventIsShowRewindDialog() {
-        viewModel.onSecondaryActionClicked(RESTORE, event)
+        viewModel.onSecondaryActionClicked(ActivityLogListItem.SecondaryAction.RESTORE, event)
 
         assertThat(navigationEvents.last().peekContent()).isInstanceOf(ShowRewindDialog::class.java)
     }
 
     @Test
     fun onSecondaryActionClickDownloadBackupNavigationEventIsShowBackupDownload() {
-        viewModel.onSecondaryActionClicked(DOWNLOAD_BACKUP, event)
+        viewModel.onSecondaryActionClicked(ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP, event)
 
         assertThat(navigationEvents.last().peekContent()).isInstanceOf(ShowBackupDownload::class.java)
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -720,7 +720,7 @@ class ActivityLogViewModelTest {
     @Test
     fun `given rewind finished with date, when reloading events, then show rewind finished message with date`() {
         val date = activity().published
-        initProgressFinishedMocks(date)
+        initProgressFinishedMocks(date, true)
 
         viewModel.reloadEvents(
                 done = false,
@@ -738,7 +738,7 @@ class ActivityLogViewModelTest {
     @Test
     fun `given rewind finished without date, when reloading events, then show rewind finished message without date`() {
         val date = null
-        initProgressFinishedMocks(date)
+        initProgressFinishedMocks(date, false)
 
         viewModel.reloadEvents(
                 done = false,
@@ -1115,8 +1115,8 @@ class ActivityLogViewModelTest {
         }
     }
 
-    private fun initProgressFinishedMocks(date: Date?) {
-        initProgressMocks()
+    private fun initProgressFinishedMocks(date: Date?, displayProgressWithDate: Boolean) {
+        initProgressMocks(displayProgressWithDate)
         viewModel.reloadEvents(
                 done = false,
                 restoreEvent = RestoreEvent(displayProgress = true, rewindId = REWIND_ID)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -69,6 +69,7 @@ private const val SITE_ID = 1L
 @RunWith(MockitoJUnitRunner::class)
 class ActivityLogViewModelTest {
     @Rule @JvmField val rule = InstantTaskExecutorRule()
+
     @Mock private lateinit var store: ActivityLogStore
     @Mock private lateinit var site: SiteModel
     @Mock private lateinit var rewindStatusService: RewindStatusService
@@ -79,8 +80,11 @@ class ActivityLogViewModelTest {
     @Mock private lateinit var activityLogTracker: ActivityLogTracker
     @Mock private lateinit var jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase
     @Mock private lateinit var restoreFeatureConfig: RestoreFeatureConfig
+
     private lateinit var fetchActivityLogCaptor: KArgumentCaptor<FetchActivityLogPayload>
     private lateinit var formatDateRangeTimezoneCaptor: KArgumentCaptor<String>
+    private lateinit var activityLogList: List<ActivityLogModel>
+    private lateinit var viewModel: ActivityLogViewModel
 
     private var events: MutableList<List<ActivityLogListItem>?> = mutableListOf()
     private var itemDetails: MutableList<ActivityLogListItem?> = mutableListOf()
@@ -89,8 +93,6 @@ class ActivityLogViewModelTest {
     private var moveToTopEvents: MutableList<Unit?> = mutableListOf()
     private var navigationEvents: MutableList<Event<ActivityLogNavigationEvents?>> = mutableListOf()
     private var showDateRangePickerEvents: MutableList<ShowDateRangePicker> = mutableListOf()
-    private lateinit var activityLogList: List<ActivityLogModel>
-    private lateinit var viewModel: ActivityLogViewModel
     private var rewindProgress = MutableLiveData<RewindStatusService.RewindProgress>()
     private var rewindAvailable = MutableLiveData<Boolean>()
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -325,16 +325,17 @@ class ActivityLogViewModelTest {
 
     @Test
     fun loadsNextPageOnScrollToBottom() = runBlocking {
+        val canLoadMore = true
         whenever(store.fetchActivities(anyOrNull()))
-                .thenReturn(OnActivityLogFetched(10, true, ActivityLogAction.FETCH_ACTIVITIES))
+                .thenReturn(OnActivityLogFetched(10, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
         viewModel.start(site, rewindableOnly)
         reset(store)
         whenever(store.fetchActivities(anyOrNull()))
-                .thenReturn(OnActivityLogFetched(10, true, ActivityLogAction.FETCH_ACTIVITIES))
+                .thenReturn(OnActivityLogFetched(10, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.onScrolledToBottom()
 
-        assertFetchEvents(true)
+        assertFetchEvents(canLoadMore)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -881,7 +881,7 @@ class ActivityLogViewModelTest {
     /* REWIND CONFIRMED */
 
     @Test
-    fun onRewindConfirmedTriggersRewindOperation() = test {
+    fun `when rewind confirmed, then trigger post restore request`() = test {
         viewModel.onRewindConfirmed(REWIND_ID)
 
         verify(postRestoreUseCase).postRestoreRequest(REWIND_ID, site)
@@ -971,7 +971,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun onRewindConfirmedShowsRewindStartedMessage() {
+    fun `when rewind confirmed, then show rewind started message`() {
         assertTrue(snackbarMessages.isEmpty())
         whenever(store.getActivityLogItemByRewindId(REWIND_ID)).thenReturn(activity())
         val snackBarMessage = "snackBar message"

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -601,8 +601,10 @@ class ActivityLogViewModelTest {
 
     /* PRIVATE */
 
-    private fun expectedActivityList(isLastPageAndFreeSite: Boolean = false, canLoadMore: Boolean = false):
-            List<ActivityLogListItem> {
+    private fun expectedActivityList(
+        isLastPageAndFreeSite: Boolean = false,
+        canLoadMore: Boolean = false
+    ): List<ActivityLogListItem> {
         val activityLogListItems = mutableListOf<ActivityLogListItem>()
         firstItem().let {
             activityLogListItems.add(ActivityLogListItem.Header(it.formattedDate))

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.viewmodel.activitylog
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.core.util.Pair
-import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.KArgumentCaptor
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
@@ -82,7 +81,6 @@ class ActivityLogViewModelTest {
 
     @Mock private lateinit var store: ActivityLogStore
     @Mock private lateinit var site: SiteModel
-    @Mock private lateinit var rewindStatusService: RewindStatusService
     @Mock private lateinit var resourceProvider: ResourceProvider
     @Mock private lateinit var activityLogFiltersFeatureConfig: ActivityLogFiltersFeatureConfig
     @Mock private lateinit var backupDownloadFeatureConfig: BackupDownloadFeatureConfig
@@ -102,8 +100,6 @@ class ActivityLogViewModelTest {
     private var moveToTopEvents: MutableList<Unit?> = mutableListOf()
     private var navigationEvents: MutableList<Event<ActivityLogNavigationEvents?>> = mutableListOf()
     private var showDateRangePickerEvents: MutableList<ShowDateRangePicker> = mutableListOf()
-    private var rewindProgress = MutableLiveData<RewindStatusService.RewindProgress>()
-    private var rewindAvailable = MutableLiveData<Boolean>()
 
     private val activityList = listOf(firstActivity(), secondActivity(), thirdActivity())
     private val rewindableOnly = false
@@ -112,7 +108,6 @@ class ActivityLogViewModelTest {
     fun setUp() = test {
         viewModel = ActivityLogViewModel(
                 store,
-                rewindStatusService,
                 resourceProvider,
                 activityLogFiltersFeatureConfig,
                 backupDownloadFeatureConfig,
@@ -137,8 +132,6 @@ class ActivityLogViewModelTest {
         formatDateRangeTimezoneCaptor = argumentCaptor()
 
         whenever(store.getActivityLogForSite(site, false, rewindableOnly)).thenReturn(activityList.toList())
-        whenever(rewindStatusService.rewindProgress).thenReturn(rewindProgress)
-        whenever(rewindStatusService.rewindAvailable).thenReturn(rewindAvailable)
         whenever(store.fetchActivities(anyOrNull())).thenReturn(mock())
         whenever(site.hasFreePlan).thenReturn(false)
         whenever(site.siteId).thenReturn(SITE_ID)
@@ -157,7 +150,6 @@ class ActivityLogViewModelTest {
         assertEquals(eventListStatuses[0], ActivityLogListStatus.FETCHING)
         assertEquals(eventListStatuses[1], ActivityLogListStatus.DONE)
         assertFetchEvents()
-        verify(rewindStatusService).start(site)
     }
 
     @Test
@@ -297,7 +289,7 @@ class ActivityLogViewModelTest {
 
         viewModel.onRewindConfirmed(REWIND_ID)
 
-        verify(rewindStatusService).rewind(REWIND_ID, site)
+        // TODO: Replace with restore use case.
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -658,8 +658,16 @@ class ActivityLogViewModelTest {
 
         val list = mutableListOf<ActivityLogModel>()
         val activity = ActivityLogModel(
-                "", "", null, "", "", "",
-                "", true, "", birthday.time
+                activityID = "",
+                summary = "",
+                content = null,
+                name = "",
+                type = "",
+                gridicon = "",
+                status = "",
+                rewindable = true,
+                rewindID = "",
+                published = birthday.time
         )
         list.add(activity)
         list.add(activity.copy(rewindable = false))

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -200,7 +200,8 @@ class ActivityLogViewModelTest {
     @Test
     fun onDataFetchedPostsDataAndChangesStatusIfCanLoadMore() = runBlocking {
         val canLoadMore = true
-        whenever(store.fetchActivities(anyOrNull())).thenReturn(OnActivityLogFetched(1, canLoadMore, FETCH_ACTIVITIES))
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.start(site, rewindableOnly)
 
@@ -215,12 +216,14 @@ class ActivityLogViewModelTest {
     @Test
     fun onDataFetchedLoadsMoreDataIfCanLoadMore() = runBlocking {
         val canLoadMore = true
-        whenever(store.fetchActivities(anyOrNull())).thenReturn(OnActivityLogFetched(1, canLoadMore, FETCH_ACTIVITIES))
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.start(site, rewindableOnly)
 
         reset(store)
-        whenever(store.fetchActivities(anyOrNull())).thenReturn(OnActivityLogFetched(1, canLoadMore, FETCH_ACTIVITIES))
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.onScrolledToBottom()
 
@@ -230,7 +233,8 @@ class ActivityLogViewModelTest {
     @Test
     fun onDataFetchedPostsDataAndChangesStatusIfCannotLoadMore() = runBlocking {
         val canLoadMore = false
-        whenever(store.fetchActivities(anyOrNull())).thenReturn(OnActivityLogFetched(1, canLoadMore, FETCH_ACTIVITIES))
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.start(site, rewindableOnly)
 
@@ -246,7 +250,8 @@ class ActivityLogViewModelTest {
     fun onDataFetchedShowsFooterIfCannotLoadMoreAndIsFreeSite() = runBlocking {
         val canLoadMore = false
         whenever(site.hasFreePlan).thenReturn(true)
-        whenever(store.fetchActivities(anyOrNull())).thenReturn(OnActivityLogFetched(1, canLoadMore, FETCH_ACTIVITIES))
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.start(site, rewindableOnly)
 
@@ -281,7 +286,8 @@ class ActivityLogViewModelTest {
     @Test
     fun onDataFetchedDoesNotLoadMoreDataIfCannotLoadMore() = runBlocking<Unit> {
         val canLoadMore = false
-        whenever(store.fetchActivities(anyOrNull())).thenReturn(OnActivityLogFetched(1, canLoadMore, FETCH_ACTIVITIES))
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.start(site, rewindableOnly)
 
@@ -296,7 +302,8 @@ class ActivityLogViewModelTest {
     fun onDataFetchedGoesToTopWhenSomeRowsAffected() = runBlocking {
         assertTrue(moveToTopEvents.isEmpty())
 
-        whenever(store.fetchActivities(anyOrNull())).thenReturn(OnActivityLogFetched(10, true, FETCH_ACTIVITIES))
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(10, true, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.start(site, rewindableOnly)
 
@@ -307,7 +314,8 @@ class ActivityLogViewModelTest {
     fun onDataFetchedDoesNotLoadMoreDataIfNoRowsAffected() = runBlocking<Unit> {
         val canLoadMore = true
 
-        whenever(store.fetchActivities(anyOrNull())).thenReturn(OnActivityLogFetched(0, canLoadMore, FETCH_ACTIVITIES))
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(0, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.start(site, rewindableOnly)
 
@@ -317,7 +325,8 @@ class ActivityLogViewModelTest {
     @Test
     fun headerIsDisplayedForFirstItemOrWhenDifferentThenPrevious() = runBlocking {
         val canLoadMore = true
-        whenever(store.fetchActivities(anyOrNull())).thenReturn(OnActivityLogFetched(3, canLoadMore, FETCH_ACTIVITIES))
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(3, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.start(site, rewindableOnly)
 
@@ -366,11 +375,13 @@ class ActivityLogViewModelTest {
 
     @Test
     fun loadsNextPageOnScrollToBottom() = runBlocking {
-        whenever(store.fetchActivities(anyOrNull())).thenReturn(OnActivityLogFetched(10, true, FETCH_ACTIVITIES))
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(10, true, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.start(site, rewindableOnly)
         reset(store)
-        whenever(store.fetchActivities(anyOrNull())).thenReturn(OnActivityLogFetched(10, true, FETCH_ACTIVITIES))
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(10, true, ActivityLogAction.FETCH_ACTIVITIES))
 
         viewModel.onScrolledToBottom()
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -33,7 +33,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.ActivityTypeModel
 import org.wordpress.android.fluxc.model.activity.RewindStatusModel
-import org.wordpress.android.fluxc.model.activity.RewindStatusModel.State.ACTIVE
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.State
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.store.ActivityLogStore.FetchActivityLogPayload
 import org.wordpress.android.fluxc.store.ActivityLogStore.OnActivityLogFetched
@@ -98,7 +98,7 @@ class ActivityLogViewModelTest {
     private var rewindAvailable = MutableLiveData<Boolean>()
 
     private val rewindStatusModel = RewindStatusModel(
-            ACTIVE,
+            State.ACTIVE,
             null,
             Date(),
             true,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -738,11 +738,17 @@ class ActivityLogViewModelTest {
 
     @Test
     fun `given rewind finished with date, when reloading events, then show rewind finished message with date`() {
-        initProgressFinishedMocks(activity())
+        val date = activity().published
+        initProgressFinishedMocks(date)
 
         viewModel.reloadEvents(
                 done = false,
-                restoreEvent = RestoreEvent(displayProgress = false, isCompleted = true, rewindId = REWIND_ID)
+                restoreEvent = RestoreEvent(
+                        displayProgress = false,
+                        isCompleted = true,
+                        rewindId = REWIND_ID,
+                        date = date
+                )
         )
 
         assertEquals(snackbarMessages.firstOrNull(), RESTORED_DATE_TIME)
@@ -750,11 +756,17 @@ class ActivityLogViewModelTest {
 
     @Test
     fun `given rewind finished without date, when reloading events, then show rewind finished message without date`() {
-        initProgressFinishedMocks(null)
+        val date = null
+        initProgressFinishedMocks(date)
 
         viewModel.reloadEvents(
                 done = false,
-                restoreEvent = RestoreEvent(displayProgress = false, isCompleted = true, rewindId = REWIND_ID)
+                restoreEvent = RestoreEvent(
+                        displayProgress = false,
+                        isCompleted = true,
+                        rewindId = REWIND_ID,
+                        date = date
+                )
         )
 
         assertEquals(snackbarMessages.firstOrNull(), RESTORED_NO_DATE)
@@ -1019,14 +1031,13 @@ class ActivityLogViewModelTest {
         }
     }
 
-    private fun initProgressFinishedMocks(activity: ActivityLogModel?) {
+    private fun initProgressFinishedMocks(date: Date?) {
         initProgressMocks()
         viewModel.reloadEvents(
                 done = false,
                 restoreEvent = RestoreEvent(displayProgress = true, rewindId = REWIND_ID)
         )
-        whenever(rewindStatusService.rewindingActivity).thenReturn(activity)
-        if (activity != null) {
+        if (date != null) {
             whenever(
                     resourceProvider.getString(
                             eq(R.string.activity_log_rewind_finished_snackbar_message),

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -718,7 +718,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun `given rewind finished with date, when reloading events, then show rewind finished message with date`() {
+    fun `given restore finished with date, when reloading events, then show restore finished message with date`() {
         val date = activity().published
         initProgressFinishedMocks(date, true)
 
@@ -736,7 +736,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun `given rewind finished without date, when reloading events, then show rewind finished message without date`() {
+    fun `given restore finished without date, when reloading events, then show restore finished message without date`() {
         val date = null
         initProgressFinishedMocks(date, false)
 
@@ -879,44 +879,44 @@ class ActivityLogViewModelTest {
         )
     }
 
-    /* REWIND CONFIRMED */
+    /* RESTORE CONFIRMED */
 
     @Test
-    fun `when rewind confirmed, then trigger post restore request`() = test {
-        viewModel.onRewindConfirmed(REWIND_ID)
+    fun `when restore confirmed, then trigger post restore request`() = test {
+        viewModel.onRestoreConfirmed(REWIND_ID)
 
         verify(postRestoreUseCase).postRestoreRequest(REWIND_ID, site)
     }
 
     @Test
-    fun `given restore requests is a success, when rewind confirmed, then do trigger get restore status`() = test {
+    fun `given restore requests is a success, when restore confirmed, then do trigger get restore status`() = test {
         val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
         whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
 
-        viewModel.onRewindConfirmed(REWIND_ID)
+        viewModel.onRestoreConfirmed(REWIND_ID)
 
         verify(getRestoreStatusUseCase).getRestoreStatus(site, RESTORE_ID)
     }
 
     @Test
-    fun `given restore requests is something else, when rewind confirmed, then do not trigger anything`() = test {
+    fun `given restore requests is something else, when restore confirmed, then do not trigger anything`() = test {
         val progress = RestoreRequestState.Progress(REWIND_ID, 50)
         whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(progress)
 
-        viewModel.onRewindConfirmed(REWIND_ID)
+        viewModel.onRestoreConfirmed(REWIND_ID)
 
         verify(getRestoreStatusUseCase, times(0)).getRestoreStatus(site, RESTORE_ID)
     }
 
     @Test
-    fun `given restore status is a progress, when rewind confirmed, then reload events for progress`() = test {
+    fun `given restore status is a progress, when restore confirmed, then reload events for progress`() = test {
         val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
         whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
         val progress = RestoreRequestState.Progress(REWIND_ID, 50)
         whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID)).thenReturn(flow { emit(progress) })
         initProgressMocks()
 
-        viewModel.onRewindConfirmed(REWIND_ID)
+        viewModel.onRestoreConfirmed(REWIND_ID)
 
         assertEquals(
                 viewModel.events.value,
@@ -933,7 +933,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun `given restore status is a complete, when rewind confirmed, then request events update for complete`() = test {
+    fun `given restore status is a complete, when restore confirmed, then request events update for complete`() = test {
         val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
         whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
         val progress = RestoreRequestState.Progress(REWIND_ID, 50)
@@ -944,7 +944,7 @@ class ActivityLogViewModelTest {
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(10, false, ActivityLogAction.FETCH_ACTIVITIES))
 
-        viewModel.onRewindConfirmed(REWIND_ID)
+        viewModel.onRestoreConfirmed(REWIND_ID)
 
         assertEquals(
                 viewModel.events.value,
@@ -961,23 +961,23 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun `given restore status is something else, when rewind confirmed, then do not trigger anything`() = test {
+    fun `given restore status is something else, when restore confirmed, then do not trigger anything`() = test {
         val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
         whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
         whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID)).thenReturn(flow { emit(success) })
 
-        viewModel.onRewindConfirmed(REWIND_ID)
+        viewModel.onRestoreConfirmed(REWIND_ID)
 
         assertNull(viewModel.events.value)
     }
 
     @Test
-    fun `when rewind confirmed, then show rewind started message`() {
+    fun `when restore confirmed, then show restore started message`() {
         whenever(store.getActivityLogItemByRewindId(REWIND_ID)).thenReturn(activity())
         whenever(resourceProvider.getString(eq(R.string.activity_log_rewind_started_snackbar_message), any(), any()))
                 .thenReturn(RESTORE_STARTED)
 
-        viewModel.onRewindConfirmed(REWIND_ID)
+        viewModel.onRestoreConfirmed(REWIND_ID)
 
         assertEquals(snackbarMessages.firstOrNull(), RESTORE_STARTED)
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -109,19 +109,6 @@ class ActivityLogViewModelTest {
             ActivityLogListItem.Icon.DEFAULT,
             false
     )
-    val activity = ActivityLogModel(
-            "activityId",
-            "",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            Date(),
-            null
-    )
 
     private val rewindableOnly = false
 
@@ -314,7 +301,7 @@ class ActivityLogViewModelTest {
     @Test
     fun onRewindConfirmedShowsRewindStartedMessage() {
         assertTrue(snackbarMessages.isEmpty())
-        whenever(rewindStatusService.rewindingActivity).thenReturn(activity)
+        whenever(rewindStatusService.rewindingActivity).thenReturn(activity())
         val snackBarMessage = "snackBar message"
         whenever(resourceProvider.getString(any(), any(), any())).thenReturn(snackBarMessage)
 
@@ -604,23 +591,28 @@ class ActivityLogViewModelTest {
 
     private fun initializeActivityList(): List<ActivityLogModel> {
         val list = mutableListOf<ActivityLogModel>()
-        val activity = ActivityLogModel(
-                activityID = "",
-                summary = "",
-                content = null,
-                name = "",
-                type = "",
-                gridicon = "",
-                status = "",
-                rewindable = true,
-                rewindID = "",
-                published = activityPublishedTime(1985, 8, 27)
-        )
-        list.add(activity)
-        list.add(activity.copy(rewindable = false))
-        list.add(activity.copy(published = activityPublishedTime(1987, 5, 26)))
+        list.add(activity())
+        list.add(activity(rewindable = false))
+        list.add(activity(published = activityPublishedTime(1987, 5, 26)))
         return list
     }
+
+    private fun activity(
+        rewindable: Boolean = true,
+        published: Date = activityPublishedTime(1985, 8, 27)
+    ) = ActivityLogModel(
+            activityID = "activityId",
+            summary = "",
+            content = null,
+            name = "",
+            type = "",
+            gridicon = "",
+            status = "",
+            rewindable = rewindable,
+            rewindID = "",
+            published = published,
+            actor = null
+    )
 
     private fun activityPublishedTime(year: Int, month: Int, date: Int): Date {
         val calendar = Calendar.getInstance()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -653,9 +653,6 @@ class ActivityLogViewModelTest {
     }
 
     private fun initializeActivityList(): List<ActivityLogModel> {
-        val birthday = Calendar.getInstance()
-        birthday.set(1985, 8, 27)
-
         val list = mutableListOf<ActivityLogModel>()
         val activity = ActivityLogModel(
                 activityID = "",
@@ -667,14 +664,17 @@ class ActivityLogViewModelTest {
                 status = "",
                 rewindable = true,
                 rewindID = "",
-                published = birthday.time
+                published = activityPublishedTime(1985, 8, 27)
         )
         list.add(activity)
         list.add(activity.copy(rewindable = false))
-
-        birthday.set(1987, 5, 26)
-        list.add(activity.copy(published = birthday.time))
-
+        list.add(activity.copy(published = activityPublishedTime(1987, 5, 26)))
         return list
+    }
+
+    private fun activityPublishedTime(year: Int, month: Int, date: Int): Date {
+        val calendar = Calendar.getInstance()
+        calendar.set(year, month, date)
+        return calendar.time
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -95,20 +95,6 @@ class ActivityLogViewModelTest {
     private var rewindProgress = MutableLiveData<RewindStatusService.RewindProgress>()
     private var rewindAvailable = MutableLiveData<Boolean>()
 
-    val event = ActivityLogListItem.Event(
-            "activityId",
-            "",
-            ",",
-            null,
-            null,
-            true,
-            null,
-            Date(),
-            true,
-            ActivityLogListItem.Icon.DEFAULT,
-            false
-    )
-
     private val rewindableOnly = false
 
     @Before
@@ -272,6 +258,7 @@ class ActivityLogViewModelTest {
 
     @Test
     fun onItemClickShowsItemDetail() {
+        val event = event()
         assertTrue(itemDetails.isEmpty())
 
         viewModel.onItemClicked(event)
@@ -281,7 +268,7 @@ class ActivityLogViewModelTest {
 
     @Test
     fun onActionButtonClickShowsRewindDialog() {
-        viewModel.onActionButtonClicked(event)
+        viewModel.onActionButtonClicked(event())
 
         assertThat(navigationEvents.last().peekContent())
                 .isInstanceOf(ActivityLogNavigationEvents.ShowRewindDialog::class.java)
@@ -403,7 +390,7 @@ class ActivityLogViewModelTest {
 
     @Test
     fun onSecondaryActionClickRestoreNavigationEventIsShowRewindDialog() {
-        viewModel.onSecondaryActionClicked(ActivityLogListItem.SecondaryAction.RESTORE, event)
+        viewModel.onSecondaryActionClicked(ActivityLogListItem.SecondaryAction.RESTORE, event())
 
         assertThat(navigationEvents.last().peekContent())
                 .isInstanceOf(ActivityLogNavigationEvents.ShowRewindDialog::class.java)
@@ -411,7 +398,7 @@ class ActivityLogViewModelTest {
 
     @Test
     fun onSecondaryActionClickDownloadBackupNavigationEventIsShowBackupDownload() {
-        viewModel.onSecondaryActionClicked(ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP, event)
+        viewModel.onSecondaryActionClicked(ActivityLogListItem.SecondaryAction.DOWNLOAD_BACKUP, event())
 
         assertThat(navigationEvents.last().peekContent())
                 .isInstanceOf(ActivityLogNavigationEvents.ShowBackupDownload::class.java)
@@ -671,4 +658,18 @@ class ActivityLogViewModelTest {
             assertEquals(this@ActivityLogViewModelTest.site, site)
         }
     }
+
+    private fun event() = ActivityLogListItem.Event(
+            "activityId",
+            "",
+            ",",
+            null,
+            null,
+            true,
+            null,
+            Date(),
+            true,
+            ActivityLogListItem.Icon.DEFAULT,
+            false
+    )
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -601,6 +601,32 @@ class ActivityLogViewModelTest {
 
     /* PRIVATE */
 
+    private fun initializeActivityList(): List<ActivityLogModel> {
+        val list = mutableListOf<ActivityLogModel>()
+        val activity = ActivityLogModel(
+                activityID = "",
+                summary = "",
+                content = null,
+                name = "",
+                type = "",
+                gridicon = "",
+                status = "",
+                rewindable = true,
+                rewindID = "",
+                published = activityPublishedTime(1985, 8, 27)
+        )
+        list.add(activity)
+        list.add(activity.copy(rewindable = false))
+        list.add(activity.copy(published = activityPublishedTime(1987, 5, 26)))
+        return list
+    }
+
+    private fun activityPublishedTime(year: Int, month: Int, date: Int): Date {
+        val calendar = Calendar.getInstance()
+        calendar.set(year, month, date)
+        return calendar.time
+    }
+
     private fun expectedActivityList(
         isLastPageAndFreeSite: Boolean = false,
         canLoadMore: Boolean = false
@@ -652,31 +678,5 @@ class ActivityLogViewModelTest {
             assertEquals(canLoadMore, loadMore)
             assertEquals(this@ActivityLogViewModelTest.site, site)
         }
-    }
-
-    private fun initializeActivityList(): List<ActivityLogModel> {
-        val list = mutableListOf<ActivityLogModel>()
-        val activity = ActivityLogModel(
-                activityID = "",
-                summary = "",
-                content = null,
-                name = "",
-                type = "",
-                gridicon = "",
-                status = "",
-                rewindable = true,
-                rewindID = "",
-                published = activityPublishedTime(1985, 8, 27)
-        )
-        list.add(activity)
-        list.add(activity.copy(rewindable = false))
-        list.add(activity.copy(published = activityPublishedTime(1987, 5, 26)))
-        return list
-    }
-
-    private fun activityPublishedTime(year: Int, month: Int, date: Int): Date {
-        val calendar = Calendar.getInstance()
-        calendar.set(year, month, date)
-        return calendar.time
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -13,7 +13,6 @@ import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertEquals
@@ -124,8 +123,7 @@ class ActivityLogViewModelTest {
                 dateUtils,
                 activityLogTracker,
                 jetpackCapabilitiesUseCase,
-                restoreFeatureConfig,
-                Dispatchers.Unconfined
+                restoreFeatureConfig
         )
         viewModel.site = site
         viewModel.rewindableOnly = rewindableOnly

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -150,6 +150,7 @@ class ActivityLogViewModelTest {
         )
         viewModel.site = site
         viewModel.rewindableOnly = rewindableOnly
+
         viewModel.events.observeForever { events.add(it) }
         viewModel.eventListStatus.observeForever { eventListStatuses.add(it) }
         viewModel.showItemDetail.observeForever { itemDetails.add(it) }
@@ -157,6 +158,7 @@ class ActivityLogViewModelTest {
         viewModel.moveToTop.observeForever { moveToTopEvents.add(it) }
         viewModel.navigationEvents.observeForever { navigationEvents.add(it) }
         viewModel.showDateRangePicker.observeForever { showDateRangePickerEvents.add(it) }
+
         fetchActivityLogCaptor = argumentCaptor()
         formatDateRangeTimezoneCaptor = argumentCaptor()
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -180,13 +180,9 @@ class ActivityLogViewModelTest {
 
         viewModel.start(site, rewindableOnly)
 
-        assertEquals(
-                viewModel.events.value,
-                expectedActivityList()
-        )
+        assertEquals(viewModel.events.value, expectedActivityList())
         assertEquals(eventListStatuses[0], ActivityLogListStatus.FETCHING)
         assertEquals(eventListStatuses[1], ActivityLogListStatus.DONE)
-
         assertFetchEvents()
         verify(rewindStatusService).start(site)
     }
@@ -206,11 +202,7 @@ class ActivityLogViewModelTest {
 
         viewModel.start(site, rewindableOnly)
 
-        assertEquals(
-                viewModel.events.value,
-                expectedActivityList(false, canLoadMore)
-        )
-
+        assertEquals(viewModel.events.value, expectedActivityList(false, canLoadMore))
         assertEquals(viewModel.eventListStatus.value, ActivityLogListStatus.CAN_LOAD_MORE)
     }
 
@@ -219,9 +211,7 @@ class ActivityLogViewModelTest {
         val canLoadMore = true
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
-
         viewModel.start(site, rewindableOnly)
-
         reset(store)
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
@@ -239,11 +229,7 @@ class ActivityLogViewModelTest {
 
         viewModel.start(site, rewindableOnly)
 
-        assertEquals(
-                viewModel.events.value,
-                expectedActivityList()
-        )
-
+        assertEquals(viewModel.events.value, expectedActivityList())
         assertEquals(viewModel.eventListStatus.value, ActivityLogListStatus.DONE)
     }
 
@@ -256,11 +242,7 @@ class ActivityLogViewModelTest {
 
         viewModel.start(site, rewindableOnly)
 
-        assertEquals(
-                viewModel.events.value,
-                expectedActivityList(true)
-        )
-
+        assertEquals(viewModel.events.value, expectedActivityList(true))
         assertEquals(viewModel.eventListStatus.value, ActivityLogListStatus.DONE)
     }
 
@@ -304,9 +286,7 @@ class ActivityLogViewModelTest {
         val canLoadMore = false
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
-
         viewModel.start(site, rewindableOnly)
-
         reset(store)
 
         viewModel.onScrolledToBottom()
@@ -317,7 +297,6 @@ class ActivityLogViewModelTest {
     @Test
     fun onDataFetchedGoesToTopWhenSomeRowsAffected() = runBlocking {
         assertTrue(moveToTopEvents.isEmpty())
-
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(10, true, ActivityLogAction.FETCH_ACTIVITIES))
 
@@ -329,7 +308,6 @@ class ActivityLogViewModelTest {
     @Test
     fun onDataFetchedDoesNotLoadMoreDataIfNoRowsAffected() = runBlocking<Unit> {
         val canLoadMore = true
-
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(0, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
 
@@ -393,7 +371,6 @@ class ActivityLogViewModelTest {
     fun loadsNextPageOnScrollToBottom() = runBlocking {
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(10, true, ActivityLogAction.FETCH_ACTIVITIES))
-
         viewModel.start(site, rewindableOnly)
         reset(store)
         whenever(store.fetchActivities(anyOrNull()))
@@ -541,38 +518,28 @@ class ActivityLogViewModelTest {
 
         viewModel.onDateRangeSelected(Pair(10L, 20L))
 
-        assertThat((viewModel.filtersUiState.value as FiltersShown).dateRangeLabel)
-                .isEqualTo(UiStringText("TEST"))
+        assertThat((viewModel.filtersUiState.value as FiltersShown).dateRangeLabel).isEqualTo(UiStringText("TEST"))
     }
 
     @Test
     fun dateRangeLabelFormattingUsesGMT0Timezone() {
-        whenever(
-                dateUtils.formatDateRange(
-                        anyOrNull(),
-                        anyOrNull(),
-                        formatDateRangeTimezoneCaptor.capture()
-                )
-        ).thenReturn("TEST")
+        whenever(dateUtils.formatDateRange(anyOrNull(), anyOrNull(), formatDateRangeTimezoneCaptor.capture()))
+                .thenReturn("TEST")
 
         viewModel.onDateRangeSelected(Pair(10L, 20L))
 
-        assertThat(formatDateRangeTimezoneCaptor.firstValue)
-                .isEqualTo(TIMEZONE_GMT_0)
+        assertThat(formatDateRangeTimezoneCaptor.firstValue).isEqualTo(TIMEZONE_GMT_0)
     }
 
     @Test
     fun dateRangeEndTimestampGetsAdjustedToEndOfDay() {
-        whenever(
-                dateUtils.formatDateRange(anyOrNull(), anyOrNull(), anyOrNull())
-        ).thenReturn("TEST")
+        whenever(dateUtils.formatDateRange(anyOrNull(), anyOrNull(), anyOrNull())).thenReturn("TEST")
 
         viewModel.onDateRangeSelected(Pair(DATE_1_IN_MILLIS, DATE_2_IN_MILLIS))
         viewModel.dateRangePickerClicked()
 
-        assertThat(showDateRangePickerEvents[0].initialSelection).isEqualTo(
-                Pair(DATE_1_IN_MILLIS, DATE_2_IN_MILLIS + ONE_DAY_WITHOUT_SECOND_IN_MILLIS)
-        )
+        assertThat(showDateRangePickerEvents[0].initialSelection)
+                .isEqualTo(Pair(DATE_1_IN_MILLIS, DATE_2_IN_MILLIS + ONE_DAY_WITHOUT_SECOND_IN_MILLIS))
     }
 
     @Test
@@ -593,9 +560,7 @@ class ActivityLogViewModelTest {
 
     @Test
     fun onActivityTypeFilterClearActionClickClearActionDisappears() {
-        viewModel.onActivityTypesSelected(
-                listOf(ActivityTypeModel("user", "User", 10))
-        )
+        viewModel.onActivityTypesSelected(listOf(ActivityTypeModel("user", "User", 10)))
 
         (viewModel.filtersUiState.value as FiltersShown).onClearActivityTypeFilterClicked!!.invoke()
 
@@ -630,13 +595,9 @@ class ActivityLogViewModelTest {
                 )
         )
 
+        val params = listOf(UiStringText("2"))
         assertThat((viewModel.filtersUiState.value as FiltersShown).activityTypeLabel)
-                .isEqualTo(
-                        UiStringResWithParams(
-                                R.string.activity_log_activity_type_filter_active_label,
-                                listOf(UiStringText("2"))
-                        )
-                )
+                .isEqualTo(UiStringResWithParams(R.string.activity_log_activity_type_filter_active_label, params))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -293,108 +293,6 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun onRewindConfirmedTriggersRewindOperation() = test {
-        viewModel.onRewindConfirmed(REWIND_ID)
-
-        verify(postRestoreUseCase).postRestoreRequest(REWIND_ID, site)
-    }
-
-    @Test
-    fun `given restore requests is a success, when rewind confirmed, then do trigger get restore status`() = test {
-        val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
-        whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
-
-        viewModel.onRewindConfirmed(REWIND_ID)
-
-        verify(getRestoreStatusUseCase).getRestoreStatus(site, RESTORE_ID)
-    }
-
-    @Test
-    fun `given restore requests is something else, when rewind confirmed, then do not trigger anything`() = test {
-        val progress = RestoreRequestState.Progress(REWIND_ID, 50)
-        whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(progress)
-
-        viewModel.onRewindConfirmed(REWIND_ID)
-
-        verify(getRestoreStatusUseCase, times(0)).getRestoreStatus(site, RESTORE_ID)
-    }
-
-    @Test
-    fun `given restore status is a progress, when rewind confirmed, then reload events for progress`() = test {
-        val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
-        whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
-        val progress = RestoreRequestState.Progress(REWIND_ID, 50)
-        whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID)).thenReturn(flow { emit(progress) })
-        initProgressMocks()
-
-        viewModel.onRewindConfirmed(REWIND_ID)
-
-        assertEquals(
-                viewModel.events.value,
-                expectedActivityList(
-                        displayProgress = true,
-                        progressWithDate = true,
-                        emptyList = false,
-                        rewindDisabled = true,
-                        isLastPageAndFreeSite = false,
-                        canLoadMore = true,
-                        withFooter = false
-                )
-        )
-    }
-
-    @Test
-    fun `given restore status is a complete, when rewind confirmed, then request events update for complete`() = test {
-        val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
-        whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
-        val progress = RestoreRequestState.Progress(REWIND_ID, 50)
-        val complete = RestoreRequestState.Complete(REWIND_ID, RESTORE_ID)
-        whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID))
-                .thenReturn(flow { emit(progress); emit(complete) })
-        initProgressMocks()
-        whenever(store.fetchActivities(anyOrNull()))
-                .thenReturn(OnActivityLogFetched(10, false, ActivityLogAction.FETCH_ACTIVITIES))
-
-        viewModel.onRewindConfirmed(REWIND_ID)
-
-        assertEquals(
-                viewModel.events.value,
-                expectedActivityList(
-                        displayProgress = false,
-                        progressWithDate = false,
-                        emptyList = false,
-                        rewindDisabled = false,
-                        isLastPageAndFreeSite = false,
-                        canLoadMore = false,
-                        withFooter = false
-                )
-        )
-    }
-
-    @Test
-    fun `given restore status is something else, when rewind confirmed, then do not trigger anything`() = test {
-        val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
-        whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
-        whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID)).thenReturn(flow { emit(success) })
-
-        viewModel.onRewindConfirmed(REWIND_ID)
-
-        assertNull(viewModel.events.value)
-    }
-
-    @Test
-    fun onRewindConfirmedShowsRewindStartedMessage() {
-        assertTrue(snackbarMessages.isEmpty())
-        whenever(store.getActivityLogItemByRewindId(REWIND_ID)).thenReturn(activity())
-        val snackBarMessage = "snackBar message"
-        whenever(resourceProvider.getString(any(), any(), any())).thenReturn(snackBarMessage)
-
-        viewModel.onRewindConfirmed(REWIND_ID)
-
-        assertEquals(snackbarMessages.firstOrNull(), snackBarMessage)
-    }
-
-    @Test
     fun loadsNextPageOnScrollToBottom() = test {
         val canLoadMore = true
         whenever(store.fetchActivities(anyOrNull()))
@@ -978,6 +876,110 @@ class ActivityLogViewModelTest {
                         withFooter = true
                 )
         )
+    }
+
+    /* REWIND CONFIRMED */
+
+    @Test
+    fun onRewindConfirmedTriggersRewindOperation() = test {
+        viewModel.onRewindConfirmed(REWIND_ID)
+
+        verify(postRestoreUseCase).postRestoreRequest(REWIND_ID, site)
+    }
+
+    @Test
+    fun `given restore requests is a success, when rewind confirmed, then do trigger get restore status`() = test {
+        val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
+        whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
+
+        viewModel.onRewindConfirmed(REWIND_ID)
+
+        verify(getRestoreStatusUseCase).getRestoreStatus(site, RESTORE_ID)
+    }
+
+    @Test
+    fun `given restore requests is something else, when rewind confirmed, then do not trigger anything`() = test {
+        val progress = RestoreRequestState.Progress(REWIND_ID, 50)
+        whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(progress)
+
+        viewModel.onRewindConfirmed(REWIND_ID)
+
+        verify(getRestoreStatusUseCase, times(0)).getRestoreStatus(site, RESTORE_ID)
+    }
+
+    @Test
+    fun `given restore status is a progress, when rewind confirmed, then reload events for progress`() = test {
+        val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
+        whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
+        val progress = RestoreRequestState.Progress(REWIND_ID, 50)
+        whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID)).thenReturn(flow { emit(progress) })
+        initProgressMocks()
+
+        viewModel.onRewindConfirmed(REWIND_ID)
+
+        assertEquals(
+                viewModel.events.value,
+                expectedActivityList(
+                        displayProgress = true,
+                        progressWithDate = true,
+                        emptyList = false,
+                        rewindDisabled = true,
+                        isLastPageAndFreeSite = false,
+                        canLoadMore = true,
+                        withFooter = false
+                )
+        )
+    }
+
+    @Test
+    fun `given restore status is a complete, when rewind confirmed, then request events update for complete`() = test {
+        val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
+        whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
+        val progress = RestoreRequestState.Progress(REWIND_ID, 50)
+        val complete = RestoreRequestState.Complete(REWIND_ID, RESTORE_ID)
+        whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID))
+                .thenReturn(flow { emit(progress); emit(complete) })
+        initProgressMocks()
+        whenever(store.fetchActivities(anyOrNull()))
+                .thenReturn(OnActivityLogFetched(10, false, ActivityLogAction.FETCH_ACTIVITIES))
+
+        viewModel.onRewindConfirmed(REWIND_ID)
+
+        assertEquals(
+                viewModel.events.value,
+                expectedActivityList(
+                        displayProgress = false,
+                        progressWithDate = false,
+                        emptyList = false,
+                        rewindDisabled = false,
+                        isLastPageAndFreeSite = false,
+                        canLoadMore = false,
+                        withFooter = false
+                )
+        )
+    }
+
+    @Test
+    fun `given restore status is something else, when rewind confirmed, then do not trigger anything`() = test {
+        val success = RestoreRequestState.Success(REWIND_ID, REWIND_ID, RESTORE_ID)
+        whenever(postRestoreUseCase.postRestoreRequest(REWIND_ID, site)).thenReturn(success)
+        whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID)).thenReturn(flow { emit(success) })
+
+        viewModel.onRewindConfirmed(REWIND_ID)
+
+        assertNull(viewModel.events.value)
+    }
+
+    @Test
+    fun onRewindConfirmedShowsRewindStartedMessage() {
+        assertTrue(snackbarMessages.isEmpty())
+        whenever(store.getActivityLogItemByRewindId(REWIND_ID)).thenReturn(activity())
+        val snackBarMessage = "snackBar message"
+        whenever(resourceProvider.getString(any(), any(), any())).thenReturn(snackBarMessage)
+
+        viewModel.onRewindConfirmed(REWIND_ID)
+
+        assertEquals(snackbarMessages.firstOrNull(), snackBarMessage)
     }
 
     /* PRIVATE */

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -13,7 +13,6 @@ import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -113,7 +112,7 @@ class ActivityLogViewModelTest {
     private val rewindableOnly = false
 
     @Before
-    fun setUp() = runBlocking<Unit> {
+    fun setUp() = test {
         viewModel = ActivityLogViewModel(
                 store,
                 rewindStatusService,
@@ -152,7 +151,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun onStartEmitsDataFromStoreAndStartsFetching() = runBlocking {
+    fun onStartEmitsDataFromStoreAndStartsFetching() = test {
         assertNull(viewModel.events.value)
         assertTrue(eventListStatuses.isEmpty())
 
@@ -166,14 +165,14 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun fetchesEventsOnPullToRefresh() = runBlocking {
+    fun fetchesEventsOnPullToRefresh() = test {
         viewModel.onPullToRefresh()
 
         assertFetchEvents()
     }
 
     @Test
-    fun onDataFetchedPostsDataAndChangesStatusIfCanLoadMore() = runBlocking {
+    fun onDataFetchedPostsDataAndChangesStatusIfCanLoadMore() = test {
         val canLoadMore = true
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
@@ -185,7 +184,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun onDataFetchedLoadsMoreDataIfCanLoadMore() = runBlocking {
+    fun onDataFetchedLoadsMoreDataIfCanLoadMore() = test {
         val canLoadMore = true
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
@@ -200,7 +199,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun onDataFetchedPostsDataAndChangesStatusIfCannotLoadMore() = runBlocking {
+    fun onDataFetchedPostsDataAndChangesStatusIfCannotLoadMore() = test {
         val canLoadMore = false
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
@@ -212,7 +211,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun onDataFetchedShowsFooterIfCannotLoadMoreAndIsFreeSite() = runBlocking {
+    fun onDataFetchedShowsFooterIfCannotLoadMoreAndIsFreeSite() = test {
         val canLoadMore = false
         whenever(site.hasFreePlan).thenReturn(true)
         whenever(store.fetchActivities(anyOrNull()))
@@ -225,7 +224,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun onDataFetchedDoesNotLoadMoreDataIfCannotLoadMore() = runBlocking<Unit> {
+    fun onDataFetchedDoesNotLoadMoreDataIfCannotLoadMore() = test {
         val canLoadMore = false
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(1, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
@@ -238,7 +237,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun onDataFetchedGoesToTopWhenSomeRowsAffected() = runBlocking {
+    fun onDataFetchedGoesToTopWhenSomeRowsAffected() = test {
         assertTrue(moveToTopEvents.isEmpty())
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(10, true, ActivityLogAction.FETCH_ACTIVITIES))
@@ -249,7 +248,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun onDataFetchedDoesNotLoadMoreDataIfNoRowsAffected() = runBlocking<Unit> {
+    fun onDataFetchedDoesNotLoadMoreDataIfNoRowsAffected() = test {
         val canLoadMore = true
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(0, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
@@ -260,7 +259,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun headerIsDisplayedForFirstItemOrWhenDifferentThenPrevious() = runBlocking {
+    fun headerIsDisplayedForFirstItemOrWhenDifferentThenPrevious() = test {
         val canLoadMore = true
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(3, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
@@ -311,7 +310,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun loadsNextPageOnScrollToBottom() = runBlocking {
+    fun loadsNextPageOnScrollToBottom() = test {
         val canLoadMore = true
         whenever(store.fetchActivities(anyOrNull()))
                 .thenReturn(OnActivityLogFetched(10, canLoadMore, ActivityLogAction.FETCH_ACTIVITIES))
@@ -326,7 +325,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun filtersAreNotVisibleWhenFiltersFeatureFlagIsDisabled() = runBlocking {
+    fun filtersAreNotVisibleWhenFiltersFeatureFlagIsDisabled() = test {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(false)
 
         viewModel.start(site, rewindableOnly)
@@ -335,7 +334,7 @@ class ActivityLogViewModelTest {
     }
 
     @Test
-    fun filtersAreVisibleWhenFiltersFeatureFlagIsEnabled() = runBlocking {
+    fun filtersAreVisibleWhenFiltersFeatureFlagIsEnabled() = test {
         whenever(activityLogFiltersFeatureConfig.isEnabled()).thenReturn(true)
 
         viewModel.start(site, rewindableOnly)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -91,7 +91,6 @@ class ActivityLogViewModelTest {
 
     private lateinit var fetchActivityLogCaptor: KArgumentCaptor<FetchActivityLogPayload>
     private lateinit var formatDateRangeTimezoneCaptor: KArgumentCaptor<String>
-    private lateinit var activityLogList: List<ActivityLogModel>
     private lateinit var viewModel: ActivityLogViewModel
 
     private var events: MutableList<List<ActivityLogListItem>?> = mutableListOf()
@@ -104,6 +103,7 @@ class ActivityLogViewModelTest {
     private var rewindProgress = MutableLiveData<RewindStatusService.RewindProgress>()
     private var rewindAvailable = MutableLiveData<Boolean>()
 
+    private val activityList = listOf(firstActivity(), secondActivity(), thirdActivity())
     private val rewindableOnly = false
 
     @Before
@@ -134,8 +134,7 @@ class ActivityLogViewModelTest {
         fetchActivityLogCaptor = argumentCaptor()
         formatDateRangeTimezoneCaptor = argumentCaptor()
 
-        activityLogList = initializeActivityList()
-        whenever(store.getActivityLogForSite(site, false, rewindableOnly)).thenReturn(activityLogList.toList())
+        whenever(store.getActivityLogForSite(site, false, rewindableOnly)).thenReturn(activityList.toList())
         whenever(rewindStatusService.rewindProgress).thenReturn(rewindProgress)
         whenever(rewindStatusService.rewindAvailable).thenReturn(rewindAvailable)
         whenever(store.fetchActivities(anyOrNull())).thenReturn(mock())
@@ -797,7 +796,7 @@ class ActivityLogViewModelTest {
 
     @Test
     fun `given not done and the event list is not empty, when reloading events, then the loading item is visible`() {
-        whenever(store.getActivityLogForSite(site, false, rewindableOnly)).thenReturn(activityLogList.toList())
+        whenever(store.getActivityLogForSite(site, false, rewindableOnly)).thenReturn(activityList.toList())
         val done = false
 
         viewModel.reloadEvents(
@@ -847,7 +846,7 @@ class ActivityLogViewModelTest {
 
     @Test
     fun `given done and the event list is not empty, when reloading events, then the loading item is not visible`() {
-        whenever(store.getActivityLogForSite(site, false, rewindableOnly)).thenReturn(activityLogList.toList())
+        whenever(store.getActivityLogForSite(site, false, rewindableOnly)).thenReturn(activityList.toList())
         val done = true
 
         viewModel.reloadEvents(
@@ -873,7 +872,7 @@ class ActivityLogViewModelTest {
     @Test
     fun `given done a not empty event list and free plan, when reloading events, then the footer item is visible`() {
         whenever(site.hasFreePlan).thenReturn(true)
-        whenever(store.getActivityLogForSite(site, false, rewindableOnly)).thenReturn(activityLogList.toList())
+        whenever(store.getActivityLogForSite(site, false, rewindableOnly)).thenReturn(activityList.toList())
         val done = true
 
         viewModel.reloadEvents(
@@ -898,13 +897,11 @@ class ActivityLogViewModelTest {
 
     /* PRIVATE */
 
-    private fun initializeActivityList(): List<ActivityLogModel> {
-        val list = mutableListOf<ActivityLogModel>()
-        list.add(activity())
-        list.add(activity(rewindable = false))
-        list.add(activity(published = activityPublishedTime(1987, 5, 26)))
-        return list
-    }
+    private fun firstActivity() = activity()
+
+    private fun secondActivity() = activity(rewindable = false)
+
+    private fun thirdActivity() = activity(published = activityPublishedTime(1987, 5, 26))
 
     private fun activity(
         rewindable: Boolean = true,
@@ -972,21 +969,21 @@ class ActivityLogViewModelTest {
     }
 
     private fun firstItem(rewindDisabled: Boolean) = ActivityLogListItem.Event(
-            model = activityLogList[0],
+            model = activityList[0],
             rewindDisabled = rewindDisabled,
             backupDownloadFeatureEnabled = false,
             restoreFeatureEnabled = false
     )
 
     private fun secondItem(rewindDisabled: Boolean) = ActivityLogListItem.Event(
-            model = activityLogList[1],
+            model = activityList[1],
             rewindDisabled = rewindDisabled,
             backupDownloadFeatureEnabled = false,
             restoreFeatureEnabled = false
     )
 
     private fun thirdItem(rewindDisabled: Boolean) = ActivityLogListItem.Event(
-            model = activityLogList[2],
+            model = activityList[2],
             rewindDisabled = rewindDisabled,
             backupDownloadFeatureEnabled = false,
             restoreFeatureEnabled = false

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -687,8 +687,8 @@ class ActivityLogViewModelTest {
         verify(store).fetchActivities(fetchActivityLogCaptor.capture())
 
         fetchActivityLogCaptor.lastValue.apply {
-            assertEquals(this.loadMore, canLoadMore)
-            assertEquals(this.site, site)
+            assertEquals(canLoadMore, loadMore)
+            assertEquals(this@ActivityLogViewModelTest.site, site)
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -605,23 +605,23 @@ class ActivityLogViewModelTest {
         isLastPageAndFreeSite: Boolean = false,
         canLoadMore: Boolean = false
     ): List<ActivityLogListItem> {
-        val activityLogListItems = mutableListOf<ActivityLogListItem>()
+        val list = mutableListOf<ActivityLogListItem>()
         firstItem().let {
-            activityLogListItems.add(ActivityLogListItem.Header(it.formattedDate))
-            activityLogListItems.add(it)
+            list.add(ActivityLogListItem.Header(it.formattedDate))
+            list.add(it)
         }
-        activityLogListItems.add(secondItem())
+        list.add(secondItem())
         thirdItem().let {
-            activityLogListItems.add(ActivityLogListItem.Header(it.formattedDate))
-            activityLogListItems.add(it)
+            list.add(ActivityLogListItem.Header(it.formattedDate))
+            list.add(it)
         }
         if (isLastPageAndFreeSite) {
-            activityLogListItems.add(ActivityLogListItem.Footer)
+            list.add(ActivityLogListItem.Footer)
         }
         if (canLoadMore) {
-            activityLogListItems.add(ActivityLogListItem.Loading)
+            list.add(ActivityLogListItem.Loading)
         }
-        return activityLogListItems
+        return list
     }
 
     private fun firstItem() = ActivityLogListItem.Event(

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -26,7 +26,7 @@ import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.action.ActivityLogAction.FETCH_ACTIVITIES
+import org.wordpress.android.fluxc.action.ActivityLogAction
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
@@ -39,7 +39,6 @@ import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents
 import org.wordpress.android.ui.activitylog.list.ActivityLogListItem
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase.JetpackPurchasedProducts
-import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.ui.stats.refresh.utils.DateUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -1002,17 +1002,17 @@ class ActivityLogViewModelTest {
     }
 
     private fun event() = ActivityLogListItem.Event(
-            "activityId",
-            "",
-            ",",
-            null,
-            null,
-            true,
-            null,
-            Date(),
-            true,
-            ActivityLogListItem.Icon.DEFAULT,
-            false
+            activityId = "activityId",
+            title = "",
+            description = ",",
+            gridIcon = null,
+            eventStatus = null,
+            isRewindable = true,
+            rewindId = null,
+            date = Date(),
+            isButtonVisible = true,
+            buttonIcon = ActivityLogListItem.Icon.DEFAULT,
+            isProgressBarVisible = false
     )
 
     private fun initProgressMocks(displayProgressWithDate: Boolean = true) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -12,7 +12,6 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.Dispatchers
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -113,8 +112,7 @@ class ActivityLogViewModelTest {
                 dateUtils,
                 activityLogTracker,
                 jetpackCapabilitiesUseCase,
-                restoreFeatureConfig,
-                Dispatchers.Unconfined
+                restoreFeatureConfig
         )
         viewModel.site = site
         viewModel.rewindableOnly = rewindableOnly

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -303,7 +303,7 @@ class ActivityLogViewModelTest {
     @Test
     fun onRewindConfirmedShowsRewindStartedMessage() {
         assertTrue(snackbarMessages.isEmpty())
-        whenever(rewindStatusService.rewindingActivity).thenReturn(activity())
+        whenever(store.getActivityLogItemByRewindId(REWIND_ID)).thenReturn(activity())
         val snackBarMessage = "snackBar message"
         whenever(resourceProvider.getString(any(), any(), any())).thenReturn(snackBarMessage)
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -246,41 +246,6 @@ class ActivityLogViewModelTest {
         assertEquals(viewModel.eventListStatus.value, ActivityLogListStatus.DONE)
     }
 
-    private fun expectedActivityList(isLastPageAndFreeSite: Boolean = false, canLoadMore: Boolean = false):
-            List<ActivityLogListItem> {
-        val activityLogListItems = mutableListOf<ActivityLogListItem>()
-        val first = ActivityLogListItem.Event(
-                model = activityLogList[0],
-                rewindDisabled = true,
-                backupDownloadFeatureEnabled = false,
-                restoreFeatureEnabled = false
-        )
-        val second = ActivityLogListItem.Event(
-                model = activityLogList[1],
-                rewindDisabled = true,
-                backupDownloadFeatureEnabled = false,
-                restoreFeatureEnabled = false
-        )
-        val third = ActivityLogListItem.Event(
-                model = activityLogList[2],
-                rewindDisabled = true,
-                backupDownloadFeatureEnabled = false,
-                restoreFeatureEnabled = false
-        )
-        activityLogListItems.add(ActivityLogListItem.Header(first.formattedDate))
-        activityLogListItems.add(first)
-        activityLogListItems.add(second)
-        activityLogListItems.add(ActivityLogListItem.Header(third.formattedDate))
-        activityLogListItems.add(third)
-        if (isLastPageAndFreeSite) {
-            activityLogListItems.add(ActivityLogListItem.Footer)
-        }
-        if (canLoadMore) {
-            activityLogListItems.add(ActivityLogListItem.Loading)
-        }
-        return activityLogListItems
-    }
-
     @Test
     fun onDataFetchedDoesNotLoadMoreDataIfCannotLoadMore() = runBlocking<Unit> {
         val canLoadMore = false
@@ -641,6 +606,43 @@ class ActivityLogViewModelTest {
         viewModel.onDateRangeSelected(Pair(1L, 2L))
 
         assertThat(viewModel.emptyUiState.value).isEqualTo(EmptyUiState.Backup.ActiveFilters)
+    }
+
+    /* PRIVATE */
+
+    private fun expectedActivityList(isLastPageAndFreeSite: Boolean = false, canLoadMore: Boolean = false):
+            List<ActivityLogListItem> {
+        val activityLogListItems = mutableListOf<ActivityLogListItem>()
+        val first = ActivityLogListItem.Event(
+                model = activityLogList[0],
+                rewindDisabled = true,
+                backupDownloadFeatureEnabled = false,
+                restoreFeatureEnabled = false
+        )
+        val second = ActivityLogListItem.Event(
+                model = activityLogList[1],
+                rewindDisabled = true,
+                backupDownloadFeatureEnabled = false,
+                restoreFeatureEnabled = false
+        )
+        val third = ActivityLogListItem.Event(
+                model = activityLogList[2],
+                rewindDisabled = true,
+                backupDownloadFeatureEnabled = false,
+                restoreFeatureEnabled = false
+        )
+        activityLogListItems.add(ActivityLogListItem.Header(first.formattedDate))
+        activityLogListItems.add(first)
+        activityLogListItems.add(second)
+        activityLogListItems.add(ActivityLogListItem.Header(third.formattedDate))
+        activityLogListItems.add(third)
+        if (isLastPageAndFreeSite) {
+            activityLogListItems.add(ActivityLogListItem.Footer)
+        }
+        if (canLoadMore) {
+            activityLogListItems.add(ActivityLogListItem.Loading)
+        }
+        return activityLogListItems
     }
 
     private suspend fun assertFetchEvents(canLoadMore: Boolean = false) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -266,9 +266,24 @@ class ActivityLogViewModelTest {
     private fun expectedActivityList(isLastPageAndFreeSite: Boolean = false, canLoadMore: Boolean = false):
             List<ActivityLogListItem> {
         val activityLogListItems = mutableListOf<ActivityLogListItem>()
-        val first = ActivityLogListItem.Event(activityLogList[0], true, false, false)
-        val second = ActivityLogListItem.Event(activityLogList[1], true, false, false)
-        val third = ActivityLogListItem.Event(activityLogList[2], true, false, false)
+        val first = ActivityLogListItem.Event(
+                model = activityLogList[0],
+                rewindDisabled = true,
+                backupDownloadFeatureEnabled = false,
+                restoreFeatureEnabled = false
+        )
+        val second = ActivityLogListItem.Event(
+                model = activityLogList[1],
+                rewindDisabled = true,
+                backupDownloadFeatureEnabled = false,
+                restoreFeatureEnabled = false
+        )
+        val third = ActivityLogListItem.Event(
+                model = activityLogList[2],
+                rewindDisabled = true,
+                backupDownloadFeatureEnabled = false,
+                restoreFeatureEnabled = false
+        )
         activityLogListItems.add(ActivityLogListItem.Header(first.formattedDate))
         activityLogListItems.add(first)
         activityLogListItems.add(second)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -71,6 +71,7 @@ private const val ONE_DAY_WITHOUT_SECOND_IN_MILLIS = 1000 * 60 * 60 * 24 - 1000
 private const val SITE_ID = 1L
 
 private const val NOW = "Now"
+private const val RESTORE_STARTED = "Your site is being restored\nRestoring to date time"
 private const val CURRENTLY_RESTORING = "Currently restoring your site"
 private const val RESTORING_DATE_TIME = "Restoring to date time"
 private const val RESTORING_NO_DATE = "Restore in progress"
@@ -972,14 +973,13 @@ class ActivityLogViewModelTest {
 
     @Test
     fun `when rewind confirmed, then show rewind started message`() {
-        assertTrue(snackbarMessages.isEmpty())
         whenever(store.getActivityLogItemByRewindId(REWIND_ID)).thenReturn(activity())
-        val snackBarMessage = "snackBar message"
-        whenever(resourceProvider.getString(any(), any(), any())).thenReturn(snackBarMessage)
+        whenever(resourceProvider.getString(eq(R.string.activity_log_rewind_started_snackbar_message), any(), any()))
+                .thenReturn(RESTORE_STARTED)
 
         viewModel.onRewindConfirmed(REWIND_ID)
 
-        assertEquals(snackbarMessages.firstOrNull(), snackBarMessage)
+        assertEquals(snackbarMessages.firstOrNull(), RESTORE_STARTED)
     }
 
     /* PRIVATE */


### PR DESCRIPTION
Parent #13328

This PR replaces the `RewindStatusService` with the `PostRestoreUseCase` and `GetRestoreStatusUseCase`. This step is necessary in order to reuse those use cases, remove the complicated status services and in general reduce the complexity within the `ActivityLogViewModel`. Also, this step is a prerequisite and as much necessary for another feature that is about to be added to this screen, which is showing a progress row when a `Backup Download` has been triggered.

⚠️ When this PR is merged into `develop` is will affect the next release as this refactor is not guarded on a feature flag. Make sure to do a thorough code review. @zwarm @malinajirka and @ashiagr I have added all of you as reviewers to this PR as this is a complicated one and I would love to get as much comments as possible. At least, testing the PR and finding out bugs would be a major help.

ℹ️ Don't be scared by the amount of commits (77), the file changes are not that many (9). The commits are that many because of the many refactors I had to do in order to improve the state of the `ActivityLogViewModel` and its corresponding tests to be able to remove the status service and replace that with the use cases. If you do this code review commit-by-commit it will help you enormously.

Future TODOs:
* Timestamp is not being shown on restore progress row and its corresponding snackbars (started and completed) when triggered from the web. An item for that will be added on the parent ticket.
* `RewindStatusService` has not been completely removed due to the fact that the `ActivityLogDetailViewModel` also uses it just to show/hide the `RESTORE` button. An item for that will be added on the parent ticket.

To test:

#### Scenario.1 (App flow)
* Open app and go to `My Site` tab,
* Launch `Activity Log` screen,
* Find a rewindable item from the list and: 
  * Either, click on the `RESTORE` icon and then on the dialog that appears, click on the `RESTORE SITE` button,
  * Or, click on the item itself to launch the `Activity Log Details` screen, click the `RESTORE` button and then on the dialog that appears, click on the `RESTORE SITE` button,
* You should automatically be navigated back to the `Activity Log` screen, on top of the list, and a restore will be triggered,
* The restore progress item should immediately appears. Make sure the restore timestamp is available on this progress item.
* A snackbar should immediately appear informing that the restore just started. Make sure the restore timestamp is available on the snackbar.
* Make sure the `RESTORE` icon, for every rewindable item, is not shown while restore progress is ongoing.
* Wait for restore to finish while having the `Activity Log` screen open both, within the app and the web (so you can see the actual progress),
* When restore finishes (looking on the web), a the restore (push) notification should appear.
* Then, the restore progress item should disappear (after at least 5'' seconds, due to the while loop check status delay).
* A pull-to-refresh should be automatically triggered and a new restore item might (or might not) appear (depending on how fast the restore progress item disappears and how fast this new item becomes available on the backend, via the `activityLogStore.fetchActivities(...)` API call). In case the new restore item does not appear, wait a bit (maybe 10'' seconds) and trigger a manual pull-to-refresh. Verify that the new restore item appears after some time.
* A snackbar should immediately appear informing that the restore just completed.  Make sure the restore timestamp is available on the snackbar.
* Make sure the `RESTORE` icon, for every rewindable item, is now shown again.

#### Scenario.2 (Web flow)
* Open app and go to `My Site` tab,
* Trigger restore from web,
* Wait for it to start,
* Either, launch `Activity Log` screen, or trigger a pull-to-refresh if you are already within that screen.
* The restore progress item should immediately appears. **CHANGE** (⚠️): The timestamp will not be available when triggered from the web, or it might become available based on some constraints (to be improved).
* Make sure the `RESTORE` icon, for every rewindable item, is not shown while restore progress is ongoing.
* Wait for restore to finish while having the `Activity Log` screen open both, within the app and the web (so you can see the actual progress),
* When restore finished (looking on the web), a the restore (push) notification should appear.
* Then, the restore progress item should disappear (after at least 5'' seconds, due to the while loop check status delay).
* A pull-to-refresh should be automatically triggered and a new restore item might (or might not) appear (depending on how fast the restore progress item disappears and how fast this new item becomes available on the backend, via the `activityLogStore.fetchActivities(...)` API call). In case the new restore item does not appear, wait a bit (maybe 10'' seconds) and trigger a manual pull-to-refresh. Verify that the new restore item appears after some time.
* A snackbar should immediately appear informing that the restore just completed. **CHANGE** (⚠️): The timestamp will not be available when triggered from the web, or it might become available based on some constraints (to be improved).
* Make sure the `RESTORE` icon, for every rewindable item, is now shown again.

#### Scenario.3 (Go wild flow)
* Trigger any of the above 2 scenarios until you reach the point where the restore progress item is shown.
* Trigger a pull-to-refresh manually and make sure the progress item is still shown.
* Go to the bottom of the list and trigger another page load, go to the top of the list and make sure the progress item is still shown.
* Go to the bottom of the list and trigger another page load, click on any item to navigate to the `Activity Log Detail` page, and then go back. Go to the top of the list and make sure the progress item is still shown.
* Go to the bottom of the list and trigger another page load, wait there until the restore finishes.
* Then, make sure you are being navigated automatically to the top of the list and the restore progress item have disappeared.

#### Scenario.4 (Restore flow)
* Since this PR updates the `GetRestoreStatusUseCase` it is recommended that the `Restore Flow` is tested as well.
* To do so, open app and go to `My Site` tab,
* Go to `My Site` -> `Toolbar Avatar` -> `App Settings` -> `Test feature configuration`.
* Enable `RestoreFeatureConfig`, scroll down and click the `RESTART THE APP` button. 
* Launch `Activity Log` screen,
* Find a rewindable item from the list, click on the ellipsis menu item and select `Restore to this point` to launch the `Restore screen,
* Click the `Restore site` button. On the confirmation screen, click on the `Confirm restore site` button.
* Wait for the restore to finish, click `Done` and in general verify everything works as expected.

PS: I **REALLY** suggest doing a commit-by-commit review as this will make it much easier for you to review the overall solution.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
