### PR TITLE
Create sheets: Add analytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.util.merge
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -122,6 +123,8 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     private fun onCreateActionClicked(actionType: ActionType) {
+        val properties = mapOf("action" to actionType.name.toLowerCase(Locale.ROOT))
+        analyticsTracker.track(Stat.MY_SITE_CREATE_SHEET_ACTION_TAPPED, properties)
         _isBottomSheetShowing.postValue(Event(false))
         _createAction.postValue(actionType)
 
@@ -163,6 +166,7 @@ class WPMainActivityViewModel @Inject constructor(
             // latest info.
             loadMainActions(site)
 
+            analyticsTracker.track(Stat.MY_SITE_CREATE_SHEET_SHOWN)
             _isBottomSheetShowing.value = Event(true)
         } else {
             // User only has one option - creating a post. Skip the bottom sheet and go straight to that action.

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -160,7 +160,7 @@ class WPMainActivityViewModel @Inject constructor(
         if (shouldShowStories(site) || hasFullAccessToContent(site)) {
             // The user has at least two create options available for this site (pages and/or story posts),
             // so we should show a bottom sheet.
-            // Future creation options added in the future should also be weighed here.
+            // Creation options added in the future should also be weighed here.
 
             // Reload main actions, since the first time this is initialized the SiteModel may not contain the
             // latest info.

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -154,26 +154,19 @@ class WPMainActivityViewModel @Inject constructor(
 
         _showQuickStarInBottomSheet.postValue(shouldShowQuickStartFocusPoint)
 
-        if (shouldShowStories(site)) {
+        if (shouldShowStories(site) || hasFullAccessToContent(site)) {
+            // The user has at least two create options available for this site (pages and/or story posts),
+            // so we should show a bottom sheet.
+            // Future creation options added in the future should also be weighed here.
+
+            // Reload main actions, since the first time this is initialized the SiteModel may not contain the
+            // latest info.
             loadMainActions(site)
+
             _isBottomSheetShowing.value = Event(true)
         } else {
-            // NOTE: this whole piece of code and comment below to be removed when we remove the feature flag.
-            // Also note: This comment below and code as is is in `develop` at the time of writing the feature
-            // flag, so bringing it all back in. See https://github.com/wordpress-mobile/WordPress-Android/pull/11930
-            // ----------------------
-            // Currently this bottom sheet has only 2 options.
-            // We should evaluate to re-introduce the bottom sheet also for users without full access to content
-            // if user has at least 2 options (eventually filtering the content not accessible like pages in this case)
-            // See p5T066-1cA-p2/#comment-4463
-            if (hasFullAccessToContent(site)) {
-                // reload main actions given the first time this is initialized, the SiteModel may not contain the
-                // latest info
-                loadMainActions(site)
-                _isBottomSheetShowing.value = Event(true)
-            } else {
-                _createAction.postValue(CREATE_NEW_POST)
-            }
+            // User only has one option - creating a post. Skip the bottom sheet and go straight to that action.
+            _createAction.postValue(CREATE_NEW_POST)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import org.wordpress.android.R.drawable
 import org.wordpress.android.R.string
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.main.MainActionListItem
 import org.wordpress.android.ui.main.MainActionListItem.ActionType
@@ -15,13 +16,16 @@ import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.main.MainFabUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.WPStoriesFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.SingleLiveEvent
+import java.util.Locale
 import javax.inject.Inject
 
 class PostListCreateMenuViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
     private val wpStoriesFeatureConfig: WPStoriesFeatureConfig
 ) : ViewModel() {
     private var isStarted = false
@@ -84,6 +88,8 @@ class PostListCreateMenuViewModel @Inject constructor(
     }
 
     private fun onCreateActionClicked(actionType: ActionType) {
+        val properties = mapOf("action" to actionType.name.toLowerCase(Locale.ROOT))
+        analyticsTracker.track(Stat.POST_LIST_CREATE_SHEET_ACTION_TAPPED, properties)
         _isBottomSheetShowing.postValue(Event(false))
         _createAction.postValue(actionType)
     }
@@ -101,6 +107,7 @@ class PostListCreateMenuViewModel @Inject constructor(
     fun onFabClicked() {
         appPrefsWrapper.setPostListFabTooltipDisabled(true)
         setMainFabUiState()
+        analyticsTracker.track(Stat.POST_LIST_CREATE_SHEET_SHOWN)
         _isBottomSheetShowing.value = Event(true)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModelTest.kt
@@ -15,17 +15,19 @@ import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_PO
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_STORY
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.WPStoriesFeatureConfig
 
 class PostListCreateMenuViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: PostListCreateMenuViewModel
     @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
     @Mock lateinit var wpStoriesFeatureConfig: WPStoriesFeatureConfig
     @Mock lateinit var site: SiteModel
 
     @Before
     fun setUp() {
-        viewModel = PostListCreateMenuViewModel(appPrefsWrapper, wpStoriesFeatureConfig)
+        viewModel = PostListCreateMenuViewModel(appPrefsWrapper, analyticsTrackerWrapper, wpStoriesFeatureConfig)
     }
 
     @Test

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -729,6 +729,8 @@ public final class AnalyticsTracker {
         COMMENT_EDITOR_OPENED,
         MY_SITE_CREATE_SHEET_SHOWN,
         MY_SITE_CREATE_SHEET_ACTION_TAPPED,
+        POST_LIST_CREATE_SHEET_SHOWN,
+        POST_LIST_CREATE_SHEET_ACTION_TAPPED,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -726,7 +726,9 @@ public final class AnalyticsTracker {
         COMMENT_BATCH_SPAMMED,
         COMMENT_BATCH_TRASHED,
         COMMENT_BATCH_DELETED,
-        COMMENT_EDITOR_OPENED
+        COMMENT_EDITOR_OPENED,
+        MY_SITE_CREATE_SHEET_SHOWN,
+        MY_SITE_CREATE_SHEET_ACTION_TAPPED,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1956,6 +1956,10 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "reader_mark_as_seen";
             case READER_POST_MARKED_AS_UNSEEN:
                 return "reader_mark_as_unseen";
+            case MY_SITE_CREATE_SHEET_SHOWN:
+                return "my_site_create_sheet_shown";
+            case MY_SITE_CREATE_SHEET_ACTION_TAPPED:
+                return "my_site_create_sheet_action_tapped";
         }
         return null;
     }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1960,6 +1960,10 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "my_site_create_sheet_shown";
             case MY_SITE_CREATE_SHEET_ACTION_TAPPED:
                 return "my_site_create_sheet_action_tapped";
+            case POST_LIST_CREATE_SHEET_SHOWN:
+                return "post_list_create_sheet_shown";
+            case POST_LIST_CREATE_SHEET_ACTION_TAPPED:
+                return "post_list_create_sheet_action_tapped";
         }
         return null;
     }


### PR DESCRIPTION
Adds some analytics events to interactions with the two create bottom sheets (in the My Site and post list screens).

This should be useful for a few things - it's come up for Stories as a useful piece of the funnel that's missing from tracked events in WPAndroid.

I also did some cleanup on the sheet showing logic for the My Site page.

### To test:

Run the app and inspect analytics events. For each of the My Site and the post list screens, verify that:

* An event fires when opening the create sheet
* An event fires when an action is taken from the create sheet, which includes the action

Example:
```
I/WordPress-STATS: 🔵 Tracked: my_site_create_sheet_shown
I/WordPress-STATS: 🔵 Tracked: my_site_create_sheet_action_tapped, Properties: {"action":"create_new_post"}
I/WordPress-STATS: 🔵 Tracked: my_site_create_sheet_shown
I/WordPress-STATS: 🔵 Tracked: my_site_create_sheet_action_tapped, Properties: {"action":"create_new_page"}
I/WordPress-STATS: 🔵 Tracked: my_site_create_sheet_shown
I/WordPress-STATS: 🔵 Tracked: my_site_create_sheet_action_tapped, Properties: {"action":"create_new_story"}



I/WordPress-STATS: 🔵 Tracked: post_list_create_sheet_shown
I/WordPress-STATS: 🔵 Tracked: post_list_create_sheet_action_tapped, Properties: {"action":"create_new_post"}
I/WordPress-STATS: 🔵 Tracked: post_list_create_sheet_shown
I/WordPress-STATS: 🔵 Tracked: post_list_create_sheet_action_tapped, Properties: {"action":"create_new_story"}
```

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.