### PR TITLE
Add "Create your site" Quick Start card illustrations

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartItemBuilder.kt
@@ -119,8 +119,7 @@ class QuickStartItemBuilder
             EDIT_HOMEPAGE -> R.drawable.img_illustration_quick_start_task_edit_your_homepage
             REVIEW_PAGES -> R.drawable.img_illustration_quick_start_task_review_site_pages
             EXPLORE_PLANS -> R.drawable.img_illustration_quick_start_task_explore_plans
-            // Replace with an actual drawable or change the tasks, and then remove the placeholders
-            CREATE_SITE -> R.drawable.bg_quick_start_customize_task_illustration_placeholder
+            CREATE_SITE -> R.drawable.img_illustration_quick_start_task_create_site
             QuickStartTask.UNKNOWN -> R.drawable.bg_quick_start_grow_task_illustration_placeholder
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartItemBuilder.kt
@@ -120,7 +120,7 @@ class QuickStartItemBuilder
             REVIEW_PAGES -> R.drawable.img_illustration_quick_start_task_review_site_pages
             EXPLORE_PLANS -> R.drawable.img_illustration_quick_start_task_explore_plans
             CREATE_SITE -> R.drawable.img_illustration_quick_start_task_create_site
-            QuickStartTask.UNKNOWN -> R.drawable.bg_quick_start_grow_task_illustration_placeholder
+            QuickStartTask.UNKNOWN -> R.drawable.img_illustration_quick_start_task_placeholder
         }
     }
 }

--- a/WordPress/src/main/res/drawable-night/bg_quick_start_customize_task_illustration_placeholder.xml
+++ b/WordPress/src/main/res/drawable-night/bg_quick_start_customize_task_illustration_placeholder.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- TODO We should remove this after updating Quick Start tasks -->
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/gray_80" />
-    <size
-        android:height="94dp"
-        android:width="168dp" />
-</shape>

--- a/WordPress/src/main/res/drawable-night/bg_quick_start_grow_task_illustration_placeholder.xml
+++ b/WordPress/src/main/res/drawable-night/bg_quick_start_grow_task_illustration_placeholder.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- TODO We should remove this after updating Quick Start tasks -->
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/gray_80" />
-    <size
-        android:height="94dp"
-        android:width="168dp" />
-</shape>

--- a/WordPress/src/main/res/drawable-night/img_illustration_quick_start_task_create_site.xml
+++ b/WordPress/src/main/res/drawable-night/img_illustration_quick_start_task_create_site.xml
@@ -1,0 +1,54 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="168dp"
+    android:height="94dp"
+    android:viewportWidth="168"
+    android:viewportHeight="94">
+    <path
+        android:fillColor="#2C2C2E"
+        android:fillType="nonZero"
+        android:pathData="M0,0h168v94h-168z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#64D2FF"
+        android:fillType="nonZero"
+        android:pathData="M143.675,53.881l0.209,7.955l-7.997,0.208l4.054,-4.086z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#FFD60A"
+        android:fillType="nonZero"
+        android:pathData="M48.796,38.69a3.272,3.255 0,1 0,6.544 0a3.272,3.255 0,1 0,-6.544 0z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#FF9500"
+        android:fillType="nonZero"
+        android:pathData="M102.34,74.712a3.272,3.255 0,1 0,6.544 0a3.272,3.255 0,1 0,-6.544 0z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#32D74B"
+        android:fillType="nonZero"
+        android:pathData="M22.686,21.084a2.43,2.417 0,1 0,4.86 0a2.43,2.417 0,1 0,-4.86 0z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#0A84FF"
+        android:fillType="nonZero"
+        android:pathData="M111.884,25.08a3.415,3.397 0,1 0,6.83 0a3.415,3.397 0,1 0,-6.83 0z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#FF375F"
+        android:fillType="nonZero"
+        android:pathData="M82.75,46.289L81.435,43.629C81.188,43.145 81.682,42.661 82.175,42.984L84.804,44.435L87.106,42.419C87.517,42.097 88.092,42.419 88.01,42.903L87.434,45.886L90.064,47.338C90.557,47.579 90.393,48.224 89.818,48.305L86.941,48.547L86.366,51.691C86.284,52.175 85.544,52.256 85.38,51.772L84.065,48.869L80.86,49.273C80.367,49.353 80.038,48.708 80.449,48.386L82.75,46.289Z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#007AFF"
+        android:fillType="nonZero"
+        android:pathData="M34.835,69.271L34.054,67.69C33.907,67.402 34.201,67.115 34.494,67.306L36.057,68.169L37.424,66.971C37.668,66.779 38.01,66.971 37.961,67.258L37.62,69.031L39.183,69.894C39.476,70.038 39.378,70.421 39.036,70.469L37.327,70.613L36.985,72.482C36.936,72.769 36.496,72.817 36.398,72.53L35.617,70.804L33.712,71.044C33.419,71.092 33.224,70.709 33.468,70.517L34.835,69.271Z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+</vector>

