### PR TITLE
Issue/13326 support provisioning and invalid scan states

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -78,7 +78,7 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
 
                     is ErrorUiState.NoConnection,
                     is ErrorUiState.GenericRequestFailed,
-                    is ErrorUiState.StartScanRequestFailed -> updateErrorLayout(uiState as ErrorUiState)
+                    is ErrorUiState.ScanRequestFailed -> updateErrorLayout(uiState as ErrorUiState)
                 }
             }
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -100,7 +100,7 @@ class ScanViewModel @Inject constructor(
                             scanStateModel = state.scanStateModel
                             updateUiState(buildContentUiState(state.scanStateModel))
                             if (state.scanStateModel.state in listOf(State.UNAVAILABLE, State.UNKNOWN)) {
-                                updateUiState(ErrorUiState.StartScanRequestFailed(::onContactSupportClicked))
+                                updateUiState(ErrorUiState.ScanRequestFailed(::onContactSupportClicked))
                             }
                         }
 
@@ -132,7 +132,7 @@ class ScanViewModel @Inject constructor(
 
                         is StartScanState.Failure.RemoteRequestFailure -> {
                             updateUiState(ContentUiState(emptyList()))
-                            updateUiState(ErrorUiState.StartScanRequestFailed(::onContactSupportClicked))
+                            updateUiState(ErrorUiState.ScanRequestFailed(::onContactSupportClicked))
                         }
                     }
                 }
@@ -324,7 +324,7 @@ class ScanViewModel @Inject constructor(
                 override val buttonText = UiStringRes(R.string.contact_support)
             }
 
