### PR TITLE
Issue/13326 start scan after delay

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -74,9 +74,9 @@ class ScanViewModel @Inject constructor(
         fetchScanState()
     }
 
-    private fun fetchScanState() {
+    private fun fetchScanState(startAfterDelay: Boolean = false) {
         launch {
-            fetchScanStateUseCase.fetchScanState(site = site)
+            fetchScanStateUseCase.fetchScanState(site = site, startAfterDelay = startAfterDelay)
                 .collect { state ->
                     when (state) {
                         is FetchScanState.Success -> updateUiState(buildContentUiState(state.scanStateModel))
@@ -92,7 +92,7 @@ class ScanViewModel @Inject constructor(
                 .collect { state ->
                     when (state) {
                         is StartScanState.ScanningStateUpdatedInDb -> updateUiState(buildContentUiState(state.model))
-                        is StartScanState.Success -> fetchScanState()
+                        is StartScanState.Success -> fetchScanState(startAfterDelay = true)
                         is StartScanState.Failure -> TODO() // TODO ashiagr to be implemented
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -74,9 +74,9 @@ class ScanViewModel @Inject constructor(
         fetchScanState()
     }
 
-    private fun fetchScanState(startAfterDelay: Boolean = false) {
+    private fun fetchScanState(startWithDelay: Boolean = false) {
         launch {
-            fetchScanStateUseCase.fetchScanState(site = site, startAfterDelay = startAfterDelay)
+            fetchScanStateUseCase.fetchScanState(site = site, startWithDelay = startWithDelay)
                 .collect { state ->
                     when (state) {
                         is FetchScanState.Success -> updateUiState(buildContentUiState(state.scanStateModel))
@@ -92,7 +92,7 @@ class ScanViewModel @Inject constructor(
                 .collect { state ->
                     when (state) {
                         is StartScanState.ScanningStateUpdatedInDb -> updateUiState(buildContentUiState(state.model))
-                        is StartScanState.Success -> fetchScanState(startAfterDelay = true)
+                        is StartScanState.Success -> fetchScanState(startWithDelay = true)
                         is StartScanState.Failure -> TODO() // TODO ashiagr to be implemented
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCase.kt
@@ -19,7 +19,7 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
 import javax.inject.Named
 
-private const val FETCH_FIX_THREATS_STATUS_DELAY_MILLIS = 5000L
+const val FETCH_FIX_THREATS_STATUS_DELAY_MILLIS = 5000L
 
 class FetchFixThreatsStatusUseCase @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
@@ -28,8 +28,7 @@ class FetchFixThreatsStatusUseCase @Inject constructor(
 ) {
     suspend fun fetchFixThreatsStatus(
         remoteSiteId: Long,
-        fixableThreatIds: List<Long>,
-        delayInMs: Long = FETCH_FIX_THREATS_STATUS_DELAY_MILLIS
+        fixableThreatIds: List<Long>
     ): Flow<FetchFixThreatsState> = flow {
         while (true) {
             if (!networkUtilsWrapper.isNetworkAvailable()) {
@@ -45,7 +44,7 @@ class FetchFixThreatsStatusUseCase @Inject constructor(
                 val fixState = mapToFixState(result.fixThreatStatusModels, fixableThreatIds)
                 emit(fixState)
                 if (fixState is InProgress) {
-                    delay(delayInMs)
+                    delay(FETCH_FIX_THREATS_STATUS_DELAY_MILLIS)
                 } else {
                     return@flow
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
@@ -25,7 +25,6 @@ class FetchScanStateUseCase @Inject constructor(
 ) {
     suspend fun fetchScanState(
         site: SiteModel,
-        delayInMs: Long = FETCH_SCAN_STATE_DELAY_MILLIS,
         startWithDelay: Boolean = false
     ): Flow<FetchScanState> = flow {
         while (true) {
@@ -47,7 +46,7 @@ class FetchScanStateUseCase @Inject constructor(
                 if (scanStateModel != null) {
                     emit(Success(scanStateModel))
                     if (scanStateModel.state == ScanStateModel.State.SCANNING) {
-                        delay(delayInMs)
+                        delay(FETCH_SCAN_STATE_DELAY_MILLIS)
                     } else {
                         return@flow
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
@@ -27,7 +27,7 @@ class FetchScanStateUseCase @Inject constructor(
         site: SiteModel,
         polling: Boolean = true,
         delayInMs: Long = FETCH_SCAN_STATE_DELAY_MILLIS,
-        startAfterDelay: Boolean = false
+        startWithDelay: Boolean = false
     ): Flow<FetchScanState> = flow {
         while (true) {
             if (!networkUtilsWrapper.isNetworkAvailable()) {
@@ -35,7 +35,7 @@ class FetchScanStateUseCase @Inject constructor(
                 return@flow
             }
 
-            if (startAfterDelay) {
+            if (startWithDelay) {
                 delay(FETCH_SCAN_STATE_DELAY_MILLIS)
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
@@ -26,12 +26,17 @@ class FetchScanStateUseCase @Inject constructor(
     suspend fun fetchScanState(
         site: SiteModel,
         polling: Boolean = true,
-        delayInMs: Long = FETCH_SCAN_STATE_DELAY_MILLIS
+        delayInMs: Long = FETCH_SCAN_STATE_DELAY_MILLIS,
+        startAfterDelay: Boolean = false
     ): Flow<FetchScanState> = flow {
         while (true) {
             if (!networkUtilsWrapper.isNetworkAvailable()) {
                 emit(Failure.NetworkUnavailable)
                 return@flow
+            }
+
+            if (startAfterDelay) {
+                delay(FETCH_SCAN_STATE_DELAY_MILLIS)
             }
 
             val result = scanStore.fetchScanState(FetchScanStatePayload(site))

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
@@ -25,7 +25,6 @@ class FetchScanStateUseCase @Inject constructor(
 ) {
     suspend fun fetchScanState(
         site: SiteModel,
-        polling: Boolean = true,
         delayInMs: Long = FETCH_SCAN_STATE_DELAY_MILLIS,
         startWithDelay: Boolean = false
     ): Flow<FetchScanState> = flow {
@@ -47,7 +46,7 @@ class FetchScanStateUseCase @Inject constructor(
                 val scanStateModel = scanStore.getScanStateForSite(site)
                 if (scanStateModel != null) {
                     emit(Success(scanStateModel))
-                    if (polling && scanStateModel.state == ScanStateModel.State.SCANNING) {
+                    if (scanStateModel.state == ScanStateModel.State.SCANNING) {
                         delay(delayInMs)
                     } else {
                         return@flow

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -110,6 +110,7 @@ class ScanViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when scan button is clicked, then start scan is triggered`() = test {
+        whenever(startScanUseCase.startScan(any())).thenReturn(flowOf(ScanningStateUpdatedInDb(fakeScanStateModel)))
         val uiStates = init().uiStates
 
         (uiStates.last() as Content).items.filterIsInstance<ActionButtonState>().first().onClick.invoke()
@@ -187,12 +188,15 @@ class ScanViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given success response, when fix threats is triggered, then fix started message is shown`() = test {
+        whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+            flowOf(FetchFixThreatsState.Complete)
+        )
         whenever(fixThreatsUseCase.fixThreats(any(), any())).thenReturn(FixThreatsState.Success)
         val observers = init()
 
         triggerFixThreatsAction(observers)
 
-        val snackBarMsg = observers.snackBarMsgs.last().peekContent()
+        val snackBarMsg = observers.snackBarMsgs.first().peekContent()
         assertThat(snackBarMsg).isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.threat_fix_all_started_message)))
     }
 
@@ -331,6 +335,9 @@ class ScanViewModelTest : BaseUnitTest() {
     @Test
     fun `given activity result fix threat status data, when fix status is requested, then fix status is fetched`() =
         test {
+            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+                flowOf(FetchFixThreatsState.Complete)
+            )
             whenever(site.siteId).thenReturn(1L)
             viewModel.start(site)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -188,7 +188,7 @@ class ScanViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given success response, when fix threats is triggered, then fix started message is shown`() = test {
-        whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+        whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any())).thenReturn(
             flowOf(FetchFixThreatsState.Complete)
         )
         whenever(fixThreatsUseCase.fixThreats(any(), any())).thenReturn(FixThreatsState.Success)
@@ -240,7 +240,7 @@ class ScanViewModelTest : BaseUnitTest() {
     @Test
     fun `given threats are fixed, when threats fix status is checked, then success message is shown`() =
         test {
-            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any())).thenReturn(
                 flowOf(FetchFixThreatsState.Complete)
             )
             val observers = init()
@@ -255,7 +255,7 @@ class ScanViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given no network, when threats fix status is checked, then network error message is shown`() = test {
-        whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+        whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any())).thenReturn(
             flowOf(FetchFixThreatsState.Failure.NetworkUnavailable)
         )
         val observers = init()
@@ -268,7 +268,7 @@ class ScanViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given server is unavailable, when threats fix status is checked, then error message is shown`() = test {
-        whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+        whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any())).thenReturn(
             flowOf(FetchFixThreatsState.Failure.RemoteRequestFailure)
         )
         val observers = init()
@@ -285,7 +285,7 @@ class ScanViewModelTest : BaseUnitTest() {
     fun `given a threat not fixed, when threats fix status checked, then some threats not fixed error message shown`() =
         test {
             whenever(fixThreatsUseCase.fixThreats(any(), any())).thenReturn(FixThreatsState.Success)
-            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any())).thenReturn(
                 flowOf(FetchFixThreatsState.Failure.FixFailure)
             )
             val observers = init()
@@ -301,7 +301,7 @@ class ScanViewModelTest : BaseUnitTest() {
     @Test
     fun `given threats are fixing, when threats fix status is checked, then an indeterminate progress bar is shown`() =
         test {
-            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any())).thenReturn(
                 flowOf(FetchFixThreatsState.InProgress(mock()))
             )
             val observers = init()
@@ -318,7 +318,7 @@ class ScanViewModelTest : BaseUnitTest() {
     @Test
     fun `given threats not fixing, when threats fix status is checked, then indeterminate progress bar is not shown`() =
         test {
-            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any())).thenReturn(
                 flowOf(FetchFixThreatsState.Complete)
             )
             val observers = init()
@@ -335,7 +335,7 @@ class ScanViewModelTest : BaseUnitTest() {
     @Test
     fun `given activity result fix threat status data, when fix status is requested, then fix status is fetched`() =
         test {
-            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any())).thenReturn(
                 flowOf(FetchFixThreatsState.Complete)
             )
             whenever(site.siteId).thenReturn(1L)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -130,13 +130,15 @@ class ScanViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when scan button is clicked, then fetch scan state is triggered on scan start success`() = test {
+    fun `given scan starts with success, when scan button is clicked, then scan state is fetched after delay`() = test {
+        whenever(fetchScanStateUseCase.fetchScanState(site = site, startAfterDelay = true))
+            .thenReturn(flowOf(Success(fakeScanStateModel)))
         whenever(startScanUseCase.startScan(any())).thenReturn(flowOf(StartScanState.Success))
         val uiStates = init().uiStates
 
         (uiStates.last() as Content).items.filterIsInstance<ActionButtonState>().first().onClick.invoke()
 
-        verify(fetchScanStateUseCase, times(2)).fetchScanState(site)
+        verify(fetchScanStateUseCase).fetchScanState(site = site, startAfterDelay = true)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -132,14 +132,14 @@ class ScanViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given scan starts with success, when scan button is clicked, then scan state is fetched after delay`() = test {
-        whenever(fetchScanStateUseCase.fetchScanState(site = site, startAfterDelay = true))
+        whenever(fetchScanStateUseCase.fetchScanState(site = site, startWithDelay = true))
             .thenReturn(flowOf(Success(fakeScanStateModel)))
         whenever(startScanUseCase.startScan(any())).thenReturn(flowOf(StartScanState.Success))
         val uiStates = init().uiStates
 
         (uiStates.last() as Content).items.filterIsInstance<ActionButtonState>().first().onClick.invoke()
 
-        verify(fetchScanStateUseCase).fetchScanState(site = site, startAfterDelay = true)
+        verify(fetchScanStateUseCase).fetchScanState(site = site, startWithDelay = true)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
@@ -4,13 +4,17 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.MainCoroutineScopeRule
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.action.ScanAction.FETCH_FIX_THREATS_STATUS
 import org.wordpress.android.fluxc.model.scan.threat.FixThreatStatusModel
@@ -25,13 +29,16 @@ import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCa
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.InProgress
 import org.wordpress.android.util.NetworkUtilsWrapper
 
+@ExperimentalCoroutinesApi
 @InternalCoroutinesApi
 class FetchFixThreatsStatusUseCaseTest : BaseUnitTest() {
+    @Rule
+    @JvmField val coroutineScope = MainCoroutineScopeRule()
+
     private lateinit var useCase: FetchFixThreatsStatusUseCase
     @Mock lateinit var networkUtilsWrapper: NetworkUtilsWrapper
     @Mock lateinit var scanStore: ScanStore
 
-    private val delayInMs = 0L
     private val fakeSiteId = 1L
     private val fakeThreatId = 11L
     private val fakeFixThreatsStatusModel = FixThreatStatusModel(fakeThreatId, FixStatus.IN_PROGRESS)
@@ -65,14 +72,14 @@ class FetchFixThreatsStatusUseCaseTest : BaseUnitTest() {
 
     @Test
     fun `when in progress threats fix status is fetched, then polling occurs until in progress status changes`() =
-        test {
+        coroutineScope.runBlockingTest {
             whenever(scanStore.fetchFixThreatsStatus(any()))
                 .thenReturn(storeResultWithInProgressFixStatusModel)
                 .thenReturn(storeResultWithInProgressFixStatusModel)
                 .thenReturn(storeResultWithFixedFixStatusModel)
 
-            val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(fakeThreatId), delayInMs)
-                .toList(mutableListOf())
+            val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(fakeThreatId)).toList(mutableListOf())
+            advanceTimeBy(FETCH_FIX_THREATS_STATUS_DELAY_MILLIS)
 
             verify(scanStore, times(3)).fetchFixThreatsStatus(any())
             assertThat(useCaseResult).containsSequence(


### PR DESCRIPTION
This PR fetches scan state after a delay once scan is started. It fixes an issue when scan state did not update immediately after starting the scan.

To test:
Prerequisite:

- Make sure both Scan feature flag and MySiteImprovements flag are set to on in the App settings.
- You have access to WP.com account with a site having scan capability (e.g. https://pressable-jetpack-daily-scan.mystagingwebsite.com).

1. Login to the app as well Calypso using above WP.com account and select the site on the My Site tab
2. Click scan menu item on My Site in the app
3. Add/ delete threat to/ from the site from Calypso
4. Start scan few times in the app
5. Notice that scan state is updated appropriately in the app

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
