### PR TITLE
Add mobile/tablet/desktop thumbnails in MLP layout selection screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 16.9
 -----
-
+* [*] Starter Page Templates: Adds the option to choose between mobile, tablet or desktop thumbnails
 
 16.8
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -20,11 +20,14 @@ import kotlinx.android.synthetic.main.modal_layout_picker_fragment.*
 import kotlinx.android.synthetic.main.modal_layout_picker_layouts_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
 import kotlinx.android.synthetic.main.modal_layout_picker_title_row.*
-import kotlinx.android.synthetic.main.modal_layout_picker_titlebar.*
+import kotlinx.android.synthetic.main.modal_layout_picker_titlebar.backButton
+import kotlinx.android.synthetic.main.modal_layout_picker_titlebar.previewTypeSelectorButton
+import kotlinx.android.synthetic.main.modal_layout_picker_titlebar.title
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.FullscreenBottomSheetDialogFragment
+import org.wordpress.android.ui.PreviewModeSelectorPopup
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AniUtils
@@ -44,6 +47,7 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
     @Inject internal lateinit var uiHelper: UiHelpers
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: ModalLayoutPickerViewModel
+    private lateinit var previewModeSelectorPopup: PreviewModeSelectorPopup
 
     companion object {
         const val MODAL_LAYOUT_PICKER_TAG = "MODAL_LAYOUT_PICKER_TAG"
@@ -95,10 +99,15 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
         retryButton.setOnClickListener {
             viewModel.onRetryClicked()
         }
+        previewTypeSelectorButton.setOnClickListener {
+            viewModel.onThumbnailModePressed()
+        }
 
         setScrollListener()
 
         setupViewModel(savedInstanceState)
+
+        previewModeSelectorPopup = PreviewModeSelectorPopup(requireActivity(), previewTypeSelectorButton)
     }
 
     private fun setScrollListener() {
@@ -183,6 +192,10 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
                     actionableEmptyView.subtitle.setText(uiState.subtitle)
                 }
             }
