### PR TITLE
Jetpack Section: Update time strings in the scan description

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1093,9 +1093,9 @@
     <string name="scan_idle_with_threats_description_singular">The scan found %1s potential threat with %2s. Please review the threat below and take action or tap the fix all button. We are %3$s if you need us.</string>
     <string name="scan_here_to_help">here to help</string>
     <string name="scan_this_site">this site</string>
-    <string name="scan_in_hours_ago">%s hours ago</string>
-    <string name="scan_in_minutes_ago">%s minutes ago</string>
-    <string name="scan_in_few_seconds">in a few seconds</string>
+    <string name="scan_in_hours_ago">%s hour(s) ago</string>
+    <string name="scan_in_minutes_ago">%s minute(s) ago</string>
+    <string name="scan_in_few_seconds">a few seconds ago</string>
     <string name="scan_progress_label" translatable="false">%1$s%%</string>
 
     <!-- scan history -->


### PR DESCRIPTION
This PR updates the time strings in the scan description as per internal feedback `p5T066-1OP#comment-7220,` `p5T066-1OP#comment-7195`. 

**To test**

Changes being simple can just be verified in the `strings.xml` and the screenshots below:

secs | mins | hours
------|-----|-------
<img width="415" alt="sec" src="https://user-images.githubusercontent.com/1405144/108170167-cbad7700-711f-11eb-98f7-7d49cf53eaa1.png"> | <img width="414" alt="hours" src="https://user-images.githubusercontent.com/1405144/108170296-f992bb80-711f-11eb-866c-ad335a4eb85e.jpg"> | <img width="414" alt="hours" src="https://user-images.githubusercontent.com/1405144/108170216-d9fb9300-711f-11eb-950b-78e703d2af2b.png">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
