### PR TITLE
With some keyboard creates chips on dot

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/WPEditTextWithChipsOutlined.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/WPEditTextWithChipsOutlined.kt
@@ -181,7 +181,7 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
         throwExceptionIfChipifyNotEnabled()
 
         if (!hasText() || !canAddMoreChips()) {
-            editor.setText("")
+            resetText()
             return null
         }
 
@@ -333,13 +333,13 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
 
     private fun addItem(item: String) {
         if (!canAddMoreChips() && item.isNotBlank()) {
-            editor.setText("")
+            resetText()
         } else {
             val cleanedItem = removeDelimiterFromItemIfPresent(item)
 
             if (cleanedItem.isNullOrBlank()) return
 
-            editor.setText("")
+            resetText()
 
             itemsManager?.onAddItem(cleanedItem) ?: chipify(cleanedItem, ItemValidationState.NEUTRAL)
         }
@@ -387,7 +387,13 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
             flexBox.addView(chip as View, index)
         }
 
-        editor.setText("")
+        resetText()
+    }
+
+    private fun resetText() {
+        editor.apply {
+            text?.clear() ?: setText("")
+        }
     }
 
     private fun removeDelimiterFromItemIfPresent(item: String?): String? {

--- a/WordPress/src/main/res/layout/wp_edit_text_with_chips_outlined.xml
+++ b/WordPress/src/main/res/layout/wp_edit_text_with_chips_outlined.xml
@@ -27,7 +27,8 @@
             app:layout_flexGrow="1"
             android:background="@android:color/transparent"
             android:imeOptions="actionDone|flagNoExtractUi"
-            android:inputType="text|textNoSuggestions"
+            android:inputType="text|textNoSuggestions|textEmailAddress"
+            android:textAlignment="viewStart"
             android:textAppearance="?attr/textAppearanceSubtitle1"
             android:minWidth="@dimen/min_touch_target_sz"
             android:minHeight="@dimen/edit_text_with_chips_edit_view_min_height"/>


### PR DESCRIPTION
Fixes #14066

In the `Invite People` screen, currently the validation and transformation into a chip of the `Usernames or emails`field is triggered by `space`, `comma`, `return` keys. 

Using some keyboards (like for example the MS SwiftKey) the insertion of a `space` is done when inserting a `dot`; this is unwanted since it triggers the validation and transformation into a chip of the text inserted until then and it could prevent the insertion of emails (containing a dot).

To avoid this we have added the `textEmailAddress` qualifier to the TextInputEditText `android:inputType` field 

| Before with MS SwiftKey | After with MS SwiftKey |
|---|---|
| ![image](https://user-images.githubusercontent.com/47797566/107889854-a1886900-6f15-11eb-96f4-e42a116010b3.png) | ![image](https://user-images.githubusercontent.com/47797566/107889774-21620380-6f15-11eb-9d04-3fca5744f471.png) |


While looking into this I also noticed some warnings when creating the chip. The warnings are like below

```
W/IInputConnectionWrapper: endBatchEdit on inactive InputConnection
W/IInputConnectionWrapper: clearMetaKeyStates on inactive InputConnection
W/IInputConnectionWrapper: beginBatchEdit on inactive InputConnection
```
This seems to be a [known issue ](https://stackoverflow.com/a/30454234) due to setting the text to empty string with setText(""). AFAIU this is not causing issues but I confirmed that using `text?.clear()` removes the warnings. Since the verification of this seems pretty confined I thought it made sense to fix this in the beta update.

## To test

### Warnings are not present any more
- Using develop (or current release 16.7) confirm that you can see warnings similar to the above mentioned when creating a chip
- Now use the apk from this PR and check the warning are no more present 

### Chips are not created with dot
- Install and enable the MS SwiftKey keyboard
- Using develop (or current release 16.7) confirm that adding a user email with a dot (like name.surname@domain.com), a chip is created when pressing the dot (so getting a chip like `name.`)
- Now use the apk from this PR and check the issue is not present and you can fully insert an email like `name.surname@domain.com`; only after tapping `space`, `comma`, `return` keys (or leaving the control focus) the chip is created as expected
- Try to send invitation and smoke test

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
