### PR TITLE
Issue/13326 tweak scan state builder tests

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -86,7 +86,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* FIXING THREATS STATE */
 
     @Test
-    fun `given fixing threats state, when items are built, items contain shield warning icon with error color`() =
+    fun `given fixing threats state, when items are built, then shield warning icon with error color exists`() =
         test {
             val scanStateItems = buildScanStateItems(
                 model = scanStateModelWithThreats,
@@ -105,7 +105,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given fixing threats state, when items are built, items contain fixing threats header`() = test {
+    fun `given fixing threats state, when items are built, then fixing threats header exists`() = test {
         val scanStateItems = buildScanStateItems(
             model = scanStateModelWithThreats,
             fixingThreatIds = listOf(threat.baseThreatModel.id)
@@ -117,7 +117,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given fixing threats state, when items are built, items contain fixing threats description`() = test {
+    fun `given fixing threats state, when items are built, then fixing threats description exists`() = test {
         val scanStateItems = buildScanStateItems(
             model = scanStateModelWithThreats,
             fixingThreatIds = listOf(threat.baseThreatModel.id)
@@ -129,7 +129,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given fixing threats state, when items are built, items contain indeterminate progress bar`() = test {
+    fun `given fixing threats state, when items are built, then indeterminate progress bar exists`() = test {
         val scanStateItems = buildScanStateItems(
             model = scanStateModelWithThreats,
             fixingThreatIds = listOf(threat.baseThreatModel.id)
@@ -141,7 +141,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given fixing threats state, when items are built, items contain fixing threats`() = test {
+    fun `given fixing threats state, when items are built, then fixing threats exist`() = test {
         val threatModel = ThreatTestData.fixableThreatInCurrentStatus
         val threatItemState = createDummyThreatItemState(threatModel)
         whenever(threatItemBuilder.buildThreatItem(threatModel)).thenReturn(threatItemState)
@@ -157,7 +157,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given fixing threats state, when items are built, items contain threats with fixable description subheader`() =
+    fun `given fixing threats state, when items are built, then threats with fixable description subheader exist`() =
         test {
             val threatModel = ThreatTestData.fixableThreatInCurrentStatus
             val threatItemState = createDummyThreatItemState(threatModel)
@@ -178,7 +178,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* IDLE - THREATS FOUND STATE */
 
     @Test
-    fun `given idle state with threats, when items are built, items contain shield warning icon with error color`() =
+    fun `given idle state with threats, when items are built, then shield warning icon with error color exists`() =
         test {
             val scanStateItems = buildScanStateItems(scanStateModelWithThreats)
 
@@ -194,7 +194,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given idle state with threats, when items are built, items contain header for threats found`() = test {
+    fun `given idle state with threats, when items are built, then header for threats found exists`() = test {
         val scanStateItems = buildScanStateItems(model = scanStateModelWithThreats)
 
         assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
@@ -203,7 +203,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given idle state with threats, when items are built, items contain threats found description`() = test {
+    fun `given idle state with threats, when items are built, then threats found description exists`() = test {
         buildScanStateItems(scanStateModelWithThreats)
 
         verify(htmlMessageUtils).getHtmlMessageFromStringFormatResId(
@@ -215,7 +215,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given idle state with threats, when items are built, items contain scan again button`() = test {
+    fun `given idle state with threats, when items are built, then scan again button exists`() = test {
         val scanStateItems = buildScanStateItems(scanStateModelWithThreats)
 
         assertThat(scanStateItems.filterIsInstance(ActionButtonState::class.java).map { it.text }).contains(
@@ -224,7 +224,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given idle state with fixable threats, when items are built, items contain fix all threats button`() = test {
+    fun `given idle state with fixable threats, when items are built, then fix all threats button exists`() = test {
         val threats = listOf(threat.copy(baseThreatModel = baseThreatModel.copy(fixable = mock())))
         val scanStateModelWithFixableThreats = scanStateModelWithThreats.copy(threats = threats)
 
@@ -236,7 +236,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given idle state with no fixable threats, when items are built, items does not contain fix all threats btn`() =
+    fun `given idle state with no fixable threats, when items are built, then fix all threats btn does not exists`() =
         test {
             val threats = listOf(threat.copy(baseThreatModel = baseThreatModel.copy(fixable = null)))
             val scanStateModelWithNoFixableThreats = scanStateModelWithThreats.copy(threats = threats)
@@ -248,7 +248,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given idle state with threats, when items are built, items contain clickable help text info in description`() =
+    fun `given idle state with threats, when items are built, then description with clickable help info exists`() =
         test {
             val clickableText = "clickable help text"
             val descriptionWithClickableText = "description with $clickableText"
@@ -271,7 +271,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* IDLE - THREATS NOT FOUND STATE */
 
     @Test
-    fun `given idle no threats state, when items are built, items contain shield tick icon with green color`() =
+    fun `given idle no threats state, when items are built, then shield tick icon with green color exists`() =
         test {
             val scanStateItems = buildScanStateItems(scanStateModelWithNoThreats)
 
@@ -287,7 +287,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given idle no threats state, when items are built, items contain header for no threats found`() = test {
+    fun `given idle no threats state, when items are built, then header for no threats found exists`() = test {
         val scanStateItems = buildScanStateItems(model = scanStateModelWithNoThreats)
 
         assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
@@ -296,7 +296,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given idle no threats state, when items are built, items contain scan now button `() = test {
+    fun `given idle no threats state, when items are built, then scan now button exists`() = test {
         val scanStateItems = buildScanStateItems(scanStateModelWithNoThreats)
 
         assertThat(scanStateItems.filterIsInstance(ActionButtonState::class.java).map { it.text }).contains(
@@ -305,7 +305,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given idle no threats state with last scan secs ago, when items are built, items contain few secs in descr`() =
+    fun `given idle no threats state with last scan secs ago, when items are built, then few secs exists in desc`() =
         test {
             whenever(dateProvider.getCurrentDate()).thenReturn(Date(DUMMY_CURRENT_TIME))
             val scanStateModelWithMostRecentStartDate = scanStateModelWithNoThreats.copy(
@@ -325,7 +325,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given idle no threats state with last scan hrs ago, when items are built, items contain hrs ago in descr`() =
+    fun `given idle no threats state with last scan hrs ago, when items are built, then hrs ago exists in descr`() =
         test {
             val scanStateModelWithMostRecentStartDate = scanStateModelWithNoThreats.copy(
                 mostRecentStatus = ScanProgressStatus(startDate = Date(DUMMY_CURRENT_TIME - ONE_HOUR))
@@ -345,7 +345,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given idle no threats state with last scan mins ago, when items are built, items contain mins ago in descr`() =
+    fun `given idle no threats state with last scan mins ago, when items are built, then mins ago exists in descr`() =
         test {
             val scanStateModelWithMostRecentStartDate = scanStateModelWithNoThreats.copy(
                 mostRecentStatus = ScanProgressStatus(startDate = Date(DUMMY_CURRENT_TIME - ONE_MINUTE))
@@ -370,7 +370,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* SCANNING STATE */
 
     @Test
-    fun `given scanning state, when items are built, items contain shield icon with light green color`() =
+    fun `given scanning state, when items are built, then shield icon with light green color exists`() =
         test {
             val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(state = State.SCANNING)
 
@@ -388,7 +388,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given scanning state with zero progress, when items are built, items contain preparing for scan header`() =
+    fun `given scanning state with zero progress, when items are built, then preparing for scan header exists`() =
         test {
             val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(
                 state = State.SCANNING,
@@ -403,7 +403,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given scanning state with non zero progress, when items are built, items contain scanning files header`() =
+    fun `given scanning state with non zero progress, when items are built, then scanning files header exists`() =
         test {
             val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(
                 state = State.SCANNING,
@@ -418,7 +418,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given initial scanning state, when items are built, items contain initial scanning descr`() =
+    fun `given initial scanning state, when items are built, then initial scanning description exists`() =
         test {
             val scanStateModelInScanningInitialState = scanStateModelWithNoThreats.copy(
                 state = State.SCANNING,
@@ -433,7 +433,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given non initial scanning state, when items are built, items contain scanning description`() = test {
+    fun `given non initial scanning state, when items are built, then scanning description exists`() = test {
         val scanStateModelInScanningNonInitialState = scanStateModelWithNoThreats.copy(
             state = State.SCANNING,
             mostRecentStatus = ScanProgressStatus(isInitial = false, startDate = Date(0))
@@ -447,7 +447,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given scanning state, when items are built, items contain progress bar with progress values`() = test {
+    fun `given scanning state, when items are built, then progress bar with progress values exists`() = test {
         val progress = 10
         val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(
             state = State.SCANNING,
@@ -470,7 +470,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* PROVISIONING STATE */
 
     @Test
-    fun `given provisioning state, when items are built, items contain shield icon with light green color`() = test {
+    fun `given provisioning state, when items are built, then shield icon with light green color exists`() = test {
         val scanStateModelInProvisioningState = scanStateModelWithNoThreats.copy(state = State.PROVISIONING)
 
         val scanStateItems = buildScanStateItems(scanStateModelInProvisioningState)
@@ -487,7 +487,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given provisioning state, when items are built, items contain preparing to scan header`() = test {
+    fun `given provisioning state, when items are built, then preparing to scan header exists`() = test {
         val scanStateModelInProvisioningState = scanStateModelWithNoThreats.copy(state = State.PROVISIONING)
 
         val scanStateItems = buildScanStateItems(scanStateModelInProvisioningState)
@@ -498,7 +498,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given provisioning state, when items are built, items contain provisioning description`() = test {
+    fun `given provisioning state, when items are built, then provisioning description exists`() = test {
         val scanStateModelInProvisioningState = scanStateModelWithNoThreats.copy(state = State.PROVISIONING)
 
         val scanStateItems = buildScanStateItems(scanStateModelInProvisioningState)
@@ -511,7 +511,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* INVALID STATES */
 
     @Test
-    fun `given unknown state, when items are built, items list is empty`() = test {
+    fun `given unknown state, when items are built, then items list is empty`() = test {
         val scanStateModelInUnknownState = scanStateModelWithNoThreats.copy(state = State.UNKNOWN)
 
         val scanStateItems = buildScanStateItems(scanStateModelInUnknownState)
@@ -520,7 +520,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given unavailable state, when items are built, items list is empty`() = test {
+    fun `given unavailable state, when items are built, then items list is empty`() = test {
         val scanStateModelInUnAvailableState = scanStateModelWithNoThreats.copy(state = State.UNAVAILABLE)
 
         val scanStateItems = buildScanStateItems(scanStateModelInUnAvailableState)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -341,7 +341,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
                 UiStringResWithParams(
                     R.string.scan_idle_last_scan_description,
                     listOf(
-                        UiStringResWithParams(R.string.scan_in_hours_ago, listOf(UiStringText("${1}"))),
+                        UiStringResWithParams(R.string.scan_in_hours_ago, listOf(UiStringText("1"))),
                         UiStringRes(R.string.scan_idle_manual_scan_description)
                     )
                 )
@@ -363,7 +363,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
                     listOf(
                         UiStringResWithParams(
                             R.string.scan_in_minutes_ago,
-                            listOf(UiStringText("${1}"))
+                            listOf(UiStringText("1"))
                         ),
                         UiStringRes(R.string.scan_idle_manual_scan_description)
                     )

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -326,12 +326,12 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
 
     @Test
     fun `builds scanning description for scanning scan state model with past recent scan`() = test {
-        val scanStateModelInScanningInitialState = scanStateModelWithNoThreats.copy(
+        val scanStateModelInScanningNonInitialState = scanStateModelWithNoThreats.copy(
             state = State.SCANNING,
             mostRecentStatus = ScanProgressStatus(isInitial = false, startDate = Date(0))
         )
 
-        val scanStateItems = buildScanStateItems(scanStateModelInScanningInitialState)
+        val scanStateItems = buildScanStateItems(scanStateModelInScanningNonInitialState)
 
         assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
             DescriptionState(UiStringRes(R.string.scan_scanning_description))

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -179,6 +179,36 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         assertThat(descriptionState.clickableTextsInfo?.first()).isEqualTo(ClickableTextInfo(17, 31, onHelpClickedMock))
     }
 
+    /* SCANNING STATE */
+
+    @Test
+    fun `builds initial scanning description for scanning scan state model with no initial recent scan`() = test {
+        val scanStateModelInScanningInitialState = scanStateModelWithNoThreats.copy(
+            state = State.SCANNING,
+            mostRecentStatus = ScanProgressStatus(isInitial = true, startDate = Date(0))
+        )
+
+        val scanStateItems = buildScanStateItems(scanStateModelInScanningInitialState)
+
+        assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
+            DescriptionState(UiStringRes(R.string.scan_scanning_is_initial_description))
+        )
+    }
+
+    @Test
+    fun `builds scanning description for scanning scan state model with past recent scan`() = test {
+        val scanStateModelInScanningInitialState = scanStateModelWithNoThreats.copy(
+            state = State.SCANNING,
+            mostRecentStatus = ScanProgressStatus(isInitial = false, startDate = Date(0))
+        )
+
+        val scanStateItems = buildScanStateItems(scanStateModelInScanningInitialState)
+
+        assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
+            DescriptionState(UiStringRes(R.string.scan_scanning_description))
+        )
+    }
+
     /* PROVISIONING STATE */
 
     @Test
@@ -238,36 +268,6 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         val scanStateItems = buildScanStateItems(scanStateModelInUnAvailableState)
 
         assertThat(scanStateItems).isEmpty()
-    }
-
-    /* SCANNING STATE */
-
-    @Test
-    fun `builds initial scanning description for scanning scan state model with no initial recent scan`() = test {
-        val scanStateModelInScanningInitialState = scanStateModelWithNoThreats.copy(
-            state = State.SCANNING,
-            mostRecentStatus = ScanProgressStatus(isInitial = true, startDate = Date(0))
-        )
-
-        val scanStateItems = buildScanStateItems(scanStateModelInScanningInitialState)
-
-        assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
-            DescriptionState(UiStringRes(R.string.scan_scanning_is_initial_description))
-        )
-    }
-
-    @Test
-    fun `builds scanning description for scanning scan state model with past recent scan`() = test {
-        val scanStateModelInScanningInitialState = scanStateModelWithNoThreats.copy(
-            state = State.SCANNING,
-            mostRecentStatus = ScanProgressStatus(isInitial = false, startDate = Date(0))
-        )
-
-        val scanStateItems = buildScanStateItems(scanStateModelInScanningInitialState)
-
-        assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
-            DescriptionState(UiStringRes(R.string.scan_scanning_description))
-        )
     }
 
     private suspend fun buildScanStateItems(

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -178,6 +178,22 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* IDLE - THREATS FOUND STATE */
 
     @Test
+    fun `given idle state with threats, when items are built, items contain shield warning icon with error color`() =
+        test {
+            val scanStateItems = buildScanStateItems(scanStateModelWithThreats)
+
+            assertThat(scanStateItems.filterIsInstance(IconState::class.java).first()).isEqualTo(
+                IconState(
+                    icon = R.drawable.ic_shield_warning_white,
+                    colorResId = R.color.error,
+                    sizeResId = R.dimen.scan_icon_size,
+                    marginResId = R.dimen.scan_icon_margin,
+                    contentDescription = UiStringRes(R.string.scan_state_icon)
+                )
+            )
+        }
+
+    @Test
     fun `given idle state with threats, when items are built, items contain threats found description`() = test {
         buildScanStateItems(scanStateModelWithThreats)
 
@@ -248,6 +264,22 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     /* IDLE - THREATS NOT FOUND STATE */
+
+    @Test
+    fun `given idle no threats state, when items are built, items contain shield tick icon with green color`() =
+        test {
+            val scanStateItems = buildScanStateItems(scanStateModelWithNoThreats)
+
+            assertThat(scanStateItems.filterIsInstance(IconState::class.java).first()).isEqualTo(
+                IconState(
+                    icon = R.drawable.ic_shield_tick_white,
+                    colorResId = R.color.jetpack_green_40,
+                    sizeResId = R.dimen.scan_icon_size,
+                    marginResId = R.dimen.scan_icon_margin,
+                    contentDescription = UiStringRes(R.string.scan_state_icon)
+                )
+            )
+        }
 
     @Test
     fun `given idle no threats state, when items are built, items contain scan again button `() = test {
@@ -322,6 +354,24 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     /* SCANNING STATE */
+
+    @Test
+    fun `given scanning state, when items are built, items contain shield icon with light green color`() =
+        test {
+            val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(state = State.SCANNING)
+
+            val scanStateItems = buildScanStateItems(scanStateModelInScanningState)
+
+            assertThat(scanStateItems.filterIsInstance(IconState::class.java).first()).isEqualTo(
+                IconState(
+                    icon = R.drawable.ic_shield_white,
+                    colorResId = R.color.jetpack_green_5,
+                    sizeResId = R.dimen.scan_icon_size,
+                    marginResId = R.dimen.scan_icon_margin,
+                    contentDescription = UiStringRes(R.string.scan_state_icon)
+                )
+            )
+        }
 
     @Test
     fun `given scanning state with zero progress, when items are built, items contain preparing for scan header`() =
@@ -406,7 +456,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* PROVISIONING STATE */
 
     @Test
-    fun `given provisioning state, when items are built, items contain shield icon with green color`() = test {
+    fun `given provisioning state, when items are built, items contain shield icon with light green color`() = test {
         val scanStateModelInProvisioningState = scanStateModelWithNoThreats.copy(state = State.PROVISIONING)
 
         val scanStateItems = buildScanStateItems(scanStateModelInProvisioningState)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -311,6 +311,34 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* SCANNING STATE */
 
     @Test
+    fun `builds preparing for scan header for scanning scan state model with zero progress`() = test {
+        val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(
+            state = State.SCANNING,
+            currentStatus = ScanProgressStatus(progress = 0, startDate = Date(0))
+        )
+
+        val scanStateItems = buildScanStateItems(scanStateModelInScanningState)
+
+        assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
+            HeaderState(UiStringRes(R.string.scan_preparing_to_scan_title))
+        )
+    }
+
+    @Test
+    fun `builds preparing for scan header for scanning scan state model with non zero progress`() = test {
+        val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(
+            state = State.SCANNING,
+            currentStatus = ScanProgressStatus(progress = 10, startDate = Date(0))
+        )
+
+        val scanStateItems = buildScanStateItems(scanStateModelInScanningState)
+
+        assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
+            HeaderState(UiStringRes(R.string.scan_scanning_title))
+        )
+    }
+
+    @Test
     fun `builds initial scanning description for scanning scan state model with no initial recent scan`() = test {
         val scanStateModelInScanningInitialState = scanStateModelWithNoThreats.copy(
             state = State.SCANNING,
@@ -335,6 +363,27 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
 
         assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
             DescriptionState(UiStringRes(R.string.scan_scanning_description))
+        )
+    }
+
+    @Test
+    fun `builds progress bar with progress values for scanning scan state model`() = test {
+        val progress = 10
+        val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(
+            state = State.SCANNING,
+            currentStatus = ScanProgressStatus(progress = progress, startDate = Date(0))
+        )
+
+        val scanStateItems = buildScanStateItems(scanStateModelInScanningState)
+
+        assertThat(scanStateItems.filterIsInstance(ProgressState::class.java).first()).isEqualTo(
+            ProgressState(
+                progress = progress,
+                progressLabel = UiStringResWithParams(
+                    R.string.scan_progress_label,
+                    listOf(UiStringText(progress.toString()))
+                )
+            )
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -86,25 +86,26 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* FIXING THREATS STATE */
 
     @Test
-    fun `builds shield warning icon with error color for fixing threats state`() = test {
-        val scanStateItems = buildScanStateItems(
-            model = scanStateModelWithThreats,
-            fixingThreatIds = listOf(threat.baseThreatModel.id)
-        )
-
-        assertThat(scanStateItems.filterIsInstance(IconState::class.java).first()).isEqualTo(
-            IconState(
-                icon = R.drawable.ic_shield_warning_white,
-                colorResId = R.color.error,
-                sizeResId = R.dimen.scan_icon_size,
-                marginResId = R.dimen.scan_icon_margin,
-                contentDescription = UiStringRes(R.string.scan_state_icon)
+    fun `given fixing threats state, when items are built, items contain shield warning icon with error color`() =
+        test {
+            val scanStateItems = buildScanStateItems(
+                model = scanStateModelWithThreats,
+                fixingThreatIds = listOf(threat.baseThreatModel.id)
             )
-        )
-    }
+
+            assertThat(scanStateItems.filterIsInstance(IconState::class.java).first()).isEqualTo(
+                IconState(
+                    icon = R.drawable.ic_shield_warning_white,
+                    colorResId = R.color.error,
+                    sizeResId = R.dimen.scan_icon_size,
+                    marginResId = R.dimen.scan_icon_margin,
+                    contentDescription = UiStringRes(R.string.scan_state_icon)
+                )
+            )
+        }
 
     @Test
-    fun `builds header for fixing threats state`() = test {
+    fun `given fixing threats state, when items are built, items contain fixing threats header`() = test {
         val scanStateItems = buildScanStateItems(
             model = scanStateModelWithThreats,
             fixingThreatIds = listOf(threat.baseThreatModel.id)
@@ -116,7 +117,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds fixing threats description for fixing threats state`() = test {
+    fun `given fixing threats state, when items are built, items contain fixing threats description`() = test {
         val scanStateItems = buildScanStateItems(
             model = scanStateModelWithThreats,
             fixingThreatIds = listOf(threat.baseThreatModel.id)
@@ -128,7 +129,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds progress bar for fixing threats state`() = test {
+    fun `given fixing threats state, when items are built, items contain indeterminate progress bar`() = test {
         val scanStateItems = buildScanStateItems(
             model = scanStateModelWithThreats,
             fixingThreatIds = listOf(threat.baseThreatModel.id)
@@ -140,7 +141,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds threat items for fixing threats state`() = test {
+    fun `given fixing threats state, when items are built, items contain fixing threats`() = test {
         val threatModel = ThreatTestData.fixableThreatInCurrentStatus
         val threatItemState = createDummyThreatItemState(threatModel)
         whenever(threatItemBuilder.buildThreatItem(threatModel)).thenReturn(threatItemState)
@@ -156,27 +157,28 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds fixable description as sub header for fixing threats state threat item`() = test {
-        val threatModel = ThreatTestData.fixableThreatInCurrentStatus
-        val threatItemState = createDummyThreatItemState(threatModel)
-        val subHeader = DescriptionState(UiStringText("sub header"))
-        whenever(threatItemBuilder.buildThreatItem(threatModel)).thenReturn(threatItemState)
-        whenever(threatDetailsListItemsBuilder.buildFixableThreatDescription(any())).thenReturn(subHeader)
-        whenever(scanStore.getThreatModelByThreatId(any())).thenReturn(threatModel)
+    fun `given fixing threats state, when items are built, items contain threats with fixable description subheader`() =
+        test {
+            val threatModel = ThreatTestData.fixableThreatInCurrentStatus
+            val threatItemState = createDummyThreatItemState(threatModel)
+            val subHeader = DescriptionState(UiStringText("sub header"))
+            whenever(threatItemBuilder.buildThreatItem(threatModel)).thenReturn(threatItemState)
+            whenever(threatDetailsListItemsBuilder.buildFixableThreatDescription(any())).thenReturn(subHeader)
+            whenever(scanStore.getThreatModelByThreatId(any())).thenReturn(threatModel)
 
-        val scanStateItems = buildScanStateItems(
-            model = scanStateModelWithThreats,
-            fixingThreatIds = listOf(threatModel.baseThreatModel.id)
-        )
+            val scanStateItems = buildScanStateItems(
+                model = scanStateModelWithThreats,
+                fixingThreatIds = listOf(threatModel.baseThreatModel.id)
+            )
 
-        assertThat(scanStateItems.filterIsInstance(ThreatItemState::class.java).first().subHeader)
-            .isEqualTo(subHeader.text)
-    }
+            assertThat(scanStateItems.filterIsInstance(ThreatItemState::class.java).first().subHeader)
+                .isEqualTo(subHeader.text)
+        }
 
     /* IDLE - THREATS FOUND STATE */
 
     @Test
-    fun `builds threats found description for idle state model contains threats`() = test {
+    fun `given idle state with threats, when items are built, items contain threats found description`() = test {
         buildScanStateItems(scanStateModelWithThreats)
 
         verify(htmlMessageUtils).getHtmlMessageFromStringFormatResId(
@@ -188,7 +190,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds scan now button for idle state model with threats`() = test {
+    fun `given idle state with threats, when items are built, items contain scan now button`() = test {
         val scanStateItems = buildScanStateItems(scanStateModelWithThreats)
 
         assertThat(scanStateItems.filterIsInstance(ActionButtonState::class.java).map { it.text }).contains(
@@ -197,7 +199,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds fix threats button for idle state model with fixable threats`() = test {
+    fun `given idle state with fixable threats, when items are built, items contain fix all threats button`() = test {
         val threats = listOf(threat.copy(baseThreatModel = baseThreatModel.copy(fixable = mock())))
         val scanStateModelWithFixableThreats = scanStateModelWithThreats.copy(threats = threats)
 
@@ -209,35 +211,46 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds fix threats button for idle state model with no fixable threats`() = test {
-        val threats = listOf(threat.copy(baseThreatModel = baseThreatModel.copy(fixable = null)))
-        val scanStateModelWithNoFixableThreats = scanStateModelWithThreats.copy(threats = threats)
+    fun `given idle state with not fixable threats, when items are built, items contain fix all threats button`() =
+        test {
+            val threats = listOf(threat.copy(baseThreatModel = baseThreatModel.copy(fixable = null)))
+            val scanStateModelWithNoFixableThreats = scanStateModelWithThreats.copy(threats = threats)
 
-        val scanStateItems = buildScanStateItems(scanStateModelWithNoFixableThreats)
+            val scanStateItems = buildScanStateItems(scanStateModelWithNoFixableThreats)
 
-        assertThat(scanStateItems.filterIsInstance(ActionButtonState::class.java).map { it.text }).doesNotContain(
-            UiStringRes(R.string.threats_fix_all)
-        )
-    }
+            assertThat(
+                scanStateItems.filterIsInstance(ActionButtonState::class.java)
+                    .map { it.text }
+            ).doesNotContain(
+                UiStringRes(R.string.threats_fix_all)
+            )
+        }
 
     @Test
-    fun `builds clickable text info in description for scan state model with threats`() = test {
-        val clickableText = "clickable text"
-        val descriptionWithClickableText = "description with $clickableText"
-        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), any()))
-            .thenReturn(descriptionWithClickableText)
-        whenever(resourceProvider.getString(R.string.scan_here_to_help)).thenReturn(clickableText)
+    fun `given idle state with threats, when items are built, items contain clickable help text info in description`() =
+        test {
+            val clickableText = "clickable help text"
+            val descriptionWithClickableText = "description with $clickableText"
+            whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), any()))
+                .thenReturn(descriptionWithClickableText)
+            whenever(resourceProvider.getString(R.string.scan_here_to_help)).thenReturn(clickableText)
 
-        val scanStateItems = buildScanStateItems(scanStateModelWithThreats)
+            val scanStateItems = buildScanStateItems(scanStateModelWithThreats)
 
-        val descriptionState = scanStateItems.filterIsInstance(DescriptionState::class.java).first()
-        assertThat(descriptionState.clickableTextsInfo?.first()).isEqualTo(ClickableTextInfo(17, 31, onHelpClickedMock))
-    }
+            val descriptionState = scanStateItems.filterIsInstance(DescriptionState::class.java).first()
+            assertThat(descriptionState.clickableTextsInfo?.first()).isEqualTo(
+                ClickableTextInfo(
+                    17,
+                    36,
+                    onHelpClickedMock
+                )
+            )
+        }
 
     /* IDLE - THREATS NOT FOUND STATE */
 
     @Test
-    fun `builds scan again button for idle state model with no threats`() = test {
+    fun `given idle no threats state, when items are built, items contain scan again button `() = test {
         val scanStateItems = buildScanStateItems(scanStateModelWithNoThreats)
 
         assertThat(scanStateItems.filterIsInstance(ActionButtonState::class.java).map { it.text }).contains(
@@ -246,7 +259,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds seconds ago description for idle state model with most recent start date secs ago from current date`() =
+    fun `given idle no threats state with last scan secs ago, when items are built, items contain few secs in descr`() =
         test {
             whenever(dateProvider.getCurrentDate()).thenReturn(Date(DUMMY_CURRENT_TIME))
             val scanStateModelWithMostRecentStartDate = scanStateModelWithNoThreats.copy(
@@ -266,7 +279,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `builds hours ago description for idle state model with most recent start date hours ago from current date`() =
+    fun `given idle no threats state with last scan hrs ago, when items are built, items contain hrs ago in descr`() =
         test {
             val scanStateModelWithMostRecentStartDate = scanStateModelWithNoThreats.copy(
                 mostRecentStatus = ScanProgressStatus(startDate = Date(DUMMY_CURRENT_TIME - ONE_HOUR))
@@ -286,7 +299,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
-    fun `builds mins ago description for idle state model with most recent start date mins ago from current date`() =
+    fun `given idle no threats state with last scan mins ago, when items are built, items contain mins ago in descr`() =
         test {
             val scanStateModelWithMostRecentStartDate = scanStateModelWithNoThreats.copy(
                 mostRecentStatus = ScanProgressStatus(startDate = Date(DUMMY_CURRENT_TIME - ONE_MINUTE))
@@ -311,49 +324,52 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* SCANNING STATE */
 
     @Test
-    fun `builds preparing for scan header for scanning scan state model with zero progress`() = test {
-        val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(
-            state = State.SCANNING,
-            currentStatus = ScanProgressStatus(progress = 0, startDate = Date(0))
-        )
+    fun `given scanning state with zero progress, when items are built, items contain preparing for scan header`() =
+        test {
+            val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(
+                state = State.SCANNING,
+                currentStatus = ScanProgressStatus(progress = 0, startDate = Date(0))
+            )
 
-        val scanStateItems = buildScanStateItems(scanStateModelInScanningState)
+            val scanStateItems = buildScanStateItems(scanStateModelInScanningState)
 
-        assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
-            HeaderState(UiStringRes(R.string.scan_preparing_to_scan_title))
-        )
-    }
-
-    @Test
-    fun `builds preparing for scan header for scanning scan state model with non zero progress`() = test {
-        val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(
-            state = State.SCANNING,
-            currentStatus = ScanProgressStatus(progress = 10, startDate = Date(0))
-        )
-
-        val scanStateItems = buildScanStateItems(scanStateModelInScanningState)
-
-        assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
-            HeaderState(UiStringRes(R.string.scan_scanning_title))
-        )
-    }
+            assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
+                HeaderState(UiStringRes(R.string.scan_preparing_to_scan_title))
+            )
+        }
 
     @Test
-    fun `builds initial scanning description for scanning scan state model with no initial recent scan`() = test {
-        val scanStateModelInScanningInitialState = scanStateModelWithNoThreats.copy(
-            state = State.SCANNING,
-            mostRecentStatus = ScanProgressStatus(isInitial = true, startDate = Date(0))
-        )
+    fun `given scanning state with non zero progress, when items are built, items contain scanning files header`() =
+        test {
+            val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(
+                state = State.SCANNING,
+                currentStatus = ScanProgressStatus(progress = 10, startDate = Date(0))
+            )
 
-        val scanStateItems = buildScanStateItems(scanStateModelInScanningInitialState)
+            val scanStateItems = buildScanStateItems(scanStateModelInScanningState)
 
-        assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
-            DescriptionState(UiStringRes(R.string.scan_scanning_is_initial_description))
-        )
-    }
+            assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
+                HeaderState(UiStringRes(R.string.scan_scanning_title))
+            )
+        }
 
     @Test
-    fun `builds scanning description for scanning scan state model with past recent scan`() = test {
+    fun `given initial scanning state, when items are built, items contain initial scanning descr`() =
+        test {
+            val scanStateModelInScanningInitialState = scanStateModelWithNoThreats.copy(
+                state = State.SCANNING,
+                mostRecentStatus = ScanProgressStatus(isInitial = true, startDate = Date(0))
+            )
+
+            val scanStateItems = buildScanStateItems(scanStateModelInScanningInitialState)
+
+            assertThat(scanStateItems.filterIsInstance(DescriptionState::class.java).first()).isEqualTo(
+                DescriptionState(UiStringRes(R.string.scan_scanning_is_initial_description))
+            )
+        }
+
+    @Test
+    fun `given non initial scanning state, when items are built, items contain scanning description`() = test {
         val scanStateModelInScanningNonInitialState = scanStateModelWithNoThreats.copy(
             state = State.SCANNING,
             mostRecentStatus = ScanProgressStatus(isInitial = false, startDate = Date(0))
@@ -367,7 +383,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds progress bar with progress values for scanning scan state model`() = test {
+    fun `given scanning state, when items are built, items contain progress bar with progress values`() = test {
         val progress = 10
         val scanStateModelInScanningState = scanStateModelWithNoThreats.copy(
             state = State.SCANNING,
@@ -390,7 +406,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* PROVISIONING STATE */
 
     @Test
-    fun `builds shield icon with green color for provisioning scan state model`() = test {
+    fun `given provisioning state, when items are built, items contain shield icon with green color`() = test {
         val scanStateModelInProvisioningState = scanStateModelWithNoThreats.copy(state = State.PROVISIONING)
 
         val scanStateItems = buildScanStateItems(scanStateModelInProvisioningState)
@@ -407,7 +423,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds preparing to scan header for provisioning scan state model`() = test {
+    fun `given provisioning state, when items are built, items contain preparing to scan header`() = test {
         val scanStateModelInProvisioningState = scanStateModelWithNoThreats.copy(state = State.PROVISIONING)
 
         val scanStateItems = buildScanStateItems(scanStateModelInProvisioningState)
@@ -418,7 +434,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds provisioning description for provisioning scan state model`() = test {
+    fun `given provisioning state, when items are built, items contain provisioning description`() = test {
         val scanStateModelInProvisioningState = scanStateModelWithNoThreats.copy(state = State.PROVISIONING)
 
         val scanStateItems = buildScanStateItems(scanStateModelInProvisioningState)
@@ -431,7 +447,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     /* INVALID STATES */
 
     @Test
-    fun `builds empty list for unknown scan state model`() = test {
+    fun `given unknown state, when items are built, items list is empty`() = test {
         val scanStateModelInUnknownState = scanStateModelWithNoThreats.copy(state = State.UNKNOWN)
 
         val scanStateItems = buildScanStateItems(scanStateModelInUnknownState)
@@ -440,7 +456,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `builds empty list for unavailable scan state model`() = test {
+    fun `given unavailable state, when items are built, items list is empty`() = test {
         val scanStateModelInUnAvailableState = scanStateModelWithNoThreats.copy(state = State.UNAVAILABLE)
 
         val scanStateItems = buildScanStateItems(scanStateModelInUnAvailableState)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -236,19 +236,15 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given idle state with not fixable threats, when items are built, items contain fix all threats button`() =
+    fun `given idle state with no fixable threats, when items are built, items does not contain fix all threats btn`() =
         test {
             val threats = listOf(threat.copy(baseThreatModel = baseThreatModel.copy(fixable = null)))
             val scanStateModelWithNoFixableThreats = scanStateModelWithThreats.copy(threats = threats)
 
             val scanStateItems = buildScanStateItems(scanStateModelWithNoFixableThreats)
 
-            assertThat(
-                scanStateItems.filterIsInstance(ActionButtonState::class.java)
-                    .map { it.text }
-            ).doesNotContain(
-                UiStringRes(R.string.threats_fix_all)
-            )
+            assertThat(scanStateItems.filterIsInstance(ActionButtonState::class.java).map { it.text })
+                .doesNotContain(UiStringRes(R.string.threats_fix_all))
         }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -194,6 +194,15 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given idle state with threats, when items are built, items contain header for threats found`() = test {
+        val scanStateItems = buildScanStateItems(model = scanStateModelWithThreats)
+
+        assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
+            HeaderState(UiStringRes(R.string.scan_idle_threats_found_title))
+        )
+    }
+
+    @Test
     fun `given idle state with threats, when items are built, items contain threats found description`() = test {
         buildScanStateItems(scanStateModelWithThreats)
 
@@ -280,6 +289,15 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
                 )
             )
         }
+
+    @Test
+    fun `given idle no threats state, when items are built, items contain header for no threats found`() = test {
+        val scanStateItems = buildScanStateItems(model = scanStateModelWithNoThreats)
+
+        assertThat(scanStateItems.filterIsInstance(HeaderState::class.java).first()).isEqualTo(
+            HeaderState(UiStringRes(R.string.scan_idle_no_threats_found_title))
+        )
+    }
 
     @Test
     fun `given idle no threats state, when items are built, items contain scan again button `() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -215,7 +215,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given idle state with threats, when items are built, items contain scan now button`() = test {
+    fun `given idle state with threats, when items are built, items contain scan again button`() = test {
         val scanStateItems = buildScanStateItems(scanStateModelWithThreats)
 
         assertThat(scanStateItems.filterIsInstance(ActionButtonState::class.java).map { it.text }).contains(
@@ -300,7 +300,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given idle no threats state, when items are built, items contain scan again button `() = test {
+    fun `given idle no threats state, when items are built, items contain scan now button `() = test {
         val scanStateItems = buildScanStateItems(scanStateModelWithNoThreats)
 
         assertThat(scanStateItems.filterIsInstance(ActionButtonState::class.java).map { it.text }).contains(


### PR DESCRIPTION
Parent #13326

This PR 
- Re-adds tests removed in commit d61a3e8 and tweaks them to fit existing list items structure (0be230e)
- Rewords test statements to `given/when/then` format (c370ddc)
- Adds few missing tests for scan state icon, header and progress bar (da44196, 1599af4, 29d803c)

It might be easier to review them commit by commit.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
