### PR TITLE
Issue/13326 hide scan on wpcom sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -154,6 +154,7 @@ import org.wordpress.android.util.QuickStartUtils.Companion.isQuickStartInProgre
 import org.wordpress.android.util.QuickStartUtils.Companion.removeQuickStartFocusPoint
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
 import org.wordpress.android.util.WPMediaUtils
@@ -211,6 +212,7 @@ class MySiteFragment : Fragment(),
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var themeBrowserUtils: ThemeBrowserUtils
     @Inject lateinit var jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase
+    @Inject lateinit var siteUtilsWrapper: SiteUtilsWrapper
     @Inject lateinit var quickStartUtilsWrapper: QuickStartUtilsWrapper
     @Inject @Named(UI_THREAD) lateinit var uiDispatcher: CoroutineDispatcher
     @Inject @Named(BG_THREAD) lateinit var bgDispatcher: CoroutineDispatcher
@@ -281,12 +283,11 @@ class MySiteFragment : Fragment(),
             uiScope.launch {
                 val itemsVisibility = jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId)
                 row_scan.setVisible(
-                        scanScreenFeatureConfig.isEnabled() &&
-                                itemsVisibility.scan &&
-                                !site.isWPCom &&
-                                !site.isWPComAtomic
+                        siteUtilsWrapper.isScanEnabled(scanScreenFeatureConfig.isEnabled(), itemsVisibility.scan, site)
                 )
