### PR TITLE
Fix restore warning confirm delay

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
@@ -6,7 +6,7 @@ import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -18,6 +18,7 @@ import org.wordpress.android.R
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
+import org.wordpress.android.fluxc.model.activity.RewindStatusModel.Rewind.Status.FINISHED
 import org.wordpress.android.test
 import org.wordpress.android.ui.jetpack.common.CheckboxSpannableLabel
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ActionButtonState
@@ -30,7 +31,8 @@ import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsPr
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType.SQLS
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType.THEMES
 import org.wordpress.android.ui.jetpack.restore.RestoreNavigationEvents.VisitSite
-import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Progress
+import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Complete
+import org.wordpress.android.ui.jetpack.restore.RestoreRequestState.Success
 import org.wordpress.android.ui.jetpack.restore.RestoreStep.COMPLETE
 import org.wordpress.android.ui.jetpack.restore.RestoreStep.DETAILS
 import org.wordpress.android.ui.jetpack.restore.RestoreStep.ERROR
@@ -56,7 +58,6 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
-import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import java.util.Date
 
@@ -68,7 +69,6 @@ class RestoreViewModelTest : BaseUnitTest() {
     @Mock private lateinit var getActivityLogItemUseCase: GetActivityLogItemUseCase
     @Mock private lateinit var restoreStatusUseCase: GetRestoreStatusUseCase
     @Mock private lateinit var postRestoreUseCase: PostRestoreUseCase
-    @Mock private lateinit var resourceProvider: ResourceProvider
     @Mock private lateinit var checkboxSpannableLabel: CheckboxSpannableLabel
     private lateinit var availableItemsProvider: JetpackAvailableItemsProvider
     private lateinit var stateListItemBuilder: RestoreStateListItemBuilder
@@ -79,10 +79,8 @@ class RestoreViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: RestoreViewModel
 
     private val restoreState = RestoreState(
-            activityId = "activityId",
             rewindId = "rewindId",
             restoreId = 100L,
-            siteId = 200L,
             optionsSelected = listOf(
                     Pair(THEMES.id, true),
                     Pair(PLUGINS.id, true),
@@ -91,7 +89,8 @@ class RestoreViewModelTest : BaseUnitTest() {
                     Pair(ROOTS.id, true),
                     Pair(CONTENTS.id, true)
             ),
-            published = Date(1609690147756)
+            published = Date(1609690147756),
+            shouldInitProgress = true
     )
 
     @Before
@@ -273,8 +272,10 @@ class RestoreViewModelTest : BaseUnitTest() {
         val uiStates = initObservers().uiStates
         clearInvocations(wizardManager)
 
+        whenever(postRestoreUseCase.postRestoreRequest(anyOrNull(), anyOrNull(), anyOrNull()))
+                .thenReturn(postSuccess)
         whenever(restoreStatusUseCase.getRestoreStatus(anyOrNull(), anyOrNull()))
-                .thenReturn(flow { emit(Progress("rewindId", 0, "nothing", "nothing")) })
+                .thenReturn(flowOf(Complete("Id", 100L, Date(1609690147756))))
 
         startViewModelForStep(PROGRESS)
 
@@ -325,15 +326,15 @@ class RestoreViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given warning step, when no network connection, then a snackbar message is shown`() = test {
+    fun `given progress step, when no network connection, then a snackbar message is shown`() = test {
         whenever(postRestoreUseCase.postRestoreRequest(anyOrNull(), anyOrNull(), anyOrNull()))
                 .thenReturn(postRestoreNetworkError)
 
         val uiStates = initObservers().uiStates
         val msgs = initObservers().snackbarMessages
 
-        startViewModelForStep(WARNING)
-        viewModel.showStep(WizardNavigationTarget(WARNING, restoreState))
+        startViewModelForStep(PROGRESS)
+        viewModel.showStep(WizardNavigationTarget(PROGRESS, restoreState))
 
         ((uiStates.last().items).first { it is ActionButtonState } as ActionButtonState).onClick.invoke()
 
@@ -341,15 +342,15 @@ class RestoreViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given warning step, when no remote request fails, then a snackbar message is shown`() = test {
+    fun `given progress step, when remote request fails, then a snackbar message is shown`() = test {
         whenever(postRestoreUseCase.postRestoreRequest(anyOrNull(), anyOrNull(), anyOrNull()))
                 .thenReturn(postRestoreRemoteRequestError)
 
         val uiStates = initObservers().uiStates
         val msgs = initObservers().snackbarMessages
 
-        startViewModelForStep(WARNING)
-        viewModel.showStep(WizardNavigationTarget(WARNING, restoreState))
+        startViewModelForStep(PROGRESS)
+        viewModel.showStep(WizardNavigationTarget(PROGRESS, restoreState))
 
         ((uiStates.last().items).first { it is ActionButtonState } as ActionButtonState).onClick.invoke()
 
@@ -357,15 +358,15 @@ class RestoreViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given warning step, when another request is running, then a snackbar message is shown`() = test {
+    fun `given progress step, when another request is running, then a snackbar message is shown`() = test {
         whenever(postRestoreUseCase.postRestoreRequest(anyOrNull(), anyOrNull(), anyOrNull()))
                 .thenReturn(otherRequestRunningError)
 
         val uiStates = initObservers().uiStates
         val msgs = initObservers().snackbarMessages
 
-        startViewModelForStep(WARNING)
-        viewModel.showStep(WizardNavigationTarget(WARNING, restoreState))
+        startViewModelForStep(PROGRESS)
+        viewModel.showStep(WizardNavigationTarget(PROGRESS, restoreState))
 
         ((uiStates.last().items).first { it is ActionButtonState } as ActionButtonState).onClick.invoke()
 
@@ -428,4 +429,6 @@ class RestoreViewModelTest : BaseUnitTest() {
     private val postRestoreNetworkError = RestoreRequestState.Failure.NetworkUnavailable
     private val postRestoreRemoteRequestError = RestoreRequestState.Failure.RemoteRequestFailure
     private val otherRequestRunningError = RestoreRequestState.Failure.OtherRequestRunning
+    private val postSuccess = Success(rewindId = "rewindId", requestRewindId = "rewindId", restoreId = 1L)
+    private val getFinished = FINISHED
 }


### PR DESCRIPTION
Parent #13328

This PR addresses a comment in PR #13900

"There is a noticeable delay after I click on "Confirm restore site" on the warning screen, it takes +- 1-2 seconds before the apps navigates me to the progress screen"

To address the issue the following have been implemented:
- On tap of the warning view `Confirm` button, the user is taken immediately to the Progress view which will indicate the process has begun.
- The  API Post Restore Request was moved out of `onConfirmRestoreClick()` into `buildProgress()`
- If an error occurs, the user is taken back to the details view so they can retry the request (this functionality remains the same)
 
**Merge Instructions**
~~Make sure #13919 has been merged~~
~~Remove Not Ready for Merge Label~~
Merge as normal

**To test:**
Happy Path
- Run the progress view from end-to-end and ensure the happy path runs as expected

Sad Paths
- Using Charles Proxy (or similar) manipulate the fetch responses to force the error situations 


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
