### PR TITLE
Issue/always hit jetpack capabilities endpoint

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -285,12 +285,10 @@ class MySiteFragment : Fragment(),
                     products = jetpackCapabilitiesUseCase.getCachedJetpackPurchasedProducts(site.siteId)
             )
             uiScope.launch {
-                if (!jetpackCapabilitiesUseCase.hasValidCache(site.siteId)) {
-                    updateScanAndBackupVisibility(
-                            site = site,
-                            products = jetpackCapabilitiesUseCase.fetchJetpackPurchasedProducts(site.siteId)
-                    )
-                }
+                updateScanAndBackupVisibility(
+                        site = site,
+                        products = jetpackCapabilitiesUseCase.fetchJetpackPurchasedProducts(site.siteId)
+                )
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -161,7 +161,6 @@ public class AppPrefs {
         READER_DISCOVER_WELCOME_BANNER_SHOWN,
         MANUAL_FEATURE_CONFIG,
         SITE_JETPACK_CAPABILITIES,
-        SITE_JETPACK_CAPABILITIES_LAST_UPDATED,
         REMOVED_QUICK_START_CARD_TYPE,
         PINNED_DYNAMIC_CARD
     }
@@ -1303,10 +1302,6 @@ public class AppPrefs {
         }
 
         Editor editor = prefs().edit();
-        editor.putLong(
-                DeletablePrefKey.SITE_JETPACK_CAPABILITIES_LAST_UPDATED + String.valueOf(remoteSiteId),
-                new Date().getTime()
-        );
         editor.putStringSet(
                 DeletablePrefKey.SITE_JETPACK_CAPABILITIES + String.valueOf(remoteSiteId),
                 capabilitiesSet
@@ -1324,10 +1319,5 @@ public class AppPrefs {
             capabilities.add(JetpackCapability.Companion.fromString(item));
         }
         return capabilities;
-    }
-
-    public static long getSiteJetpackCapabilitiesLastUpdated(long remoteSiteId) {
-        return prefs()
-                .getLong(DeletablePrefKey.SITE_JETPACK_CAPABILITIES_LAST_UPDATED + String.valueOf(remoteSiteId), 0);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -29,7 +29,6 @@ import org.wordpress.android.util.WPMediaUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -183,9 +183,6 @@ class AppPrefsWrapper @Inject constructor() {
     fun getSiteJetpackCapabilities(remoteSiteId: Long): List<JetpackCapability> =
             AppPrefs.getSiteJetpackCapabilities(remoteSiteId)
 
-    fun getSiteJetpackCapabilitiesLastUpdated(remoteSiteId: Long): Long =
-            AppPrefs.getSiteJetpackCapabilitiesLastUpdated(remoteSiteId)
-
     fun removeQuickStartTaskType(quickStartTaskType: QuickStartTaskType) =
             AppPrefs.removeQuickStartTaskType(quickStartTaskType)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCaseTest.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.jetpack
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -12,7 +11,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.Dispatcher
@@ -23,10 +21,8 @@ import org.wordpress.android.fluxc.model.JetpackCapability.BACKUP_REALTIME
 import org.wordpress.android.fluxc.model.JetpackCapability.SCAN
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnJetpackCapabilitiesFetched
-import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import org.wordpress.android.test
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import java.util.Date
 
 private const val SITE_ID = 1L
 


### PR DESCRIPTION
Updates GetJetpackCapabilities usecase so it always requests the most up to date data from the server. Previously, it'd request data from the server only when the cached data were older than 15 minutes. This change was introduced so for example the Backup/Scan menu items appear in the app as soon as you purchase the corresponding Jetpack product.

To test:
- Smoke test a couple of sites with(out) Scan and Backup capabilities
- Enable "ImprovedMySite" feature flag and smoke test a couple of sites with(out) Scan and Backup capabilities

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
