### PR TITLE
Update example encrypted logging key

### DIFF
--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -27,7 +27,7 @@ wp.zendesk.oauth_client_id=wordpress
 wp.reset_db_on_downgrade = false
 wp.sentry.dsn=https://00000000000000000000000000000000@sentry.io/00000000
 wp.tenor.api_key=wordpress
-wp.encrypted_logging_key=abcabcabcabcabcabcabcabcabcabcabcabcabcabcab
+wp.encrypted_logging_key=z0g+oVkqR4kWNUTxJfTozOZQjfXI7W9f6bD0uMJ5VkA=
 
 # Uncomment and edit the line below to use a local copy of WordPressMocks
 # You should specify a relative path to the root of your WordPressMocks repo


### PR DESCRIPTION
The previous example encrypted logging key was hitting this assertion: https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt#L62-L64. It looks like this is because the `Base64.decode(BuildConfig.ENCRYPTED_LOGGING_KEY, Base64.DEFAULT)` was resulting in a byte array with length 33, whereas our encryption code was expecting a byte array with length 32. This new example key seems to fit that requirement and should no longer crash the app.

**To test:**

1. Update your `wp.encrypted_logging_key` in your `gradle.properties` to match the one in `gradle.properties-example` file.
2. Make sure you've enabled crash tracking from `App Setting` > `Privacy`
3. Trigger a crash by adding a `throw new IllegalStateException("Testing encrypted logging key")` at the end of [`WordPress.onCreate`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/WordPress.java#L369)
4. Run the app, so it crashes at least once
5. Remove the `throw new IllegalStateException` that you added in `Step 3`.
6. Run the app
7. Verify that it doesn't crash

**Explanation for the steps:**

We encrypt the logs when we report a crash to Sentry, so we need at least one crash to trigger this flow, and it's why we need crash tracking to be enabled first.

**PR submission checklist:**

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
