### PR TITLE
Enable/disable submit button on checkbox click

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -338,9 +338,9 @@ class BackupDownloadViewModel @Inject constructor(
     }
 
     private fun onCheckboxItemClicked(itemType: JetpackAvailableItemType) {
-        _uiState.value?.let {
+        (_uiState.value as? DetailsState)?.let {
             val updatedItems = stateListItemBuilder.updateCheckboxes(it, itemType)
-            _uiState.postValue((it as DetailsState).copy(items = updatedItems))
+            _uiState.postValue(it.copy(items = updatedItems))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -42,7 +42,6 @@ import org.wordpress.android.ui.jetpack.backup.download.usecases.PostBackupDownl
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.CheckboxState
 import org.wordpress.android.ui.jetpack.common.ViewType
-import org.wordpress.android.ui.jetpack.common.ViewType.CHECKBOX
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType.CONTENTS
@@ -339,20 +338,9 @@ class BackupDownloadViewModel @Inject constructor(
     }
 
     private fun onCheckboxItemClicked(itemType: JetpackAvailableItemType) {
-        (_uiState.value as? DetailsState)?.let { details ->
-            val updatedList = details.items.map { contentState ->
-                if (contentState.type == CHECKBOX) {
-                    contentState as CheckboxState
-                    if (contentState.availableItemType == itemType) {
-                        contentState.copy(checked = !contentState.checked)
-                    } else {
-                        contentState
-                    }
-                } else {
-                    contentState
-                }
-            }
-            _uiState.postValue(details.copy(items = updatedList))
+        _uiState.value?.let {
+            val updatedItems = stateListItemBuilder.updateCheckboxes(it, itemType)
+            _uiState.postValue((it as DetailsState).copy(items = updatedItems))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
@@ -8,6 +8,7 @@ import dagger.Reusable
 import org.wordpress.android.R
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadErrorTypes
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadErrorTypes.RemoteRequestFailure
+import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadUiState
 import org.wordpress.android.ui.jetpack.common.CheckboxSpannableLabel
 import org.wordpress.android.ui.jetpack.common.JetpackBackupRestoreListItemState.BulletState
 import org.wordpress.android.ui.jetpack.common.JetpackBackupRestoreListItemState.FootnoteState
@@ -19,6 +20,8 @@ import org.wordpress.android.ui.jetpack.common.JetpackListItemState.DescriptionS
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.HeaderState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.IconState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ProgressState
+import org.wordpress.android.ui.jetpack.common.ViewType.CHECKBOX
+import org.wordpress.android.ui.jetpack.common.ViewType.PRIMARY_ACTION_BUTTON
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItem
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -229,4 +232,44 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
             label = UiStringRes(labelRes),
             itemBottomMarginResId = itemBottomMarginResId
     )
+
+    fun updateCheckboxes(
+        uiState: BackupDownloadUiState,
+        itemType: JetpackAvailableItemType
+    ): List<JetpackListItemState> {
+        var checkedCount = 0
+        val updateCheckboxes = uiState.items.map { state ->
+                if (state.type == CHECKBOX) {
+                    state as CheckboxState
+                    if (state.availableItemType == itemType) {
+                        if (!state.checked) {
+                            checkedCount++
+                        }
+                        state.copy(checked = !state.checked)
+                    } else {
+                        if (state.checked) {
+                            checkedCount++
+                        }
+                        state
+                    }
+                } else {
+                    state
+                }
+        }
+        return updateDetailsActionButtonState(updateCheckboxes, checkedCount > 0)
+    }
+
+    private fun updateDetailsActionButtonState(
+        details: List<JetpackListItemState>,
+        enableActionButton: Boolean
+    ): List<JetpackListItemState> {
+        return details.map { state ->
+            if (state.type == PRIMARY_ACTION_BUTTON) {
+                state as ActionButtonState
+                state.copy(isEnabled = enableActionButton)
+            } else {
+                state
+            }
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.jetpack.common.JetpackListItemState.HeaderState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.IconState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ProgressState
 import org.wordpress.android.ui.jetpack.common.ViewType.CHECKBOX
-import org.wordpress.android.ui.jetpack.common.ViewType.PRIMARY_ACTION_BUTTON
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItem
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -237,26 +236,20 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
         uiState: BackupDownloadUiState,
         itemType: JetpackAvailableItemType
     ): List<JetpackListItemState> {
-        var checkedCount = 0
-        val updateCheckboxes = uiState.items.map { state ->
+        val updatedCheckboxes = uiState.items.map { state ->
                 if (state.type == CHECKBOX) {
                     state as CheckboxState
                     if (state.availableItemType == itemType) {
-                        if (!state.checked) {
-                            checkedCount++
-                        }
                         state.copy(checked = !state.checked)
                     } else {
-                        if (state.checked) {
-                            checkedCount++
-                        }
                         state
                     }
                 } else {
                     state
                 }
         }
-        return updateDetailsActionButtonState(updateCheckboxes, checkedCount > 0)
+        val atLeastOneChecked = updatedCheckboxes.filterIsInstance<CheckboxState>().find { it.checked } != null
+        return updateDetailsActionButtonState(updatedCheckboxes, atLeastOneChecked)
     }
 
     private fun updateDetailsActionButtonState(
@@ -264,8 +257,7 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
         enableActionButton: Boolean
     ): List<JetpackListItemState> {
         return details.map { state ->
-            if (state.type == PRIMARY_ACTION_BUTTON) {
-                state as ActionButtonState
+            if (state is ActionButtonState) {
                 state.copy(isEnabled = enableActionButton)
             } else {
                 state

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -394,9 +394,9 @@ class RestoreViewModel @Inject constructor(
     }
 
     private fun onCheckboxItemClicked(itemType: JetpackAvailableItemType) {
-        _uiState.value?.let {
+        (_uiState.value as? DetailsState)?.let {
             val updatedItems = stateListItemBuilder.updateCheckboxes(it, itemType)
-            _uiState.postValue(((it as DetailsState).copy(items = updatedItems)))
+            _uiState.postValue(it.copy(items = updatedItems))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.CheckboxState
 import org.wordpress.android.ui.jetpack.common.ViewType
-import org.wordpress.android.ui.jetpack.common.ViewType.CHECKBOX
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType.CONTENTS
@@ -395,20 +394,9 @@ class RestoreViewModel @Inject constructor(
     }
 
     private fun onCheckboxItemClicked(itemType: JetpackAvailableItemType) {
-        (_uiState.value as? DetailsState)?.let { details ->
-            val updatedList = details.items.map { contentState ->
-                if (contentState.type == CHECKBOX) {
-                    contentState as CheckboxState
-                    if (contentState.availableItemType == itemType) {
-                        contentState.copy(checked = !contentState.checked)
-                    } else {
-                        contentState
-                    }
-                } else {
-                    contentState
-                }
-            }
-            _uiState.postValue(details.copy(items = updatedList))
+        _uiState.value?.let {
+            val updatedItems = stateListItemBuilder.updateCheckboxes(it, itemType)
+            _uiState.postValue(((it as DetailsState).copy(items = updatedItems)))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
@@ -17,10 +17,13 @@ import org.wordpress.android.ui.jetpack.common.JetpackListItemState.DescriptionS
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.HeaderState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.IconState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ProgressState
+import org.wordpress.android.ui.jetpack.common.ViewType.CHECKBOX
+import org.wordpress.android.ui.jetpack.common.ViewType.PRIMARY_ACTION_BUTTON
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItem
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType
 import org.wordpress.android.ui.jetpack.restore.RestoreErrorTypes
 import org.wordpress.android.ui.jetpack.restore.RestoreErrorTypes.RemoteRequestFailure
+import org.wordpress.android.ui.jetpack.restore.RestoreUiState
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -247,4 +250,44 @@ class RestoreStateListItemBuilder @Inject constructor(
             label = UiStringRes(labelRes),
             itemBottomMarginResId = itemBottomMarginResId
     )
+
+    fun updateCheckboxes(
+        uiState: RestoreUiState,
+        itemType: JetpackAvailableItemType
+    ): List<JetpackListItemState> {
+        var checkedCount = 0
+        val updateCheckboxes = uiState.items.map { state ->
+            if (state.type == CHECKBOX) {
+                state as CheckboxState
+                if (state.availableItemType == itemType) {
+                    if (!state.checked) {
+                        checkedCount++
+                    }
+                    state.copy(checked = !state.checked)
+                } else {
+                    if (state.checked) {
+                        checkedCount++
+                    }
+                    state
+                }
+            } else {
+                state
+            }
+        }
+        return updateDetailsActionButtonState(updateCheckboxes, checkedCount > 0)
+    }
+
+    private fun updateDetailsActionButtonState(
+        details: List<JetpackListItemState>,
+        enableActionButton: Boolean
+    ): List<JetpackListItemState> {
+        return details.map { state ->
+            if (state.type == PRIMARY_ACTION_BUTTON) {
+                state as ActionButtonState
+                state.copy(isEnabled = enableActionButton)
+            } else {
+                state
+            }
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.ui.jetpack.common.JetpackListItemState.HeaderState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.IconState
 import org.wordpress.android.ui.jetpack.common.JetpackListItemState.ProgressState
 import org.wordpress.android.ui.jetpack.common.ViewType.CHECKBOX
-import org.wordpress.android.ui.jetpack.common.ViewType.PRIMARY_ACTION_BUTTON
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItem
 import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsProvider.JetpackAvailableItemType
 import org.wordpress.android.ui.jetpack.restore.RestoreErrorTypes
@@ -255,26 +254,20 @@ class RestoreStateListItemBuilder @Inject constructor(
         uiState: RestoreUiState,
         itemType: JetpackAvailableItemType
     ): List<JetpackListItemState> {
-        var checkedCount = 0
-        val updateCheckboxes = uiState.items.map { state ->
+        val updatedCheckboxes = uiState.items.map { state ->
             if (state.type == CHECKBOX) {
                 state as CheckboxState
                 if (state.availableItemType == itemType) {
-                    if (!state.checked) {
-                        checkedCount++
-                    }
                     state.copy(checked = !state.checked)
                 } else {
-                    if (state.checked) {
-                        checkedCount++
-                    }
                     state
                 }
             } else {
                 state
             }
         }
-        return updateDetailsActionButtonState(updateCheckboxes, checkedCount > 0)
+        val atLeastOneChecked = updatedCheckboxes.filterIsInstance<CheckboxState>().find { it.checked } != null
+        return updateDetailsActionButtonState(updatedCheckboxes, atLeastOneChecked)
     }
 
     private fun updateDetailsActionButtonState(
@@ -282,8 +275,7 @@ class RestoreStateListItemBuilder @Inject constructor(
         enableActionButton: Boolean
     ): List<JetpackListItemState> {
         return details.map { state ->
-            if (state.type == PRIMARY_ACTION_BUTTON) {
-                state as ActionButtonState
+            if (state is ActionButtonState) {
                 state.copy(isEnabled = enableActionButton)
             } else {
                 state


### PR DESCRIPTION
Parent #13328 & 13329

This PR addresses the following comment
"On unchecking all checkbox items on the "Details" screen, we might want to disable action button."
By ..
1. Disabling the details action button when no items are selected
2. Enabling the action button when at least 1 checkbox is selected

This behavior now mimics Calypso.

To Test
- Launch the app
- Ensure BackupDownload and Restore feature flags are enabled
------------------
- Navigate to ActivityLog
- Tap More menu on an item
- Select "Download backup" option
- On the details view, uncheck all the checkboxes
- The "Create downloadable file" button should toggle to disabled
- Check a checkbox
- The "Create downloadable file" button should toggle to enabled
------------------
- Navigate to ActivityLog
- Tap More menu on an item
- Select "restore to this point" option
- On the details view, uncheck all the checkboxes
- The "Restore Site" button should toggle to disabled
- Check a checkbox
- The "Restore Site" button should toggle to enabled
------------------


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
