### PR TITLE
Invalidate bundler cache to fix CI failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
           init-submodules: true
       - checkout-submodules
       - bundle-install/bundle-install:
-          cache_key_prefix: installable-build
+          cache_key_prefix: installable-build-v2
       - run:
           name: Copy Secrets
           command: bundle exec fastlane run configure_apply
@@ -249,7 +249,7 @@ jobs:
           init-submodules: true
       - checkout-submodules
       - bundle-install/bundle-install:
-          cache_key_prefix: installable-build
+          cache_key_prefix: installable-build-v2
       - run:
           name: Copy Secrets
           command: bundle exec fastlane run configure_apply
@@ -375,7 +375,7 @@ jobs:
           init-submodules: true
       - checkout-submodules
       - bundle-install/bundle-install:
-          cache_key_prefix: v1-raw-screenshots
+          cache_key_prefix: raw-screenshots-v2
       - android/restore-gradle-cache
       - copy-gradle-properties
       - update-gradle-memory:
@@ -533,7 +533,7 @@ jobs:
           name: Install bundler
           command: gem install bundler --version 2.0.2
       - bundle-install/bundle-install:
-          cache_key_prefix: strings-check
+          cache_key_prefix: strings-check-v2
       - run:
           name: Validate login strings
           command: bundle exec fastlane validate_login_strings pr_url:$CIRCLE_PULL_REQUEST
@@ -548,7 +548,7 @@ jobs:
           init-submodules: true
       - checkout-submodules
       - bundle-install/bundle-install:
-          cache_key_prefix: installable-build
+          cache_key_prefix: installable-build-v2
       - run:
           name: Copy Secrets
           command: bundle exec fastlane run configure_apply


### PR DESCRIPTION
Fixes the CI failures encountered in #14077, #14078 and #14079 on the "Installable Build" job, due to a bundler cache apparently being out of sync with the rake dependency.

_(Similar fix to what I had to do on WCAndroid in https://github.com/woocommerce/woocommerce-android/pull/3583/commits/d46e8bb0212612160ef6af6ef26f8178ee1b5796)_

#### To test

 - Ensure CI passes in this PR
 - Rebase the aforementioned PRs on top of this one (or cherry-pick this PR's commit into them) and check it fixes the CI failure

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
