### PR TITLE
Remove unused TODO comment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -141,13 +141,6 @@ class QuickStartRepository
 
     @JvmOverloads fun completeTask(task: QuickStartTask, refreshImmediately: Boolean = false) {
         selectedSiteRepository.getSelectedSite()?.let { site ->
-            // TODO Remove this before the feature is done
-            // Uncomment this code to mark a task as not completed for testing purposes
-//            if (quickStartStore.hasDoneTask(site.id.toLong(), task)) {
-//                quickStartStore.setDoneTask(site.id.toLong(), task, false)
-//                refresh.value = false
-//                return
-//            }
             if (task != activeTask.value && task != pendingTask) return
             _activeTask.value = null
             pendingTask = null


### PR DESCRIPTION
This PR removes temporary comment behind a TODO

To test:
- Nothing to test here

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
