### PR TITLE
Better handling of empty state in My Site fragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteStateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteStateProvider.kt
@@ -37,7 +37,6 @@ class MySiteStateProvider(
             mySiteSources.filterIsInstance(SiteIndependentSource::class.java)
                     .map { source -> source.buildSource().distinctUntilChanged().asLiveData(bgDispatcher) }
         }
-        result.value = MySiteUiState()
         for (newSource in currentSources) {
             result.addSource(newSource) { partialState ->
                 if (partialState != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -160,7 +160,7 @@ class MySiteViewModel
             scanAvailable,
             backupAvailable,
             activeTask,
-    quickStartCategories
+            quickStartCategories
     ) ->
         val state = if (site != null) {
             val siteItems = mutableListOf<MySiteItem>()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -264,7 +264,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `model contains header of selected site`() {
         initSelectedSite()
 
-        assertThat(uiModels).hasSize(4)
+        assertThat(uiModels).hasSize(2)
         assertThat(uiModels.last().state).isInstanceOf(SiteSelected::class.java)
 
         assertThat(getLastItems()).hasSize(2)
@@ -487,7 +487,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         currentAvatar.value = CurrentAvatarUrl(avatarUrl)
 
-        assertThat(uiModels).hasSize(5)
+        assertThat(uiModels).hasSize(3)
         assertThat(uiModels.last().accountAvatarUrl).isEqualTo(avatarUrl)
     }
 
@@ -877,7 +877,8 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `when no site is selected and screen height is higher than 600 pixels, show empty view image`() {
         whenever(displayUtilsWrapper.getDisplayPixelHeight()).thenReturn(600)
 
-        onSiteSelected.value = siteId
+        initSelectedSite()
+        onSiteSelected.value = null
 
         assertThat(uiModels.last().state).isInstanceOf(State.NoSites::class.java)
         assertThat((uiModels.last().state as State.NoSites).shouldShowImage).isTrue
@@ -887,7 +888,8 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `when no site is selected and screen height is lower than 600 pixels, hide empty view image`() {
         whenever(displayUtilsWrapper.getDisplayPixelHeight()).thenReturn(500)
 
-        onSiteSelected.value = siteId
+        initSelectedSite()
+        onSiteSelected.value = null
 
         assertThat(uiModels.last().state).isInstanceOf(State.NoSites::class.java)
         assertThat((uiModels.last().state as State.NoSites).shouldShowImage).isFalse


### PR DESCRIPTION
There are two issues that cause the My Site screen to sometimes show the "No Sites" state. This PR fixes both of them. 

The first thing is that we don't need to emit empty state when site changes. The other one is that when a Site ID is emitted but the SiteModel is not yet there, we don't want to emit an empty state (because it's logically incorrect - there is a site). In this PR this state is filtered out now. 

To test:
- Make sure the my site improvements flag is turned on and the app is restarted
- Go to Plans
- Go back
- Notice you can't see the "No Site" state
- You might need to turn on the "Don't keep activites" developer options to make sure the main activity is destroyed when you leave it

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
