### PR TITLE
Start QS only for the newly created site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1060,7 +1060,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 }
                 break;
             case RequestCodes.CREATE_SITE:
-                passOnActivityResultToMySiteFragment(requestCode, resultCode, data);
                 QuickStartUtils.cancelQuickStartReminder(this);
                 AppPrefs.setQuickStartNoticeRequired(false);
                 AppPrefs.setLastSkippedQuickStartTask(null);
@@ -1096,7 +1095,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 }
                 break;
             case RequestCodes.SITE_PICKER:
-                passOnActivityResultToMySiteFragment(requestCode, resultCode, data);
                 if (getMySiteFragment() != null) {
                     boolean isSameSiteSelected = data != null
                                                  && data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1) == AppPrefs

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -434,11 +434,11 @@ class ImprovedMySiteFragment : Fragment(),
                 viewModel.handleSuccessfulDomainRegistrationResult(data.getStringExtra(RESULT_REGISTERED_DOMAIN_EMAIL))
             }
             RequestCodes.CREATE_SITE -> {
-                viewModel.startQuickStart()
+                viewModel.startQuickStart(data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1))
             }
             RequestCodes.SITE_PICKER -> {
                 if (data.getIntExtra(WPMainActivity.ARG_CREATE_SITE, 0) == RequestCodes.CREATE_SITE) {
-                    viewModel.startQuickStart()
+                    viewModel.startQuickStart(data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1))
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -574,8 +574,8 @@ class MySiteViewModel
         }
     }
 
-    fun startQuickStart() {
-        quickStartRepository.startQuickStart()
+    fun startQuickStart(newSiteLocalID: Int) {
+        quickStartRepository.startQuickStart(newSiteLocalID)
     }
 
     fun onQuickStartMenuInteraction(interaction: DynamicCardMenuInteraction) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartRepository.kt
@@ -108,9 +108,9 @@ class QuickStartRepository
         }
     }
 
-    fun startQuickStart() {
-        selectedSiteRepository.getSelectedSite()?.let { site ->
-            quickStartStore.setDoneTask(site.id.toLong(), CREATE_SITE, true)
+    fun startQuickStart(newSiteLocalID: Int) {
+        if (newSiteLocalID != -1) {
+            quickStartStore.setDoneTask(newSiteLocalID.toLong(), CREATE_SITE, true)
             refresh()
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/QuickStartRepositoryTest.kt
@@ -139,10 +139,9 @@ class QuickStartRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `start marks CREATE_SITE as done and loads model`() = test {
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         initStore()
 
-        quickStartRepository.startQuickStart()
+        quickStartRepository.startQuickStart(siteId)
 
         verify(quickStartStore).setDoneTask(siteId.toLong(), CREATE_SITE, true)
         assertModel()


### PR DESCRIPTION
Fixes #14178 

This PR removes the double call to the `passActivityResultToMySiteFragment`. In addition instead of starting the QS for the selected site, I'm passing the created site ID to the function. I think this approach should be much less error prone. Let me know what you think! 

To test:
- Make sure you're on a freshly installed app with a site
- Turn on the My Site Improvements flag and restart the app
- Create a site 
- Notice the new site has QS started
- Switch site to the previous site
- Notice the previous site doesn't have QS started

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
