### PR TITLE
Fix NPE when fetchJetpackPurchasedProduct finishes after onViewDestroyed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -286,10 +286,13 @@ class MySiteFragment : Fragment(),
                     products = jetpackCapabilitiesUseCase.getCachedJetpackPurchasedProducts(site.siteId)
             )
             uiScope.launch {
-                updateScanAndBackupVisibility(
-                        site = site,
-                        products = jetpackCapabilitiesUseCase.fetchJetpackPurchasedProducts(site.siteId)
-                )
+                val products = jetpackCapabilitiesUseCase.fetchJetpackPurchasedProducts(site.siteId)
+                view?.let {
+                    updateScanAndBackupVisibility(
+                            site = site,
+                            products = products
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
This PR re-applies changes made in https://github.com/wordpress-mobile/WordPress-Android/pull/14108. The changes disappeared during conflict resolution when we were merging `release/16.7` into `develop`.

To test:
See original issue: https://github.com/wordpress-mobile/WordPress-Android/pull/14108

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


@JavonDavis This PR is targeting the frozen branch. 
