### PR TITLE
Retries image fetching if mshot service has not finished

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/LayoutViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/LayoutViewHolder.kt
@@ -4,14 +4,13 @@ import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.ImageView
-import android.widget.ImageView.ScaleType.FIT_CENTER
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.card.MaterialCardView
 import kotlinx.android.synthetic.main.modal_layout_picker_layouts_card.view.*
 import org.wordpress.android.R
+import org.wordpress.android.networking.MShot
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageManager.RequestListener
-import org.wordpress.android.util.image.ImageType
 import org.wordpress.android.util.setVisible
 
 /**
@@ -33,7 +32,7 @@ class LayoutViewHolder(internal val parent: ViewGroup) :
         uiState: LayoutListItemUiState,
         imageManager: ImageManager
     ) {
-        imageManager.loadWithResultListener(preview, ImageType.THEME, uiState.preview, FIT_CENTER, null,
+        imageManager.loadWithResultListener(preview, MShot(uiState.preview),
                 object : RequestListener<Drawable> {
                     override fun onLoadFailed(e: Exception?, model: Any?) {
                     }


### PR DESCRIPTION
## Description
Retries image fetching if mshot service has not finished. This fix is needed since the new endpoint introduced with https://github.com/wordpress-mobile/WordPress-Android/pull/13905 uses the mshot service.

## To test:
1. Clean the application cache or delete and reinstall the App
2. Open the app and login
3. Tap the fab icon in the My Site screen
2. Choose **Site Page**
3. Verify that the thumbnails load as expected

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
