### PR TITLE
Fix NPE when fetchJetpackPurchasedProduct finishes after onViewDestroyed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -287,10 +287,13 @@ class MySiteFragment : Fragment(),
             )
             uiScope.launch {
                 if (!jetpackCapabilitiesUseCase.hasValidCache(site.siteId)) {
-                    updateScanAndBackupVisibility(
-                            site = site,
-                            products = jetpackCapabilitiesUseCase.fetchJetpackPurchasedProducts(site.siteId)
-                    )
+                    val products = jetpackCapabilitiesUseCase.fetchJetpackPurchasedProducts(site.siteId)
+                    view?.let {
+                        updateScanAndBackupVisibility(
+                                site = site,
+                                products = products
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/14107

Hopefully last fix for the beta build. This PR fixes NPE happening when fetchJetpackPurchasedProduct finishes after the fragment's view gets already destroyed - eg. when user switches to a different tab or puts the app into the background.

To test:
1. Slow down internet connection on an emulator
2. Switch site and quickly switch to "Notifications" tab in the bottom navigation
3. Notice the app doesn't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @JavonDavis 
