### PR TITLE
Issue/14128 revert removed related posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -367,7 +367,7 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
                 AnalyticsUtils.trackWithBlogPostDetails(AnalyticsTracker.Stat.READER_VIEWPOST_INTERCEPTED,
                         blogId, postId);
 
-                ReaderActivityLauncher.showReaderPostDetail(this, false, blogId, postId, null, 0,
+                ReaderActivityLauncher.showReaderPostDetail(this, false, blogId, postId, null, 0, false,
                         mInterceptedUri);
             } catch (NumberFormatException e) {
                 AppLog.e(T.READER, e);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -33,7 +33,7 @@ public class ReaderActivityLauncher {
      * with a single post
      */
     public static void showReaderPostDetail(Context context, long blogId, long postId) {
-        showReaderPostDetail(context, false, blogId, postId, null, 0, null);
+        showReaderPostDetail(context, false, blogId, postId, null, 0, false, null);
     }
 
     public static void showReaderPostDetail(Context context,
@@ -42,6 +42,7 @@ public class ReaderActivityLauncher {
                                             long postId,
                                             DirectOperation directOperation,
                                             int commentId,
+                                            boolean isRelatedPost,
                                             String interceptedUri) {
         Intent intent = new Intent(context, ReaderPostPagerActivity.class);
         intent.putExtra(ReaderConstants.ARG_IS_FEED, isFeed);
@@ -50,6 +51,7 @@ public class ReaderActivityLauncher {
         intent.putExtra(ReaderConstants.ARG_DIRECT_OPERATION, directOperation);
         intent.putExtra(ReaderConstants.ARG_COMMENT_ID, commentId);
         intent.putExtra(ReaderConstants.ARG_IS_SINGLE_POST, true);
+        intent.putExtra(ReaderConstants.ARG_IS_RELATED_POST, isRelatedPost);
         intent.putExtra(ReaderConstants.ARG_INTERCEPTED_URI, interceptedUri);
         context.startActivity(intent);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -47,6 +47,7 @@ public class ReaderConstants {
     static final String ARG_POST_LIST_TYPE = "post_list_type";
     static final String ARG_CONTENT = "content";
     static final String ARG_IS_SINGLE_POST = "is_single_post";
+    static final String ARG_IS_RELATED_POST = "is_related_post";
     static final String ARG_SEARCH_QUERY = "search_query";
     static final String ARG_VIDEO_URL = "video_url";
     static final String ARG_IS_TOP_LEVEL = "is_top_level";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -121,6 +121,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
     private boolean mPostSlugsResolutionUnderway;
     private boolean mIsRequestingMorePosts;
     private boolean mIsSinglePostView;
+    private boolean mIsRelatedPostView;
 
     private boolean mBackFromLogin;
 
@@ -153,6 +154,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
                     .getSerializable(ReaderConstants.ARG_DIRECT_OPERATION);
             mCommentId = savedInstanceState.getInt(ReaderConstants.ARG_COMMENT_ID);
             mIsSinglePostView = savedInstanceState.getBoolean(ReaderConstants.ARG_IS_SINGLE_POST);
+            mIsRelatedPostView = savedInstanceState.getBoolean(ReaderConstants.ARG_IS_RELATED_POST);
             mInterceptedUri = savedInstanceState.getString(ReaderConstants.ARG_INTERCEPTED_URI);
             if (savedInstanceState.containsKey(ReaderConstants.ARG_POST_LIST_TYPE)) {
                 mPostListType =
@@ -177,6 +179,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
                     .getSerializableExtra(ReaderConstants.ARG_DIRECT_OPERATION);
             mCommentId = getIntent().getIntExtra(ReaderConstants.ARG_COMMENT_ID, 0);
             mIsSinglePostView = getIntent().getBooleanExtra(ReaderConstants.ARG_IS_SINGLE_POST, false);
+            mIsRelatedPostView = getIntent().getBooleanExtra(ReaderConstants.ARG_IS_RELATED_POST, false);
             mInterceptedUri = getIntent().getStringExtra(ReaderConstants.ARG_INTERCEPTED_URI);
             if (getIntent().hasExtra(ReaderConstants.ARG_POST_LIST_TYPE)) {
                 mPostListType =
@@ -299,6 +302,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
             postIdentifier) {
         if (!TextUtils.isEmpty(blogIdentifier) && !TextUtils.isEmpty(postIdentifier)) {
             mIsSinglePostView = true;
+            mIsRelatedPostView = false;
 
             switch (interceptType) {
                 case READER_BLOG:
@@ -518,6 +522,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
     @Override
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putBoolean(ReaderConstants.ARG_IS_SINGLE_POST, mIsSinglePostView);
+        outState.putBoolean(ReaderConstants.ARG_IS_RELATED_POST, mIsRelatedPostView);
         outState.putString(ReaderConstants.ARG_INTERCEPTED_URI, mInterceptedUri);
 
         outState.putSerializable(ReaderConstants.ARG_DIRECT_OPERATION, mDirectOperation);
@@ -867,6 +872,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
                     mIdList.get(position).getPostId(),
                     mDirectOperation,
                     mCommentId,
+                    mIsRelatedPostView,
                     mInterceptedUri,
                     getPostListType(),
                     mPostSlugsResolutionUnderway);

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -46,15 +46,40 @@
                         android:layout_below="@+id/header_view"
                         android:layout_centerHorizontal="true"
                         android:layout_marginEnd="@dimen/reader_detail_margin"
-                        android:layout_marginStart="@dimen/reader_detail_margin"
-                        android:layout_marginBottom="@dimen/margin_extra_large"
-                        />
+                        android:layout_marginStart="@dimen/reader_detail_margin" />
+
+                    <LinearLayout
+                        android:id="@+id/container_related_posts"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@+id/layout_post_detail_content"
+                        android:orientation="vertical"
+                        android:layout_alignEnd="@+id/layout_post_detail_content"
+                        android:layout_alignStart="@+id/layout_post_detail_content"
+                        tools:ignore="UnknownIdInLayout">
+
+                        <org.wordpress.android.ui.reader.views.ReaderSimplePostContainerView
+                            android:id="@+id/related_posts_view_local"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/margin_extra_large"
+                            android:visibility="gone"
+                            tools:visibility="visible" />
+
+                        <org.wordpress.android.ui.reader.views.ReaderSimplePostContainerView
+                            android:id="@+id/related_posts_view_global"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:visibility="gone"
+                            tools:visibility="visible" />
+
+                    </LinearLayout>
 
                     <View
                         android:id="@+id/footer_spacer"
                         android:layout_width="match_parent"
                         android:layout_height="@dimen/toolbar_height"
-                        android:layout_below="@id/layout_post_detail_content" />
+                        android:layout_below="@id/container_related_posts" />
 
                 </RelativeLayout>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1870,6 +1870,7 @@
     <string name="reader_title_blog_preview">Reader Site</string>
     <string name="reader_title_tag_preview">Topic</string>
     <string name="reader_title_post_detail">Reader Post</string>
+    <string name="reader_title_related_post_detail">Related Post</string>
     <string name="reader_title_subs">Manage Topics &amp; Sites</string>
     <string name="reader_title_photo_viewer">%1$d of %2$d</string>
     <string name="reader_title_comments" translatable="false">@string/comments</string>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -75,6 +75,7 @@
     <ID>EmptyFunctionBlock:PrepublishingAddCategoryFragment.kt$PrepublishingAddCategoryFragment.&lt;no name provided&gt;${ }</ID>
     <ID>EmptyFunctionBlock:QuickStartFocusPoint.kt$QuickStartFocusPoint.&lt;no name provided&gt;${}</ID>
     <ID>EmptyFunctionBlock:ReaderDiscoverDataProvider.kt$ReaderDiscoverDataProvider${ }</ID>
+    <ID>EmptyFunctionBlock:ReaderPostDetailFragment.kt$ReaderPostDetailFragment${ }</ID>
     <ID>EmptyFunctionBlock:ScanHistoryFragment.kt$ScanHistoryFragment.&lt;no name provided&gt;${ }</ID>
     <ID>EmptyFunctionBlock:SearchInputWithHeader.kt$SearchInputWithHeader.&lt;no name provided&gt;${}</ID>
     <ID>EmptyFunctionBlock:SettingsUsernameChangerFragment.kt$SettingsUsernameChangerFragment.&lt;no name provided&gt;${ }</ID>
@@ -100,7 +101,7 @@
     <ID>FunctionParameterNaming:WizardManager.kt$WizardManager$T: WizardStep</ID>
     <ID>LargeClass:MySiteFragment.kt$MySiteFragment : FragmentOnScrollToTopListenerBasicDialogPositiveClickInterfaceBasicDialogNegativeClickInterfaceBasicDialogOnDismissByOutsideTouchInterfacePromoDialogClickInterfaceOnConfirmListenerOnDismissListenerCallback</ID>
     <ID>LargeClass:PagesViewModel.kt$PagesViewModel : ScopedViewModel</ID>
-    <ID>LargeClass:ReaderPostDetailFragment.kt$ReaderPostDetailFragment : ViewPagerFragmentOnActivityBackPressedListenerReaderCustomViewListenerReaderWebViewPageFinishedListenerReaderWebViewUrlClickListenerPrivateAtCookieProgressDialogOnDismissListenerAutoHideToolbarListener</ID>
+    <ID>LargeClass:ReaderPostDetailFragment.kt$ReaderPostDetailFragment : ViewPagerFragmentOnActivityBackPressedListenerScrollDirectionListenerReaderCustomViewListenerReaderWebViewPageFinishedListenerReaderWebViewUrlClickListenerPrivateAtCookieProgressDialogOnDismissListenerAutoHideToolbarListener</ID>
     <ID>LongMethod:ActivityLogDetailFragment.kt$ActivityLogDetailFragment$override fun onActivityCreated(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:ActivityLogListFragment.kt$ActivityLogListFragment$private fun setupObservers()</ID>
     <ID>LongMethod:AuthorsUseCase.kt$AuthorsUseCase$override fun buildUiModel(domainModel: AuthorsModel, uiState: SelectedAuthor): List&lt;BlockListItem&gt;</ID>
@@ -126,6 +127,7 @@
     <ID>LongMethod:PrepublishingHomeViewModel.kt$PrepublishingHomeViewModel$private fun setupHomeUiState( editPostRepository: EditPostRepository, site: SiteModel, isStoryPost: Boolean )</ID>
     <ID>LongMethod:PublishSettingsFragment.kt$PublishSettingsFragment$override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?</ID>
     <ID>LongMethod:ReaderDiscoverFragment.kt$ReaderDiscoverFragment$private fun initViewModel()</ID>
+    <ID>LongMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment$override fun onCreateView( inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle? ): View?</ID>
     <ID>LongMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment$private fun initViewModel()</ID>
     <ID>LongMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment.ShowPostTask$override fun onPostExecute(result: Boolean)</ID>
     <ID>LongMethod:ReaderPostMoreButtonUiStateBuilder.kt$ReaderPostMoreButtonUiStateBuilder$fun buildMoreMenuItemsBlocking( post: ReaderPost, onButtonClicked: (Long, Long, ReaderPostCardActionType) -&gt; Unit ): MutableList&lt;SecondaryAction&gt;</ID>
@@ -228,7 +230,7 @@
     <ID>LongParameterList:ReaderDiscoverDataProvider.kt$ReaderDiscoverDataProvider$( @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher, @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher, private val eventBusWrapper: EventBusWrapper, private val readerTagWrapper: ReaderTagWrapper, private val getDiscoverCardsUseCase: GetDiscoverCardsUseCase, private val shouldAutoUpdateTagUseCase: ShouldAutoUpdateTagUseCase, private val fetchDiscoverCardsUseCase: FetchDiscoverCardsUseCase )</ID>
     <ID>LongParameterList:ReaderDiscoverViewModel.kt$ReaderDiscoverViewModel$( private val postUiStateBuilder: ReaderPostUiStateBuilder, private val readerPostMoreButtonUiStateBuilder: ReaderPostMoreButtonUiStateBuilder, private val readerPostCardActionsHandler: ReaderPostCardActionsHandler, private val readerDiscoverDataProvider: ReaderDiscoverDataProvider, private val reblogUseCase: ReblogUseCase, private val readerUtilsWrapper: ReaderUtilsWrapper, private val appPrefsWrapper: AppPrefsWrapper, private val analyticsTrackerWrapper: AnalyticsTrackerWrapper, displayUtilsWrapper: DisplayUtilsWrapper, private val getFollowedTagsUseCase: GetFollowedTagsUseCase, @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher, @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher )</ID>
     <ID>LongParameterList:ReaderPostCardActionsHandler.kt$ReaderPostCardActionsHandler$( private val analyticsTrackerWrapper: AnalyticsTrackerWrapper, private val reblogUseCase: ReblogUseCase, private val bookmarkUseCase: ReaderPostBookmarkUseCase, private val followUseCase: ReaderSiteFollowUseCase, private val blockBlogUseCase: BlockBlogUseCase, private val likeUseCase: PostLikeUseCase, private val siteNotificationsUseCase: ReaderSiteNotificationsUseCase, private val undoBlockBlogUseCase: UndoBlockBlogUseCase, private val fetchSiteUseCase: ReaderFetchSiteUseCase, private val appPrefsWrapper: AppPrefsWrapper, private val dispatcher: Dispatcher, private val resourceProvider: ResourceProvider, private val htmlMessageUtils: HtmlMessageUtils, private val appRatingDialogWrapper: AppRatingDialogWrapper, private val seenStatusToggleUseCase: ReaderSeenStatusToggleUseCase, private val readerBlogTableWrapper: ReaderBlogTableWrapper, @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher )</ID>
-    <ID>LongParameterList:ReaderPostDetailFragment.kt$ReaderPostDetailFragment.Companion$( isFeed: Boolean, blogId: Long, postId: Long, directOperation: DirectOperation?, commentId: Int, interceptedUri: String?, postListType: ReaderPostListType?, postSlugsResolutionUnderway: Boolean )</ID>
+    <ID>LongParameterList:ReaderPostDetailFragment.kt$ReaderPostDetailFragment.Companion$( isFeed: Boolean, blogId: Long, postId: Long, directOperation: DirectOperation?, commentId: Int, isRelatedPost: Boolean, interceptedUri: String?, postListType: ReaderPostListType?, postSlugsResolutionUnderway: Boolean )</ID>
     <ID>LongParameterList:ReaderPostDetailUiStateBuilder.kt$ReaderPostDetailUiStateBuilder$( post: ReaderPost, moreMenuItems: List&lt;SecondaryAction&gt;? = null, onButtonClicked: (Long, Long, ReaderPostCardActionType) -&gt; Unit, onBlogSectionClicked: (Long, Long) -&gt; Unit, onFollowClicked: () -&gt; Unit, onTagItemClicked: (String) -&gt; Unit )</ID>
     <ID>LongParameterList:ReaderPostDetailViewModel.kt$ReaderPostDetailViewModel$( private val readerPostCardActionsHandler: ReaderPostCardActionsHandler, private val readerUtilsWrapper: ReaderUtilsWrapper, private val readerPostTableWrapper: ReaderPostTableWrapper, private val readerPostMoreButtonUiStateBuilder: ReaderPostMoreButtonUiStateBuilder, private val postDetailUiStateBuilder: ReaderPostDetailUiStateBuilder, private val reblogUseCase: ReblogUseCase, @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher, @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher )</ID>
     <ID>LongParameterList:ReaderPostUiStateBuilder.kt$ReaderPostUiStateBuilder$( post: ReaderPost, isDiscover: Boolean = false, photonWidth: Int, photonHeight: Int, postListType: ReaderPostListType, onButtonClicked: (Long, Long, ReaderPostCardActionType) -&gt; Unit, onItemClicked: (Long, Long) -&gt; Unit, onItemRendered: (ReaderCardUiState) -&gt; Unit, onDiscoverSectionClicked: (Long, Long) -&gt; Unit, onMoreButtonClicked: (ReaderPostUiState) -&gt; Unit, onMoreDismissed: (ReaderPostUiState) -&gt; Unit, onVideoOverlayClicked: (Long, Long) -&gt; Unit, onPostHeaderViewClicked: (Long, Long) -&gt; Unit, onTagItemClicked: (String) -&gt; Unit, moreMenuItems: List&lt;SecondaryAction&gt;? = null )</ID>
@@ -424,12 +426,14 @@
     <ID>MultiLineIfElse:org.wordpress.android.ui.posts.PostsListActivity.kt:295</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.posts.PrepublishingHomeViewModel.kt:138</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.posts.prepublishing.visibility.usecases.UpdatePostStatusUseCase.kt:25</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1002</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1004</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:874</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:876</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:880</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:882</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1036</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1038</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1042</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1044</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1164</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1166</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:835</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:837</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.reader.repository.usecases.FetchDiscoverCardsUseCase.kt:26</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.reader.repository.usecases.FetchDiscoverCardsUseCase.kt:28</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.reader.subfilter.SubFilterViewModel.kt:251</ID>
@@ -635,7 +639,7 @@
     <ID>TooManyFunctions:ReaderInterestsFragment.kt$ReaderInterestsFragment : Fragment</ID>
     <ID>TooManyFunctions:ReaderInterestsViewModel.kt$ReaderInterestsViewModel : ViewModel</ID>
     <ID>TooManyFunctions:ReaderPostCardActionsHandler.kt$ReaderPostCardActionsHandler</ID>
-    <ID>TooManyFunctions:ReaderPostDetailFragment.kt$ReaderPostDetailFragment : ViewPagerFragmentOnActivityBackPressedListenerReaderCustomViewListenerReaderWebViewPageFinishedListenerReaderWebViewUrlClickListenerPrivateAtCookieProgressDialogOnDismissListenerAutoHideToolbarListener</ID>
+    <ID>TooManyFunctions:ReaderPostDetailFragment.kt$ReaderPostDetailFragment : ViewPagerFragmentOnActivityBackPressedListenerScrollDirectionListenerReaderCustomViewListenerReaderWebViewPageFinishedListenerReaderWebViewUrlClickListenerPrivateAtCookieProgressDialogOnDismissListenerAutoHideToolbarListener</ID>
     <ID>TooManyFunctions:ReaderPostDetailViewModel.kt$ReaderPostDetailViewModel : ScopedViewModel</ID>
     <ID>TooManyFunctions:ReaderPostListViewModel.kt$ReaderPostListViewModel : ScopedViewModel</ID>
     <ID>TooManyFunctions:ReaderPostUiStateBuilder.kt$ReaderPostUiStateBuilder</ID>


### PR DESCRIPTION
Task #14128

This PR only reverts old code to display related posts which was removed in PR #13107 with no changes to design or any refactoring.

It currently targets `issue/14128-reader-related-posts` which will be merged to `develop` _after_ implementing remaining sub-tasks from the linked task.

To test:
- Open a Reader post.
- Notice related posts are displayed at the bottom of the  Reader post details screen.
- Click a related post.
- Notice that related post is opened.

https://user-images.githubusercontent.com/1405144/108836093-70372980-75f6-11eb-8c4f-c9b1127bc5d0.mp4

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
