### PR TITLE
Update Quick Start card headings to use sentence case

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2907,8 +2907,8 @@
     <string name="quick_start_list_review_pages_subtitle">Check your pages and make changes, or add or remove pages.</string>
     <string name="quick_start_list_review_pages_title" translatable="false">@string/quick_start_dialog_review_pages_title</string>
     <string name="quick_start_sites">Next Steps</string>
-    <string name="quick_start_sites_type_customize">Customize Your Site</string>
-    <string name="quick_start_sites_type_grow">Grow Your Audience</string>
+    <string name="quick_start_sites_type_customize">Customize your site</string>
+    <string name="quick_start_sites_type_grow">Grow your audience</string>
     <string name="quick_start_sites_type_subtitle">%1$d of %2$d complete</string>
     <string name="quick_start_span_end" translatable="false">&lt;/span&gt;</string>
     <string name="quick_start_span_start" translatable="false">&lt;span&gt;</string>


### PR DESCRIPTION
This PR updates the Quick Start card headings to use sentence case, as this is more consistent to what we have throughout the app:

<img width=300 src="https://user-images.githubusercontent.com/830056/109052537-7a226080-76ba-11eb-9b68-f33e328eeece.png"/>


To test:

1. Turn on the Improved My Site flag and restart the app.
1. Go to the My Site screen.
1. Create a new site.
1. Notice the Quick Start task cards and make sure their headings use sentence case:
   - `Customize your site` instead of `Customize Your Site`.
   - `Grow your audience` instead of `Grow Your Audience`.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
