### PR TITLE
Scroll to a Quick Start item on each item click

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -185,7 +185,7 @@ class ImprovedMySiteFragment : Fragment(),
         })
         viewModel.onScrollTo.observe(viewLifecycleOwner, {
             it?.applyIfNotHandled {
-                (recycler_view.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(this.second, 0)
+                (recycler_view.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(this, 0)
             }
         })
         viewModel.onBasicDialogShown.observe(viewLifecycleOwner, {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -6,6 +6,7 @@ import android.text.TextUtils
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.distinctUntilChanged
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
@@ -149,9 +150,18 @@ class MySiteViewModel
     private val _onDynamicCardMenuShown = MutableLiveData<Event<DynamicCardMenuModel>>()
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     private val _onMediaUpload = MutableLiveData<Event<MediaModel>>()
-    private val _scrollToQuickStartTask = MutableLiveData<Event<Pair<QuickStartTask, Int>>>()
+    private val _activeTaskPosition = MutableLiveData<Pair<QuickStartTask, Int>>()
 
-    val onScrollTo: LiveData<Event<Pair<QuickStartTask, Int>>> = _scrollToQuickStartTask
+    val onScrollTo: LiveData<Event<Int>> = merge(
+            _activeTaskPosition.distinctUntilChanged(),
+            quickStartRepository.activeTask
+    ) { pair, activeTask ->
+        if (pair != null && activeTask != null && pair.first == activeTask) {
+            Event(pair.second)
+        } else {
+            null
+        }
+    }
     val onSnackbarMessage = merge(_onSnackbarMessage, siteStoriesHandler.onSnackbar, quickStartRepository.onSnackbar)
     val onQuickStartMySitePrompts = quickStartRepository.onQuickStartMySitePrompts
     val onTextInputDialogShown = _onTechInputDialogShown as LiveData<Event<TextInputDialogModel>>
@@ -256,9 +266,9 @@ class MySiteViewModel
         position: Int
     ) {
         if (quickStartTask == null) {
-            _scrollToQuickStartTask.postValue(null)
-        } else if (_scrollToQuickStartTask.value?.peekContent()?.first != quickStartTask && position >= 0) {
-            _scrollToQuickStartTask.postValue(Event(quickStartTask to position))
+            _activeTaskPosition.postValue(null)
+        } else if (_activeTaskPosition.value?.first != quickStartTask && position >= 0) {
+            _activeTaskPosition.postValue(quickStartTask to position)
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.model.DynamicCardType.CUSTOMIZE_QUICK_START
 import org.wordpress.android.fluxc.model.DynamicCardType.GROW_QUICK_START
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.CHECK_STATS
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EDIT_HOMEPAGE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask.EXPLORE_PLANS
@@ -149,6 +150,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private val jetpackCapabilities = MutableLiveData(JetpackCapabilities(false, false))
     private val currentAvatar = MutableLiveData(CurrentAvatarUrl(""))
     private val quickStartUpdate = MutableLiveData(QuickStartUpdate())
+    private val activeTask = MutableLiveData<QuickStartTask>()
     private val dynamicCards = MutableLiveData(
             DynamicCardsUpdate(
                     cards = listOf(
@@ -173,6 +175,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(selectedSiteRepository.selectedSiteChange).thenReturn(onSiteChange)
         whenever(selectedSiteRepository.siteSelected).thenReturn(onSiteSelected)
         whenever(selectedSiteRepository.showSiteIconProgressBar).thenReturn(onShowSiteIconProgressBar)
+        whenever(quickStartRepository.activeTask).thenReturn(activeTask)
         viewModel = MySiteViewModel(
                 networkUtilsWrapper,
                 TEST_DISPATCHER,


### PR DESCRIPTION
Fixes #14132 

This PR changes the behaviour of the QS scrolling so that it scrolls to the selected active item each time the user selects an active task. 

To test:
- Turn on My Site Improvements flag and restart the app
- Make sure you're on a site with Quick Start started
- Click on "Enable sharing" card
- Notice it scrolls to the "Sharing" item
- Scroll back up and click on "Enable sharing" again
- Notice the app scrolls again
- Check rotation to see the app doesn't scroll without tapping on an item
- Stress test scrolling

https://user-images.githubusercontent.com/1079756/109289210-2af93e80-7826-11eb-9dcc-5967020269dd.mp4


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
