### PR TITLE
Only show Snackbar in stories when the target view is present

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -6,6 +6,7 @@ import android.app.ProgressDialog
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -80,7 +81,6 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.util.ToastUtils
-import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.widgets.WPSnackbar
 import java.util.Objects
@@ -383,16 +383,17 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
                 }
         )
         storyEditorMedia.snackBarMessage.observe(this,
-                Observer<Event<SnackbarMessageHolder>> { event: Event<SnackbarMessageHolder?> ->
-                    val messageHolder = event.getContentIfNotHandled()
-                    if (messageHolder != null) {
-                        WPSnackbar
-                                .make(
-                                        findViewById(org.wordpress.android.R.id.editor_activity),
-                                        uiHelpers.getTextOfUiString(this, messageHolder.message),
-                                        Snackbar.LENGTH_SHORT
-                                )
-                                .show()
+                { event: Event<SnackbarMessageHolder?> ->
+                    event.getContentIfNotHandled()?.let { messageHolder ->
+                        findViewById<View>(R.id.editor_activity)?.let {
+                            WPSnackbar
+                                    .make(
+                                            it,
+                                            uiHelpers.getTextOfUiString(this, messageHolder.message),
+                                            Snackbar.LENGTH_SHORT
+                                    )
+                                    .show()
+                        }
                     }
                 }
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -385,7 +385,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         storyEditorMedia.snackBarMessage.observe(this,
                 { event: Event<SnackbarMessageHolder?> ->
                     event.getContentIfNotHandled()?.let { messageHolder ->
-                        findViewById<View>(R.id.editor_activity)?.let {
+                        findViewById<View>(R.id.compose_loop_frame_layout)?.let {
                             WPSnackbar
                                     .make(
                                             it,


### PR DESCRIPTION
Fixes #13679 

This fix is fairly straightforward problem. We're trying to show a snackbar on a view that's not there. The reason is that the target view is in the EditPostActivity and the crash happens in StoryComposerActivity. What is the desired behaviour? Do we want to show the snackbar in the EPA or is it an oversight? We might want to consider switching views to `compose_loop_frame_layout`. WDYT @mzorz ? 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
