### PR TITLE
Replace FragmentContainerView with Fragment to fix proguard issue

### DIFF
--- a/WordPress/src/main/res/layout/restore_activity.xml
+++ b/WordPress/src/main/res/layout/restore_activity.xml
@@ -6,13 +6,13 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.fragment.app.FragmentContainerView
+    <fragment
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:name="org.wordpress.android.ui.jetpack.restore.RestoreFragment"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
-    </androidx.fragment.app.FragmentContainerView>
+    </fragment>
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"

--- a/WordPress/src/main/res/layout/scan_activity.xml
+++ b/WordPress/src/main/res/layout/scan_activity.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.fragment.app.FragmentContainerView
+    <fragment
         android:id="@+id/fragment_container_view"
         android:name="org.wordpress.android.ui.jetpack.scan.ScanFragment"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/scan_history_activity.xml
+++ b/WordPress/src/main/res/layout/scan_history_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+<fragment xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/fragment_container_view"
     android:name="org.wordpress.android.ui.jetpack.scan.history.ScanHistoryFragment"
     android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/threat_details_activity.xml
+++ b/WordPress/src/main/res/layout/threat_details_activity.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.fragment.app.FragmentContainerView
+    <fragment
         android:id="@+id/fragment_container_view"
         android:name="org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsFragment"
         android:layout_width="match_parent"


### PR DESCRIPTION
Debug builds work just fine, however, release builds with ProGuard fail with the following exception:

```
Caused by: android.view.InflateException: Binary XML file line #9 in org.wordpress.android:layout/restore_activity: Binary XML file line #9 in org.wordpress.android:layout/restore_activity: Error inflating class androidx.fragment.app.FragmentContainerView
     Caused by: android.view.InflateException: Binary XML file line #9 in org.wordpress.android:layout/restore_activity: Error inflating class androidx.fragment.app.FragmentContainerView
     Caused by: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment org.wordpress.android.ui.jetpack.restore.RestoreFragment: make sure class name exists
```

ProGuard strips out classes which are referenced only from FragmentContainerView.

Affected screens are “Scan, Scan History, Threat Detail, Restore”. 

Fix: We decided to replace `FragmentContainerView` with `Fragment` for now since we don't need features of `FragmentContainerView`. The issue with proguard is fixed in Android Gradle Plugin 4.1 which requires gradle 6.5 (we are currently on 6.1.1.)

To test:
Test that Restore flow, Scan, Scan History and Threat detail screens don't crash during inflation.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
