### PR TITLE
Small Reader Improvements: Topics Management

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -541,6 +541,10 @@
             android:name=".ui.reader.ReaderVideoViewerActivity"
             android:screenOrientation="landscape"
             android:theme="@style/ReaderMediaViewerTheme" />
+        <activity
+            android:name=".ui.reader.discover.interests.ReaderInterestsActivity"
+            android:label="@string/reader_title_interests"
+            android:theme="@style/WordPress.NoActionBar" />
 
         <!-- Gutenberg activities -->
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -69,4 +69,7 @@ public class RequestCodes {
     // Story creator
     public static final int CREATE_STORY = 8000;
     public static final int EDIT_STORY = 8001;
+
+    // Reader Interests
+    public static final int READER_INTERESTS = 9001;
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -20,12 +20,16 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity.DirectOperation;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
+import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsActivity;
+import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsFragment.EntryPoint;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.WPUrlUtils;
 
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.wordpress.android.ui.reader.discover.interests.ReaderInterestsFragment.READER_INTEREST_ENTRY_POINT;
 
 public class ReaderActivityLauncher {
     /*
@@ -210,6 +214,12 @@ public class ReaderActivityLauncher {
         Intent intent = new Intent(context, ReaderSubsActivity.class);
         intent.putExtra(ReaderConstants.ARG_SUBS_TAB_POSITION, selectPosition);
         context.startActivity(intent);
+    }
+
+    public static void showReaderInterests(Activity activity) {
+        Intent intent = new Intent(activity, ReaderInterestsActivity.class);
+        intent.putExtra(READER_INTEREST_ENTRY_POINT, EntryPoint.SETTINGS);
+        activity.startActivityForResult(intent, RequestCodes.READER_INTERESTS);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.KeyEvent;
@@ -11,6 +12,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
@@ -20,6 +22,7 @@ import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
 import com.google.android.material.elevation.ElevationOverlayProvider;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.tabs.TabLayout;
 
@@ -35,6 +38,7 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.LocaleAwareActivity;
+import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
@@ -66,6 +70,7 @@ import javax.inject.Inject;
 public class ReaderSubsActivity extends LocaleAwareActivity
         implements ReaderTagAdapter.TagDeletedListener {
     private EditText mEditAdd;
+    private FloatingActionButton mFabButton;
     private ReaderFollowButton mBtnAdd;
     private WPViewPager mViewPager;
     private SubsPageAdapter mPageAdapter;
@@ -134,6 +139,9 @@ public class ReaderSubsActivity extends LocaleAwareActivity
                 return false;
             }
         });
+
+        mFabButton = findViewById(R.id.fab_button);
+        mFabButton.setOnClickListener(view -> ReaderActivityLauncher.showReaderInterests(this));
 
         mBtnAdd = findViewById(R.id.btn_add);
         mBtnAdd.setOnClickListener(new View.OnClickListener() {
@@ -511,6 +519,14 @@ public class ReaderSubsActivity extends LocaleAwareActivity
                 mViewPager.setCurrentItem(i);
                 return;
             }
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == RequestCodes.READER_INTERESTS) {
+            performUpdate(EnumSet.of(UpdateTask.TAGS));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsActivity.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui.reader.discover.interests
+
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import kotlinx.android.synthetic.main.toolbar_main.*
+import org.wordpress.android.R
+
+class ReaderInterestsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.reader_interests_activity)
+
+        setSupportActionBar(toolbar_main)
+        supportActionBar?.let {
+            it.setHomeButtonEnabled(true)
+            it.setDisplayHomeAsUpEnabled(true)
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -86,7 +86,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
             updateDoneButton(uiState.doneButtonUiState)
             with(uiHelpers) {
                 updateVisibility(progress_bar, uiState.progressBarVisible)
-                updateVisibility(title, if (entryPoint == EntryPoint.DISCOVER) uiState.titleVisible else false)
+                updateVisibility(title, uiState.titleVisible)
                 updateVisibility(error_layout, uiState.errorLayoutVisible)
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -118,7 +118,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
 
     private fun updateErrorLayout(uiState: ErrorUiState) {
         with(uiHelpers) {
-            setTextOrHide(error_title, uiState.titleResId)
+            setTextOrHide(error_title, uiState.titleRes)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -97,6 +97,12 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
             }
         })
 
+        viewModel.closeReaderInterests.observe(viewLifecycleOwner, { event ->
+            event?.getContentIfNotHandled()?.let {
+                requireActivity().finish()
+            }
+        })
+
         viewModel.start(
                 LocaleManager.getLanguage(WordPress.getContext()),
                 parentViewModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -92,8 +92,8 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
         })
 
         viewModel.start(
-                parentViewModel,
                 LocaleManager.getLanguage(WordPress.getContext()),
+                parentViewModel,
                 EntryPoint.DISCOVER
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -86,7 +86,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
             updateDoneButton(uiState.doneButtonUiState)
             with(uiHelpers) {
                 updateVisibility(progress_bar, uiState.progressBarVisible)
-                updateVisibility(title, uiState.titleVisible)
+                updateVisibility(title, if (entryPoint == EntryPoint.DISCOVER) uiState.titleVisible else false)
                 updateVisibility(error_layout, uiState.errorLayoutVisible)
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.reader.discover.interests
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.chip.Chip
 import com.google.android.material.snackbar.Snackbar
@@ -66,7 +65,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
     }
 
     private fun startObserving() {
-        viewModel.uiState.observe(viewLifecycleOwner, Observer { uiState ->
+        viewModel.uiState.observe(viewLifecycleOwner, { uiState ->
             when (uiState) {
                 is InitialLoadingUiState -> {
                 }
@@ -85,7 +84,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
             }
         })
 
-        viewModel.snackbarEvents.observe(viewLifecycleOwner, Observer {
+        viewModel.snackbarEvents.observe(viewLifecycleOwner, {
             it?.applyIfNotHandled {
                 showSnackbar()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -157,6 +157,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
 
     companion object {
         const val TAG = "reader_interests_fragment_tag"
+        const val READER_INTEREST_ENTRY_POINT = "reader_interest_entry_point"
     }
 
     enum class EntryPoint {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -25,7 +25,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: ReaderInterestsViewModel
-    private lateinit var parentViewModel: ReaderViewModel
+    private var parentViewModel: ReaderViewModel? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -62,7 +62,9 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
 
     private fun initViewModel(entryPoint: EntryPoint) {
         viewModel = ViewModelProvider(this, viewModelFactory).get(ReaderInterestsViewModel::class.java)
-        parentViewModel = ViewModelProvider(requireParentFragment()).get(ReaderViewModel::class.java)
+        if (entryPoint == EntryPoint.DISCOVER) {
+            parentViewModel = ViewModelProvider(requireParentFragment()).get(ReaderViewModel::class.java)
+        }
         startObserving(entryPoint)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -105,7 +105,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
     private fun updateInterests(interestsUiState: List<TagUiState>) {
         interestsUiState.forEachIndexed { index, interestTagUiState ->
             val chip = interests_chip_group.findViewWithTag(interestTagUiState.slug)
-                ?: createChipView(interestTagUiState.slug, index)
+                    ?: createChipView(interestTagUiState.slug, index)
             with(chip) {
                 text = interestTagUiState.title
                 isChecked = interestTagUiState.isChecked
@@ -130,15 +130,15 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
                 this.buttonAction.invoke()
             }
         }
-        snackbar.setAnchorView(bottom_bar)
+        snackbar.anchorView = bottom_bar
         snackbar.show()
     }
 
     private fun createChipView(slug: String, index: Int): Chip {
         val chip = layoutInflater.inflate(
-            R.layout.reader_interest_filter_chip,
-            interests_chip_group,
-            false
+                R.layout.reader_interest_filter_chip,
+                interests_chip_group,
+                false
         ) as Chip
         with(chip) {
             tag = slug

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -38,7 +38,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
                 ?: EntryPoint.DISCOVER
         initDoneButton()
         initRetryButton()
-        initBackButton()
+        initBackButton(entryPoint)
         initViewModel(entryPoint)
     }
 
@@ -54,9 +54,12 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
         }
     }
 
-    private fun initBackButton() {
-        back_button.setOnClickListener {
-            viewModel.onBackButtonClick()
+    private fun initBackButton(entryPoint: EntryPoint) {
+        if (entryPoint == EntryPoint.DISCOVER) {
+            back_button.visibility = View.VISIBLE
+            back_button.setOnClickListener {
+                viewModel.onBackButtonClick()
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -34,10 +34,12 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val entryPoint = requireActivity().intent.getSerializableExtra(READER_INTEREST_ENTRY_POINT) as? EntryPoint
+                ?: EntryPoint.DISCOVER
         initDoneButton()
         initRetryButton()
         initBackButton()
-        initViewModel()
+        initViewModel(entryPoint)
     }
 
     private fun initDoneButton() {
@@ -58,13 +60,13 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
         }
     }
 
-    private fun initViewModel() {
+    private fun initViewModel(entryPoint: EntryPoint) {
         viewModel = ViewModelProvider(this, viewModelFactory).get(ReaderInterestsViewModel::class.java)
         parentViewModel = ViewModelProvider(requireParentFragment()).get(ReaderViewModel::class.java)
-        startObserving()
+        startObserving(entryPoint)
     }
 
-    private fun startObserving() {
+    private fun startObserving(entryPoint: EntryPoint) {
         viewModel.uiState.observe(viewLifecycleOwner, { uiState ->
             when (uiState) {
                 is InitialLoadingUiState -> {
@@ -93,7 +95,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
         viewModel.start(
                 LocaleManager.getLanguage(WordPress.getContext()),
                 parentViewModel,
-                EntryPoint.DISCOVER
+                entryPoint
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -91,7 +91,11 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
             }
         })
 
-        viewModel.start(parentViewModel, LocaleManager.getLanguage(WordPress.getContext()))
+        viewModel.start(
+                parentViewModel,
+                LocaleManager.getLanguage(WordPress.getContext()),
+                EntryPoint.DISCOVER
+        )
     }
 
     private fun updateDoneButton(doneButtonUiState: DoneButtonUiState) {
@@ -154,5 +158,10 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
 
     companion object {
         const val TAG = "reader_interests_fragment_tag"
+    }
+
+    enum class EntryPoint {
+        DISCOVER,
+        SETTINGS
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -152,11 +152,11 @@ class ReaderInterestsViewModel @Inject constructor(
                 is Error -> {
                     if (result is NetworkUnavailable) {
                         _snackbarEvents.postValue(
-                            Event(SnackbarMessageHolder(UiStringRes(string.no_network_message)))
+                                Event(SnackbarMessageHolder(UiStringRes(string.no_network_message)))
                         )
                     } else if (result is RemoteRequestFailure) {
                         _snackbarEvents.postValue(
-                            Event(SnackbarMessageHolder(UiStringRes(R.string.reader_error_request_failed_title)))
+                                Event(SnackbarMessageHolder(UiStringRes(R.string.reader_error_request_failed_title)))
                         )
                     }
                     updateUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -54,21 +54,19 @@ class ReaderInterestsViewModel @Inject constructor(
     private var userTagsFetchedSuccessfully = false
 
     fun start(
-        parentViewModel: ReaderViewModel,
         currentLanguage: String,
+        parentViewModel: ReaderViewModel,
         entryPoint: EntryPoint
     ) {
-        this.parentViewModel = parentViewModel
-        if (isStarted && isLanguageSame(currentLanguage)) {
+        if (isStarted && this.currentLanguage == currentLanguage) {
             return
         }
-        loadUserTags()
-        this.currentLanguage = currentLanguage
-        this.entryPoint = entryPoint
         isStarted = true
+        this.currentLanguage = currentLanguage
+        this.parentViewModel = parentViewModel
+        this.entryPoint = entryPoint
+        loadUserTags()
     }
-
-    private fun isLanguageSame(currentLanguage: String) = this.currentLanguage == currentLanguage
 
     private fun loadUserTags() {
         updateUiState(InitialLoadingUiState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -40,7 +40,7 @@ class ReaderInterestsViewModel @Inject constructor(
 ) : ViewModel() {
     private var isStarted = false
     private lateinit var currentLanguage: String
-    private lateinit var parentViewModel: ReaderViewModel
+    private var parentViewModel: ReaderViewModel? = null
 
     private var entryPoint = EntryPoint.DISCOVER
     private var userTags = ReaderTagList()
@@ -58,7 +58,7 @@ class ReaderInterestsViewModel @Inject constructor(
 
     fun start(
         currentLanguage: String,
-        parentViewModel: ReaderViewModel,
+        parentViewModel: ReaderViewModel?,
         entryPoint: EntryPoint
     ) {
         if (isStarted && this.currentLanguage == currentLanguage) {
@@ -98,7 +98,7 @@ class ReaderInterestsViewModel @Inject constructor(
         if (userTags.isEmpty()) {
             loadInterests(userTags)
         } else {
-            parentViewModel.onCloseReaderInterests()
+            parentViewModel?.onCloseReaderInterests()
         }
     }
 
@@ -182,7 +182,7 @@ class ReaderInterestsViewModel @Inject constructor(
             when (val result = readerTagRepository.saveInterests(contentUiState.getSelectedInterests())) {
                 is Success -> {
                     when (entryPoint) {
-                        EntryPoint.DISCOVER -> parentViewModel.onCloseReaderInterests()
+                        EntryPoint.DISCOVER -> parentViewModel?.onCloseReaderInterests()
                         EntryPoint.SETTINGS -> _closeReaderInterests.value = Event(Unit)
                     }
                 }
@@ -246,7 +246,7 @@ class ReaderInterestsViewModel @Inject constructor(
 
     fun onBackButtonClick() {
         when (entryPoint) {
-            EntryPoint.DISCOVER -> parentViewModel.onCloseReaderInterests()
+            EntryPoint.DISCOVER -> parentViewModel?.onCloseReaderInterests()
             EntryPoint.SETTINGS -> _closeReaderInterests.value = Event(Unit)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.SELECT_INTERESTS_PI
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsFragment.EntryPoint
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.DoneButtonUiState.DoneButtonDisabledUiState
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.DoneButtonUiState.DoneButtonEnabledUiState
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.DoneButtonUiState.DoneButtonHiddenUiState
@@ -42,6 +43,8 @@ class ReaderInterestsViewModel @Inject constructor(
     private lateinit var currentLanguage: String
     private lateinit var parentViewModel: ReaderViewModel
 
+    private var entryPoint = EntryPoint.DISCOVER
+
     private val _uiState: MutableLiveData<UiState> = MutableLiveData()
     val uiState: LiveData<UiState> = _uiState
 
@@ -50,13 +53,18 @@ class ReaderInterestsViewModel @Inject constructor(
 
     private var userTagsFetchedSuccessfully = false
 
-    fun start(parentViewModel: ReaderViewModel, currentLanguage: String) {
+    fun start(
+        parentViewModel: ReaderViewModel,
+        currentLanguage: String,
+        entryPoint: EntryPoint
+    ) {
         this.parentViewModel = parentViewModel
         if (isStarted && isLanguageSame(currentLanguage)) {
             return
         }
         loadUserTags()
         this.currentLanguage = currentLanguage
+        this.entryPoint = entryPoint
         isStarted = true
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -73,12 +73,7 @@ class ReaderInterestsViewModel @Inject constructor(
             when (val result = readerTagRepository.getUserTags()) {
                 is SuccessWithData<*> -> {
                     userTagsFetchedSuccessfully = true
-                    val userTags = result.data as ReaderTagList
-                    if (userTags.isEmpty()) {
-                        loadInterests()
-                    } else {
-                        parentViewModel.onCloseReaderInterests()
-                    }
+                    checkAndLoadInterests(result.data as ReaderTagList)
                 }
                 is Error -> {
                     if (result is NetworkUnavailable) {
@@ -88,6 +83,14 @@ class ReaderInterestsViewModel @Inject constructor(
                     }
                 }
             }
+        }
+    }
+
+    private fun checkAndLoadInterests(userTags: ReaderTagList) {
+        if (userTags.isEmpty()) {
+            loadInterests()
+        } else {
+            parentViewModel.onCloseReaderInterests()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -156,7 +156,10 @@ class ReaderInterestsViewModel @Inject constructor(
             updateUiState(
                     currentUiState.copy(
                             interestsUiState = updatedInterestsUiState,
-                            doneButtonUiState = currentUiState.getDoneButtonState(isInterestChecked = isChecked)
+                            doneButtonUiState = currentUiState.getDoneButtonState(
+                                    entryPoint = entryPoint,
+                                    isInterestChecked = isChecked
+                            )
                     )
             )
         }
@@ -298,13 +301,17 @@ class ReaderInterestsViewModel @Inject constructor(
         }
 
         fun getDoneButtonState(
+            entryPoint: EntryPoint,
             isInterestChecked: Boolean = false
         ): DoneButtonUiState {
             return if (this is ContentUiState) {
                 val disableDoneButton = interests.isEmpty() ||
                         (getCheckedInterestsUiState().size == 1 && !isInterestChecked)
                 if (disableDoneButton) {
-                    DoneButtonDisabledUiState()
+                    when (entryPoint) {
+                        EntryPoint.DISCOVER -> DoneButtonDisabledUiState()
+                        EntryPoint.SETTINGS -> DoneButtonDisabledUiState(R.string.reader_btn_done)
+                    }
                 } else {
                     DoneButtonEnabledUiState()
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
-import org.wordpress.android.R.string
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_TAG_FOLLOWED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.SELECT_INTERESTS_PICKED
@@ -158,7 +157,7 @@ class ReaderInterestsViewModel @Inject constructor(
                 is Error -> {
                     if (result is NetworkUnavailable) {
                         _snackbarEvents.postValue(
-                                Event(SnackbarMessageHolder(UiStringRes(string.no_network_message)))
+                                Event(SnackbarMessageHolder(UiStringRes(R.string.no_network_message)))
                         )
                     } else if (result is RemoteRequestFailure) {
                         _snackbarEvents.postValue(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -200,7 +200,7 @@ class ReaderInterestsViewModel @Inject constructor(
     }
 
     private fun trackInterests(tags: List<ReaderTag>) {
-        tags.forEach { it ->
+        tags.forEach {
             trackerWrapper.track(
                     READER_TAG_FOLLOWED,
                     mapOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -51,6 +51,9 @@ class ReaderInterestsViewModel @Inject constructor(
     private val _snackbarEvents = MediatorLiveData<Event<SnackbarMessageHolder>>()
     val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
+    private val _closeReaderInterests = MutableLiveData<Event<Unit>>()
+    val closeReaderInterests: LiveData<Event<Unit>> = _closeReaderInterests
+
     private var userTagsFetchedSuccessfully = false
 
     fun start(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -272,7 +272,7 @@ class ReaderInterestsViewModel @Inject constructor(
             val interests: ReaderTagList,
             override val progressBarVisible: Boolean = false,
             override val doneButtonUiState: DoneButtonUiState,
-            override val titleVisible: Boolean,
+            override val titleVisible: Boolean
         ) : UiState(
                 progressBarVisible = false,
                 titleVisible = titleVisible,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -111,14 +111,20 @@ class ReaderInterestsViewModel @Inject constructor(
 
                     val tags = (result.data as ReaderTagList).filter { checkAndExcludeTag(userTags, it) }
                     val distinctTags = ReaderTagList().apply { addAll(tags.distinctBy { it.tagSlug }) }
-                    ContentUiState(
-                            interestsUiState = transformToInterestsUiState(distinctTags),
-                            interests = distinctTags,
-                            doneButtonUiState = when (entryPoint) {
-                                EntryPoint.DISCOVER -> DoneButtonDisabledUiState()
-                                EntryPoint.SETTINGS -> DoneButtonDisabledUiState(R.string.reader_btn_done)
-                            }
-                    )
+                    when (entryPoint) {
+                        EntryPoint.DISCOVER -> ContentUiState(
+                                interestsUiState = transformToInterestsUiState(distinctTags),
+                                interests = distinctTags,
+                                doneButtonUiState = DoneButtonDisabledUiState(),
+                                titleVisible = true
+                        )
+                        EntryPoint.SETTINGS -> ContentUiState(
+                                interestsUiState = transformToInterestsUiState(distinctTags),
+                                interests = distinctTags,
+                                doneButtonUiState = DoneButtonDisabledUiState(R.string.reader_btn_done),
+                                titleVisible = false
+                        )
+                    }
                 }
                 is NetworkUnavailable -> {
                     ConnectionErrorUiState
@@ -254,7 +260,7 @@ class ReaderInterestsViewModel @Inject constructor(
     sealed class UiState(
         open val doneButtonUiState: DoneButtonUiState = DoneButtonHiddenUiState,
         open val progressBarVisible: Boolean = false,
-        val titleVisible: Boolean = false,
+        open val titleVisible: Boolean = false,
         val errorLayoutVisible: Boolean = false
     ) {
         object InitialLoadingUiState : UiState(
@@ -265,10 +271,11 @@ class ReaderInterestsViewModel @Inject constructor(
             val interestsUiState: List<TagUiState>,
             val interests: ReaderTagList,
             override val progressBarVisible: Boolean = false,
-            override val doneButtonUiState: DoneButtonUiState
+            override val doneButtonUiState: DoneButtonUiState,
+            override val titleVisible: Boolean,
         ) : UiState(
                 progressBarVisible = false,
-                titleVisible = true,
+                titleVisible = titleVisible,
                 errorLayoutVisible = false
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -165,7 +165,7 @@ class ReaderInterestsViewModel @Inject constructor(
         updateUiState(
                 contentUiState.copy(
                         progressBarVisible = true,
-                        doneButtonUiState = DoneButtonDisabledUiState(titleRes = R.string.reader_btn_done)
+                        doneButtonUiState = DoneButtonDisabledUiState(R.string.reader_btn_done)
                 )
         )
 
@@ -190,7 +190,7 @@ class ReaderInterestsViewModel @Inject constructor(
                     updateUiState(
                             contentUiState.copy(
                                     progressBarVisible = false,
-                                    doneButtonUiState = DoneButtonEnabledUiState(titleRes = R.string.reader_btn_done)
+                                    doneButtonUiState = DoneButtonEnabledUiState(R.string.reader_btn_done)
                             )
                     )
                 }
@@ -261,18 +261,14 @@ class ReaderInterestsViewModel @Inject constructor(
         )
 
         sealed class ErrorUiState constructor(
-            val titleResId: Int
+            val titleRes: Int
         ) : UiState(
                 progressBarVisible = false,
                 errorLayoutVisible = true
         ) {
-            object ConnectionErrorUiState : ErrorUiState(
-                    titleResId = R.string.no_network_message
-            )
+            object ConnectionErrorUiState : ErrorUiState(R.string.no_network_message)
 
-            object RequestFailedErrorUiState : ErrorUiState(
-                    titleResId = R.string.reader_error_request_failed_title
-            )
+            object RequestFailedErrorUiState : ErrorUiState(R.string.reader_error_request_failed_title)
         }
 
         private fun getCheckedInterestsUiState(): List<TagUiState> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -110,7 +110,11 @@ class ReaderInterestsViewModel @Inject constructor(
                     val distinctTags = ReaderTagList().apply { addAll(tags.distinctBy { it.tagSlug }) }
                     ContentUiState(
                             interestsUiState = transformToInterestsUiState(distinctTags),
-                            interests = distinctTags
+                            interests = distinctTags,
+                            doneButtonUiState = when (entryPoint) {
+                                EntryPoint.DISCOVER -> DoneButtonDisabledUiState()
+                                EntryPoint.SETTINGS -> DoneButtonDisabledUiState(R.string.reader_btn_done)
+                            }
                     )
                 }
                 is NetworkUnavailable -> {
@@ -249,7 +253,7 @@ class ReaderInterestsViewModel @Inject constructor(
             val interestsUiState: List<TagUiState>,
             val interests: ReaderTagList,
             override val progressBarVisible: Boolean = false,
-            override val doneButtonUiState: DoneButtonUiState = DoneButtonDisabledUiState()
+            override val doneButtonUiState: DoneButtonUiState
         ) : UiState(
                 progressBarVisible = false,
                 titleVisible = true,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -245,7 +245,10 @@ class ReaderInterestsViewModel @Inject constructor(
     }
 
     fun onBackButtonClick() {
-        parentViewModel.onCloseReaderInterests()
+        when (entryPoint) {
+            EntryPoint.DISCOVER -> parentViewModel.onCloseReaderInterests()
+            EntryPoint.SETTINGS -> _closeReaderInterests.value = Event(Unit)
+        }
     }
 
     sealed class UiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -178,7 +178,10 @@ class ReaderInterestsViewModel @Inject constructor(
             readerTagRepository.clearTagLastUpdated(ReaderTag.createDiscoverPostCardsTag())
             when (val result = readerTagRepository.saveInterests(contentUiState.getSelectedInterests())) {
                 is Success -> {
-                    parentViewModel.onCloseReaderInterests()
+                    when (entryPoint) {
+                        EntryPoint.DISCOVER -> parentViewModel.onCloseReaderInterests()
+                        EntryPoint.SETTINGS -> _closeReaderInterests.value = Event(Unit)
+                    }
                 }
                 is Error -> {
                     if (result is NetworkUnavailable) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -73,7 +73,10 @@ class ReaderInterestsViewModel @Inject constructor(
             when (val result = readerTagRepository.getUserTags()) {
                 is SuccessWithData<*> -> {
                     userTagsFetchedSuccessfully = true
-                    checkAndLoadInterests(result.data as ReaderTagList)
+                    when (entryPoint) {
+                        EntryPoint.DISCOVER -> checkAndLoadInterests(result.data as ReaderTagList)
+                        EntryPoint.SETTINGS -> loadInterests()
+                    }
                 }
                 is Error -> {
                     if (result is NetworkUnavailable) {

--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -30,6 +30,18 @@
         android:layout_above="@+id/divider_list"
         android:layout_below="@+id/appbar" />
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/divider_list"
+        android:layout_alignParentEnd="true"
+        android:layout_marginBottom="@dimen/fab_margin"
+        android:layout_marginEnd="@dimen/fab_margin"
+        android:contentDescription="@string/add"
+        android:src="@drawable/ic_plus_white_24dp"
+        app:borderWidth="0dp" />
+
     <View
         android:id="@+id/divider_list"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/reader_interests_activity.xml
+++ b/WordPress/src/main/res/layout/reader_interests_activity.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:theme="@style/WordPress.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <fragment
+        android:id="@+id/fragment_container_view"
+        android:name="org.wordpress.android.ui.reader.discover.interests.ReaderInterestsFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/reader_interests_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_interests_fragment_layout.xml
@@ -10,12 +10,14 @@
 
     <RelativeLayout
         android:id="@+id/back_button"
+        android:visibility="gone"
         android:layout_width="@dimen/min_touch_target_sz"
         android:layout_height="@dimen/min_touch_target_sz"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintRight_toLeftOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/scroll_view">
+        app:layout_constraintBottom_toTopOf="@+id/scroll_view"
+        tools:visibility="visible">
 
         <ImageView
             android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/reader_interests_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_interests_fragment_layout.xml
@@ -67,13 +67,15 @@
                 style="@style/ReaderTextView.Interests.Title"
                 android:id="@+id/title"
                 android:text="@string/reader_label_choose_your_interests"
+                android:visibility="gone"
                 app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toStartOf="@id/guideline_beginning"
                 app:layout_constraintEnd_toEndOf="@id/guideline_end"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toTopOf="@+id/interests_chip_group"
                 app:layout_constraintVertical_chainStyle="packed"
-                tools:text="Choose your interests" />
+                tools:text="Choose your interests"
+                tools:visibility="visible" />
 
             <com.google.android.material.chip.ChipGroup
                 android:id="@+id/interests_chip_group"

--- a/WordPress/src/main/res/layout/reader_interests_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_interests_fragment_layout.xml
@@ -80,7 +80,7 @@
             <com.google.android.material.chip.ChipGroup
                 android:id="@+id/interests_chip_group"
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
                 android:layout_marginBottom="@dimen/margin_extra_large"
                 android:layoutDirection="locale"
                 app:chipSpacing="@dimen/margin_small_medium"

--- a/WordPress/src/main/res/layout/reader_listitem_tag.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_tag.xml
@@ -35,6 +35,6 @@
         android:background="?attr/selectableItemBackground"
         android:contentDescription="@string/remove"
         android:padding="@dimen/margin_small"
-        android:src="@drawable/ic_cross_white_24dp"
+        android:src="@drawable/ic_reader_following_white_24dp"
         app:tint="?attr/wpColorOnSurfaceMedium" />
 </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1873,6 +1873,7 @@
     <string name="reader_title_subs">Manage Topics &amp; Sites</string>
     <string name="reader_title_photo_viewer">%1$d of %2$d</string>
     <string name="reader_title_comments" translatable="false">@string/comments</string>
+    <string name="reader_title_interests">Follow topics</string>
 
     <!-- view pager titles -->
     <string name="reader_page_followed_tags">Followed topics</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -543,6 +543,28 @@ class ReaderInterestsViewModelTest {
                         .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.reader_error_request_failed_title)))
             }
 
+    @Test
+    fun `discover close reader screen on back button click`() {
+        // When
+        initViewModel()
+        viewModel.onBackButtonClick()
+
+        // Then
+        verify(parentViewModel, times(1)).onCloseReaderInterests()
+    }
+
+    @Test
+    fun `settings close reader screen on back button click`() {
+        // When
+        initViewModel(
+                entryPoint = EntryPoint.SETTINGS
+        )
+        viewModel.onBackButtonClick()
+
+        // Then
+        assertThat(viewModel.closeReaderInterests.value).isNotNull
+    }
+
     private fun initViewModel(
         entryPoint: EntryPoint = EntryPoint.DISCOVER
     ) = viewModel.start(

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -315,7 +315,7 @@ class ReaderInterestsViewModelTest {
             }
 
     @Test
-    fun `done button shown in disabled state if no interests are in selected state`() =
+    fun `discover done button shown in disabled state if no interests are in selected state`() =
             testWithEmptyUserTags {
                 // Given
                 val interests = getInterests()
@@ -327,6 +327,27 @@ class ReaderInterestsViewModelTest {
                 // Then
                 assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
                         .isInstanceOf(DoneButtonDisabledUiState::class.java)
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState.titleRes)
+                        .isEqualTo(R.string.reader_btn_select_few_interests)
+            }
+
+    @Test
+    fun `settings done button shown in disabled state if no interests are in selected state`() =
+            testWithEmptyUserTags {
+                // Given
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
+
+                // When
+                initViewModel(
+                        entryPoint = EntryPoint.SETTINGS
+                )
+
+                // Then
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
+                        .isInstanceOf(DoneButtonDisabledUiState::class.java)
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState.titleRes)
+                        .isEqualTo(R.string.reader_btn_done)
             }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -222,6 +222,35 @@ class ReaderInterestsViewModelTest {
 
                 assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
                         .isInstanceOf(DoneButtonDisabledUiState::class.java)
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState.titleRes)
+                        .isEqualTo(R.string.reader_btn_select_few_interests)
+            }
+
+    @Test
+    fun `settings done button hidden on start switches to disabled state when interests tags received from repo`() =
+            testWithEmptyUserTags {
+                // Given
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
+
+                // Pause dispatcher so we can verify done button initial state
+                coroutineScope.pauseDispatcher()
+
+                // Trigger data load
+                initViewModel(
+                        entryPoint = EntryPoint.SETTINGS
+                )
+
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
+                        .isInstanceOf(DoneButtonHiddenUiState::class.java)
+
+                // Resume pending coroutines execution
+                coroutineScope.resumeDispatcher()
+
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
+                        .isInstanceOf(DoneButtonDisabledUiState::class.java)
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState.titleRes)
+                        .isEqualTo(R.string.reader_btn_done)
             }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -90,13 +90,25 @@ class ReaderInterestsViewModelTest {
             }
 
     @Test
-    fun `close reader screen triggered if non empty user tags are received from repo`() =
+    fun `discover close reader screen triggered if non empty user tags are received from repo`() =
             testWithNonEmptyUserTags {
                 // When
                 initViewModel()
 
                 // Then
                 verify(parentViewModel, times(1)).onCloseReaderInterests()
+            }
+
+    @Test
+    fun `settings does not close reader screen triggered if non empty user tags are received from repo`() =
+            testWithNonEmptyUserTags {
+                // When
+                initViewModel(
+                        entryPoint = EntryPoint.SETTINGS
+                )
+
+                // Then
+                verify(parentViewModel, times(0)).onCloseReaderInterests()
             }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -200,6 +200,44 @@ class ReaderInterestsViewModelTest {
             }
 
     @Test
+    fun `discover title shown on start when interests tags received from repo`() =
+            testWithEmptyUserTags {
+                // Given
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
+
+                // Pause dispatcher so we can verify done button initial state
+                coroutineScope.pauseDispatcher()
+
+                // Trigger data load
+                initViewModel(EntryPoint.DISCOVER)
+
+                // Resume pending coroutines execution
+                coroutineScope.resumeDispatcher()
+
+                assertThat(requireNotNull(viewModel.uiState.value).titleVisible).isTrue
+            }
+
+    @Test
+    fun `settings title hidden on start when interests tags received from repo`() =
+            testWithEmptyUserTags {
+                // Given
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
+
+                // Pause dispatcher so we can verify done button initial state
+                coroutineScope.pauseDispatcher()
+
+                // Trigger data load
+                initViewModel(EntryPoint.SETTINGS)
+
+                // Resume pending coroutines execution
+                coroutineScope.resumeDispatcher()
+
+                assertThat(requireNotNull(viewModel.uiState.value).titleVisible).isFalse
+            }
+
+    @Test
     fun `discover done button hidden on start switches to disabled state when interests tags received from repo`() =
             testWithEmptyUserTags {
                 // Given

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.models.ReaderTagType
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsFragment.EntryPoint
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.DoneButtonUiState.DoneButtonDisabledUiState
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.DoneButtonUiState.DoneButtonEnabledUiState
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.DoneButtonUiState.DoneButtonHiddenUiState
@@ -435,9 +436,12 @@ class ReaderInterestsViewModelTest {
                         .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.reader_error_request_failed_title)))
             }
 
-    private fun initViewModel() = viewModel.start(
+    private fun initViewModel(
+        entryPoint: EntryPoint = EntryPoint.DISCOVER
+    ) = viewModel.start(
+            currentLanguage = CURRENT_LANGUAGE,
             parentViewModel = parentViewModel,
-            currentLanguage = CURRENT_LANGUAGE
+            entryPoint = entryPoint
     )
 
     private fun <T> testWithEmptyUserTags(block: suspend CoroutineScope.() -> T) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -64,8 +64,8 @@ class ReaderInterestsViewModelTest {
     fun `getUserTags invoked on start`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
 
                 // When
                 initViewModel()
@@ -78,8 +78,8 @@ class ReaderInterestsViewModelTest {
     fun `getInterests invoked if empty user tags received from repo`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
 
                 // When
                 initViewModel()
@@ -102,8 +102,8 @@ class ReaderInterestsViewModelTest {
     fun `progress bar shown on start hides on successful interests data load`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
 
                 // Pause dispatcher so we can verify progress bar initial state
                 coroutineScope.pauseDispatcher()
@@ -123,8 +123,8 @@ class ReaderInterestsViewModelTest {
     fun `title hidden on start become visible on successful interests data load`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
 
                 // Pause dispatcher so we can verify title initial state
                 coroutineScope.pauseDispatcher()
@@ -144,8 +144,8 @@ class ReaderInterestsViewModelTest {
     fun `interests correctly shown on successful interests data load`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
 
                 // When
                 initViewModel()
@@ -153,20 +153,20 @@ class ReaderInterestsViewModelTest {
                 // Then
                 assertThat(viewModel.uiState.value).isInstanceOf(ContentUiState::class.java)
                 assertThat(requireNotNull(viewModel.uiState.value as ContentUiState).interests)
-                        .isEqualTo(mockInterests)
+                        .isEqualTo(interests)
 
                 val uiState = requireNotNull(viewModel.uiState.value) as ContentUiState
-                assertThat(uiState.interests).isEqualTo(mockInterests)
+                assertThat(uiState.interests).isEqualTo(interests)
                 assertThat(uiState.interestsUiState[0]).isInstanceOf(TagUiState::class.java)
-                assertThat(uiState.interestsUiState[0].title).isEqualTo(mockInterests[0].tagTitle)
+                assertThat(uiState.interestsUiState[0].title).isEqualTo(interests[0].tagTitle)
             }
 
     @Test
     fun `done button hidden on start switches to disabled state when interests tags received from repo`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
 
                 // Pause dispatcher so we can verify done button initial state
                 coroutineScope.pauseDispatcher()
@@ -188,8 +188,8 @@ class ReaderInterestsViewModelTest {
     fun `interest selected if onInterestAtIndexToggled invoked on a deselected interest`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
                 val selectedIndex = 0
 
                 // When
@@ -208,8 +208,8 @@ class ReaderInterestsViewModelTest {
     fun `interest deselected if onInterestAtIndexToggled invoked on a selected interest`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
                 val selectedIndex = 0
 
                 // When
@@ -229,8 +229,8 @@ class ReaderInterestsViewModelTest {
     fun `done button shown in enabled state if an interest is in selected state`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
 
                 // When
                 initViewModel()
@@ -249,8 +249,8 @@ class ReaderInterestsViewModelTest {
     fun `done button shown in disabled state if no interests are in selected state`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
 
                 // When
                 initViewModel()
@@ -264,8 +264,8 @@ class ReaderInterestsViewModelTest {
     fun `close reader interests screen triggered when interests are saved successfully`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
                 whenever(readerTagRepository.saveInterests(any())).thenReturn(Success)
 
                 // When
@@ -280,8 +280,8 @@ class ReaderInterestsViewModelTest {
     fun `selected interests saved on done button click`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
                 val selectInterestAtIndex = 2
 
                 // When
@@ -290,7 +290,7 @@ class ReaderInterestsViewModelTest {
                 viewModel.onDoneButtonClick()
 
                 // Then
-                verify(readerTagRepository, times(1)).saveInterests(eq(listOf(mockInterests[selectInterestAtIndex])))
+                verify(readerTagRepository, times(1)).saveInterests(eq(listOf(interests[selectInterestAtIndex])))
             }
 
     @Test
@@ -373,8 +373,8 @@ class ReaderInterestsViewModelTest {
     fun `snackbar is shown on save interests error`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
                 whenever(readerTagRepository.saveInterests(any())).thenReturn(NetworkUnavailable)
 
                 // When
@@ -389,8 +389,8 @@ class ReaderInterestsViewModelTest {
     fun `snackbar is not shown when interests are saved successfully`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
                 whenever(readerTagRepository.saveInterests(any())).thenReturn(Success)
 
                 // When
@@ -405,8 +405,8 @@ class ReaderInterestsViewModelTest {
     fun `network error shown when internet access not available on save interests`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
                 whenever(readerTagRepository.saveInterests(any())).thenReturn(NetworkUnavailable)
 
                 // When
@@ -422,8 +422,8 @@ class ReaderInterestsViewModelTest {
     fun `request failed error shown on save interests remote request failure`() =
             testWithEmptyUserTags {
                 // Given
-                val mockInterests = getMockInterests()
-                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
                 whenever(readerTagRepository.saveInterests(any())).thenReturn(RemoteRequestFailure)
 
                 // When
@@ -465,7 +465,7 @@ class ReaderInterestsViewModelTest {
         }
     }
 
-    private fun getMockInterests() =
+    private fun getInterests() =
             ReaderTagList().apply {
                 for (c in 'A'..'Z')
                     (add(

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -420,7 +420,7 @@ class ReaderInterestsViewModelTest {
                 // Then
                 assertThat(viewModel.uiState.value).isInstanceOf(ConnectionErrorUiState::class.java)
                 val errorUiState = requireNotNull(viewModel.uiState.value) as ConnectionErrorUiState
-                assertThat(errorUiState.titleResId).isEqualTo(R.string.no_network_message)
+                assertThat(errorUiState.titleRes).isEqualTo(R.string.no_network_message)
             }
 
     @Test
@@ -435,7 +435,7 @@ class ReaderInterestsViewModelTest {
                 // Then
                 assertThat(viewModel.uiState.value).isInstanceOf(RequestFailedErrorUiState::class.java)
                 val errorUiState = requireNotNull(viewModel.uiState.value) as RequestFailedErrorUiState
-                assertThat(errorUiState.titleResId).isEqualTo(R.string.reader_error_request_failed_title)
+                assertThat(errorUiState.titleRes).isEqualTo(R.string.reader_error_request_failed_title)
             }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.DoneButtonUiState.DoneButtonDisabledUiState
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.DoneButtonUiState.DoneButtonEnabledUiState
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.DoneButtonUiState.DoneButtonHiddenUiState
-
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.UiState.ContentUiState
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.UiState.ErrorUiState.ConnectionErrorUiState
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.UiState.ErrorUiState.RequestFailedErrorUiState
@@ -36,10 +35,11 @@ import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.
 import org.wordpress.android.ui.reader.repository.ReaderRepositoryCommunication.SuccessWithData
 import org.wordpress.android.ui.reader.repository.ReaderTagRepository
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
-import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
 private const val CURRENT_LANGUAGE = "en"
+
 @RunWith(MockitoJUnitRunner::class)
 class ReaderInterestsViewModelTest {
     @Rule
@@ -63,400 +63,404 @@ class ReaderInterestsViewModelTest {
     @ExperimentalCoroutinesApi
     @Test
     fun `getUserTags invoked on start`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
 
-            // When
-            initViewModel()
+                // When
+                initViewModel()
 
-            // Then
-            verify(readerTagRepository, times(1)).getUserTags()
-        }
+                // Then
+                verify(readerTagRepository, times(1)).getUserTags()
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `getInterests invoked if empty user tags received from repo`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
 
-            // When
-            initViewModel()
+                // When
+                initViewModel()
 
-            // Then
-            verify(readerTagRepository, times(1)).getInterests()
-        }
+                // Then
+                verify(readerTagRepository, times(1)).getInterests()
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `close reader screen triggered if non empty user tags are received from repo`() =
-        testWithNonEmptyUserTags {
-            // When
-            initViewModel()
+            testWithNonEmptyUserTags {
+                // When
+                initViewModel()
 
-            // Then
-            verify(parentViewModel, times(1)).onCloseReaderInterests()
-        }
+                // Then
+                verify(parentViewModel, times(1)).onCloseReaderInterests()
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `progress bar shown on start hides on successful interests data load`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
 
-            // Pause dispatcher so we can verify progress bar initial state
-            coroutineScope.pauseDispatcher()
+                // Pause dispatcher so we can verify progress bar initial state
+                coroutineScope.pauseDispatcher()
 
-            // Trigger data load
-            initViewModel()
+                // Trigger data load
+                initViewModel()
 
-            assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(true)
+                assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(true)
 
-            // Resume pending coroutines execution
-            coroutineScope.resumeDispatcher()
+                // Resume pending coroutines execution
+                coroutineScope.resumeDispatcher()
 
-            assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
-        }
+                assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `title hidden on start become visible on successful interests data load`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
 
-            // Pause dispatcher so we can verify title initial state
-            coroutineScope.pauseDispatcher()
+                // Pause dispatcher so we can verify title initial state
+                coroutineScope.pauseDispatcher()
 
-            // Trigger data load
-            initViewModel()
+                // Trigger data load
+                initViewModel()
 
-            assertThat(requireNotNull(viewModel.uiState.value).titleVisible).isEqualTo(false)
+                assertThat(requireNotNull(viewModel.uiState.value).titleVisible).isEqualTo(false)
 
-            // Resume pending coroutines execution
-            coroutineScope.resumeDispatcher()
+                // Resume pending coroutines execution
+                coroutineScope.resumeDispatcher()
 
-            assertThat(requireNotNull(viewModel.uiState.value).titleVisible).isEqualTo(true)
-        }
+                assertThat(requireNotNull(viewModel.uiState.value).titleVisible).isEqualTo(true)
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `interests correctly shown on successful interests data load`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
 
-            // When
-            initViewModel()
+                // When
+                initViewModel()
 
-            // Then
-            assertThat(viewModel.uiState.value).isInstanceOf(ContentUiState::class.java)
-            assertThat(requireNotNull(viewModel.uiState.value as ContentUiState).interests)
-                .isEqualTo(mockInterests)
+                // Then
+                assertThat(viewModel.uiState.value).isInstanceOf(ContentUiState::class.java)
+                assertThat(requireNotNull(viewModel.uiState.value as ContentUiState).interests)
+                        .isEqualTo(mockInterests)
 
-            val uiState = requireNotNull(viewModel.uiState.value) as ContentUiState
-            assertThat(uiState.interests).isEqualTo(mockInterests)
-            assertThat(uiState.interestsUiState[0]).isInstanceOf(TagUiState::class.java)
-            assertThat(uiState.interestsUiState[0].title).isEqualTo(mockInterests[0].tagTitle)
-        }
+                val uiState = requireNotNull(viewModel.uiState.value) as ContentUiState
+                assertThat(uiState.interests).isEqualTo(mockInterests)
+                assertThat(uiState.interestsUiState[0]).isInstanceOf(TagUiState::class.java)
+                assertThat(uiState.interestsUiState[0].title).isEqualTo(mockInterests[0].tagTitle)
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `done button hidden on start switches to disabled state when interests tags received from repo`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
 
-            // Pause dispatcher so we can verify done button initial state
-            coroutineScope.pauseDispatcher()
+                // Pause dispatcher so we can verify done button initial state
+                coroutineScope.pauseDispatcher()
 
-            // Trigger data load
-            initViewModel()
+                // Trigger data load
+                initViewModel()
 
-            assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
-                .isInstanceOf(DoneButtonHiddenUiState::class.java)
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
+                        .isInstanceOf(DoneButtonHiddenUiState::class.java)
 
-            // Resume pending coroutines execution
-            coroutineScope.resumeDispatcher()
+                // Resume pending coroutines execution
+                coroutineScope.resumeDispatcher()
 
-            assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
-                .isInstanceOf(DoneButtonDisabledUiState::class.java)
-        }
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
+                        .isInstanceOf(DoneButtonDisabledUiState::class.java)
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `interest selected if onInterestAtIndexToggled invoked on a deselected interest`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
-            val selectedIndex = 0
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val selectedIndex = 0
 
-            // When
-            initViewModel()
-            viewModel.onInterestAtIndexToggled(index = selectedIndex, isChecked = true)
+                // When
+                initViewModel()
+                viewModel.onInterestAtIndexToggled(index = selectedIndex, isChecked = true)
 
-            // Then
-            assertThat(requireNotNull(viewModel.uiState.value as ContentUiState)
-                .interestsUiState[selectedIndex].isChecked)
-                .isEqualTo(true)
-        }
+                // Then
+                assertThat(
+                        requireNotNull(viewModel.uiState.value as ContentUiState)
+                                .interestsUiState[selectedIndex].isChecked
+                )
+                        .isEqualTo(true)
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `interest deselected if onInterestAtIndexToggled invoked on a selected interest`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
-            val selectedIndex = 0
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val selectedIndex = 0
 
-            // When
-            initViewModel()
-            viewModel.onInterestAtIndexToggled(index = selectedIndex, isChecked = true)
-            viewModel.onInterestAtIndexToggled(index = selectedIndex, isChecked = false)
+                // When
+                initViewModel()
+                viewModel.onInterestAtIndexToggled(index = selectedIndex, isChecked = true)
+                viewModel.onInterestAtIndexToggled(index = selectedIndex, isChecked = false)
 
-            // Then
-            assertThat(requireNotNull(viewModel.uiState.value as ContentUiState)
-                .interestsUiState[selectedIndex].isChecked)
-                .isEqualTo(false)
-        }
+                // Then
+                assertThat(
+                        requireNotNull(viewModel.uiState.value as ContentUiState)
+                                .interestsUiState[selectedIndex].isChecked
+                )
+                        .isEqualTo(false)
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `done button shown in enabled state if an interest is in selected state`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
 
-            // When
-            initViewModel()
-            viewModel.onInterestAtIndexToggled(index = 0, isChecked = true)
+                // When
+                initViewModel()
+                viewModel.onInterestAtIndexToggled(index = 0, isChecked = true)
 
-            // Then
-            assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
-                .isInstanceOf(DoneButtonEnabledUiState::class.java)
-            assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState.titleRes)
-                .isEqualTo(R.string.reader_btn_done)
-            assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState.enabled)
-                .isEqualTo(true)
-        }
+                // Then
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
+                        .isInstanceOf(DoneButtonEnabledUiState::class.java)
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState.titleRes)
+                        .isEqualTo(R.string.reader_btn_done)
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState.enabled)
+                        .isEqualTo(true)
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `done button shown in disabled state if no interests are in selected state`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
 
-            // When
-            initViewModel()
+                // When
+                initViewModel()
 
-            // Then
-            assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
-                .isInstanceOf(DoneButtonDisabledUiState::class.java)
-        }
+                // Then
+                assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
+                        .isInstanceOf(DoneButtonDisabledUiState::class.java)
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `close reader interests screen triggered when interests are saved successfully`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
-            whenever(readerTagRepository.saveInterests(any())).thenReturn(Success)
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                whenever(readerTagRepository.saveInterests(any())).thenReturn(Success)
 
-            // When
-            initViewModel()
-            viewModel.onDoneButtonClick()
+                // When
+                initViewModel()
+                viewModel.onDoneButtonClick()
 
-            // Then
-            verify(parentViewModel, times(1)).onCloseReaderInterests()
-        }
+                // Then
+                verify(parentViewModel, times(1)).onCloseReaderInterests()
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `selected interests saved on done button click`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
-            val selectInterestAtIndex = 2
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                val selectInterestAtIndex = 2
 
-            // When
-            initViewModel()
-            viewModel.onInterestAtIndexToggled(index = selectInterestAtIndex, isChecked = true)
-            viewModel.onDoneButtonClick()
+                // When
+                initViewModel()
+                viewModel.onInterestAtIndexToggled(index = selectInterestAtIndex, isChecked = true)
+                viewModel.onDoneButtonClick()
 
-            // Then
-            verify(readerTagRepository, times(1)).saveInterests(eq(listOf(mockInterests[selectInterestAtIndex])))
-        }
+                // Then
+                verify(readerTagRepository, times(1)).saveInterests(eq(listOf(mockInterests[selectInterestAtIndex])))
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `get interests triggered on retry`() =
-        testWithEmptyUserTags {
-            // When
-            viewModel.onRetryButtonClick()
+            testWithEmptyUserTags {
+                // When
+                viewModel.onRetryButtonClick()
 
-            // Then
-            verify(readerTagRepository, times(1)).getInterests()
-        }
+                // Then
+                verify(readerTagRepository, times(1)).getInterests()
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `get user tags re-triggered on retry if user tags request had failed earlier`() =
-        testWithFailedUserTags {
-            // When
-            initViewModel()
-            viewModel.onRetryButtonClick()
+            testWithFailedUserTags {
+                // When
+                initViewModel()
+                viewModel.onRetryButtonClick()
 
-            // Then
-            verify(readerTagRepository, times(2)).getUserTags()
-        }
+                // Then
+                verify(readerTagRepository, times(2)).getUserTags()
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `get user tags not re-triggered on retry if user tags request had not failed earlier`() =
-        testWithEmptyUserTags {
-            // When
-            initViewModel()
-            viewModel.onRetryButtonClick()
+            testWithEmptyUserTags {
+                // When
+                initViewModel()
+                viewModel.onRetryButtonClick()
 
-            // Then
-            verify(readerTagRepository, times(1)).getUserTags()
-        }
+                // Then
+                verify(readerTagRepository, times(1)).getUserTags()
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `error layout is shown on interests load error`() =
-        testWithEmptyUserTags {
-            // Given
-            whenever(readerTagRepository.getInterests()).thenReturn(NetworkUnavailable)
+            testWithEmptyUserTags {
+                // Given
+                whenever(readerTagRepository.getInterests()).thenReturn(NetworkUnavailable)
 
-            // When
-            initViewModel()
+                // When
+                initViewModel()
 
-            // Then
-            val contentLoadFailedUiState = requireNotNull(viewModel.uiState.value) as ConnectionErrorUiState
-            assertThat(contentLoadFailedUiState.errorLayoutVisible).isEqualTo(true)
-        }
+                // Then
+                val contentLoadFailedUiState = requireNotNull(viewModel.uiState.value) as ConnectionErrorUiState
+                assertThat(contentLoadFailedUiState.errorLayoutVisible).isEqualTo(true)
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `network error shown when internet access not available on interests load`() =
-        testWithEmptyUserTags {
-            // Given
-            whenever(readerTagRepository.getInterests()).thenReturn(NetworkUnavailable)
+            testWithEmptyUserTags {
+                // Given
+                whenever(readerTagRepository.getInterests()).thenReturn(NetworkUnavailable)
 
-            // When
-            initViewModel()
+                // When
+                initViewModel()
 
-            // Then
-            assertThat(viewModel.uiState.value).isInstanceOf(ConnectionErrorUiState::class.java)
-            val errorUiState = requireNotNull(viewModel.uiState.value) as ConnectionErrorUiState
-            assertThat(errorUiState.titleResId).isEqualTo(R.string.no_network_message)
-        }
+                // Then
+                assertThat(viewModel.uiState.value).isInstanceOf(ConnectionErrorUiState::class.java)
+                val errorUiState = requireNotNull(viewModel.uiState.value) as ConnectionErrorUiState
+                assertThat(errorUiState.titleResId).isEqualTo(R.string.no_network_message)
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `request failed error shown on load interests remote request failure`() =
-        testWithEmptyUserTags {
-            // Given
-            whenever(readerTagRepository.getInterests()).thenReturn(RemoteRequestFailure)
+            testWithEmptyUserTags {
+                // Given
+                whenever(readerTagRepository.getInterests()).thenReturn(RemoteRequestFailure)
 
-            // When
-            initViewModel()
+                // When
+                initViewModel()
 
-            // Then
-            assertThat(viewModel.uiState.value).isInstanceOf(RequestFailedErrorUiState::class.java)
-            val errorUiState = requireNotNull(viewModel.uiState.value) as RequestFailedErrorUiState
-            assertThat(errorUiState.titleResId).isEqualTo(R.string.reader_error_request_failed_title)
-        }
+                // Then
+                assertThat(viewModel.uiState.value).isInstanceOf(RequestFailedErrorUiState::class.java)
+                val errorUiState = requireNotNull(viewModel.uiState.value) as RequestFailedErrorUiState
+                assertThat(errorUiState.titleResId).isEqualTo(R.string.reader_error_request_failed_title)
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `snackbar is shown on save interests error`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
-            whenever(readerTagRepository.saveInterests(any())).thenReturn(NetworkUnavailable)
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                whenever(readerTagRepository.saveInterests(any())).thenReturn(NetworkUnavailable)
 
-            // When
-            initViewModel()
-            viewModel.onDoneButtonClick()
+                // When
+                initViewModel()
+                viewModel.onDoneButtonClick()
 
-            // Then
-            assertThat(viewModel.snackbarEvents.value).isNotNull
-        }
+                // Then
+                assertThat(viewModel.snackbarEvents.value).isNotNull
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `snackbar is not shown when interests are saved successfully`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
-            whenever(readerTagRepository.saveInterests(any())).thenReturn(Success)
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                whenever(readerTagRepository.saveInterests(any())).thenReturn(Success)
 
-            // When
-            initViewModel()
-            viewModel.onDoneButtonClick()
+                // When
+                initViewModel()
+                viewModel.onDoneButtonClick()
 
-            // Then
-            assertThat(viewModel.snackbarEvents.value).isNull()
-        }
+                // Then
+                assertThat(viewModel.snackbarEvents.value).isNull()
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `network error shown when internet access not available on save interests`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
-            whenever(readerTagRepository.saveInterests(any())).thenReturn(NetworkUnavailable)
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                whenever(readerTagRepository.saveInterests(any())).thenReturn(NetworkUnavailable)
 
-            // When
-            initViewModel()
-            viewModel.onDoneButtonClick()
+                // When
+                initViewModel()
+                viewModel.onDoneButtonClick()
 
-            // Then
-            assertThat(requireNotNull(viewModel.snackbarEvents.value).peekContent())
-                    .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.no_network_message)))
-        }
+                // Then
+                assertThat(requireNotNull(viewModel.snackbarEvents.value).peekContent())
+                        .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.no_network_message)))
+            }
 
     @ExperimentalCoroutinesApi
     @Test
     fun `request failed error shown on save interests remote request failure`() =
-        testWithEmptyUserTags {
-            // Given
-            val mockInterests = getMockInterests()
-            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
-            whenever(readerTagRepository.saveInterests(any())).thenReturn(RemoteRequestFailure)
+            testWithEmptyUserTags {
+                // Given
+                val mockInterests = getMockInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(mockInterests))
+                whenever(readerTagRepository.saveInterests(any())).thenReturn(RemoteRequestFailure)
 
-            // When
-            initViewModel()
-            viewModel.onDoneButtonClick()
+                // When
+                initViewModel()
+                viewModel.onDoneButtonClick()
 
-            // Then
-            assertThat(requireNotNull(viewModel.snackbarEvents.value).peekContent())
-                .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.reader_error_request_failed_title)))
-        }
+                // Then
+                assertThat(requireNotNull(viewModel.snackbarEvents.value).peekContent())
+                        .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.reader_error_request_failed_title)))
+            }
 
     private fun initViewModel() = viewModel.start(
-        parentViewModel = parentViewModel,
-        currentLanguage = CURRENT_LANGUAGE
+            parentViewModel = parentViewModel,
+            currentLanguage = CURRENT_LANGUAGE
     )
 
     @ExperimentalCoroutinesApi
@@ -488,14 +492,14 @@ class ReaderInterestsViewModelTest {
     }
 
     private fun getMockInterests() =
-        ReaderTagList().apply {
-            for (c in 'A'..'Z')
-                (add(
-                    ReaderTag(
-                        c.toString(), c.toString(), c.toString(),
-                        "https://public-api.wordpress.com/rest/v1.2/read/tags/$c/posts",
-                        ReaderTagType.DEFAULT
-                    )
-                ))
-        }
+            ReaderTagList().apply {
+                for (c in 'A'..'Z')
+                    (add(
+                            ReaderTag(
+                                    c.toString(), c.toString(), c.toString(),
+                                    "https://public-api.wordpress.com/rest/v1.2/read/tags/$c/posts",
+                                    ReaderTagType.DEFAULT
+                            )
+                    ))
+            }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -93,7 +93,7 @@ class ReaderInterestsViewModelTest {
     fun `discover close reader screen triggered if non empty user tags are received from repo`() =
             testWithNonEmptyUserTags {
                 // When
-                initViewModel()
+                initViewModel(EntryPoint.DISCOVER)
 
                 // Then
                 verify(parentViewModel, times(1)).onCloseReaderInterests()
@@ -103,9 +103,7 @@ class ReaderInterestsViewModelTest {
     fun `settings does not close reader screen triggered if non empty user tags are received from repo`() =
             testWithNonEmptyUserTags {
                 // When
-                initViewModel(
-                        entryPoint = EntryPoint.SETTINGS
-                )
+                initViewModel(EntryPoint.SETTINGS)
 
                 // Then
                 verify(parentViewModel, times(0)).onCloseReaderInterests()
@@ -212,7 +210,7 @@ class ReaderInterestsViewModelTest {
                 coroutineScope.pauseDispatcher()
 
                 // Trigger data load
-                initViewModel()
+                initViewModel(EntryPoint.DISCOVER)
 
                 assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
                         .isInstanceOf(DoneButtonHiddenUiState::class.java)
@@ -237,9 +235,7 @@ class ReaderInterestsViewModelTest {
                 coroutineScope.pauseDispatcher()
 
                 // Trigger data load
-                initViewModel(
-                        entryPoint = EntryPoint.SETTINGS
-                )
+                initViewModel(EntryPoint.SETTINGS)
 
                 assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
                         .isInstanceOf(DoneButtonHiddenUiState::class.java)
@@ -322,7 +318,7 @@ class ReaderInterestsViewModelTest {
                 whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
 
                 // When
-                initViewModel()
+                initViewModel(EntryPoint.DISCOVER)
 
                 // Then
                 assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
@@ -339,9 +335,7 @@ class ReaderInterestsViewModelTest {
                 whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
 
                 // When
-                initViewModel(
-                        entryPoint = EntryPoint.SETTINGS
-                )
+                initViewModel(EntryPoint.SETTINGS)
 
                 // Then
                 assertThat(requireNotNull(viewModel.uiState.value).doneButtonUiState)
@@ -359,7 +353,7 @@ class ReaderInterestsViewModelTest {
                 whenever(readerTagRepository.saveInterests(any())).thenReturn(Success)
 
                 // When
-                initViewModel()
+                initViewModel(EntryPoint.DISCOVER)
                 viewModel.onDoneButtonClick()
 
                 // Then
@@ -375,9 +369,7 @@ class ReaderInterestsViewModelTest {
                 whenever(readerTagRepository.saveInterests(any())).thenReturn(Success)
 
                 // When
-                initViewModel(
-                        entryPoint = EntryPoint.SETTINGS
-                )
+                initViewModel(EntryPoint.SETTINGS)
                 viewModel.onDoneButtonClick()
 
                 // Then
@@ -546,7 +538,8 @@ class ReaderInterestsViewModelTest {
     @Test
     fun `discover close reader screen on back button click`() {
         // When
-        initViewModel()
+        initViewModel(EntryPoint.DISCOVER)
+
         viewModel.onBackButtonClick()
 
         // Then
@@ -556,9 +549,8 @@ class ReaderInterestsViewModelTest {
     @Test
     fun `settings close reader screen on back button click`() {
         // When
-        initViewModel(
-                entryPoint = EntryPoint.SETTINGS
-        )
+        initViewModel(EntryPoint.SETTINGS)
+
         viewModel.onBackButtonClick()
 
         // Then
@@ -568,9 +560,9 @@ class ReaderInterestsViewModelTest {
     private fun initViewModel(
         entryPoint: EntryPoint = EntryPoint.DISCOVER
     ) = viewModel.start(
+            entryPoint = entryPoint,
             currentLanguage = CURRENT_LANGUAGE,
-            parentViewModel = parentViewModel,
-            entryPoint = entryPoint
+            parentViewModel = parentViewModel
     )
 
     private fun <T> testWithEmptyUserTags(block: suspend CoroutineScope.() -> T) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -330,7 +330,7 @@ class ReaderInterestsViewModelTest {
             }
 
     @Test
-    fun `close reader interests screen triggered when interests are saved successfully`() =
+    fun `discover close reader interests screen triggered when interests are saved successfully`() =
             testWithEmptyUserTags {
                 // Given
                 val interests = getInterests()
@@ -343,6 +343,24 @@ class ReaderInterestsViewModelTest {
 
                 // Then
                 verify(parentViewModel, times(1)).onCloseReaderInterests()
+            }
+
+    @Test
+    fun `settings close reader interests screen triggered when interests are saved successfully`() =
+            testWithEmptyUserTags {
+                // Given
+                val interests = getInterests()
+                whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
+                whenever(readerTagRepository.saveInterests(any())).thenReturn(Success)
+
+                // When
+                initViewModel(
+                        entryPoint = EntryPoint.SETTINGS
+                )
+                viewModel.onDoneButtonClick()
+
+                // Then
+                assertThat(viewModel.closeReaderInterests.value).isNotNull
             }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -40,12 +40,12 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
 private const val CURRENT_LANGUAGE = "en"
 
+@ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class ReaderInterestsViewModelTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 
-    @ExperimentalCoroutinesApi
     @Rule
     @JvmField val coroutineScope = MainCoroutineScopeRule()
 
@@ -60,7 +60,6 @@ class ReaderInterestsViewModelTest {
         viewModel = ReaderInterestsViewModel(readerTagRepository, trackerWrapper)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `getUserTags invoked on start`() =
             testWithEmptyUserTags {
@@ -75,7 +74,6 @@ class ReaderInterestsViewModelTest {
                 verify(readerTagRepository, times(1)).getUserTags()
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `getInterests invoked if empty user tags received from repo`() =
             testWithEmptyUserTags {
@@ -90,7 +88,6 @@ class ReaderInterestsViewModelTest {
                 verify(readerTagRepository, times(1)).getInterests()
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `close reader screen triggered if non empty user tags are received from repo`() =
             testWithNonEmptyUserTags {
@@ -101,7 +98,6 @@ class ReaderInterestsViewModelTest {
                 verify(parentViewModel, times(1)).onCloseReaderInterests()
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `progress bar shown on start hides on successful interests data load`() =
             testWithEmptyUserTags {
@@ -123,7 +119,6 @@ class ReaderInterestsViewModelTest {
                 assertThat(requireNotNull(viewModel.uiState.value).progressBarVisible).isEqualTo(false)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `title hidden on start become visible on successful interests data load`() =
             testWithEmptyUserTags {
@@ -145,7 +140,6 @@ class ReaderInterestsViewModelTest {
                 assertThat(requireNotNull(viewModel.uiState.value).titleVisible).isEqualTo(true)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `interests correctly shown on successful interests data load`() =
             testWithEmptyUserTags {
@@ -167,7 +161,6 @@ class ReaderInterestsViewModelTest {
                 assertThat(uiState.interestsUiState[0].title).isEqualTo(mockInterests[0].tagTitle)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `done button hidden on start switches to disabled state when interests tags received from repo`() =
             testWithEmptyUserTags {
@@ -191,7 +184,6 @@ class ReaderInterestsViewModelTest {
                         .isInstanceOf(DoneButtonDisabledUiState::class.java)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `interest selected if onInterestAtIndexToggled invoked on a deselected interest`() =
             testWithEmptyUserTags {
@@ -212,7 +204,6 @@ class ReaderInterestsViewModelTest {
                         .isEqualTo(true)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `interest deselected if onInterestAtIndexToggled invoked on a selected interest`() =
             testWithEmptyUserTags {
@@ -234,7 +225,6 @@ class ReaderInterestsViewModelTest {
                         .isEqualTo(false)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `done button shown in enabled state if an interest is in selected state`() =
             testWithEmptyUserTags {
@@ -255,7 +245,6 @@ class ReaderInterestsViewModelTest {
                         .isEqualTo(true)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `done button shown in disabled state if no interests are in selected state`() =
             testWithEmptyUserTags {
@@ -271,7 +260,6 @@ class ReaderInterestsViewModelTest {
                         .isInstanceOf(DoneButtonDisabledUiState::class.java)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `close reader interests screen triggered when interests are saved successfully`() =
             testWithEmptyUserTags {
@@ -288,7 +276,6 @@ class ReaderInterestsViewModelTest {
                 verify(parentViewModel, times(1)).onCloseReaderInterests()
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `selected interests saved on done button click`() =
             testWithEmptyUserTags {
@@ -306,7 +293,6 @@ class ReaderInterestsViewModelTest {
                 verify(readerTagRepository, times(1)).saveInterests(eq(listOf(mockInterests[selectInterestAtIndex])))
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `get interests triggered on retry`() =
             testWithEmptyUserTags {
@@ -317,7 +303,6 @@ class ReaderInterestsViewModelTest {
                 verify(readerTagRepository, times(1)).getInterests()
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `get user tags re-triggered on retry if user tags request had failed earlier`() =
             testWithFailedUserTags {
@@ -329,7 +314,6 @@ class ReaderInterestsViewModelTest {
                 verify(readerTagRepository, times(2)).getUserTags()
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `get user tags not re-triggered on retry if user tags request had not failed earlier`() =
             testWithEmptyUserTags {
@@ -341,7 +325,6 @@ class ReaderInterestsViewModelTest {
                 verify(readerTagRepository, times(1)).getUserTags()
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `error layout is shown on interests load error`() =
             testWithEmptyUserTags {
@@ -356,7 +339,6 @@ class ReaderInterestsViewModelTest {
                 assertThat(contentLoadFailedUiState.errorLayoutVisible).isEqualTo(true)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `network error shown when internet access not available on interests load`() =
             testWithEmptyUserTags {
@@ -372,7 +354,6 @@ class ReaderInterestsViewModelTest {
                 assertThat(errorUiState.titleResId).isEqualTo(R.string.no_network_message)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `request failed error shown on load interests remote request failure`() =
             testWithEmptyUserTags {
@@ -388,7 +369,6 @@ class ReaderInterestsViewModelTest {
                 assertThat(errorUiState.titleResId).isEqualTo(R.string.reader_error_request_failed_title)
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `snackbar is shown on save interests error`() =
             testWithEmptyUserTags {
@@ -405,7 +385,6 @@ class ReaderInterestsViewModelTest {
                 assertThat(viewModel.snackbarEvents.value).isNotNull
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `snackbar is not shown when interests are saved successfully`() =
             testWithEmptyUserTags {
@@ -422,7 +401,6 @@ class ReaderInterestsViewModelTest {
                 assertThat(viewModel.snackbarEvents.value).isNull()
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `network error shown when internet access not available on save interests`() =
             testWithEmptyUserTags {
@@ -440,7 +418,6 @@ class ReaderInterestsViewModelTest {
                         .isEqualTo(SnackbarMessageHolder(UiStringRes(R.string.no_network_message)))
             }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `request failed error shown on save interests remote request failure`() =
             testWithEmptyUserTags {
@@ -463,7 +440,6 @@ class ReaderInterestsViewModelTest {
             currentLanguage = CURRENT_LANGUAGE
     )
 
-    @ExperimentalCoroutinesApi
     private fun <T> testWithEmptyUserTags(block: suspend CoroutineScope.() -> T) {
         coroutineScope.runBlockingTest {
             whenever(readerTagRepository.getUserTags()).thenReturn(SuccessWithData(ReaderTagList()))
@@ -471,7 +447,6 @@ class ReaderInterestsViewModelTest {
         }
     }
 
-    @ExperimentalCoroutinesApi
     private fun <T> testWithFailedUserTags(block: suspend CoroutineScope.() -> T) {
         coroutineScope.runBlockingTest {
             whenever(readerTagRepository.getUserTags()).thenReturn(NetworkUnavailable)
@@ -479,7 +454,6 @@ class ReaderInterestsViewModelTest {
         }
     }
 
-    @ExperimentalCoroutinesApi
     private fun <T> testWithNonEmptyUserTags(block: suspend CoroutineScope.() -> T) {
         coroutineScope.runBlockingTest {
             val nonEmptyUserTags = ReaderTagList().apply {


### PR DESCRIPTION
Fixes #13972

This PR makes it possible for users to see the `Topic Picker` screen again after they have added some topics. Previously, this screen would only be shown once, within the `Discover` tab and only if the user hasn't followed any topics yet. With this change, even if the user has already followed some topics, they will still be able to see the `Topic Picker` screen through the `Manage Topics & Sites` settings screen.

Discover | Settings
-------|------
<img width="250" height="500" alt="discover" src="https://user-images.githubusercontent.com/9729923/109326115-6ebc6a00-785f-11eb-8686-6830515f9bf1.mp4"> | <img width="250" height="500" alt="settings" src="https://user-images.githubusercontent.com/9729923/109326516-f86c3780-785f-11eb-8e7e-974382b82906.mp4">

To test:
- Unfollow all topics and navigate to `Reader` -> `DISCOVER` tab.
- Make sure the `DISCOVER` screen is empty. Click on the `GET STARTED` button.
- Verify that the `Topic Picker` screen is shown and everything looks as expected. Nothing changes here. Notice the `Choose your interests` title and the `Select a few to continue` text on the disabled state of the button.
- Select a few topics and click the `Done` button.
- Verify that the `DISCOVER` screen is now showing some content.
- Find the ⚙️ icon on top, within the `Reader` toolbar, and click on it to navigate to the `Manage Topics & Sites` settings screen.
- Verify that at least a few topics are listed under the `FOLLOWED TOPICS` tab list.
- Verify that the `cross` icon has been replaced with the `reader following` icon. Click on the `FAB` button.
- Verify that the `Topic Picker` screen is shown and everything looks familiar. Few things change here. Notice that the `Choose your interests` title is no longer shown. Instead the `Follow topics` toolbar title is shown. Also, notice that the `Select a few to continue` text on the disable state of the button has been now replaced with `Done`.
- Select a few topics and click the `Done` button.
- Verify that you get navigated back to the `Manage Topics & Sites` setting screen and that those newly picked topics are now shown within the `FOLLOWED TOPICS` tab list.
- Remove some topics by clicking the `reader following` icon and verify that this functionality works as expected.
- Go wild... play some more, select a lot of topics, select all the topics, verify everything works as expected, then remove lots of topics, remove all topics, check the `DISCOVER` tab again, make sure everything looks and feel okay, continue...

Note:
After talking to @mbshakti, we decided to add another improvement to the `Topics Picker` screen, where we will show some illustration and copy that there are no recommendations left on an empty state. But, this will be done on a separate PR when it will be design ready.

**Merge Instructions** (:warning:):
1. ~~Wait for @mbshakti to do design review.~~
1. ~~Remove the `Needs Design Review` label.~~
1. Merge this PR.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
