### PR TITLE
Fix develop

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilder.kt
@@ -79,7 +79,7 @@ class ThreatItemBuilder @Inject constructor(
         return when (threatModel.baseThreatModel.status) {
             FIXED -> {
                 UiStringResWithParams(
-                    R.string.threat_item_sub_header_status_fixed,
+                    R.string.threat_item_sub_header_status_fixed_on,
                     listOf(getDateString(threatModel.baseThreatModel.fixedOn))
                 )
             }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1105,7 +1105,7 @@
     <string name="threat_item_sub_header_file_signature">Threat found %s</string>
     <string name="threat_item_sub_header_vulnerable_plugin">Vulnerability found in plugin</string>
     <string name="threat_item_sub_header_vulnerable_theme">Vulnerability found in theme</string>
-    <string name="threat_item_sub_header_status_fixed">Threat fixed on %s</string>
+    <string name="threat_item_sub_header_status_fixed_on">Threat fixed on %s</string>
     <string name="threat_item_sub_header_status_ignored">Threat ignored</string>
 
     <!-- threat details -->

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ThreatItemBuilderTest.kt
@@ -45,7 +45,7 @@ class ThreatItemBuilderTest : BaseUnitTest() {
     fun `builds threat sub header correctly for fixed threat`() {
         // Arrange
         val expectedSubHeader = UiStringResWithParams(
-            R.string.threat_item_sub_header_status_fixed,
+            R.string.threat_item_sub_header_status_fixed_on,
             listOf(UiStringText(TEST_FIXED_ON_DATE))
         )
         val threatModel = GenericThreatModel(ThreatTestData.baseThreatModel.copy(status = FIXED))


### PR DESCRIPTION
`threat_item_sub_header_status_fixed` string resource has a parameter in main/strings.xml but it doesn't have parameters in the other strings.xml files. This PR updates the name of the string so it's treated as a new string.

To test:
1. Enable Scan feature flag
2. Open Scan screen
3. Open History screen
4. Notice Fixed threats have "Fixed on [date]" label

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
