### PR TITLE
Update login / signup buttons copy

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2698,7 +2698,7 @@
     <string name="signup_magic_link_title">Magic link sent</string>
     <string name="signup_confirmation_title">Signup confirmation</string>
 
-    <string name="continue_with_wpcom">Continue with WordPress.com</string>
+    <string name="continue_with_wpcom">Log in or sign up with WordPress.com</string>
     <string name="enter_your_site_address">Enter your existing site address</string>
 
     <string name="username_changer_action">Save</string>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -92,7 +92,7 @@
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>
     <string name="signup_with_google_progress">Signing up with Google&#8230;</string>
-    <string name="continue_with_wpcom">Continue with WordPress.com</string>
+    <string name="continue_with_wpcom">Log in or sign up with WordPress.com</string>
     <string name="enter_your_site_address">Enter your existing site address</string>
 
     <string name="google_error_timeout">Google took too long to respond. You may need to wait until you have a stronger internet connection.</string>


### PR DESCRIPTION
Fixes #13879
Related [WordPressAuthenticator-iOS#572](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/572)

This PR updates the copy on the login/signup button from `Continue to WordPress.com` to `Log in or sign up with WordPress.com`.

<img src="https://user-images.githubusercontent.com/9729923/106743107-9a647f80-6626-11eb-8db3-b4c35ca86ea0.png" width="250" height="500">

To test:
- Be signed out.
- See copy as described.

Warning (⚠️): On iOS, since the title is more lengthy now, @yaelirub updated the title label font of both buttons from `title3` to `body` (per design). However, on Android we already are using `textAppearanceSubtitle2`, which is a small font. An alternative would be to use `textAppearanceBody2` or `textAppearanceCaption`, but that doesn't help much, just making the font look less bold.

textAppearanceSubtitle2 | textAppearanceBody2 | textAppearanceCaption
-------|------|------
<img width="250" height="500" alt="before" src="https://user-images.githubusercontent.com/9729923/106744203-2034fa80-6628-11eb-86b4-36e4fc6da661.png"> | <img width="250" height="500" alt="after" src="https://user-images.githubusercontent.com/9729923/106744217-23c88180-6628-11eb-8bec-936f767a7b49.png"> | <img width="250" height="500" alt="after" src="https://user-images.githubusercontent.com/9729923/106744511-8b7ecc80-6628-11eb-8f4f-b05a591db8da.png">

What are your thoughts on that @mattmiklic ? 🙏 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
