### PR TITLE
Use StringBuilder instead of += when building Site Settings blacklist

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -460,20 +460,20 @@ public class SiteSettingsModel {
         values.put(JETPACK_SEARCH_SUPPORTED_COLUMN_NAME, jetpackSearchSupported);
         values.put(JETPACK_SEARCH_ENABLED_COLUMN_NAME, jetpackSearchEnabled);
 
-        String moderationKeys = "";
+        StringBuilder moderationKeys = new StringBuilder();
         if (holdForModeration != null) {
             for (String key : holdForModeration) {
-                moderationKeys += key + "\n";
+                moderationKeys.append(key).append("\n");
             }
         }
-        String blacklistKeys = "";
+        StringBuilder blacklistKeys = new StringBuilder();
         if (blacklist != null) {
             for (String key : blacklist) {
-                blacklistKeys += key + "\n";
+                blacklistKeys.append(key).append("\n");
             }
         }
-        values.put(MODERATION_KEYS_COLUMN_NAME, moderationKeys);
-        values.put(BLACKLIST_KEYS_COLUMN_NAME, blacklistKeys);
+        values.put(MODERATION_KEYS_COLUMN_NAME, moderationKeys.toString());
+        values.put(BLACKLIST_KEYS_COLUMN_NAME, blacklistKeys.toString());
         values.put(SHARING_LABEL_COLUMN_NAME, sharingLabel);
         values.put(SHARING_BUTTON_STYLE_COLUMN_NAME, sharingButtonStyle);
         values.put(ALLOW_REBLOG_BUTTON_COLUMN_NAME, allowReblogButton);


### PR DESCRIPTION
Fixes #14070 

We've confirmed that this ANR happens to a site with a lot of commenters spammed out (42k). The building of the `blacklist` field is quite inefficient. I was able to reproduce this issue and it's gone when the blacklist handling is changed to StringBuilder.

To test:
- Put lot of items in the blacklist (ping me if you want the list)
- Switch to the site with the blacklist
- The app is normally responding

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
