### PR TITLE
WebViewActivity : Stop audio playback after exiting post preview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -120,7 +120,9 @@ public abstract class WebViewActivity extends LocaleAwareActivity {
     private void pauseWebView() {
         if (mWebView != null) {
             mWebView.onPause();
-            loadUrl("about:blank");
+            if (isFinishing()) {
+                loadUrl("about:blank");
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -120,6 +120,7 @@ public abstract class WebViewActivity extends LocaleAwareActivity {
     private void pauseWebView() {
         if (mWebView != null) {
             mWebView.onPause();
+            loadUrl("about:blank");
         }
     }
 


### PR DESCRIPTION
Fixes #14046

## Findings

This issue was occurring because the basic activity for displaying a WebView was not able to pause the audio playback when the user leaves the activity and `onPause` was run.   Currently, the `onPause` of the `WebViewActivity` contains logic for stopping flash video via `mWebView.onPause();` Since this solution does not extend to rendered `<audio controls> </audio>` an alternative solution was found.  

## Solution

### Option 1  

The first idea that came to mind was to do some form of Javascript injection into the preview page, that would traverse through the elements in the HTML document, find the active <audio> component, and stop it.   

### Option 2

  Another idea I thought of was to simply clear the view in some way or form. After verifying with the Android documentation to validate that this is an accepted practice, I implemented the behavior they showcased as the optimal approach. This simply involves clearing the `WebView` with `WebView.load(“about:blank”)`. Doing this reliably resets the `WebView` state and releases all the page resources. In our case, the target page resources is that of the post/page preview that contains the playing content. Once the post/page preview’s resources are cleared up any running JavaScript will be released.  


###  Choice : Option 2 

Based on the simplicity, readability, and maintainability I decided to go with Option 2. I like the approach because it doesn’t just load any random URL, It loads the “about:blank” page that is built in the web browser. Other engineers who see this will be able to associate it with seeing this address in their browser with an empty page.   I considered putting the contents of the “load” method in a constant but decided against this, as when I checked in other places where a similar solution was utilized, they kept the “about:blank” inline to communicate intent. 

## Testing

1. Create a post. 
2. Add an Audio block.
3. Add a playable file with good length; over 20 seconds.
4. Ensure you have a moderate volume setting so the sound file is audible.
3. Start the playback. 
4. Exit the preview by pressing the back button to go back to the post content.
5. Notice that the audio has stopped.

## Regression testing

1. Ensure that you can open the link externally and navigate back with you no issues. 
2. Ensure that you can switch between mobile, desktop, and tablet, and no content or resources are lost.

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 
