### PR TITLE
Update geochart version to the latest stable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapViewHolder.kt
@@ -31,10 +31,6 @@ class MapViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     fun bind(item: MapItem) {
         coroutineScope.launch {
             delay(100)
-            // See: https://developers.google.com/chart/interactive/docs/gallery/geochart
-            // Loading the v42 of the Google Charts API, since the latest stable version has a problem with
-            // the legend. https://github.com/wordpress-mobile/WordPress-Android/issues/4131
-            // https://developers.google.com/chart/interactive/docs/release_notes#release-candidate-details
             val colorLow = Integer.toHexString(
                     ContextCompat.getColor(
                             itemView.context,
@@ -61,7 +57,7 @@ class MapViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                     "<script type=\"text/javascript\" src=\"https://www.gstatic.com/charts/loader.js\"></script>" +
                     "<script type=\"text/javascript\" src=\"https://www.google.com/jsapi\"></script>" +
                     "<script type=\"text/javascript\">" +
-                    " google.charts.load('42', {'packages':['geochart']});" +
+                    " google.charts.load('current', {'packages':['geochart']});" +
                     " google.charts.setOnLoadCallback(drawRegionsMap);" +
                     " function drawRegionsMap() {" +
                     " var data = google.visualization.arrayToDataTable(" +


### PR DESCRIPTION
Fixes #13637 

We were using an old version of geochart on purpose ([original issue from 2016](https://github.com/wordpress-mobile/WordPress-Android/issues/4131), fix in this [PR](https://github.com/wordpress-mobile/WordPress-Android/issues/4131)). However, I'm not seeing the missing label issue so it might have been fixed already by google (the testing steps in the original issue just say to open stats/period and check the countries block).  

To test:
- Open Stats on a site with some views
- Check one of Day/Week/Month/Year tab that has countries block
- Scroll to the countries block
- Notice the legend is present
- Notice the map looks OK

<img width="463" alt="Screenshot 2021-02-09 at 13 37 09" src="https://user-images.githubusercontent.com/1079756/107365808-9b415980-6add-11eb-86ec-a4f8b6a0d650.png">
<img width="412" alt="Screenshot 2021-02-09 at 13 36 04" src="https://user-images.githubusercontent.com/1079756/107365818-9da3b380-6add-11eb-940d-7b91f92453fb.png">


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
