### PR TITLE
Add blank jetpack capabilities wiremock response for failing connected tests

### DIFF
--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/jetpack/wpcom_v2_sites_0_rewind_capabilities.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/jetpack/wpcom_v2_sites_0_rewind_capabilities.json
@@ -1,0 +1,17 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPattern": "/wpcom/v2/sites/0/rewind/capabilities(/)?($|\\?.*)"
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "capabilities": []
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive",
+            "Cache-Control": "no-cache, must-revalidate, max-age=0"
+        }
+    }
+}

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/jetpack/wpcom_v2_sites_106707880_rewind_capabilities.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/jetpack/wpcom_v2_sites_106707880_rewind_capabilities.json
@@ -1,0 +1,17 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPattern": "/wpcom/v2/sites/106707880/rewind/capabilities(/)?($|\\?.*)"
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "capabilities": []
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive",
+            "Cache-Control": "no-cache, must-revalidate, max-age=0"
+        }
+    }
+}

--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/jetpack/wpcom_v2_sites_181851495_rewind_capabilities.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/jetpack/wpcom_v2_sites_181851495_rewind_capabilities.json
@@ -1,0 +1,17 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPattern": "/wpcom/v2/sites/181851495/rewind/capabilities(/)?($|\\?.*)"
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "capabilities": []
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive",
+            "Cache-Control": "no-cache, must-revalidate, max-age=0"
+        }
+    }
+}


### PR DESCRIPTION
This PR adds blank jetpack capabilities `WireMock` json response for existing sites to fix [failing connected tests.](https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.e0c3a59bd9ed670/matrices/8058690995053500699/executions/bs.5009a08aa1577ab0/testcases/20/test-cases)

To test:

` ./gradlew :WordPress:connectedVanillaDebugAndroidTest` should not return failing connected tests due to jetpack capabilities request for a site.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
