### PR TITLE
Save page info to PostRepository when creating a new page from Layout picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -556,7 +556,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
                 mIsPage = extras.getBoolean(EXTRA_IS_PAGE);
                 if (mIsPage && !TextUtils.isEmpty(extras.getString(EXTRA_PAGE_TITLE))) {
-                    newPageFromLayoutPickerSetup(extras.getString(EXTRA_PAGE_TITLE), extras.getString(EXTRA_PAGE_CONTENT));
+                    newPageFromLayoutPickerSetup(extras.getString(EXTRA_PAGE_TITLE),
+                            extras.getString(EXTRA_PAGE_CONTENT));
                 } else {
                     newPostSetup();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -451,6 +451,31 @@ public class EditPostActivity extends LocaleAwareActivity implements
         mShortcutUtils.reportShortcutUsed(Shortcut.CREATE_NEW_POST);
     }
 
+    private void newPageFromLayoutPickerSetup(String title, String content) {
+        mIsNewPost = true;
+
+        if (mSite == null) {
+            showErrorAndFinish(R.string.blog_not_found);
+            return;
+        }
+        if (!mSite.isVisible()) {
+            showErrorAndFinish(R.string.error_blog_hidden);
+            return;
+        }
+
+        // Create a new post
+        mEditPostRepository.set(() -> {
+            PostModel post = mPostStore.instantiatePostModel(mSite, mIsPage, title, content, null,
+                    null, null, false);
+            post.setStatus(PostStatus.DRAFT.toString());
+            return post;
+        });
+        mEditPostRepository.savePostSnapshot();
+        EventBus.getDefault().postSticky(
+                new PostEvents.PostOpenedInEditor(mEditPostRepository.getLocalSiteId(), mEditPostRepository.getId()));
+        mShortcutUtils.reportShortcutUsed(Shortcut.CREATE_NEW_POST);
+    }
+
     private void createPostEditorAnalyticsSessionTracker(boolean showGutenbergEditor, PostImmutableModel post,
                                                          SiteModel site, boolean isNewPost) {
         if (mPostEditorAnalyticsSession == null) {
@@ -530,7 +555,11 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 }
 
                 mIsPage = extras.getBoolean(EXTRA_IS_PAGE);
-                newPostSetup();
+                if (mIsPage && !TextUtils.isEmpty(extras.getString(EXTRA_PAGE_TITLE))) {
+                    newPageFromLayoutPickerSetup(extras.getString(EXTRA_PAGE_TITLE), extras.getString(EXTRA_PAGE_CONTENT));
+                } else {
+                    newPostSetup();
+                }
             } else {
                 mEditPostRepository.loadPostByLocalPostId(extras.getInt(EXTRA_POST_LOCAL_ID));
                 // Load post from extra)s


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2701

To test:

1. Run the WPApp in DEBUG mode from the PR above.
2. In the My Site screen press the Add(+) floating button
3. Select Site page from the bottom menu
4. Scroll to the bottom and select the first layout of the Contact pages category
5. Press the Create page button
6. Wait for the page to load
7. Press the back button without editing the page
8. Notice that the app no longer crashes


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
