### PR TITLE
Enable feature config for Backup/Restore flows, Backup screen and Scan screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/BackupDownloadFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BackupDownloadFeatureConfig.kt
@@ -1,15 +1,21 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.BackupDownloadFeatureConfig.Companion.BACKUP_DOWNLOAD_FLOW
 import javax.inject.Inject
 
 /**
  * Configuration of the 'Jetpack Backup Download' feature.
  */
-@FeatureInDevelopment
+@Feature(remoteField = BACKUP_DOWNLOAD_FLOW, defaultValue = true)
 class BackupDownloadFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.BACKUP_DOWNLOAD_AVAILABLE
-)
+        BuildConfig.BACKUP_DOWNLOAD_AVAILABLE,
+        BACKUP_DOWNLOAD_FLOW
+) {
+    companion object {
+        const val BACKUP_DOWNLOAD_FLOW = "backup_download_flow"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BackupScreenFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BackupScreenFeatureConfig.kt
@@ -1,15 +1,21 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.BackupScreenFeatureConfig.Companion.BACKUP_SCREEN
 import javax.inject.Inject
 
 /**
  * Configuration of the 'Jetpack Backup Screen' feature.
  */
-@FeatureInDevelopment
+@Feature(remoteField = BACKUP_SCREEN, defaultValue = true)
 class BackupScreenFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.BACKUP_SCREEN_AVAILABLE
-)
+        BuildConfig.BACKUP_SCREEN_AVAILABLE,
+        BACKUP_SCREEN
+) {
+    companion object {
+        const val BACKUP_SCREEN = "backup_screen"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/RestoreFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/RestoreFeatureConfig.kt
@@ -1,15 +1,21 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.RestoreFeatureConfig.Companion.RESTORE_FLOW
 import javax.inject.Inject
 
 /**
  * Configuration of the 'Jetpack Restore' feature.
  */
-@FeatureInDevelopment
+@Feature(remoteField = RESTORE_FLOW, defaultValue = true)
 class RestoreFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.RESTORE_AVAILABLE
-)
+        BuildConfig.RESTORE_AVAILABLE,
+        RESTORE_FLOW
+) {
+    companion object {
+        const val RESTORE_FLOW = "restore_flow"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ScanScreenFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ScanScreenFeatureConfig.kt
@@ -1,15 +1,21 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.ScanScreenFeatureConfig.Companion.SCAN_SCREEN
 import javax.inject.Inject
 
 /**
  * Configuration of the 'Jetpack Scan Screen' feature.
  */
-@FeatureInDevelopment
+@Feature(remoteField = SCAN_SCREEN, defaultValue = true)
 class ScanScreenFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
         appConfig,
-        BuildConfig.SCAN_SCREEN_AVAILABLE
-)
+        BuildConfig.SCAN_SCREEN_AVAILABLE,
+        SCAN_SCREEN
+) {
+    companion object {
+        const val SCAN_SCREEN = "scan_screen"
+    }
+}


### PR DESCRIPTION
Parent issue #13267

Enables feature flag for the new Jetpack features.

To test:
- Clear app data to make sure all feature flags are set to default
1. Select a Jetpack site with both Backup and Scan features
2. Notice both Scan and Backup menu items are visible
3. Open Backup
4. Click on the more menu on one of the items
5. Select Restore to this point and notice you are taken to the new flow
6. Go back and select Download and notice you are taken to the new flow
7. Go back to MySite screen
8. Open Scan and notice you are taken to the new Scan feature

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
