### PR TITLE
Show post/page updated notification if this is not a first time publish

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -344,14 +344,25 @@ public class PostUtils {
     }
 
     public static boolean isPublishDateInThePast(String dateCreated, Date currentDate) {
-        Date pubDate = DateTimeUtils.dateFromIso8601(dateCreated);
+        // just use half an hour before now as a threshold to make sure this is backdated, to avoid false positives
+        return isPublishDateInThePast(dateCreated, currentDate, 30);
+    }
 
+    /**
+     * Checks if the post publish date is in the past
+     *
+     * @param dateCreated date created
+     * @param currentDate current date
+     * @param threshold   threshold in minutes
+     * @return true if the post was published in the past
+     */
+    public static boolean isPublishDateInThePast(String dateCreated, Date currentDate, int threshold) {
+        Date pubDate = DateTimeUtils.dateFromIso8601(dateCreated);
         Calendar cal = Calendar.getInstance();
         cal.setTime(currentDate);
-        // just use half an hour before now as a threshold to make sure this is backdated, to avoid false positives
-        cal.add(Calendar.MINUTE, -30);
-        Date halfHourBack = cal.getTime();
-        return pubDate != null && pubDate.before(halfHourBack);
+        cal.add(Calendar.MINUTE, -threshold);
+        Date timeThreshold = cal.getTime();
+        return pubDate != null && pubDate.before(timeThreshold);
     }
 
     // Only drafts should have the option to publish immediately to avoid user confusion

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -50,6 +50,7 @@ import org.wordpress.android.util.UploadWorkerKt;
 import org.wordpress.android.util.WPMediaUtils;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -510,10 +511,14 @@ public class UploadUtils {
                     case PUBLISHED:
                         snackbarButtonRes = R.string.button_view;
 
+                        // If the post was published in the last minute we consider that this is a first time publish
+                        boolean isFirstTimePublish =
+                                !PostUtils.isPublishDateInThePast(post.getDateCreated(), new Date(), 1);
+
                         if (post.isPage()) {
-                            snackbarMessageRes = R.string.page_published;
+                            snackbarMessageRes = isFirstTimePublish ? R.string.page_published : R.string.page_updated;
                         } else if (userCanPublish) {
-                            snackbarMessageRes = R.string.post_published;
+                            snackbarMessageRes = isFirstTimePublish ? R.string.post_published : R.string.post_updated;
                         } else {
                             snackbarMessageRes = R.string.post_submitted;
                         }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3018

## To test:

1. Go to a published Page / Post
2. Make a change
3. Save the change
4. Verify that the toast says “Page Updated”

Note: This implementation makes the assumption that the post/page is new if it was created in the last minute

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