--- a/WordPress/src/main/res/drawable-night/img_illustration_quick_start_task_create_site.xml
+++ b/WordPress/src/main/res/drawable-night/img_illustration_quick_start_task_create_site.xml
@@ -4,51 +4,27 @@
     android:viewportWidth="168"
     android:viewportHeight="94">
     <path
-        android:fillColor="#2C2C2E"
-        android:fillType="nonZero"
-        android:pathData="M0,0h168v94h-168z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:fillColor="@color/gray_80"
+        android:pathData="M0 0h168v94H0z" />
     <path
         android:fillColor="#64D2FF"
-        android:fillType="nonZero"
-        android:pathData="M143.675,53.881l0.209,7.955l-7.997,0.208l4.054,-4.086z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M143.675 53.881l0.209 7.955-7.997 0.208 4.054-4.086z" />
     <path
         android:fillColor="#FFD60A"
-        android:fillType="nonZero"
-        android:pathData="M48.796,38.69a3.272,3.255 0,1 0,6.544 0a3.272,3.255 0,1 0,-6.544 0z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M48.796 38.69a3.272 3.255 0 1 0 6.544 0 3.272 3.255 0 1 0-6.544 0z" />
     <path
         android:fillColor="#FF9500"
-        android:fillType="nonZero"
-        android:pathData="M102.34,74.712a3.272,3.255 0,1 0,6.544 0a3.272,3.255 0,1 0,-6.544 0z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M102.34 74.712a3.272 3.255 0 1 0 6.544 0 3.272 3.255 0 1 0-6.544 0z" />
     <path
         android:fillColor="#32D74B"
-        android:fillType="nonZero"
-        android:pathData="M22.686,21.084a2.43,2.417 0,1 0,4.86 0a2.43,2.417 0,1 0,-4.86 0z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M22.686 21.084a2.43 2.417 0 1 0 4.86 0 2.43 2.417 0 1 0-4.86 0z" />
     <path
         android:fillColor="#0A84FF"
-        android:fillType="nonZero"
-        android:pathData="M111.884,25.08a3.415,3.397 0,1 0,6.83 0a3.415,3.397 0,1 0,-6.83 0z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M111.884 25.08a3.415 3.397 0 1 0 6.83 0 3.415 3.397 0 1 0-6.83 0z" />
     <path
         android:fillColor="#FF375F"
-        android:fillType="nonZero"
-        android:pathData="M82.75,46.289L81.435,43.629C81.188,43.145 81.682,42.661 82.175,42.984L84.804,44.435L87.106,42.419C87.517,42.097 88.092,42.419 88.01,42.903L87.434,45.886L90.064,47.338C90.557,47.579 90.393,48.224 89.818,48.305L86.941,48.547L86.366,51.691C86.284,52.175 85.544,52.256 85.38,51.772L84.065,48.869L80.86,49.273C80.367,49.353 80.038,48.708 80.449,48.386L82.75,46.289Z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M82.75 46.289l-1.315-2.66c-0.247-0.484 0.247-0.968 0.74-0.645l2.629 1.451 2.302-2.016c0.411-0.322 0.986 0 0.904 0.484l-0.576 2.983 2.63 1.452c0.493 0.241 0.329 0.886-0.246 0.967l-2.877 0.242-0.575 3.144c-0.082 0.484-0.822 0.565-0.986 0.081l-1.315-2.903-3.205 0.404c-0.493 0.08-0.822-0.565-0.411-0.887l2.301-2.097z" />
     <path
         android:fillColor="#007AFF"
-        android:fillType="nonZero"
-        android:pathData="M34.835,69.271L34.054,67.69C33.907,67.402 34.201,67.115 34.494,67.306L36.057,68.169L37.424,66.971C37.668,66.779 38.01,66.971 37.961,67.258L37.62,69.031L39.183,69.894C39.476,70.038 39.378,70.421 39.036,70.469L37.327,70.613L36.985,72.482C36.936,72.769 36.496,72.817 36.398,72.53L35.617,70.804L33.712,71.044C33.419,71.092 33.224,70.709 33.468,70.517L34.835,69.271Z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M34.835 69.271l-0.781-1.581c-0.147-0.288 0.147-0.575 0.44-0.384l1.563 0.863 1.367-1.198c0.244-0.192 0.586 0 0.537 0.287l-0.341 1.773 1.563 0.863c0.293 0.144 0.195 0.527-0.147 0.575l-1.709 0.144-0.342 1.869c-0.049 0.287-0.489 0.335-0.587 0.048l-0.781-1.726-1.905 0.24c-0.293 0.048-0.488-0.335-0.244-0.527l1.367-1.246z" />
 </vector>

