### PR TITLE
Modal Layout Picker: Handles null category emoji

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
@@ -198,7 +198,7 @@ class ModalLayoutPickerViewModel @Inject constructor(
                 CategoryListItemUiState(
                         it.slug,
                         it.title,
-                        it.emoji,
+                        it.emoji ?: "",
                         state.selectedCategoriesSlugs.contains(it.slug)
                 ) { onCategoryTapped(it.slug) }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.12.0-beta-1'
+    fluxCVersion = '1.12.0-beta-2'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/WordPress-Android/issues/14152 and https://github.com/wordpress-mobile/WordPress-Android/issues/14150

Depends on: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1894

Fixes crash: https://sentry.io/share/issue/84d9ff222a3248ccab6c168bf7de8361/

To test:
* Please [check FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1894)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
