### PR TITLE
Remove fetch delay for normal processing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/usecases/GetRestoreStatusUseCase.kt
@@ -74,7 +74,6 @@ class GetRestoreStatusUseCase @Inject constructor(
                     QUEUED -> emitProgress(rewind)
                 }
             }
-            delay(DELAY_MILLIS)
         }
     }.flowOn(bgDispatcher)
 


### PR DESCRIPTION
Parent #13328 

Addresses the following by removing the delay for normal processing:
The email informing of a successful restore arrives while the app is still “Importing SQL dump” or “renaming tables”, maybe it’s a latency issue but the delay was quite noticeable.

See p5T066-p2

NOTE: This change DOES NOT guarantee that the restore process notification comes before the view is finished, but it _should_ help with the noticeable delay.

**Merge Instructions**
I'm not sure if this should be pushed to the beta or go into the develop branch. 

- If it needs to go to beta, then please change the base branch. If it can wait for next release, then leave develop as the base.
- Remove the Not ready for merge label
- Merge the PR

cc @malinajirka @ashiagr @ParaskP7  - thoughts on when this should get pushed? Thanks.

To test:
- Launch the app
- Navigate to the Activity Log
- Chose an item that is restorable
- Tap on the menu for the item and select "Restore to this point"
- Kick off the restore process and wait
- Note that the progress view finishes before the email notification arrives (or that the timing is less noticeable)

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
