### PR TITLE
Issue/13326 scan full screen loading & error handling

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -172,7 +172,8 @@ class HelpActivity : LocaleAwareActivity() {
         SITE_CREATION_SEGMENTS("origin:site-create-site-segments"),
         SITE_CREATION_VERTICALS("origin:site-create-site-verticals"),
         SITE_CREATION_DOMAINS("origin:site-create-domains"),
-        SITE_CREATION_SITE_INFO("origin:site-create-site-info");
+        SITE_CREATION_SITE_INFO("origin:site-create-site-info"),
+        SCAN_SCREEN_HELP("origin:scan-screen-help");
 
         override fun toString(): String {
             return stringValue

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -49,6 +49,7 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         recycler_view.addItemDecoration(
             HorizontalMarginItemDecoration(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
         )
+        recycler_view.setEmptyView(actionable_empty_view)
         initAdapter()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -45,15 +45,15 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
     }
 
     private fun initRecyclerView() {
+        recycler_view.itemAnimator = null
+        recycler_view.addItemDecoration(
+            HorizontalMarginItemDecoration(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
+        )
         initAdapter()
     }
 
     private fun initAdapter() {
         recycler_view.adapter = ScanAdapter(imageManager, uiHelpers)
-        recycler_view.itemAnimator = null
-        recycler_view.addItemDecoration(
-            HorizontalMarginItemDecoration(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
-        )
     }
 
     private fun initViewModel(site: SiteModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -77,7 +77,8 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
                     is FullScreenLoadingUiState -> updateFullScreenLoadingLayout(uiState)
 
                     is ErrorUiState.NoConnection,
-                    is ErrorUiState.GenericRequestFailed -> updateErrorLayout(uiState as ErrorUiState)
+                    is ErrorUiState.GenericRequestFailed,
+                    is ErrorUiState.StartScanRequestFailed -> updateErrorLayout(uiState as ErrorUiState)
                 }
             }
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreatsConfirmationDialog
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ContentUiState
+import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.FullScreenLoadingUiState
 import org.wordpress.android.ui.jetpack.scan.adapters.HorizontalMarginItemDecoration
 import org.wordpress.android.ui.jetpack.scan.adapters.ScanAdapter
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsFragment
@@ -67,8 +68,9 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         viewModel.uiState.observe(
             viewLifecycleOwner,
             { uiState ->
-                if (uiState is ContentUiState) {
-                    updateContentLayout(uiState)
+                when (uiState) {
+                    is ContentUiState -> updateContentLayout(uiState)
+                    is FullScreenLoadingUiState -> updateFullScreenLoadingLayout(uiState)
                 }
             }
         )
@@ -89,6 +91,11 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
                 }
             }
         )
+    }
+
+    private fun updateFullScreenLoadingLayout(state: FullScreenLoadingUiState) {
+        uiHelpers.setTextOrHide(actionable_empty_view.title, state.title)
+        actionable_empty_view.image.setImageResource(state.image)
     }
 
     private fun updateContentLayout(state: ContentUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -16,7 +16,7 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreatsConfirmationDialog
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
-import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.Content
+import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ContentUiState
 import org.wordpress.android.ui.jetpack.scan.adapters.HorizontalMarginItemDecoration
 import org.wordpress.android.ui.jetpack.scan.adapters.ScanAdapter
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsFragment
@@ -67,8 +67,8 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         viewModel.uiState.observe(
             viewLifecycleOwner,
             { uiState ->
-                if (uiState is Content) {
-                    refreshContentScreen(uiState)
+                if (uiState is ContentUiState) {
+                    updateContentLayout(uiState)
                 }
             }
         )
@@ -91,8 +91,8 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         )
     }
 
