### PR TITLE
Hide notify me button and footnote on backup download progress view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/builders/BackupDownloadStateListItemBuilder.kt
@@ -84,8 +84,9 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
                 buildActionButtonState(
                         titleRes = R.string.backup_download_progress_action_button,
                         contentDescRes = R.string.backup_download_progress_action_button_content_description,
-                        onClick = onNotifyMeClick),
-                buildFootnoteState(R.string.backup_download_progress_footnote)
+                        onClick = onNotifyMeClick,
+                        isVisible = false),
+                buildFootnoteState(R.string.backup_download_progress_footnote, false)
         )
     }
 
@@ -189,13 +190,15 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
         @StringRes contentDescRes: Int,
         isSecondary: Boolean = false,
         @DrawableRes iconRes: Int? = null,
+        isVisible: Boolean = true,
         onClick: () -> Unit
     ) = ActionButtonState(
         text = UiStringRes(titleRes),
         contentDescription = UiStringRes(contentDescRes),
         isSecondary = isSecondary,
         iconRes = iconRes,
-        onClick = onClick
+        onClick = onClick,
+        isVisible = isVisible
     )
 
     private fun buildSubHeaderState(
@@ -207,8 +210,9 @@ class BackupDownloadStateListItemBuilder @Inject constructor(
                     itemTopMarginResId = topMarginResId,
                     itemBottomMarginResId = bottomMarginResId)
 
-    private fun buildFootnoteState(@StringRes textRes: Int) = FootnoteState(
-            UiStringRes(textRes)
+    private fun buildFootnoteState(@StringRes textRes: Int, isVisible: Boolean = true) = FootnoteState(
+            text = UiStringRes(textRes),
+            isVisible = isVisible
     )
 
     private fun buildProgressState(progress: Int) = ProgressState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/JetpackBackupRestoreListItemState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/JetpackBackupRestoreListItemState.kt
@@ -13,7 +13,7 @@ sealed class JetpackBackupRestoreListItemState(override val type: ViewType) : Je
         @DimenRes val itemBottomMarginResId: Int? = null
     ) : JetpackBackupRestoreListItemState(ViewType.BACKUP_RESTORE_SUB_HEADER)
 
-    data class FootnoteState(val text: UiString) :
+    data class FootnoteState(val text: UiString, val isVisible: Boolean = true) :
             JetpackListItemState(ViewType.BACKUP_RESTORE_FOOTNOTE)
 
     data class BulletState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/viewholders/JetpackBackupRestoreFootnoteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/common/viewholders/JetpackBackupRestoreFootnoteViewHolder.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.jetpack.common.viewholders
 
+import android.view.View
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.jetpack_backup_restore_list_footnote_item.*
 import org.wordpress.android.R
@@ -14,5 +15,6 @@ class JetpackBackupRestoreFootnoteViewHolder(
     override fun onBind(itemUiState: JetpackListItemState) {
         val state = itemUiState as FootnoteState
         footnote.text = uiHelpers.getTextOfUiString(itemView.context, state.text)
+        footnote.visibility = if (state.isVisible) View.VISIBLE else View.GONE
     }
 }


### PR DESCRIPTION
Fixes #14110 

This PR addresses an issue in the Jetpack Backup Download feature. It temporarily hides the "Let me know when finished" button and the informational footnote from the backup download in progress view.

**To test:**
- Go to My Site > Jetpack > Backup > overflow menu > Download backup.
- Tap the "Create downloadable file" button.
- Observe that following:
- The  "Let me know when finished!" button is not shown
- The footnote "No need to wait around. We'll notify you when your backup is ready." is not shown

**Notes**
-This PR will be merged against release/16.7
- Merging back into develop may be tricky since the button code no longer exists and FootnoteState has changed. Please reach out and I can give a hand. Thanks!

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

FYI @designsimply 