### PR TITLE
Issue/13326 extract to use case

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
@@ -8,12 +8,9 @@ import kotlinx.android.parcel.Parcelize
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
-import org.wordpress.android.fluxc.store.ScanStore
-import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType.ALL
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType.FIXED

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanHistoryUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanHistoryUseCase.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.ui.jetpack.scan.usecases
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.ScanStore
+import org.wordpress.android.fluxc.store.ScanStore.FetchScanHistoryPayload
+import org.wordpress.android.util.NetworkUtilsWrapper
+import javax.inject.Inject
+
+class FetchScanHistoryUseCase @Inject constructor(
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val scanStore: ScanStore
+) {
+    suspend fun fetch(site: SiteModel): FetchScanHistoryState {
+        return if (!networkUtilsWrapper.isNetworkAvailable()) {
+            FetchScanHistoryState.Failure.NetworkUnavailable
+        } else {
+            val result = scanStore.fetchScanHistory(FetchScanHistoryPayload(site))
+            if (result.isError) {
+                FetchScanHistoryState.Failure.RemoteRequestFailure
+            } else {
+                FetchScanHistoryState.Success
+            }
+        }
+    }
+
+    sealed class FetchScanHistoryState {
+        object Success : FetchScanHistoryState()
+        sealed class Failure : FetchScanHistoryState() {
+            object NetworkUnavailable : Failure()
+            object RemoteRequestFailure : Failure()
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanHistoryUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanHistoryUseCase.kt
@@ -1,30 +1,44 @@
 package org.wordpress.android.ui.jetpack.scan.usecases
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.scan.threat.ThreatModel
 import org.wordpress.android.fluxc.store.ScanStore
 import org.wordpress.android.fluxc.store.ScanStore.FetchScanHistoryPayload
+import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.analytics.ScanTracker
 import javax.inject.Inject
+import javax.inject.Named
 
 class FetchScanHistoryUseCase @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
-    private val scanStore: ScanStore
+    private val scanStore: ScanStore,
+    private val scanTracker: ScanTracker,
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
-    suspend fun fetch(site: SiteModel): FetchScanHistoryState {
+    suspend fun fetch(
+        site: SiteModel
+    ): FetchScanHistoryState {
         return if (!networkUtilsWrapper.isNetworkAvailable()) {
+            scanTracker.trackOnError(ScanTracker.ErrorAction.FETCH_SCAN_HISTORY, ScanTracker.ErrorCause.OFFLINE)
             FetchScanHistoryState.Failure.NetworkUnavailable
         } else {
             val result = scanStore.fetchScanHistory(FetchScanHistoryPayload(site))
             if (result.isError) {
+                scanTracker.trackOnError(ScanTracker.ErrorAction.FETCH_SCAN_HISTORY, ScanTracker.ErrorCause.REMOTE)
                 FetchScanHistoryState.Failure.RemoteRequestFailure
             } else {
-                FetchScanHistoryState.Success
+                withContext(bgDispatcher) {
+                    FetchScanHistoryState.Success(scanStore.getScanHistoryForSite(site))
+                }
             }
         }
     }
 
     sealed class FetchScanHistoryState {
-        object Success : FetchScanHistoryState()
+        data class Success(val threatModels: List<ThreatModel>) : FetchScanHistoryState()
         sealed class Failure : FetchScanHistoryState() {
             object NetworkUnavailable : Failure()
             object RemoteRequestFailure : Failure()

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModelTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.jetpack.scan.history
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -14,7 +13,6 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.ScanStore
 import org.wordpress.android.test
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType.ALL
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType.FIXED
@@ -32,7 +30,6 @@ class ScanHistoryViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 
-    @Mock private lateinit var scanStore: ScanStore
     @Mock private lateinit var scanTracker: ScanTracker
     @Mock private lateinit var fetchScanHistoryUseCase: FetchScanHistoryUseCase
 
@@ -43,15 +40,12 @@ class ScanHistoryViewModelTest {
     @Before
     fun setUp() = test {
         viewModel = ScanHistoryViewModel(
-                scanStore,
                 scanTracker,
                 fetchScanHistoryUseCase,
-                TEST_DISPATCHER,
                 TEST_DISPATCHER
         )
         whenever(fetchScanHistoryUseCase.fetch(site))
-                .thenReturn(FetchScanHistoryUseCase.FetchScanHistoryState.Success)
-        whenever(scanStore.getScanHistoryForSite(anyOrNull())).thenReturn(listOf(mock()))
+                .thenReturn(FetchScanHistoryUseCase.FetchScanHistoryState.Success(listOf(mock())))
     }
 
     @Test
@@ -104,7 +98,7 @@ class ScanHistoryViewModelTest {
         val observers = init()
 
         whenever(fetchScanHistoryUseCase.fetch(site))
-                .thenReturn(FetchScanHistoryUseCase.FetchScanHistoryState.Success)
+                .thenReturn(FetchScanHistoryUseCase.FetchScanHistoryState.Success(listOf(mock())))
         (observers.uiStates.last() as NoConnection).retry.invoke()
 
         assertThat(viewModel.threats.value!!.size).isEqualTo(1)
@@ -117,7 +111,7 @@ class ScanHistoryViewModelTest {
         val observers = init()
 
         whenever(fetchScanHistoryUseCase.fetch(site))
-                .thenReturn(FetchScanHistoryUseCase.FetchScanHistoryState.Success)
+                .thenReturn(FetchScanHistoryUseCase.FetchScanHistoryState.Success(listOf(mock())))
         (observers.uiStates.last() as RequestFailed).retry.invoke()
 
         assertThat(viewModel.threats.value!!.size).isEqualTo(1)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanHistoryUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanHistoryUseCaseTest.kt
@@ -1,0 +1,65 @@
+package org.wordpress.android.ui.jetpack.scan.usecases
+
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.action.ScanAction.FETCH_SCAN_HISTORY
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.ScanStore
+import org.wordpress.android.fluxc.store.ScanStore.FetchScanHistoryError
+import org.wordpress.android.fluxc.store.ScanStore.FetchScanHistoryErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.ScanStore.OnScanHistoryFetched
+import org.wordpress.android.test
+import org.wordpress.android.ui.jetpack.scan.usecases.FetchScanHistoryUseCase.FetchScanHistoryState.Failure
+import org.wordpress.android.ui.jetpack.scan.usecases.FetchScanHistoryUseCase.FetchScanHistoryState.Success
+import org.wordpress.android.util.NetworkUtilsWrapper
+
+class FetchScanHistoryUseCaseTest : BaseUnitTest() {
+    private lateinit var fetchScanHistoryUseCase: FetchScanHistoryUseCase
+
+    @Mock private lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+    @Mock private lateinit var scanStore: ScanStore
+    private val site: SiteModel = SiteModel()
+
+    @Before
+    fun setUp() {
+        fetchScanHistoryUseCase = FetchScanHistoryUseCase(networkUtilsWrapper, scanStore)
+
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+    }
+
+    @Test
+    fun `Network failure returned, when the device is offline`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        val result = fetchScanHistoryUseCase.fetch(site)
+
+        assertThat(result).isInstanceOf(Failure.NetworkUnavailable::class.java)
+    }
+
+    @Test
+    fun `Request failure returned, when the request fails`() = test {
+        whenever(scanStore.fetchScanHistory(anyOrNull())).thenReturn(
+                OnScanHistoryFetched(site.siteId, FetchScanHistoryError(GENERIC_ERROR), FETCH_SCAN_HISTORY)
+        )
+
+        val result = fetchScanHistoryUseCase.fetch(site)
+
+        assertThat(result).isInstanceOf(Failure.RemoteRequestFailure::class.java)
+    }
+
+    @Test
+    fun `Success returned, when the request succeeds`() = test {
+        whenever(scanStore.fetchScanHistory(anyOrNull())).thenReturn(
+                OnScanHistoryFetched(site.siteId, null, FETCH_SCAN_HISTORY)
+        )
+
+        val result = fetchScanHistoryUseCase.fetch(site)
+
+        assertThat(result).isInstanceOf(Success::class.java)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanHistoryUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanHistoryUseCaseTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
-import org.greenrobot.eventbus.ThreadMode
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -104,5 +103,4 @@ class FetchScanHistoryUseCaseTest : BaseUnitTest() {
 
         assertThat((result as Success).threatModels).isEqualTo(threats)
     }
-
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanHistoryUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanHistoryUseCaseTest.kt
@@ -81,18 +81,7 @@ class FetchScanHistoryUseCaseTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Success returned, when the request succeeds`() = test {
-        whenever(scanStore.fetchScanHistory(anyOrNull())).thenReturn(
-                OnScanHistoryFetched(site.siteId, null, FETCH_SCAN_HISTORY)
-        )
-
-        val result = fetchScanHistoryUseCase.fetch(site)
-
-        assertThat(result).isInstanceOf(Success::class.java)
-    }
-
-    @Test
-    fun `Data from db returned, when the request suceeds`() = test {
+    fun `Data from db returned, when the request succeeds`() = test {
         val threats = listOf<ThreatModel>(mock(), mock())
         whenever(scanStore.fetchScanHistory(anyOrNull())).thenReturn(
                 OnScanHistoryFetched(site.siteId, null, FETCH_SCAN_HISTORY)


### PR DESCRIPTION
Parent issue #13326

This PR wraps "fetchScanHistory" call into a usecase as per [this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/13802#discussion_r559942517).

To be honest, I'm still not sure if we should be wrapping these types of code blocks into use cases. If you look at the changes in `ScanHistoryViewModel.kt`, the before/after code is almost identical, but we have an extra class which doesn't do almost anything. I'm not even sure this make the code more consistent, because AFAIK we mostly don't use usecases for basic calls to FluxC or do we? It feels to me that we are just adding one extra layer which has basically no purpose and doesn't bring any benefits right now. I'd personally introduce use cases only in [the following scenarios](https://github.com/wordpress-mobile/WordPress-Android/pull/13802#discussion_r560046539).

Wdyt @ParaskP7 @zwarm @ashiagr?

To test:
tbd

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
