### PR TITLE
Issue/backup restore design tweaks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
@@ -151,10 +151,7 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
                     R.string.backup_download_complete_failed_icon_content_description,
                     R.color.error),
             buildHeaderState(R.string.backup_download_complete_failed_description),
-            buildSubHeaderState(
-                    R.string.request_failed_message,
-                    R.dimen.margin_none,
-                    R.dimen.jetpack_backup_restore_sub_header_bottom_margin),
+            buildDescriptionState(descRes = R.string.request_failed_message),
             buildActionButtonState(
                     titleRes = R.string.backup_download_complete_failed_action_button,
                     contentDescRes = R.string.backup_download_complete_failed_action_button_content_description,
@@ -173,14 +170,18 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
 
     private fun buildHeaderState(@StringRes titleRes: Int) = HeaderState(UiStringRes(titleRes))
 
-    private fun buildDescriptionState(published: Date, @StringRes descRes: Int) = DescriptionState(
-            UiStringResWithParams(
-                    descRes,
-                    listOf(
-                            UiStringText(published.toFormattedDateString()),
-                            UiStringText(published.toFormattedTimeString())
-                    )
-            )
+    private fun buildDescriptionState(published: Date? = null, @StringRes descRes: Int) = DescriptionState(
+            if (published != null) {
+                UiStringResWithParams(
+                        descRes,
+                        listOf(
+                                UiStringText(published.toFormattedDateString()),
+                                UiStringText(published.toFormattedTimeString())
+                        )
+                )
+            } else {
+                UiStringRes(descRes)
+            }
     )
 
     private fun buildActionButtonState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
@@ -45,7 +45,7 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
                 buildIconState(
                         R.drawable.ic_get_app_white_24dp,
                         R.string.backup_download_details_icon_content_description,
-                        R.color.success_50),
+                        R.color.success),
                 buildHeaderState(R.string.backup_download_details_header),
                 buildDescriptionState(published, R.string.backup_download_details_description_with_two_parameters),
                 buildActionButtonState(
@@ -77,7 +77,7 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
                 buildIconState(
                         R.drawable.ic_get_app_white_24dp,
                         R.string.backup_download_progress_icon_content_description,
-                        R.color.success_50),
+                        R.color.success),
                 buildHeaderState(R.string.backup_download_progress_header),
                 buildDescriptionState(published, R.string.backup_download_progress_description_with_two_parameters),
                 buildProgressState(progress),
@@ -98,7 +98,7 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
                 buildIconState(
                         R.drawable.ic_cloud_done_white_24dp,
                         R.string.backup_download_complete_icon_content_description,
-                        R.color.success_50),
+                        R.color.success),
                 buildHeaderState(R.string.backup_download_complete_header),
                 buildDescriptionState(published, R.string.backup_download_complete_description_with_two_parameters),
                 buildActionButtonState(
@@ -126,17 +126,17 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
             buildBulletState(
                     R.drawable.ic_query_builder_white_24dp,
                     R.string.backup_download_status_bullet_clock_icon_content_desc,
-                    R.color.warning_50,
+                    R.color.warning,
                     R.string.backup_download_status_failure_bullet1),
             buildBulletState(
                     R.drawable.ic_gridicons_checkmark_circle,
                     R.string.backup_download_status_bullet_checkmark_icon_content_desc,
-                    R.color.success_50,
+                    R.color.success,
                     R.string.backup_download_status_failure_bullet2),
             buildBulletState(
                     R.drawable.ic_gridicons_checkmark_circle,
                     R.string.backup_download_status_bullet_checkmark_icon_content_desc,
-                    R.color.success_50,
+                    R.color.success,
                     R.string.backup_download_status_failure_bullet3,
                     R.dimen.jetpack_backup_restore_last_bullet_bottom_margin),
             buildActionButtonState(
@@ -149,7 +149,7 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
             buildIconState(
                     R.drawable.ic_cloud_off_white_24dp,
                     R.string.backup_download_complete_failed_icon_content_description,
-                    R.color.error_50),
+                    R.color.error),
             buildHeaderState(R.string.backup_download_complete_failed_description),
             buildSubHeaderState(
                     R.string.request_failed_message,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/CheckboxSpannableLabel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/CheckboxSpannableLabel.kt
@@ -23,7 +23,7 @@ class CheckboxSpannableLabel @Inject constructor(
         val labelHintText = resourceProvider.getString(labelHintRes)
         val spannable = SpannableString(labelHintText)
         spannable.setSpan(
-                ForegroundColorSpan(resourceProvider.getColor(color.neutral_40)),
+                ForegroundColorSpan(resourceProvider.getColor(color.neutral)),
                 0,
                 labelHintText.length,
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
@@ -45,7 +45,7 @@ class RestoreStateListItemBuilder @Inject constructor(
                 buildIconState(
                         R.drawable.ic_history_white_24dp,
                         R.string.restore_details_icon_content_description,
-                        R.color.success_50),
+                        R.color.success),
                 buildHeaderState(R.string.restore_details_header),
                 buildDescriptionState(published, R.string.restore_details_description_with_two_parameters),
                 buildActionButtonState(
@@ -76,7 +76,7 @@ class RestoreStateListItemBuilder @Inject constructor(
             buildIconState(
                     R.drawable.ic_notice_white_24dp,
                     R.string.restore_warning_icon_content_description,
-                    R.color.error_50),
+                    R.color.error),
             buildHeaderState(R.string.restore_warning_header),
             buildDescriptionState(published, R.string.restore_warning_description_with_two_parameters),
             buildActionButtonState(
@@ -100,7 +100,7 @@ class RestoreStateListItemBuilder @Inject constructor(
                 buildIconState(
                         R.drawable.ic_history_white_24dp,
                         R.string.restore_progress_icon_content_description,
-                        R.color.success_50),
+                        R.color.success),
                 buildHeaderState(R.string.restore_progress_header),
                 buildDescriptionState(published, R.string.restore_progress_description_with_two_parameters),
                 buildProgressState(progress, isIndeterminate),
@@ -121,7 +121,7 @@ class RestoreStateListItemBuilder @Inject constructor(
                 buildIconState(
                         R.drawable.ic_history_white_24dp,
                         R.string.restore_complete_icon_content_description,
-                        R.color.success_50),
+                        R.color.success),
                 buildHeaderState(R.string.restore_complete_header),
                 buildDescriptionState(published, R.string.restore_complete_description_with_two_parameters),
                 buildActionButtonState(
@@ -146,17 +146,17 @@ class RestoreStateListItemBuilder @Inject constructor(
             buildBulletState(
                     R.drawable.ic_query_builder_white_24dp,
                     R.string.restore_status_bullet_clock_icon_content_desc,
-                    R.color.warning_50,
+                    R.color.warning,
                     R.string.restore_status_failure_bullet1),
             buildBulletState(
                     R.drawable.ic_gridicons_checkmark_circle,
                     R.string.restore_status_bullet_checkmark_icon_content_desc,
-                    R.color.success_50,
+                    R.color.success,
                     R.string.restore_status_failure_bullet2),
             buildBulletState(
                     R.drawable.ic_gridicons_checkmark_circle,
                     R.string.restore_status_bullet_checkmark_icon_content_desc,
-                    R.color.success_50,
+                    R.color.success,
                     R.string.restore_status_failure_bullet3,
                     R.dimen.jetpack_backup_restore_last_bullet_bottom_margin),
             buildActionButtonState(
@@ -169,7 +169,7 @@ class RestoreStateListItemBuilder @Inject constructor(
             buildIconState(
                     R.drawable.ic_notice_white_24dp,
                     R.string.restore_complete_failed_icon_content_description,
-                    R.color.error_50),
+                    R.color.error),
             buildHeaderState(R.string.restore_complete_failed_description),
             buildSubHeaderState(
                     R.string.request_failed_message,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
@@ -171,10 +171,7 @@ class RestoreStateListItemBuilder @Inject constructor(
                     R.string.restore_complete_failed_icon_content_description,
                     R.color.error),
             buildHeaderState(R.string.restore_complete_failed_description),
-            buildSubHeaderState(
-                    R.string.request_failed_message,
-                    R.dimen.margin_none,
-                    R.dimen.jetpack_backup_restore_sub_header_bottom_margin),
+            buildDescriptionState(descRes = R.string.request_failed_message),
             buildActionButtonState(
                     titleRes = R.string.restore_complete_failed_action_button,
                     contentDescRes = R.string.restore_complete_failed_action_button_content_description,
@@ -193,14 +190,18 @@ class RestoreStateListItemBuilder @Inject constructor(
 
     private fun buildHeaderState(@StringRes titleRes: Int) = HeaderState(UiStringRes(titleRes))
 
-    private fun buildDescriptionState(published: Date, @StringRes descRes: Int) = DescriptionState(
-            UiStringResWithParams(
-                    descRes,
-                    listOf(
-                            UiStringText(published.toFormattedDateString()),
-                            UiStringText(published.toFormattedTimeString())
-                    )
-            )
+    private fun buildDescriptionState(published: Date? = null, @StringRes descRes: Int) = DescriptionState(
+            if (published != null) {
+                UiStringResWithParams(
+                        descRes,
+                        listOf(
+                                UiStringText(published.toFormattedDateString()),
+                                UiStringText(published.toFormattedTimeString())
+                        )
+                )
+            } else {
+                UiStringRes(descRes)
+            }
     )
 
     private fun buildActionButtonState(

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -432,7 +432,6 @@
 
     <!-- jetpack backup restore last bullet bottom margin-->
     <dimen name="jetpack_backup_restore_last_bullet_bottom_margin">20dp</dimen>
-    <dimen name="jetpack_backup_restore_sub_header_bottom_margin">20dp</dimen>
 
     <!-- scan -->
     <dimen name="scan_list_threat_skeleton_text_height">20dp</dimen>


### PR DESCRIPTION
Parent #13328 & #13329

This PR addresses a few design tweaks
1. Drops explicit color references and uses default. So instead of referencing `error_50` directly, it now uses `error`. Same for `warning`, `success`, and `default`.
2. Swaps subheader for description in the generic error view

To Test
- Run the restore & backup download process to the end and ensure all works correctly.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