-                row_backup.setVisible(backupScreenFeatureConfig.isEnabled() && itemsVisibility.backup)
+                row_backup.setVisible(
+                        siteUtilsWrapper.isBackupEnabled(backupScreenFeatureConfig.isEnabled(), itemsVisibility.backup)
+                )
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -281,8 +281,10 @@ class MySiteFragment : Fragment(),
             uiScope.launch {
                 val itemsVisibility = jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId)
                 row_scan.setVisible(
-                        scanScreenFeatureConfig.isEnabled() && itemsVisibility.scan &&
-                                !site.isWPCom && !site.isWPComAtomic
+                        scanScreenFeatureConfig.isEnabled() &&
+                                itemsVisibility.scan &&
+                                !site.isWPCom &&
+                                !site.isWPComAtomic
                 )
                 row_backup.setVisible(backupScreenFeatureConfig.isEnabled() && itemsVisibility.backup)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -280,7 +280,10 @@ class MySiteFragment : Fragment(),
         if (scanScreenFeatureConfig.isEnabled() || backupScreenFeatureConfig.isEnabled()) {
             uiScope.launch {
                 val itemsVisibility = jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId)
-                row_scan.setVisible(scanScreenFeatureConfig.isEnabled() && !site.isWPCom && itemsVisibility.scan)
+                row_scan.setVisible(
+                        scanScreenFeatureConfig.isEnabled() && itemsVisibility.scan &&
+                                !site.isWPCom && !site.isWPComAtomic
+                )
                 row_backup.setVisible(backupScreenFeatureConfig.isEnabled() && itemsVisibility.backup)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -280,7 +280,7 @@ class MySiteFragment : Fragment(),
         if (scanScreenFeatureConfig.isEnabled() || backupScreenFeatureConfig.isEnabled()) {
             uiScope.launch {
                 val itemsVisibility = jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId)
-                row_scan.setVisible(scanScreenFeatureConfig.isEnabled() && itemsVisibility.scan)
+                row_scan.setVisible(scanScreenFeatureConfig.isEnabled() && !site.isWPCom && itemsVisibility.scan)
                 row_backup.setVisible(backupScreenFeatureConfig.isEnabled() && itemsVisibility.backup)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -7,8 +7,7 @@ import org.wordpress.android.util.config.BackupScreenFeatureConfig
 import org.wordpress.android.util.config.ScanScreenFeatureConfig
 import javax.inject.Inject
 
-class ScanAndBackupSource
-@Inject constructor(
+class ScanAndBackupSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val scanScreenFeatureConfig: ScanScreenFeatureConfig,
     private val backupScreenFeatureConfig: BackupScreenFeatureConfig,
@@ -22,9 +21,12 @@ class ScanAndBackupSource
             val itemsVisibility = jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId)
             emit(
                     JetpackCapabilities(
-                            scanAvailable = scanScreenFeatureConfig.isEnabled() && itemsVisibility.scan &&
-                                    !site.isWPCom && !site.isWPComAtomic,
-                            backupAvailable = backupScreenFeatureConfig.isEnabled() && itemsVisibility.backup
+                            scanAvailable = scanScreenFeatureConfig.isEnabled()
+                                    && itemsVisibility.scan
+                                    && !site.isWPCom
+                                    && !site.isWPComAtomic,
+                            backupAvailable = backupScreenFeatureConfig.isEnabled()
+                                    && itemsVisibility.backup
                     )
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -21,12 +21,12 @@ class ScanAndBackupSource @Inject constructor(
             val itemsVisibility = jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId)
             emit(
                     JetpackCapabilities(
-                            scanAvailable = scanScreenFeatureConfig.isEnabled()
-                                    && itemsVisibility.scan
-                                    && !site.isWPCom
-                                    && !site.isWPComAtomic,
-                            backupAvailable = backupScreenFeatureConfig.isEnabled()
-                                    && itemsVisibility.backup
+                            scanAvailable = scanScreenFeatureConfig.isEnabled() &&
+                                    itemsVisibility.scan &&
+                                    !site.isWPCom &&
+                                    !site.isWPComAtomic,
+                            backupAvailable = backupScreenFeatureConfig.isEnabled() &&
+                                    itemsVisibility.backup
                     )
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -22,7 +22,7 @@ class ScanAndBackupSource
             val itemsVisibility = jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId)
             emit(
                     JetpackCapabilities(
-                            scanAvailable = scanScreenFeatureConfig.isEnabled() && itemsVisibility.scan,
+                            scanAvailable = scanScreenFeatureConfig.isEnabled() && !site.isWPCom && itemsVisibility.scan,
                             backupAvailable = backupScreenFeatureConfig.isEnabled() && itemsVisibility.backup
                     )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -22,7 +22,8 @@ class ScanAndBackupSource
             val itemsVisibility = jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId)
             emit(
                     JetpackCapabilities(
-                            scanAvailable = scanScreenFeatureConfig.isEnabled() && !site.isWPCom && itemsVisibility.scan,
+                            scanAvailable = scanScreenFeatureConfig.isEnabled() && itemsVisibility.scan &&
+                                    !site.isWPCom && !site.isWPComAtomic,
                             backupAvailable = backupScreenFeatureConfig.isEnabled() && itemsVisibility.backup
                     )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.mysite
 import kotlinx.coroutines.flow.flow
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.JetpackCapabilities
+import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.config.BackupScreenFeatureConfig
 import org.wordpress.android.util.config.ScanScreenFeatureConfig
 import javax.inject.Inject
@@ -11,7 +12,8 @@ class ScanAndBackupSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val scanScreenFeatureConfig: ScanScreenFeatureConfig,
     private val backupScreenFeatureConfig: BackupScreenFeatureConfig,
-    private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase
+    private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase,
+    private val siteUtilsWrapper: SiteUtilsWrapper
 ) : MySiteSource<JetpackCapabilities> {
     override fun buildSource(siteId: Int) = flow {
         emit(JetpackCapabilities(scanAvailable = false, backupAvailable = false))
@@ -21,12 +23,15 @@ class ScanAndBackupSource @Inject constructor(
             val itemsVisibility = jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId)
             emit(
                     JetpackCapabilities(
-                            scanAvailable = scanScreenFeatureConfig.isEnabled() &&
-                                    itemsVisibility.scan &&
-                                    !site.isWPCom &&
-                                    !site.isWPComAtomic,
-                            backupAvailable = backupScreenFeatureConfig.isEnabled() &&
+                            scanAvailable = siteUtilsWrapper.isScanEnabled(
+                                    scanScreenFeatureConfig.isEnabled(),
+                                    itemsVisibility.scan,
+                                    site
+                            ),
+                            backupAvailable = siteUtilsWrapper.isBackupEnabled(
+                                    backupScreenFeatureConfig.isEnabled(),
                                     itemsVisibility.backup
+                            )
                     )
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.reader.utils.SiteAccessibilityInfo;
 import org.wordpress.android.ui.reader.utils.SiteVisibility;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
-import org.wordpress.android.util.config.ScanScreenFeatureConfig;
 import org.wordpress.android.util.helpers.Version;
 import org.wordpress.android.util.image.BlavatarShape;
 import org.wordpress.android.util.image.ImageType;

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.reader.utils.SiteAccessibilityInfo;
 import org.wordpress.android.ui.reader.utils.SiteVisibility;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
+import org.wordpress.android.util.config.ScanScreenFeatureConfig;
 import org.wordpress.android.util.helpers.Version;
 import org.wordpress.android.util.image.BlavatarShape;
 import org.wordpress.android.util.image.ImageType;
@@ -364,5 +365,15 @@ public class SiteUtils {
 
     public static boolean hasFullAccessToContent(@Nullable SiteModel site) {
         return site != null && (site.isSelfHostedAdmin() || site.getHasCapabilityEditPages());
+    }
+
+    // TODO: Inline this method when legacy MySiteFragment is removed
+    public static boolean isScanEnabled(boolean scanFeatureFlagEnabled, boolean scanPurchased, SiteModel site) {
+        return scanFeatureFlagEnabled && scanPurchased && !site.isWPCom() && !site.isWPComAtomic();
+    }
+
+    // TODO: Inline this method when legacy MySiteFragment is removed
+    public static boolean isBackupEnabled(boolean backupFeatureFlagEnabled, boolean backupPurchased) {
+        return backupFeatureFlagEnabled && backupPurchased;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
@@ -21,4 +21,11 @@ class SiteUtilsWrapper @Inject constructor() {
     fun isAccessedViaWPComRest(site: SiteModel): Boolean = SiteUtils.isAccessedViaWPComRest(site)
     fun onFreePlan(site: SiteModel): Boolean = SiteUtils.onFreePlan(site)
     fun hasCustomDomain(site: SiteModel): Boolean = SiteUtils.hasCustomDomain(site)
+
+    // TODO: Inline this method when legacy MySiteFragment is removed
+    fun isScanEnabled(scanFeatureFlagEnabled: Boolean, scanPurchased: Boolean, site: SiteModel) =
+            SiteUtils.isScanEnabled(scanFeatureFlagEnabled, scanPurchased, site)
+    // TODO: Inline this method when legacy MySiteFragment is removed
+    fun isBackupEnabled(backupFeatureFlagEnabled: Boolean, backupPurchased: Boolean) =
+            SiteUtils.isBackupEnabled(backupFeatureFlagEnabled, backupPurchased)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mysite
 
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.take
@@ -7,12 +8,14 @@ import kotlinx.coroutines.flow.toList
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.test
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase.JetpackPurchasedProducts
+import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.config.BackupScreenFeatureConfig
 import org.wordpress.android.util.config.ScanScreenFeatureConfig
 
@@ -22,6 +25,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
     @Mock lateinit var backupScreenFeatureConfig: BackupScreenFeatureConfig
     @Mock lateinit var jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase
     @Mock lateinit var site: SiteModel
+    @Mock lateinit var siteUtilsWrapper: SiteUtilsWrapper
     private lateinit var scanAndBackupSource: ScanAndBackupSource
     private val siteId = 1
     private val siteRemoteId = 2L
@@ -32,8 +36,11 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 selectedSiteRepository,
                 scanScreenFeatureConfig,
                 backupScreenFeatureConfig,
-                jetpackCapabilitiesUseCase
+                jetpackCapabilitiesUseCase,
+                siteUtilsWrapper
         )
+        whenever(siteUtilsWrapper.isBackupEnabled(anyBoolean(), anyBoolean())).thenCallRealMethod()
+        whenever(siteUtilsWrapper.isScanEnabled(anyBoolean(), anyBoolean(), eq(site))).thenCallRealMethod()
         whenever(site.id).thenReturn(siteId)
         whenever(site.isWPCom).thenReturn(false)
         whenever(site.isWPComAtomic).thenReturn(false)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -123,6 +123,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 JetpackPurchasedProducts(scan = true, backup = false)
         )
         whenever(site.isWPCom).thenReturn(true)
+        whenever(site.isWPComAtomic).thenReturn(false)
 
         val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
 
@@ -136,6 +137,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
                 JetpackPurchasedProducts(scan = true, backup = false)
         )
+        whenever(site.isWPCom).thenReturn(false)
         whenever(site.isWPComAtomic).thenReturn(true)
 
         val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -130,7 +130,6 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 JetpackPurchasedProducts(scan = true, backup = false)
         )
         whenever(site.isWPCom).thenReturn(true)
-        whenever(site.isWPComAtomic).thenReturn(false)
 
         val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
 
@@ -144,7 +143,6 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
                 JetpackPurchasedProducts(scan = true, backup = false)
         )
-        whenever(site.isWPCom).thenReturn(false)
         whenever(site.isWPComAtomic).thenReturn(true)
 
         val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -43,8 +43,8 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
         val result = scanAndBackupSource.buildSource(siteId).single()
 
-        assertThat(result.backupAvailable).isFalse()
-        assertThat(result.scanAvailable).isFalse()
+        assertThat(result.backupAvailable).isFalse
+        assertThat(result.scanAvailable).isFalse
     }
 
     @Test
@@ -53,8 +53,8 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
         val result = scanAndBackupSource.buildSource(siteId).single()
 
-        assertThat(result.backupAvailable).isFalse()
-        assertThat(result.scanAvailable).isFalse()
+        assertThat(result.backupAvailable).isFalse
+        assertThat(result.scanAvailable).isFalse
     }
 
     @Test
@@ -67,8 +67,8 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
         val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
 
-        assertThat(result.backupAvailable).isFalse()
-        assertThat(result.scanAvailable).isTrue()
+        assertThat(result.backupAvailable).isFalse
+        assertThat(result.scanAvailable).isTrue
     }
 
     @Test
@@ -81,8 +81,8 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
         val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
 
-        assertThat(result.backupAvailable).isTrue()
-        assertThat(result.scanAvailable).isFalse()
+        assertThat(result.backupAvailable).isTrue
+        assertThat(result.scanAvailable).isFalse
     }
 
     @Test
