### PR TITLE
Fix failing connected tests for sign up tests

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/SignupFlow.java
@@ -35,10 +35,6 @@ public class SignupFlow {
     }
 
     public SignupFlow openMagicLink(ActivityTestRule<LoginMagicLinkInterceptActivity> magicLinkActivityTestRule) {
-        // Receive Magic Link – Choose "Send link by email"
-        // See SignupConfirmationFragment
-        clickOn(R.id.signup_confirmation_button);
-
         // Should see "Check email" button
         // See SignupMagicLinkFragment
         waitForElementToBeDisplayed(R.id.signup_magic_link_button);


### PR DESCRIPTION
Fixes #13971
Related #14025
Related [Circle CI Failure](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/21316/workflows/b68ae852-7c83-4fb6-8781-b38cec6b0b4b/jobs/96001/tests#failed-test-0)

This PR fixes a failing test on the `SignUpTests` suite, which was introduced with #14025. The fix is actually very simple as it removes the intermediate step where the sign up confirmation button was clicked, since this screen is no longer available. As such, clicking on the check email button happens immediately after and the sign up test flows continues as usual.

To test:
- Run the `SignUpTests` connected test and verify success.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
