### PR TITLE
Lower min value of bar chart in stats to 4

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -27,7 +27,7 @@ import org.wordpress.android.ui.stats.refresh.utils.LargeValueFormatter
 import org.wordpress.android.util.DisplayUtils
 
 private const val MIN_COLUMN_COUNT = 5
-private const val MIN_VALUE = 5f
+private const val MIN_VALUE = 4f
 
 private typealias BarCount = Int
 


### PR DESCRIPTION
Fixes #13671 

As discussed in the issue, this PR solves the anomaly in the stats Day/Week/Month/Year graph with very low data by lowering the minimal top value of the graph to 4. This way each row in the graph represents one whole item.

To test:
- Check stats for a site with very low views
- Notice the Left axis now says 0, 1, 2, 3, 4 where 4 is the top value and no number there is missing
- Sanity check the other graphs with more data

![Screenshot_1612798529](https://user-images.githubusercontent.com/1079756/107242403-3679f680-6a2c-11eb-9161-6214cd6fccdb.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
