### PR TITLE
Fix empty screen when logging in without a site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -21,7 +21,7 @@ class SelectedSiteRepository
     private val _selectedSiteChange = MutableLiveData<SiteModel>()
     private val _showSiteIconProgressBar = MutableLiveData<Boolean>()
     val selectedSiteChange = _selectedSiteChange as LiveData<SiteModel>
-    val siteSelected: LiveData<Int> by lazy {
+    val siteSelected: LiveData<Int?> by lazy {
         val result = MediatorLiveData<Int>()
         result.addSource(_selectedSiteChange) { site -> result.value = site?.id }
         result.value = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.mysite
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.map
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
@@ -21,7 +21,12 @@ class SelectedSiteRepository
     private val _selectedSiteChange = MutableLiveData<SiteModel>()
     private val _showSiteIconProgressBar = MutableLiveData<Boolean>()
     val selectedSiteChange = _selectedSiteChange as LiveData<SiteModel>
-    val siteSelected = _selectedSiteChange.map { it?.id }.distinctUntilChanged()
+    val siteSelected: LiveData<Int> by lazy {
+        val result = MediatorLiveData<Int>()
+        result.addSource(_selectedSiteChange) { site -> result.value = site?.id }
+        result.value = null
+        result.distinctUntilChanged()
+    }
     val showSiteIconProgressBar = _showSiteIconProgressBar as LiveData<Boolean>
     fun updateSite(selectedSite: SiteModel?) {
         if (getSelectedSite()?.iconUrl != selectedSite?.iconUrl) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -1,13 +1,13 @@
 package org.wordpress.android.ui.mysite
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
+import org.wordpress.android.util.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,15 +18,10 @@ class SelectedSiteRepository
     private val siteSettingsInterfaceFactory: SiteSettingsInterfaceWrapper.Factory
 ) {
     private var siteSettings: SiteSettingsInterfaceWrapper? = null
-    private val _selectedSiteChange = MutableLiveData<SiteModel>()
+    private val _selectedSiteChange = MutableLiveData<SiteModel?>(null)
     private val _showSiteIconProgressBar = MutableLiveData<Boolean>()
-    val selectedSiteChange = _selectedSiteChange as LiveData<SiteModel>
-    val siteSelected: LiveData<Int?> by lazy {
-        val result = MediatorLiveData<Int>()
-        result.addSource(_selectedSiteChange) { site -> result.value = site?.id }
-        result.value = null
-        result.distinctUntilChanged()
-    }
+    val selectedSiteChange = _selectedSiteChange as LiveData<SiteModel?>
+    val siteSelected = _selectedSiteChange.map { it?.id }.distinctUntilChanged()
     val showSiteIconProgressBar = _showSiteIconProgressBar as LiveData<Boolean>
     fun updateSite(selectedSite: SiteModel?) {
         if (getSelectedSite()?.iconUrl != selectedSite?.iconUrl) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
@@ -198,6 +198,15 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
         verify(siteSettingsInterfaceWrapper).clear()
     }
 
+    @Test
+    fun `emits null site ID when site not selected`() {
+        var emptySiteIdEmitted = false
+
+        selectedSiteRepository.siteSelected.observeForever { emptySiteIdEmitted = true }
+
+        assertThat(emptySiteIdEmitted).isTrue()
+    }
+
     private fun initializeSiteAndSiteSettings() {
         selectedSiteRepository.updateSite(siteModel)
         doAnswer {


### PR DESCRIPTION
When logging in with an account without a site the app didn't show the empty view. The reason for this bug was that the `siteSelected` didn't emit the null after the change we did when it was set up in `map`. I've changed the initialization so it's now correctly set up with `null` value and added a unit test for it.


Before: 

![Screenshot_1614178005](https://user-images.githubusercontent.com/1079756/109128542-e26f5180-774f-11eb-942b-54bd1eb536c2.png)

After: 

![Screenshot_1614243465](https://user-images.githubusercontent.com/1079756/109128587-eb602300-774f-11eb-87bc-aea0c63c1d80.png)



To test:
- Log in with an account without a site
- Turn on the My Site Improvements flag and restart the app
- Go to "My site"
- The empty view is visible and the "Add new site" button is there



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
