### PR TITLE
Issue/13326 missing server credentials

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -162,7 +162,7 @@ class ScanViewModel @Inject constructor(
                 is FetchFixThreatsState.Failure.FixFailure -> {
                     if (!status.containsOnlyErrors) {
                         someOrAllThreatFixed = true
-                    } else if(isInvokedByUser) {
+                    } else if (isInvokedByUser) {
                         messageRes = R.string.threat_fix_all_status_error_message
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCase.kt
@@ -58,7 +58,7 @@ class FetchFixThreatsStatusUseCase @Inject constructor(
         val fixingThreatIds = models.filter { it.status == FixStatus.IN_PROGRESS }.map { it.id }
         val isFixing = fixingThreatIds.isNotEmpty()
         val isFixingComplete = models.filter { it.status == FixStatus.FIXED }.size == fixableThreatIds.size
-        val errors = models.filter { it.error != null }
+        val errors = models.filter { it.error != null || it.status == FixStatus.NOT_FIXED }
 
         return when {
             isFixingNotStarted -> NotStarted

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -393,8 +393,8 @@ class ScanViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given FixFailure(onlyErrors=true) returned, when fetch fix status invoked by user, then snackbar is shown`()
-    = test {
+    fun `given FixFailure(onlyErr=true) returned, when fetch fix status invoked by user, then snackbar is shown`() =
+            test {
         val messages = init().snackBarMsgs
         whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any())).thenReturn(
             flowOf(FetchFixThreatsState.Failure.FixFailure(containsOnlyErrors = true))
@@ -406,8 +406,8 @@ class ScanViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given FixFailure(onlyErrors=true) returned, when fetchStatus NOT invoked by user, then snackbar is NOT shown`()
-        = test {
+    fun `given FixFailure(onlyErr=true) returned, when fetchStatus NOT invoked by user, then snackbar is NOT shown`() =
+            test {
         whenever(fetchFixThreatsStatusUseCase.fetchFixThreatsStatus(any(), any())).thenReturn(
             flowOf(FetchFixThreatsState.Failure.FixFailure(containsOnlyErrors = true))
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchFixThreatsStatusUseCaseTest.kt
@@ -153,4 +153,24 @@ class FetchFixThreatsStatusUseCaseTest : BaseUnitTest() {
 
             assertThat(useCaseResult).isEqualTo(NotStarted)
         }
+
+    @Test
+    fun `given all threats NOT_FIXED, when status is fetched, then FixFailure(containsOnly = true) returned`() = test {
+        val fixThreatsStatusModels = listOf(
+            fakeFixThreatsStatusModel.copy(status = FixStatus.NOT_FIXED),
+            fakeFixThreatsStatusModel.copy(status = FixStatus.NOT_FIXED)
+        )
+        val storeResultWithErrorFixStatusModel = OnFixThreatsStatusFetched(
+            fakeSiteId,
+            fixThreatsStatusModels,
+            FETCH_FIX_THREATS_STATUS
+        )
+        whenever(scanStore.fetchFixThreatsStatus(any())).thenReturn(storeResultWithErrorFixStatusModel)
+
+        val useCaseResult = useCase.fetchFixThreatsStatus(fakeSiteId, listOf(1L, 2L))
+            .toList(mutableListOf())
+            .last()
+
+        assertThat(useCaseResult).isEqualTo(Failure.FixFailure(containsOnlyErrors = true))
+    }
 }


### PR DESCRIPTION
Parent issue #13326

This PR fixes an issue where snackbar was not being shown when the server returned a response containing all threats in "NOT_FIXED" status. It also adds "invokedByUser" flag so the snackbar is shown only when the action is invoked by the user - it's not shown, when it's eg invoked by vm's "init()" method.

To test:
Prerequisites
- Make sure Scan feature flag is enabled
1. Select a site which doesn't have sever credentials and has some threats
2. Select Scan
3. Make sure snackbar is not shown when you open the screen
4. Click on "Fix threat" button
5. Verify a snackbar saying that you need to contact support is shown

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
