### PR TITLE
Use firebase config to retrieve codeable url

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -84,7 +84,7 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
                             ActivityLauncher.viewScanRequestFixState(requireActivity(), site, this.threatId)
                         }
                         is ThreatDetailsNavigationEvents.ShowGetFreeEstimate -> {
-                            ActivityLauncher.openUrlExternal(context, this.url)
+                            ActivityLauncher.openUrlExternal(context, this.url())
                         }
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsNavigationEvents.kt
@@ -1,8 +1,11 @@
 package org.wordpress.android.ui.jetpack.scan.details
 
 import androidx.annotation.StringRes
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.utils.UiString
+
+private const val CODEABLE_GET_FREE_ESTIMATE_FIREBASE_KEY = "codeable_get_free_estimate_url"
 
 sealed class ThreatDetailsNavigationEvents {
     class OpenThreatActionDialog(
@@ -19,6 +22,6 @@ sealed class ThreatDetailsNavigationEvents {
     data class ShowUpdatedFixState(val threatId: Long) : ThreatDetailsNavigationEvents()
 
     object ShowGetFreeEstimate : ThreatDetailsNavigationEvents() {
-        const val url = "https://codeable.io/partners/jetpack-scan/"
+        fun url() = FirebaseRemoteConfig.getInstance().getString(CODEABLE_GET_FREE_ESTIMATE_FIREBASE_KEY)
     }
 }


### PR DESCRIPTION
Parent issue #13326

This PR uses firebase config to retrieve Codeable URL so we can update it in all apps version if needed.

To test:
1. Select "pressable-jetpack-daily-scan"
2. Open Scan
3. Open History
4. Switch to Ignored tab
5. Open a threat
6. Click on "Get free estimate" button and verify it redirects you to codeable.com

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
