### PR TITLE
Jetpack Section: Update My Site Menu Items Strings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteListItemBuilder.kt
@@ -35,7 +35,7 @@ class SiteListItemBuilder
         return if (site.hasCapabilityManageOptions && isWpComOrJetpack && !site.isWpForTeamsSite) {
             ListItem(
                     R.drawable.ic_gridicons_clipboard_white_24dp,
-                    UiStringRes(R.string.activity),
+                    UiStringRes(R.string.activity_log),
                     onClick = ListItemInteraction.create(ListItemAction.ACTIVITY_LOG, onClick)
             )
         } else null

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -441,7 +441,7 @@
                         <org.wordpress.android.widgets.WPTextView
                             android:id="@+id/my_site_activity_log_text_view"
                             style="@style/MySiteListRowTextView"
-                            android:text="@string/activity" />
+                            android:text="@string/activity_log" />
 
                     </LinearLayout>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1010,7 +1010,6 @@
     <string name="login_to_to_connect_jetpack">Log in to the WordPress.com account you used to connect Jetpack.</string>
 
     <!-- activity log -->
-    <string name="activity">Activity log</string>
     <string name="activity_log">Activity Log</string>
     <string name="activity_log_icon">Activity icon</string>
     <string name="activity_log_event">Event</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2063,7 +2063,7 @@
     <string name="my_site_header_look_and_feel">Look and Feel</string>
     <string name="my_site_header_jetpack">Jetpack</string>
     <string name="my_site_header_publish">Publish</string>
-    <string name="my_site_btn_jetpack_settings">Jetpack settings</string>
+    <string name="my_site_btn_jetpack_settings">Jetpack Settings</string>
     <string name="my_site_btn_site_pages">Site Pages</string>
     <string name="my_site_btn_blog_posts">Blog Posts</string>
     <string name="my_site_btn_sharing">Sharing</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SiteItemFixtures.kt
@@ -38,7 +38,7 @@ val STATS_ITEM = ListItem(
 )
 val ACTIVITY_ITEM = ListItem(
         R.drawable.ic_gridicons_clipboard_white_24dp,
-        UiStringRes(R.string.activity),
+        UiStringRes(R.string.activity_log),
         onClick = ListItemInteraction.create(ListItemAction.ACTIVITY_LOG, SITE_ITEM_ACTION)
 )
 val BACKUP_ITEM = ListItem(


### PR DESCRIPTION
Parent #13629
Related #13969

This PR updates the following for the `My Site` screen menu items:
- The `Activity log` string to `Activity Log` (title case).
- The `Jetpack settings` string to `Jetpack Settings` (title case).

To test:
- Launch the app and go to `My Site` tab.
- Make sure that the above mentioned `string` changes are as described.
- Go to `My Site` -> `Toolbar Avatar` -> `App Settings` -> `Test feature configuration`.
- Enable `MySiteImprovementsFeatureConfig`, scroll down and click the `RESTART THE APP` button.
- Make sure that the above mentioned `string` changes are as described.

**Merge Instructions**
1. Make sure this PR has been reviewed by design.
1. Remove the `Needs Design Review` label.
1. Merge this PR.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
