### PR TITLE
Implement "Check your site stats" QS task

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItem.kt
@@ -44,8 +44,9 @@ sealed class MySiteItem(val type: Type, val activeQuickStartItem: Boolean = fals
         val onPagesClick: ListItemInteraction,
         val onPostsClick: ListItemInteraction,
         val onMediaClick: ListItemInteraction,
-        val showPages: Boolean = true
-    ) : MySiteItem(QUICK_ACTIONS_BLOCK)
+        val showPages: Boolean = true,
+        val showStatsFocusPoint: Boolean = false
+    ) : MySiteItem(QUICK_ACTIONS_BLOCK, activeQuickStartItem = showStatsFocusPoint)
 
     data class DomainRegistrationBlock(val onClick: ListItemInteraction) : MySiteItem(DOMAIN_REGISTRATION_BLOCK)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -334,6 +334,7 @@ class MySiteViewModel
     private fun quickActionStatsClick() {
         val site = requireNotNull(selectedSiteRepository.getSelectedSite())
         analyticsTrackerWrapper.track(QUICK_ACTION_STATS_TAPPED)
+        quickStartRepository.completeTask(CHECK_STATS)
         _onNavigation.value = Event(getStatsNavigationActionForSite(site))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -250,7 +250,10 @@ class MySiteViewModel
                 SITE_SETTINGS -> OpenSiteSettings(site)
                 THEMES -> OpenThemes(site)
                 PLUGINS -> OpenPlugins(site)
-                STATS -> getStatsNavigationActionForSite(site)
+                STATS -> {
+                    quickStartRepository.completeTask(CHECK_STATS)
+                    getStatsNavigationActionForSite(site)
+                }
                 MEDIA -> OpenMedia(site)
                 COMMENTS -> OpenComments(site)
                 VIEW_SITE -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_POST_SHARING
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
@@ -181,7 +182,8 @@ class MySiteViewModel
                             ListItemInteraction.create(this::quickActionPagesClick),
                             ListItemInteraction.create(this::quickActionPostsClick),
                             ListItemInteraction.create(this::quickActionMediaClick),
-                            site.isSelfHostedAdmin || site.hasCapabilityEditPages
+                            site.isSelfHostedAdmin || site.hasCapabilityEditPages,
+                            activeTask == CHECK_STATS
                     )
             )
             if (isDomainCreditAvailable) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickActionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickActionsViewHolder.kt
@@ -16,5 +16,7 @@ class QuickActionsViewHolder(parent: ViewGroup) : MySiteItemViewHolder(parent, R
         val pagesVisibility = if (item.showPages) View.VISIBLE else View.GONE
         quick_action_pages_container.visibility = pagesVisibility
         middle_quick_action_spacing.visibility = pagesVisibility
+
+        quick_start_stats_focus_point.setVisibleOrGone(item.showStatsFocusPoint)
     }
 }

--- a/WordPress/src/main/res/layout/quick_actions_block.xml
+++ b/WordPress/src/main/res/layout/quick_actions_block.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/quick_actions_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -23,6 +25,18 @@
             style="@style/MySiteQuickActionButtonLabel"
             android:layout_below="@+id/quick_action_stats_button"
             android:text="@string/stats" />
+
+        <org.wordpress.android.widgets.QuickStartFocusPoint
+            android:id="@+id/quick_start_stats_focus_point"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:layout_alignParentEnd="true"
+            android:layout_gravity="center_vertical|center"
+            android:contentDescription="@string/quick_start_focus_point_description"
+            android:elevation="@dimen/quick_start_focus_point_elevation"
+            app:size="small"
+            tools:ignore="RtlSymmetry" />
     </RelativeLayout>
 
     <Space

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEM
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
 import org.wordpress.android.test
@@ -578,6 +579,15 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `quick action stats click completes CHECK_STATS task`() {
+        initSelectedSite()
+
+        findQuickActionsBlock()?.onStatsClick?.click()
+
+        verify(quickStartRepository).completeTask(CHECK_STATS)
+    }
+
+    @Test
     fun `quick action pages click opens pages screen`() {
         initSelectedSite()
 
@@ -723,6 +733,13 @@ class MySiteViewModelTest : BaseUnitTest() {
         invokeItemClickAction(STATS)
 
         assertThat(navigationActions).containsExactly(OpenStats(site))
+    }
+
+    @Test
+    fun `stats item click completes CHECK_STATS task`() {
+        invokeItemClickAction(STATS)
+
+        verify(quickStartRepository).completeTask(CHECK_STATS)
     }
 
     @Test


### PR DESCRIPTION
Fixes #13847

This task implements the "Check your site stats" Quick Start task, which is part of the "Grow your audience" category.

This PR shows a snackbar message and a focus point on top of the "Stats" quick action button and then completes the tasks when the user clicks on either that button or the Stats item on the My Site menu list.

## To test

1. Turn on the Improved My Site flag and restart the app.
1. Go to the My Site screen and select a site where Quick Start is active.
1. Under the "Grow your audience" category, tap the "Check your site stats" task.
1. Notice that:
   1. The screen scrolls to the "Stats" quick action button.
   1. A focus point appears over the button.
   1. The correct snackbar message appears.
1. Tap on the "Stats" quick action button.
1. Notice the Stats screen.
1. Go back to the My Site screen and scroll to the "Grow your audience" category.
1. Notice that the "Check your site stats" task is now completed.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
