### PR TITLE
Issue/13326 get free estimate

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -83,6 +83,9 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
                                 .getSerializable(WordPress.SITE) as SiteModel
                             ActivityLauncher.viewScanRequestFixState(requireActivity(), site, this.threatId)
                         }
+                        is ThreatDetailsNavigationEvents.ShowGetFreeEstimate -> {
+                            ActivityLauncher.openUrlExternal(context, this.url)
+                        }
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsNavigationEvents.kt
@@ -17,4 +17,8 @@ sealed class ThreatDetailsNavigationEvents {
     data class ShowUpdatedScanStateWithMessage(@StringRes val messageRes: Int) : ThreatDetailsNavigationEvents()
 
     data class ShowUpdatedFixState(val threatId: Long) : ThreatDetailsNavigationEvents()
+
+    object ShowGetFreeEstimate : ThreatDetailsNavigationEvents() {
+        const val url = "https://codeable.io/partners/jetpack-scan/"
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModel.kt
@@ -142,7 +142,8 @@ class ThreatDetailsViewModel @Inject constructor(
         )
     }
 
-    private fun onGetFreeEstimateButtonClicked() { // TODO ashiagr to be implemented
+    private fun onGetFreeEstimateButtonClicked() {
+        updateNavigationEvent(ThreatDetailsNavigationEvents.ShowGetFreeEstimate)
     }
 
     private fun updateThreatActionButtons(isEnabled: Boolean) {
@@ -173,7 +174,7 @@ class ThreatDetailsViewModel @Inject constructor(
     private fun buildContentUiState(model: ThreatModel) = Content(
         builder.buildThreatDetailsListItems(
             model,
-            this@ThreatDetailsViewModel::onFixThreatButtonClicked,
+                this@ThreatDetailsViewModel::onFixThreatButtonClicked,
             this@ThreatDetailsViewModel::onGetFreeEstimateButtonClicked,
             this@ThreatDetailsViewModel::onIgnoreThreatButtonClicked
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModelTest.kt
@@ -293,22 +293,27 @@ class ThreatDetailsViewModelTest : BaseUnitTest() {
     }
 
     private fun createDummyThreatDetailsListItems(
-        onFixThreatItemClicked: () -> Unit,
-        onIgnoreThreatItemClicked: () -> Unit
-    ) = listOf(
-        ActionButtonState(
-            text = fakeUiStringText,
-            contentDescription = fakeUiStringText,
-            isSecondary = false,
-            onClick = onFixThreatItemClicked
-        ),
-        ActionButtonState(
-            text = fakeUiStringText,
-            contentDescription = fakeUiStringText,
-            isSecondary = true,
-            onClick = onIgnoreThreatItemClicked
+        primaryAction: () -> Unit,
+        secondaryAction: (() -> Unit)? = null
+    ): List<ActionButtonState> {
+        val list = mutableListOf(
+                ActionButtonState(
+                        text = fakeUiStringText,
+                        contentDescription = fakeUiStringText,
+                        isSecondary = false,
+                        onClick = primaryAction
+                )
         )
-    )
+        secondaryAction?.let {
+            list.add(ActionButtonState(
+                    text = fakeUiStringText,
+                    contentDescription = fakeUiStringText,
+                    isSecondary = true,
+                    onClick = secondaryAction
+            ))
+        }
+        return list
+    }
 
     private fun init(): Observers {
         val uiStates = mutableListOf<UiState>()

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsViewModelTest.kt
@@ -38,6 +38,7 @@ import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 
 private const val ON_FIX_THREAT_BUTTON_CLICKED_PARAM_POSITION = 1
+private const val ON_GET_FREE_ESTIMATE_BUTTON_CLICKED_PARAM_POSITION = 2
 private const val ON_IGNORE_THREAT_BUTTON_CLICKED_PARAM_POSITION = 3
 private const val TEST_SITE_NAME = "test site name"
 
@@ -129,6 +130,22 @@ class ThreatDetailsViewModelTest : BaseUnitTest() {
                 assertThat(negativeButtonLabel).isEqualTo(R.string.dialog_button_cancel)
             }
         }
+
+    @Test
+    fun `when get free estimate button is clicked, then ShowGetFreeEstimate event is triggered`() = test {
+        whenever(builder.buildThreatDetailsListItems(any(), any(), any(), any())).thenAnswer {
+            createDummyThreatDetailsListItems(
+                    it.getArgument(ON_GET_FREE_ESTIMATE_BUTTON_CLICKED_PARAM_POSITION)
+            )
+        }
+        val observers = init()
+
+        (observers.uiStates.last() as Content).items.filterIsInstance<ActionButtonState>()
+                .first().onClick.invoke()
+
+        assertThat(observers.navigation.last().peekContent())
+                .isInstanceOf(ThreatDetailsNavigationEvents.ShowGetFreeEstimate::class.java)
+    }
 
     @Test
     fun `given server unavailable, when fix threat action is triggered, then fix threat error msg is shown`() =


### PR DESCRIPTION
Parent issue #13326

This PR implements "get free estimate" action which is shown on ThreatDetail screen for non-fixable threats.

To test:
Prerequisites:
- enable scan feature flag
- select a site which either has a current non-fixable threat or it has a non-fixable threat in Scan History (eg. pressable-jetpack-daily-scan)
1. Open scan
2. Optional: (Open Scan History)
3. Open detail of a non-fixable ignored threat
4. Click on the "Get free estimate" button
5. Notice the app redirects you to an external webview

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
