### PR TITLE
Video compression: managing npe and tracking it in MEDIA_VIDEO_CANT_OPTIMIZE event

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/VideoOptimizer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/VideoOptimizer.java
@@ -97,7 +97,10 @@ public class VideoOptimizer implements org.m4m.IProgressListener {
                     AppPrefs.getVideoOptimizeWidth(),
                     AppPrefs.getVideoOptimizeQuality());
         } catch (NullPointerException npe) {
-            AppLog.w(AppLog.T.MEDIA, "VideoOptimizer > NullPointerException while getting composer " + npe.getMessage());
+            AppLog.w(
+                    AppLog.T.MEDIA,
+                    "VideoOptimizer > NullPointerException while getting composer " + npe.getMessage()
+            );
             wasNpeDetected = true;
         }
 


### PR DESCRIPTION
Fixes #13692 

This PR introduces the management of NPE when attempting to compress a video file before the upload and align the behavior in this scenario to what we already do with other cases when getting an error during compression operations (that is fallback to uploading the video uncompressed).

An npe event is tracked in the `MEDIA_VIDEO_CANT_OPTIMIZE` event adding the `was_npe_detected=true` property.

NOTE: we have an open PR contributed [here](https://github.com/INDExOS/media-for-mobile/pull/100) that actually fixes the original issue but waiting for an eventual follow up this fix seems good enough also given it seems a pretty edge case looking at numbers in sentry with `m4m` string. Reporting here also this internal reference (p2y3YZ-4nh-p2) where we considered other possible approaches.

### To test
Not trivial to replicate since it happens only with specific videos, but you can use the mp4 video linked in p2y3YZ-4nh-p2

- Check Video Compression and tracks are active in the app settings
- Place the mp4 video on your device or on google drive
- In the Media screen, try to upload it from device
- With the debugger (or filtering logcat with `VideoOptimizer >`) check you get a npe but it is managed (so no crash) and the video is uploaded uncompressed
- Check that `MEDIA_VIDEO_CANT_OPTIMIZE` event is fired and contains `was_npe_detected=true`
- Make same check as above in the editor trying to upload the video from device
- Smoke test that no regression is introduced in other scenarios or with other media(s) file or type

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
