### PR TITLE
Update Pin/Unpin/Hide copy based on the designs

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2891,9 +2891,9 @@
     <string name="quick_start_span_start" translatable="false">&lt;span&gt;</string>
     <string name="quick_start_focus_point_description">tap here</string>
 
-    <string name="quick_start_card_menu_pin">Pin</string>
-    <string name="quick_start_card_menu_unpin">Unpin</string>
-    <string name="quick_start_card_menu_hide">Hide</string>
+    <string name="quick_start_card_menu_pin">Pin this</string>
+    <string name="quick_start_card_menu_unpin">Unpin this</string>
+    <string name="quick_start_card_menu_hide">Hide for now</string>
     <string name="quick_start_card_menu_remove">Don\'t show again</string>
 
     <!-- Pages -->


### PR DESCRIPTION
Fixes #14043 

This PR updates copy of the dynamic card menu:
- From "Pin" to "Pin this"
- From "Unpin" to "Unpin this"
- From "Hide" to "Hide for now"

To test:
- Make sure the My Site improvements flag is turned on and the app is restarted
- Make sure you're on a site with QS started
- Click on the dynamic card menu
- Notice the updated copy
- Pin a card
- Click on the menu of the pinned card
- Notice the updated "Unpin this" copy


<img width="478" alt="Screenshot 2021-02-12 at 11 08 48" src="https://user-images.githubusercontent.com/1079756/107755159-bea91600-6d22-11eb-8409-4ad5382e80a5.png">
<img width="476" alt="Screenshot 2021-02-12 at 11 08 59" src="https://user-images.githubusercontent.com/1079756/107755167-c10b7000-6d22-11eb-9477-98cd27f7f22f.png">


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
