### PR TITLE
Issue/13328 restore error retry

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -44,7 +44,7 @@ class GetRestoreStatusUseCase @Inject constructor(
 
             if (!fetchActivitiesRewind(site)) {
                 if (retryAttempts++ >= MAX_RETRY) {
-                    AppLog.d(T.JETPACK_BACKUP,"$tag: Exceeded 3 retries while fetching status")
+                    AppLog.d(T.JETPACK_BACKUP, "$tag: Exceeded 3 retries while fetching status")
                     emit(RemoteRequestFailure)
                     return@flow
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -19,6 +19,8 @@ import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Complete
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Failure.NetworkUnavailable
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Failure.RemoteRequestFailure
 import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Progress
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.NetworkUtilsWrapper
 import javax.inject.Inject
 import javax.inject.Named
@@ -31,6 +33,7 @@ class GetRestoreStatusUseCase @Inject constructor(
     private val activityLogStore: ActivityLogStore,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
+    private val tag = this@GetRestoreStatusUseCase.javaClass.simpleName
     suspend fun getRestoreStatus(
         site: SiteModel,
         restoreId: Long? = null
@@ -41,6 +44,7 @@ class GetRestoreStatusUseCase @Inject constructor(
 
             if (!fetchActivitiesRewind(site)) {
                 if (retryAttempts++ >= MAX_RETRY) {
+                    AppLog.e(T.JETPACK_BACKUP,"$tag: Exceeded 3 retries while fetching status")
                     emit(RemoteRequestFailure)
                     return@flow
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -33,7 +33,7 @@ class GetRestoreStatusUseCase @Inject constructor(
     private val activityLogStore: ActivityLogStore,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
-    private val tag = this@GetRestoreStatusUseCase.javaClass.simpleName
+    private val tag = javaClass.simpleName
     suspend fun getRestoreStatus(
         site: SiteModel,
         restoreId: Long? = null
@@ -44,7 +44,7 @@ class GetRestoreStatusUseCase @Inject constructor(
 
             if (!fetchActivitiesRewind(site)) {
                 if (retryAttempts++ >= MAX_RETRY) {
-                    AppLog.e(T.JETPACK_BACKUP,"$tag: Exceeded 3 retries while fetching status")
+                    AppLog.d(T.JETPACK_BACKUP,"$tag: Exceeded 3 retries while fetching status")
                     emit(RemoteRequestFailure)
                     return@flow
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -79,7 +79,7 @@ class GetRestoreStatusUseCase @Inject constructor(
 
     private suspend fun fetchActivitiesRewind(site: SiteModel): Boolean {
         val result = activityLogStore.fetchActivitiesRewind(FetchRewindStatePayload(site))
-        return result.isError
+        return !result.isError
     }
 
     private suspend fun FlowCollector<RestoreRequestState>.emitFinished(rewind: Rewind) =

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCaseTest.kt
@@ -81,83 +81,99 @@ class GetRestoreStatusUseCaseTest {
     }
 
     @Test
-    fun `given failure without restore id, when restore status triggers, then return remote request failure`() = test {
-        whenever(activityLogStore.fetchActivitiesRewind(any()))
-                .thenReturn(OnRewindStatusFetched(RewindStatusError(GENERIC_ERROR), FETCH_REWIND_STATE))
+    fun `given failure without restore id, when restore status triggers, then return remote request failure`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.fetchActivitiesRewind(any()))
+                        .thenReturn(OnRewindStatusFetched(RewindStatusError(GENERIC_ERROR), FETCH_REWIND_STATE))
 
-        val result = useCase.getRestoreStatus(site, null).toList()
+                val result = useCase.getRestoreStatus(site, null).toList()
+                advanceTimeBy(DELAY_MILLIS)
 
-        assertThat(result).contains(Failure.RemoteRequestFailure)
+                assertThat(result).contains(Failure.RemoteRequestFailure)
     }
 
     @Test
-    fun `given failure with restore id, when restore status triggers, then return failure`() = test {
-        whenever(activityLogStore.fetchActivitiesRewind(any()))
-                .thenReturn(OnRewindStatusFetched(RewindStatusError(GENERIC_ERROR), FETCH_REWIND_STATE))
+    fun `given failure with restore id, when restore status triggers, then return failure`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.fetchActivitiesRewind(any()))
+                        .thenReturn(OnRewindStatusFetched(RewindStatusError(GENERIC_ERROR), FETCH_REWIND_STATE))
 
-        val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+                val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+                advanceTimeBy(DELAY_MILLIS)
 
-        assertThat(result).contains(Failure.RemoteRequestFailure)
+                assertThat(result).contains(Failure.RemoteRequestFailure)
     }
 
     @Test
-    fun `given finished without restore id and rewind id, when restore status triggers, then return complete`() = test {
-        whenever(activityLogStore.getRewindStatusForSite(site))
-                .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FINISHED))
+    fun `given finished without restore id and rewind id, when restore status triggers, then return complete`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.getRewindStatusForSite(site))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FINISHED))
 
-        val result = useCase.getRestoreStatus(site, null).toList()
+                val result = useCase.getRestoreStatus(site, null).toList()
+                advanceTimeBy(DELAY_MILLIS)
 
-        assertThat(result).contains(Complete(REWIND_ID, RESTORE_ID, PUBLISHED))
+                assertThat(result).contains(Complete(REWIND_ID, RESTORE_ID, PUBLISHED))
     }
 
     @Test
-    fun `given finished with restore id and rewind id, when restore status triggers, then return complete`() = test {
-        whenever(activityLogStore.getRewindStatusForSite(site))
-                .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FINISHED))
+    fun `given finished with restore id and rewind id, when restore status triggers, then return complete`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.getRewindStatusForSite(site))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FINISHED))
 
-        val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+                val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+                advanceTimeBy(DELAY_MILLIS)
 
-        assertThat(result).contains(Complete(REWIND_ID, RESTORE_ID, PUBLISHED))
+                assertThat(result).contains(Complete(REWIND_ID, RESTORE_ID, PUBLISHED))
     }
 
     @Test
-    fun `given finished without restore id no rewind id, when restore status triggers, then return failure`() = test {
-        whenever(activityLogStore.getRewindStatusForSite(site))
-                .thenReturn(rewindStatusModel(null, Rewind.Status.FINISHED))
+    fun `given finished without restore id no rewind id, when restore status triggers, then return failure`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.getRewindStatusForSite(site))
+                        .thenReturn(rewindStatusModel(null, Rewind.Status.FINISHED))
 
-        val result = useCase.getRestoreStatus(site, null).toList()
+                val result = useCase.getRestoreStatus(site, null).toList()
+                advanceTimeBy(DELAY_MILLIS)
 
-        assertThat(result).contains(Failure.RemoteRequestFailure)
+                assertThat(result).contains(Failure.RemoteRequestFailure)
     }
 
     @Test
-    fun `given finished with restore id no rewind id, when restore status triggers, then return failure`() = test {
-        whenever(activityLogStore.getRewindStatusForSite(site))
-                .thenReturn(rewindStatusModel(null, Rewind.Status.FINISHED))
+    fun `given finished with restore id no rewind id, when restore status triggers, then return failure`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.getRewindStatusForSite(site))
+                        .thenReturn(rewindStatusModel(null, Rewind.Status.FINISHED))
 
-        val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+                val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+                advanceTimeBy(DELAY_MILLIS)
 
-        assertThat(result).contains(Failure.RemoteRequestFailure)
+                assertThat(result).contains(Failure.RemoteRequestFailure)
     }
 
     @Test