-            data class StartScanRequestFailed(override val action: () -> Unit) : ErrorUiState() {
+            data class ScanRequestFailed(override val action: () -> Unit) : ErrorUiState() {
                 @DrawableRes override val image = R.drawable.img_illustration_empty_results_216dp
                 override val title = UiStringRes(R.string.scan_start_request_failed_title)
                 override val subtitle = UiStringRes(R.string.scan_start_request_failed_subtitle)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
+import org.wordpress.android.fluxc.model.scan.ScanStateModel.State
 import org.wordpress.android.fluxc.store.ScanStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
@@ -98,6 +99,9 @@ class ScanViewModel @Inject constructor(
                         is FetchScanState.Success -> {
                             scanStateModel = state.scanStateModel
                             updateUiState(buildContentUiState(state.scanStateModel))
+                            if (state.scanStateModel.state in listOf(State.UNAVAILABLE, State.UNKNOWN)) {
+                                updateUiState(ErrorUiState.StartScanRequestFailed(::onContactSupportClicked))
+                            }
                         }
 
                         is FetchScanState.Failure.NetworkUnavailable ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
@@ -41,7 +41,6 @@ class ScanStateListItemsBuilder @Inject constructor(
         onFixAllButtonClicked: () -> Unit,
         onThreatItemClicked: (threatId: Long) -> Unit
     ): List<JetpackListItemState> {
-        val progress = model.currentStatus?.progress ?: 0
         return when (model.state) {
             ScanStateModel.State.IDLE -> {
                 model.threats?.takeIf { threats -> threats.isNotEmpty() }?.let { threats ->
@@ -54,10 +53,9 @@ class ScanStateListItemsBuilder @Inject constructor(
                     )
                 } ?: buildThreatsNotFoundStateItems(model, onScanButtonClicked)
             }
-            ScanStateModel.State.SCANNING -> buildScanningStateItems(progress)
+            ScanStateModel.State.SCANNING -> buildScanningStateItems(model.currentStatus?.progress ?: 0)
             ScanStateModel.State.PROVISIONING -> buildProvisioningStateItems()
-            ScanStateModel.State.UNAVAILABLE, ScanStateModel.State.UNKNOWN ->
-                buildScanningStateItems(progress) // TODO: ashiagr filter out invalid states
+            ScanStateModel.State.UNAVAILABLE, ScanStateModel.State.UNKNOWN -> emptyList()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
@@ -55,7 +55,8 @@ class ScanStateListItemsBuilder @Inject constructor(
                 } ?: buildThreatsNotFoundStateItems(model, onScanButtonClicked)
             }
             ScanStateModel.State.SCANNING -> buildScanningStateItems(progress)
-            ScanStateModel.State.PROVISIONING, ScanStateModel.State.UNAVAILABLE, ScanStateModel.State.UNKNOWN ->
+            ScanStateModel.State.PROVISIONING -> buildProvisioningStateItems()
+            ScanStateModel.State.UNAVAILABLE, ScanStateModel.State.UNKNOWN ->
                 buildScanningStateItems(progress) // TODO: ashiagr filter out invalid states
         }
     }
@@ -138,6 +139,19 @@ class ScanStateListItemsBuilder @Inject constructor(
         items.add(scanHeader)
         items.add(scanDescription)
         items.add(scanProgress)
+
+        return items
+    }
+
+    private fun buildProvisioningStateItems(): List<JetpackListItemState> {
+        val items = mutableListOf<JetpackListItemState>()
+        val scanIcon = buildScanIcon(R.drawable.ic_shield_white, R.color.jetpack_green_5)
+        val scanHeader = HeaderState(UiStringRes(R.string.scan_preparing_to_scan_title))
+        val scanDescription = DescriptionState(UiStringRes(R.string.scan_provisioning_description))
+
+        items.add(scanIcon)
+        items.add(scanHeader)
+        items.add(scanDescription)
 
         return items
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
@@ -130,7 +130,7 @@ class ScanStateListItemsBuilder @Inject constructor(
         val scanProgress = ProgressState(
             progress = progress,
             progressLabel = UiStringResWithParams(
-                R.string.backup_download_progress_label, // TODO ashiagr replace label
+                R.string.scan_progress_label,
                 listOf(UiStringText(progress.toString()))
             )
         )

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1076,8 +1076,8 @@
     <string name="scan_scanning_title">Scanning files</string>
     <string name="scan_idle_no_threats_found_title">Don\'t worry about a thing</string>
     <string name="scan_idle_threats_found_title">Your site may be at risk</string>
-    <string name="scan_scanning_description">Welcome to Jetpack Scan, we are taking a first look at your site now and the result will be with you soon.\n
-        \n We will send you a notification once the scan is complete. In the meantime feel free to continue to use your site as normal. you can check the progress at anytime.</string>
+    <string name="scan_scanning_description">We will send you a notification once the scan is complete. In the meantime feel free to continue to use your site as normal, you can check the progress at anytime.</string>
+    <string name="scan_scanning_is_initial_description">Welcome to Jetpack Scan, we are taking a first look at your site now and the results will be with you soon.</string>
     <string name="scan_provisioning_description">Welcome to Jetpack Scan! We\'re scoping out your site, setting up to do a full scan. We\'ll let you know if we spot any issues that might impact a scan, then your first full scan will start.</string>
     <string name="scan_idle_manual_scan_description">Run a manual scan now or wait for Jetpack to scan your site later today.</string>
     <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and everything looked great. %s</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1078,6 +1078,7 @@
     <string name="scan_idle_threats_found_title">Your site may be at risk</string>
     <string name="scan_scanning_description">Welcome to Jetpack Scan, we are taking a first look at your site now and the result will be with you soon.\n
         \n We will send you a notification once the scan is complete. In the meantime feel free to continue to use your site as normal. you can check the progress at anytime.</string>
+    <string name="scan_provisioning_description">Welcome to Jetpack Scan! We\'re scoping out your site, setting up to do a full scan. We\'ll let you know if we spot any issues that might impact a scan, then your first full scan will start.</string>
     <string name="scan_idle_manual_scan_description">Run a manual scan now or wait for Jetpack to scan your site later today.</string>
     <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and everything looked great. %s</string>
     <string name="scan_idle_threats_found_description">The scan found %s potential threats on %s. Please review them below and take action. We\'re here to help if you need us.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1086,6 +1086,7 @@
     <string name="scan_in_hours_ago">%s hours ago</string>
     <string name="scan_in_minutes_ago">%s minutes ago</string>
     <string name="scan_in_few_seconds">in a few seconds</string>
+    <string name="scan_progress_label" translatable="false">%1$s%%</string>
 
     <!-- scan history -->
     <string name="scan_history_all_threats_tab">All</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -309,7 +309,7 @@ class ScanViewModelTest : BaseUnitTest() {
             (observers.uiStates.last() as ContentUiState)
                 .items.filterIsInstance<ActionButtonState>().first().onClick.invoke()
 
-            assertThat(observers.uiStates.last()).isInstanceOf(ErrorUiState.StartScanRequestFailed::class.java)
+            assertThat(observers.uiStates.last()).isInstanceOf(ErrorUiState.ScanRequestFailed::class.java)
         }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -177,10 +177,34 @@ class ScanViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given fetch scan state succeeds, when scan state is fetched, then ui is updated with content`() = test {
-        val uiStates = init().uiStates
+    fun `given fetch scan state succeeds with valid state, when scan state is fetched, then ui updated with content`() =
+        test {
+            val uiStates = init().uiStates
 
-        assertThat(uiStates.last()).isInstanceOf(ContentUiState::class.java)
+            assertThat(uiStates.last()).isInstanceOf(ContentUiState::class.java)
+        }
+
+    @Test
+    fun `given fetch scan state succeeds with invalid state, when scan state is fetched, then error ui is shown`() =
+        test {
+            whenever(fetchScanStateUseCase.fetchScanState(site))
+                .thenReturn(flowOf(Success(fakeScanStateModel.copy(state = ScanStateModel.State.UNKNOWN))))
+
+            val uiStates = init().uiStates
+
+            val errorState = uiStates.last() as ErrorUiState
+            assertThat(errorState).isInstanceOf(ErrorUiState.ScanRequestFailed::class.java)
+        }
+
+    @Test
+    fun `given invalid scan state error ui, when contact support is clicked, then contact support is shown`() = test {
+        whenever(fetchScanStateUseCase.fetchScanState(site))
+            .thenReturn(flowOf(Success(fakeScanStateModel.copy(state = ScanStateModel.State.UNKNOWN))))
+        val observers = init()
+
+        (observers.uiStates.last() as ErrorUiState).action.invoke()
+
+        assertThat(observers.navigation.last().peekContent()).isEqualTo(ShowContactSupport(site))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -260,7 +260,7 @@ class ScanViewModelTest : BaseUnitTest() {
 
         val errorState = observers.uiStates.last() as ErrorUiState
         with(errorState) {
-            assertThat(this).isInstanceOf(ErrorUiState.StartScanRequestFailed::class.java)
+            assertThat(this).isInstanceOf(ErrorUiState.ScanRequestFailed::class.java)
             assertThat(image).isEqualTo(R.drawable.img_illustration_empty_results_216dp)
             assertThat(title).isEqualTo(UiStringRes(R.string.scan_start_request_failed_title))
             assertThat(subtitle).isEqualTo(UiStringRes(R.string.scan_start_request_failed_subtitle))
@@ -269,7 +269,7 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given start scan request failed error state, when contact support is clicked, then contact support shown`() =
+    fun `given scan request failed error state, when contact support is clicked, then contact support shown`() =
         test {
             whenever(startScanUseCase.startScan(any())).thenReturn(flowOf(StartScanState.Failure.RemoteRequestFailure))
             val observers = init()

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -8,7 +8,6 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.State
@@ -212,7 +211,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
                 colorResId = R.color.jetpack_green_5,
                 sizeResId = R.dimen.scan_icon_size,
                 marginResId = R.dimen.scan_icon_margin,
-                contentDescription = UiStringRes(string.scan_state_icon)
+                contentDescription = UiStringRes(R.string.scan_state_icon)
             )
         )
     }
@@ -224,7 +223,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         val scanStateItems = buildScanStateItems(scanStateModelInProvisioningState)
 
         assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
-            HeaderState(UiStringRes(string.scan_preparing_to_scan_title))
+            HeaderState(UiStringRes(R.string.scan_preparing_to_scan_title))
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -1,13 +1,25 @@
 package org.wordpress.android.ui.jetpack.scan.builders
 
+import com.nhaarman.mockitokotlin2.mock
 import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.R.string
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.scan.ScanStateModel
+import org.wordpress.android.fluxc.model.scan.ScanStateModel.State
+import org.wordpress.android.fluxc.model.scan.ScanStateModel.State.IDLE
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.DescriptionState
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.HeaderState
+import org.wordpress.android.ui.jetpack.common.JetpackListItemState.IconState
 import org.wordpress.android.ui.reader.utils.DateProvider
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
 
@@ -19,7 +31,7 @@ import org.wordpress.android.viewmodel.ResourceProvider
 class ScanStateListItemsBuilderTest : BaseUnitTest() {
     private lateinit var builder: ScanStateListItemsBuilder
 
-//    @Mock private lateinit var site: SiteModel
+    @Mock private lateinit var site: SiteModel
     @Mock private lateinit var dateProvider: DateProvider
     @Mock private lateinit var htmlMessageUtils: HtmlMessageUtils
     @Mock private lateinit var resourceProvider: ResourceProvider
@@ -36,7 +48,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
 //    )
 //    private val threat = ThreatModel.GenericThreatModel(baseThreatModel)
 //    private val threats = listOf(threat)
-//    private val scanStateModelWithNoThreats = ScanStateModel(state = ScanStateModel.State.IDLE, hasCloud = true)
+    private val scanStateModelWithNoThreats = ScanStateModel(state = IDLE)
 //    private val scanStateModelWithThreats = scanStateModelWithNoThreats.copy(threats = threats)
 
     @Before
@@ -185,14 +197,54 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
             "<b>${threats.size}</b>",
             "<b>${site.name ?: resourceProvider.getString(R.string.scan_this_site)}</b>"
         )
+    }*/
+
+    @Test
+    fun `builds shield icon with green color for provisioning scan state model`() {
+        val scanStateModelInProvisioningState = scanStateModelWithNoThreats.copy(state = State.PROVISIONING)
+
+        val scanStateItems = buildScanStateItems(scanStateModelInProvisioningState)
+
+        assertThat(scanStateItems.filterIsInstance(IconState::class.java).first()).isEqualTo(
+            IconState(
+                icon = R.drawable.ic_shield_white,
+                colorResId = R.color.jetpack_green_5,
+                sizeResId = R.dimen.scan_icon_size,
+                marginResId = R.dimen.scan_icon_margin,
+                contentDescription = UiStringRes(string.scan_state_icon)
+            )
+        )
     }
 
-    private fun mapToScanState(
+    @Test
+    fun `builds preparing to scan header for provisioning scan state model`() {
+        val scanStateModelInProvisioningState = scanStateModelWithNoThreats.copy(state = State.PROVISIONING)
+
+        val scanStateItems = buildScanStateItems(scanStateModelInProvisioningState)
+
+        assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
+            HeaderState(UiStringRes(string.scan_preparing_to_scan_title))
+        )
+    }
+
+    @Test
+    fun `builds provisioning description for provisioning scan state model`() {
+        val scanStateModelInProvisioningState = scanStateModelWithNoThreats.copy(state = State.PROVISIONING)
+
+        val scanStateItems = buildScanStateItems(scanStateModelInProvisioningState)
+
+        assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
+            DescriptionState(UiStringRes(R.string.scan_provisioning_description))
+        )
+    }
+
+    private fun buildScanStateItems(
         model: ScanStateModel
     ) = builder.buildScanStateListItems(
         model = model,
         site = site,
         onScanButtonClicked = mock(),
-        onFixAllButtonClicked = mock()
-    )*/
+        onFixAllButtonClicked = mock(),
+        onThreatItemClicked = mock()
+    )
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -260,7 +260,9 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
             state = State.SCANNING,
             mostRecentStatus = ScanProgressStatus(isInitial = true, startDate = Date(0))
         )
