### PR TITLE
Remove setHasStableIds

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/adapters/JetpackBackupRestoreAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/adapters/JetpackBackupRestoreAdapter.kt
@@ -24,10 +24,6 @@ class JetpackBackupRestoreAdapter(
 ) : RecyclerView.Adapter<JetpackViewHolder>() {
     private val items = mutableListOf<JetpackListItemState>()
 
-    init {
-        setHasStableIds(true)
-    }
-
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int


### PR DESCRIPTION
parent #13328 

This PR addresses a [comment](https://github.com/wordpress-mobile/WordPress-Android/pull/13900#pullrequestreview-578171638) in PR #13900

"When I click on "Restore site" it navigates me to Warning screen -> there is a noticeable animation glitch -> the cancel button appears after a delay and the confirmation button changes it's vertical position a bit"

To fix the issue I removed `setHasStableIds(true)` because the adapter is being reused and the view holders are not the same. 

**To test:**
- Launch the app
- Navigate to Activity Log
- Tap on the more menu for an item
- Tap on Restore to this point
- Tap on Restore Site to get to the warning view
- Note that the Cancel button doesn't jump and confirmation button doesn't change position.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
