### PR TITLE
Update copy on new Quick Start task cards

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskDetails.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskDetails.java
@@ -70,7 +70,7 @@ public enum QuickStartTaskDetails {
     REVIEW_PAGES(
             QuickStartTask.REVIEW_PAGES,
             R.string.quick_start_dialog_review_pages_title,
-            R.string.quick_start_dialog_edit_homepage_message,
+            R.string.quick_start_dialog_review_pages_message,
             R.drawable.ic_pages_white_24dp
     );
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskDetails.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTaskDetails.java
@@ -63,14 +63,14 @@ public enum QuickStartTaskDetails {
     ),
     EDIT_HOMEPAGE(
             QuickStartTask.EDIT_HOMEPAGE,
-            R.string.quick_start_dialog_edit_homepage_title,
-            R.string.quick_start_dialog_edit_homepage_message,
+            R.string.quick_start_list_edit_homepage_title,
+            R.string.quick_start_list_edit_homepage_subtitle,
             R.drawable.ic_homepage_16dp
     ),
     REVIEW_PAGES(
             QuickStartTask.REVIEW_PAGES,
-            R.string.quick_start_dialog_review_pages_title,
-            R.string.quick_start_dialog_review_pages_message,
+            R.string.quick_start_list_review_pages_title,
+            R.string.quick_start_list_review_pages_subtitle,
             R.drawable.ic_pages_white_24dp
     );
 

--- a/WordPress/src/main/res/layout/quick_start_task_card.xml
+++ b/WordPress/src/main/res/layout/quick_start_task_card.xml
@@ -23,7 +23,6 @@
             android:id="@+id/task_card_illustration"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
             app:shapeAppearance="@style/ShapeAppearance.QuickStartTaskCardIllustration"
             tools:ignore="ContentDescription"
             tools:src="@drawable/img_illustration_quick_start_task_set_site_title" />
@@ -45,7 +44,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_small"
             android:ellipsize="end"
-            android:maxLines="3"
+            android:lines="3"
             tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ac erat." />
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2873,6 +2873,10 @@
     <string name="quick_start_list_upload_icon_title" translatable="false">@string/quick_start_dialog_upload_icon_title</string>
     <string name="quick_start_list_view_site_subtitle" translatable="false">@string/quick_start_dialog_view_site_message</string>
     <string name="quick_start_list_view_site_title" translatable="false">@string/quick_start_dialog_view_site_title</string>
+    <string name="quick_start_list_edit_homepage_subtitle" translatable="false">@string/quick_start_dialog_edit_homepage_message</string>
+    <string name="quick_start_list_edit_homepage_title" translatable="false">@string/quick_start_dialog_edit_homepage_title</string>
+    <string name="quick_start_list_review_pages_subtitle" translatable="false">@string/quick_start_dialog_review_pages_message</string>
+    <string name="quick_start_list_review_pages_title" translatable="false">@string/quick_start_dialog_review_pages_title</string>
     <string name="quick_start_sites">Next Steps</string>
     <string name="quick_start_sites_type_customize">Customize Your Site</string>
     <string name="quick_start_sites_type_grow">Grow Your Audience</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2856,26 +2856,26 @@
     <string name="quick_start_dialog_review_pages_message_short" tools:ignore="UnusedResources">Select %1$s Pages %2$s to see your page list.</string>
     <string name="quick_start_complete_tasks_header">Complete (%d)</string>
     <string name="quick_start_list_check_stats_subtitle" translatable="false">@string/quick_start_dialog_check_stats_message</string>
-    <string name="quick_start_list_check_stats_title" translatable="false">@string/quick_start_dialog_check_stats_title</string>
+    <string name="quick_start_list_check_stats_title">Check your stats</string>
     <string name="quick_start_list_create_site_subtitle">Get your site up and running.</string>
     <string name="quick_start_list_create_site_title">Create your site</string>
     <string name="quick_start_list_update_site_title_title">Set your site title</string>
-    <string name="quick_start_list_update_site_title_subtitle">Give your site a name that reflects its personality and topic. First impressions count!</string>
-    <string name="quick_start_list_enable_sharing_subtitle" translatable="false">@string/quick_start_dialog_enable_sharing_message</string>
-    <string name="quick_start_list_enable_sharing_title" translatable="false">@string/quick_start_dialog_enable_sharing_title</string>
+    <string name="quick_start_list_update_site_title_subtitle">Give your site a name that reflects its personality and topic.</string>
+    <string name="quick_start_list_enable_sharing_subtitle">Automatically share new posts to your social media.</string>
+    <string name="quick_start_list_enable_sharing_title">Enable sharing</string>
     <string name="quick_start_list_explore_plans_subtitle" translatable="false">@string/quick_start_dialog_explore_plans_message</string>
     <string name="quick_start_list_explore_plans_title" translatable="false">@string/quick_start_dialog_explore_plans_title</string>
-    <string name="quick_start_list_follow_site_subtitle" translatable="false">@string/quick_start_dialog_follow_sites_message</string>
+    <string name="quick_start_list_follow_site_subtitle">Discover and follow sites that inspire you.</string>
     <string name="quick_start_list_follow_site_title" translatable="false">@string/quick_start_dialog_follow_sites_title</string>
     <string name="quick_start_list_publish_post_subtitle" translatable="false">@string/quick_start_dialog_publish_post_message</string>
     <string name="quick_start_list_publish_post_title" translatable="false">@string/quick_start_dialog_publish_post_title</string>
-    <string name="quick_start_list_upload_icon_subtitle" translatable="false">@string/quick_start_dialog_upload_icon_message</string>
+    <string name="quick_start_list_upload_icon_subtitle">Add a site icon for a polished, pro look.</string>
     <string name="quick_start_list_upload_icon_title" translatable="false">@string/quick_start_dialog_upload_icon_title</string>
     <string name="quick_start_list_view_site_subtitle" translatable="false">@string/quick_start_dialog_view_site_message</string>
-    <string name="quick_start_list_view_site_title" translatable="false">@string/quick_start_dialog_view_site_title</string>
+    <string name="quick_start_list_view_site_title">Visit your site</string>
     <string name="quick_start_list_edit_homepage_subtitle" translatable="false">@string/quick_start_dialog_edit_homepage_message</string>
     <string name="quick_start_list_edit_homepage_title" translatable="false">@string/quick_start_dialog_edit_homepage_title</string>
-    <string name="quick_start_list_review_pages_subtitle" translatable="false">@string/quick_start_dialog_review_pages_message</string>
+    <string name="quick_start_list_review_pages_subtitle">Check your pages and make changes, or add or remove pages.</string>
     <string name="quick_start_list_review_pages_title" translatable="false">@string/quick_start_dialog_review_pages_title</string>
     <string name="quick_start_sites">Next Steps</string>
     <string name="quick_start_sites_type_customize">Customize Your Site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2815,10 +2815,10 @@
     <string name="quick_start_dialog_remove_next_steps_message">Removing Next Steps will hide all tours on this site. This action cannot be undone.</string>
     <string name="quick_start_dialog_check_stats_message">Keep up to date on your site\'s performance.</string>
     <string name="quick_start_dialog_check_stats_title">Check your site stats</string>
-    <string name="quick_start_dialog_enable_sharing_message">Automatically share new posts to your social media accounts.</string>
+    <string name="quick_start_dialog_enable_sharing_message" tools:ignore="UnusedResources">Automatically share new posts to your social media accounts.</string>
     <string name="quick_start_dialog_enable_sharing_message_short_connections">Tap the %1$s Connections %2$s to add your social media accounts</string>
     <string name="quick_start_dialog_enable_sharing_message_short_sharing" tools:ignore="UnusedResources">Tap %1$s Sharing %2$s to continue</string>
-    <string name="quick_start_dialog_enable_sharing_title">Enable post sharing</string>
+    <string name="quick_start_dialog_enable_sharing_title" tools:ignore="UnusedResources">Enable post sharing</string>
     <string name="quick_start_dialog_explore_plans_message">Learn about the marketing and SEO tools in our paid plans.</string>
     <string name="quick_start_dialog_explore_plans_title">Explore plans</string>
     <string name="quick_start_dialog_follow_sites_message">Find sites that inspire you, and follow them to get updates when they post.</string>


### PR DESCRIPTION
Fixes #13995

This PR updates the title and subtitle strings for each Quick Start card according to the copy defined in #13995. I've also updated the Quick Start card item layout to make sure it maintains a fixed height.

To test:

1. Turn on the Improved My Site flag and restart the app.
1. Go to the My Site screen.
1. Notice the Quick Start Task cards.
1. Scroll through each category and compare the title and subtitle of each card to the ones defined in the #13995.
1. Make sure all titles and subtitles are correct and that nothing looks out-of-place.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
