### PR TITLE
Suppress detekt warnings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/usecases/GetBackupDownloadStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/usecases/GetBackupDownloadStatusUseCase.kt
@@ -34,6 +34,7 @@ class GetBackupDownloadStatusUseCase @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
     private val tag = javaClass.simpleName
+    @Suppress("ComplexMethod", "LoopWithTooManyJumpStatements")
     suspend fun getBackupDownloadStatus(
         site: SiteModel,
         downloadId: Long? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -38,6 +38,7 @@ class GetRestoreStatusUseCase @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) {
     private val tag = javaClass.simpleName
+    @Suppress("ComplexMethod", "LoopWithTooManyJumpStatements")
     suspend fun getRestoreStatus(
         site: SiteModel,
         restoreId: Long? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/usecases/FetchScanStateUseCase.kt
@@ -32,6 +32,7 @@ class FetchScanStateUseCase @Inject constructor(
 ) {
     private val tag = javaClass.simpleName
 
+    @Suppress("ComplexMethod", "LoopWithTooManyJumpStatements")
     suspend fun fetchScanState(
         site: SiteModel,
         startWithDelay: Boolean = false


### PR DESCRIPTION
This PR fixes broken `develop` by suppressing warnings in some useCases. We considered fixing the issues, but we couldn't come up with a cleaner approach without making significant changes.

To test:
CI build
