### PR TITLE
Offer domain credit to atomic sites without domain.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -359,7 +359,7 @@ public class SiteUtils {
     }
 
     public static boolean hasCustomDomain(@NonNull SiteModel site) {
-        return !site.getUrl().contains(".wordpress.com");
+        return !site.getUrl().contains(".wordpress.com") && !site.getUrl().contains(".wpcomstaging.com");
     }
 
     public static boolean hasFullAccessToContent(@Nullable SiteModel site) {


### PR DESCRIPTION
Fixes #13580 

This PR fixes an issue where we didn't offer domain credit to atomic sites without a custom domain. 

To test:
- Make sure you have an atomic site without a custom domain. If you don't have one, purchase a bussines plan for a site, and install at least one plugin to transform site into Atomic. Confirm that it's using `.wpcomstaging.com` subdomain.
- Open the app, and confirm that domain credit CTA appears for that site on My Site screen.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
