### PR TITLE
Jetpack Section: Connect Restore with Activity Log/Backup Screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -28,6 +28,7 @@ public class RequestCodes {
     public static final int SMART_LOCK_READ = 1500;
     public static final int NOTIFICATION_SETTINGS = 1600;
     public static final int ACTIVITY_LOG_DETAIL = 1700;
+    public static final int RESTORE = 1720;
     public static final int PAGE_PARENT = 1800;
     public static final int HISTORY_DETAIL = 1900;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -28,6 +28,7 @@ public class RequestCodes {
     public static final int SMART_LOCK_READ = 1500;
     public static final int NOTIFICATION_SETTINGS = 1600;
     public static final int ACTIVITY_LOG_DETAIL = 1700;
+    public static final int BACKUP_DOWNLOAD = 1710;
     public static final int RESTORE = 1720;
     public static final int PAGE_PARENT = 1800;
     public static final int HISTORY_DETAIL = 1900;

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -70,7 +70,7 @@ class ActivityLogListActivity : LocaleAwareActivity(),
 
     private fun onActivityResultForActivityLogDetails(data: Intent?) {
         data?.getStringExtra(ACTIVITY_LOG_REWIND_ID_KEY)?.let {
-            passRewindConfirmation(it)
+            passRestoreConfirmation(it)
         }
     }
 
@@ -83,17 +83,17 @@ class ActivityLogListActivity : LocaleAwareActivity(),
     }
 
     override fun onPositiveClicked(instanceTag: String) {
-        passRewindConfirmation(instanceTag)
+        passRestoreConfirmation(instanceTag)
     }
 
     override fun onNegativeClicked(instanceTag: String) {
         // Unused
     }
 
-    private fun passRewindConfirmation(rewindId: String) {
+    private fun passRestoreConfirmation(rewindId: String) {
         val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
         if (fragment is ActivityLogListFragment) {
-            fragment.onRewindConfirmed(rewindId)
+            fragment.onRestoreConfirmed(rewindId)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -63,18 +63,22 @@ class ActivityLogListActivity : LocaleAwareActivity(),
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {
-            RequestCodes.ACTIVITY_LOG_DETAIL -> {
-                data?.getStringExtra(ACTIVITY_LOG_REWIND_ID_KEY)?.let {
-                    passRewindConfirmation(it)
-                }
-            }
-            RequestCodes.RESTORE -> {
-                val rewindId = data?.getStringExtra(KEY_RESTORE_REWIND_ID)
-                val restoreId = data?.getLongExtra(KEY_RESTORE_RESTORE_ID, 0)
-                if (rewindId != null && restoreId != null) {
-                    passQueryRestoreStatus(rewindId, restoreId)
-                }
-            }
+            RequestCodes.ACTIVITY_LOG_DETAIL -> onActivityResultForActivityLogDetails(data)
+            RequestCodes.RESTORE -> onActivityResultForRestore(data)
+        }
+    }
+
+    private fun onActivityResultForActivityLogDetails(data: Intent?) {
+        data?.getStringExtra(ACTIVITY_LOG_REWIND_ID_KEY)?.let {
+            passRewindConfirmation(it)
+        }
+    }
+
+    private fun onActivityResultForRestore(data: Intent?) {
+        val rewindId = data?.getStringExtra(KEY_RESTORE_REWIND_ID)
+        val restoreId = data?.getLongExtra(KEY_RESTORE_RESTORE_ID, 0)
+        if (rewindId != null && restoreId != null) {
+            passQueryRestoreStatus(rewindId, restoreId)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -62,15 +62,18 @@ class ActivityLogListActivity : LocaleAwareActivity(),
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == RequestCodes.ACTIVITY_LOG_DETAIL) {
-            data?.getStringExtra(ACTIVITY_LOG_REWIND_ID_KEY)?.let {
-                passRewindConfirmation(it)
+        when (requestCode) {
+            RequestCodes.ACTIVITY_LOG_DETAIL -> {
+                data?.getStringExtra(ACTIVITY_LOG_REWIND_ID_KEY)?.let {
+                    passRewindConfirmation(it)
+                }
             }
-        } else if (requestCode == RequestCodes.RESTORE) {
-            val rewindId = data?.getStringExtra(KEY_RESTORE_REWIND_ID)
-            val restoreId = data?.getLongExtra(KEY_RESTORE_RESTORE_ID, 0)
-            if (rewindId != null && restoreId != null) {
-                passQueryRestoreStatus(rewindId, restoreId)
+            RequestCodes.RESTORE -> {
+                val rewindId = data?.getStringExtra(KEY_RESTORE_REWIND_ID)
+                val restoreId = data?.getLongExtra(KEY_RESTORE_RESTORE_ID, 0)
+                if (rewindId != null && restoreId != null) {
+                    passQueryRestoreStatus(rewindId, restoreId)
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -9,6 +9,8 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.RequestCodes
+import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_RESTORE_ID
+import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_REWIND_ID
 import org.wordpress.android.ui.posts.BasicFragmentDialog
 import org.wordpress.android.util.config.BackupDownloadFeatureConfig
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_KEY
@@ -64,6 +66,12 @@ class ActivityLogListActivity : LocaleAwareActivity(),
             data?.getStringExtra(ACTIVITY_LOG_REWIND_ID_KEY)?.let {
                 passRewindConfirmation(it)
             }
+        } else if (requestCode == RequestCodes.RESTORE) {
+            val rewindId = data?.getStringExtra(KEY_RESTORE_REWIND_ID)
+            val restoreId = data?.getLongExtra(KEY_RESTORE_RESTORE_ID, 0)
+            if (rewindId != null && restoreId != null) {
+                passQueryRestoreStatus(rewindId, restoreId)
+            }
         }
     }
 
@@ -79,6 +87,13 @@ class ActivityLogListActivity : LocaleAwareActivity(),
         val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
         if (fragment is ActivityLogListFragment) {
             fragment.onRewindConfirmed(rewindId)
+        }
+    }
+
+    private fun passQueryRestoreStatus(rewindId: String, restoreId: Long) {
+        val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
+        if (fragment is ActivityLogListFragment) {
+            fragment.onQueryRestoreStatus(rewindId, restoreId)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -131,6 +131,10 @@ class ActivityLogListFragment : Fragment() {
         viewModel.onRestoreConfirmed(activityId)
     }
 
+    fun onQueryRestoreStatus(rewindId: String, restoreId: Long) {
+        viewModel.onQueryRestoreStatus(rewindId, restoreId)
+    }
+
     private fun setupObservers() {
         viewModel.events.observe(viewLifecycleOwner, {
             reloadEvents(it ?: emptyList())

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -127,7 +127,7 @@ class ActivityLogListFragment : Fragment() {
         super.onSaveInstanceState(outState)
     }
 
-    fun onRewindConfirmed(activityId: String) {
+    fun onRestoreConfirmed(activityId: String) {
         viewModel.onRestoreConfirmed(activityId)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -42,7 +42,6 @@ import javax.inject.Inject
 
 private const val ACTIVITY_TYPE_FILTER_TAG = "activity_log_type_filter_tag"
 private const val DATE_PICKER_TAG = "activity_log_date_picker_tag"
-private const val BACKUP_DOWNLOAD_REQUEST_CODE = 1710
 
 /**
  * It was decided to reuse the 'Activity Log' screen instead of creating a new 'Backup' screen. This was due to the
@@ -190,7 +189,7 @@ class ActivityLogListFragment : Fragment() {
                             requireActivity(),
                             viewModel.site,
                             event.activityId,
-                            BACKUP_DOWNLOAD_REQUEST_CODE
+                            RequestCodes.BACKUP_DOWNLOAD
                     )
                     is ShowRestore -> ActivityLauncher.showRestoreForResult(
                             requireActivity(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -144,7 +144,7 @@ class ActivityLogListFragment : Fragment() {
         viewModel.filtersUiState.observe(viewLifecycleOwner, { uiState ->
             uiHelpers.updateVisibility(requireActivity().filters_bar, uiState.visibility)
             uiHelpers.updateVisibility(requireActivity().filters_bar_divider, uiState.visibility)
-            if (uiState is FiltersShown) { updateFilters(uiState) }
+            if (uiState is FiltersShown) updateFilters(uiState)
         })
 
         viewModel.emptyUiState.observe(viewLifecycleOwner, { emptyState ->
@@ -190,12 +190,14 @@ class ActivityLogListFragment : Fragment() {
                             requireActivity(),
                             viewModel.site,
                             event.activityId,
-                            BACKUP_DOWNLOAD_REQUEST_CODE)
+                            BACKUP_DOWNLOAD_REQUEST_CODE
+                    )
                     is ShowRestore -> ActivityLauncher.showRestoreForResult(
                             requireActivity(),
                             viewModel.site,
                             event.activityId,
-                            RESTORE_REQUEST_CODE)
+                            RESTORE_REQUEST_CODE
+                    )
                     is ShowRewindDialog -> displayRewindDialog(event)
                 }
             }
@@ -205,11 +207,13 @@ class ActivityLogListFragment : Fragment() {
     private fun displayRewindDialog(item: ActivityLogListItem.Event) {
         val dialog = BasicFragmentDialog()
         item.rewindId?.let {
-            dialog.initialize(it,
+            dialog.initialize(
+                    it,
                     getString(R.string.activity_log_rewind_site),
                     getString(R.string.activity_log_rewind_dialog_message, item.formattedDate, item.formattedTime),
                     getString(R.string.activity_log_rewind_site),
-                    getString(R.string.cancel))
+                    getString(R.string.cancel)
+            )
             dialog.show(requireFragmentManager(), it)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowBackupDownload
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRestore
 import org.wordpress.android.ui.activitylog.ActivityLogNavigationEvents.ShowRewindDialog
@@ -42,7 +43,6 @@ import javax.inject.Inject
 private const val ACTIVITY_TYPE_FILTER_TAG = "activity_log_type_filter_tag"
 private const val DATE_PICKER_TAG = "activity_log_date_picker_tag"
 private const val BACKUP_DOWNLOAD_REQUEST_CODE = 1710
-private const val RESTORE_REQUEST_CODE = 1720
 
 /**
  * It was decided to reuse the 'Activity Log' screen instead of creating a new 'Backup' screen. This was due to the
@@ -196,7 +196,7 @@ class ActivityLogListFragment : Fragment() {
                             requireActivity(),
                             viewModel.site,
                             event.activityId,
-                            RESTORE_REQUEST_CODE
+                            RequestCodes.RESTORE
                     )
                     is ShowRewindDialog -> displayRewindDialog(event)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
@@ -125,11 +125,10 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
                 }
                 intent.putExtra(KEY_RESTORE_REWIND_ID, ids?.first)
                 intent.putExtra(KEY_RESTORE_RESTORE_ID, ids?.second)
-                requireActivity().setResult(
-                        if (restoreCreated) RESULT_OK else RESULT_CANCELED,
-                        intent
-                )
-                requireActivity().finish()
+                requireActivity().let { activity ->
+                    activity.setResult(if (restoreCreated) RESULT_OK else RESULT_CANCELED, intent)
+                    activity.finish()
+                }
             }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
 
+const val KEY_RESTORE_REWIND_ID = "key_restore_rewind_id"
 const val KEY_RESTORE_RESTORE_ID = "key_restore_restore_id"
 
 class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
@@ -117,12 +118,13 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
         viewModel.wizardFinishedObservable.observe(viewLifecycleOwner, {
             it.applyIfNotHandled {
                 val intent = Intent()
-                val (restoreCreated, restoreId) = when (this) {
+                val (restoreCreated, ids) = when (this) {
                     is RestoreCanceled -> Pair(false, null)
-                    is RestoreInProgress -> Pair(true, restoreId)
+                    is RestoreInProgress -> Pair(true, Pair(rewindId, restoreId))
                     is RestoreCompleted -> Pair(true, null)
                 }
-                intent.putExtra(KEY_RESTORE_RESTORE_ID, restoreId)
+                intent.putExtra(KEY_RESTORE_REWIND_ID, ids?.first)
+                intent.putExtra(KEY_RESTORE_RESTORE_ID, ids?.second)
                 requireActivity().setResult(
                         if (restoreCreated) RESULT_OK else RESULT_CANCELED,
                         intent

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -142,16 +142,16 @@ class RestoreViewModel @Inject constructor(
         when (wizardManager.currentStep) {
             DETAILS.id -> { _wizardFinishedObservable.value = Event(RestoreCanceled) }
             WARNING.id -> { _wizardFinishedObservable.value = Event(RestoreCanceled) }
-            PROGRESS.id -> {
-                _wizardFinishedObservable.value = if (restoreState.restoreId != null) {
-                    Event(RestoreInProgress(restoreState.restoreId as Long))
-                } else {
-                    Event(RestoreCanceled)
-                }
-            }
+            PROGRESS.id -> { _wizardFinishedObservable.value = constructProgressEvent() }
             COMPLETE.id -> { _wizardFinishedObservable.value = Event(RestoreCompleted) }
             ERROR.id -> { _wizardFinishedObservable.value = Event(RestoreCanceled) }
         }
+    }
+
+    private fun constructProgressEvent() = if (restoreState.restoreId != null) {
+        Event(RestoreInProgress(restoreState.restoreId as Long))
+    } else {
+        Event(RestoreCanceled)
     }
 
     fun writeToBundle(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -140,11 +140,11 @@ class RestoreViewModel @Inject constructor(
 
     fun onBackPressed() {
         when (wizardManager.currentStep) {
-            DETAILS.id -> { _wizardFinishedObservable.value = Event(RestoreCanceled) }
-            WARNING.id -> { _wizardFinishedObservable.value = Event(RestoreCanceled) }
-            PROGRESS.id -> { _wizardFinishedObservable.value = constructProgressEvent() }
-            COMPLETE.id -> { _wizardFinishedObservable.value = Event(RestoreCompleted) }
-            ERROR.id -> { _wizardFinishedObservable.value = Event(RestoreCanceled) }
+            DETAILS.id -> _wizardFinishedObservable.value = Event(RestoreCanceled)
+            WARNING.id -> _wizardFinishedObservable.value = Event(RestoreCanceled)
+            PROGRESS.id -> _wizardFinishedObservable.value = constructProgressEvent()
+            COMPLETE.id -> _wizardFinishedObservable.value = Event(RestoreCompleted)
+            ERROR.id -> _wizardFinishedObservable.value = Event(RestoreCanceled)
         }
     }
 
@@ -231,11 +231,7 @@ class RestoreViewModel @Inject constructor(
             WARNING -> buildWarning()
             PROGRESS -> buildProgress()
             COMPLETE -> buildComplete()
-            ERROR -> buildError(
-                    RestoreErrorTypes.fromInt(
-                            target.wizardState.errorType ?: GenericFailure.id
-                    )
-            )
+            ERROR -> buildError(RestoreErrorTypes.fromInt(target.wizardState.errorType ?: GenericFailure.id))
         }
     }
 
@@ -279,21 +275,11 @@ class RestoreViewModel @Inject constructor(
 
     private fun handleRestoreRequestResult(result: RestoreRequestState) {
         when (result) {
-            is NetworkUnavailable -> {
-                handleRestoreRequestError(NetworkUnavailableMsg)
-            }
-            is RemoteRequestFailure -> {
-                handleRestoreRequestError(GenericFailureMsg)
-            }
-            is Success -> {
-                handleRestoreRequestSuccess(result)
-            }
-            is OtherRequestRunning -> {
-                handleRestoreRequestError(OtherRequestRunningMsg)
-            }
-            else -> {
-                throw Throwable("Unexpected restoreRequestResult ${this.javaClass.simpleName}")
-            }
+            is NetworkUnavailable -> handleRestoreRequestError(NetworkUnavailableMsg)
+            is RemoteRequestFailure -> handleRestoreRequestError(GenericFailureMsg)
+            is Success -> handleRestoreRequestSuccess(result)
+            is OtherRequestRunning -> handleRestoreRequestError(OtherRequestRunningMsg)
+            else -> throw Throwable("Unexpected restoreRequestResult ${this.javaClass.simpleName}")
         }
     }
 
@@ -324,13 +310,11 @@ class RestoreViewModel @Inject constructor(
 
     private fun handleQueryStatus(restoreStatus: RestoreRequestState) {
         when (restoreStatus) {
-            is NetworkUnavailable -> { transitionToError(RestoreErrorTypes.NetworkUnavailable) }
-            is RemoteRequestFailure -> { transitionToError(RestoreErrorTypes.RemoteRequestFailure) }
-            is Progress -> { transitionToProgress(restoreStatus) }
-            is Complete -> { wizardManager.showNextStep() }
-            else -> {
-                throw Throwable("Unexpected queryStatus result ${this.javaClass.simpleName}")
-            }
+            is NetworkUnavailable -> transitionToError(RestoreErrorTypes.NetworkUnavailable)
+            is RemoteRequestFailure -> transitionToError(RestoreErrorTypes.RemoteRequestFailure)
+            is Progress -> transitionToProgress(restoreStatus)
+            is Complete -> wizardManager.showNextStep()
+            else -> throw Throwable("Unexpected queryStatus result ${this.javaClass.simpleName}")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -286,11 +286,7 @@ class RestoreViewModel @Inject constructor(
                 handleRestoreRequestError(GenericFailureMsg)
             }
             is Success -> {
-                restoreState = restoreState.copy(
-                        rewindId = result.rewindId,
-                        restoreId = result.restoreId
-                )
-                wizardManager.showNextStep()
+                handleRestoreRequestSuccess(result)
             }
             is OtherRequestRunning -> {
                 handleRestoreRequestError(OtherRequestRunningMsg)
@@ -299,6 +295,14 @@ class RestoreViewModel @Inject constructor(
                 throw Throwable("Unexpected restoreRequestResult ${this.javaClass.simpleName}")
             }
         }
+    }
+
+    private fun handleRestoreRequestSuccess(result: Success) {
+        restoreState = restoreState.copy(
+                rewindId = result.rewindId,
+                restoreId = result.restoreId
+        )
+        wizardManager.showNextStep()
     }
 
     private fun handleRestoreRequestError(snackbarMessageHolder: SnackbarMessageHolder) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -149,7 +149,12 @@ class RestoreViewModel @Inject constructor(
     }
 
     private fun constructProgressEvent() = if (restoreState.restoreId != null) {
-        Event(RestoreInProgress(restoreState.restoreId as Long))
+        Event(
+                RestoreInProgress(
+                        restoreState.rewindId as String,
+                        restoreState.restoreId as Long
+                )
+        )
     } else {
         Event(RestoreCanceled)
     }
@@ -417,7 +422,12 @@ class RestoreViewModel @Inject constructor(
     }
 
     private fun onNotifyMeClick() {
-        _wizardFinishedObservable.value = Event(RestoreInProgress(restoreState.restoreId as Long))
+        _wizardFinishedObservable.value = Event(
+                RestoreInProgress(
+                        restoreState.rewindId as String,
+                        restoreState.restoreId as Long
+                )
+        )
     }
 
     private fun onVisitSiteClick() {
@@ -444,7 +454,10 @@ class RestoreViewModel @Inject constructor(
         object RestoreCanceled : RestoreWizardState()
 
         @Parcelize
-        data class RestoreInProgress(val restoreId: Long) : RestoreWizardState()
+        data class RestoreInProgress(
+            val rewindId: String,
+            val restoreId: Long
+        ) : RestoreWizardState()
 
         @Parcelize
         object RestoreCompleted : RestoreWizardState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -326,40 +326,42 @@ class RestoreViewModel @Inject constructor(
         when (restoreStatus) {
             is NetworkUnavailable -> { transitionToError(RestoreErrorTypes.NetworkUnavailable) }
             is RemoteRequestFailure -> { transitionToError(RestoreErrorTypes.RemoteRequestFailure) }
-            is Progress -> {
-                (_uiState.value as? ProgressState)?.let { content ->
-                    val updatedList = content.items.map { contentState ->
-                        if (contentState.type == ViewType.PROGRESS) {
-                            contentState as JetpackListItemState.ProgressState
-                            contentState.copy(
-                                    progress = restoreStatus.progress ?: 0,
-                                    progressLabel = UiStringResWithParams(
-                                            R.string.restore_progress_label,
-                                            listOf(UiStringText(restoreStatus.progress?.toString() ?: "0"))
-                                    ),
-                                    progressInfoLabel = if (restoreStatus.currentEntry != null) {
-                                            UiStringText("${restoreStatus.currentEntry}")
-                                        } else {
-                                            null
-                                        },
-                                    progressStateLabel = if (restoreStatus.message != null) {
-                                        UiStringText("${restoreStatus.message}")
-                                    } else {
-                                        null
-                                    },
-                                    isIndeterminate = (restoreStatus.progress ?: 0) <= 0
-                            )
-                        } else {
-                            contentState
-                        }
-                    }
-                    _uiState.postValue(content.copy(items = updatedList))
-                }
-            }
+            is Progress -> { transitionToProgress(restoreStatus) }
             is Complete -> { wizardManager.showNextStep() }
             else -> {
                 throw Throwable("Unexpected queryStatus result ${this.javaClass.simpleName}")
             }
+        }
+    }
+
+    private fun transitionToProgress(restoreStatus: Progress) {
+        (_uiState.value as? ProgressState)?.let { content ->
+            val updatedList = content.items.map { contentState ->
+                if (contentState.type == ViewType.PROGRESS) {
+                    contentState as JetpackListItemState.ProgressState
+                    contentState.copy(
+                            progress = restoreStatus.progress ?: 0,
+                            progressLabel = UiStringResWithParams(
+                                    R.string.restore_progress_label,
+                                    listOf(UiStringText(restoreStatus.progress?.toString() ?: "0"))
+                            ),
+                            progressInfoLabel = if (restoreStatus.currentEntry != null) {
+                                UiStringText("${restoreStatus.currentEntry}")
+                            } else {
+                                null
+                            },
+                            progressStateLabel = if (restoreStatus.message != null) {
+                                UiStringText("${restoreStatus.message}")
+                            } else {
+                                null
+                            },
+                            isIndeterminate = (restoreStatus.progress ?: 0) <= 0
+                    )
+                } else {
+                    contentState
+                }
+            }
+            _uiState.postValue(content.copy(items = updatedList))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -250,10 +250,13 @@ class RestoreViewModel @Inject constructor(
 
     private fun buildOptionsSelected(items: List<JetpackListItemState>): List<Pair<Int, Boolean>> {
         val checkboxes = items.filterIsInstance(CheckboxState::class.java)
-        return listOf(Pair(THEMES.id, checkboxes.firstOrNull { it.availableItemType == THEMES }?.checked ?: true),
+        return listOf(
+                Pair(THEMES.id, checkboxes.firstOrNull { it.availableItemType == THEMES }?.checked ?: true),
                 Pair(PLUGINS.id, checkboxes.firstOrNull { it.availableItemType == PLUGINS }?.checked ?: true),
-                Pair(MEDIA_UPLOADS.id, checkboxes.firstOrNull { it.availableItemType == MEDIA_UPLOADS }?.checked
-                        ?: true),
+                Pair(
+                        MEDIA_UPLOADS.id, checkboxes.firstOrNull { it.availableItemType == MEDIA_UPLOADS }?.checked
+                        ?: true
+                ),
                 Pair(SQLS.id, checkboxes.firstOrNull { it.availableItemType == SQLS }?.checked ?: true),
                 Pair(ROOTS.id, checkboxes.firstOrNull { it.availableItemType == ROOTS }?.checked ?: true),
                 Pair(CONTENTS.id, checkboxes.firstOrNull { it.availableItemType == CONTENTS }?.checked ?: true)
@@ -261,17 +264,17 @@ class RestoreViewModel @Inject constructor(
     }
 
     private fun buildRewindRequestTypes(optionsSelected: List<Pair<Int, Boolean>>?) =
-        RewindRequestTypes(
-                themes = optionsSelected?.firstOrNull { it.first == THEMES.id }?.second ?: true,
-                plugins = optionsSelected?.firstOrNull { it.first == PLUGINS.id }?.second
-                        ?: true,
-                uploads = optionsSelected?.firstOrNull { it.first == MEDIA_UPLOADS.id }?.second
-                        ?: true,
-                sqls = optionsSelected?.firstOrNull { it.first == SQLS.id }?.second ?: true,
-                roots = optionsSelected?.firstOrNull { it.first == ROOTS.id }?.second ?: true,
-                contents = optionsSelected?.firstOrNull { it.first == CONTENTS.id }?.second
-                        ?: true
-        )
+            RewindRequestTypes(
+                    themes = optionsSelected?.firstOrNull { it.first == THEMES.id }?.second ?: true,
+                    plugins = optionsSelected?.firstOrNull { it.first == PLUGINS.id }?.second
+                            ?: true,
+                    uploads = optionsSelected?.firstOrNull { it.first == MEDIA_UPLOADS.id }?.second
+                            ?: true,
+                    sqls = optionsSelected?.firstOrNull { it.first == SQLS.id }?.second ?: true,
+                    roots = optionsSelected?.firstOrNull { it.first == ROOTS.id }?.second ?: true,
+                    contents = optionsSelected?.firstOrNull { it.first == CONTENTS.id }?.second
+                            ?: true
+            )
 
     private fun handleRestoreRequestResult(result: RestoreRequestState) {
         when (result) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -498,7 +498,8 @@ class ActivityLogViewModel @Inject constructor(
     }
 
     fun onQueryRestoreStatus(rewindId: String, restoreId: Long) {
-        // TODO: Continue here...
+        queryRestoreStatus(restoreId)
+        showRestoreStartedMessage(rewindId)
     }
 
     private fun handleRestoreRequest(state: RestoreRequestState) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -497,6 +497,10 @@ class ActivityLogViewModel @Inject constructor(
         showRestoreStartedMessage(rewindId)
     }
 
+    fun onQueryRestoreStatus(rewindId: String, restoreId: Long) {
+        // TODO: Continue here...
+    }
+
     private fun handleRestoreRequest(state: RestoreRequestState) {
         when (state) {
             is RestoreRequestState.Success -> state.restoreId?.let { queryRestoreStatus(it) }


### PR DESCRIPTION
Parent #13328

This PR connects the restore flow with the activity log/backup screens. This means that this PR makes sure that when a user presses the `Ok, notify me!` button or presses/swipes back (triggering the `onBackPressed()`), while restore is in progress from within the restore screen, then a restore progress row appears on the activity log screen immediately. Before, a user would had to do a manual re-launch or pull-to-refresh on the activity log/backup screen to get the progress row appear.

To test:
* Open app and go to `My Site` tab,
* Go to `My Site` -> `Toolbar Avatar` -> `App Settings` -> `Test feature configuration`.
* Enable `RestoreFeatureConfig`, scroll down and click the `RESTART THE APP` button. 
* Launch `Activity Log` screen,
* Find a rewindable item from the list, click on the ellipsis menu item and select `Restore to this point` to launch the `Restore` screen,
* Click the `Restore site` button. On the confirmation screen, click on the `Confirm restore site` button.
* Click the `Ok, notify me!` or navigate back manually (by clicking the `X` toolbar button or pressing/swiping back).
* You should automatically be navigated back to the `Activity Log` screen and a restore status will be triggered,
* The restore progress item should immediately appears. Make sure the restore timestamp is available on this progress item.
* A snackbar should immediately appear informing that the restore just started. Make sure the restore timestamp is available on the snackbar.
* Make sure the ellipsis menu item, for every rewindable item, is not shown while restore progress is ongoing.
* Wait for restore to finish while having the `Activity Log` screen open both, within the app and the web (so you can see the actual progress),
* When restore finishes (looking on the web), a restore (push) notification should appears.
* Then, the restore progress item should disappear (after at least 5'' seconds, due to the while loop check status delay).
* A pull-to-refresh should be automatically triggered and a new restore item might (or might not) appear (depending on how fast the restore progress item disappears and how fast this new item becomes available on the backend, via the `activityLogStore.fetchActivities(...)` API call). In case the new restore item does not appear, wait a bit (maybe 10'' seconds) and trigger a manual pull-to-refresh. Verify that the new restore item appears after some time.
* A snackbar should immediately appear informing that the restore just completed. Make sure the restore timestamp is available on the snackbar.
* Make sure the ellipsis menu items, for every rewindable item, is now shown again.

PS: As always, I suggest doing a commit-by-commit review, from within the IDE, as this will make it much easier for you to review the overall solution. If you need to focus on the feature itself and not the refactor or tests filter the commits by `Feature` to get a quick overall.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
