### PR TITLE
Issue/13326 navigate to scan screen from detail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -10,6 +10,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.core.app.TaskStackBuilder;
 import androidx.fragment.app.Fragment;
 
@@ -651,15 +652,10 @@ public class ActivityLauncher {
         activity.startActivity(intent);
     }
 
-    public static void viewThreatDetailsForResult(@NonNull Fragment fragment, @NonNull Long threatId) {
+    public static void viewThreatDetails(@NonNull Fragment fragment, SiteModel site, @NonNull Long threatId) {
         Intent intent = new Intent(fragment.getContext(), ThreatDetailsActivity.class);
         intent.putExtra(ARG_THREAT_ID, threatId);
-        fragment.startActivityForResult(intent, RequestCodes.SHOW_THREAT_DETAILS);
-    }
-
-    public static void viewThreatDetails(@NonNull Fragment fragment, @NonNull Long threatId) {
-        Intent intent = new Intent(fragment.getContext(), ThreatDetailsActivity.class);
-        intent.putExtra(ARG_THREAT_ID, threatId);
+        intent.putExtra(WordPress.SITE, site);
         fragment.startActivity(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -639,6 +639,31 @@ public class ActivityLauncher {
         }
         Intent intent = new Intent(activity, ScanActivity.class);
         intent.putExtra(WordPress.SITE, site);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        activity.startActivity(intent);
+    }
+
+    public static void viewScanRequestScanState(Activity activity, SiteModel site, @StringRes int messageRes) {
+        if (site == null) {
+            ToastUtils.showToast(activity, R.string.blog_not_found, ToastUtils.Duration.SHORT);
+            return;
+        }
+        Intent intent = new Intent(activity, ScanActivity.class);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(ScanActivity.REQUEST_SCAN_STATE, messageRes);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        activity.startActivity(intent);
+    }
+
+    public static void viewScanRequestFixState(Activity activity, SiteModel site, long threatId) {
+        if (site == null) {
+            ToastUtils.showToast(activity, R.string.blog_not_found, ToastUtils.Duration.SHORT);
+            return;
+        }
+        Intent intent = new Intent(activity, ScanActivity.class);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(ScanActivity.REQUEST_FIX_STATE, threatId);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         activity.startActivity(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -67,7 +67,4 @@ public class RequestCodes {
     // Story creator
     public static final int CREATE_STORY = 8000;
     public static final int EDIT_STORY = 8001;
-
-    // Scan
-    public static final int SHOW_THREAT_DETAILS = 9000;
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.jetpack.scan
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -11,6 +12,12 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 
 class ScanActivity : AppCompatActivity() {
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        (supportFragmentManager.findFragmentById(R.id.fragment_container_view) as? ScanFragment)?.let {
+            it.onNewIntent(intent)
+        }
+    }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -37,5 +44,10 @@ class ScanActivity : AppCompatActivity() {
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.scan_menu, menu)
         return true
+    }
+
+    companion object {
+        const val REQUEST_SCAN_STATE = "request_scan_state"
+        const val REQUEST_FIX_STATE = "request_fix_state"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -13,13 +13,11 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
-import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.OpenFixThreatsConfirmationDialog
 import org.wordpress.android.ui.jetpack.scan.ScanNavigationEvents.ShowThreatDetails
 import org.wordpress.android.ui.jetpack.scan.ScanViewModel.UiState.Content
 import org.wordpress.android.ui.jetpack.scan.adapters.HorizontalMarginItemDecoration
 import org.wordpress.android.ui.jetpack.scan.adapters.ScanAdapter
-import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsFragment
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -128,24 +128,21 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         }
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == RequestCodes.SHOW_THREAT_DETAILS) {
-            data?.let {
-                val threatId = it.getLongExtra(ThreatDetailsFragment.REQUEST_FIX_STATE, 0L)
-                val messageRes = it.getIntExtra(ThreatDetailsFragment.REQUEST_SCAN_STATE, 0)
-                if (threatId > 0L) {
-                    viewModel.onFixStateRequested(threatId)
-                } else if (messageRes > 0) {
-                    viewModel.onScanStateRequestedWithMessage(messageRes)
-                }
-            }
-        }
-    }
-
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putSerializable(WordPress.SITE, viewModel.site)
         super.onSaveInstanceState(outState)
+    }
+
+    fun onNewIntent(intent: Intent?) {
+        intent?.let {
+            val threatId = intent.getLongExtra(ScanActivity.REQUEST_FIX_STATE, 0L)
+            val messageRes = intent.getIntExtra(ScanActivity.REQUEST_SCAN_STATE, 0)
+            if (threatId > 0L) {
+                viewModel.onFixStateRequested(threatId)
+            } else if (messageRes > 0) {
+                viewModel.onScanStateRequestedWithMessage(messageRes)
+            }
+        }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -80,8 +80,9 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
                 it.applyIfNotHandled {
                     when (this) {
                         is OpenFixThreatsConfirmationDialog -> showFixThreatsConfirmationDialog(this)
-                        is ShowThreatDetails -> ActivityLauncher.viewThreatDetailsForResult(
+                        is ShowThreatDetails -> ActivityLauncher.viewThreatDetails(
                             this@ScanFragment,
+                            siteModel,
                             threatId
                         )
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanNavigationEvents.kt
@@ -2,10 +2,11 @@ package org.wordpress.android.ui.jetpack.scan
 
 import androidx.annotation.StringRes
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.utils.UiString
 
 sealed class ScanNavigationEvents {
-    data class ShowThreatDetails(val threatId: Long) : ScanNavigationEvents()
+    data class ShowThreatDetails(val siteModel: SiteModel, val threatId: Long) : ScanNavigationEvents()
 
     class OpenFixThreatsConfirmationDialog(
         val title: UiString,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -193,7 +193,7 @@ class ScanViewModel @Inject constructor(
     }
 
     private fun onThreatItemClicked(threatId: Long) {
-        _navigationEvents.value = Event(ShowThreatDetails(threatId))
+        _navigationEvents.value = Event(ShowThreatDetails(site, threatId))
     }
 
     fun onScanStateRequestedWithMessage(@StringRes messageRes: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -74,15 +74,14 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
                         is OpenThreatActionDialog -> showThreatActionDialog(this)
 
                         is ShowUpdatedScanStateWithMessage -> {
-                            val intent = Intent().putExtra(REQUEST_SCAN_STATE, this.messageRes)
-                            activity?.setResult(Activity.RESULT_OK, intent)
-                            activity?.finish()
+                            val site = requireNotNull(requireActivity().intent.extras)
+                                .getSerializable(WordPress.SITE) as SiteModel
+                            ActivityLauncher.viewScanRequestScanState(requireActivity(), site, this.messageRes)
                         }
-
                         is ShowUpdatedFixState -> {
-                            val intent = Intent().putExtra(REQUEST_FIX_STATE, this.threatId)
-                            activity?.setResult(Activity.RESULT_OK, intent)
-                            activity?.finish()
+                            val site = requireNotNull(requireActivity().intent.extras)
+                                .getSerializable(WordPress.SITE) as SiteModel
+                            ActivityLauncher.viewScanRequestFixState(requireActivity(), site, this.threatId)
                         }
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -1,7 +1,5 @@
 package org.wordpress.android.ui.jetpack.scan.details
 
-import android.app.Activity
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
@@ -12,6 +10,8 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.threat_details_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.jetpack.scan.ScanFragment.Companion.ARG_THREAT_ID
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.OpenThreatActionDialog
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsNavigationEvents.ShowUpdatedFixState
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.widgets.WPSnackbar
+import java.lang.RuntimeException
 import javax.inject.Inject
 
 class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
@@ -113,13 +114,15 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
         threatActionDialog?.show()
     }
 
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        if (requireActivity().intent.extras?.containsKey(WordPress.SITE) != true) {
+            throw RuntimeException("ThreatDetailsFragment - missing siteModel extras.")
+        }
+    }
+
     override fun onPause() {
         super.onPause()
         threatActionDialog?.dismiss()
-    }
-
-    companion object {
-        const val REQUEST_SCAN_STATE = "request_scan_state"
-        const val REQUEST_FIX_STATE = "request_fix_state"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -70,7 +70,7 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
         })
         viewModel.navigation.observe(viewLifecycleOwner, { event ->
             event.applyIfNotHandled {
-                ActivityLauncher.viewThreatDetails(this@ScanHistoryListFragment, threatId)
+                ActivityLauncher.viewThreatDetails(this@ScanHistoryListFragment, siteModel, threatId)
             }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListViewModel.kt
@@ -77,7 +77,7 @@ class ScanHistoryListViewModel @Inject constructor(
             threatList.map { scanThreatItemBuilder.buildThreatItem(it, this::onItemClicked) }
 
     private fun onItemClicked(threatId: Long) {
-        _navigation.value = Event(ShowThreatDetails(threatId))
+        _navigation.value = Event(ShowThreatDetails(site, threatId))
     }
 
     private fun mapTabTypeToThreatStatuses(tabType: ScanHistoryTabType): List<ThreatStatus> =


### PR DESCRIPTION
Parent issue #13326

This PR update the approach used to propagate data from ThreatDetail screen to Scan screen. 

The previous approach was using "startActivityForResult(ThreatDetail)/setResult". The ThreatDetail screen would set a flag in the result and the Scan screen would read this flag and force update the screen. This approach is great when the ThreatDetail screen is always started from Scan screen, but it's not the case anymore. We need to start ThreatDetail screen even from Scan History screen and perhaps even from notifications in the near future.

The new approach uses "startActivity(ThreatDetail)/startActivity(Scan)" . The ThreatDetail screen requests "startActivity(Scan screen)" with "clear top | single top" flags. If the Scan screen is already on the backstack, it's "onNewMethod" is invoked and the screen is force updated. If the Scan screen is not on the backstack, it's started from scratch in which case we don't need to force update it, because the screen always fetches new data on initialization.

Known issues:
1. When "fix threat" action is invoked from a detail of an ignored threat, the progress indicator on the Scan screen is not visible.

To test:
Prerequisites:
- A threat is added to the testing site. In case you run out of threats, re-install bad calendar plugin and re-run scan.
- Scan feature flag is enabled
1. Open Scan screen
2. Start scan
3. Open detail of the found threat
4. Click on "Fix threat" button
5. Notice the app redirects you back to the "Scan" screen and the correct progress state + snackbar is shown

----------------------------
Prerequisites:
- A threat is added to the testing site. In case you run out of threats, re-install bad calendar plugin and re-run scan.
- Scan feature flag is enabled
1. Open Scan screen
2. Start scan
3. Open detail of the found threat
4. Click on "Ignore threat" button
5. Notice you get redirected back to the "scan" screen and snackbar is shown
6. Open History
7. Open detail of the ignored threat
8. Click on "Fix threat" button
9. Notice the app redirects you back to the "Scan" screen, snackbar is shown (there is a known bug, the progress indicator is not visible)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
