### PR TITLE
Add fading edges to Quick Start list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartCardViewHolder.kt
@@ -20,10 +20,8 @@ import androidx.recyclerview.widget.RecyclerView.RecycledViewPool
 import kotlinx.android.synthetic.main.quick_start_card.view.*
 import org.wordpress.android.R
 import org.wordpress.android.ui.mysite.MySiteItem.DynamicCard.QuickStartCard
-import org.wordpress.android.util.ColorUtils
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.util.DisplayUtils
-import org.wordpress.android.widgets.RecyclerItemDecoration
+import org.wordpress.android.util.ColorUtils
 
 class QuickStartCardViewHolder(
     parent: ViewGroup,
@@ -41,7 +39,12 @@ class QuickStartCardViewHolder(
                 adapter = QuickStartTaskCardAdapter(uiHelpers)
                 layoutManager = LinearLayoutManager(context, HORIZONTAL, false)
                 setRecycledViewPool(viewPool)
-                addItemDecoration(RecyclerItemDecoration(DisplayUtils.dpToPx(context, 2), 0))
+                addItemDecoration(
+                        QuickStartListItemDecoration(
+                                resources.getDimensionPixelSize(R.dimen.margin_extra_small),
+                                resources.getDimensionPixelSize(R.dimen.margin_large)
+                        )
+                )
                 addOnScrollListener(object : OnScrollListener() {
                     override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                         if (newState == RecyclerView.SCROLL_STATE_IDLE) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartListItemDecoration.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartListItemDecoration.kt
@@ -6,7 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 
 data class QuickStartListItemDecoration(
     val itemHorizontalSpacing: Int,
-    val edgeHorizontalSpacing: Int,
+    val edgeHorizontalSpacing: Int
 ) : RecyclerView.ItemDecoration() {
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
         super.getItemOffsets(outRect, view, parent, state)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartListItemDecoration.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartListItemDecoration.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.mysite
+
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+data class QuickStartListItemDecoration(
+    val itemHorizontalSpacing: Int,
+    val edgeHorizontalSpacing: Int,
+) : RecyclerView.ItemDecoration() {
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
+        super.getItemOffsets(outRect, view, parent, state)
+        val itemPosition: Int = parent.getChildAdapterPosition(view)
+        val itemCount = state.itemCount
+        val isFirst = itemPosition == 0
+        val isLast = itemCount > 0 && itemPosition == itemCount - 1
+        outRect.set(
+                if (isFirst) edgeHorizontalSpacing else itemHorizontalSpacing,
+                0,
+                if (isLast) edgeHorizontalSpacing else itemHorizontalSpacing,
+                0
+        )
+    }
+}

--- a/WordPress/src/main/res/layout/quick_start_card.xml
+++ b/WordPress/src/main/res/layout/quick_start_card.xml
@@ -56,7 +56,5 @@
         android:id="@+id/quick_start_card_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:clipToPadding="false"
-        android:paddingEnd="@dimen/margin_medium_large"
-        android:paddingStart="@dimen/margin_medium_large" />
+        android:clipToPadding="false" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/quick_start_card.xml
+++ b/WordPress/src/main/res/layout/quick_start_card.xml
@@ -56,5 +56,6 @@
         android:id="@+id/quick_start_card_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:clipToPadding="false" />
+        android:clipToPadding="false"
+        android:requiresFadingEdge="horizontal" />
 </LinearLayout>


### PR DESCRIPTION
This PR adds fading edges to the horizontal Quick Start list to make it more intuitive:

|Light|Dark|
|---|---|
|![light-fading-edges](https://user-images.githubusercontent.com/830056/109565305-07055980-7ac1-11eb-9f51-ab8912238fcc.png)|![dark-fading-edges](https://user-images.githubusercontent.com/830056/109565301-053b9600-7ac1-11eb-8d7c-083c39a74ef8.png)|

The biggest change is that we're adding a custom `ItemDecoration` for the list, to make it easier to control spacing between items and for the first and last items.

To test:

1. Turn on the Improved My Site flag and restart the app.
1. Go to the My Site screen and select a site where Quick Start is active.
1. Notice the horizontal tasks lists.
1. Make sure the spacing between items look right.
1. Swipe left and right and make sure the edges are fading.
1. Repeat for light/dark mode.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
