### PR TITLE
Force text color on reader post.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [*] Adds tablet mode in site and post/page previews [https://github.com/wordpress-mobile/WordPress-Android/pull/13787]
 * [*] Reader: show post menu for posts in Blog Preview and Search results [https://github.com/wordpress-mobile/WordPress-Android/pull/13897]
 * [**] Site Creation: Enables dot blog subdomains for each site design. [https://github.com/wordpress-mobile/WordPress-Android/pull/13917]
+* [*] Reader: render all colored text using a single color. [https://github.com/wordpress-mobile/WordPress-Android/pull/13958]
 
 16.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -344,7 +344,8 @@ public class ReaderPostRenderer {
               // force font style
         sbHtml.append(" body.reader-full-post__story-content { font-family: 'Noto Serif', serif; font-weight: 400; ")
               .append("font-size: 16px; margin: 0px; padding: 0px; }")
-              .append(" p, div, li { line-height: 1.6em; font-size: 100%; }")
+              .append(" p, div, li { line-height: 1.6em; font-size: 100%; color: var(--color-text) !important; }")
+              .append(" .has-inline-color { color: var(--color-text) !important; }")
               .append(" body, p, div { max-width: 100% !important; word-wrap: break-word; }")
               // set line-height, font-size but not for .tiled-gallery divs when rendering as tiled
               // gallery as those will be handled with the .tiled-gallery rules bellow.


### PR DESCRIPTION
Fixes #13841 

This PR forces text inside blocks (`<p>` tags) and elements with `.has-inline-color` class to use a preferred text color. 
This fixes issued of text color readability in light/dark modes and aligns us with iOS.

I'm not aware of other ways we change text color in our editors, so please let me know if you think I'm missing something. 

Before-After comparisons:

[![Image from Gyazo](https://i.gyazo.com/d1935d01e5b960084c1ee67e675799b9.png)](https://gyazo.com/d1935d01e5b960084c1ee67e675799b9)

[![Image from Gyazo](https://i.gyazo.com/d69148ca76f6b0535d73c22e7614540c.png)](https://gyazo.com/d69148ca76f6b0535d73c22e7614540c)

PS. Red is colored using GB block level setting, and it was not showing up in Reader anyway.

To test:
- Open post with colored text in Reader.
- Confirm that the colors are not shown.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
