### PR TITLE
Issue/14128 related posts actions refactoring

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -106,7 +106,6 @@ import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.ReaderPostDetailsUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.ReaderPostDetailsUiState.RelatedPostsUiState
 import org.wordpress.android.ui.reader.views.ReaderSimplePostContainerView
-import org.wordpress.android.ui.reader.views.ReaderSimplePostView
 import org.wordpress.android.ui.reader.views.ReaderIconCountView
 import org.wordpress.android.ui.reader.views.ReaderPostDetailsHeaderViewUiStateBuilder
 import org.wordpress.android.ui.reader.views.ReaderWebView
@@ -746,14 +745,9 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
      * across wp.com) or local (related posts from the same site as the current post)
      */
     private fun showRelatedPosts(state: RelatedPostsUiState) {
-        // tapping a related post should open the related post detail
-        val listener = ReaderSimplePostView.OnSimplePostClickListener { _, siteId, postId ->
-            showRelatedPostDetail(siteId, postId, state.isGlobal)
-        }
-
         // different container views for global/local related posts
         val relatedPostsView = if (state.isGlobal) globalRelatedPostsView else localRelatedPostsView
-        relatedPostsView.showPosts(state, listener)
+        relatedPostsView.showPosts(state)
 
         // fade in this related posts view
         if (relatedPostsView.visibility != View.VISIBLE) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -461,7 +461,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                         showBookmarkSavedLocallyDialog(this)
 
                     is ReaderNavigationEvents.ShowRelatedPostDetails ->
-                        showRelatedPostDetail(postId = this.postId, blogId = this.blogId, isGlobal = this.isGlobal)
+                        showRelatedPostDetail(postId = this.postId, blogId = this.blogId)
 
                     is ReaderNavigationEvents.ReplaceRelatedPostDetailsWithHistory ->
                         replaceRelatedPostDetailWithHistory(
@@ -793,7 +793,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         return false
     }
 
-    private fun showRelatedPostDetail(postId: Long, blogId: Long, isGlobal: Boolean) {
+    private fun showRelatedPostDetail(postId: Long, blogId: Long) {
         ReaderActivityLauncher.showReaderPostDetail(
                 activity,
                 false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -399,84 +399,81 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private fun initViewModel() {
         viewModel = ViewModelProvider(this, viewModelFactory).get(ReaderPostDetailViewModel::class.java)
 
-        viewModel.uiState.observe(
-                viewLifecycleOwner, { state ->
-                    header_view.updatePost(state.headerUiState)
-                    showOrHideMoreMenu(state)
-
-                    updateActionButton(state.postId, state.blogId, state.actions.likeAction, count_likes)
-                    updateActionButton(state.postId, state.blogId, state.actions.reblogAction, reblog)
-                    updateActionButton(state.postId, state.blogId, state.actions.commentsAction, count_comments)
-                    updateActionButton(state.postId, state.blogId, state.actions.bookmarkAction, bookmark)
-
-                    state.localRelatedPosts?.let { showRelatedPosts(it) }
-                    state.globalRelatedPosts?.let { showRelatedPosts(it) }
-                }
-        )
+        viewModel.uiState.observe(viewLifecycleOwner, { renderUiState(it) })
 
         viewModel.refreshPost.observe(viewLifecycleOwner, {} /* Do nothing */)
 
         viewModel.snackbarEvents.observe(viewLifecycleOwner, { it?.applyIfNotHandled { showSnackbar() } })
 
-        viewModel.navigationEvents.observe(viewLifecycleOwner, {
-            it.applyIfNotHandled {
-                when (this) {
-                    is ReaderNavigationEvents.ShowPostsByTag ->
-                        ReaderActivityLauncher.showReaderTagPreview(context, this.tag)
+        viewModel.navigationEvents.observe(viewLifecycleOwner, { it.applyIfNotHandled { handleNavigationEvent() } })
 
-                    is ReaderNavigationEvents.ShowBlogPreview -> ReaderActivityLauncher.showReaderBlogOrFeedPreview(
-                            context,
-                            this.siteId,
-                            this.feedId
-                    )
-
-                    is ReaderNavigationEvents.SharePost -> ReaderActivityLauncher.sharePost(context, post)
-
-                    is ReaderNavigationEvents.OpenPost -> ReaderActivityLauncher.openPost(context, post)
-
-                    is ReaderNavigationEvents.ShowReportPost ->
-                        ReaderActivityLauncher.openUrl(
-                                context,
-                                readerUtilsWrapper.getReportPostUrl(url),
-                                OpenUrlType.INTERNAL
-                        )
-
-                    is ReaderNavigationEvents.ShowReaderComments ->
-                        ReaderActivityLauncher.showReaderComments(context, blogId, postId)
-
-                    is ReaderNavigationEvents.ShowNoSitesToReblog ->
-                        ReaderActivityLauncher.showNoSiteToReblog(activity)
-
-                    is ReaderNavigationEvents.ShowSitePickerForResult ->
-                        ActivityLauncher
-                                .showSitePickerForResult(this@ReaderPostDetailFragment, this.preselectedSite, this.mode)
-
-                    is ReaderNavigationEvents.OpenEditorForReblog ->
-                        ActivityLauncher.openEditorForReblog(activity, this.site, this.post, this.source)
-
-                    is ReaderNavigationEvents.ShowBookmarkedTab ->
-                        ActivityLauncher.viewSavedPostsListInReader(activity)
-
-                    is ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog ->
-                        showBookmarkSavedLocallyDialog(this)
-
-                    is ReaderNavigationEvents.ShowRelatedPostDetails ->
-                        showRelatedPostDetail(postId = this.postId, blogId = this.blogId)
-
-                    is ReaderNavigationEvents.ReplaceRelatedPostDetailsWithHistory ->
-                        replaceRelatedPostDetailWithHistory(
-                                postId = this.postId,
-                                blogId = this.blogId,
-                                isGlobal = this.isGlobal
-                        )
-
-                    is ReaderNavigationEvents.ShowPostDetail,
-                    is ReaderNavigationEvents.ShowVideoViewer,
-                    is ReaderNavigationEvents.ShowReaderSubs -> Unit // Do Nothing
-                }
-            }
-        })
         viewModel.start(isRelatedPost)
+    }
+
+    private fun renderUiState(state: ReaderPostDetailsUiState) {
+        header_view.updatePost(state.headerUiState)
+        showOrHideMoreMenu(state)
+
+        updateActionButton(state.postId, state.blogId, state.actions.likeAction, count_likes)
+        updateActionButton(state.postId, state.blogId, state.actions.reblogAction, reblog)
+        updateActionButton(state.postId, state.blogId, state.actions.commentsAction, count_comments)
+        updateActionButton(state.postId, state.blogId, state.actions.bookmarkAction, bookmark)
+
+        state.localRelatedPosts?.let { showRelatedPosts(it) }
+        state.globalRelatedPosts?.let { showRelatedPosts(it) }
+    }
+
+    private fun ReaderNavigationEvents.handleNavigationEvent() {
+        when (this) {
+            is ReaderNavigationEvents.ShowPostsByTag -> ReaderActivityLauncher.showReaderTagPreview(context, this.tag)
+
+            is ReaderNavigationEvents.ShowBlogPreview -> ReaderActivityLauncher.showReaderBlogOrFeedPreview(
+                    context,
+                    this.siteId,
+                    this.feedId
+            )
+
+            is ReaderNavigationEvents.SharePost -> ReaderActivityLauncher.sharePost(context, post)
+
+            is ReaderNavigationEvents.OpenPost -> ReaderActivityLauncher.openPost(context, post)
+
+            is ReaderNavigationEvents.ShowReportPost ->
+                ReaderActivityLauncher.openUrl(
+                        context,
+                        readerUtilsWrapper.getReportPostUrl(url),
+                        OpenUrlType.INTERNAL
+                )
+
+            is ReaderNavigationEvents.ShowReaderComments ->
+                ReaderActivityLauncher.showReaderComments(context, blogId, postId)
+
+            is ReaderNavigationEvents.ShowNoSitesToReblog -> ReaderActivityLauncher.showNoSiteToReblog(activity)
+
+            is ReaderNavigationEvents.ShowSitePickerForResult ->
+                ActivityLauncher
+                        .showSitePickerForResult(this@ReaderPostDetailFragment, this.preselectedSite, this.mode)
+
+            is ReaderNavigationEvents.OpenEditorForReblog ->
+                ActivityLauncher.openEditorForReblog(activity, this.site, this.post, this.source)
+
+            is ReaderNavigationEvents.ShowBookmarkedTab -> ActivityLauncher.viewSavedPostsListInReader(activity)
+
+            is ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog -> showBookmarkSavedLocallyDialog(this)
+
+            is ReaderNavigationEvents.ShowRelatedPostDetails ->
+                showRelatedPostDetail(postId = this.postId, blogId = this.blogId)
+
+            is ReaderNavigationEvents.ReplaceRelatedPostDetailsWithHistory ->
+                replaceRelatedPostDetailWithHistory(
+                        postId = this.postId,
+                        blogId = this.blogId,
+                        isGlobal = this.isGlobal
+                )
+
+            is ReaderNavigationEvents.ShowPostDetail,
+            is ReaderNavigationEvents.ShowVideoViewer,
+            is ReaderNavigationEvents.ShowReaderSubs -> Unit // Do Nothing
+        }
     }
 
     private fun updateActionButton(postId: Long, blogId: Long, state: PrimaryAction, view: View) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -792,12 +792,6 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
      * activity for this related post
      */
     private fun showRelatedPostDetail(postId: Long, blogId: Long, isGlobal: Boolean) {
-        val stat = if (isGlobal)
-            Stat.READER_GLOBAL_RELATED_POST_CLICKED
-        else
-            Stat.READER_LOCAL_RELATED_POST_CLICKED
-        AnalyticsUtils.trackWithReaderPostDetails(stat, blogId, postId)
-
         if (isRelatedPost) {
             postHistory.push(ReaderBlogIdPostId(post!!.blogId, post!!.postId))
             replacePost(blogId, postId, true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -470,6 +470,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                     is ShowBookmarkedSavedOnlyLocallyDialog -> {
                         showBookmarkSavedLocallyDialog(this)
                     }
+                    is ReaderNavigationEvents.ShowRelatedPostDetails ->
+                        showRelatedPostDetail(postId = this.postId, blogId = this.blogId, isGlobal = this.isGlobal)
                 }
             }
         })
@@ -793,7 +795,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
      * history stack so the user can back-button through the history - otherwise start a new detail
      * activity for this related post
      */
-    private fun showRelatedPostDetail(blogId: Long, postId: Long, isGlobal: Boolean) {
+    private fun showRelatedPostDetail(postId: Long, blogId: Long, isGlobal: Boolean) {
         val stat = if (isGlobal)
             Stat.READER_GLOBAL_RELATED_POST_CLICKED
         else

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -463,13 +463,20 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                     is ReaderNavigationEvents.ShowRelatedPostDetails ->
                         showRelatedPostDetail(postId = this.postId, blogId = this.blogId, isGlobal = this.isGlobal)
 
+                    is ReaderNavigationEvents.ReplaceRelatedPostDetailsWithHistory ->
+                        replaceRelatedPostDetailWithHistory(
+                                postId = this.postId,
+                                blogId = this.blogId,
+                                isGlobal = this.isGlobal
+                        )
+
                     is ReaderNavigationEvents.ShowPostDetail,
                     is ReaderNavigationEvents.ShowVideoViewer,
                     is ReaderNavigationEvents.ShowReaderSubs -> Unit // Do Nothing
                 }
             }
         })
-        viewModel.start()
+        viewModel.start(isRelatedPost)
     }
 
     private fun updateActionButton(postId: Long, blogId: Long, state: PrimaryAction, view: View) {
@@ -786,24 +793,21 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         return false
     }
 