@@ -95,8 +95,8 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
         val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
 
-        assertThat(result.backupAvailable).isTrue()
-        assertThat(result.scanAvailable).isTrue()
+        assertThat(result.backupAvailable).isTrue
+        assertThat(result.scanAvailable).isTrue
     }
 
     @Test
@@ -109,8 +109,8 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
         val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
 
-        assertThat(result.backupAvailable).isFalse()
-        assertThat(result.scanAvailable).isFalse()
+        assertThat(result.backupAvailable).isFalse
+        assertThat(result.scanAvailable).isFalse
     }
 
     @Test
@@ -124,7 +124,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
         val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
 
-        assertThat(result.scanAvailable).isFalse()
+        assertThat(result.scanAvailable).isFalse
     }
 
     @Test
@@ -138,7 +138,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
 
         val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
 
-        assertThat(result.scanAvailable).isTrue()
+        assertThat(result.scanAvailable).isTrue
     }
 
     private fun init(scanScreenFeatureEnabled: Boolean = false, backupScreenFeatureEnabled: Boolean = false) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -113,6 +113,34 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         assertThat(result.scanAvailable).isFalse()
     }
 
+    @Test
+    fun `Scan not visible on wpcom sites even when Scan product is available`() = test {
+        init(scanScreenFeatureEnabled = true)
+        whenever(site.siteId).thenReturn(siteRemoteId)
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
+                JetpackPurchasedProducts(scan = true, backup = false)
+        )
+        whenever(site.isWPCom).thenReturn(true)
+
+        val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
+
+        assertThat(result.scanAvailable).isFalse()
+    }
+
+    @Test
+    fun `Scan visible on non-wpcom sites when Scan product is available and feature flag enabled`() = test {
+        init(scanScreenFeatureEnabled = true)
+        whenever(site.siteId).thenReturn(siteRemoteId)
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
+                JetpackPurchasedProducts(scan = true, backup = false)
+        )
+        whenever(site.isWPCom).thenReturn(false)
+
+        val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
+
+        assertThat(result.scanAvailable).isTrue()
+    }
+
     private fun init(scanScreenFeatureEnabled: Boolean = false, backupScreenFeatureEnabled: Boolean = false) {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         if (scanScreenFeatureEnabled) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -35,6 +35,8 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 jetpackCapabilitiesUseCase
         )
         whenever(site.id).thenReturn(siteId)
