### PR TITLE
Disable progress action button until started

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -212,7 +212,8 @@ class RestoreViewModel @Inject constructor(
                         progress = progressStart,
                         published = restoreState.published as Date,
                         isIndeterminate = true,
-                        onNotifyMeClick = this@RestoreViewModel::onNotifyMeClick
+                        onNotifyMeClick = this@RestoreViewModel::onNotifyMeClick,
+                        showNotifyMe = !restoreState.shouldInitProgress
                 ),
                 type = StateType.PROGRESS
         )
@@ -348,6 +349,10 @@ class RestoreViewModel @Inject constructor(
                 rewindId = result.rewindId,
                 restoreId = result.restoreId
         )
+        (_uiState.value as? ProgressState)?.let {
+            val updatedItems = stateListItemBuilder.updateProgressActionButtonState(it, result.restoreId != null)
+            _uiState.postValue(it.copy(items = updatedItems))
+        }
         queryRestoreStatus()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/builders/RestoreStateListItemBuilder.kt
@@ -94,6 +94,7 @@ class RestoreStateListItemBuilder @Inject constructor(
         progress: Int = 0,
         published: Date,
         isIndeterminate: Boolean = false,
+        showNotifyMe: Boolean,
         onNotifyMeClick: () -> Unit
     ): List<JetpackListItemState> {
         return mutableListOf(
@@ -107,7 +108,9 @@ class RestoreStateListItemBuilder @Inject constructor(
                 buildActionButtonState(
                         titleRes = R.string.restore_progress_action_button,
                         contentDescRes = R.string.restore_progress_action_button_content_description,
-                        onClick = onNotifyMeClick),
+                        onClick = onNotifyMeClick,
+                        isEnabled = showNotifyMe
+                ),
                 buildFootnoteState(R.string.restore_progress_footnote)
         )
     }
@@ -208,12 +211,14 @@ class RestoreStateListItemBuilder @Inject constructor(
         @StringRes titleRes: Int,
         @StringRes contentDescRes: Int,
         isSecondary: Boolean = false,
+        isEnabled: Boolean = true,
         onClick: () -> Unit
     ) = ActionButtonState(
         text = UiStringRes(titleRes),
         contentDescription = UiStringRes(contentDescRes),
         isSecondary = isSecondary,
-        onClick = onClick
+        onClick = onClick,
+        isEnabled = isEnabled
     )
 
     private fun buildSubHeaderState(
@@ -278,6 +283,16 @@ class RestoreStateListItemBuilder @Inject constructor(
         return details.map { state ->
             if (state is ActionButtonState) {
                 state.copy(isEnabled = enableActionButton)
+            } else {
+                state
+            }
+        }
+    }
+
+    fun updateProgressActionButtonState(uiState: RestoreUiState, value: Boolean): List<JetpackListItemState> {
+        return uiState.items.map { state ->
+            if (state is ActionButtonState) {
+                state.copy(isEnabled = value)
             } else {
                 state
             }


### PR DESCRIPTION
Parent #13328 

This PR disables the "Action button" on the progress view until after we get a response for the restore request. This change supports properly showing the progress row on the Activity Log. 

**Merge Instructions**
I'm not sold on the button state transition from disabled to enabled. It gets the job done, but 🤷   If the reviewer is okay with it, then go ahead and remove the label and merge. Thanks.

To test:
- Launch the app
- Navigate to Activity Log
- Choose a row that has the more menu and tap on it
- Tap on the Restore to this point option
- Tap on `Restore Site`
- Tap on `Confirm`
- Note that the action button is disabled upon entry to the view and becomes enabled shortly thereafter.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
