### PR TITLE
Jetpack Section - Tablet layout

### DIFF
--- a/WordPress/src/main/res/layout/scan_fragment.xml
+++ b/WordPress/src/main/res/layout/scan_fragment.xml
@@ -18,6 +18,8 @@
 
     <org.wordpress.android.ui.prefs.EmptyViewRecyclerView
         android:id="@+id/recycler_view"
+        android:paddingStart="@dimen/jetpack_scan_content_margin"
+        android:paddingEnd="@dimen/jetpack_scan_content_margin"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"

--- a/WordPress/src/main/res/layout/scan_history_list_fragment.xml
+++ b/WordPress/src/main/res/layout/scan_history_list_fragment.xml
@@ -8,6 +8,8 @@
         android:id="@+id/recycler_view"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:paddingEnd="@dimen/jetpack_scan_content_margin"
+        android:paddingStart="@dimen/jetpack_scan_content_margin"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/layout/threat_details_fragment.xml
+++ b/WordPress/src/main/res/layout/threat_details_fragment.xml
@@ -10,12 +10,14 @@
         android:id="@+id/recycler_view"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginStart="@dimen/margin_extra_large"
         android:layout_marginEnd="@dimen/margin_extra_large"
+        android:layout_marginStart="@dimen/margin_extra_large"
+        android:paddingEnd="@dimen/jetpack_scan_content_margin"
+        android:paddingStart="@dimen/jetpack_scan_content_margin"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values-land/dimens.xml
+++ b/WordPress/src/main/res/values-land/dimens.xml
@@ -4,5 +4,4 @@
     <!-- login -->
     <dimen name="prologue_promo_title_size">24sp</dimen>
     <dimen name="prologue_promo_illustration_margin_bottom">48dp</dimen>
-    <dimen name="jetpack_button_max_width">244dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values-land/dimens.xml
+++ b/WordPress/src/main/res/values-land/dimens.xml
@@ -4,5 +4,5 @@
     <!-- login -->
     <dimen name="prologue_promo_title_size">24sp</dimen>
     <dimen name="prologue_promo_illustration_margin_bottom">48dp</dimen>
-
+    <dimen name="jetpack_button_max_width">244dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w600dp/dimens.xml
+++ b/WordPress/src/main/res/values-w600dp/dimens.xml
@@ -11,5 +11,5 @@
     <dimen name="site_creation_content_margin">@dimen/content_margin_tablet</dimen>
     <dimen name="post_list_content_margin_standard">@dimen/content_margin_tablet</dimen>
     <dimen name="interests_content_margin">@dimen/margin_extra_extra_large</dimen>
-
+    <dimen name="jetpack_scan_content_margin">@dimen/content_margin_tablet</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w720dp/dimens.xml
+++ b/WordPress/src/main/res/values-w720dp/dimens.xml
@@ -10,5 +10,6 @@
     <dimen name="notifications_content_margin">@dimen/content_margin_tablet_big</dimen>
     <dimen name="site_creation_content_margin">@dimen/content_margin_tablet_big</dimen>
     <dimen name="post_list_content_margin_standard">@dimen/content_margin_tablet_big</dimen>
-
+    <dimen name="jetpack_scan_content_margin">@dimen/content_margin_tablet_big</dimen>
+    <dimen name="jetpack_button_max_width">244dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w720dp/dimens.xml
+++ b/WordPress/src/main/res/values-w720dp/dimens.xml
@@ -11,5 +11,4 @@
     <dimen name="site_creation_content_margin">@dimen/content_margin_tablet_big</dimen>
     <dimen name="post_list_content_margin_standard">@dimen/content_margin_tablet_big</dimen>
     <dimen name="jetpack_scan_content_margin">@dimen/content_margin_tablet_big</dimen>
-    <dimen name="jetpack_button_max_width">244dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -440,6 +440,8 @@
     <dimen name="scan_icon_size">48dp</dimen>
     <dimen name="scan_icon_margin">16dp</dimen>
     <dimen name="scan_threat_item_icon_size">40dp</dimen>
+    <dimen name="jetpack_scan_content_margin">@dimen/content_margin_none</dimen>
+    <dimen name="jetpack_button_max_width">0dp</dimen>
 
     <!-- actionable empty view -->
     <dimen name="actionable_empty_view_text_margin_horizontal">30dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -441,7 +441,6 @@
     <dimen name="scan_icon_margin">16dp</dimen>
     <dimen name="scan_threat_item_icon_size">40dp</dimen>
     <dimen name="jetpack_scan_content_margin">@dimen/content_margin_none</dimen>
-    <dimen name="jetpack_button_max_width">0dp</dimen>
 
     <!-- actionable empty view -->
     <dimen name="actionable_empty_view_text_margin_horizontal">30dp</dimen>

--- a/WordPress/src/main/res/values/jetpack_styles.xml
+++ b/WordPress/src/main/res/values/jetpack_styles.xml
@@ -52,6 +52,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">@dimen/margin_small</item>
         <item name="android:layout_marginBottom">@dimen/margin_small</item>
+        <item name="layout_constraintWidth_max">@dimen/jetpack_button_max_width</item>
+        <item name="layout_constraintHorizontal_bias">0</item>
     </style>
 
     <style name="Jetpack.SecondaryButton" parent="Widget.MaterialComponents.Button.OutlinedButton">
@@ -61,6 +63,8 @@
         <item name="materialThemeOverlay">@style/ThemeOverlay.SecondaryButton.OnSurface</item>
         <item name="android:layout_marginTop">@dimen/margin_small</item>
         <item name="android:layout_marginBottom">@dimen/margin_small</item>
+        <item name="layout_constraintWidth_max">@dimen/jetpack_button_max_width</item>
+        <item name="layout_constraintHorizontal_bias">0</item>
     </style>
 
     <style name="ThemeOverlay.SecondaryButton.OnSurface" parent="">

--- a/WordPress/src/main/res/values/jetpack_styles.xml
+++ b/WordPress/src/main/res/values/jetpack_styles.xml
@@ -52,7 +52,6 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">@dimen/margin_small</item>
         <item name="android:layout_marginBottom">@dimen/margin_small</item>
-        <item name="layout_constraintWidth_max">@dimen/jetpack_button_max_width</item>
         <item name="layout_constraintHorizontal_bias">0</item>
     </style>
 
@@ -63,7 +62,6 @@
         <item name="materialThemeOverlay">@style/ThemeOverlay.SecondaryButton.OnSurface</item>
         <item name="android:layout_marginTop">@dimen/margin_small</item>
         <item name="android:layout_marginBottom">@dimen/margin_small</item>
-        <item name="layout_constraintWidth_max">@dimen/jetpack_button_max_width</item>
         <item name="layout_constraintHorizontal_bias">0</item>
     </style>
 


### PR DESCRIPTION
Parent issue #13326

- Updates max_content_width on Scan screens

Todo 
- Update max content width on Activity Log/Backup list
- Update max content width on Restore/Download flows
- Update "Fix All/Scan" buttons on Scan screen per Chris's suggestion -> next to each other using wrap_content + padding


~@osullivanchris To be honest, I'm not fully convinced the smaller buttons look better. Here is a list of screenshots - https://cloudup.com/icSAHnNNNbp~



 
To test:
tbd

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
