### PR TITLE
Use Activity context to style QS snackbar text color with an attr color

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -1564,6 +1564,7 @@ class MySiteFragment : Fragment(),
                     )
                 } else {
                     quickStartUtilsWrapper.stylizeQuickStartPrompt(
+                            requireContext(),
                             activeTutorialPrompt!!.shortMessagePrompt,
                             activeTutorialPrompt!!.iconId
                     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -71,9 +71,11 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.BasicDialogModel
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MAIN
 import org.wordpress.android.util.AppLog.T.UTILS
+import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarItem.Action
 import org.wordpress.android.util.SnackbarItem.Info
@@ -95,6 +97,7 @@ class ImprovedMySiteFragment : Fragment(),
     @Inject lateinit var meGravatarLoader: MeGravatarLoader
     @Inject lateinit var mediaPickerLauncher: MediaPickerLauncher
     @Inject lateinit var uploadUtilsWrapper: UploadUtilsWrapper
+    @Inject lateinit var quickStartUtils: QuickStartUtilsWrapper
     private lateinit var viewModel: MySiteViewModel
     private lateinit var dialogViewModel: BasicDialogViewModel
     private lateinit var quickStartMenuViewModel: QuickStartMenuViewModel
@@ -276,6 +279,16 @@ class ImprovedMySiteFragment : Fragment(),
         viewModel.onSnackbarMessage.observe(viewLifecycleOwner, {
             it?.getContentIfNotHandled()?.let { messageHolder ->
                 showSnackbar(messageHolder)
+            }
+        })
+        viewModel.onQuickStartMySitePrompts.observe(viewLifecycleOwner, {
+            it?.getContentIfNotHandled()?.let { activeTutorialPrompt ->
+                val message = quickStartUtils.stylizeQuickStartPrompt(
+                        requireContext(),
+                        activeTutorialPrompt.shortMessagePrompt,
+                        activeTutorialPrompt.iconId
+                )
+                showSnackbar(SnackbarMessageHolder(UiStringText(message)))
             }
         })
         viewModel.onMediaUpload.observe(viewLifecycleOwner, {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -283,7 +283,7 @@ class ImprovedMySiteFragment : Fragment(),
         })
         viewModel.onQuickStartMySitePrompts.observe(viewLifecycleOwner, {
             it?.getContentIfNotHandled()?.let { activeTutorialPrompt ->
-                val message = quickStartUtils.stylizeQuickStartPrompt(
+                val message = quickStartUtils.stylizeThemedQuickStartPrompt(
                         requireContext(),
                         activeTutorialPrompt.shortMessagePrompt,
                         activeTutorialPrompt.iconId

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -146,6 +146,7 @@ class MySiteViewModel
 
     val onScrollTo: LiveData<Event<Pair<QuickStartTask, Int>>> = _scrollToQuickStartTask
     val onSnackbarMessage = merge(_onSnackbarMessage, siteStoriesHandler.onSnackbar, quickStartRepository.onSnackbar)
+    val onQuickStartMySitePrompts = quickStartRepository.onQuickStartMySitePrompts
     val onTextInputDialogShown = _onTechInputDialogShown as LiveData<Event<TextInputDialogModel>>
     val onBasicDialogShown = _onBasicDialogShown as LiveData<Event<SiteDialogModel>>
     val onQuickStartMenuShown = _onQuickStartMenuShown as LiveData<Event<String>>

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -124,7 +124,6 @@ class QuickStartRepository
                 _onQuickStartMySitePrompts.postValue(Event(activeTutorialPrompt))
             }
         }
-
     }
 
     fun completeTask(task: QuickStartTask) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -63,7 +63,9 @@ class QuickStartRepository
     private val quickStartTaskTypes = MutableLiveData<Set<QuickStartTaskType>>()
     private val _activeTask = MutableLiveData<QuickStartTask?>()
     private val _onSnackbar = MutableLiveData<Event<SnackbarMessageHolder>>()
+    private val _onQuickStartMySitePrompts = MutableLiveData<Event<QuickStartMySitePrompts>>()
     val onSnackbar = _onSnackbar as LiveData<Event<SnackbarMessageHolder>>
+    val onQuickStartMySitePrompts = _onQuickStartMySitePrompts as LiveData<Event<QuickStartMySitePrompts>>
     val activeTask = _activeTask as LiveData<QuickStartTask?>
 
     init {
@@ -109,22 +111,20 @@ class QuickStartRepository
 
     fun setActiveTask(task: QuickStartTask) {
         _activeTask.postValue(task)
-        val shortQuickStartMessage =
-                if (task == UPDATE_SITE_TITLE) {
-                    HtmlCompat.fromHtml(
-                            resourceProvider.getString(
-                                    R.string.quick_start_dialog_update_site_title_message_short,
-                                    SiteUtils.getSiteNameOrHomeURL(selectedSiteRepository.getSelectedSite())
-                            ), HtmlCompat.FROM_HTML_MODE_COMPACT
-                    )
-                } else {
-                    val activeTutorialPrompt = QuickStartMySitePrompts.getPromptDetailsForTask(task)
-                    quickStartUtils.stylizeQuickStartPrompt(
-                            activeTutorialPrompt!!.shortMessagePrompt,
-                            activeTutorialPrompt.iconId
-                    )
-                }
-        _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(shortQuickStartMessage))))
+        if (task == UPDATE_SITE_TITLE) {
+            val shortQuickStartMessage = HtmlCompat.fromHtml(
+                    resourceProvider.getString(
+                            R.string.quick_start_dialog_update_site_title_message_short,
+                            SiteUtils.getSiteNameOrHomeURL(selectedSiteRepository.getSelectedSite())
+                    ), HtmlCompat.FROM_HTML_MODE_COMPACT
+            )
+            _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(shortQuickStartMessage))))
+        } else {
+            QuickStartMySitePrompts.getPromptDetailsForTask(task)?.let { activeTutorialPrompt ->
+                _onQuickStartMySitePrompts.postValue(Event(activeTutorialPrompt))
+            }
+        }
+
     }
 
     fun completeTask(task: QuickStartTask) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -176,6 +176,7 @@ class PageListFragment : ViewPagerFragment() {
     fun showSnackbar() {
             view?.post {
                 val title = quickStartUtilsWrapper.stylizeQuickStartPrompt(
+                        requireContext(),
                         R.string.quick_start_dialog_edit_homepage_message_pages_short,
                         R.drawable.ic_homepage_16dp
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -142,8 +142,8 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
         if (mQuickStartEvent.getTask() == ENABLE_POST_SHARING) {
             showQuickStartFocusPoint();
 
-            Spannable title = mQuickStartUtilsWrapper
-                    .stylizeQuickStartPrompt(R.string.quick_start_dialog_enable_sharing_message_short_connections);
+            Spannable title = mQuickStartUtilsWrapper.stylizeQuickStartPrompt(requireContext(),
+                    R.string.quick_start_dialog_enable_sharing_message_short_connections);
 
             WPDialogSnackbar.make(getView(), title,
                     getResources().getInteger(R.integer.quick_start_snackbar_duration_ms)).show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -895,6 +895,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         if (mQuickStartEvent.getTask() == QuickStartTask.FOLLOW_SITE
             && isAdded() && getActivity() instanceof WPMainActivity) {
             Spannable title = mQuickStartUtilsWrapper.stylizeQuickStartPrompt(
+                    requireContext(),
                     R.string.quick_start_dialog_follow_sites_message_short_search,
                     R.drawable.ic_search_white_24dp);
 

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -97,7 +97,7 @@ class QuickStartUtils {
             )
             // nothing to highlight
             if (startOfHighlight != -1 && endOfHighlight != -1) {
-                val highlightColor = resourceProvider.getAttr(activityContext, R.attr.colorSurface)
+                val highlightColor = activityContext.getColorFromAttribute(R.attr.colorSurface)
                 mutableSpannedMessage.setSpan(
                         ForegroundColorSpan(highlightColor),
                         startOfHighlight, endOfHighlight, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -15,7 +15,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
-import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.text.HtmlCompat
 import org.wordpress.android.R

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -15,6 +15,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
+import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.text.HtmlCompat
 import org.wordpress.android.R
@@ -69,6 +70,7 @@ class QuickStartUtils {
             resourceProvider: ResourceProvider,
             activityContext: Context,
             messageId: Int,
+            isThemedSnackbar: Boolean = true,
             iconId: Int = ICON_NOT_SET
         ): Spannable {
             val spanTagOpen = resourceProvider.getString(R.string.quick_start_span_start)
@@ -97,7 +99,11 @@ class QuickStartUtils {
             )
             // nothing to highlight
             if (startOfHighlight != -1 && endOfHighlight != -1) {
-                val highlightColor = activityContext.getColorFromAttribute(R.attr.colorSurface)
+                val highlightColor = if (isThemedSnackbar) {
+                    activityContext.getColorFromAttribute(R.attr.colorSurface)
+                } else {
+                    resourceProvider.getColor(android.R.color.white)
+                }
                 mutableSpannedMessage.setSpan(
                         ForegroundColorSpan(highlightColor),
                         startOfHighlight, endOfHighlight, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -67,6 +67,7 @@ class QuickStartUtils {
         @JvmOverloads
         fun stylizeQuickStartPrompt(
             resourceProvider: ResourceProvider,
+            activityContext: Context,
             messageId: Int,
             iconId: Int = ICON_NOT_SET
         ): Spannable {
@@ -96,7 +97,7 @@ class QuickStartUtils {
             )
             // nothing to highlight
             if (startOfHighlight != -1 && endOfHighlight != -1) {
-                val highlightColor = resourceProvider.getColor(android.R.color.white)
+                val highlightColor = resourceProvider.getAttr(activityContext, R.attr.colorSurface)
                 mutableSpannedMessage.setSpan(
                         ForegroundColorSpan(highlightColor),
                         startOfHighlight, endOfHighlight, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt
@@ -15,6 +15,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
+import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.text.HtmlCompat
 import org.wordpress.android.R
@@ -46,7 +47,6 @@ import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.quickstart.QuickStartReminderReceiver
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.themes.ThemeBrowserUtils
-import org.wordpress.android.viewmodel.ResourceProvider
 
 class QuickStartUtils {
     companion object {
@@ -66,15 +66,14 @@ class QuickStartUtils {
         @JvmStatic
         @JvmOverloads
         fun stylizeQuickStartPrompt(
-            resourceProvider: ResourceProvider,
             activityContext: Context,
             messageId: Int,
             isThemedSnackbar: Boolean = true,
             iconId: Int = ICON_NOT_SET
         ): Spannable {
-            val spanTagOpen = resourceProvider.getString(R.string.quick_start_span_start)
-            val spanTagEnd = resourceProvider.getString(R.string.quick_start_span_end)
-            var formattedMessage = resourceProvider.getString(messageId, spanTagOpen, spanTagEnd)
+            val spanTagOpen = activityContext.getString(R.string.quick_start_span_start)
+            val spanTagEnd = activityContext.getString(R.string.quick_start_span_end)
+            var formattedMessage = activityContext.getString(messageId, spanTagOpen, spanTagEnd)
 
             val startOfHighlight = formattedMessage.indexOf(spanTagOpen)
 
@@ -101,7 +100,7 @@ class QuickStartUtils {
                 val highlightColor = if (isThemedSnackbar) {
                     activityContext.getColorFromAttribute(R.attr.colorSurface)
                 } else {
-                    resourceProvider.getColor(android.R.color.white)
+                    ContextCompat.getColor(activityContext, android.R.color.white)
                 }
                 mutableSpannedMessage.setSpan(
                         ForegroundColorSpan(highlightColor),
@@ -110,13 +109,14 @@ class QuickStartUtils {
 
                 val icon: Drawable? = try {
                     // .mutate() allows us to avoid sharing the state of drawables
-                    resourceProvider.getDrawable(iconId)?.mutate()
+                    activityContext.getDrawable(iconId)?.mutate()
                 } catch (e: Resources.NotFoundException) {
                     null
                 }
 
                 if (icon != null) {
-                    val iconSize = resourceProvider.getDimensionPixelOffset(R.dimen.dialog_snackbar_max_icons_size)
+                    val iconSize = activityContext.resources
+                            .getDimensionPixelOffset(R.dimen.dialog_snackbar_max_icons_size)
                     icon.setBounds(0, 0, iconSize, iconSize)
 
                     DrawableCompat.setTint(icon, highlightColor)

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.util
 
+import android.content.Context
 import android.text.Spannable
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.store.QuickStartStore
@@ -18,10 +19,11 @@ class QuickStartUtilsWrapper
 
     @JvmOverloads
     fun stylizeQuickStartPrompt(
+        activityContext: Context,
         messageId: Int,
         iconId: Int = QuickStartUtils.ICON_NOT_SET
     ): Spannable {
-        return QuickStartUtils.stylizeQuickStartPrompt(resourceProvider, messageId, iconId)
+        return QuickStartUtils.stylizeQuickStartPrompt(resourceProvider, activityContext, messageId, iconId)
     }
 
     fun isEveryQuickStartTaskDone(siteId: Int): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
@@ -23,7 +23,28 @@ class QuickStartUtilsWrapper
         messageId: Int,
         iconId: Int = QuickStartUtils.ICON_NOT_SET
     ): Spannable {
-        return QuickStartUtils.stylizeQuickStartPrompt(resourceProvider, activityContext, messageId, iconId)
+        return QuickStartUtils.stylizeQuickStartPrompt(
+                resourceProvider = resourceProvider,
+                activityContext = activityContext,
+                messageId = messageId,
+                isThemedSnackbar = false,
+                iconId = iconId
+        )
+    }
+
+    @JvmOverloads
+    fun stylizeThemedQuickStartPrompt(
+        activityContext: Context,
+        messageId: Int,
+        iconId: Int = QuickStartUtils.ICON_NOT_SET
+    ): Spannable {
+        return QuickStartUtils.stylizeQuickStartPrompt(
+                resourceProvider = resourceProvider,
+                activityContext = activityContext,
+                messageId = messageId,
+                isThemedSnackbar = true,
+                iconId = iconId
+        )
     }
 
     fun isEveryQuickStartTaskDone(siteId: Int): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtilsWrapper.kt
@@ -5,13 +5,11 @@ import android.text.Spannable
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
-import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
 class QuickStartUtilsWrapper
 @Inject constructor(
-    private val quickStartStore: QuickStartStore,
-    private val resourceProvider: ResourceProvider
+    private val quickStartStore: QuickStartStore
 ) {
     fun isQuickStartInProgress(siteId: Int): Boolean {
         return QuickStartUtils.isQuickStartInProgress(quickStartStore, siteId)
@@ -24,7 +22,6 @@ class QuickStartUtilsWrapper
         iconId: Int = QuickStartUtils.ICON_NOT_SET
     ): Spannable {
         return QuickStartUtils.stylizeQuickStartPrompt(
-                resourceProvider = resourceProvider,
                 activityContext = activityContext,
                 messageId = messageId,
                 isThemedSnackbar = false,
@@ -39,7 +36,6 @@ class QuickStartUtilsWrapper
         iconId: Int = QuickStartUtils.ICON_NOT_SET
     ): Spannable {
         return QuickStartUtils.stylizeQuickStartPrompt(
-                resourceProvider = resourceProvider,
                 activityContext = activityContext,
                 messageId = messageId,
                 isThemedSnackbar = true,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
@@ -1,6 +1,9 @@
 package org.wordpress.android.viewmodel
 
+import android.content.Context
 import android.graphics.drawable.Drawable
+import android.util.TypedValue
+import androidx.annotation.AttrRes
 import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
 import androidx.annotation.StringRes
@@ -20,6 +23,14 @@ class ResourceProvider @Inject constructor(private val contextProvider: ContextP
 
     fun getColor(@ColorRes resourceId: Int): Int {
         return ContextCompat.getColor(contextProvider.getContext(), resourceId)
+    }
+
+    fun getAttr(activityContext: Context, @AttrRes colorAttr: Int): Int {
+        return ContextCompat.getColor(activityContext,
+                TypedValue().let {
+                    activityContext.theme.resolveAttribute(colorAttr, it, true)
+                    it.resourceId
+                })
     }
 
     fun getDimensionPixelSize(@DimenRes dimen: Int): Int {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
@@ -25,14 +25,6 @@ class ResourceProvider @Inject constructor(private val contextProvider: ContextP
         return ContextCompat.getColor(contextProvider.getContext(), resourceId)
     }
 
-    fun getAttr(activityContext: Context, @AttrRes colorAttr: Int): Int {
-        return ContextCompat.getColor(activityContext,
-                TypedValue().let {
-                    activityContext.theme.resolveAttribute(colorAttr, it, true)
-                    it.resourceId
-                })
-    }
-
     fun getDimensionPixelSize(@DimenRes dimen: Int): Int {
         val resources = contextProvider.getContext().resources
         return resources.getDimensionPixelSize(dimen)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/ResourceProvider.kt
@@ -1,9 +1,6 @@
 package org.wordpress.android.viewmodel
 
-import android.content.Context
 import android.graphics.drawable.Drawable
-import android.util.TypedValue
-import androidx.annotation.AttrRes
 import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
 import androidx.annotation.StringRes

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -1,8 +1,5 @@
 package org.wordpress.android.ui.mysite
 
-import android.text.SpannableString
-import com.nhaarman.mockitokotlin2.eq
-import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
@@ -37,7 +34,6 @@ import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails.CREATE_SITE_TUTORIAL
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails.PUBLISH_POST_TUTORIAL
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails.SHARE_SITE_TUTORIAL
-import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper


### PR DESCRIPTION
Fixes #14015 

We were previously using fixed white color to stylize the QS snackbars. This PR replaces the color with attr colorSurface which works well both in light and dark modes. In order to obtain it we need to pass the activity context into the the utils so I've moved the logic around a bit. 

To test:
- Make sure the my site improvements flag is turned on and the app is restarted
- Make sure you're on a site with QuickStart in progress
- Turn on the light mode
- Click on a few of the QS tasks
- Notice the snackbar message is consistently in white (light gray) color and the background is dark
- Turn on the dark mode
- Click on a few of the QS tasks
- Notice the snackbar message is consistently in black (dark gray) color and the background is light


<img width="640" alt="Screenshot 2021-02-10 at 13 24 18" src="https://user-images.githubusercontent.com/1079756/107510507-546a6700-6ba4-11eb-8b3b-5bc074f8a0b8.png">
<img width="481" alt="Screenshot 2021-02-10 at 13 21 42" src="https://user-images.githubusercontent.com/1079756/107510509-559b9400-6ba4-11eb-8698-f97766d3c8ea.png">


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
