### PR TITLE
Jetpack Scan: Apply copy improvements

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1086,9 +1086,9 @@
     <string name="scan_fixing_threats_description">We\'re hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check the progress at anytime.</string>
     <string name="scan_scanning_is_initial_description">Welcome to Jetpack Scan, we are taking a first look at your site now and the results will be with you soon.</string>
     <string name="scan_provisioning_description">Welcome to Jetpack Scan! We\'re scoping out your site, setting up to do a full scan. We\'ll let you know if we spot any issues that might impact a scan, then your first full scan will start.</string>
-    <string name="scan_idle_manual_scan_description">Run a manual scan now or wait for Jetpack to scan your site later today.</string>
-    <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and everything looked great. %s</string>
-    <string name="scan_idle_with_threats_description">The scan found %1s potential threats on %2s. Please review them below and take action. We\'re %3$s if you need us.</string>
+    <string name="scan_idle_manual_scan_description">To review your site again run a manual scan, or wait for Jetpack to scan your site later today.</string>
+    <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and did not find any risks. %s</string>
+    <string name="scan_idle_with_threats_description">The scan found %1s potential threats with %2s. Please review them below and take action or tap the fix all button. We\'re %3$s if you need us.</string>
     <string name="scan_here_to_help">here to help</string>
     <string name="scan_this_site">this site</string>
     <string name="scan_in_hours_ago">%s hours ago</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1088,7 +1088,7 @@
     <string name="scan_provisioning_description">Welcome to Jetpack Scan! We\'re scoping out your site, setting up to do a full scan. We\'ll let you know if we spot any issues that might impact a scan, then your first full scan will start.</string>
     <string name="scan_idle_manual_scan_description">To review your site again run a manual scan, or wait for Jetpack to scan your site later today.</string>
     <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and did not find any risks. %s</string>
-    <string name="scan_idle_with_threats_description">The scan found %1s potential threats with %2s. Please review them below and take action or tap the fix all button. We\'re %3$s if you need us.</string>
+    <string name="scan_idle_with_threats_description">The scan found %1s potential threats with %2s. Please review them below and take action or tap the fix all button. We are %3$s if you need us.</string>
     <string name="scan_here_to_help">here to help</string>
     <string name="scan_this_site">this site</string>
     <string name="scan_in_hours_ago">%s hours ago</string>


### PR DESCRIPTION
Fixes #13916 

This PR applies copy improvements for the Jetpack Scan section:

1. `The scan found [N] potential threats with [SiteName]. Please review them below and take action. We are here to help if you need us.` -> `The scan found [N] potential threats with [SiteName]. Please review them below and take action or tap the fix all button. We are here to help if you need us.`

2. `The last jetpack scan ran just now and everything looked great. Run a manual scan now or wait for Jetpack to scan your site later today. `-> `The last jetpack scan did not find any risks. To review your site again run a manual scan, or wait for Jetpack to scan your site later today.`

Not Applicable

1. `Don’t worry about a thing` -> `Risks Removed.` (Not needed as per https://github.com/wordpress-mobile/WordPress-iOS/pull/15790#discussion_r570386647)

    There was a slight change in the fix threats flow and these messages do not exist now (Compared with iOS [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/15790)): 

2. `You resolved 2 threats just now and everything looked great. Run a manual scan now or wait for Jetpack to scan your site later today.` -> `You resolved the 2 threats listed below and your site is now risk free.. To review your site again run a manual scan, or wait for Jetpack to scan your site later today. `

3. `You resolved [N] threats just now `-> `You resolved [N] threats`

**Merge Instructions**

I targeted `16.8` milestone as changes are not critical but it'll great if it can be merged in `16.7`.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
