### PR TITLE
Remove Quick Start category card when all its tasks are completed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -76,7 +76,6 @@ class QuickStartRepository
     val activeTask = _activeTask as LiveData<QuickStartTask?>
 
     private var pendingTask: QuickStartTask? = null
-    private var pendingCategoryCompletion: QuickStartTaskType? = null
 
     private fun buildQuickStartCategory(siteId: Int, quickStartTaskType: QuickStartTaskType) = QuickStartCategory(
             quickStartTaskType,
@@ -94,7 +93,11 @@ class QuickStartRepository
             refresh()
         }
         val quickStartTaskTypes = refresh.mapAsync(coroutineScope) {
-            dynamicCardStore.getCards(siteId).dynamicCardTypes.map { it.toQuickStartTaskType() }
+            dynamicCardStore.getCards(siteId).dynamicCardTypes.map { it.toQuickStartTaskType() }.onEach { taskType ->
+                if (quickStartUtils.isEveryQuickStartTaskDoneForType(siteId, taskType)) {
+                    onCategoryCompleted(taskType)
+                }
+            }
         }
         return merge(quickStartTaskTypes, activeTask) { types, activeTask ->
             val categories = if (quickStartUtils.isQuickStartInProgress(siteId)) {
@@ -115,7 +118,6 @@ class QuickStartRepository
 
     fun refresh() {
         refresh.postValue(true)
-        showCategoryCompletionMessageIfNeeded()
     }
 
     fun setActiveTask(task: QuickStartTask) {
@@ -154,9 +156,6 @@ class QuickStartRepository
             // If we want notice and reminders, we should call QuickStartUtils.completeTaskAndRemindNextOne here
             quickStartStore.setDoneTask(site.id.toLong(), task, true)
             analyticsTrackerWrapper.track(quickStartUtils.getTaskCompletedTracker(task))
-            if (quickStartUtils.isEveryQuickStartTaskDoneForType(site.id, task.taskType)) {
-                pendingCategoryCompletion = task.taskType
-            }
             // We need to refresh immediately. This is useful for tasks that are completed on the My Site screen.
             if (refreshImmediately) {
                 refresh()
@@ -180,9 +179,8 @@ class QuickStartRepository
         job.cancel()
     }
 
-    private fun showCategoryCompletionMessageIfNeeded() = pendingCategoryCompletion?.let { taskType ->
-        pendingCategoryCompletion = null
-        val completionMessage = getCategoryCompletionMessage(taskType)
+    private fun onCategoryCompleted(categoryType: QuickStartTaskType) {
+        val completionMessage = getCategoryCompletionMessage(categoryType)
         _onSnackbar.postValue(Event(SnackbarMessageHolder(UiStringText(completionMessage.asHtml()))))
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -102,7 +102,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `refresh shows completion message if all tasks of a same type have been completed`() = test {
+    fun `refresh shows completion message and removes card if all tasks of a same type have been completed`() = test {
         initStore()
 
         val completionMessage = "All tasks completed!"
@@ -118,6 +118,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
         quickStartRepository.refresh()
 
         assertThat(snackbars).containsOnly(SnackbarMessageHolder(UiStringText(completionMessage)))
+
+        verify(dynamicCardStore).removeCard(siteId, GROW_QUICK_START)
     }
 
     @Test
@@ -251,6 +253,8 @@ class QuickStartRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `marks EDIT_HOMEPAGE task as done when site showing Posts instead of Homepage`() = test {
+        initStore()
+
         val updatedSiteId = 2
         site.id = updatedSiteId
         site.showOnFront = ShowOnFront.POSTS.value


### PR DESCRIPTION
Fixes #14073 

This PR is sort of a follow up to #14064 as it removes the card of a Quick Start category after all its tasks have been completed:

https://user-images.githubusercontent.com/830056/108789300-bb9afa80-7558-11eb-8907-2d35cc8b58f5.mp4

### To test

1. Turn on the Improved My Site flag and restart the app.
1. Go to the My Site screen and select a site where Quick Start is active.
1. Complete all tasks under the same Quick Start category.
1. After completing the last task, notice the completion snackbar message for that category is shown.
1. Notice the category is still being shown.
1. Go to another screen and then come back.
1. Notice the category is now gone.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
