### PR TITLE
Use safe call when saving instance state in ImprovedMySiteFragment.kt

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -351,10 +351,10 @@ class ImprovedMySiteFragment : Fragment(),
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        recycler_view.layoutManager?.let {
+        recycler_view?.layoutManager?.let {
             outState.putParcelable(KEY_LIST_STATE, it.onSaveInstanceState())
         }
-        (recycler_view.adapter as? MySiteAdapter)?.let {
+        (recycler_view?.adapter as? MySiteAdapter)?.let {
             outState.putBundle(KEY_NESTED_LISTS_STATES, it.onSaveInstanceState())
         }
     }


### PR DESCRIPTION
Fixes #14024 

I think this crash sometimes happens when the bottom navigation initializes a fragment without a view and immediately kills it. I think safe call in the onSaveInstanceState is a good solution. 

To test:
- I don't know how to reproduce this crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
