### PR TITLE
Fix EventBusException(already registered) in JetpackCapabilitiesUseCase

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -246,6 +246,7 @@ class MySiteFragment : Fragment(),
     override fun onDestroy() {
         selectedSiteRepository.clear()
         job.cancel()
+        jetpackCapabilitiesUseCase.clear()
         super.onDestroy()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -130,7 +130,7 @@ class MySiteViewModel
     private val siteIconUploadHandler: SiteIconUploadHandler,
     private val siteStoriesHandler: SiteStoriesHandler,
     private val domainRegistrationHandler: DomainRegistrationHandler,
-    scanAndBackupSource: ScanAndBackupSource,
+    private val scanAndBackupSource: ScanAndBackupSource,
     private val displayUtilsWrapper: DisplayUtilsWrapper,
     private val quickStartRepository: QuickStartRepository,
     private val quickStartItemBuilder: QuickStartItemBuilder,
@@ -523,6 +523,7 @@ class MySiteViewModel
         siteStoriesHandler.clear()
         domainRegistrationHandler.clear()
         quickStartRepository.clear()
+        scanAndBackupSource.clear()
         super.onCleared()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ScanAndBackupSource.kt
@@ -39,4 +39,8 @@ class ScanAndBackupSource @Inject constructor(
             emit(JetpackCapabilities(scanAvailable = false, backupAvailable = false))
         }
     }
+
+    fun clear() {
+        jetpackCapabilitiesUseCase.clear()
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -380,6 +380,7 @@ class ActivityLogViewModel @Inject constructor(
              */
             activityLogStore.clearActivityLogCache(site)
         }
+        jetpackCapabilitiesUseCase.clear()
 
         super.onCleared()
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/JetpackCapabilitiesUseCaseTest.kt
@@ -66,24 +66,6 @@ class JetpackCapabilitiesUseCaseTest {
     }
 
     @Test
-    fun `useCase subscribes to event bus`() = test {
-        whenever(dispatcher.dispatch(any())).then { useCase.onJetpackCapabilitiesFetched(event) }
-
-        useCase.getJetpackPurchasedProducts(SITE_ID).toList(mutableListOf())
-
-        verify(dispatcher).register(useCase)
-    }
-
-    @Test
-    fun `useCase unsubscribes from event bus`() = test {
-        whenever(dispatcher.dispatch(any())).then { useCase.onJetpackCapabilitiesFetched(event) }
-
-        useCase.getJetpackPurchasedProducts(SITE_ID).toList(mutableListOf())
-
-        verify(dispatcher).unregister(useCase)
-    }
-
-    @Test
     fun `fetch not invoked, when not older than MAX_CACHE_VALIDITY`() = test {
         val expected = listOf(BACKUP, SCAN)
         whenever(currentTimeProvider.currentDate()).thenReturn(Date(MAX_CACHE_VALIDITY - 1))


### PR DESCRIPTION
Fixes https://sentry.io/share/issue/f425f33b2f5c4245835c7e0fa9e3a3fc/
```
Subscriber class org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase already registered to event class org.wordpress.android.fluxc.store.SiteStore$OnJetpackCapabilitiesFetched
```

The crash happens when jetpack capabilities for multiple site are fetched at the same time. When I wrote the use case I didn't realize that multiple registration to the event bus result in an exception. This PR fixes the issue by moving the registration to "init" and leaving the unregistration to the parent of the use case.

To test:
1. Clear app data
2. Login to an account with at least 3 sites
3. Set Network type: GSM and Signal Strength: Poor in the emulator settings
4. Switch to SiteB
5. Quickly switch to SiteC and notice the app doesn't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


@JavonDavis I'm sorry for not noticing this issue sooner. Unfortunately I think this bug needs to be fixed before the release as it might crash to a lot of users. Trends in Sentry seems to be confirming this. Let me know if I can help with something.
