### PR TITLE
Fix/lint pr annotations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
           command: |
             if [ -n "$GITHUB_API_TOKEN" ]; then
-              ./gradlew --stacktrace violationCommentsToGitHub -DGITHUB_PULLREQUESTID=${CIRCLE_PULL_REQUEST##*/} -DGITHUB_OAUTH2TOKEN=$GITHUB_API_TOKEN
+              ./gradlew --stacktrace violationCommentsToGitHub -DGITHUB_PULLREQUESTID=${CIRCLE_PULL_REQUEST##*/} -DGITHUB_OAUTH2TOKEN=$GHHELPER_ACCESS
             else
               echo "Not posting lint errors to Github because \$GITHUB_API_TOKEN is not found"
             fi

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.google.gms:google-services:3.2.0'
-        classpath 'se.bjurr.violations:violation-comments-to-github-gradle-plugin:1.51'
+        classpath 'se.bjurr.violations:violation-comments-to-github-gradle-plugin:1.67'
         classpath 'io.sentry:sentry-android-gradle-plugin:1.7.28'
     }
 }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -442,7 +442,8 @@ task violationCommentsToGitHub(type: se.bjurr.violations.comments.github.plugin.
 {{violation.message}}
 """
     violations = [
-            ["CHECKSTYLE", ".", ".*/build/.*\\.xml\$", "Checkstyle"]
+            ["CHECKSTYLE", ".", ".*/build/.*\\.xml\$", "Checkstyle"],
+            ["CHECKSTYLE", ".", ".*/build/.*/detekt/.*\\.xml\$", "Detekt"]
     ]
 }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -442,7 +442,7 @@ task violationCommentsToGitHub(type: se.bjurr.violations.comments.github.plugin.
 {{violation.message}}
 """
     violations = [
-            ["CHECKSTYLE", ".", ".*/build/.*\\.xml\$", "Checkstyle"],
+            ["CHECKSTYLE", ".", ".*/build/.*/checkstyle/.*\\.xml\$", "CheckStyle"],
             ["CHECKSTYLE", ".", ".*/build/.*/detekt/.*\\.xml\$", "Detekt"]
     ]
 }


### PR DESCRIPTION
This PR fixes https://github.com/wordpress-mobile/WordPress-Android/issues/14051 by upgrading the Violations plugin. 
I also updated the GH token the plugin uses in order to consolidate across the various tools (for reasons, we have two different token used, which is confusing) and configured it to annotate the violations found by Detekt as well. 

To test:
- [This PR](https://github.com/wordpress-mobile/WordPress-Android/pull/14056) shows a failure reported by Checkstyle.
- [This PR](https://github.com/wordpress-mobile/WordPress-Android/pull/14060) shows a failure reported by Detekt.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
