### PR TITLE
Remove APKs from GH releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -714,11 +714,13 @@ ENV["validate_translations"]="lintVanillaRelease"
     version = options[:version]
     apk_file_path = universal_apk_file_path(version)
     aab_file_path = bundle_file_path(version)
+    # APKs built on CI are unsigned, so don't upload them until we have a fix
+    release_assets = is_ci ? aab_file_path : "#{apk_file_path},#{aab_file_path}" 
     create_release(repository:GHHELPER_REPO, 
       version: version["name"], 
       release_notes_file_path:release_notes_path,
       prerelease: set_prerelease_flag,
-      release_assets:"#{apk_file_path},#{aab_file_path}"
+      release_assets: release_assets
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -715,7 +715,8 @@ ENV["validate_translations"]="lintVanillaRelease"
     apk_file_path = universal_apk_file_path(version)
     aab_file_path = bundle_file_path(version)
     # APKs built on CI are unsigned, so don't upload them until we have a fix
-    release_assets = is_ci ? aab_file_path : "#{apk_file_path},#{aab_file_path}" 
+    release_assets = [aab_file_path]
+    release_assets.append(apk_file_path) unless is_ci
     create_release(repository:GHHELPER_REPO, 
       version: version["name"], 
       release_notes_file_path:release_notes_path,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -721,7 +721,7 @@ ENV["validate_translations"]="lintVanillaRelease"
       version: version["name"], 
       release_notes_file_path:release_notes_path,
       prerelease: set_prerelease_flag,
-      release_assets: release_assets
+      release_assets: release_assets.join(',')
     )
   end
 


### PR DESCRIPTION
Currently, the universal APKs we upload to GH releases are unsigned, so they are not easily installable. 
We already upload the app bundle from which a valid APK can be generated with the proper key, so there's no advantage in having the unsigned APK as well. 
The standard expectation is for people to be able to install the APK directly, so the unsigned APK generates confusion. 

This PR disables the upload of the APK from CI. 
We may evaluate sharing a replaceable key on CI for signing the APKs in the future if there will be a need for it.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
