### PR TITLE
Issue/14129 topics you might like

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -99,7 +99,7 @@ sealed class ReaderCardUiState {
 
     enum class ReaderInterestChipStyleColor(val id: Int) {
         GREEN(0),
-        BLUE(1),
+        PURPLE(1),
         YELLOW(2),
         ORANGE(3)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -75,24 +75,24 @@ sealed class ReaderCardUiState {
             @ColorRes val chipFillColorResId: Int
         ) {
             object ChipStyleGreen : ChipStyle(
-                    chipStrokeColorResId = R.color.green_5,
-                    chipFontColorResId = R.color.green_50,
-                    chipFillColorResId = R.color.green_0
+                    chipStrokeColorResId = R.color.reader_topics_you_might_like_chip_green_stroke,
+                    chipFontColorResId = R.color.reader_topics_you_might_like_chip_green_font,
+                    chipFillColorResId = R.color.reader_topics_you_might_like_chip_green_fill
             )
-            object ChipStyleBlue : ChipStyle(
-                    chipStrokeColorResId = R.color.blue_5,
-                    chipFontColorResId = R.color.blue_50,
-                    chipFillColorResId = R.color.blue_0
+            object ChipStylePurple : ChipStyle(
+                    chipStrokeColorResId = R.color.reader_topics_you_might_like_chip_purple_stroke,
+                    chipFontColorResId = R.color.reader_topics_you_might_like_chip_purple_font,
+                    chipFillColorResId = R.color.reader_topics_you_might_like_chip_purple_fill
             )
             object ChipStyleYellow : ChipStyle(
-                    chipStrokeColorResId = R.color.yellow_5,
-                    chipFontColorResId = R.color.yellow_50,
-                    chipFillColorResId = R.color.yellow_0
+                    chipStrokeColorResId = R.color.reader_topics_you_might_like_chip_yellow_stroke,
+                    chipFontColorResId = R.color.reader_topics_you_might_like_chip_yellow_font,
+                    chipFillColorResId = R.color.reader_topics_you_might_like_chip_yellow_fill
             )
             object ChipStyleOrange : ChipStyle(
-                    chipStrokeColorResId = R.color.orange_5,
-                    chipFontColorResId = R.color.orange_50,
-                    chipFillColorResId = R.color.orange_0
+                    chipStrokeColorResId = R.color.reader_topics_you_might_like_chip_orange_stroke,
+                    chipFontColorResId = R.color.reader_topics_you_might_like_chip_orange_font,
+                    chipFillColorResId = R.color.reader_topics_you_might_like_chip_orange_fill
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.reader.discover
 
 import android.text.Spanned
 import androidx.annotation.AttrRes
+import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import org.wordpress.android.R
@@ -64,9 +65,43 @@ sealed class ReaderCardUiState {
     data class ReaderInterestsCardUiState(val interest: List<ReaderInterestUiState>) : ReaderCardUiState() {
         data class ReaderInterestUiState(
             val interest: String,
-            val isDividerVisible: Boolean,
-            val onClicked: ((String) -> Unit)
+            val onClicked: ((String) -> Unit),
+            val chipStyle: ChipStyle
         )
+
+        sealed class ChipStyle(
+            @ColorRes val chipStrokeColorResId: Int,
+            @ColorRes val chipFontColorResId: Int,
+            @ColorRes val chipFillColorResId: Int
+        ) {
+            object ChipStyleGreen : ChipStyle(
+                    chipStrokeColorResId = R.color.green_5,
+                    chipFontColorResId = R.color.green_50,
+                    chipFillColorResId = R.color.green_0
+            )
+            object ChipStyleBlue : ChipStyle(
+                    chipStrokeColorResId = R.color.blue_5,
+                    chipFontColorResId = R.color.blue_50,
+                    chipFillColorResId = R.color.blue_0
+            )
+            object ChipStyleYellow : ChipStyle(
+                    chipStrokeColorResId = R.color.yellow_5,
+                    chipFontColorResId = R.color.yellow_50,
+                    chipFillColorResId = R.color.yellow_0
+            )
+            object ChipStyleOrange : ChipStyle(
+                    chipStrokeColorResId = R.color.orange_5,
+                    chipFontColorResId = R.color.orange_50,
+                    chipFillColorResId = R.color.orange_0
+            )
+        }
+    }
+
+    enum class ReaderInterestChipStyleColor(val id: Int) {
+        GREEN(0),
+        BLUE(1),
+        YELLOW(2),
+        ORANGE(3)
     }
 
     data class ReaderRecommendedBlogsCardUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -248,9 +248,6 @@ class ReaderPostUiStateBuilder @Inject constructor(
         )
     }
 
-    private fun buildIsStartingChip(readerTag: ReaderTag, readerTagList: ReaderTagList, firstIndex: Int) =
-            readerTagList.indexOf(readerTag) == firstIndex
-
     private fun buildOnBlogSectionClicked(
         onBlogSectionClicked: (Long, Long) -> Unit,
         postListType: ReaderPostListType?

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -455,7 +455,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
 
         return when (index % colorCount) {
             ReaderInterestChipStyleColor.GREEN.id -> ChipStyleGreen
-            ReaderInterestChipStyleColor.BLUE.id -> ChipStylePurple
+            ReaderInterestChipStyleColor.PURPLE.id -> ChipStylePurple
             ReaderInterestChipStyleColor.YELLOW.id -> ChipStyleYellow
             ReaderInterestChipStyleColor.ORANGE.id -> ChipStyleOrange
             else -> ChipStyleGreen

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -20,12 +20,17 @@ import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.reader.ReaderConstants
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestChipStyleColor
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleBlue
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleGreen
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleOrange
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleYellow
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ReaderInterestUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState.DiscoverLayoutUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState.GalleryThumbnailStripData
-
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommendedBlogsCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommendedBlogsCardUiState.ReaderRecommendedBlogUiState
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
@@ -181,13 +186,12 @@ class ReaderPostUiStateBuilder @Inject constructor(
             } else {
                 READER_INTEREST_LIST_SIZE_LIMIT
             }
-            val lastIndex = listSize - 1
 
             return@withContext ReaderInterestsCardUiState(interests.take(listSize).map { interest ->
                 ReaderInterestUiState(
-                        interest.tagTitle,
-                        buildIsDividerVisible(interest, interests, lastIndex),
-                        onClicked
+                        interest = interest.tagTitle,
+                        onClicked = onClicked,
+                        chipStyle = buildChipStyle(interest, interests)
                 )
             })
         }
@@ -244,8 +248,8 @@ class ReaderPostUiStateBuilder @Inject constructor(
         )
     }
 
-    private fun buildIsDividerVisible(readerTag: ReaderTag, readerTagList: ReaderTagList, lastIndex: Int) =
-            readerTagList.indexOf(readerTag) != lastIndex
+    private fun buildIsStartingChip(readerTag: ReaderTag, readerTagList: ReaderTagList, firstIndex: Int) =
+            readerTagList.indexOf(readerTag) == firstIndex
 
     private fun buildOnBlogSectionClicked(
         onBlogSectionClicked: (Long, Long) -> Unit,
@@ -445,6 +449,19 @@ class ReaderPostUiStateBuilder @Inject constructor(
                     contentDescription = contentDescription,
                     type = ReaderPostCardActionType.COMMENTS
             )
+        }
+    }
+
+    private fun buildChipStyle(readerTag: ReaderTag, readerTagList: ReaderTagList): ChipStyle {
+        val colorCount = ReaderInterestChipStyleColor.values().size
+        val index = readerTagList.indexOf(readerTag)
+
+        return when (index % colorCount) {
+            ReaderInterestChipStyleColor.GREEN.id -> ChipStyleGreen
+            ReaderInterestChipStyleColor.BLUE.id -> ChipStyleBlue
+            ReaderInterestChipStyleColor.YELLOW.id -> ChipStyleYellow
+            ReaderInterestChipStyleColor.ORANGE.id -> ChipStyleOrange
+            else -> ChipStyleGreen
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestChipStyleColor
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle
-import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleBlue
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStylePurple
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleGreen
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleOrange
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleYellow
@@ -455,7 +455,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
 
         return when (index % colorCount) {
             ReaderInterestChipStyleColor.GREEN.id -> ChipStyleGreen
-            ReaderInterestChipStyleColor.BLUE.id -> ChipStyleBlue
+            ReaderInterestChipStyleColor.BLUE.id -> ChipStylePurple
             ReaderInterestChipStyleColor.YELLOW.id -> ChipStyleYellow
             ReaderInterestChipStyleColor.ORANGE.id -> ChipStyleOrange
             else -> ChipStyleGreen

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestViewHolder.kt
@@ -19,7 +19,7 @@ class ReaderInterestViewHolder(
 ) : RecyclerView.ViewHolder(containerView), LayoutContainer {
     fun onBind(uiState: ReaderInterestUiState) {
         uiHelpers.setTextOrHide(interest, uiState.interest)
-        reader_interest_container.setOnClickListener { uiState.onClicked.invoke(uiState.interest) }
+        interest.setOnClickListener { uiState.onClicked.invoke(uiState.interest) }
 
         with(uiState.chipStyle) {
             interest.setChipStrokeColorResource(chipStrokeColorResId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestViewHolder.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.reader.discover.viewholders
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.content.res.AppCompatResources.getColorStateList
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.reader_interest_item.*
@@ -18,7 +19,12 @@ class ReaderInterestViewHolder(
 ) : RecyclerView.ViewHolder(containerView), LayoutContainer {
     fun onBind(uiState: ReaderInterestUiState) {
         uiHelpers.setTextOrHide(interest, uiState.interest)
-        uiHelpers.updateVisibility(divider, uiState.isDividerVisible)
         reader_interest_container.setOnClickListener { uiState.onClicked.invoke(uiState.interest) }
+
+        with(uiState.chipStyle) {
+            interest.setChipStrokeColorResource(chipStrokeColorResId)
+            interest.setChipBackgroundColorResource(chipFillColorResId)
+            interest.setTextColor(getColorStateList(interest.context, chipFontColorResId))
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardViewHolder.kt
@@ -22,6 +22,9 @@ class ReaderInterestsCardViewHolder(
             val readerInterestAdapter = ReaderInterestAdapter(uiHelpers)
             interests_list.adapter = readerInterestAdapter
         }
+    }
+
+    private fun setOnTouchItemListener() {
         interests_list.addOnItemTouchListener(object : OnItemTouchListener {
             override fun onInterceptTouchEvent(recyclerView: RecyclerView, e: MotionEvent): Boolean {
                 val action = e.action
@@ -53,6 +56,7 @@ class ReaderInterestsCardViewHolder(
 
     override fun onBind(uiState: ReaderCardUiState) {
         uiState as ReaderInterestsCardUiState
+        setOnTouchItemListener()
         (interests_list.adapter as ReaderInterestAdapter).update(uiState.interest)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardViewHolder.kt
@@ -1,8 +1,10 @@
 package org.wordpress.android.ui.reader.discover.viewholders
 
+import android.view.MotionEvent
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.OnItemTouchListener
 import kotlinx.android.synthetic.main.reader_interest_card.*
 import org.wordpress.android.R
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState
@@ -16,10 +18,37 @@ class ReaderInterestsCardViewHolder(
 ) : ReaderViewHolder(parentView, R.layout.reader_interest_card) {
     init {
         if (interests_list.adapter == null) {
-            interests_list.layoutManager = LinearLayoutManager(interests_list.context, RecyclerView.VERTICAL, false)
+            interests_list.layoutManager = LinearLayoutManager(interests_list.context, RecyclerView.HORIZONTAL, false)
             val readerInterestAdapter = ReaderInterestAdapter(uiHelpers)
             interests_list.adapter = readerInterestAdapter
         }
+        interests_list.addOnItemTouchListener(object : OnItemTouchListener {
+            override fun onInterceptTouchEvent(recyclerView: RecyclerView, e: MotionEvent): Boolean {
+                val action = e.action
+                return if (recyclerView.canScrollHorizontally(RecyclerView.FOCUS_FORWARD)) {
+                    when (action) {
+                        MotionEvent.ACTION_MOVE -> recyclerView.parent
+                                .requestDisallowInterceptTouchEvent(true)
+                    }
+                    false
+                } else {
+                    when (action) {
+                        MotionEvent.ACTION_MOVE -> recyclerView.parent
+                                .requestDisallowInterceptTouchEvent(false)
+                    }
+                    recyclerView.removeOnItemTouchListener(this)
+                    true
+                }
+            }
+
+            override fun onTouchEvent(rv: RecyclerView, e: MotionEvent) {
+                // NO OP
+            }
+
+            override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+                // NO OP
+            }
+        })
     }
 
     override fun onBind(uiState: ReaderCardUiState) {

--- a/WordPress/src/main/res/layout/reader_interest_card.xml
+++ b/WordPress/src/main/res/layout/reader_interest_card.xml
@@ -14,6 +14,9 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/interests_list"
             android:layout_marginTop="@dimen/margin_extra_large"
+            android:layout_marginBottom="@dimen/margin_extra_large"
+            android:layout_marginStart="@dimen/margin_small"
+            android:layout_marginEnd="@dimen/margin_medium"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/WordPress/src/main/res/layout/reader_interest_card.xml
+++ b/WordPress/src/main/res/layout/reader_interest_card.xml
@@ -13,8 +13,6 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/interests_list"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            android:layout_marginBottom="@dimen/margin_extra_large"
             android:layout_marginStart="@dimen/margin_small"
             android:layout_marginEnd="@dimen/margin_medium"
             android:layout_width="0dp"

--- a/WordPress/src/main/res/layout/reader_interest_item.xml
+++ b/WordPress/src/main/res/layout/reader_interest_item.xml
@@ -6,7 +6,9 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/margin_medium"
-    android:layout_marginEnd="@dimen/margin_medium">
+    android:layout_marginEnd="@dimen/margin_medium"
+    android:layout_marginBottom="@dimen/margin_extra_large"
+    android:layout_marginTop="@dimen/margin_extra_large">
 
     <com.google.android.material.chip.Chip
         android:id="@+id/interest"

--- a/WordPress/src/main/res/layout/reader_interest_item.xml
+++ b/WordPress/src/main/res/layout/reader_interest_item.xml
@@ -17,7 +17,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:chipStrokeWidth="@dimen/divider_size"
-        app:chipStartPadding="@dimen/margin_extra_large"
-        app:chipEndPadding="@dimen/margin_extra_large"
+        app:chipStartPadding="@dimen/margin_large"
+        app:chipEndPadding="@dimen/margin_large"
         tools:text="Photography"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/reader_interest_item.xml
+++ b/WordPress/src/main/res/layout/reader_interest_item.xml
@@ -5,8 +5,8 @@
     android:id="@+id/reader_interest_container"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/margin_medium"
-    android:layout_marginEnd="@dimen/margin_medium"
+    android:layout_marginStart="@dimen/margin_small"
+    android:layout_marginEnd="@dimen/margin_small"
     android:layout_marginBottom="@dimen/margin_extra_large"
     android:layout_marginTop="@dimen/margin_extra_large">
 

--- a/WordPress/src/main/res/layout/reader_interest_item.xml
+++ b/WordPress/src/main/res/layout/reader_interest_item.xml
@@ -3,31 +3,19 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/reader_interest_container"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:background="?attr/selectableItemBackground">
+    android:layout_marginStart="@dimen/margin_medium"
+    android:layout_marginEnd="@dimen/margin_medium">
 
-    <View
-        android:id="@+id/divider"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/divider_size"
-        android:alpha="@dimen/material_emphasis_disabled"
-        android:background="?android:attr/listDivider"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/interest"
-        tools:visibility="visible" />
-
-    <org.wordpress.android.widgets.WPTextView
+    <com.google.android.material.chip.Chip
         android:id="@+id/interest"
-        style="@style/ReaderTextView.Interests.ListItem.Text"
-        app:layout_constraintBottom_toTopOf="@+id/divider"
-        app:layout_constraintHorizontal_bias="0.0"
+        style="@style/ReaderTextView.Interests.ListItem.Chip"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0"
-        tools:text="Photography" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:chipStrokeWidth="@dimen/divider_size"
+        app:chipStartPadding="@dimen/margin_extra_large"
+        app:chipEndPadding="@dimen/margin_extra_large"
+        tools:text="Photography"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -99,4 +99,18 @@
     <color name="quick_start_task_card_illustration_set_site_title_body">@color/gray_0</color>
     <color name="quick_start_task_card_illustration_set_site_title_box_stroke">@color/gray_50</color>
     <color name="quick_start_task_card_illustration_visit_your_site_star">@color/purple_30</color>
+
+    <!-- Reader Topics You Might Like Chips -->
+    <color name="reader_topics_you_might_like_chip_green_stroke">@color/green_100</color>
+    <color name="reader_topics_you_might_like_chip_green_font">@color/green_40</color>
+    <color name="reader_topics_you_might_like_chip_green_fill">@color/green_90</color>
+    <color name="reader_topics_you_might_like_chip_purple_stroke">@color/purple_100</color>
+    <color name="reader_topics_you_might_like_chip_purple_font">@color/purple_40</color>
+    <color name="reader_topics_you_might_like_chip_purple_fill">@color/purple_90</color>
+    <color name="reader_topics_you_might_like_chip_yellow_stroke">@color/yellow_100</color>
+    <color name="reader_topics_you_might_like_chip_yellow_font">@color/yellow_40</color>
+    <color name="reader_topics_you_might_like_chip_yellow_fill">@color/yellow_90</color>
+    <color name="reader_topics_you_might_like_chip_orange_stroke">@color/orange_100</color>
+    <color name="reader_topics_you_might_like_chip_orange_font">@color/orange_40</color>
+    <color name="reader_topics_you_might_like_chip_orange_fill">@color/orange_90</color>
 </resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -368,4 +368,18 @@
     <color name="quick_start_task_card_illustration_set_site_title_body">@color/white</color>
     <color name="quick_start_task_card_illustration_set_site_title_box_stroke">@color/blue_5</color>
     <color name="quick_start_task_card_illustration_visit_your_site_star">#FFD60A</color>
+
+    <!-- Reader Topics You Might Like Chips -->
+    <color name="reader_topics_you_might_like_chip_green_stroke">@color/green_5</color>
+    <color name="reader_topics_you_might_like_chip_green_font">@color/green_50</color>
+    <color name="reader_topics_you_might_like_chip_green_fill">@color/green_0</color>
+    <color name="reader_topics_you_might_like_chip_purple_stroke">@color/purple_5</color>
+    <color name="reader_topics_you_might_like_chip_purple_font">@color/purple_50</color>
+    <color name="reader_topics_you_might_like_chip_purple_fill">@color/purple_0</color>
+    <color name="reader_topics_you_might_like_chip_yellow_stroke">@color/yellow_5</color>
+    <color name="reader_topics_you_might_like_chip_yellow_font">@color/yellow_50</color>
+    <color name="reader_topics_you_might_like_chip_yellow_fill">@color/yellow_0</color>
+    <color name="reader_topics_you_might_like_chip_orange_stroke">@color/orange_5</color>
+    <color name="reader_topics_you_might_like_chip_orange_font">@color/orange_50</color>
+    <color name="reader_topics_you_might_like_chip_orange_fill">@color/orange_0</color>
 </resources>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -152,6 +152,12 @@
         <item name="android:textAlignment">viewStart</item>
     </style>
 
+    <style name="ReaderTextView.Interests.ListItem.Chip" parent="">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:textAppearance">?attr/textAppearanceBody1</item>
+    </style>
+
     <style name="ReaderTextView.Interests.Title" parent="ReaderTextView">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -141,17 +141,6 @@
         <item name="android:textAppearance">?attr/textAppearanceHeadline6</item>
     </style>
 
-    <style name="ReaderTextView.Interests.ListItem.Text" parent="ReaderTextView">
-        <item name="android:layout_width">0dp</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_marginBottom">@dimen/margin_large</item>
-        <item name="android:layout_marginEnd">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginStart">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginTop">@dimen/margin_large</item>
-        <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="android:textAlignment">viewStart</item>
-    </style>
-
     <style name="ReaderTextView.Interests.ListItem.Chip" parent="">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -696,7 +696,7 @@ class ReaderDiscoverViewModelTest {
     }
 
     private fun createReaderInterestsCardUiState(readerTagList: ReaderTagList) =
-            ReaderInterestsCardUiState(readerTagList.map { ReaderInterestUiState("", false, mock()) })
+            ReaderInterestsCardUiState(readerTagList.map { ReaderInterestUiState("", mock(), mock()) })
 
     private fun createReaderRecommendedBlogsCardUiState(
         recommendedBlogs: List<ReaderBlog>,

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -40,6 +40,10 @@ import org.wordpress.android.ui.Organization.P2
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.BLOG_PREVIEW
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleBlue
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleGreen
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleOrange
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleYellow
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BOOKMARK
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.LIKE
@@ -824,30 +828,36 @@ class ReaderPostUiStateBuilderTest {
     }
 
     @Test
-    fun `Ensures that the first InterestUiState has isDividerVisible set to true`() = test {
+    fun `given a tag list with 4 elements, then the uiState contains each style`() = test {
         // arrange
-        val currentReaderTagListSize = 2
+        val currentReaderTagListSize = 4
+        val expectedListStyles = listOf(ChipStyleGreen, ChipStyleBlue, ChipStyleYellow, ChipStyleOrange)
+
         val readerTagList = createReaderTagList(currentReaderTagListSize)
 
         // act
         val result = builder.mapTagListToReaderInterestUiState(readerTagList, mock())
 
         // assert
-        assertThat(result.interest.first().isDividerVisible).isTrue()
+        for ((index, interest) in result.interest.withIndex()) {
+            assertThat(interest.chipStyle).isEqualTo(expectedListStyles[index])
+        }
     }
 
     @Test
-    fun `Ensures that the last InterestUiState has isDividerVisible set to false`() = test {
+    fun `given a tag list with 5 elements, then the 5th interest within the uiState is styled green`() = test {
         // arrange
-        val currentReaderTagListSize = 2
+        val currentReaderTagListSize = 5
+
         val readerTagList = createReaderTagList(currentReaderTagListSize)
 
         // act
         val result = builder.mapTagListToReaderInterestUiState(readerTagList, mock())
 
         // assert
-        assertThat(result.interest.last().isDividerVisible).isFalse()
+        assertThat(result.interest.last().chipStyle).isInstanceOf(ChipStyleGreen::class.java)
     }
+
     // endregion
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilderTest.kt
@@ -40,7 +40,7 @@ import org.wordpress.android.ui.Organization.P2
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.BLOG_PREVIEW
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
-import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleBlue
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStylePurple
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleGreen
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleOrange
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ChipStyle.ChipStyleYellow
@@ -831,7 +831,7 @@ class ReaderPostUiStateBuilderTest {
     fun `given a tag list with 4 elements, then the uiState contains each style`() = test {
         // arrange
         val currentReaderTagListSize = 4
-        val expectedListStyles = listOf(ChipStyleGreen, ChipStyleBlue, ChipStyleYellow, ChipStyleOrange)
+        val expectedListStyles = listOf(ChipStyleGreen, ChipStylePurple, ChipStyleYellow, ChipStyleOrange)
 
         val readerTagList = createReaderTagList(currentReaderTagListSize)
 


### PR DESCRIPTION
Fixes #14129

This PR redesigns the "Topics you like" section" of the Discover feed by swapping out the vertical topic text list with a horizontal topic chip list.

Highlights include
- `ReaderInterestsCardViewHolder`
 -- Updated the recyclerView from Vertical to Horizontal
 -- Attached an `OnItemTouchListener` to the recyclerView to handle the chip scrolling because the topics Horizontal recyclerView is contained within a Vertical recyclerView which is then contained in a ViewPager2. We need to have the inner most recycler view scroll correctly, while still allowing tab scrolling. 
- `ReaderPostUiStateBuilder`
-- Logic was added to build the color style profile for the chips
-- There are currently 4 fixed colors and if the list contains more than 4, the colors will recycle. Note: The max topics allowed at the time of this PR is 5
 
|light |dark|scrolling
|---|---|--|
|![light](https://user-images.githubusercontent.com/506707/109540243-3354b200-7a90-11eb-9a3a-d9ea83825494.png)|![dark](https://user-images.githubusercontent.com/506707/109540238-318aee80-7a90-11eb-9c29-fd02dd69afa2.png)|![scroll](https://user-images.githubusercontent.com/506707/109540774-ef15e180-7a90-11eb-8c36-1651782cbddc.gif)

*To Test*
- Launch the app
- Navigate to the Discover Tab
- Scroll down until you come to "Topics you like" section
- Note the following:
-- The card is no longer vertical text
-- Chips are shown
-- The chip colors follows the pattern: Green, Blue, Yellow and Orange
-- You can still scroll down & up
-- You can still page left & right

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
