### PR TITLE
Issue/12465 update install referrer library

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -236,7 +236,7 @@ dependencies {
     implementation 'com.android.volley:volley:1.1.1'
     implementation 'com.google.firebase:firebase-messaging:20.1.5'
     implementation 'com.google.android.gms:play-services-auth:18.1.0'
-    implementation 'com.android.installreferrer:installreferrer:1.0'
+    implementation 'com.android.installreferrer:installreferrer:2.2'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
     implementation 'org.greenrobot:eventbus:3.1.1'
     implementation ('com.automattic:rest:1.0.8') {

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/service/InstallationReferrerServiceLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/service/InstallationReferrerServiceLogic.java
@@ -104,6 +104,9 @@ public class InstallationReferrerServiceLogic {
                         // if this is retried but the error persists
                         AppLog.i(T.UTILS, "installation referrer: service unavailable");
                         break;
+                    case InstallReferrerResponse.PERMISSION_ERROR:
+                        AppLog.i(T.UTILS, "installation referrer:  app is not allowed to bind to the Service");
+                        break;
                     case InstallReferrerResponse.DEVELOPER_ERROR:
                         break;
                     case InstallReferrerResponse.SERVICE_DISCONNECTED:

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/service/InstallationReferrerServiceLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/service/InstallationReferrerServiceLogic.java
@@ -105,7 +105,10 @@ public class InstallationReferrerServiceLogic {
                         AppLog.i(T.UTILS, "installation referrer: service unavailable");
                         break;
                     case InstallReferrerResponse.PERMISSION_ERROR:
-                        AppLog.i(T.UTILS, "installation referrer:  app is not allowed to bind to the Service");
+                        // Fix for this issue https://github.com/wordpress-mobile/WordPress-Android/issues/10532 was
+                        // added to Referrer Service library, and currently instead of crashing we should get this
+                        // response. For now we will ignore it and log for informational purposes.
+                        AppLog.i(T.UTILS, "installation referrer: app is not allowed to bind to the Service");
                         break;
                     case InstallReferrerResponse.DEVELOPER_ERROR:
                         break;


### PR DESCRIPTION
Fixes #10532 
Hopefully fixes #12465

Updating Install Referrer Library to ver 2.2. According to the [release notes](https://developer.android.com/google/play/installreferrer/release-notes) there was a good amount of work focused on fixing crashes, so hopefully updating to the latest version would fix at lest some of the issues we had with this library.

Apart from adding an extra log, there is no special migration steps necessary.

In test build I added an extra logging and confirmed that referrer is correctly received:
[![Image from Gyazo](https://i.gyazo.com/3cc7bbb1065877914f6ab2e48558dd04.png)](https://gyazo.com/3cc7bbb1065877914f6ab2e48558dd04)

To test:
- Make sure app does not crash on fresh install.
 

*_Optionally_ test the referrer capture:
- Install [Play URL Builder](https://play.google.com/store/apps/details?id=com.jamitools.googleplayurlbuilder&hl=en_US&gl=US)
- Create a campaign url for `org.wordpress.android` 
- Open generated link in Play Store
- Add desired logging somewhere around [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/util/analytics/service/InstallationReferrerServiceLogic.java#L84)
- Build an APK and install in onto device using adb (eg. `adb install wp.apk`)
- Notice that the `Install` button in play store changes to `Open`.
- Press the Open button and confirm desired information in you logs.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
