### PR TITLE
Jetpack Section: Connect Activity Log Detail with Restore

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
@@ -40,6 +40,7 @@ class ActivityLogDetailActivity : LocaleAwareActivity(), BasicDialogPositiveClic
     }
 
     override fun onNegativeClicked(instanceTag: String) {
+        // Do nothing.
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
@@ -1,10 +1,12 @@
 package org.wordpress.android.ui.activitylog.detail
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.R
 import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
 
@@ -38,5 +40,17 @@ class ActivityLogDetailActivity : LocaleAwareActivity(), BasicDialogPositiveClic
     }
 
     override fun onNegativeClicked(instanceTag: String) {
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        when (requestCode) {
+            RequestCodes.RESTORE -> if (resultCode == RESULT_OK) onActivityResultForRestore(data)
+        }
+    }
+
+    private fun onActivityResultForRestore(data: Intent?) {
+        setResult(RESULT_OK, data)
+        finish()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -13,6 +13,8 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.tools.FormattableRange
+import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan
 import org.wordpress.android.ui.notifications.utils.FormattableContentClickHandler
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
@@ -24,6 +26,8 @@ import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_ID_KEY
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWIND_ID_KEY
 import org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModel
 import javax.inject.Inject
+
+private const val DETAIL_TRACKING_SOURCE = "detail"
 
 class ActivityLogDetailFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -103,6 +107,13 @@ class ActivityLogDetailFragment : Fragment() {
             viewModel.navigationEvents.observe(viewLifecycleOwner, {
                 it.applyIfNotHandled {
                     when (this) {
+                        is ActivityLogDetailNavigationEvents.ShowRestore -> ActivityLauncher.showRestoreForResult(
+                                requireActivity(),
+                                viewModel.site,
+                                model.activityID,
+                                RequestCodes.RESTORE,
+                                DETAIL_TRACKING_SOURCE
+                        )
                         is ActivityLogDetailNavigationEvents.ShowRewindDialog -> onRewindButtonClicked(model)
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -6,13 +6,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import kotlinx.android.synthetic.main.activity_log_item_detail.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan
@@ -70,7 +68,7 @@ class ActivityLogDetailFragment : Fragment() {
                 else -> throw Throwable("Couldn't initialize Activity Log view model")
             }
 
-            viewModel.activityLogItem.observe(viewLifecycleOwner, Observer { activityLogModel ->
+            viewModel.activityLogItem.observe(viewLifecycleOwner, { activityLogModel ->
                 setActorIcon(activityLogModel?.actorIconUrl, activityLogModel?.showJetpackIcon)
                 uiHelpers.setTextOrHide(activityActorName, activityLogModel?.actorName)
                 uiHelpers.setTextOrHide(activityActorRole, activityLogModel?.actorRole)
@@ -100,7 +98,7 @@ class ActivityLogDetailFragment : Fragment() {
                 }
             })
 
-            viewModel.rewindAvailable.observe(viewLifecycleOwner, Observer { available ->
+            viewModel.rewindAvailable.observe(viewLifecycleOwner, { available ->
                 activityRewindButton.visibility = if (available == true) View.VISIBLE else View.GONE
             })
 
@@ -119,7 +117,7 @@ class ActivityLogDetailFragment : Fragment() {
                 }
             })
 
-            viewModel.handleFormattableRangeClick.observe(viewLifecycleOwner, Observer<FormattableRange> { range ->
+            viewModel.handleFormattableRangeClick.observe(viewLifecycleOwner, { range ->
                 if (range != null) {
                     formattableContentClickHandler.onClick(activity, range)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -100,8 +100,12 @@ class ActivityLogDetailFragment : Fragment() {
                 activityRewindButton.visibility = if (available == true) View.VISIBLE else View.GONE
             })
 
-            viewModel.showRewindDialog.observe(viewLifecycleOwner, Observer<ActivityLogDetailModel> { detailModel ->
-                detailModel?.let { onRewindButtonClicked(it) }
+            viewModel.navigationEvents.observe(viewLifecycleOwner, {
+                it.applyIfNotHandled {
+                    when (this) {
+                        is ActivityLogDetailNavigationEvents.ShowRewindDialog -> onRewindButtonClicked(model)
+                    }
+                }
             })
 
             viewModel.handleFormattableRangeClick.observe(viewLifecycleOwner, Observer<FormattableRange> { range ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailNavigationEvents.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.ui.activitylog.detail
+
+sealed class ActivityLogDetailNavigationEvents {
+    data class ShowRewindDialog(val model: ActivityLogDetailModel) : ActivityLogDetailNavigationEvents()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailNavigationEvents.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.activitylog.detail
 
 sealed class ActivityLogDetailNavigationEvents {
+    data class ShowRestore(val model: ActivityLogDetailModel) : ActivityLogDetailNavigationEvents()
     data class ShowRewindDialog(val model: ActivityLogDetailModel) : ActivityLogDetailNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_RESTORE_ID
 import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_REWIND_ID
 import org.wordpress.android.ui.posts.BasicFragmentDialog
 import org.wordpress.android.util.config.BackupDownloadFeatureConfig
+import org.wordpress.android.util.config.RestoreFeatureConfig
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_KEY
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWIND_ID_KEY
 import javax.inject.Inject
@@ -23,6 +24,7 @@ class ActivityLogListActivity : LocaleAwareActivity(),
         BasicFragmentDialog.BasicDialogPositiveClickInterface,
         BasicFragmentDialog.BasicDialogNegativeClickInterface {
     @Inject lateinit var backupDownloadFeatureConfig: BackupDownloadFeatureConfig
+    @Inject lateinit var restoreFeatureConfig: RestoreFeatureConfig
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
@@ -65,7 +67,13 @@ class ActivityLogListActivity : LocaleAwareActivity(),
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {
-            RequestCodes.ACTIVITY_LOG_DETAIL -> onActivityResultForActivityLogDetails(data)
+            RequestCodes.ACTIVITY_LOG_DETAIL -> {
+                if (restoreFeatureConfig.isEnabled()) {
+                    onActivityResultForRestore(data)
+                } else {
+                    onActivityResultForActivityLogDetails(data)
+                }
+            }
             RequestCodes.RESTORE -> onActivityResultForRestore(data)
             RequestCodes.BACKUP_DOWNLOAD -> onActivityResultForBackupDownload(data)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.ui.jetpack.backup.download.KEY_BACKUP_DOWNLOAD_REWI
 import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_RESTORE_ID
 import org.wordpress.android.ui.jetpack.restore.KEY_RESTORE_REWIND_ID
 import org.wordpress.android.ui.posts.BasicFragmentDialog
-import org.wordpress.android.util.config.BackupDownloadFeatureConfig
 import org.wordpress.android.util.config.RestoreFeatureConfig
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_KEY
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWIND_ID_KEY
@@ -23,8 +22,8 @@ import javax.inject.Inject
 class ActivityLogListActivity : LocaleAwareActivity(),
         BasicFragmentDialog.BasicDialogPositiveClickInterface,
         BasicFragmentDialog.BasicDialogNegativeClickInterface {
-    @Inject lateinit var backupDownloadFeatureConfig: BackupDownloadFeatureConfig
     @Inject lateinit var restoreFeatureConfig: RestoreFeatureConfig
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -11,12 +11,14 @@ import org.wordpress.android.fluxc.model.activity.ActivityLogModel.ActivityActor
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailModel
+import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEvents
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.ACTIVITY_LOG
 import org.wordpress.android.util.config.RestoreFeatureConfig
 import org.wordpress.android.util.toFormattedDateString
 import org.wordpress.android.util.toFormattedTimeString
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 
@@ -33,9 +35,9 @@ class ActivityLogDetailViewModel
     lateinit var site: SiteModel
     lateinit var activityLogId: String
 
-    private val _showRewindDialog = SingleLiveEvent<ActivityLogDetailModel>()
-    val showRewindDialog: LiveData<ActivityLogDetailModel>
-        get() = _showRewindDialog
+    private val _navigationEvents = MutableLiveData<Event<ActivityLogDetailNavigationEvents>>()
+    val navigationEvents: LiveData<Event<ActivityLogDetailNavigationEvents>>
+        get() = _navigationEvents
 
     private val _handleFormattableRangeClick = SingleLiveEvent<FormattableRange>()
     val handleFormattableRangeClick: LiveData<FormattableRange>
@@ -97,7 +99,7 @@ class ActivityLogDetailViewModel
 
     fun onRewindClicked(model: ActivityLogDetailModel) {
         if (model.rewindId != null) {
-            _showRewindDialog.value = model
+            _navigationEvents.value = Event(ActivityLogDetailNavigationEvents.ShowRewindDialog(model))
         } else {
             AppLog.e(
                     ACTIVITY_LOG,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -10,10 +10,11 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel.ActivityActor
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.tools.FormattableRange
-import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailModel
+import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.ACTIVITY_LOG
+import org.wordpress.android.util.config.RestoreFeatureConfig
 import org.wordpress.android.util.toFormattedDateString
 import org.wordpress.android.util.toFormattedTimeString
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -26,7 +27,8 @@ class ActivityLogDetailViewModel
 @Inject constructor(
     val dispatcher: Dispatcher,
     private val activityLogStore: ActivityLogStore,
-    private val rewindStatusService: RewindStatusService
+    private val rewindStatusService: RewindStatusService,
+    private val restoreFeatureConfig: RestoreFeatureConfig
 ) : ViewModel() {
     lateinit var site: SiteModel
     lateinit var activityLogId: String

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -106,10 +106,7 @@ class ActivityLogDetailViewModel
             }
             _navigationEvents.value = Event(navigationEvent)
         } else {
-            AppLog.e(
-                    ACTIVITY_LOG,
-                    "Trying to rewind activity without rewind ID"
-            )
+            AppLog.e(ACTIVITY_LOG, "Trying to rewind activity without rewind ID")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -99,7 +99,12 @@ class ActivityLogDetailViewModel
 
     fun onRewindClicked(model: ActivityLogDetailModel) {
         if (model.rewindId != null) {
-            _navigationEvents.value = Event(ActivityLogDetailNavigationEvents.ShowRewindDialog(model))
+            val navigationEvent = if (restoreFeatureConfig.isEnabled()) {
+                ActivityLogDetailNavigationEvents.ShowRestore(model)
+            } else {
+                ActivityLogDetailNavigationEvents.ShowRewindDialog(model)
+            }
+            _navigationEvents.value = Event(navigationEvent)
         } else {
             AppLog.e(
                     ACTIVITY_LOG,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -7,6 +7,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -20,8 +21,10 @@ import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailModel
+import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailNavigationEvents
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.util.config.RestoreFeatureConfig
+import org.wordpress.android.viewmodel.Event
 import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
@@ -63,6 +66,7 @@ class ActivityLogDetailViewModelTest {
     )
 
     private var lastEmittedItem: ActivityLogDetailModel? = null
+    private var navigationEvents: MutableList<Event<ActivityLogDetailNavigationEvents?>> = mutableListOf()
 
     @Before
     fun setUp() {
@@ -73,6 +77,7 @@ class ActivityLogDetailViewModelTest {
                 restoreFeatureConfig
         )
         viewModel.activityLogItem.observeForever { lastEmittedItem = it }
+        viewModel.navigationEvents.observeForever { navigationEvents.add(it) }
     }
 
     @After
@@ -193,7 +198,7 @@ class ActivityLogDetailViewModelTest {
 
         viewModel.onRewindClicked(model)
 
-        assertEquals(null, viewModel.showRewindDialog.value)
+        assertTrue(navigationEvents.isEmpty())
     }
 
     @Test
@@ -203,6 +208,8 @@ class ActivityLogDetailViewModelTest {
 
         viewModel.onRewindClicked(model)
 
-        assertEquals(model, viewModel.showRewindDialog.value)
+        navigationEvents.last().peekContent()?.let {
+            assertEquals(model, (it as ActivityLogDetailNavigationEvents.ShowRewindDialog).model)
+        }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -19,8 +19,8 @@ import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.fluxc.tools.FormattableRange
-import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailModel
+import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
 import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
@@ -91,11 +91,13 @@ class ActivityLogDetailViewModelTest {
 
     @Test
     fun showsJetpackIconWhenActorIconEmptyAndNameIsJetpackAndTypeIsApplication() {
-        val updatedActivity = activityLogModel.copy(actor = activityLogModel.actor?.copy(
-                avatarURL = null,
-                displayName = "Jetpack",
-                type = "Application"
-        ))
+        val updatedActivity = activityLogModel.copy(
+                actor = activityLogModel.actor?.copy(
+                        avatarURL = null,
+                        displayName = "Jetpack",
+                        type = "Application"
+                )
+        )
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(updatedActivity))
 
         viewModel.start(site, activityID)
@@ -109,11 +111,13 @@ class ActivityLogDetailViewModelTest {
 
     @Test
     fun showsJetpackIconWhenActorIconEmptyAndNameAndTypeIsHappinessEngineer() {
-        val updatedActivity = activityLogModel.copy(actor = activityLogModel.actor?.copy(
-                avatarURL = null,
-                displayName = "Happiness Engineer",
-                type = "Happiness Engineer"
-        ))
+        val updatedActivity = activityLogModel.copy(
+                actor = activityLogModel.actor?.copy(
+                        avatarURL = null,
+                        displayName = "Happiness Engineer",
+                        type = "Happiness Engineer"
+                )
+        )
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(updatedActivity))
 
         viewModel.start(site, activityID)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -184,6 +184,16 @@ class ActivityLogDetailViewModelTest {
     }
 
     @Test
+    fun `given without rewind id, when on rewind clicked, then do nothing`() {
+        val model = mock<ActivityLogDetailModel>()
+        whenever(model.rewindId).thenReturn(null)
+
+        viewModel.onRewindClicked(model)
+
+        assertEquals(null, viewModel.showRewindDialog.value)
+    }
+
+    @Test
     fun `given with rewind id, when on rewind clicked, then show rewind dialog with model`() {
         val model = mock<ActivityLogDetailModel>()
         whenever(model.rewindId).thenReturn("123")

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -202,14 +202,28 @@ class ActivityLogDetailViewModelTest {
     }
 
     @Test
-    fun `given with rewind id, when on rewind clicked, then show rewind dialog with model`() {
+    fun `given restore feature is disabled, when on rewind clicked, then show rewind dialog with model`() {
         val model = mock<ActivityLogDetailModel>()
         whenever(model.rewindId).thenReturn("123")
+        whenever(restoreFeatureConfig.isEnabled()).thenReturn(false)
 
         viewModel.onRewindClicked(model)
 
         navigationEvents.last().peekContent()?.let {
             assertEquals(model, (it as ActivityLogDetailNavigationEvents.ShowRewindDialog).model)
+        }
+    }
+
+    @Test
+    fun `given restore feature is enabled, when on rewind clicked, then show restore with model`() {
+        val model = mock<ActivityLogDetailModel>()
+        whenever(model.rewindId).thenReturn("123")
+        whenever(restoreFeatureConfig.isEnabled()).thenReturn(true)
+
+        viewModel.onRewindClicked(model)
+
+        navigationEvents.last().peekContent()?.let {
+            assertEquals(model, (it as ActivityLogDetailNavigationEvents.ShowRestore).model)
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -184,7 +184,7 @@ class ActivityLogDetailViewModelTest {
     }
 
     @Test
-    fun onRewindClickTriggersRewindIfRewindIdNotNull() {
+    fun `given with rewind id, when on rewind clicked, then show rewind dialog with model`() {
         val model = mock<ActivityLogDetailModel>()
         whenever(model.rewindId).thenReturn("123")
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailModel
 import org.wordpress.android.ui.jetpack.rewind.RewindStatusService
+import org.wordpress.android.util.config.RestoreFeatureConfig
 import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
@@ -31,6 +32,7 @@ class ActivityLogDetailViewModelTest {
     @Mock private lateinit var activityLogStore: ActivityLogStore
     @Mock private lateinit var site: SiteModel
     @Mock private lateinit var rewindStatusService: RewindStatusService
+    @Mock private lateinit var restoreFeatureConfig: RestoreFeatureConfig
     private lateinit var viewModel: ActivityLogDetailViewModel
 
     private val activityID = "id1"
@@ -67,7 +69,8 @@ class ActivityLogDetailViewModelTest {
         viewModel = ActivityLogDetailViewModel(
                 dispatcher,
                 activityLogStore,
-                rewindStatusService
+                rewindStatusService,
+                restoreFeatureConfig
         )
         viewModel.activityLogItem.observeForever { lastEmittedItem = it }
     }


### PR DESCRIPTION
Parent #13328

This PR connects the restore flow the activity log detail screen. This means that this PR makes sure that when a user presses the `RESTORE` button within the `Activity Log Detail` screen, then instead of getting a `Rewind Dialog` they get redirected to the `Restore` screen and the new restore flow. Also, when a restore gets triggered from within the new restore flow, this PR makes sure that the user get redirected back to the `Activity Log` screen, skipping the `Activity Log Detail` screen and starts seeing the restore progress row within that screen.

To test:
* Open app and go to `My Site` tab.
* Launch `Activity Log` or `Backup` screen,
* Find a rewindable item from the list and click on it. You will now enter the `Activity Log Detail` screen.
* On that screen, click the `RESTORE` button to launch the `Restore` screen,
* Click the `Restore site` button. On the confirmation screen, click on the `Confirm restore site` button.
* Click the `Ok, notify me!` or navigate back manually (by clicking the `X` toolbar button or pressing/swiping back).
* You should automatically be navigated back to the `Activity Log` screen, skipping the `Activity Log Detail` screen and a restore status will be triggered,
* The restore progress item should immediately appears. Make sure the restore timestamp is available on this progress item.
* Try doing the same steps again, but this time when within the `Restore` screen and flows, go back.
* Make sure that going back will navigate to to the `Activity Log Detail` screen.
-----
* Since the restore feature flag now defaults to `true`, in order to test the old flow you will need to manually override the default to `false`.
* Do that and make sure that the old flow, through the `Rewind Dialog` works as well.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