--- a/WordPress/src/main/res/drawable/bg_quick_start_customize_task_illustration_placeholder.xml
+++ b/WordPress/src/main/res/drawable/bg_quick_start_customize_task_illustration_placeholder.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- TODO We should remove this after updating Quick Start tasks -->
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/gray_0" />
-    <size
-        android:height="94dp"
-        android:width="168dp" />
-</shape>

--- a/WordPress/src/main/res/drawable/bg_quick_start_grow_task_illustration_placeholder.xml
+++ b/WordPress/src/main/res/drawable/bg_quick_start_grow_task_illustration_placeholder.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- TODO We should remove this after updating Quick Start tasks -->
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/orange_0" />
-    <size
-        android:height="94dp"
-        android:width="168dp" />
-</shape>

--- a/WordPress/src/main/res/drawable/img_illustration_quick_start_task_create_site.xml
+++ b/WordPress/src/main/res/drawable/img_illustration_quick_start_task_create_site.xml
@@ -4,51 +4,27 @@
     android:viewportWidth="168"
     android:viewportHeight="94">
     <path
-        android:fillColor="#F6F7F7"
-        android:fillType="nonZero"
-        android:pathData="M0,0h168v94h-168z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:fillColor="@color/gray_0"
+        android:pathData="M0 0h168v94H0z" />
     <path
         android:fillColor="#64D2FF"
-        android:fillType="nonZero"
-        android:pathData="M143.675,53.881l0.209,7.955l-7.997,0.208l4.054,-4.086z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M143.675 53.881l0.209 7.955-7.997 0.208 4.054-4.086z" />
     <path
         android:fillColor="#FFD60A"
-        android:fillType="nonZero"
-        android:pathData="M48.796,38.69a3.272,3.255 0,1 0,6.544 0a3.272,3.255 0,1 0,-6.544 0z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M48.796 38.69a3.272 3.255 0 1 0 6.544 0 3.272 3.255 0 1 0-6.544 0z" />
     <path
         android:fillColor="#FF9500"
-        android:fillType="nonZero"
-        android:pathData="M102.34,74.712a3.272,3.255 0,1 0,6.544 0a3.272,3.255 0,1 0,-6.544 0z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M102.34 74.712a3.272 3.255 0 1 0 6.544 0 3.272 3.255 0 1 0-6.544 0z" />
     <path
         android:fillColor="#32D74B"
-        android:fillType="nonZero"
-        android:pathData="M22.686,21.084a2.43,2.417 0,1 0,4.86 0a2.43,2.417 0,1 0,-4.86 0z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M22.686 21.084a2.43 2.417 0 1 0 4.86 0 2.43 2.417 0 1 0-4.86 0z" />
     <path
         android:fillColor="#0A84FF"
-        android:fillType="nonZero"
-        android:pathData="M111.884,25.08a3.415,3.397 0,1 0,6.83 0a3.415,3.397 0,1 0,-6.83 0z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M111.884 25.08a3.415 3.397 0 1 0 6.83 0 3.415 3.397 0 1 0-6.83 0z" />
     <path
         android:fillColor="#FF375F"
-        android:fillType="nonZero"
-        android:pathData="M82.75,46.289L81.435,43.629C81.188,43.145 81.682,42.661 82.175,42.984L84.804,44.435L87.106,42.419C87.517,42.097 88.092,42.419 88.01,42.903L87.434,45.886L90.064,47.338C90.557,47.579 90.393,48.224 89.818,48.305L86.941,48.547L86.366,51.691C86.284,52.175 85.544,52.256 85.38,51.772L84.065,48.869L80.86,49.273C80.367,49.353 80.038,48.708 80.449,48.386L82.75,46.289Z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M82.75 46.289l-1.315-2.66c-0.247-0.484 0.247-0.968 0.74-0.645l2.629 1.451 2.302-2.016c0.411-0.322 0.986 0 0.904 0.484l-0.576 2.983 2.63 1.452c0.493 0.241 0.329 0.886-0.246 0.967l-2.877 0.242-0.575 3.144c-0.082 0.484-0.822 0.565-0.986 0.081l-1.315-2.903-3.205 0.404c-0.493 0.08-0.822-0.565-0.411-0.887l2.301-2.097z" />
     <path
         android:fillColor="#007AFF"
