### PR TITLE
Prepublishing Nudges fix : Publish button cut off

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -121,7 +121,7 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
      * off. To fix this, we add the bottom inset as the margin bottom of the fragment container.
      */
     private fun addWindowInsetToFragmentContainer() {
-        if (VERSION.SDK_INT == VERSION_CODES.Q) {
+        if (VERSION.SDK_INT >= VERSION_CODES.Q) {
             activity?.window?.decorView?.rootWindowInsets?.systemWindowInsetBottom?.let { bottomInset ->
                 val param = prepublishing_content_fragment.layoutParams as ViewGroup.MarginLayoutParams
                 param.setMargins(0, 0, 0, bottomInset)


### PR DESCRIPTION
Fixes #12491

## Description 

This solution is a continuation of https://github.com/wordpress-mobile/WordPress-Android/pull/13298 It basically fixes the logic in that PR that resolved this cut-off issue. The previous solution only targeted Android 10 but this issue exists on versions above  Android 10 so the code now incorporates those versions. 

## Testing

1. Create a story post on an Android 11/ API 30 device. 
2. Click Next. 
3. Observe that the publish button is no longer cut off.

Before | After 
--------|-------
<kbd><img src="https://user-images.githubusercontent.com/1509205/98307182-308afa00-1f93-11eb-9d34-2b9392fcee08.png" width="320"></kbd> |    <kbd><img src="https://user-images.githubusercontent.com/1509205/98307201-3bde2580-1f93-11eb-8c08-c76786675057.png" width="320"></kbd>

Before | After 
--------|-------
 <kbd><img src="https://user-images.githubusercontent.com/1509205/98307190-3385ea80-1f93-11eb-8a22-32879dae7a49.png" width="320"></kbd>   |    <kbd><img src="https://user-images.githubusercontent.com/1509205/98307208-3ed91600-1f93-11eb-8e6f-9679cf5af8cd.png" width="320"></kbd>
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