-    fun `given failed without restore id, when restore status triggers, then return failure`() = test {
-        whenever(activityLogStore.getRewindStatusForSite(site))
-                .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FAILED))
+    fun `given failed without restore id, when restore status triggers, then return failure`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.getRewindStatusForSite(site))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FAILED))
 
-        val result = useCase.getRestoreStatus(site, null).toList()
+                val result = useCase.getRestoreStatus(site, null).toList()
+                advanceTimeBy(DELAY_MILLIS)
 
-        assertThat(result).contains(Failure.RemoteRequestFailure)
+                assertThat(result).contains(Failure.RemoteRequestFailure)
     }
 
     @Test
-    fun `given failed with restore id, when restore status triggers, then return failure`() = test {
-        whenever(activityLogStore.getRewindStatusForSite(site))
-                .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FAILED))
+    fun `given failed with restore id, when restore status triggers, then return failure`() =
+            coroutineScope.runBlockingTest {
+                whenever(activityLogStore.getRewindStatusForSite(site))
+                        .thenReturn(rewindStatusModel(REWIND_ID, Rewind.Status.FAILED))
 
-        val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+                val result = useCase.getRestoreStatus(site, RESTORE_ID).toList()
+                advanceTimeBy(DELAY_MILLIS)
 
-        assertThat(result).contains(Failure.RemoteRequestFailure)
+                assertThat(result).contains(Failure.RemoteRequestFailure)
     }
 
     @Test


### PR DESCRIPTION
Parent #13328

This PR updates `GetRestoreStatusUseCase` with the following:
(1) Reorders execution so that the Fetch from the server is first, then a get on the local db
(2) Enable 3 retries when error is received from server fetch
(3) Update tests in `GetRestoreStatusUseCaseTest` to account for delay

To test:
- Launch the app
- Ensure that the `RestoreFeatureConfig` flag is turned on
- Navigate to Activity Log
- Choose a activity item that is available for restore
- Tap on the more menu
- Tap on the Restore to this point menu option
- Tap the Restore site button
- Tap on confirm button
- Let the process flow
- Note that the progress view is working as expected

------------------
- Launch the app
- Ensure that the `RestoreFeatureConfig` flag is turned on
- Navigate to Activity Log
- Choose a activity item that is available for restore
- Tap on the more menu
- Tap on the Restore to this point menu option
- Tap the Restore site button
- Tap on confirm button
- Tap the `Let me know when finished!` button to return to the activity log list
- Note that the restore progress item is shown on the activity log 

FYI @ParaskP7

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