+
         val scanStateItems = buildScanStateItems(scanStateModelInScanningInitialState)
+
         assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
             DescriptionState(UiStringRes(R.string.scan_scanning_is_initial_description))
         )
@@ -272,7 +274,9 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
             state = State.SCANNING,
             mostRecentStatus = ScanProgressStatus(isInitial = false, startDate = Date(0))
         )
+
         val scanStateItems = buildScanStateItems(scanStateModelInScanningInitialState)
+
         assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
             DescriptionState(UiStringRes(R.string.scan_scanning_description))
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.ScanStateModel
+import org.wordpress.android.fluxc.model.scan.ScanStateModel.ScanProgressStatus
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.State
 import org.wordpress.android.fluxc.model.scan.ScanStateModel.State.IDLE
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.DescriptionState
@@ -21,6 +22,7 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.util.Date
 
 // private const val DUMMY_CURRENT_TIME = 10000000L
 // private const val ONE_MINUTE = 60 * 1000L
@@ -64,10 +66,6 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
 //        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), any())).thenReturn(SpannedString(""))
 //        whenever(site.name).thenReturn((""))
 //        whenever(dateProvider.getCurrentDate()).thenReturn(Date(DUMMY_CURRENT_TIME))
-    }
-
-    @Test
-    fun dummyTest() {
     }
 
     /*@Test
@@ -254,6 +252,30 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         val scanStateItems = buildScanStateItems(scanStateModelInUnAvailableState)
 
         assertThat(scanStateItems).isEmpty()
+    }
+
+    @Test
+    fun `builds initial scanning description for scanning scan state model with no initial recent scan`() {
+        val scanStateModelInScanningInitialState = scanStateModelWithNoThreats.copy(
+            state = State.SCANNING,
+            mostRecentStatus = ScanProgressStatus(isInitial = true, startDate = Date(0))
+        )
+        val scanStateItems = buildScanStateItems(scanStateModelInScanningInitialState)
+        assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
+            DescriptionState(UiStringRes(R.string.scan_scanning_is_initial_description))
+        )
+    }
+
+    @Test
+    fun `builds scanning description for scanning scan state model with past recent scan`() {
+        val scanStateModelInScanningInitialState = scanStateModelWithNoThreats.copy(
+            state = State.SCANNING,
+            mostRecentStatus = ScanProgressStatus(isInitial = false, startDate = Date(0))
+        )
+        val scanStateItems = buildScanStateItems(scanStateModelInScanningInitialState)
+        assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
+            DescriptionState(UiStringRes(R.string.scan_scanning_description))
+        )
     }
 
     private fun buildScanStateItems(

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -238,6 +238,24 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `builds empty list for unknown scan state model`() {
+        val scanStateModelInUnknownState = scanStateModelWithNoThreats.copy(state = State.UNKNOWN)
+
+        val scanStateItems = buildScanStateItems(scanStateModelInUnknownState)
+
+        assertThat(scanStateItems).isEmpty()
+    }
+
+    @Test
+    fun `builds empty list for unavailable scan state model`() {
+        val scanStateModelInUnAvailableState = scanStateModelWithNoThreats.copy(state = State.UNAVAILABLE)
+
+        val scanStateItems = buildScanStateItems(scanStateModelInUnAvailableState)
+
+        assertThat(scanStateItems).isEmpty()
+    }
+
     private fun buildScanStateItems(
         model: ScanStateModel
     ) = builder.buildScanStateListItems(

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -1,12 +1,10 @@
-package org.wordpress.android.ui.jetpack.scan
+package org.wordpress.android.ui.jetpack.scan.builders
 
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.ui.jetpack.scan.builders.ScanStateListItemsBuilder
-import org.wordpress.android.ui.jetpack.scan.builders.ThreatItemBuilder
 import org.wordpress.android.ui.reader.utils.DateProvider
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiHelpers

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.viewmodel.ResourceProvider
 // private const val ONE_MINUTE = 60 * 1000L
 // private const val ONE_HOUR = 60 * ONE_MINUTE
 
+// TODO ashiagr tweak existing tests
 @InternalCoroutinesApi
 class ScanStateListItemsBuilderTest : BaseUnitTest() {
     private lateinit var builder: ScanStateListItemsBuilder

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ThreatItemBuilderTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.jetpack.scan
+package org.wordpress.android.ui.jetpack.scan.builders
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -17,7 +17,11 @@ import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.FI
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.ThreatStatus.IGNORED
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel.VulnerableExtensionThreatModel.Extension.ExtensionType
 import org.wordpress.android.test
-import org.wordpress.android.ui.jetpack.scan.builders.ThreatItemBuilder
+import org.wordpress.android.ui.jetpack.scan.TEST_FILE_NAME
+import org.wordpress.android.ui.jetpack.scan.TEST_SIGNATURE
+import org.wordpress.android.ui.jetpack.scan.TEST_VULNERABLE_THREAT_SLUG
+import org.wordpress.android.ui.jetpack.scan.TEST_VULNERABLE_THREAT_VERSION
+import org.wordpress.android.ui.jetpack.scan.ThreatTestData
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -141,7 +145,9 @@ class ThreatItemBuilderTest : BaseUnitTest() {
         // Arrange
         val expectedHeader = UiStringResWithParams(
             R.string.threat_item_header_vulnerable_plugin,
-            listOf(UiStringText(TEST_VULNERABLE_THREAT_SLUG), UiStringText(TEST_VULNERABLE_THREAT_VERSION))
+            listOf(UiStringText(TEST_VULNERABLE_THREAT_SLUG), UiStringText(
+                    TEST_VULNERABLE_THREAT_VERSION
+            ))
         )
         // Act
         val threatItem = buildThreatItem(ThreatTestData.vulnerableExtensionThreatModel)
@@ -164,7 +170,9 @@ class ThreatItemBuilderTest : BaseUnitTest() {
         // Arrange
         val expectedHeader = UiStringResWithParams(
             R.string.threat_item_header_vulnerable_theme,
-            listOf(UiStringText(TEST_VULNERABLE_THREAT_SLUG), UiStringText(TEST_VULNERABLE_THREAT_VERSION))
+            listOf(UiStringText(TEST_VULNERABLE_THREAT_SLUG), UiStringText(
+                    TEST_VULNERABLE_THREAT_VERSION
+            ))
         )
         // Act
         val threatItem = buildThreatItem(


### PR DESCRIPTION
Parent #13326

This PR supports below scan states: 
- `Provisioning` (displays provisioning state items using [Calypso's logic](https://opengrok.a8c.com/source/xref/calypso/client/my-sites/scan/main.tsx?r=e0bf4b63#74))
- Invalid: `UnAvailable` and `Unknown` (displays full screen error)

Provisioning State | Invalid State
-------------------|-------------
![provisioning](https://user-images.githubusercontent.com/1405144/106418811-2a66c580-647d-11eb-9704-91dae4cfd61b.png)| ![full-screen-error](https://user-images.githubusercontent.com/1405144/106417364-e8885000-6479-11eb-9c8e-b33d437f6b15.png)

EDIT: 
This PR also updates scanning state description for initial scan ([Calypso's logic](https://opengrok.a8c.com/source/xref/calypso/client/my-sites/scan/main.tsx?r=e0bf4b63#176-190)).

Scanning  (`MostRecentStatus.isInitial = true)` | Scanning (`MostRecentStatus.isInitial = false`)
-----------------------------------------------|-----------------------------------------------
![initial_scanning](https://user-images.githubusercontent.com/1405144/106424866-f4c7d980-6488-11eb-9d57-746883391de0.png) | ![initial_false_scanning](https://user-images.githubusercontent.com/1405144/106424586-6f442980-6488-11eb-849e-4be33a8363b7.png)

**To test**

Prerequisite:

- Make sure both Scan feature flag and MySiteImprovements flag are set to on in the App settings.
- You have access to WP.com account with a site having scan capability and threats (e.g. https://pressable-jetpack-daily-scan.mystagingwebsite.com). Server credentials should be set on the site.

You can test the changes in either ways:

1. by running newly added tests in `ScanStateListItemsBuilderTest` and `ScanViewModelTest`

or 

2. by commenting [these lines in FetchScanStateUseCase](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt#L40-L57), adding below lines for required scan state at line 39 and accessing the scan screen in the app.

`PROVISIONING` State
```
emit(Success(ScanStateModel(state = ScanStateModel.State.PROVISIONING)))
return@flow
```

`UNKNOWN` State
```
emit(Success(ScanStateModel(state = ScanStateModel.State.UNKNOWN)))
return@flow
```

`UNAVAILABLE` State
```
emit(Success(ScanStateModel(state = ScanStateModel.State.UNAVAILABLE)))
return@flow
```

`SCANNING` State

```
emit(Success(ScanStateModel(state = ScanStateModel.State.SCANNING, mostRecentStatus = ScanProgressStatus(isInitial = <true/false>, startDate = Date(0)))))
return@flow
```

**Merge Instructions**

1. Make sure PR #13920 is merged to develop 
2. Remove the "Not Ready for Merge label"
3. Merge this PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
