### PR TITLE
Update Stats item layout to support larger font sizes 

### DIFF
--- a/WordPress/src/main/res/layout/stats_block_dialog_buttons_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_dialog_buttons_item.xml
@@ -2,8 +2,9 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/stats_insights_button_container_height"
-    android:gravity="end">
+    android:layout_height="wrap_content"
+    android:gravity="end"
+    android:minHeight="@dimen/stats_insights_button_container_height">
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/button_negative"

--- a/WordPress/src/main/res/layout/stats_block_dialog_buttons_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_dialog_buttons_item.xml
@@ -11,8 +11,6 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:layout_marginTop="@dimen/margin_medium"
-        android:layout_marginBottom="@dimen/margin_medium"
         tools:text="Cancel" />
 
     <com.google.android.material.button.MaterialButton
@@ -21,9 +19,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:layout_marginTop="@dimen/margin_medium"
         android:layout_marginEnd="@dimen/margin_medium"
-        android:layout_marginBottom="@dimen/margin_medium"
         tools:text="OK" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/stats_block_dialog_buttons_item.xml
+++ b/WordPress/src/main/res/layout/stats_block_dialog_buttons_item.xml
@@ -9,7 +9,7 @@
         android:id="@+id/button_negative"
         style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_gravity="center"
         tools:text="Cancel" />
 
@@ -17,7 +17,7 @@
         android:id="@+id/button_positive"
         style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginEnd="@dimen/margin_medium"
         tools:text="OK" />


### PR DESCRIPTION
Fixes #13791 

This PR updates the `stats_block_dialog_buttons_item.xml` layout so it can better support larger fonts:

https://user-images.githubusercontent.com/830056/109728550-2f5e8800-7b95-11eb-92f7-6cf3f994ff6b.mp4

There were basically three changes that were made to the layout:
- The buttons top and bottom margins were removed.
- The buttons height were updated from `match_parent` to `wrap_content`.
- The item layout was updated to use `minHeight` instead of `layout_height`, which was set to `wrap_content` as well.

To test:

1. Open the app. 
1. Select a new site or create a new one.
1. Go to the Stats screen.
1. Notice the "Manage Your Stats" card.
1. Make sure the buttons are not being cut out.
1. Repeat for larger font sizes by going to the system Settings > Accessibility > Font size.
1. Make sure nothing else looks off.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
