### PR TITLE
Replace flow with live data in sources

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/DomainRegistrationHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/DomainRegistrationHandler.kt
@@ -1,8 +1,12 @@
 package org.wordpress.android.ui.mysite
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -11,15 +15,18 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore.OnPlansFetched
 import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DomainCreditAvailable
 import org.wordpress.android.ui.plans.isDomainCreditAvailable
 import org.wordpress.android.util.AppLog.T.DOMAIN_REGISTRATION
 import org.wordpress.android.util.SiteUtilsWrapper
 import javax.inject.Inject
+import javax.inject.Named
 import kotlin.coroutines.resume
 
 class DomainRegistrationHandler
 @Inject constructor(
+    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val dispatcher: Dispatcher,
     private val selectedSiteRepository: SelectedSiteRepository,
     private val appLogWrapper: AppLogWrapper,
@@ -27,31 +34,35 @@ class DomainRegistrationHandler
 ) : MySiteSource<DomainCreditAvailable> {
     private var continuation: CancellableContinuation<OnPlansFetched>? = null
 
-    override fun buildSource(siteId: Int) = flow {
+    override fun buildSource(coroutineScope: CoroutineScope, siteId: Int): LiveData<DomainCreditAvailable> {
         continuation?.cancel()
         continuation = null
         val site = selectedSiteRepository.getSelectedSite()
         if (site == null || site.id != siteId) {
-            return@flow
+            return MutableLiveData()
         }
         if (shouldFetchPlans(site)) {
-            try {
-                val event = suspendCancellableCoroutine<OnPlansFetched> { cancellableContinuation ->
-                    continuation = cancellableContinuation
-                    fetchPlans(site)
+            val result = MutableLiveData<DomainCreditAvailable>()
+            coroutineScope.launch(bgDispatcher) {
+                try {
+                    val event = suspendCancellableCoroutine<OnPlansFetched> { cancellableContinuation ->
+                        continuation = cancellableContinuation
+                        fetchPlans(site)
+                    }
+                    continuation = null
+                    if (event.isError) {
+                        val message = "An error occurred while fetching plans : " + event.error.message
+                        appLogWrapper.e(DOMAIN_REGISTRATION, message)
+                    } else if (siteId == event.site.id) {
+                        result.postValue(DomainCreditAvailable(isDomainCreditAvailable(event.plans)))
+                    }
+                } catch (e: CancellationException) {
+                    result.postValue(DomainCreditAvailable(false))
                 }
-                continuation = null
-                if (event.isError) {
-                    val message = "An error occurred while fetching plans : " + event.error.message
-                    appLogWrapper.e(DOMAIN_REGISTRATION, message)
-                } else if (siteId == event.site.id) {
-                    emit(DomainCreditAvailable(isDomainCreditAvailable(event.plans)))
-                }
-            } catch (e: CancellationException) {
-                emit(DomainCreditAvailable(false))
             }
+            return result
         } else {
-            emit(DomainCreditAvailable(false))
+            return MutableLiveData(DomainCreditAvailable(false))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.mysite
 
 import androidx.lifecycle.LiveData
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState
 
 interface MySiteSource<T : PartialState> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSource.kt
@@ -1,12 +1,14 @@
 package org.wordpress.android.ui.mysite
 
+import androidx.lifecycle.LiveData
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState
 
 interface MySiteSource<T : PartialState> {
-    fun buildSource(siteId: Int): Flow<T?>
+    fun buildSource(coroutineScope: CoroutineScope, siteId: Int): LiveData<T>
     interface SiteIndependentSource<T : PartialState> : MySiteSource<T> {
-        fun buildSource(): Flow<T?>
-        override fun buildSource(siteId: Int): Flow<T?> = buildSource()
+        fun buildSource(coroutineScope: CoroutineScope): LiveData<T>
+        override fun buildSource(coroutineScope: CoroutineScope, siteId: Int): LiveData<T> = buildSource(coroutineScope)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteStateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteStateProvider.kt
@@ -2,24 +2,18 @@ package org.wordpress.android.ui.mysite
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.asFlow
-import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.switchMap
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import org.wordpress.android.modules.BG_THREAD
+import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.ui.mysite.MySiteSource.SiteIndependentSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.SelectedSite
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.ShowSiteIconProgressBar
 import org.wordpress.android.util.filter
 import org.wordpress.android.util.map
-import javax.inject.Named
 
 class MySiteStateProvider(
-    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    private val coroutineScope: CoroutineScope,
     private val selectedSiteRepository: SelectedSiteRepository,
     vararg sources: MySiteSource<*>
 ) {
@@ -33,10 +27,10 @@ class MySiteStateProvider(
     val state: LiveData<MySiteUiState> = selectedSiteRepository.siteSelected.switchMap { siteId ->
         val result = MediatorLiveData<SiteIdToState>()
         val currentSources = if (siteId != null) {
-            mySiteSources.map { source -> source.buildSource(siteId).distinctUntilChanged().asLiveData(bgDispatcher) }
+            mySiteSources.map { source -> source.buildSource(coroutineScope, siteId).distinctUntilChanged() }
         } else {
             mySiteSources.filterIsInstance(SiteIndependentSource::class.java)
-                    .map { source -> source.buildSource().distinctUntilChanged().asLiveData(bgDispatcher) }
+                    .map { source -> source.buildSource(coroutineScope).distinctUntilChanged() }
         }
         for (newSource in currentSources) {
             result.addSource(newSource) { partialState ->
@@ -58,18 +52,18 @@ class MySiteStateProvider(
 
     private fun selectedSiteSource(): MySiteSource<SelectedSite> =
             object : MySiteSource<SelectedSite> {
-                override fun buildSource(siteId: Int): Flow<SelectedSite?> {
+                override fun buildSource(coroutineScope: CoroutineScope, siteId: Int): LiveData<SelectedSite> {
                     return selectedSiteRepository.selectedSiteChange
                             .filter { it == null || it.id == siteId }
-                            .map { SelectedSite(it) }.asFlow()
+                            .map { SelectedSite(it) }
                 }
             }
 
     private fun siteIconProgressSource(): MySiteSource<ShowSiteIconProgressBar> =
             object : MySiteSource<ShowSiteIconProgressBar> {
-                override fun buildSource(siteId: Int): Flow<ShowSiteIconProgressBar> {
-                    return selectedSiteRepository.showSiteIconProgressBar.map { ShowSiteIconProgressBar(it == true) }
-                            .asFlow()
+                override fun buildSource(coroutineScope: CoroutineScope, siteId: Int): LiveData<ShowSiteIconProgressBar> {
+                    return selectedSiteRepository.showSiteIconProgressBar
+                            .map { ShowSiteIconProgressBar(it == true) }
                             .distinctUntilChanged()
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteStateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteStateProvider.kt
@@ -61,7 +61,10 @@ class MySiteStateProvider(
 
     private fun siteIconProgressSource(): MySiteSource<ShowSiteIconProgressBar> =
             object : MySiteSource<ShowSiteIconProgressBar> {
-                override fun buildSource(coroutineScope: CoroutineScope, siteId: Int): LiveData<ShowSiteIconProgressBar> {
+                override fun buildSource(
+                    coroutineScope: CoroutineScope,
+                    siteId: Int
+                ): LiveData<ShowSiteIconProgressBar> {
                     return selectedSiteRepository.showSiteIconProgressBar
                             .map { ShowSiteIconProgressBar(it == true) }
                             .distinctUntilChanged()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -154,7 +154,7 @@ class MySiteViewModel
     val onUploadedItem = siteIconUploadHandler.onUploadedItem
 
     val uiModel: LiveData<UiModel> = MySiteStateProvider(
-            bgDispatcher,
+            this,
             selectedSiteRepository,
             quickStartRepository,
             currentAvatarSource,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -3,11 +3,9 @@ package org.wordpress.android.ui.mysite
 import androidx.core.text.HtmlCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.asFlow
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
@@ -81,7 +79,7 @@ class QuickStartRepository
             completedTasks = quickStartStore.getCompletedTasksByType(siteId.toLong(), quickStartTaskType)
                     .mapNotNull { detailsMap[it] })
 
-    override fun buildSource(siteId: Int): Flow<QuickStartUpdate> {
+    override fun buildSource(coroutineScope: CoroutineScope, siteId: Int): LiveData<QuickStartUpdate> {
         _activeTask.value = null
         if (selectedSiteRepository.getSelectedSite()?.showOnFront == ShowOnFront.POSTS.value &&
                 !quickStartStore.hasDoneTask(siteId.toLong(), EDIT_HOMEPAGE)) {
@@ -95,7 +93,7 @@ class QuickStartRepository
                 listOf()
             }
             QuickStartUpdate(activeTask, categories)
-        }.asFlow()
+        }
     }
 
     fun startQuickStart() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -1,42 +1,53 @@
 package org.wordpress.android.ui.mysite
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.JetpackCapabilities
 import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.config.BackupScreenFeatureConfig
 import org.wordpress.android.util.config.ScanScreenFeatureConfig
 import javax.inject.Inject
+import javax.inject.Named
 
 class ScanAndBackupSource @Inject constructor(
+    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val selectedSiteRepository: SelectedSiteRepository,
     private val scanScreenFeatureConfig: ScanScreenFeatureConfig,
     private val backupScreenFeatureConfig: BackupScreenFeatureConfig,
     private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase,
     private val siteUtilsWrapper: SiteUtilsWrapper
 ) : MySiteSource<JetpackCapabilities> {
-    override fun buildSource(siteId: Int) = flow {
+    override fun buildSource(coroutineScope: CoroutineScope, siteId: Int): LiveData<JetpackCapabilities> {
         val site = selectedSiteRepository.getSelectedSite()
         if (site != null && site.id == siteId &&
                 (scanScreenFeatureConfig.isEnabled() || backupScreenFeatureConfig.isEnabled())) {
-            jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId).collect {
-                emit(
-                        JetpackCapabilities(
-                                scanAvailable = siteUtilsWrapper.isScanEnabled(
-                                        scanScreenFeatureConfig.isEnabled(),
-                                        it.scan,
-                                        site
-                                ),
-                                backupAvailable = siteUtilsWrapper.isBackupEnabled(
-                                        backupScreenFeatureConfig.isEnabled(),
-                                        it.backup
-                                )
-                        )
-                )
+            val result = MutableLiveData<JetpackCapabilities>()
+            coroutineScope.launch(bgDispatcher) {
+                jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId).collect {
+                    result.postValue(
+                            JetpackCapabilities(
+                                    scanAvailable = siteUtilsWrapper.isScanEnabled(
+                                            scanScreenFeatureConfig.isEnabled(),
+                                            it.scan,
+                                            site
+                                    ),
+                                    backupAvailable = siteUtilsWrapper.isBackupEnabled(
+                                            backupScreenFeatureConfig.isEnabled(),
+                                            it.backup
+                                    )
+                            )
+                    )
+                }
             }
+            return result
         } else {
-            emit(JetpackCapabilities(scanAvailable = false, backupAvailable = false))
+            return MutableLiveData(JetpackCapabilities(scanAvailable = false, backupAvailable = false))
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/CurrentAvatarSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/CurrentAvatarSourceTest.kt
@@ -1,20 +1,20 @@
 package org.wordpress.android.ui.mysite
 
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_SCOPE
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.test
+import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
 
-@RunWith(MockitoJUnitRunner::class)
-class CurrentAvatarSourceTest {
+class CurrentAvatarSourceTest: BaseUnitTest() {
     @Mock lateinit var accountStore: AccountStore
     @Mock lateinit var accountModel: AccountModel
     private lateinit var currentAvatarSource: CurrentAvatarSource
@@ -26,9 +26,10 @@ class CurrentAvatarSourceTest {
 
     @Test
     fun `current avatar is empty on start`() = test {
-        val result = currentAvatarSource.buildSource().take(1).toList()
+        var result: CurrentAvatarUrl? = null
+        currentAvatarSource.buildSource(this).observeForever { it?.let { result = it } }
 
-        assertThat(result.last().url).isEqualTo("")
+        assertThat(result!!.url).isEqualTo("")
     }
 
     @Test
@@ -37,9 +38,11 @@ class CurrentAvatarSourceTest {
         val avatarUrl = "avatar.jpg"
         whenever(accountModel.avatarUrl).thenReturn(avatarUrl)
 
+        var result: CurrentAvatarUrl? = null
+        currentAvatarSource.buildSource(this).observeForever { it?.let { result = it } }
+
         currentAvatarSource.refresh()
 
-        val result = currentAvatarSource.buildSource().take(1).toList()
-        assertThat(result.last().url).isEqualTo(avatarUrl)
+        assertThat(result!!.url).isEqualTo(avatarUrl)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/CurrentAvatarSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/CurrentAvatarSourceTest.kt
@@ -4,17 +4,14 @@ import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.TEST_SCOPE
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.test
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
 
-class CurrentAvatarSourceTest: BaseUnitTest() {
+class CurrentAvatarSourceTest : BaseUnitTest() {
     @Mock lateinit var accountStore: AccountStore
     @Mock lateinit var accountModel: AccountModel
     private lateinit var currentAvatarSource: CurrentAvatarSource

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -32,8 +31,8 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.REVIEW_PAGES
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EXPLORE_PLANS
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.REVIEW_PAGES
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPDATE_SITE_TITLE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.UPLOAD_SITE_ICON
 import org.wordpress.android.test
@@ -142,10 +141,10 @@ class MySiteViewModelTest : BaseUnitTest() {
     private val onSiteChange = MutableLiveData<SiteModel>()
     private val onSiteSelected = MutableLiveData<Int>()
     private val onShowSiteIconProgressBar = MutableLiveData<Boolean>()
-    private val isDomainCreditAvailable = MutableStateFlow(DomainCreditAvailable(false))
-    private val jetpackCapabilities = MutableStateFlow(JetpackCapabilities(false, false))
-    private val currentAvatar = MutableStateFlow(CurrentAvatarUrl(""))
-    private val quickStartUpdate = MutableStateFlow(QuickStartUpdate())
+    private val isDomainCreditAvailable = MutableLiveData(DomainCreditAvailable(false))
+    private val jetpackCapabilities = MutableLiveData(JetpackCapabilities(false, false))
+    private val currentAvatar = MutableLiveData(CurrentAvatarUrl(""))
+    private val quickStartUpdate = MutableLiveData(QuickStartUpdate())
 
     @InternalCoroutinesApi
     @Before
@@ -153,11 +152,11 @@ class MySiteViewModelTest : BaseUnitTest() {
         onSiteChange.value = null
         onShowSiteIconProgressBar.value = null
         onSiteSelected.value = null
-        whenever(domainRegistrationHandler.buildSource(any())).thenReturn(isDomainCreditAvailable)
-        whenever(scanAndBackupSource.buildSource(any())).thenReturn(jetpackCapabilities)
-        whenever(currentAvatarSource.buildSource()).thenReturn(currentAvatar)
+        whenever(domainRegistrationHandler.buildSource(any(), any())).thenReturn(isDomainCreditAvailable)
+        whenever(scanAndBackupSource.buildSource(any(), any())).thenReturn(jetpackCapabilities)
         whenever(currentAvatarSource.buildSource(any())).thenReturn(currentAvatar)
-        whenever(quickStartRepository.buildSource(any())).thenReturn(quickStartUpdate)
+        whenever(currentAvatarSource.buildSource(any(), any())).thenReturn(currentAvatar)
+        whenever(quickStartRepository.buildSource(any(), any())).thenReturn(quickStartUpdate)
         whenever(selectedSiteRepository.selectedSiteChange).thenReturn(onSiteChange)
         whenever(selectedSiteRepository.siteSelected).thenReturn(onSiteSelected)
         whenever(selectedSiteRepository.showSiteIconProgressBar).thenReturn(onShowSiteIconProgressBar)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -4,9 +4,6 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.single
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/ScanAndBackupSourceTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.mysite
 
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.take
@@ -12,10 +13,13 @@ import org.junit.Test
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.TEST_SCOPE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.test
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase.JetpackPurchasedProducts
+import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.JetpackCapabilities
 import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.config.BackupScreenFeatureConfig
 import org.wordpress.android.util.config.ScanScreenFeatureConfig
@@ -31,9 +35,11 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
     private val siteId = 1
     private val siteRemoteId = 2L
 
+    @InternalCoroutinesApi
     @Before
     fun setUp() {
         scanAndBackupSource = ScanAndBackupSource(
+                TEST_DISPATCHER,
                 selectedSiteRepository,
                 scanScreenFeatureConfig,
                 backupScreenFeatureConfig,
@@ -51,20 +57,22 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
     fun `jetpack capabilities disabled when site not present`() = test {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
 
-        val result = scanAndBackupSource.buildSource(siteId).single()
+        var result: JetpackCapabilities? = null
+        scanAndBackupSource.buildSource(TEST_SCOPE, siteId).observeForever { result = it }
 
-        assertThat(result.backupAvailable).isFalse
-        assertThat(result.scanAvailable).isFalse
+        assertThat(result!!.backupAvailable).isFalse
+        assertThat(result!!.scanAvailable).isFalse
     }
 
     @Test
     fun `jetpack capabilities disabled when both scan and flag are disabled`() = test {
         init(scanScreenFeatureEnabled = false, backupScreenFeatureEnabled = false)
 
-        val result = scanAndBackupSource.buildSource(siteId).single()
+        var result: JetpackCapabilities? = null
+        scanAndBackupSource.buildSource(TEST_SCOPE, siteId).observeForever { result = it }
 
-        assertThat(result.backupAvailable).isFalse
-        assertThat(result.scanAvailable).isFalse
+        assertThat(result!!.backupAvailable).isFalse
+        assertThat(result!!.scanAvailable).isFalse
     }
 
     @Test
@@ -75,10 +83,11 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
         )
 
-        val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
+        var result: JetpackCapabilities? = null
+        scanAndBackupSource.buildSource(TEST_SCOPE, siteId).observeForever { result = it }
 
-        assertThat(result.backupAvailable).isFalse
-        assertThat(result.scanAvailable).isTrue
+        assertThat(result!!.backupAvailable).isFalse
+        assertThat(result!!.scanAvailable).isTrue
     }
 
     @Test
@@ -89,10 +98,11 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
         )
 
-        val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
+        var result: JetpackCapabilities? = null
+        scanAndBackupSource.buildSource(TEST_SCOPE, siteId).observeForever { result = it }
 
-        assertThat(result.backupAvailable).isTrue
-        assertThat(result.scanAvailable).isFalse
+        assertThat(result!!.backupAvailable).isTrue
+        assertThat(result!!.scanAvailable).isFalse
     }
 
     @Test
@@ -103,10 +113,11 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 flow { emit(JetpackPurchasedProducts(scan = true, backup = true)) }
         )
 
-        val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
+        var result: JetpackCapabilities? = null
+        scanAndBackupSource.buildSource(TEST_SCOPE, siteId).observeForever { result = it }
 
-        assertThat(result.backupAvailable).isTrue
-        assertThat(result.scanAvailable).isTrue
+        assertThat(result!!.backupAvailable).isTrue
+        assertThat(result!!.scanAvailable).isTrue
     }
 
     @Test
@@ -117,10 +128,11 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
                 flow { emit(JetpackPurchasedProducts(scan = false, backup = false)) }
         )
 
-        val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
+        var result: JetpackCapabilities? = null
+        scanAndBackupSource.buildSource(TEST_SCOPE, siteId).observeForever { result = it }
 
-        assertThat(result.backupAvailable).isFalse
-        assertThat(result.scanAvailable).isFalse
+        assertThat(result!!.backupAvailable).isFalse
+        assertThat(result!!.scanAvailable).isFalse
     }
 
     @Test
@@ -132,9 +144,10 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         )
         whenever(site.isWPCom).thenReturn(true)
 
-        val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
+        var result: JetpackCapabilities? = null
+        scanAndBackupSource.buildSource(TEST_SCOPE, siteId).observeForever { result = it }
 
-        assertThat(result.scanAvailable).isFalse
+        assertThat(result!!.scanAvailable).isFalse
     }
 
     @Test
@@ -146,9 +159,10 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         )
         whenever(site.isWPComAtomic).thenReturn(true)
 
-        val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
+        var result: JetpackCapabilities? = null
+        scanAndBackupSource.buildSource(TEST_SCOPE, siteId).observeForever { result = it }
 
-        assertThat(result.scanAvailable).isFalse
+        assertThat(result!!.scanAvailable).isFalse
     }
 
     @Test
@@ -161,9 +175,10 @@ class ScanAndBackupSourceTest : BaseUnitTest() {
         whenever(site.isWPCom).thenReturn(false)
         whenever(site.isWPComAtomic).thenReturn(false)
 
-        val result = scanAndBackupSource.buildSource(siteId).take(2).toList().last()
+        var result: JetpackCapabilities? = null
+        scanAndBackupSource.buildSource(TEST_SCOPE, siteId).observeForever { result = it }
 
-        assertThat(result.scanAvailable).isTrue
+        assertThat(result!!.scanAvailable).isTrue
     }
 
     private fun init(scanScreenFeatureEnabled: Boolean = false, backupScreenFeatureEnabled: Boolean = false) {


### PR DESCRIPTION
I've been looking a bit into the flows/livedata and I think it doesn't make sense to build flows and call asLiveData. I think it also quite lowers the performance and doesn't improve readibility. I've changed the interface in this PR so that the `buildSource` method now returns live data. The only problem with this approach is that it stops us from running slower operations (flow runs as a suspend function by default). I've fixed this by adding coroutine scope as the parameter to the build source. I think the result is quite neat and more readable tbh. Let me know what you think! 

To test:
- Make sure you have the my site improvements flag turned on and the app is restarted
- Click around the my site to check if everything looks ok
- Switch between a few sites to see if the screen gets updated.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
