### PR TITLE
Add "Explore Plans" Quick Start card illustrations

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartItemBuilder.kt
@@ -106,10 +106,10 @@ class QuickStartItemBuilder
             CHECK_STATS -> R.drawable.img_illustration_quick_start_task_check_site_stats
             EDIT_HOMEPAGE -> R.drawable.img_illustration_quick_start_task_edit_your_homepage
             REVIEW_PAGES -> R.drawable.img_illustration_quick_start_task_review_site_pages
+            EXPLORE_PLANS -> R.drawable.img_illustration_quick_start_task_explore_plans
             // Replace with an actual drawable or change the tasks, and then remove the placeholders
             CREATE_SITE -> R.drawable.bg_quick_start_customize_task_illustration_placeholder
-            QuickStartTask.UNKNOWN,
-            EXPLORE_PLANS -> R.drawable.bg_quick_start_grow_task_illustration_placeholder
+            QuickStartTask.UNKNOWN -> R.drawable.bg_quick_start_grow_task_illustration_placeholder
         }
     }
 }

--- a/WordPress/src/main/res/drawable-night/img_illustration_quick_start_task_explore_plans.xml
+++ b/WordPress/src/main/res/drawable-night/img_illustration_quick_start_task_explore_plans.xml
@@ -4,14 +4,9 @@
     android:viewportWidth="168"
     android:viewportHeight="94">
     <path
-        android:pathData="M0,0h168v94h-168z"
-        android:fillColor="#2C3338"/>
-    <group>
-        <clip-path
-            android:pathData="M84,22.833C70.708,22.833 59.833,33.708 59.833,47C59.833,60.292 70.708,71.167 84,71.167C97.292,71.167 108.167,60.292 108.167,47C108.167,33.708 97.292,22.833 84,22.833ZM81.583,51.833H69.5L81.583,27.667V51.833ZM86.417,42.167V66.333L98.5,42.167H86.417Z"
-            android:fillType="evenOdd"/>
-        <path
-            android:pathData="M55,18h58v58h-58z"
-            android:fillColor="#F6F7F7"/>
-    </group>
+        android:pathData="M0 0h168v94H0z"
+        android:fillColor="@color/gray_80" />
+    <path
+        android:pathData="M84 22.833c13.292 0 24.167 10.875 24.167 24.167 0 13.292-10.875 24.167-24.167 24.167-13.292 0-24.167-10.875-24.167-24.167 0-13.292 10.875-24.167 24.167-24.167zm14.5 19.334H86.417v24.166L98.5 42.167zm-16.917-14.5L69.5 51.833h12.083V27.667z"
+        android:fillColor="@color/gray_0" />
 </vector>

--- a/WordPress/src/main/res/drawable-night/img_illustration_quick_start_task_explore_plans.xml
+++ b/WordPress/src/main/res/drawable-night/img_illustration_quick_start_task_explore_plans.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="168dp"
+    android:height="94dp"
+    android:viewportWidth="168"
+    android:viewportHeight="94">
+    <path
+        android:pathData="M0,0h168v94h-168z"
+        android:fillColor="#2C3338"/>
+    <group>
+        <clip-path
+            android:pathData="M84,22.833C70.708,22.833 59.833,33.708 59.833,47C59.833,60.292 70.708,71.167 84,71.167C97.292,71.167 108.167,60.292 108.167,47C108.167,33.708 97.292,22.833 84,22.833ZM81.583,51.833H69.5L81.583,27.667V51.833ZM86.417,42.167V66.333L98.5,42.167H86.417Z"
+            android:fillType="evenOdd"/>
+        <path
+            android:pathData="M55,18h58v58h-58z"
+            android:fillColor="#F6F7F7"/>
+    </group>
+</vector>

--- a/WordPress/src/main/res/drawable/img_illustration_quick_start_task_explore_plans.xml
+++ b/WordPress/src/main/res/drawable/img_illustration_quick_start_task_explore_plans.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="168dp"
+    android:height="94dp"
+    android:viewportWidth="168"
+    android:viewportHeight="94">
+    <path
+        android:pathData="M0,0h168v94h-168z"
+        android:fillColor="#F5ECE6"/>
+    <group>
+        <clip-path
+            android:pathData="M84,22.833C70.708,22.833 59.833,33.708 59.833,47C59.833,60.292 70.708,71.167 84,71.167C97.292,71.167 108.167,60.292 108.167,47C108.167,33.708 97.292,22.833 84,22.833ZM81.583,51.833H69.5L81.583,27.667V51.833ZM86.417,42.167V66.333L98.5,42.167H86.417Z"
+            android:fillType="evenOdd"/>
+        <path
+            android:pathData="M55,18h58v58h-58z"
+            android:fillColor="#72AEE6"/>
+    </group>
+</vector>

--- a/WordPress/src/main/res/drawable/img_illustration_quick_start_task_explore_plans.xml
+++ b/WordPress/src/main/res/drawable/img_illustration_quick_start_task_explore_plans.xml
@@ -4,14 +4,9 @@
     android:viewportWidth="168"
     android:viewportHeight="94">
     <path
-        android:pathData="M0,0h168v94h-168z"
-        android:fillColor="#F5ECE6"/>
-    <group>
-        <clip-path
-            android:pathData="M84,22.833C70.708,22.833 59.833,33.708 59.833,47C59.833,60.292 70.708,71.167 84,71.167C97.292,71.167 108.167,60.292 108.167,47C108.167,33.708 97.292,22.833 84,22.833ZM81.583,51.833H69.5L81.583,27.667V51.833ZM86.417,42.167V66.333L98.5,42.167H86.417Z"
-            android:fillType="evenOdd"/>
-        <path
-            android:pathData="M55,18h58v58h-58z"
-            android:fillColor="#72AEE6"/>
-    </group>
+        android:pathData="M0 0h168v94H0z"
+        android:fillColor="@color/orange_0" />
+    <path
+        android:pathData="M84 22.833c13.292 0 24.167 10.875 24.167 24.167 0 13.292-10.875 24.167-24.167 24.167-13.292 0-24.167-10.875-24.167-24.167 0-13.292 10.875-24.167 24.167-24.167zm14.5 19.334H86.417v24.166L98.5 42.167zm-16.917-14.5L69.5 51.833h12.083V27.667z"
+        android:fillColor="@color/blue_20" />
 </vector>


### PR DESCRIPTION
This PR adds illustrations for the "Explore plans" Quick Start task:

Light | Dark
--|--
![explore-plans-light](https://user-images.githubusercontent.com/830056/107240492-baba8280-6a08-11eb-8764-2f00ad9af3a4.jpeg) | ![explore-plans-dark](https://user-images.githubusercontent.com/830056/107240488-b9895580-6a08-11eb-8097-4114f6c82687.jpeg)

To test:

1. Turn on the Improved My Site flag and restart the app.
1. Go to the My Site screen.
1. Notice the Quick Start Task cards.
1. Scroll to the end of the "Grow your audience" section.
1. Make sure the "Explore plans" tasks have the correct illustration and that nothing looks off.
1. Switch to dark mode and repeat.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
