### PR TITLE
Issue/13328 restore tracks details

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -633,14 +633,13 @@ public class ActivityLauncher {
     ) {
         Map<String, Object> properties = new HashMap<>();
         properties.put(ACTIVITY_LOG_ACTIVITY_ID_KEY, activityId);
-        String source = null;
+        String source;
         if (rewindableOnly) {
             source = BACKUP_TRACK_EVENT_PROPERTY_VALUE;
-            properties.put(SOURCE_TRACK_EVENT_PROPERTY_KEY, BACKUP_TRACK_EVENT_PROPERTY_VALUE);
         } else {
             source = ACTIVITY_LOG_TRACK_EVENT_PROPERTY_VALUE;
-            properties.put(SOURCE_TRACK_EVENT_PROPERTY_KEY, ACTIVITY_LOG_TRACK_EVENT_PROPERTY_VALUE);
         }
+        properties.put(SOURCE_TRACK_EVENT_PROPERTY_KEY, source);
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.ACTIVITY_LOG_DETAIL_OPENED, site, properties);
 
         Intent intent = new Intent(activity, ActivityLogDetailActivity.class);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1445,7 +1445,6 @@ public class ActivityLauncher {
 
     public static void showRestoreForResult(Activity activity, @NonNull SiteModel site, String activityId,
                                                    int resultCode, String source) {
-
         Map<String, String> properties = new HashMap<>();
         properties.put(SOURCE_TRACK_EVENT_PROPERTY_KEY, source);
         AnalyticsTracker.track(Stat.JETPACK_RESTORE_OPENED, properties);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -633,9 +633,12 @@ public class ActivityLauncher {
     ) {
         Map<String, Object> properties = new HashMap<>();
         properties.put(ACTIVITY_LOG_ACTIVITY_ID_KEY, activityId);
+        String source = null;
         if (rewindableOnly) {
+            source = BACKUP_TRACK_EVENT_PROPERTY_VALUE;
             properties.put(SOURCE_TRACK_EVENT_PROPERTY_KEY, BACKUP_TRACK_EVENT_PROPERTY_VALUE);
         } else {
+            source = ACTIVITY_LOG_TRACK_EVENT_PROPERTY_VALUE;
             properties.put(SOURCE_TRACK_EVENT_PROPERTY_KEY, ACTIVITY_LOG_TRACK_EVENT_PROPERTY_VALUE);
         }
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.ACTIVITY_LOG_DETAIL_OPENED, site, properties);
@@ -643,6 +646,7 @@ public class ActivityLauncher {
         Intent intent = new Intent(activity, ActivityLogDetailActivity.class);
         intent.putExtra(WordPress.SITE, site);
         intent.putExtra(ACTIVITY_LOG_ID_KEY, activityId);
+        intent.putExtra(SOURCE_TRACK_EVENT_PROPERTY_KEY, source);
         activity.startActivityForResult(intent, RequestCodes.ACTIVITY_LOG_DETAIL);
     }
 
@@ -1417,7 +1421,7 @@ public class ActivityLauncher {
     public static void showBackupDownloadForResult(Activity activity, @NonNull SiteModel site, String activityId,
                                                    int resultCode, String source) {
         Map<String, String> properties = new HashMap<>();
-        properties.put("source", source);
+        properties.put(SOURCE_TRACK_EVENT_PROPERTY_KEY, source);
         AnalyticsTracker.track(Stat.JETPACK_BACKUP_DOWNLOAD_OPENED, properties);
 
         Intent intent = new Intent(activity, BackupDownloadActivity.class);
@@ -1441,8 +1445,9 @@ public class ActivityLauncher {
 
     public static void showRestoreForResult(Activity activity, @NonNull SiteModel site, String activityId,
                                                    int resultCode, String source) {
+
         Map<String, String> properties = new HashMap<>();
-        properties.put("source", source);
+        properties.put(SOURCE_TRACK_EVENT_PROPERTY_KEY, source);
         AnalyticsTracker.track(Stat.JETPACK_RESTORE_OPENED, properties);
 
         Intent intent = new Intent(activity, RestoreActivity.class);

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -200,13 +200,11 @@ class ActivityLogDetailFragment : Fragment() {
         }
     }
 
-    private val forwardSlash = "/"
-
     private fun buildTrackingSource() =
         requireActivity().intent?.extras?.let {
             when {
                 it.containsKey(SOURCE_TRACK_EVENT_PROPERTY_KEY) -> {
-                    it.getString(SOURCE_TRACK_EVENT_PROPERTY_KEY) + "$forwardSlash$DETAIL_TRACKING_SOURCE"
+                    it.getString(SOURCE_TRACK_EVENT_PROPERTY_KEY) + "/$DETAIL_TRACKING_SOURCE"
                 }
                 else -> {
                     DETAIL_TRACKING_SOURCE

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModel
 import javax.inject.Inject
 
 private const val DETAIL_TRACKING_SOURCE = "detail"
+private const val FORWARD_SLASH = "/"
 
 class ActivityLogDetailFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -200,15 +201,11 @@ class ActivityLogDetailFragment : Fragment() {
         }
     }
 
-    private fun buildTrackingSource() =
-        requireActivity().intent?.extras?.let {
+    private fun buildTrackingSource() = requireActivity().intent?.extras?.let {
+        val source = it.getString(SOURCE_TRACK_EVENT_PROPERTY_KEY)
             when {
-                it.containsKey(SOURCE_TRACK_EVENT_PROPERTY_KEY) -> {
-                    it.getString(SOURCE_TRACK_EVENT_PROPERTY_KEY) + "/$DETAIL_TRACKING_SOURCE"
-                }
-                else -> {
-                    DETAIL_TRACKING_SOURCE
-                }
+                source != null -> source + FORWARD_SLASH + DETAIL_TRACKING_SOURCE
+                else -> DETAIL_TRACKING_SOURCE
             }
         }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.ActivityLauncher.SOURCE_TRACK_EVENT_PROPERTY_KEY
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan
 import org.wordpress.android.ui.notifications.utils.FormattableContentClickHandler
@@ -57,7 +58,11 @@ class ActivityLogDetailFragment : Fragment() {
             val (site, activityLogId) = when {
                 savedInstanceState != null -> {
                     val site = savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
-                    val activityLogId = requireNotNull(savedInstanceState.getString(ACTIVITY_LOG_ID_KEY))
+                    val activityLogId = requireNotNull(
+                            savedInstanceState.getString(
+                                    ACTIVITY_LOG_ID_KEY
+                            )
+                    )
                     site to activityLogId
                 }
                 intent != null -> {
@@ -74,12 +79,21 @@ class ActivityLogDetailFragment : Fragment() {
                 uiHelpers.setTextOrHide(activityActorRole, activityLogModel?.actorRole)
 
                 val spannable = activityLogModel?.content?.let {
-                    notificationsUtilsWrapper.getSpannableContentForRanges(it, activityMessage, { range ->
-                        viewModel.onRangeClicked(range)
-                    }, false)
+                    notificationsUtilsWrapper.getSpannableContentForRanges(
+                            it,
+                            activityMessage,
+                            { range ->
+                                viewModel.onRangeClicked(range)
+                            },
+                            false
+                    )
                 }
 
-                val noteBlockSpans = spannable?.getSpans(0, spannable.length, NoteBlockClickableSpan::class.java)
+                val noteBlockSpans = spannable?.getSpans(
+                        0,
+                        spannable.length,
+                        NoteBlockClickableSpan::class.java
+                )
 
                 noteBlockSpans?.forEach {
                     it.enableColors(activity)
@@ -110,9 +124,11 @@ class ActivityLogDetailFragment : Fragment() {
                                 viewModel.site,
                                 model.activityID,
                                 RequestCodes.RESTORE,
-                                DETAIL_TRACKING_SOURCE
+                                buildTrackingSource()
                         )
-                        is ActivityLogDetailNavigationEvents.ShowRewindDialog -> onRewindButtonClicked(model)
+                        is ActivityLogDetailNavigationEvents.ShowRewindDialog -> onRewindButtonClicked(
+                                model
+                        )
                     }
                 }
             })
@@ -127,7 +143,11 @@ class ActivityLogDetailFragment : Fragment() {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         return inflater.inflate(R.layout.activity_log_item_detail, container, false)
     }
 
@@ -168,11 +188,29 @@ class ActivityLogDetailFragment : Fragment() {
             dialog.initialize(
                     it,
                     getString(R.string.activity_log_rewind_site),
-                    getString(R.string.activity_log_rewind_dialog_message, item.createdDate, item.createdTime),
+                    getString(
+                            R.string.activity_log_rewind_dialog_message,
+                            item.createdDate,
+                            item.createdTime
+                    ),
                     getString(R.string.activity_log_rewind_site),
                     getString(R.string.cancel)
             )
             dialog.show(requireFragmentManager(), it)
         }
     }
+
+    private val forwardSlash = "/"
+
+    private fun buildTrackingSource() =
+        requireActivity().intent?.extras?.let {
+            when {
+                it.containsKey(SOURCE_TRACK_EVENT_PROPERTY_KEY) -> {
+                    it.getString(SOURCE_TRACK_EVENT_PROPERTY_KEY) + "$forwardSlash$DETAIL_TRACKING_SOURCE"
+                }
+                else -> {
+                    DETAIL_TRACKING_SOURCE
+                }
+            }
+        }
 }


### PR DESCRIPTION
Parent #13328 

This PR
(1) updates the Tracks source when transitioning from Activity Log Detail view to the Restore flow as follows:
- backup/detail
- activity_log/detail

(2) Refactor to use `SOURCE_TRACK_EVENT_PROPERTY_KEY` in `showBackupDownloadForResult()` and `showRestoreForResult()` instead of hardcoding the word "source"


**To test:**
-Launch the app
- Navigate to Activity Log
- Select an item that is available for restore
- Tap on the item row
- Tap on the Restore icon
- Note the log shows: activity_log/detail

---------------
-Launch the app
- Navigate to Activity Log
- Select an item that is available for restore
- Tap on the item row
- Tap on the Restore icon
- Note the log shows: backup/detail

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
