### PR TITLE
Analytics: Adds global app_scheme property to store the build flavor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -178,7 +178,7 @@ public class AnalyticsUtils {
         metadata.setUsername(accountStore.getAccount().getUserName());
         metadata.setEmail(accountStore.getAccount().getEmail());
         if (BuildConfig.DEBUG) {
-            metadata.setAppScheme(BuildConfig.BUILD_TYPE);
+            metadata.setAppScheme("debug");
         } else {
             metadata.setAppScheme(BuildConfig.FLAVOR);
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -177,7 +177,11 @@ public class AnalyticsUtils {
         metadata.setNumBlogs(siteStore.getSitesCount());
         metadata.setUsername(accountStore.getAccount().getUserName());
         metadata.setEmail(accountStore.getAccount().getEmail());
-        metadata.setAppScheme(BuildConfig.FLAVOR.toString());
+        if (BuildConfig.BUILD_TYPE == "debug") {
+            metadata.setAppScheme(BuildConfig.BUILD_TYPE);
+        } else {
+            metadata.setAppScheme(BuildConfig.FLAVOR);
+        }
         if (siteStore.hasSite()) {
             metadata.setGutenbergEnabled(isGutenbergEnabledOnAnySite(siteStore.getSites()));
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -177,11 +177,8 @@ public class AnalyticsUtils {
         metadata.setNumBlogs(siteStore.getSitesCount());
         metadata.setUsername(accountStore.getAccount().getUserName());
         metadata.setEmail(accountStore.getAccount().getEmail());
-        if (BuildConfig.DEBUG) {
-            metadata.setAppScheme("debug");
-        } else {
-            metadata.setAppScheme(BuildConfig.FLAVOR);
-        }
+        String scheme = BuildConfig.DEBUG ? "debug" : BuildConfig.FLAVOR;
+        metadata.setAppScheme(scheme);
         if (siteStore.hasSite()) {
             metadata.setGutenbergEnabled(isGutenbergEnabledOnAnySite(siteStore.getSites()));
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -14,6 +14,7 @@ import androidx.annotation.VisibleForTesting;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsMetadata;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -176,6 +177,7 @@ public class AnalyticsUtils {
         metadata.setNumBlogs(siteStore.getSitesCount());
         metadata.setUsername(accountStore.getAccount().getUserName());
         metadata.setEmail(accountStore.getAccount().getEmail());
+        metadata.setAppScheme(BuildConfig.FLAVOR.toString());
         if (siteStore.hasSite()) {
             metadata.setGutenbergEnabled(isGutenbergEnabledOnAnySite(siteStore.getSites()));
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -177,7 +177,7 @@ public class AnalyticsUtils {
         metadata.setNumBlogs(siteStore.getSitesCount());
         metadata.setUsername(accountStore.getAccount().getUserName());
         metadata.setEmail(accountStore.getAccount().getEmail());
-        if (BuildConfig.BUILD_TYPE == "debug") {
+        if (BuildConfig.DEBUG) {
             metadata.setAppScheme(BuildConfig.BUILD_TYPE);
         } else {
             metadata.setAppScheme(BuildConfig.FLAVOR);

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsMetadata.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsMetadata.java
@@ -8,6 +8,7 @@ public class AnalyticsMetadata {
     private int mNumBlogs;
     private String mUsername = "";
     private String mEmail = "";
+    private String mAppScheme = "";
     private boolean mIsGutenbergEnabled;
     private boolean mIsGutenbergEnabledVariableSet;
 
@@ -68,6 +69,14 @@ public class AnalyticsMetadata {
 
     public void setEmail(String email) {
         this.mEmail = email;
+    }
+
+    public String getAppScheme() {
+        return mAppScheme;
+    }
+
+    public void setAppScheme(String scheme) {
+        this.mAppScheme = scheme;
     }
 
     public boolean isGutenbergEnabled() {

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -20,6 +20,7 @@ public class AnalyticsTrackerNosara extends Tracker {
     @SuppressWarnings("checkstyle:RegexpSingleline")
     private static final String WPCOM_USER = "dotcom_user";
     private static final String IS_GUTENBERG_ENABLED = "gutenberg_enabled";
+    private static final String APP_SCHEME = "app_scheme";
 
     private static final String EVENTS_PREFIX = "wpandroid_";
 
@@ -567,6 +568,7 @@ public class AnalyticsTrackerNosara extends Tracker {
             properties.put(JETPACK_USER, metadata.isJetpackUser());
             properties.put(NUMBER_OF_BLOGS, metadata.getNumBlogs());
             properties.put(WPCOM_USER, metadata.isWordPressComUser());
+            properties.put(APP_SCHEME, metadata.getAppScheme());
             // Only add the editor information if it was set before.
             // See: https://github.com/wordpress-mobile/WordPress-Android/pull/10300#discussion_r309145514
             if (metadata.isGutenbergEnabledVariableSet()) {


### PR DESCRIPTION
Closes #13890

This PR attempts to add a new global analytics property to identify the type of build emitting the tracks event, and is the Android version of https://github.com/wordpress-mobile/WordPress-iOS/pull/15742.  The property is reported as `user_info_app_scheme`.

What this PR _should_ do is correctly distinguish events by development, alpha (github), beta, and app store release builds.  My understanding is we use different build variants for each of these deployments, and i think this is the breakdown:
- wasabi: usually development
- jalapeno: github alphas
- vanilla: app store release
- zalpha: either a beta build or no longer used?
Did I get this correct? 

With these changes a debug build should always report "debug", but a release build should report it's flavor.

Opening this as a draft since I'm not sure if there's a better way to distinguish between release types. Please let me know! I'm all ears. :) 

@oguzkocer, (Hey! Long time!)  I wonder if I could borrow your eyes for this one since it's correctness depends on release builds?  
Props to @khaykov and @mzorz who gave some early helpful advice.  Much appreciated sirs! Would love your insights as well!

To test:
Run the build. 
After a few minutes, check the tracks live console for events form your user.  Confirm you see `user_info_app_scheme` logged with the correct build flavor for a release build or "debug" for a debug build.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @yaelirub 
