### PR TITLE
Add stubbing for experiments endpoint

### DIFF
--- a/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/experiments/assignments.json
+++ b/libs/mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/experiments/assignments.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/wpcom/v2/experiments/.*/assignments/.*"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "variations": {},
+      "ttl": 3600
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes the connected tests which were failing because new calls to the `/wpcom/v2/experiments` endpoint were not being stubbed.

To test:

- Make sure all connected tests pass in CI.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

