### PR TITLE
Fix Detekt 'MultiLineIfElse' issue on 'LayoutViewHolder'

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/LayoutViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/LayoutViewHolder.kt
@@ -45,8 +45,11 @@ class LayoutViewHolder(internal val parent: ViewGroup) :
         selected.setVisible(uiState.selectedOverlayVisible)
         preview.contentDescription = parent.context.getString(uiState.contentDescriptionResId, uiState.title)
         preview.context?.let { ctx ->
-            container.strokeWidth = if (uiState.selectedOverlayVisible)
-                ctx.resources.getDimensionPixelSize(R.dimen.picker_header_selection_overlay_width) else 0
+            container.strokeWidth = if (uiState.selectedOverlayVisible) {
+                ctx.resources.getDimensionPixelSize(R.dimen.picker_header_selection_overlay_width)
+            } else {
+                0
+            }
         }
         container.setOnClickListener {
             uiState.onItemTapped.invoke()

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -414,7 +414,6 @@
     <ID>MemberNameEqualsClassName:ActivityLogTypeFilterViewModel.kt$ActivityLogTypeFilterViewModel.Action$lateinit var action: (() -&gt; Unit)</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.activitylog.list.EventItemViewHolder.kt:33</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.activitylog.list.EventItemViewHolder.kt:35</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.mlp.LayoutViewHolder.kt:50</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.pages.PageItemViewHolder.kt:252</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.pages.PageItemViewHolder.kt:254</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.pages.PageItemViewHolder.kt:84</ID>


### PR DESCRIPTION
This PR fixes the `MultiLineIfElse` issue on `LayoutViewHolder`. Since this issue was in the baseline, after fixing it, it was also safely removed from Detekt's `baseline.xml` file. This was done automatically running this command: `./gradlew WordPress:detektBaseline`

To test:
- Pull this branch locally.
- Run `./gradlew WordPress:detekt` and verify that  there are no Detekt issues.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
