### PR TITLE
Add "Review pages" quick start task

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.ENABLE_POST_SHARING
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.REVIEW_PAGES
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
 import org.wordpress.android.modules.BG_THREAD
@@ -185,7 +186,7 @@ class MySiteViewModel
                             ListItemInteraction.create(this::quickActionMediaClick),
                             site.isSelfHostedAdmin || site.hasCapabilityEditPages,
                             activeTask == CHECK_STATS,
-                            activeTask == EDIT_HOMEPAGE
+                            activeTask == EDIT_HOMEPAGE || activeTask == REVIEW_PAGES
                     )
             )
             if (isDomainCreditAvailable) {
@@ -347,6 +348,7 @@ class MySiteViewModel
         val site = requireNotNull(selectedSiteRepository.getSelectedSite())
         analyticsTrackerWrapper.track(QUICK_ACTION_PAGES_TAPPED)
         quickStartRepository.requestNextStepOfTask(EDIT_HOMEPAGE)
+        quickStartRepository.completeTask(REVIEW_PAGES)
         _onNavigation.value = Event(OpenPages(site))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -243,7 +243,10 @@ class MySiteViewModel
                 SCAN -> OpenScan(site)
                 PLAN -> OpenPlan(site)
                 POSTS -> OpenPosts(site)
-                PAGES -> OpenPages(site)
+                PAGES -> {
+                    quickStartRepository.completeTask(REVIEW_PAGES)
+                    OpenPages(site)
+                }
                 ADMIN -> OpenAdmin(site)
                 PEOPLE -> OpenPeople(site)
                 SHARING -> {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.REVIEW_PAGES
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
 import org.wordpress.android.test
@@ -591,12 +592,21 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `quick action pages click opens pages screen and requests next step of EDIT_HOMEPAGE task`() {
-        quickStartUpdate.value = QuickStartUpdate(EDIT_HOMEPAGE, listOf())
         initSelectedSite()
 
         findQuickActionsBlock()?.onPagesClick?.click()
 
         verify(quickStartRepository).requestNextStepOfTask(EDIT_HOMEPAGE)
+        assertThat(navigationActions).containsOnly(OpenPages(site))
+    }
+
+    @Test
+    fun `quick action pages click opens pages screen and completes REVIEW_PAGES task`() {
+        initSelectedSite()
+
+        findQuickActionsBlock()?.onPagesClick?.click()
+
+        verify(quickStartRepository).completeTask(REVIEW_PAGES)
         assertThat(navigationActions).containsOnly(OpenPages(site))
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -669,6 +669,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `pages item click emits OpenPages navigation event`() {
         invokeItemClickAction(PAGES)
 
+        verify(quickStartRepository).completeTask(REVIEW_PAGES)
         assertThat(navigationActions).containsExactly(OpenPages(site))
     }
 


### PR DESCRIPTION
Fixes #13878

This is a super simple change. It adds the focus point to the Pages quick actions item when the user clicks on the "Review pages" QS card. The task is completed 

To test:
- Make sure the my site improvements flag is turned on and the app is restarted
- Make sure you're on a site with quick start started
- Click on the "Review pages" card
- Notice the app scrolls to the "Pages" quick action
- Notice the focus point on the "Pages" quick action
- Click on the "Pages" quick action
- Go back
- Notice the "Review pages" card is now marked as done
- 
![review_pages_task](https://user-images.githubusercontent.com/1079756/106879996-1e2c7380-66dc-11eb-815c-c265d22df12b.gif)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
