### PR TITLE
Make sure site model is selected before the ID of the site is emitted

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.mysite
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.map
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
@@ -17,19 +19,15 @@ class SelectedSiteRepository
 ) {
     private var siteSettings: SiteSettingsInterfaceWrapper? = null
     private val _selectedSiteChange = MutableLiveData<SiteModel>()
-    private val _siteSelected = MutableLiveData<Int>()
     private val _showSiteIconProgressBar = MutableLiveData<Boolean>()
     val selectedSiteChange = _selectedSiteChange as LiveData<SiteModel>
-    val siteSelected = _siteSelected as LiveData<Int?>
+    val siteSelected = _selectedSiteChange.map { it?.id }.distinctUntilChanged()
     val showSiteIconProgressBar = _showSiteIconProgressBar as LiveData<Boolean>
     fun updateSite(selectedSite: SiteModel?) {
         if (getSelectedSite()?.iconUrl != selectedSite?.iconUrl) {
             showSiteIconProgressBar(false)
         }
         _selectedSiteChange.value = selectedSite
-        if (selectedSite?.id != _siteSelected.value) {
-            _siteSelected.value = selectedSite?.id
-        }
     }
 
     fun updateSiteIconMediaId(mediaId: Int, showProgressBar: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -26,10 +26,10 @@ class SelectedSiteRepository
         if (getSelectedSite()?.iconUrl != selectedSite?.iconUrl) {
             showSiteIconProgressBar(false)
         }
+        _selectedSiteChange.value = selectedSite
         if (selectedSite?.id != _siteSelected.value) {
             _siteSelected.value = selectedSite?.id
         }
-        _selectedSiteChange.value = selectedSite
     }
 
     fun updateSiteIconMediaId(mediaId: Int, showProgressBar: Boolean) {


### PR DESCRIPTION
Fixes #14104 

The original issue is caused by the selected site missing the first time the app is started. The fix is quite simple. When a site change happens, we first update the site object and as a second step emit the "SiteSelectedId" event.

To test:
- Enable ImprovedMySite feature flag
- Select a site which has Jetpack "Backup" or "Scan" features enabled
- Select MySite screen
- Force close the app
- Start the app and notice "Backup"/"Scan" items are visible

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