-    /*
-     * user clicked a single related post - if we're already viewing a related post, add it to the
-     * history stack so the user can back-button through the history - otherwise start a new detail
-     * activity for this related post
-     */
     private fun showRelatedPostDetail(postId: Long, blogId: Long, isGlobal: Boolean) {
-        if (isRelatedPost) {
-            postHistory.push(ReaderBlogIdPostId(post!!.blogId, post!!.postId))
+        ReaderActivityLauncher.showReaderPostDetail(
+                activity,
+                false,
+                blogId,
+                postId, null,
+                0,
+                true, null
+        )
+    }
+
+    private fun replaceRelatedPostDetailWithHistory(postId: Long, blogId: Long, isGlobal: Boolean) {
+        post?.let {
+            postHistory.push(ReaderBlogIdPostId(it.blogId, it.postId))
             replacePost(blogId, postId, true)
-        } else {
-            ReaderActivityLauncher.showReaderPostDetail(
-                    activity,
-                    false,
-                    blogId,
-                    postId, null,
-                    0,
-                    true, null
-            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -472,6 +472,10 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                     }
                     is ReaderNavigationEvents.ShowRelatedPostDetails ->
                         showRelatedPostDetail(postId = this.postId, blogId = this.blogId, isGlobal = this.isGlobal)
+
+                    is ReaderNavigationEvents.ShowPostDetail,
+                    is ReaderNavigationEvents.ShowVideoViewer,
+                    is ReaderNavigationEvents.ShowReaderSubs -> Unit // Do Nothing
                 }
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostD
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderComments
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReaderSubs
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowRelatedPostDetails
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowReportPost
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowVideoViewer
@@ -146,6 +147,7 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
                     is ShowReaderSubs -> {
                         ReaderActivityLauncher.showReaderSubs(context)
                     }
+                    is ShowRelatedPostDetails -> Unit // Do Nothing
                 }
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -36,4 +36,7 @@ sealed class ReaderNavigationEvents {
     object ShowReaderSubs : ReaderNavigationEvents()
     data class ShowRelatedPostDetails(val postId: Long, val blogId: Long, val isGlobal: Boolean) :
             ReaderNavigationEvents()
+
+    data class ReplaceRelatedPostDetailsWithHistory(val postId: Long, val blogId: Long, val isGlobal: Boolean) :
+            ReaderNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -34,4 +34,6 @@ sealed class ReaderNavigationEvents {
     data class ShowBlogPreview(val siteId: Long, val feedId: Long) : ReaderNavigationEvents()
     data class ShowReportPost(val url: String) : ReaderNavigationEvents()
     object ShowReaderSubs : ReaderNavigationEvents()
+    data class ShowRelatedPostDetails(val postId: Long, val blogId: Long, val isGlobal: Boolean) :
+            ReaderNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -34,7 +34,7 @@ sealed class ReaderNavigationEvents {
     data class ShowBlogPreview(val siteId: Long, val feedId: Long) : ReaderNavigationEvents()
     data class ShowReportPost(val url: String) : ReaderNavigationEvents()
     object ShowReaderSubs : ReaderNavigationEvents()
-    data class ShowRelatedPostDetails(val postId: Long, val blogId: Long, val isGlobal: Boolean) :
+    data class ShowRelatedPostDetails(val postId: Long, val blogId: Long) :
             ReaderNavigationEvents()
 
     data class ReplaceRelatedPostDetailsWithHistory(val postId: Long, val blogId: Long, val isGlobal: Boolean) :

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -146,6 +146,13 @@ class ReaderPostCardActionsHandler @Inject constructor(
         }
     }
 
+    suspend fun onFollowRelatedPostBlog(blogId: Long, siteName: String) {
+        withContext(bgDispatcher) {
+            if (!preFetchSite(blogId = blogId, feedId = 0)) return@withContext
+            handleFollowClicked(blogId = blogId, feedId = 0, blogName = siteName)
+        }
+    }
+
     private suspend fun preFetchSite(blogId: Long, feedId: Long): Boolean {
         var isSiteFetched = false
         when (fetchSiteUseCase.fetchSite(blogId = blogId, feedId = feedId, blogUrl = null)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandler.kt
@@ -136,7 +136,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
             if (type == FOLLOW || type == SITE_NOTIFICATIONS) {
                 val readerBlog = readerBlogTableWrapper.getReaderBlog(post.blogId, post.feedId)
                 if (readerBlog == null) {
-                    val isSiteFetched = preFetchSite(post)
+                    val isSiteFetched = preFetchSite(post.blogId, post.feedId)
                     if (!isSiteFetched) {
                         return@withContext
                     }
@@ -146,9 +146,9 @@ class ReaderPostCardActionsHandler @Inject constructor(
         }
     }
 
-    private suspend fun preFetchSite(post: ReaderPost): Boolean {
+    private suspend fun preFetchSite(blogId: Long, feedId: Long): Boolean {
         var isSiteFetched = false
-        when (fetchSiteUseCase.fetchSite(post.blogId, post.feedId, null)) {
+        when (fetchSiteUseCase.fetchSite(blogId = blogId, feedId = feedId, blogUrl = null)) {
             FetchSiteState.AlreadyRunning -> { // Do Nothing
             }
             FetchSiteState.Success -> {
@@ -177,7 +177,7 @@ class ReaderPostCardActionsHandler @Inject constructor(
         isBookmarkList: Boolean
     ) {
         when (type) {
-            FOLLOW -> handleFollowClicked(post)
+            FOLLOW -> handleFollowClicked(post.blogId, post.feedId, post.blogName)
             SITE_NOTIFICATIONS -> handleSiteNotificationsClicked(post.blogId)
             SHARE -> handleShareClicked(post)
             VISIT_SITE -> handleVisitSiteClicked(post)
@@ -266,8 +266,8 @@ class ReaderPostCardActionsHandler @Inject constructor(
         followSite(param)
     }
 
-    private suspend fun handleFollowClicked(post: ReaderPost) {
-        followSite(ReaderSiteFollowUseCase.Param(post.blogId, post.feedId, post.blogName))
+    private suspend fun handleFollowClicked(blogId: Long, feedId: Long, blogName: String) {
+        followSite(ReaderSiteFollowUseCase.Param(blogId, feedId, blogName))
     }
 
     private suspend fun followSite(followSiteParam: ReaderSiteFollowUseCase.Param) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRelatedPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRelatedPostViewHolder.kt
@@ -29,6 +29,7 @@ class ReaderRelatedPostViewHolder(
         updateFeaturedImage(state)
         updateFollowButton(state)
         uiHelpers.setTextOrHide(text_title, state.title)
+        itemView.setOnClickListener { state.onItemClicked.invoke(state.postId, state.blogId, state.isGlobal) }
     }
 
     private fun updateFeaturedImage(state: ReaderRelatedPostUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailUiStateBuilder.kt
@@ -46,7 +46,7 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
         sourcePost: ReaderPost,
         relatedPosts: ReaderSimplePostList,
         isGlobal: Boolean,
-        onRelatedPostFollowClicked: (ReaderSimplePost) -> Unit,
+        onRelatedPostFollowClicked: (Long, String) -> Unit,
         onRelatedPostItemClicked: (Long, Long, Boolean) -> Unit
     ) = RelatedPostsUiState(
             cards = relatedPosts.map {
@@ -55,7 +55,7 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
                         isGlobal = isGlobal,
                         followButtonUiState = if (isGlobal) {
                             FollowButtonUiState(
-                                    onFollowButtonClicked = { onRelatedPostFollowClicked(it) },
+                                    onFollowButtonClicked = { onRelatedPostFollowClicked( it.siteId, it.siteName) },
                                     isFollowed = it.isFollowing,
                                     isEnabled = true
                             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailUiStateBuilder.kt
@@ -45,7 +45,8 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
     fun mapRelatedPostsToUiState(
         sourcePost: ReaderPost,
         relatedPosts: ReaderSimplePostList,
-        isGlobal: Boolean
+        isGlobal: Boolean,
+        onItemClicked: (Long, Long, Boolean) -> Unit
     ) = RelatedPostsUiState(
             cards = relatedPosts.map {
                 mapRelatedPostToUiState(
@@ -57,7 +58,8 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
                                     isFollowed = it.isFollowing,
                                     isEnabled = true
                             )
-                        } else null
+                        } else null,
+                        onItemClicked = onItemClicked
                 )
             },
             isGlobal = isGlobal,
@@ -67,7 +69,8 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
     private fun mapRelatedPostToUiState(
         post: ReaderSimplePost,
         isGlobal: Boolean,
-        followButtonUiState: FollowButtonUiState?
+        followButtonUiState: FollowButtonUiState?,
+        onItemClicked: (Long, Long, Boolean) -> Unit
     ) = ReaderRelatedPostUiState(
             postId = post.postId,
             blogId = post.siteId,
@@ -75,7 +78,8 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
             title = post.title?.let { UiStringText(it) },
             featuredImageUrl = post.featuredImageUrl,
             featuredImageCornerRadius = UIDimenRes(R.dimen.reader_featured_image_corner_radius),
-            followButtonUiState = followButtonUiState
+            followButtonUiState = followButtonUiState,
+            onItemClicked = onItemClicked
     )
 
     private fun buildPostDetailsHeaderUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailUiStateBuilder.kt
@@ -46,7 +46,8 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
         sourcePost: ReaderPost,
         relatedPosts: ReaderSimplePostList,
         isGlobal: Boolean,
-        onItemClicked: (Long, Long, Boolean) -> Unit
+        onRelatedPostFollowClicked: (ReaderSimplePost) -> Unit,
+        onRelatedPostItemClicked: (Long, Long, Boolean) -> Unit
     ) = RelatedPostsUiState(
             cards = relatedPosts.map {
                 mapRelatedPostToUiState(
@@ -54,12 +55,12 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
                         isGlobal = isGlobal,
                         followButtonUiState = if (isGlobal) {
                             FollowButtonUiState(
-                                    onFollowButtonClicked = null, // TODO: ashiagr implement follow button action
+                                    onFollowButtonClicked = { onRelatedPostFollowClicked(it) },
                                     isFollowed = it.isFollowing,
                                     isEnabled = true
                             )
                         } else null,
-                        onItemClicked = onItemClicked
+                        onItemClicked = onRelatedPostItemClicked
                 )
             },
             isGlobal = isGlobal,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailUiStateBuilder.kt
@@ -55,7 +55,7 @@ class ReaderPostDetailUiStateBuilder @Inject constructor(
                         isGlobal = isGlobal,
                         followButtonUiState = if (isGlobal) {
                             FollowButtonUiState(
-                                    onFollowButtonClicked = { onRelatedPostFollowClicked( it.siteId, it.siteName) },
+                                    onFollowButtonClicked = { onRelatedPostFollowClicked(it.siteId, it.siteName) },
                                     isFollowed = it.isFollowing,
                                     isEnabled = true
                             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -83,13 +83,13 @@ class ReaderPostDetailViewModel @Inject constructor(
 
     private fun init() {
         readerPostCardActionsHandler.initScope(this)
-        _uiState.addSource(readerPostCardActionsHandler.followStatusUpdated) { data ->
+        _uiState.addSource(readerPostCardActionsHandler.followStatusUpdated) { followStatusChanged ->
             val currentUiState: ReaderPostDetailsUiState? = _uiState.value
 
             currentUiState?.let {
                 findPost(currentUiState.postId, currentUiState.blogId)?.let { post ->
-                    post.isFollowedByCurrentUser = data.following
-                    updateFollowButtonUiState(
+                    post.isFollowedByCurrentUser = followStatusChanged.following
+                    updateSelectedPostFollowButton(
                             currentUiState = currentUiState,
                             isFollowed = post.isFollowedByCurrentUser
                     )
@@ -246,7 +246,7 @@ class ReaderPostDetailViewModel @Inject constructor(
             onItemClicked = this@ReaderPostDetailViewModel::onRelatedPostItemClicked
     )
 
-    private fun updateFollowButtonUiState(
+    private fun updateSelectedPostFollowButton(
         currentUiState: ReaderPostDetailsUiState,
         isFollowed: Boolean
     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionsHandler
 import org.wordpress.android.ui.reader.discover.ReaderPostMoreButtonUiStateBuilder
-import org.wordpress.android.ui.reader.models.ReaderSimplePost
 import org.wordpress.android.ui.reader.models.ReaderSimplePostList
 import org.wordpress.android.ui.reader.reblog.ReblogUseCase
 import org.wordpress.android.ui.reader.usecases.ReaderFetchRelatedPostsUseCase
@@ -218,12 +217,9 @@ class ReaderPostDetailViewModel @Inject constructor(
         }
     }
 
-    private fun onRelatedPostFollowClicked(relatedPost: ReaderSimplePost) {
+    private fun onRelatedPostFollowClicked(blogId: Long, siteName: String) {
         launch {
-            readerPostCardActionsHandler.onFollowRelatedPostBlog(
-                    blogId = relatedPost.siteId,
-                    siteName = relatedPost.siteName
-            )
+            readerPostCardActionsHandler.onFollowRelatedPostBlog(blogId = blogId, siteName = siteName)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -214,7 +214,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         _navigationEvents.value = if (isRelatedPost) {
             Event(ReplaceRelatedPostDetailsWithHistory(postId = postId, blogId = blogId, isGlobal = isGlobal))
         } else {
-            Event(ShowRelatedPostDetails(postId = postId, blogId = blogId, isGlobal = isGlobal))
+            Event(ShowRelatedPostDetails(postId = postId, blogId = blogId))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.R
 import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.models.ReaderPost
@@ -33,6 +34,7 @@ import org.wordpress.android.ui.reader.views.uistates.ReaderPostDetailsHeaderVie
 import org.wordpress.android.ui.utils.UiDimen
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -47,6 +49,7 @@ class ReaderPostDetailViewModel @Inject constructor(
     private val postDetailUiStateBuilder: ReaderPostDetailUiStateBuilder,
     private val reblogUseCase: ReblogUseCase,
     private val readerFetchRelatedPostsUseCase: ReaderFetchRelatedPostsUseCase,
+    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper,
     private val eventBusWrapper: EventBusWrapper,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(IO_THREAD) private val ioDispatcher: CoroutineDispatcher
@@ -204,6 +207,7 @@ class ReaderPostDetailViewModel @Inject constructor(
     }
 
     private fun onRelatedPostItemClicked(postId: Long, blogId: Long, isGlobal: Boolean) {
+        trackRelatedPostClickAction(postId, blogId, isGlobal)
         _navigationEvents.value = Event(ShowRelatedPostDetails(postId = postId, blogId = blogId, isGlobal = isGlobal))
     }
 
@@ -229,6 +233,11 @@ class ReaderPostDetailViewModel @Inject constructor(
                 is FetchRelatedPostsState.Success -> updateRelatedPostsUiState(sourcePost, fetchRelatedPostsState)
             }
         }
+    }
+
+    private fun trackRelatedPostClickAction(postId: Long, blogId: Long, isGlobal: Boolean) {
+        val stat = if (isGlobal) Stat.READER_GLOBAL_RELATED_POST_CLICKED else Stat.READER_LOCAL_RELATED_POST_CLICKED
+        analyticsUtilsWrapper.trackWithReaderPostDetails(stat = stat, blogId = blogId, postId = postId)
     }
 
     private fun findPost(postId: Long, blogId: Long): ReaderPost? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -259,7 +259,8 @@ class ReaderPostDetailViewModel @Inject constructor(
             sourcePost = sourcePost,
             relatedPosts = relatedPosts,
             isGlobal = isGlobal,
-            onItemClicked = this@ReaderPostDetailViewModel::onRelatedPostItemClicked
+            onRelatedPostFollowClicked = this@ReaderPostDetailViewModel::onRelatedPostFollowClicked,
+            onRelatedPostItemClicked = this@ReaderPostDetailViewModel::onRelatedPostItemClicked
     )
 
     private fun updateSelectedPostFollowButton(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -195,6 +195,10 @@ class ReaderPostDetailViewModel @Inject constructor(
         }
     }
 
+    private fun onRelatedPostItemClicked(blogId: Long, postId: Long, isGlobal: Boolean) {
+        // TODO: ashiagr implement
+    }
+
     fun onRelatedPostsRequested(sourcePost: ReaderPost) {
         /* Related posts only available for wp.com */
         if (!sourcePost.isWP) return
@@ -237,7 +241,8 @@ class ReaderPostDetailViewModel @Inject constructor(
     ) = postDetailUiStateBuilder.mapRelatedPostsToUiState(
             sourcePost = sourcePost,
             relatedPosts = relatedPosts,
-            isGlobal = isGlobal
+            isGlobal = isGlobal,
+            onItemClicked = this@ReaderPostDetailViewModel::onRelatedPostItemClicked
     )
 
     private fun updateFollowButtonUiState(
@@ -301,7 +306,8 @@ class ReaderPostDetailViewModel @Inject constructor(
                 val title: UiString?,
                 val featuredImageUrl: String?,
                 val featuredImageCornerRadius: UiDimen,
-                val followButtonUiState: FollowButtonUiState?
+                val followButtonUiState: FollowButtonUiState?,
+                val onItemClicked: (Long, Long, Boolean) -> Unit
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowRelatedPostDetails
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.discover.ReaderPostActions
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
@@ -195,8 +196,8 @@ class ReaderPostDetailViewModel @Inject constructor(
         }
     }
 
-    private fun onRelatedPostItemClicked(blogId: Long, postId: Long, isGlobal: Boolean) {
-        // TODO: ashiagr implement
+    private fun onRelatedPostItemClicked(postId: Long, blogId: Long, isGlobal: Boolean) {
+        _navigationEvents.value = Event(ShowRelatedPostDetails(postId = postId, blogId = blogId, isGlobal = isGlobal))
     }
 
     fun onRelatedPostsRequested(sourcePost: ReaderPost) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSimplePostContainerView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSimplePostContainerView.kt
@@ -8,7 +8,6 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.reader_simple_posts_container_view.view.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.ui.reader.ReaderInterfaces.OnFollowListener
 import org.wordpress.android.ui.reader.adapters.ReaderRelatedPostsAdapter
 import org.wordpress.android.ui.reader.models.ReaderSimplePostList
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.ReaderPostDetailsUiState.RelatedPostsUiState
@@ -26,7 +25,6 @@ class ReaderSimplePostContainerView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : LinearLayout(context, attrs, defStyleAttr) {
-    private var followListener: OnFollowListener? = null
     private val simplePostList = ReaderSimplePostList()
 
     @Inject lateinit var uiHelpers: UiHelpers
@@ -67,10 +65,6 @@ class ReaderSimplePostContainerView @JvmOverloads constructor(
                     state.siteName
             )
         }
-    }
-
-    fun setOnFollowListener(listener: OnFollowListener?) {
-        followListener = listener
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSimplePostContainerView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSimplePostContainerView.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.ui.reader.ReaderInterfaces.OnFollowListener
 import org.wordpress.android.ui.reader.adapters.ReaderRelatedPostsAdapter
 import org.wordpress.android.ui.reader.models.ReaderSimplePostList
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.ReaderPostDetailsUiState.RelatedPostsUiState
-import org.wordpress.android.ui.reader.views.ReaderSimplePostView.OnSimplePostClickListener
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.util.image.ImageManager
@@ -54,7 +53,7 @@ class ReaderSimplePostContainerView @JvmOverloads constructor(
         recycler_view.adapter = ReaderRelatedPostsAdapter(uiHelpers, imageManager)
     }
 
-    fun showPosts(state: RelatedPostsUiState, listener: OnSimplePostClickListener?) {
+    fun showPosts(state: RelatedPostsUiState) {
         if (state.cards?.size == 0) return
 
         state.cards?.let { (recycler_view.adapter as ReaderRelatedPostsAdapter).update(it) }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
@@ -27,6 +27,9 @@ class AnalyticsUtilsWrapper @Inject constructor(private val appContext: Context)
 
     fun trackWithSiteId(stat: AnalyticsTracker.Stat, blogId: Long) = AnalyticsUtils.trackWithSiteId(stat, blogId)
 
+    fun trackWithReaderPostDetails(stat: AnalyticsTracker.Stat, blogId: Long, postId: Long) =
+            AnalyticsUtils.trackWithReaderPostDetails(stat, blogId, postId)
+
     fun trackWithReaderPostDetails(stat: AnalyticsTracker.Stat, post: ReaderPost) =
             AnalyticsUtils.trackWithReaderPostDetails(stat, post)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
@@ -54,56 +54,56 @@ class ReaderPostDetailUiStateBuilderTest {
     }
 
     @Test
-    fun `when related posts ui is built, site name exists`() = test {
+    fun `when related posts ui is built, then site name exists`() = test {
         val relatedPostsUiState = init(relatedPosts = globalRelatedPosts, isGlobal = true)
 
         assertThat(relatedPostsUiState.siteName).isNotNull
     }
 
     @Test
-    fun `given empty related posts, when related posts ui is built, related post cards are empty`() = test {
+    fun `given empty related posts, when related posts ui is built, then related post cards are empty`() = test {
         val relatedPostsUiState = init(relatedPosts = ReaderSimplePostList())
 
         assertThat(relatedPostsUiState.cards).isEmpty()
     }
 
     @Test
-    fun `given local related posts, when related posts ui is built, related post cards exist`() = test {
+    fun `given local related posts, when related posts ui is built, then related post cards exist`() = test {
         val relatedPostsUiState = init(relatedPosts = localRelatedPosts, isGlobal = false)
 
         assertThat(relatedPostsUiState.cards).isNotEmpty
     }
 
     @Test
-    fun `given global related posts, when related posts ui is built, related post cards exists`() = test {
+    fun `given global related posts, when related posts ui is built, then related post cards exists`() = test {
         val relatedPostsUiState = init(relatedPosts = globalRelatedPosts, isGlobal = true)
 
         assertThat(relatedPostsUiState.cards).isNotEmpty
     }
 
     @Test
-    fun `given local related posts, when related posts ui is built, follow button does not exist`() = test {
+    fun `given local related posts, when related posts ui is built, then follow button does not exist`() = test {
         val relatedPostsUiState = init(relatedPosts = localRelatedPosts, isGlobal = false)
 
         assertThat(relatedPostsUiState.cards?.first()?.followButtonUiState).isNull()
     }
 
     @Test
-    fun `given global related posts, when related posts ui is built, follow button exists`() = test {
+    fun `given global related posts, when related posts ui is built, then follow button exists`() = test {
         val relatedPostsUiState = init(relatedPosts = globalRelatedPosts, isGlobal = true)
 
         assertThat(relatedPostsUiState.cards?.first()?.followButtonUiState).isNotNull
     }
 
     @Test
-    fun `given related post title, when related posts ui is built, related post title exists`() = test {
+    fun `given related post title, when related posts ui is built, then related post title exists`() = test {
         val relatedPostsUiState = init(relatedPosts = localRelatedPosts, isGlobal = false)
 
         assertThat(relatedPostsUiState.cards?.first()?.title).isEqualTo(UiStringText(readerSimplePost.title))
     }
 
     @Test
-    fun `given related post null title, when related posts ui is built, related post title does not exists`() = test {
+    fun `given related post null title, when related posts ui is built, then related post title does not exists`() = test {
         whenever(readerSimplePost.title).thenReturn(null)
 
         val relatedPostsUiState = init(relatedPosts = globalRelatedPosts, isGlobal = true)
@@ -112,7 +112,7 @@ class ReaderPostDetailUiStateBuilderTest {
     }
 
     @Test
-    fun `given related post featured image url, when related posts ui is built, featured image exists`() = test {
+    fun `given related post featured image url, when related posts ui is built, then featured image exists`() = test {
         val relatedPostsUiState = init(relatedPosts = localRelatedPosts, isGlobal = false)
 
         assertThat(relatedPostsUiState.cards?.first()?.featuredImageUrl).isEqualTo(readerSimplePost.featuredImageUrl)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
@@ -96,27 +96,30 @@ class ReaderPostDetailUiStateBuilderTest {
     }
 
     @Test
-    fun `given related post title, when related posts ui is built, then related post title exists`() = test {
+    fun `given related post with title, when related posts ui is built, then related post title exists`() = test {
         val relatedPostsUiState = init(relatedPosts = localRelatedPosts, isGlobal = false)
 
         assertThat(relatedPostsUiState.cards?.first()?.title).isEqualTo(UiStringText(readerSimplePost.title))
     }
 
     @Test
-    fun `given related post null title, when related posts ui is built, then related post title does not exists`() = test {
-        whenever(readerSimplePost.title).thenReturn(null)
+    fun `given related post without title, when related posts ui is built, then related post title does not exists`() =
+            test {
+                whenever(readerSimplePost.title).thenReturn(null)
 
-        val relatedPostsUiState = init(relatedPosts = globalRelatedPosts, isGlobal = true)
+                val relatedPostsUiState = init(relatedPosts = globalRelatedPosts, isGlobal = true)
 
-        assertThat(relatedPostsUiState.cards?.first()?.title).isNull()
-    }
+                assertThat(relatedPostsUiState.cards?.first()?.title).isNull()
+            }
 
     @Test
-    fun `given related post featured image url, when related posts ui is built, then featured image exists`() = test {
-        val relatedPostsUiState = init(relatedPosts = localRelatedPosts, isGlobal = false)
+    fun `given related post with featured image url, when related posts ui is built, then featured image exists`() =
+            test {
+                val relatedPostsUiState = init(relatedPosts = localRelatedPosts, isGlobal = false)
 
-        assertThat(relatedPostsUiState.cards?.first()?.featuredImageUrl).isEqualTo(readerSimplePost.featuredImageUrl)
-    }
+                assertThat(relatedPostsUiState.cards?.first()?.featuredImageUrl)
+                        .isEqualTo(readerSimplePost.featuredImageUrl)
+            }
 
     private fun init(
         relatedPosts: ReaderSimplePostList,

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailUiStateBuilderTest.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 
 @InternalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
-class ReaderPostDetailsUiStateBuilderTest {
+class ReaderPostDetailUiStateBuilderTest {
     @Rule
     @JvmField val rule = InstantTaskExecutorRule()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailsUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailsUiStateBuilderTest.kt
@@ -38,7 +38,7 @@ class ReaderPostDetailsUiStateBuilderTest {
         this.blogName = "blog name"
     }
     private val dummyOnRelatedPostItemClicked: (Long, Long, Boolean) -> Unit = { _, _, _ -> }
-    private val dummyOnRelatedPostFollowClicked: (ReaderSimplePost) -> Unit = { _ -> }
+    private val dummyOnRelatedPostFollowClicked: (Long, String) -> Unit = { _, _ -> }
 
     @Before
     fun setUp() = test {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailsUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderPostDetailsUiStateBuilderTest.kt
@@ -37,6 +37,8 @@ class ReaderPostDetailsUiStateBuilderTest {
         this.feedId = 2L
         this.blogName = "blog name"
     }
+    private val dummyOnRelatedPostItemClicked: (Long, Long, Boolean) -> Unit = { _, _, _ -> }
+    private val dummyOnRelatedPostFollowClicked: (ReaderSimplePost) -> Unit = { _ -> }
 
     @Before
     fun setUp() = test {
@@ -122,6 +124,8 @@ class ReaderPostDetailsUiStateBuilderTest {
     ) = builder.mapRelatedPostsToUiState(
             sourcePost = dummyReaderPost,
             relatedPosts = relatedPosts,
-            isGlobal = isGlobal
+            isGlobal = isGlobal,
+            onRelatedPostItemClicked = dummyOnRelatedPostItemClicked,
+            onRelatedPostFollowClicked = dummyOnRelatedPostFollowClicked
     )
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderPostSeenStatusToggleUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/usecases/ReaderPostSeenStatusToggleUseCaseTest.kt
@@ -107,7 +107,11 @@ class ReaderPostSeenStatusToggleUseCaseTest {
 
         verify(postSeenStatusApiCallsProvider, times(0)).markPostAsSeen(any())
         verify(readerPostTableWrapper, times(0)).setPostSeenStatusInDb(any(), any())
-        verify(analyticsUtilsWrapper, times(0)).trackWithReaderPostDetails(any(), any(), any())
+        verify(analyticsUtilsWrapper, times(0)).trackWithReaderPostDetails(
+                stat = any(),
+                post = any(),
+                properties = any()
+        )
 
         seenStatusToggleUseCase.markPostAsSeenIfNecessary(unseenPost)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -68,7 +68,6 @@ private const val ON_POST_BLOG_SECTION_CLICKED_PARAM_POSITION = 3
 private const val ON_POST_FOLLOW_BUTTON_CLICKED_PARAM_POSITION = 4
 private const val ON_TAG_CLICKED_PARAM_POSITION = 5
 
-private const val RELATED_POSTS_PARAM_POSITION = 1
 private const val IS_GLOBAL_RELATED_POSTS_PARAM_POSITION = 2
 private const val ON_RELATED_POST_FOLLOW_CLICKED_PARAM_POSITION = 3
 private const val ON_RELATED_POST_ITEM_CLICKED_PARAM_POSITION = 4
@@ -99,8 +98,7 @@ class ReaderPostDetailViewModelTest {
 
     private val readerPost = createDummyReaderPost(2)
 
-    private lateinit var localRelatedPosts: ReaderSimplePostList
-    private lateinit var globalRelatedPosts: ReaderSimplePostList
+    private lateinit var relatedPosts: ReaderSimplePostList
 
     @Before
     fun setUp() = test {
@@ -152,8 +150,7 @@ class ReaderPostDetailViewModelTest {
         }
 
         whenever(readerSimplePost.siteName).thenReturn("")
-        localRelatedPosts = ReaderSimplePostList().apply { add(readerSimplePost) }
-        globalRelatedPosts = ReaderSimplePostList().apply { add(readerSimplePost) }
+        relatedPosts = ReaderSimplePostList().apply { add(readerSimplePost) }
 
         whenever(
                 postDetailsUiStateBuilder.mapRelatedPostsToUiState(
@@ -166,7 +163,6 @@ class ReaderPostDetailViewModelTest {
         ).thenAnswer {
             // propagate some of the arguments
             createDummyRelatedPostsUiState(
-                    it.getArgument(RELATED_POSTS_PARAM_POSITION),
                     it.getArgument(IS_GLOBAL_RELATED_POSTS_PARAM_POSITION),
                     it.getArgument(ON_RELATED_POST_FOLLOW_CLICKED_PARAM_POSITION),
                     it.getArgument(ON_RELATED_POST_ITEM_CLICKED_PARAM_POSITION)
@@ -332,14 +328,11 @@ class ReaderPostDetailViewModelTest {
     @Test
     fun `given local related posts fetch succeeds, when related posts are requested, then local related posts shown`() =
             test {
-                val localRelatedPostsUiState = createDummyRelatedPostsUiState(
-                        relatedPosts = localRelatedPosts,
-                        isGlobal = false
-                )
+                val localRelatedPostsUiState = createDummyRelatedPostsUiState(isGlobal = false)
                 whenever(
                         postDetailsUiStateBuilder.mapRelatedPostsToUiState(
                                 sourcePost = eq(readerPost),
-                                relatedPosts = eq(localRelatedPosts),
+                                relatedPosts = eq(relatedPosts),
                                 isGlobal = eq(false),
                                 onRelatedPostFollowClicked = any(),
                                 onRelatedPostItemClicked = any()
@@ -348,7 +341,7 @@ class ReaderPostDetailViewModelTest {
                 whenever(readerFetchRelatedPostsUseCase.fetchRelatedPosts(readerPost))
                         .thenReturn(
                                 FetchRelatedPostsState.Success(
-                                        localRelatedPosts = localRelatedPosts,
+                                        localRelatedPosts = relatedPosts,
                                         globalRelatedPosts = ReaderSimplePostList()
                                 )
                         )
@@ -362,14 +355,11 @@ class ReaderPostDetailViewModelTest {
     @Test
     fun `given global related posts fetch succeeds, when related posts requested, then global related posts shown`() =
             test {
-                val globalRelatedPostsUiState = createDummyRelatedPostsUiState(
-                        relatedPosts = globalRelatedPosts,
-                        isGlobal = false
-                )
+                val globalRelatedPostsUiState = createDummyRelatedPostsUiState(isGlobal = false)
                 whenever(
                         postDetailsUiStateBuilder.mapRelatedPostsToUiState(
                                 sourcePost = eq(readerPost),
-                                relatedPosts = eq(globalRelatedPosts),
+                                relatedPosts = eq(relatedPosts),
                                 isGlobal = eq(true),
                                 onRelatedPostFollowClicked = any(),
                                 onRelatedPostItemClicked = any()
@@ -379,7 +369,7 @@ class ReaderPostDetailViewModelTest {
                         .thenReturn(
                                 FetchRelatedPostsState.Success(
                                         localRelatedPosts = ReaderSimplePostList(),
-                                        globalRelatedPosts = globalRelatedPosts
+                                        globalRelatedPosts = relatedPosts
                                 )
                         )
                 val uiStates = init().uiStates
@@ -461,7 +451,7 @@ class ReaderPostDetailViewModelTest {
                         .thenReturn(
                                 FetchRelatedPostsState.Success(
                                         localRelatedPosts = ReaderSimplePostList(),
-                                        globalRelatedPosts = globalRelatedPosts
+                                        globalRelatedPosts = relatedPosts
                                 )
                         )
                 val observers = init(isRelatedPost = false)
@@ -480,7 +470,7 @@ class ReaderPostDetailViewModelTest {
                         .thenReturn(
                                 FetchRelatedPostsState.Success(
                                         localRelatedPosts = ReaderSimplePostList(),
-                                        globalRelatedPosts = globalRelatedPosts
+                                        globalRelatedPosts = relatedPosts
                                 )
                         )
                 val observers = init(isRelatedPost = true)
@@ -499,7 +489,7 @@ class ReaderPostDetailViewModelTest {
                 whenever(readerPostCardActionsHandler.onFollowRelatedPostBlog(any(), any())).thenAnswer {
                     fakePostFollowStatusChangedFeed.postValue(
                             FollowStatusChanged(
-                                    blogId = globalRelatedPosts.first().siteId,
+                                    blogId = relatedPosts.first().siteId,
                                     following = true,
                                     deleteNotificationSubscription = false,
                                     showEnableNotification = true
@@ -510,7 +500,7 @@ class ReaderPostDetailViewModelTest {
                         .thenReturn(
                                 FetchRelatedPostsState.Success(
                                         localRelatedPosts = ReaderSimplePostList(),
-                                        globalRelatedPosts = globalRelatedPosts
+                                        globalRelatedPosts = relatedPosts
                                 )
                         )
                 val uiStates = init().uiStates
@@ -528,7 +518,7 @@ class ReaderPostDetailViewModelTest {
                 whenever(readerPostCardActionsHandler.onFollowRelatedPostBlog(any(), any())).thenAnswer {
                     fakePostFollowStatusChangedFeed.postValue(
                             FollowStatusChanged(
-                                    blogId = globalRelatedPosts.first().siteId,
+                                    blogId = relatedPosts.first().siteId,
                                     following = false,
                                     deleteNotificationSubscription = true,
                                     showEnableNotification = false
@@ -539,7 +529,7 @@ class ReaderPostDetailViewModelTest {
                         .thenReturn(
                                 FetchRelatedPostsState.Success(
                                         localRelatedPosts = ReaderSimplePostList(),
-                                        globalRelatedPosts = globalRelatedPosts
+                                        globalRelatedPosts = relatedPosts
                                 )
                         )
                 val uiStates = init().uiStates
@@ -606,7 +596,6 @@ class ReaderPostDetailViewModelTest {
     }
 
     private fun createDummyRelatedPostsUiState(
-        relatedPosts: ReaderSimplePostList,
         isGlobal: Boolean,
         onRelatedPostFollowClicked: ((Long, String) -> Unit)? = null,
         onRelatedPostItemClicked: ((Long, Long, Boolean) -> Unit)? = null

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -608,7 +608,7 @@ class ReaderPostDetailViewModelTest {
     private fun createDummyRelatedPostsUiState(
         relatedPosts: ReaderSimplePostList,
         isGlobal: Boolean,
-        onRelatedPostFollowClicked: ((ReaderSimplePost) -> Unit)? = null,
+        onRelatedPostFollowClicked: ((Long, String) -> Unit)? = null,
         onRelatedPostItemClicked: ((Long, Long, Boolean) -> Unit)? = null
     ) = RelatedPostsUiState(
             cards = relatedPosts.map {
@@ -621,7 +621,9 @@ class ReaderPostDetailViewModelTest {
                         featuredImageCornerRadius = UIDimenRes(dimen.reader_featured_image_corner_radius),
                         followButtonUiState = if (isGlobal) {
                             FollowButtonUiState(
-                                    onFollowButtonClicked = { onRelatedPostFollowClicked?.invoke(it) },
+                                    onFollowButtonClicked = {
+                                        onRelatedPostFollowClicked?.invoke(it.siteId, it.siteName)
+                                    },
                                     isFollowed = true,
                                     isEnabled = true
                             )

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.reader.viewmodels
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
@@ -301,7 +302,9 @@ class ReaderPostDetailViewModelTest {
                         postDetailsUiStateBuilder.mapRelatedPostsToUiState(
                                 sourcePost = eq(readerPost),
                                 relatedPosts = eq(localRelatedPosts),
-                                isGlobal = eq(false)
+                                isGlobal = eq(false),
+                                onRelatedPostFollowClicked = any(),
+                                onRelatedPostItemClicked = any()
                         )
                 ).thenReturn(localRelatedPostsUiState)
                 whenever(readerFetchRelatedPostsUseCase.fetchRelatedPosts(readerPost))
@@ -326,7 +329,9 @@ class ReaderPostDetailViewModelTest {
                         postDetailsUiStateBuilder.mapRelatedPostsToUiState(
                                 sourcePost = eq(readerPost),
                                 relatedPosts = eq(globalRelatedPosts),
-                                isGlobal = eq(true)
+                                isGlobal = eq(true),
+                                onRelatedPostFollowClicked = any(),
+                                onRelatedPostItemClicked = any()
                         )
                 ).thenReturn(globalRelatedPostsUiState)
                 whenever(readerFetchRelatedPostsUseCase.fetchRelatedPosts(readerPost))

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -46,6 +46,7 @@
     <ID>ComplexMethod:PostPageListLabelColorUseCase.kt$PostPageListLabelColorUseCase$@ColorRes private fun getLabelColor( postStatus: PostStatus, isLocalDraft: Boolean, isLocallyChanged: Boolean, uploadUiState: PostUploadUiState, hasUnhandledConflicts: Boolean, hasAutoSave: Boolean ): Int?</ID>
     <ID>ComplexMethod:ReaderDiscoverFragment.kt$ReaderDiscoverFragment$private fun initViewModel()</ID>
     <ID>ComplexMethod:ReaderPostBookmarkUseCase.kt$ReaderPostBookmarkUseCase$private fun trackEvent(bookmarked: Boolean, isBookmarkList: Boolean, fromPostDetails: Boolean)</ID>
+    <ID>ComplexMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment$private fun ReaderNavigationEvents.handleNavigationEvent()</ID>
     <ID>ComplexMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment.ShowPostTask$override fun onPostExecute(result: Boolean)</ID>
     <ID>ComplexMethod:ReferrersUseCase.kt$ReferrersUseCase$override fun buildUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List&lt;BlockListItem&gt;</ID>
     <ID>ComplexMethod:StatsFragment.kt$StatsFragment$private fun setupObservers(activity: FragmentActivity)</ID>
@@ -128,7 +129,6 @@
     <ID>LongMethod:PublishSettingsFragment.kt$PublishSettingsFragment$override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?</ID>
     <ID>LongMethod:ReaderDiscoverFragment.kt$ReaderDiscoverFragment$private fun initViewModel()</ID>
     <ID>LongMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment$override fun onCreateView( inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle? ): View?</ID>
-    <ID>LongMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment$private fun initViewModel()</ID>
     <ID>LongMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment.ShowPostTask$override fun onPostExecute(result: Boolean)</ID>
     <ID>LongMethod:ReaderPostMoreButtonUiStateBuilder.kt$ReaderPostMoreButtonUiStateBuilder$fun buildMoreMenuItemsBlocking( post: ReaderPost, onButtonClicked: (Long, Long, ReaderPostCardActionType) -&gt; Unit ): MutableList&lt;SecondaryAction&gt;</ID>
     <ID>LongMethod:ReferrersUseCase.kt$ReferrersUseCase$override fun buildUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List&lt;BlockListItem&gt;</ID>
@@ -360,14 +360,12 @@
     <ID>MultiLineIfElse:org.wordpress.android.ui.posts.PostsListActivity.kt:295</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.posts.PrepublishingHomeViewModel.kt:138</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.posts.prepublishing.visibility.usecases.UpdatePostStatusUseCase.kt:25</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1005</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1007</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1011</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1013</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1133</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1135</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:804</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:806</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1000</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1120</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:1122</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:992</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:994</ID>
+    <ID>MultiLineIfElse:org.wordpress.android.ui.reader.ReaderPostDetailFragment.kt:998</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.reader.repository.usecases.FetchDiscoverCardsUseCase.kt:26</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.reader.repository.usecases.FetchDiscoverCardsUseCase.kt:28</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.reader.subfilter.SubFilterViewModel.kt:251</ID>


### PR DESCRIPTION
Task: #14128

This PR is a sub-task of Issue #14128 and refactors below reader related posts actions making them testable:

1. Related post click action from post details screen.
2. Related post click action from related post details screen (replaces previous related post keeping it in history).
3. Global related post follow button action by reusing `ReaderPostCardActionsHandler`.

### To test

Test.1 Related post click action from post details screen

1. Open a wp.com Reader post from the Reader tab.
2. Click a related post on the selected post details screen. 
3. Notice that "Related Post" screen is displayed with selected related post details and with cross button.

Test.2 Related post click action from "Related Post" screen

1. Continue from above and click a related post from "Related Post" screen.
2. Notice that selected related post details are shown on "Related Post" screen.
3. Click back button.
4. Notice that previous related post (which was added to history) is displayed (as before refactoring)  on "Related Post" screen.

Test.3 Global related post follow button action (see notes)

1. Open a wp.com Reader post from the Reader tab.
2. Scroll to the global related post (from wp.com) at the bottom of the selected post details screen. 
3. Click follow button on global related post.
4. Notice that follow state is toggled for the post.

Tests included in `ReaderPostDetailViewModelTest`.

### Notes

1. Ignore all styling.
2. Test.3 can be skipped for now as we're deciding on whether to show follow button for global related posts due to limited space.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
