### PR TITLE
Fix positional printf strings

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1089,8 +1089,8 @@
     <string name="scan_provisioning_description">Welcome to Jetpack Scan! We\'re scoping out your site, setting up to do a full scan. We\'ll let you know if we spot any issues that might impact a scan, then your first full scan will start.</string>
     <string name="scan_idle_manual_scan_description">To review your site again run a manual scan, or wait for Jetpack to scan your site later today.</string>
     <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and did not find any risks. %s</string>
-    <string name="scan_idle_with_threats_description_plural">The scan found %1s potential threats with %2s. Please review them below and take action or tap the fix all button. We are %3$s if you need us.</string>
-    <string name="scan_idle_with_threats_description_singular">The scan found %1s potential threat with %2s. Please review the threat below and take action or tap the fix all button. We are %3$s if you need us.</string>
+    <string name="scan_idle_with_threats_description_plural">The scan found %1$s potential threats with %2$s. Please review them below and take action or tap the fix all button. We are %3$s if you need us.</string>
+    <string name="scan_idle_with_threats_description_singular">The scan found %1$s potential threat with %2$s. Please review the threat below and take action or tap the fix all button. We are %3$s if you need us.</string>
     <string name="scan_here_to_help">here to help</string>
     <string name="scan_this_site">this site</string>
     <string name="scan_in_hours_ago">%s hour(s) ago</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1089,8 +1089,8 @@
     <string name="scan_provisioning_description">Welcome to Jetpack Scan! We\'re scoping out your site, setting up to do a full scan. We\'ll let you know if we spot any issues that might impact a scan, then your first full scan will start.</string>
     <string name="scan_idle_manual_scan_description">To review your site again run a manual scan, or wait for Jetpack to scan your site later today.</string>
     <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and did not find any risks. %s</string>
-    <string name="scan_idle_with_threats_description_plural">The scan found %1s potential threats with %2s. Please review them below and take action or tap the fix all button. We are %3$s if you need us.</string>
-    <string name="scan_idle_with_threats_description_singular">The scan found %1s potential threat with %2s. Please review the threat below and take action or tap the fix all button. We are %3$s if you need us.</string>
+    <string name="scan_idle_with_threats_description_plural">The scan found %1$s potential threats with %2$s. Please review them below and take action or tap the fix all button. We are %3$s if you need us.</string>
+    <string name="scan_idle_with_threats_description_singular">The scan found %1$s potential threat with %2$s. Please review the threat below and take action or tap the fix all button. We are %3$s if you need us.</string>
     <string name="scan_here_to_help">here to help</string>
     <string name="scan_this_site">this site</string>
     <string name="scan_in_hours_ago">%s hour(s) ago</string>


### PR DESCRIPTION
A comment was made in slack about a missing placeholder: https://wordpress.slack.com/archives/C02RP50LK/p1614636159170000 which triggered me to notice that a string in the app uses padding placeholders rather than positional placeholders, when it's the latter that's intended.

An example of this (in PHP, but I'm almost certain it's universal)

    printf( "|%10s|", 'ten' );
    |       ten|

No testing of this change has been done, other than visual inspection.

I originally also updated the translations https://github.com/wordpress-mobile/WordPress-Android/commit/037beb855085e6b9b84d6bfb265c3a0b6e06b9c4, but removed it from the branch as updating the translations isn't needed. The change will fuzzy the translations, which can easily be picked up.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
