### PR TITLE
Show snackbar in activity context

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -17,6 +17,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity
+import kotlinx.android.synthetic.main.main_activity.*
 import kotlinx.android.synthetic.main.me_action_layout.*
 import kotlinx.android.synthetic.main.new_my_site_fragment.*
 import org.wordpress.android.R
@@ -429,22 +430,24 @@ class ImprovedMySiteFragment : Fragment(),
     }
 
     private fun showSnackbar(holder: SnackbarMessageHolder) {
-        snackbarSequencer.enqueue(
-                SnackbarItem(
-                        Info(
-                                view = coordinator_layout,
-                                textRes = holder.message,
-                                duration = Snackbar.LENGTH_LONG
-                        ),
-                        holder.buttonTitle?.let {
-                            Action(
-                                    textRes = holder.buttonTitle,
-                                    clickListener = { holder.buttonAction() }
-                            )
-                        },
-                        dismissCallback = { _, _ -> holder.onDismissAction() }
-                )
-        )
+        activity?.let { parent ->
+            snackbarSequencer.enqueue(
+                    SnackbarItem(
+                            Info(
+                                    view = parent.coordinator,
+                                    textRes = holder.message,
+                                    duration = Snackbar.LENGTH_LONG
+                            ),
+                            holder.buttonTitle?.let {
+                                Action(
+                                        textRes = holder.buttonTitle,
+                                        clickListener = { holder.buttonAction() }
+                                )
+                            },
+                            dismissCallback = { _, _ -> holder.onDismissAction() }
+                    )
+            )
+        }
     }
 
     companion object {


### PR DESCRIPTION
Fixes #13853 

This PR changes the target view of the snackbar from the fragment to the main activity coordinator in order to show the snackbar under the FAB.

To test:
- Make sure the MySiteImprovements flag is turned on and the app is restarted
- Make sure you're on a site with QS active
- Click on a task
- Notice the snackbar is shown and the FAB is moved up


![Screenshot_1612803991](https://user-images.githubusercontent.com/1079756/107255258-67f8bf00-6a38-11eb-8b37-351395d5bbe6.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