-        android:fillType="nonZero"
-        android:pathData="M34.835,69.271L34.054,67.69C33.907,67.402 34.201,67.115 34.494,67.306L36.057,68.169L37.424,66.971C37.668,66.779 38.01,66.971 37.961,67.258L37.62,69.031L39.183,69.894C39.476,70.038 39.378,70.421 39.036,70.469L37.327,70.613L36.985,72.482C36.936,72.769 36.496,72.817 36.398,72.53L35.617,70.804L33.712,71.044C33.419,71.092 33.224,70.709 33.468,70.517L34.835,69.271Z"
-        android:strokeWidth="1"
-        android:strokeColor="#00000000" />
+        android:pathData="M34.835 69.271l-0.781-1.581c-0.147-0.288 0.147-0.575 0.44-0.384l1.563 0.863 1.367-1.198c0.244-0.192 0.586 0 0.537 0.287l-0.341 1.773 1.563 0.863c0.293 0.144 0.195 0.527-0.147 0.575l-1.709 0.144-0.342 1.869c-0.049 0.287-0.489 0.335-0.587 0.048l-0.781-1.726-1.905 0.24c-0.293 0.048-0.488-0.335-0.244-0.527l1.367-1.246z" />
 </vector>

--- a/WordPress/src/main/res/drawable/img_illustration_quick_start_task_create_site.xml
+++ b/WordPress/src/main/res/drawable/img_illustration_quick_start_task_create_site.xml
@@ -1,0 +1,54 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="168dp"
+    android:height="94dp"
+    android:viewportWidth="168"
+    android:viewportHeight="94">
+    <path
+        android:fillColor="#F6F7F7"
+        android:fillType="nonZero"
+        android:pathData="M0,0h168v94h-168z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#64D2FF"
+        android:fillType="nonZero"
+        android:pathData="M143.675,53.881l0.209,7.955l-7.997,0.208l4.054,-4.086z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#FFD60A"
+        android:fillType="nonZero"
+        android:pathData="M48.796,38.69a3.272,3.255 0,1 0,6.544 0a3.272,3.255 0,1 0,-6.544 0z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#FF9500"
+        android:fillType="nonZero"
+        android:pathData="M102.34,74.712a3.272,3.255 0,1 0,6.544 0a3.272,3.255 0,1 0,-6.544 0z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#32D74B"
+        android:fillType="nonZero"
+        android:pathData="M22.686,21.084a2.43,2.417 0,1 0,4.86 0a2.43,2.417 0,1 0,-4.86 0z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#0A84FF"
+        android:fillType="nonZero"
+        android:pathData="M111.884,25.08a3.415,3.397 0,1 0,6.83 0a3.415,3.397 0,1 0,-6.83 0z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#FF375F"
+        android:fillType="nonZero"
+        android:pathData="M82.75,46.289L81.435,43.629C81.188,43.145 81.682,42.661 82.175,42.984L84.804,44.435L87.106,42.419C87.517,42.097 88.092,42.419 88.01,42.903L87.434,45.886L90.064,47.338C90.557,47.579 90.393,48.224 89.818,48.305L86.941,48.547L86.366,51.691C86.284,52.175 85.544,52.256 85.38,51.772L84.065,48.869L80.86,49.273C80.367,49.353 80.038,48.708 80.449,48.386L82.75,46.289Z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+    <path
+        android:fillColor="#007AFF"
+        android:fillType="nonZero"
+        android:pathData="M34.835,69.271L34.054,67.69C33.907,67.402 34.201,67.115 34.494,67.306L36.057,68.169L37.424,66.971C37.668,66.779 38.01,66.971 37.961,67.258L37.62,69.031L39.183,69.894C39.476,70.038 39.378,70.421 39.036,70.469L37.327,70.613L36.985,72.482C36.936,72.769 36.496,72.817 36.398,72.53L35.617,70.804L33.712,71.044C33.419,71.092 33.224,70.709 33.468,70.517L34.835,69.271Z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+</vector>

--- a/WordPress/src/main/res/drawable/img_illustration_quick_start_task_placeholder.xml
+++ b/WordPress/src/main/res/drawable/img_illustration_quick_start_task_placeholder.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/purple_0" />
+    <size
+        android:width="168dp"
+        android:height="94dp" />
+</shape>


### PR DESCRIPTION
This PR adds illustrations for the "Create your site" Quick Start task and also removes some old placeholders.

To test:

1. Turn on the Improved My Site flag and restart the app.
1. Go to the My Site screen.
1. Notice the Quick Start Task cards.
1. Scroll to the end of the "Customize your site" section.
1. Make sure the "Create your site" task have the correct illustration and that nothing looks off.
1. Switch to dark mode and repeat.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

