### PR TITLE
Increases the drag to dismiss distance in FullscreenBottomSheetDialogFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FullscreenBottomSheetDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FullscreenBottomSheetDialogFragment.kt
@@ -31,6 +31,7 @@ abstract class FullscreenBottomSheetDialogFragment : BottomSheetDialogFragment()
                 setupFullHeight(it)
                 behaviour.skipCollapsed = true
                 behaviour.state = BottomSheetBehavior.STATE_EXPANDED
+                behaviour.peekHeight = resources.displayMetrics.heightPixels / 2
             }
         }
     }


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-Android/issues/13939

## Description
Increases the drag to dismiss distance in FullscreenBottomSheetDialogFragment by setting it at half the screen height

## To test:

1. Start the site creation flow (e.g. Choose site > Add button)
1. Select the Create WordPress.com site option
1. Select a design
1. Press Preview
1. Verify that the the modal needs to be dragged down at the middle of the screen before dismissing 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