+        whenever(site.isWPCom).thenReturn(false)
+        whenever(site.isWPComAtomic).thenReturn(false)
     }
 
     @Test
@@ -128,6 +130,20 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
     }
 
     @Test
+    fun `Scan not visible on atomic sites even when Scan product is available`() = test {
+        init(scanScreenFeatureEnabled = true)
+        whenever(site.siteId).thenReturn(siteRemoteId)
+        whenever(jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(siteRemoteId)).thenReturn(
+                JetpackPurchasedProducts(scan = true, backup = false)
+        )
+        whenever(site.isWPComAtomic).thenReturn(true)
+
+        val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
+
+        assertThat(result.scanAvailable).isFalse
+    }
+
+    @Test
     fun `Scan visible on non-wpcom sites when Scan product is available and feature flag enabled`() = test {
         init(scanScreenFeatureEnabled = true)
         whenever(site.siteId).thenReturn(siteRemoteId)
@@ -135,6 +151,7 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 JetpackPurchasedProducts(scan = true, backup = false)
         )
         whenever(site.isWPCom).thenReturn(false)
+        whenever(site.isWPComAtomic).thenReturn(false)
 
         val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
 


### PR DESCRIPTION
Parent issue #13326

This PR hides Scan menu item on .com sites (even atomic). The scan feature is supported on sites with Business plan, however, it's auto-managed so the Scan feature shouldn't be visible to the users on such sites.

To test:
1. Make sure Scan feature flag is enabled
2. Select a site with Business plan
3. Make sure Scan item is not visible
-------------------
1. Make sure Scan feature flag and MySiteImprovements feature flag are enabled
2. Select a site with Business plan
3. Make sure Scan item is not visible

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