+        })
+
+        viewModel.onThumbnailModeButtonPressed.observe(viewLifecycleOwner, Observer {
+            previewModeSelectorPopup.show(viewModel)
         })
 
         viewModel.onPreviewPageRequested.observe(this, Observer { request ->

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
@@ -18,6 +18,10 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchBlockLayoutsPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnBlockLayoutsFetched
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.PreviewMode
+import org.wordpress.android.ui.PreviewMode.MOBILE
+import org.wordpress.android.ui.PreviewMode.TABLET
+import org.wordpress.android.ui.PreviewModeHandler
 import org.wordpress.android.ui.mlp.CategoryListItemUiState
 import org.wordpress.android.ui.mlp.ButtonsUiState
 import org.wordpress.android.ui.mlp.GutenbergPageLayouts
@@ -26,6 +30,7 @@ import org.wordpress.android.ui.mlp.LayoutCategoryUiState
 import org.wordpress.android.ui.mlp.SupportedBlocksProvider
 import org.wordpress.android.ui.mlp.ThumbDimensionProvider
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.viewmodel.Event
@@ -46,10 +51,11 @@ class ModalLayoutPickerViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val supportedBlocksProvider: SupportedBlocksProvider,
     private val thumbDimensionProvider: ThumbDimensionProvider,
+    private val displayUtilsWrapper: DisplayUtilsWrapper,
     private val networkUtils: NetworkUtilsWrapper,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
-) : ScopedViewModel(mainDispatcher) {
+) : ScopedViewModel(mainDispatcher), PreviewModeHandler {
     private lateinit var layouts: GutenbergPageLayouts
 
     /**
@@ -64,6 +70,9 @@ class ModalLayoutPickerViewModel @Inject constructor(
     private val _uiState: MutableLiveData<UiState> = MutableLiveData()
     val uiState: LiveData<UiState> = _uiState
 
+    private val _previewMode = SingleLiveEvent<PreviewMode>()
+    private val previewMode: LiveData<PreviewMode> = _previewMode
+
     /**
      * Create new page event
      */
@@ -76,10 +85,19 @@ class ModalLayoutPickerViewModel @Inject constructor(
     private val _onPreviewPageRequested = SingleLiveEvent<PageRequest.Preview>()
     val onPreviewPageRequested: LiveData<PageRequest.Preview> = _onPreviewPageRequested
 
+    /**
+     * Thumbnail mode button event
+     */
+    private val _onThumbnailModeButtonPressed = SingleLiveEvent<Unit>()
+    val onThumbnailModeButtonPressed: LiveData<Unit> = _onThumbnailModeButtonPressed
+
     sealed class PageRequest(val template: String?, val content: String) {
         open class Create(template: String?, content: String, val title: String) : PageRequest(template, content)
         object Blank : Create(null, "", "")
-        class Preview(template: String?, content: String, val site: SiteModel) : PageRequest(template, content)
+        class Preview(template: String?, content: String, val site: SiteModel, val demoUrl: String?) : PageRequest(
+                template,
+                content
+        )
     }
 
     init {
@@ -136,15 +154,24 @@ class ModalLayoutPickerViewModel @Inject constructor(
         launch(bgDispatcher) {
             val listItems = ArrayList<LayoutCategoryUiState>()
 
-            val selectedCategories = if (state.selectedCategoriesSlugs.isNotEmpty())
+            val selectedCategories = if (state.selectedCategoriesSlugs.isNotEmpty()) {
                 layouts.categories.filter { state.selectedCategoriesSlugs.contains(it.slug) }
-            else layouts.categories
+            } else {
+                layouts.categories
+            }
 
             selectedCategories.sortedBy { it.title }.forEach { category ->
 
                 val layouts = layouts.getFilteredLayouts(category.slug).map { layout ->
-                    val selected = layout.slug == state.selectedLayoutSlug
-                    LayoutListItemUiState(layout.slug, layout.title, layout.preview, selected,
+                    LayoutListItemUiState(
+                            slug = layout.slug,
+                            title = layout.title,
+                            preview = when (_previewMode.value) {
+                                MOBILE -> layout.previewMobile
+                                TABLET -> layout.previewTablet
+                                else -> layout.preview
+                            },
+                            selected = layout.slug == state.selectedLayoutSlug,
                             onItemTapped = { onLayoutTapped(layoutSlug = layout.slug) },
                             onThumbnailReady = { onThumbnailReady(layoutSlug = layout.slug) }
                     )
@@ -198,6 +225,13 @@ class ModalLayoutPickerViewModel @Inject constructor(
      */
     fun createPageFlowTriggered() {
         _isModalLayoutPickerShowing.value = Event(true)
+        if (_previewMode.value == null) {
+            _previewMode.value = if (displayUtilsWrapper.isTablet()) {
+                TABLET
+            } else {
+                MOBILE
+            }
+        }
         fetchLayouts()
     }
 
@@ -302,9 +336,13 @@ class ModalLayoutPickerViewModel @Inject constructor(
         (uiState.value as? ContentUiState)?.let { state ->
             layouts.layouts.firstOrNull { it.slug == state.selectedLayoutSlug }?.let { layout ->
                 val site = siteStore.getSiteByLocalId(appPrefsWrapper.getSelectedSite())
-                _onPreviewPageRequested.value = PageRequest.Preview(layout.slug, layout.content, site)
+                _onPreviewPageRequested.value = PageRequest.Preview(layout.slug, layout.content, site, layout.demoUrl)
             }
         }
+    }
+
+    fun onThumbnailModePressed() {
+        _onThumbnailModeButtonPressed.call()
     }
 
     /**
@@ -371,5 +409,16 @@ class ModalLayoutPickerViewModel @Inject constructor(
                 isDescriptionVisible = false,
                 buttonsUiState = ButtonsUiState(retryVisible = true)
         )
+    }
+
+    override fun selectedPreviewMode() = previewMode.value ?: MOBILE
+
+    override fun onPreviewModeChanged(mode: PreviewMode) {
+        if (_previewMode.value !== mode) {
+            _previewMode.value = mode
+            if (uiState.value is ContentUiState) {
+                loadLayouts()
+            }
+        }
     }
 }

--- a/WordPress/src/main/res/layout-land/modal_layout_picker_titlebar.xml
+++ b/WordPress/src/main/res/layout-land/modal_layout_picker_titlebar.xml
@@ -23,4 +23,14 @@
         style="@style/ModalLayoutPickerHeader"
         android:layout_marginEnd="@dimen/margin_medium"
         android:text="@string/mlp_choose_layout_title" />
+
+    <ImageButton
+        android:id="@+id/previewTypeSelectorButton"
+        style="@style/WebPreviewNavbarButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical|end"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:contentDescription="@string/preview_type_desc"
+        android:src="@drawable/ic_devices_white_24dp" />
 </FrameLayout>

--- a/WordPress/src/main/res/layout/modal_layout_picker_titlebar.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_titlebar.xml
@@ -19,4 +19,14 @@
         android:layout_marginEnd="@dimen/margin_medium"
         android:text="@string/mlp_choose_layout_title"
         android:visibility="gone" />
+
+    <ImageButton
+        android:id="@+id/previewTypeSelectorButton"
+        style="@style/WebPreviewNavbarButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical|end"
+        android:layout_marginEnd="@dimen/margin_extra_large"
+        android:contentDescription="@string/preview_type_desc"
+        android:src="@drawable/ic_devices_white_24dp" />
 </FrameLayout>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.mlp.SupportedBlocks
 import org.wordpress.android.ui.mlp.SupportedBlocksProvider
 import org.wordpress.android.ui.mlp.ThumbDimensionProvider
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.NoDelayCoroutineDispatcher
 import org.wordpress.android.util.SiteUtils.GB_EDITOR_NAME
@@ -56,6 +57,7 @@ class ModalLayoutPickerViewModelTest {
     @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
     @Mock lateinit var supportedBlocksProvider: SupportedBlocksProvider
     @Mock lateinit var thumbDimensionProvider: ThumbDimensionProvider
+    @Mock lateinit var displayUtilsWrapper: DisplayUtilsWrapper
     @Mock lateinit var networkUtils: NetworkUtilsWrapper
     @Mock lateinit var onCreateNewPageRequestedObserver: Observer<Create>
     @Mock lateinit var onPreviewPageRequestedObserver: Observer<Preview>
@@ -71,8 +73,11 @@ class ModalLayoutPickerViewModelTest {
             val aboutLayout = GutenbergLayout(
                     slug = "about",
                     title = "About",
+                    previewTablet = "https://headstartdata.files.wordpress.com/2020/01/about-2.png",
+                    previewMobile = "https://headstartdata.files.wordpress.com/2020/01/about-2.png",
                     preview = "https://headstartdata.files.wordpress.com/2020/01/about-2.png",
                     content = "",
+                    demoUrl = "",
                     categories = listOf(aboutCategory)
             )
             return OnBlockLayoutsFetched(listOf(aboutLayout), listOf(aboutCategory), null)
@@ -86,6 +91,7 @@ class ModalLayoutPickerViewModelTest {
                 appPrefsWrapper,
                 supportedBlocksProvider,
                 thumbDimensionProvider,
+                displayUtilsWrapper,
                 networkUtils,
                 NoDelayCoroutineDispatcher(),
                 NoDelayCoroutineDispatcher()

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '9ce0427d9f5c7e7ccf83ec845e1f20ca5329a7d9'
+    fluxCVersion = '1.12.0-beta-1'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -154,8 +154,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.11.0'
-
+    fluxCVersion = '9ce0427d9f5c7e7ccf83ec845e1f20ca5329a7d9'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -373,7 +373,6 @@
     <ID>MultiLineIfElse:org.wordpress.android.ui.sitecreation.theme.HomePagePickerViewHolder.kt:37</ID>
     <ID>MultiLineIfElse:org.wordpress.android.viewmodel.main.SitePickerViewModel.kt:54</ID>
     <ID>MultiLineIfElse:org.wordpress.android.viewmodel.main.SitePickerViewModel.kt:56</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel.kt:140</ID>
     <ID>MultiLineIfElse:org.wordpress.android.viewmodel.pages.PageListViewModel.kt:309</ID>
     <ID>MultiLineIfElse:org.wordpress.android.viewmodel.pages.PageListViewModel.kt:343</ID>
     <ID>MultiLineIfElse:org.wordpress.android.viewmodel.pages.PageListViewModel.kt:354</ID>
@@ -520,7 +519,7 @@
     <ID>TooManyFunctions:MediaPickerViewModel.kt$MediaPickerViewModel : ScopedViewModel</ID>
     <ID>TooManyFunctions:MediaUtilsWrapper.kt$MediaUtilsWrapper</ID>
     <ID>TooManyFunctions:ModalLayoutPickerFragment.kt$ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment</ID>
-    <ID>TooManyFunctions:ModalLayoutPickerViewModel.kt$ModalLayoutPickerViewModel : ScopedViewModel</ID>
+    <ID>TooManyFunctions:ModalLayoutPickerViewModel.kt$ModalLayoutPickerViewModel : ScopedViewModelPreviewModeHandler</ID>
     <ID>TooManyFunctions:MySiteFragment.kt$MySiteFragment : FragmentOnScrollToTopListenerBasicDialogPositiveClickInterfaceBasicDialogNegativeClickInterfaceBasicDialogOnDismissByOutsideTouchInterfacePromoDialogClickInterfaceOnConfirmListenerOnDismissListenerCallback</ID>
     <ID>TooManyFunctions:MySiteViewModel.kt$MySiteViewModel : ScopedViewModel</ID>
     <ID>TooManyFunctions:NestedCoordinatorLayout.kt$NestedCoordinatorLayout : CoordinatorLayoutNestedScrollingChild3</ID>


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2979

Depends on: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1869

*Note: Refactoring of the preview action to use a webview instead of the editor [will be handled separately](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2980).*

## Description
This PR enhances the MLP screen adding the ability to select between mobile, tablet and desktop thumbnails

## To test:

### Initial Mode on a Phone
1. Open the app on a *phone* device 
1. In the *My Site* screen tap the fab (+) button and select *Site page*
1. **Verify** that **mobile** thumbnails are displayed

### Initial Mode on a Tablet
1. Open the app on a *tablet* device 
1. In the *My Site* screen tap the fab (+) button and select *Site page*
1.  **Verify** that **tablet** thumbnails are displayed

### Thumbnail options availability
1. In the *My Site* screen tap the fab (+) button and select *Site page*
1.  **Verify** that there is a **thumbnail mode button** at the top left of the screen
1. Press the thumbnail button
1.  **Verify** that three options are displayed: **Mobile, Tablet, Desktop**

### Change to Tablet
1. Open the app on a *phone* device 
1. In the *My Site* screen tap the fab (+) button and select *Site page*
1. Press the **thumbnail mode button**
1. Select **Tablet**
1.  **Verify** that tablet thumbnails are displayed

### Change to Desktop
1. In the *My Site* screen tap the fab (+) button and select *Site page*
1. Press the **thumbnail mode button**
1. Select **Desktop**
1.  **Verify** that desktop thumbnails are displayed

### Change to Mobile
1. In the *My Site* screen tap the fab (+) button and select *Site page*
1. **Change to Desktop** as above
1. Press the **thumbnail mode button**
1. Select **Mobile**
1.  **Verify** that mobile thumbnails are displayed

## Screenshots

|Mobile Mode|Tablet Mode|Desktop Mode|
|---|---|---|
|![m](https://user-images.githubusercontent.com/304044/108874631-01150180-7605-11eb-89fc-152eda26cf31.png)|![t](https://user-images.githubusercontent.com/304044/108874635-02dec500-7605-11eb-8255-ba12d395d40c.png)|![d](https://user-images.githubusercontent.com/304044/108874622-ff4b3e00-7604-11eb-9a62-0d45ece6631c.png)|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
