### PR TITLE
Issue/13326 check fix threat status on init

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -119,7 +119,6 @@ class ScanViewModel @Inject constructor(
             updateActionButtons(isVisible = false)
             when (fixThreatsUseCase.fixThreats(remoteSiteId = site.siteId, fixableThreatIds = fixableThreatIds)) {
                 is FixThreatsState.Success -> {
-                    updateSnackbarMessageEvent(UiStringRes(R.string.threat_fix_all_started_message))
                     val someOrAllThreatFixed = fetchFixThreatsStatus(fixableThreatIds)
                     if (someOrAllThreatFixed) fetchScanState()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -145,6 +145,8 @@ class ScanViewModel @Inject constructor(
         ).collect { status ->
             var fixingThreatIds = emptyList<Long>()
             when (status) {
+                is FetchFixThreatsState.NotStarted -> { // Do nothing
+                }
                 is FetchFixThreatsState.InProgress -> {
                     fixingThreatIds = status.threatIds
                 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1140,7 +1140,6 @@
     <string name="threat_ignore_error_message">Error ignoring threat. Please contact support.</string>
     <string name="threat_fix_all_warning_title">Fix all threats</string>
     <string name="threat_fix_all_warning_message">Please confirm you want to fix %s active threats.</string>
-    <string name="threat_fix_all_started_message">We\'re hard at work fixing these threats in the background. Please check back shortly.</string>
     <string name="threat_fix_all_error_message">Error fixing threats. Please contact our support.</string>
     <string name="threat_fix_all_status_success_message">Threats were successfully fixed.</string>
     <string name="threat_fix_all_status_error_message">Error getting fix status. Please contact our support.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1144,7 +1144,6 @@
     <string name="threat_fix_all_error_message">Error fixing threats. Please contact our support.</string>
     <string name="threat_fix_all_status_success_message">Threats were successfully fixed.</string>
     <string name="threat_fix_all_status_error_message">Error getting fix status. Please contact our support.</string>
-    <string name="threat_fix_all_status_some_threats_not_fixed_error_message">Not all threats could be fixed. Please contact our support.</string>
 
     <!-- stats: labels for timeframes -->
     <string name="stats_timeframe_today">Today</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -93,6 +93,21 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given fixable threats present in db, when vm starts, fetch fix threats status is triggered`() =
+        test {
+            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+                flowOf(FetchFixThreatsState.Complete)
+            )
+            val scanStateModelWithFixableThreats = fakeScanStateModel
+                .copy(threats = listOf(ThreatTestData.fixableThreatInCurrentStatus))
+            whenever(scanStore.getScanStateForSite(site)).thenReturn(scanStateModelWithFixableThreats)
+
+            viewModel.start(site)
+
+            verify(fetchFixThreatsStatusUseCase).fetchFixThreatsStatus(any(), any(), any())
+        }
+
+    @Test
     fun `when scan state is fetched successfully, then ui is updated with content`() = test {
         val uiStates = init().uiStates
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -121,6 +121,7 @@ class ScanViewModelTest : BaseUnitTest() {
     @Test
     fun `when scan button is clicked, then content updated on scan optimistic start (scanning state updated in db)`() =
         test {
+            whenever(scanStore.getScanStateForSite(site)).thenReturn(null)
             whenever(startScanUseCase.startScan(any()))
                 .thenReturn(flowOf(ScanningStateUpdatedInDb(fakeScanStateModel)))
             val uiStates = init().uiStates
@@ -156,6 +157,10 @@ class ScanViewModelTest : BaseUnitTest() {
     @Test
     fun `when fix threats confirmation dialog action is triggered, then fix threats confirmation dialog is shown`() =
         test {
+            val scanStateModelWithFixableThreats = fakeScanStateModel
+                .copy(threats = listOf(ThreatTestData.fixableThreatInCurrentStatus))
+            whenever(fetchScanStateUseCase.fetchScanState(site))
+                .thenReturn(flowOf(Success(scanStateModelWithFixableThreats)))
             val observers = init()
 
             (observers.uiStates.last() as Content).items.filterIsInstance<ActionButtonState>().last().onClick.invoke()

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -83,6 +83,9 @@ class ScanViewModelTest : BaseUnitTest() {
             )
         }
         whenever(scanStore.getScanStateForSite(site)).thenReturn(fakeScanStateModel)
+        whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
+            flowOf(FetchFixThreatsState.Complete)
+        )
     }
 
     @Test
@@ -95,9 +98,6 @@ class ScanViewModelTest : BaseUnitTest() {
     @Test
     fun `given fixable threats present in db, when vm starts, fetch fix threats status is triggered`() =
         test {
-            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
-                flowOf(FetchFixThreatsState.Complete)
-            )
             val scanStateModelWithFixableThreats = fakeScanStateModel
                 .copy(threats = listOf(ThreatTestData.fixableThreatInCurrentStatus))
             whenever(scanStore.getScanStateForSite(site)).thenReturn(scanStateModelWithFixableThreats)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -104,7 +104,7 @@ class ScanViewModelTest : BaseUnitTest() {
 
             viewModel.start(site)
 
-            verify(fetchFixThreatsStatusUseCase).fetchFixThreatsStatus(any(), any(), any())
+            verify(fetchFixThreatsStatusUseCase).fetchFixThreatsStatus(any(), any())
         }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -207,20 +207,6 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given success response, when fix threats is triggered, then fix started message is shown`() = test {
-        whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
-            flowOf(FetchFixThreatsState.Complete)
-        )
-        whenever(fixThreatsUseCase.fixThreats(any(), any())).thenReturn(FixThreatsState.Success)
-        val observers = init()
-
-        triggerFixThreatsAction(observers)
-
-        val snackBarMsg = observers.snackBarMsgs.first().peekContent()
-        assertThat(snackBarMsg).isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.threat_fix_all_started_message)))
-    }
-
-    @Test
     fun `given invalid response, when fix threats action is triggered, then fix threats error message is shown`() =
         test {
             whenever(fixThreatsUseCase.fixThreats(any(), any()))
@@ -370,9 +356,6 @@ class ScanViewModelTest : BaseUnitTest() {
     @Test
     fun `given activity result fix threat status data, when fix status is requested, then fix status is fetched`() =
         test {
-            whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any(), any())).thenReturn(
-                flowOf(FetchFixThreatsState.Complete)
-            )
             whenever(site.siteId).thenReturn(1L)
             viewModel.start(site)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
@@ -110,18 +110,22 @@ class FetchFixThreatsStatusUseCaseTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given result model contains error, when threats fix status is fetched, then FixFailure is returned`() = test {
+    fun `given result models contain error, when threats fix status is fetched, then FixFailure is returned`() = test {
+        val fixThreatsStatusModels = listOf(
+            fakeFixThreatsStatusModel.copy(status = FixStatus.FIXED),
+            fakeFixThreatsStatusModel.copy(status = FixStatus.UNKNOWN, error = "not_found")
+        )
         val storeResultWithErrorFixStatusModel = OnFixThreatsStatusFetched(
             fakeSiteId,
-            listOf(fakeFixThreatsStatusModel.copy(status = FixStatus.UNKNOWN, error = "not_found")),
+            fixThreatsStatusModels,
             FETCH_FIX_THREATS_STATUS
         )
         whenever(scanStore.fetchFixThreatsStatus(any())).thenReturn(storeResultWithErrorFixStatusModel)
 
-        val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(fakeThreatId))
+        val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(1L, 2L))
             .toList(mutableListOf())
             .last()
 
-        assertThat(useCaseResult).isEqualTo(Failure.FixFailure)
+        assertThat(useCaseResult).isEqualTo(Failure.FixFailure(containsOnlyErrors = false))
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.test
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.Complete
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.Failure
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.InProgress
+import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState.NotStarted
 import org.wordpress.android.util.NetworkUtilsWrapper
 
 @InternalCoroutinesApi
@@ -128,4 +129,21 @@ class FetchFixThreatsStatusUseCaseTest : BaseUnitTest() {
 
         assertThat(useCaseResult).isEqualTo(Failure.FixFailure(containsOnlyErrors = false))
     }
+
+    @Test
+    fun `given model contains not started state, when threats fix status is fetched, then NotStarted is returned`() =
+        test {
+            val storeResultWithErrorFixStatusModel = OnFixThreatsStatusFetched(
+                fakeSiteId,
+                listOf(fakeFixThreatsStatusModel.copy(status = FixStatus.NOT_STARTED)),
+                FETCH_FIX_THREATS_STATUS
+            )
+            whenever(scanStore.fetchFixThreatsStatus(any())).thenReturn(storeResultWithErrorFixStatusModel)
+
+            val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(fakeThreatId))
+                .toList(mutableListOf())
+                .last()
+
+            assertThat(useCaseResult).isEqualTo(NotStarted)
+        }
 }


### PR DESCRIPTION
Parent #13326

This PR fetches fix threats status for fixable threats (from scan state in db), and if found in fix in progress state, displays a progress bar on vm init.

It also 
- Adds `FetchFixThreatsState.NotStarted` for `FixStatus.NOT_STARTED` 7814b6c
- Refreshes threats list when `FixFailure` state is encountered only for a sublist of status models  d294252, b187ebe
- Removes fix threats started message 46638b2

**To test**

Prerequisite:

- Make sure both Scan feature flag and MySiteImprovements flag are set to on in the App settings.
- You have access to WP.com account with a site having scan capability and multiple threats (e.g. http://do.wpmt.co/jp-scan-daily). 

1. Login to the app using above WP.com account and select the site on the My Site tab.
2. Click scan menu item on My Site.
3. Click fix threats button on scan screen.
4. Notice that fix threats progress bar is shown.
5. Return to My Site, re-enter Scan screen while threats are fixing.
6. Notice that fix threats progress bar is re-shown on scan screen.
7. Wait for fix to complete.
8. Notice that scan screen is refreshed with latest scan state.

   Test covered in `FetchFixThreatsStatusUseCaseTest`, `ScanViewModelTest`.

**Notes** 

1. Moving "in progress" fix threats state to a full screen modal and other proposed changes in `pcdRpT-cM#comment-222` are not yet covered in this PR.
2. Jetpack Threat Tester (Internal ref: pbuNQi-Kb) can be used to re-add threats once they're fixed. Let me know if you need a help.

**Merge Instructions**

1. ~~Make sure PR #13903 is merged to develop~~ - Done
2. ~~Remove the "Not Ready for Merge label"~~  - Done
3. Merge this PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