-    private fun refreshContentScreen(content: Content) {
-        ((recycler_view.adapter) as ScanAdapter).update(content.items)
+    private fun updateContentLayout(state: ContentUiState) {
+        ((recycler_view.adapter) as ScanAdapter).update(state.items)
     }
 
     private fun SnackbarMessageHolder.showSnackbar() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -71,10 +71,15 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         viewModel.uiState.observe(
             viewLifecycleOwner,
             { uiState ->
+                uiHelpers.updateVisibility(progress_bar, uiState.loadingVisible)
+                uiHelpers.updateVisibility(recycler_view, uiState.contentVisible)
+                uiHelpers.updateVisibility(actionable_empty_view, uiState.errorVisible)
+
                 when (uiState) {
                     is ContentUiState -> updateContentLayout(uiState)
 
-                    is FullScreenLoadingUiState -> updateFullScreenLoadingLayout(uiState)
+                    is FullScreenLoadingUiState -> { // Do Nothing
+                    }
 
                     is ErrorUiState.NoConnection,
                     is ErrorUiState.GenericRequestFailed,
@@ -102,11 +107,6 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
                 }
             }
         )
-    }
-
-    private fun updateFullScreenLoadingLayout(state: FullScreenLoadingUiState) {
-        uiHelpers.setTextOrHide(actionable_empty_view.title, state.title)
-        actionable_empty_view.image.setImageResource(state.image)
     }
 
     private fun updateContentLayout(state: ContentUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanNavigationEvents.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.jetpack.scan
 
 import androidx.annotation.StringRes
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.utils.UiString
 
 sealed class ScanNavigationEvents {
@@ -15,4 +16,6 @@ sealed class ScanNavigationEvents {
         @StringRes val positiveButtonLabel: Int = R.string.dialog_button_ok
         @StringRes val negativeButtonLabel: Int = R.string.dialog_button_cancel
     }
+
+    data class ShowContactSupport(val site: SiteModel) : ScanNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -120,8 +120,16 @@ class ScanViewModel @Inject constructor(
                 .collect { state ->
                     when (state) {
                         is StartScanState.ScanningStateUpdatedInDb -> updateUiState(buildContentUiState(state.model))
+
                         is StartScanState.Success -> fetchScanState(startWithDelay = true)
-                        is StartScanState.Failure -> TODO() // TODO ashiagr to be implemented
+
+                        is StartScanState.Failure.NetworkUnavailable ->
+                            updateSnackbarMessageEvent(UiStringRes(R.string.error_generic_network))
+
+                        is StartScanState.Failure.RemoteRequestFailure -> {
+                            updateUiState(ContentUiState(emptyList()))
+                            updateUiState(ErrorUiState.StartScanRequestFailed(::onContactSupportClicked))
+                        }
                     }
                 }
         }
@@ -309,6 +317,13 @@ class ScanViewModel @Inject constructor(
                 @DrawableRes override val image = R.drawable.img_illustration_cloud_off_152dp
                 override val title = UiStringRes(R.string.scan_request_failed_title)
                 override val subtitle = UiStringRes(R.string.scan_request_failed_subtitle)
+                override val buttonText = UiStringRes(R.string.contact_support)
+            }
+
+            data class StartScanRequestFailed(override val action: () -> Unit) : ErrorUiState() {
+                @DrawableRes override val image = R.drawable.img_illustration_empty_results_216dp
+                override val title = UiStringRes(R.string.scan_start_request_failed_title)
+                override val subtitle = UiStringRes(R.string.scan_start_request_failed_subtitle)
                 override val buttonText = UiStringRes(R.string.contact_support)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButton
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ProgressState
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreatsConfirmationDialog
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
-import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.Content
+import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ContentUiState
 import org.wordpress.android.ui.jetpack.scan.builders.ScanStateListItemsBuilder
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState
@@ -209,7 +209,7 @@ class ScanViewModel @Inject constructor(
     }
 
     private fun updateActionButtons(isVisible: Boolean) {
-        (_uiState.value as? Content)?.let { content ->
+        (_uiState.value as? ContentUiState)?.let { content ->
             val updatesContentItems = content.items.map { contentItem ->
                 if (contentItem is ActionButtonState) {
                     contentItem.copy(isVisible = isVisible)
@@ -222,7 +222,7 @@ class ScanViewModel @Inject constructor(
     }
 
     private fun updateFixThreatsStatusProgressBar(fixingThreatIds: List<Long>) {
-        (_uiState.value as? Content)?.let { content ->
+        (_uiState.value as? ContentUiState)?.let { content ->
             val updatesContentItems = content.items.map { contentItem ->
                 if (contentItem is ProgressState && contentItem.isIndeterminate) {
                     contentItem.copy(
@@ -248,11 +248,11 @@ class ScanViewModel @Inject constructor(
         _navigationEvents.value = Event(navigationEvent)
     }
 
-    private fun updateUiState(contentState: Content) {
-        _uiState.value = contentState
+    private fun updateUiState(state: UiState) {
+        _uiState.value = state
     }
 
-    private fun buildContentUiState(model: ScanStateModel) = Content(
+    private fun buildContentUiState(model: ScanStateModel) = ContentUiState(
         scanStateListItemsBuilder.buildScanStateListItems(
             model,
             site,
@@ -263,6 +263,6 @@ class ScanViewModel @Inject constructor(
     )
 
     sealed class UiState { // TODO: ashiagr add states for loading, error as needed
-        data class Content(val items: List<JetpackListItemState>) : UiState()
+        data class ContentUiState(val items: List<JetpackListItemState>) : UiState()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
@@ -40,6 +41,8 @@ import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
+
+const val RETRY_DELAY = 300L
 
 class ScanViewModel @Inject constructor(
     private val scanStateListItemsBuilder: ScanStateListItemsBuilder,
@@ -85,13 +88,16 @@ class ScanViewModel @Inject constructor(
             scanStateModel?.let {
                 updateUiState(buildContentUiState(it))
                 if (fixableThreatIds.isNotEmpty()) fetchFixThreatsStatus(fixableThreatIds)
-            } ?: updateUiState(FullScreenLoadingUiState)
+            }
             fetchScanState()
         }
     }
 
-    private fun fetchScanState(startWithDelay: Boolean = false) {
+    private fun fetchScanState(startWithDelay: Boolean = false, isRetry: Boolean = false) {
         launch {
+            if (scanStateModel == null) updateUiState(FullScreenLoadingUiState)
+            if (isRetry) delay(RETRY_DELAY)
+
             fetchScanStateUseCase.fetchScanState(site = site, startWithDelay = startWithDelay)
                 .collect { state ->
                     when (state) {
@@ -197,7 +203,7 @@ class ScanViewModel @Inject constructor(
     }
 
     private fun onRetryClicked() {
-        fetchScanState()
+        fetchScanState(isRetry = true)
     }
 
     private fun onContactSupportClicked() {
@@ -291,15 +297,16 @@ class ScanViewModel @Inject constructor(
         )
     )
 
-    sealed class UiState {
-        object FullScreenLoadingUiState : UiState() {
-            @DrawableRes val image = R.drawable.img_illustration_empty_results_216dp
-            val title = UiStringRes(R.string.scan_loading_title)
-        }
+    sealed class UiState(
+        val loadingVisible: Boolean = false,
+        val contentVisible: Boolean = false,
+        val errorVisible: Boolean = false
+    ) {
+        object FullScreenLoadingUiState : UiState(loadingVisible = true)
 
-        data class ContentUiState(val items: List<JetpackListItemState>) : UiState()
+        data class ContentUiState(val items: List<JetpackListItemState>) : UiState(contentVisible = true)
 
-        sealed class ErrorUiState : UiState() {
+        sealed class ErrorUiState : UiState(errorVisible = true) {
             abstract val image: Int
             abstract val title: UiString
             abstract val subtitle: UiString

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.jetpack.scan
 
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
@@ -18,6 +19,7 @@ import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ProgressStat
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreatsConfirmationDialog
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ContentUiState
+import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.FullScreenLoadingUiState
 import org.wordpress.android.ui.jetpack.scan.builders.ScanStateListItemsBuilder
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState
@@ -81,7 +83,7 @@ class ScanViewModel @Inject constructor(
             scanStateModel?.let {
                 updateUiState(buildContentUiState(it))
                 if (fixableThreatIds.isNotEmpty()) fetchFixThreatsStatus(fixableThreatIds)
-            }
+            } ?: updateUiState(FullScreenLoadingUiState)
             fetchScanState()
         }
     }
@@ -262,7 +264,12 @@ class ScanViewModel @Inject constructor(
         )
     )
 
-    sealed class UiState { // TODO: ashiagr add states for loading, error as needed
+    sealed class UiState {
+        object FullScreenLoadingUiState : UiState() {
+            @DrawableRes val image = R.drawable.img_illustration_empty_results_216dp
+            val title = UiStringRes(R.string.scan_loading_title)
+        }
+
         data class ContentUiState(val items: List<JetpackListItemState>) : UiState()
     }
 }

--- a/WordPress/src/main/res/layout/scan_fragment.xml
+++ b/WordPress/src/main/res/layout/scan_fragment.xml
@@ -26,5 +26,14 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"/>
 
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/WordPress/src/main/res/layout/scan_fragment.xml
+++ b/WordPress/src/main/res/layout/scan_fragment.xml
@@ -2,9 +2,19 @@
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/scan_state_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <org.wordpress.android.ui.ActionableEmptyView
+        android:id="@+id/actionable_empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        app:aevImage="@drawable/img_illustration_empty_results_216dp"
+        app:aevTitle="@string/loading"
+        tools:visibility="visible" />
 
     <org.wordpress.android.ui.prefs.EmptyViewRecyclerView
         android:id="@+id/recycler_view"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1061,10 +1061,10 @@
     <string name="scan_history">Scan History</string>
     <string name="scan_history_menu_title">History</string>
 
-    <string name="scan_loading_title">Loading scan</string>
+    <string name="scan_loading_title">Loading scan…</string>
     <string name="scan_no_network_title" translatable="false">@string/no_network_title</string>
     <string name="scan_no_network_subtitle" translatable="false">@string/no_network_message</string>
-    <string name="scan_request_failed_title" translatable="false">Something went wrong</string>
+    <string name="scan_request_failed_title">Something went wrong</string>
     <string name="scan_request_failed_subtitle" translatable="false">@string/request_failed_message</string>
     <string name="scan_start_request_failed_title" translatable="false">@string/scan_request_failed_title</string>
     <string name="scan_start_request_failed_subtitle">Jetpack Scan couldn\'t complete a scan of your site. Please check to see if your site is down – if it\'s not, try again. If it is, or if Jetpack Scan is still having problems, contact our support team.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1062,6 +1062,10 @@
     <string name="scan_history_menu_title">History</string>
 
     <string name="scan_loading_title">Loading scan</string>
+    <string name="scan_no_network_title" translatable="false">@string/no_network_title</string>
+    <string name="scan_no_network_subtitle" translatable="false">@string/no_network_message</string>
+    <string name="scan_request_failed_title" translatable="false">@string/error</string>
+    <string name="scan_request_failed_subtitle" translatable="false">@string/request_failed_message</string>
 
     <string name="scan_state_icon">Scan state icon</string>
     <string name="scan_now">Scan now</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1064,8 +1064,10 @@
     <string name="scan_loading_title">Loading scan</string>
     <string name="scan_no_network_title" translatable="false">@string/no_network_title</string>
     <string name="scan_no_network_subtitle" translatable="false">@string/no_network_message</string>
-    <string name="scan_request_failed_title" translatable="false">@string/error</string>
+    <string name="scan_request_failed_title" translatable="false">Something went wrong</string>
     <string name="scan_request_failed_subtitle" translatable="false">@string/request_failed_message</string>
+    <string name="scan_start_request_failed_title" translatable="false">@string/scan_request_failed_title</string>
+    <string name="scan_start_request_failed_subtitle">Jetpack Scan couldn\'t complete a scan of your site. Please check to see if your site is down – if it\'s not, try again. If it is, or if Jetpack Scan is still having problems, contact our support team.</string>
 
     <string name="scan_state_icon">Scan state icon</string>
     <string name="scan_now">Scan now</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1061,6 +1061,8 @@
     <string name="scan_history">Scan History</string>
     <string name="scan_history_menu_title">History</string>
 
+    <string name="scan_loading_title">Loading scan</string>
+
     <string name="scan_state_icon">Scan state icon</string>
     <string name="scan_now">Scan now</string>
     <string name="scan_again">Scan again</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1061,7 +1061,6 @@
     <string name="scan_history">Scan History</string>
     <string name="scan_history_menu_title">History</string>
 
-    <string name="scan_loading_title">Loading scan…</string>
     <string name="scan_no_network_title" translatable="false">@string/no_network_title</string>
     <string name="scan_no_network_subtitle" translatable="false">@string/no_network_message</string>
     <string name="scan_request_failed_title">Something went wrong</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreats
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ContentUiState
+import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.FullScreenLoadingUiState
 import org.wordpress.android.ui.jetpack.scan.builders.ScanStateListItemsBuilder
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState
@@ -87,6 +88,18 @@ class ScanViewModelTest : BaseUnitTest() {
         whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any())).thenReturn(
             flowOf(FetchFixThreatsState.Complete)
         )
+    }
+
+    @Test
+    fun `given last scan state not present in db, when vm starts, then loading scan state is displayed`() = test {
+        whenever(scanStore.getScanStateForSite(site)).thenReturn(null)
+        val uiStates = init().uiStates
+
+        val state = uiStates.first() as FullScreenLoadingUiState
+        with(state) {
+            assertThat(image).isEqualTo(R.drawable.img_illustration_empty_results_216dp)
+            assertThat(title).isEqualTo(UiStringRes(R.string.scan_loading_title))
+        }
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -24,7 +24,7 @@ import org.wordpress.android.ui.jetpack.scan.ScanListItemState.ThreatItemState
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreatsConfirmationDialog
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState
-import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.Content
+import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.ContentUiState
 import org.wordpress.android.ui.jetpack.scan.builders.ScanStateListItemsBuilder
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase
 import org.wordpress.android.ui.jetpack.scan.usecases.FetchFixThreatsStatusUseCase.FetchFixThreatsState
@@ -112,14 +112,14 @@ class ScanViewModelTest : BaseUnitTest() {
     fun `when scan state is fetched successfully, then ui is updated with content`() = test {
         val uiStates = init().uiStates
 
-        assertThat(uiStates.last()).isInstanceOf(Content::class.java)
+        assertThat(uiStates.last()).isInstanceOf(ContentUiState::class.java)
     }
 
     @Test
     fun `when threat item is clicked, then app navigates to threat details`() = test {
         val observers = init()
 
-        (observers.uiStates.last() as Content).items.filterIsInstance<ThreatItemState>().first().onClick.invoke()
+        (observers.uiStates.last() as ContentUiState).items.filterIsInstance<ThreatItemState>().first().onClick.invoke()
 
         assertThat(observers.navigation.last().peekContent()).isInstanceOf(ShowThreatDetails::class.java)
     }
@@ -129,7 +129,7 @@ class ScanViewModelTest : BaseUnitTest() {
         whenever(startScanUseCase.startScan(any())).thenReturn(flowOf(ScanningStateUpdatedInDb(fakeScanStateModel)))
         val uiStates = init().uiStates
 
-        (uiStates.last() as Content).items.filterIsInstance<ActionButtonState>().first().onClick.invoke()
+        (uiStates.last() as ContentUiState).items.filterIsInstance<ActionButtonState>().first().onClick.invoke()
 
         verify(startScanUseCase).startScan(site)
     }
@@ -142,9 +142,9 @@ class ScanViewModelTest : BaseUnitTest() {
                 .thenReturn(flowOf(ScanningStateUpdatedInDb(fakeScanStateModel)))
             val uiStates = init().uiStates
 
-            (uiStates.last() as Content).items.filterIsInstance<ActionButtonState>().first().onClick.invoke()
+            (uiStates.last() as ContentUiState).items.filterIsInstance<ActionButtonState>().first().onClick.invoke()
 
-            assertThat(uiStates.filterIsInstance<Content>()).size().isEqualTo(2)
+            assertThat(uiStates.filterIsInstance<ContentUiState>()).size().isEqualTo(2)
         }
 
     @Test
@@ -154,7 +154,7 @@ class ScanViewModelTest : BaseUnitTest() {
         whenever(startScanUseCase.startScan(any())).thenReturn(flowOf(StartScanState.Success))
         val uiStates = init().uiStates
 
-        (uiStates.last() as Content).items.filterIsInstance<ActionButtonState>().first().onClick.invoke()
+        (uiStates.last() as ContentUiState).items.filterIsInstance<ActionButtonState>().first().onClick.invoke()
 
         verify(fetchScanStateUseCase).fetchScanState(site = site, startWithDelay = true)
     }
@@ -164,7 +164,7 @@ class ScanViewModelTest : BaseUnitTest() {
         test {
             val observers = init()
 
-            (observers.uiStates.last() as Content).items.filterIsInstance<ActionButtonState>()
+            (observers.uiStates.last() as ContentUiState).items.filterIsInstance<ActionButtonState>()
                 .last().onClick.invoke()
 
             val fixThreatsDialogAction = observers.navigation.last().peekContent()
@@ -180,7 +180,7 @@ class ScanViewModelTest : BaseUnitTest() {
                 .thenReturn(flowOf(Success(scanStateModelWithFixableThreats)))
             val observers = init()
 
-            (observers.uiStates.last() as Content).items.filterIsInstance<ActionButtonState>()
+            (observers.uiStates.last() as ContentUiState).items.filterIsInstance<ActionButtonState>()
                 .last().onClick.invoke()
 
             val confirmationDialog = observers.navigation.last().peekContent() as OpenFixThreatsConfirmationDialog
@@ -229,7 +229,7 @@ class ScanViewModelTest : BaseUnitTest() {
 
             triggerFixThreatsAction(observers)
 
-            val contentItems = (observers.uiStates.last() as Content).items
+            val contentItems = (observers.uiStates.last() as ContentUiState).items
             val disabledActionButtons = contentItems.filterIsInstance<ActionButtonState>().map { !it.isEnabled }
             assertThat(disabledActionButtons.size).isEqualTo(2)
         }
@@ -241,7 +241,7 @@ class ScanViewModelTest : BaseUnitTest() {
 
         triggerFixThreatsAction(observers)
 
-        val contentItems = (observers.uiStates.last() as Content).items
+        val contentItems = (observers.uiStates.last() as ContentUiState).items
         val enabledActionButtons = contentItems.filterIsInstance<ActionButtonState>().map { it.isEnabled }
         assertThat(enabledActionButtons.size).isEqualTo(2)
     }
@@ -332,7 +332,7 @@ class ScanViewModelTest : BaseUnitTest() {
 
             fetchFixThreatsStatus(observers)
 
-            val indeterminateProgressBars = (observers.uiStates.last() as Content).items
+            val indeterminateProgressBars = (observers.uiStates.last() as ContentUiState).items
                 .filterIsInstance<ProgressState>()
                 .filter { it.isIndeterminate && it.isVisible }
 
@@ -349,7 +349,7 @@ class ScanViewModelTest : BaseUnitTest() {
 
             fetchFixThreatsStatus(observers)
 
-            val indeterminateProgressBars = (observers.uiStates.last() as Content).items
+            val indeterminateProgressBars = (observers.uiStates.last() as ContentUiState).items
                 .filterIsInstance<ProgressState>()
                 .filter { it.isIndeterminate && it.isVisible }
 
@@ -393,7 +393,8 @@ class ScanViewModelTest : BaseUnitTest() {
         }
 
     private fun triggerFixThreatsAction(observers: Observers) {
-        (observers.uiStates.last() as Content).items.filterIsInstance<ActionButtonState>().last().onClick.invoke()
+        (observers.uiStates.last() as ContentUiState)
+            .items.filterIsInstance<ActionButtonState>().last().onClick.invoke()
         (observers.navigation.last().peekContent() as OpenFixThreatsConfirmationDialog).okButtonAction.invoke()
     }
 


### PR DESCRIPTION
Parent #13326

This PR displays full screen loading and errors on fetch scan and start scan requests. 

Full screen loading/ errors
Loading (0) | No Network (1) | Generic Request Failed (3)  | Start Scan Request Failed (4) 
---------|-------------|------------------------|--------------------------
![loading_scan](https://user-images.githubusercontent.com/1405144/106376887-24aaaa80-63bf-11eb-91d3-5780701d90dd.png)| ![no-network-full screen](https://user-images.githubusercontent.com/1405144/106376942-78b58f00-63bf-11eb-89da-d5ed9edb477e.jpg) |![generic_request_failed](https://user-images.githubusercontent.com/1405144/106376911-45730000-63bf-11eb-87df-e4b5e3cf8fd8.png)|![Something went wrong_start_scan](https://user-images.githubusercontent.com/1405144/106376931-5c195700-63bf-11eb-9aad-f96361af859a.png)

Snack bars
No Network (5)| Generic Request Failed (6)
-----------| -----------------------
![no network snackbar](https://user-images.githubusercontent.com/1405144/106376981-b74b4980-63bf-11eb-978d-83c067736cde.jpg)|![generic_request_failed_snackbar](https://user-images.githubusercontent.com/1405144/106376963-9be03e80-63bf-11eb-80f5-76687b31af0b.png)

### To test

#### Loading (0), No Network (1)

1. Fresh install the app and logon to wp.com account with site having scan capability
2. Switch to site with scan capability
3. Enable airplane mode
4. Click Scan menu
5. Notice that fullscreen "Loading scan" is shown, followed by full screen "No network available" message
6. Disable airplane mode
7. Click retry
8. Notice that scan content is shown
 
------------------------------------------------------------

#### No network snackbar (5)

1. Continuing from above, while being on the scan screen, enable airplane mode
2. Click scan button
3. Notice that a snackbar is shown with  no network available message

------------------------------------------------------------

#### Generic Request Failed (3), Start Scan Request Failed (4), Generic Request Failed snackbar (6)
These states can be tested by using
`ScanViewModel` tests:

Generic Request Failed (3)
`given fetch scan fails, when scan state fetched over empty scan state, then request failed ui state shown`
`given request failed error ui state, when contact support is clicked, then contact support screen is shown`

Start Scan Request Failed (4)
`given scan start request fails, when scan button is clicked, then request failed state is shown`
`given start scan request failed error state, when contact support is clicked, then contact support shown`

Generic Request Failed snackbar (6)
`given fetch scan state fails, when scan state fetched over last scan state, then request failed msg shown`

Notes: 

1. Start scan request fail displays a full screen error with contact support button, message string is copied from the iOS app. 
2. I plan to implement pull-to-refresh which will enable users to retry fetch scan state on full screen errors. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
