### PR TITLE
Update singular strings for threats to use 1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -270,12 +270,11 @@ class ScanViewModel @Inject constructor(
         updateNavigationEvent(
             OpenFixThreatsConfirmationDialog(
                 title = UiStringRes(R.string.threat_fix_all_warning_title),
-                message = UiStringResWithParams(
-                    if (fixableThreatIds.size > 1) {
-                        R.string.threat_fix_all_warning_message_plural
-                    } else R.string.threat_fix_all_warning_message_singular,
-                    listOf(UiStringText("${fixableThreatIds.size}"))
-                ),
+                message = if (fixableThreatIds.size > 1) {
+                            UiStringResWithParams(
+                                R.string.threat_fix_all_warning_message_plural,
+                                listOf(UiStringText("${fixableThreatIds.size}")))
+                } else UiStringRes(R.string.threat_fix_all_warning_message_singular),
                 okButtonAction = this@ScanViewModel::fixAllThreats
             )
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -145,7 +145,7 @@ class ScanViewModel @Inject constructor(
                 )
 
                 1 -> htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                    R.string.scan_finished_threats_found_message_singular
+                    R.string.scan_finished_potential_threats_found_message_singular
                 )
 
                 else -> htmlMessageUtils.getHtmlMessageFromStringFormatResId(
@@ -274,7 +274,7 @@ class ScanViewModel @Inject constructor(
                             UiStringResWithParams(
                                 R.string.threat_fix_all_warning_message_plural,
                                 listOf(UiStringText("${fixableThreatIds.size}")))
-                } else UiStringRes(R.string.threat_fix_all_warning_message_singular),
+                } else UiStringRes(R.string.threat_fix_all_confirmation_message_singular),
                 okButtonAction = this@ScanViewModel::fixAllThreats
             )
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanViewModel.kt
@@ -149,7 +149,7 @@ class ScanViewModel @Inject constructor(
                 )
 
                 else -> htmlMessageUtils.getHtmlMessageFromStringFormatResId(
-                    R.string.scan_finished_threats_found_message_plural,
+                    R.string.scan_finished_potential_threats_found_message_plural,
                     "$threatsCount"
                 )
             }
@@ -272,7 +272,7 @@ class ScanViewModel @Inject constructor(
                 title = UiStringRes(R.string.threat_fix_all_warning_title),
                 message = if (fixableThreatIds.size > 1) {
                             UiStringResWithParams(
-                                R.string.threat_fix_all_warning_message_plural,
+                                R.string.threat_fix_all_confirmation_message_plural,
                                 listOf(UiStringText("${fixableThreatIds.size}")))
                 } else UiStringRes(R.string.threat_fix_all_confirmation_message_singular),
                 okButtonAction = this@ScanViewModel::fixAllThreats

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
@@ -256,13 +256,10 @@ class ScanStateListItemsBuilder @Inject constructor(
     ): DescriptionState {
         val clickableText = resourceProvider.getString(R.string.scan_here_to_help)
 
-        val descriptionTextResId = if (threatsCount > 1) {
-            R.string.scan_idle_threats_description_plural
-        } else R.string.scan_idle_threats_description_singular
         val descriptionText = if (threatsCount > 1) {
             htmlMessageUtils
                     .getHtmlMessageFromStringFormatResId(
-                            descriptionTextResId,
+                            R.string.scan_idle_threats_description_plural,
                             "<b>$threatsCount</b>",
                             "<b>${site.name ?: resourceProvider.getString(R.string.scan_this_site)}</b>",
                             clickableText
@@ -270,7 +267,7 @@ class ScanStateListItemsBuilder @Inject constructor(
         } else {
             htmlMessageUtils
                     .getHtmlMessageFromStringFormatResId(
-                            descriptionTextResId,
+                            R.string.scan_idle_threats_description_singular,
                             "<b>${site.name ?: resourceProvider.getString(R.string.scan_this_site)}</b>",
                             clickableText
                     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
@@ -258,8 +258,8 @@ class ScanStateListItemsBuilder @Inject constructor(
 
         val descriptionTextResId = if (threatsCount > 1) {
             R.string.scan_idle_with_threats_description_plural
-        } else R.string.scan_idle_with_threats_description_singular
-        val descriptionText = if(threatsCount > 1) {
+        } else R.string.scan_idle_threats_description_singular
+        val descriptionText = if (threatsCount > 1) {
             htmlMessageUtils
                     .getHtmlMessageFromStringFormatResId(
                             descriptionTextResId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
@@ -257,7 +257,7 @@ class ScanStateListItemsBuilder @Inject constructor(
         val clickableText = resourceProvider.getString(R.string.scan_here_to_help)
 
         val descriptionTextResId = if (threatsCount > 1) {
-            R.string.scan_idle_with_threats_description_plural
+            R.string.scan_idle_threats_description_plural
         } else R.string.scan_idle_threats_description_singular
         val descriptionText = if (threatsCount > 1) {
             htmlMessageUtils

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilder.kt
@@ -259,13 +259,22 @@ class ScanStateListItemsBuilder @Inject constructor(
         val descriptionTextResId = if (threatsCount > 1) {
             R.string.scan_idle_with_threats_description_plural
         } else R.string.scan_idle_with_threats_description_singular
-        val descriptionText = htmlMessageUtils
-            .getHtmlMessageFromStringFormatResId(
-                descriptionTextResId,
-                "<b>$threatsCount</b>",
-                "<b>${site.name ?: resourceProvider.getString(R.string.scan_this_site)}</b>",
-                clickableText
-            )
+        val descriptionText = if(threatsCount > 1) {
+            htmlMessageUtils
+                    .getHtmlMessageFromStringFormatResId(
+                            descriptionTextResId,
+                            "<b>$threatsCount</b>",
+                            "<b>${site.name ?: resourceProvider.getString(R.string.scan_this_site)}</b>",
+                            clickableText
+                    )
+        } else {
+            htmlMessageUtils
+                    .getHtmlMessageFromStringFormatResId(
+                            descriptionTextResId,
+                            "<b>${site.name ?: resourceProvider.getString(R.string.scan_this_site)}</b>",
+                            clickableText
+                    )
+        }
 
         val clickableTextStartIndex = descriptionText.indexOf(clickableText)
         val clickableTextEndIndex = clickableTextStartIndex + clickableText.length

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1095,7 +1095,7 @@
     <string name="scan_idle_manual_scan_description">To review your site again run a manual scan, or wait for Jetpack to scan your site later today.</string>
     <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and did not find any risks. %s</string>
     <string name="scan_idle_with_threats_description_plural">The scan found %1s potential threats with %2s. Please review them below and take action or tap the fix all button. We are %3$s if you need us.</string>
-    <string name="scan_idle_with_threats_description_singular">The scan found 1 potential threat with %1s. Please review the threat below and take action or tap the fix all button. We are %2$s if you need us.</string>
+    <string name="scan_idle_with_threats_description_singular">The scan found one potential threat with %1s. Please review the threat below and take action or tap the fix all button. We are %2$s if you need us.</string>
     <string name="scan_here_to_help">here to help</string>
     <string name="scan_this_site">this site</string>
     <string name="scan_in_hours_ago">%s hour(s) ago</string>
@@ -1103,7 +1103,7 @@
     <string name="scan_in_few_seconds">a few seconds ago</string>
     <string name="scan_progress_label" translatable="false">%1$s%%</string>
     <string name="scan_finished_no_threats_found_message">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; No threats found</string>
-    <string name="scan_finished_threats_found_message_singular">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; 1 potential threat found</string>
+    <string name="scan_finished_threats_found_message_singular">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; one potential threat found</string>
     <string name="scan_finished_threats_found_message_plural">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; %s potential threats found</string>
 
     <!-- scan history -->
@@ -1171,7 +1171,7 @@
     <string name="threat_ignore_error_message">Error ignoring threat. Please contact support.</string>
     <string name="threat_fix_all_warning_title">Fix all threats</string>
     <string name="threat_fix_all_warning_message_plural">Please confirm you want to fix all %s active threats.</string>
-    <string name="threat_fix_all_warning_message_singular">Please confirm you want to fix 1 active threat.</string>
+    <string name="threat_fix_all_warning_message_singular">Please confirm you want to fix one active threat.</string>
     <string name="threat_fix_all_error_message">Error fixing threats. Please contact our support.</string>
     <string name="threat_fix_all_status_success_message_plural">Threats were successfully fixed.</string>
     <string name="threat_fix_all_status_success_message_singular">Threat was successfully fixed.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1095,7 +1095,7 @@
     <string name="scan_idle_manual_scan_description">To review your site again run a manual scan, or wait for Jetpack to scan your site later today.</string>
     <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and did not find any risks. %s</string>
     <string name="scan_idle_with_threats_description_plural">The scan found %1s potential threats with %2s. Please review them below and take action or tap the fix all button. We are %3$s if you need us.</string>
-    <string name="scan_idle_with_threats_description_singular">The scan found one potential threat with %1s. Please review the threat below and take action or tap the fix all button. We are %2$s if you need us.</string>
+    <string name="scan_idle_threats_description_singular">The scan found one potential threat with %1s. Please review the threat below and take action or tap the fix all button. We are %2$s if you need us.</string>
     <string name="scan_here_to_help">here to help</string>
     <string name="scan_this_site">this site</string>
     <string name="scan_in_hours_ago">%s hour(s) ago</string>
@@ -1103,7 +1103,7 @@
     <string name="scan_in_few_seconds">a few seconds ago</string>
     <string name="scan_progress_label" translatable="false">%1$s%%</string>
     <string name="scan_finished_no_threats_found_message">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; No threats found</string>
-    <string name="scan_finished_threats_found_message_singular">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; one potential threat found</string>
+    <string name="scan_finished_potential_threats_found_message_singular">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; One potential threat found</string>
     <string name="scan_finished_threats_found_message_plural">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; %s potential threats found</string>
 
     <!-- scan history -->
@@ -1171,7 +1171,7 @@
     <string name="threat_ignore_error_message">Error ignoring threat. Please contact support.</string>
     <string name="threat_fix_all_warning_title">Fix all threats</string>
     <string name="threat_fix_all_warning_message_plural">Please confirm you want to fix all %s active threats.</string>
-    <string name="threat_fix_all_warning_message_singular">Please confirm you want to fix one active threat.</string>
+    <string name="threat_fix_all_confirmation_message_singular">Please confirm you want to fix one active threat.</string>
     <string name="threat_fix_all_error_message">Error fixing threats. Please contact our support.</string>
     <string name="threat_fix_all_status_success_message_plural">Threats were successfully fixed.</string>
     <string name="threat_fix_all_status_success_message_singular">Threat was successfully fixed.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1095,7 +1095,7 @@
     <string name="scan_idle_manual_scan_description">To review your site again run a manual scan, or wait for Jetpack to scan your site later today.</string>
     <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and did not find any risks. %s</string>
     <string name="scan_idle_with_threats_description_plural">The scan found %1s potential threats with %2s. Please review them below and take action or tap the fix all button. We are %3$s if you need us.</string>
-    <string name="scan_idle_with_threats_description_singular">The scan found %1s potential threat with %2s. Please review the threat below and take action or tap the fix all button. We are %3$s if you need us.</string>
+    <string name="scan_idle_with_threats_description_singular">The scan found 1 potential threat with %1s. Please review the threat below and take action or tap the fix all button. We are %2$s if you need us.</string>
     <string name="scan_here_to_help">here to help</string>
     <string name="scan_this_site">this site</string>
     <string name="scan_in_hours_ago">%s hour(s) ago</string>
@@ -1171,7 +1171,7 @@
     <string name="threat_ignore_error_message">Error ignoring threat. Please contact support.</string>
     <string name="threat_fix_all_warning_title">Fix all threats</string>
     <string name="threat_fix_all_warning_message_plural">Please confirm you want to fix all %s active threats.</string>
-    <string name="threat_fix_all_warning_message_singular">Please confirm you want to fix %s active threat.</string>
+    <string name="threat_fix_all_warning_message_singular">Please confirm you want to fix 1 active threat.</string>
     <string name="threat_fix_all_error_message">Error fixing threats. Please contact our support.</string>
     <string name="threat_fix_all_status_success_message_plural">Threats were successfully fixed.</string>
     <string name="threat_fix_all_status_success_message_singular">Threat was successfully fixed.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1094,7 +1094,7 @@
     <string name="scan_provisioning_description">Welcome to Jetpack Scan! We\'re scoping out your site, setting up to do a full scan. We\'ll let you know if we spot any issues that might impact a scan, then your first full scan will start.</string>
     <string name="scan_idle_manual_scan_description">To review your site again run a manual scan, or wait for Jetpack to scan your site later today.</string>
     <string name="scan_idle_last_scan_description">The last Jetpack scan ran %s and did not find any risks. %s</string>
-    <string name="scan_idle_with_threats_description_plural">The scan found %1s potential threats with %2s. Please review them below and take action or tap the fix all button. We are %3$s if you need us.</string>
+    <string name="scan_idle_threats_description_plural">The scan found %1s potential threats with %2s. Please review them below and take action or tap the fix all button. We are %3$s if you need us.</string>
     <string name="scan_idle_threats_description_singular">The scan found one potential threat with %1s. Please review the threat below and take action or tap the fix all button. We are %2$s if you need us.</string>
     <string name="scan_here_to_help">here to help</string>
     <string name="scan_this_site">this site</string>
@@ -1104,7 +1104,7 @@
     <string name="scan_progress_label" translatable="false">%1$s%%</string>
     <string name="scan_finished_no_threats_found_message">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; No threats found</string>
     <string name="scan_finished_potential_threats_found_message_singular">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; One potential threat found</string>
-    <string name="scan_finished_threats_found_message_plural">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; %s potential threats found</string>
+    <string name="scan_finished_potential_threats_found_message_plural">&lt;b&gt;Scan Finished&lt;/b&gt; &lt;br&gt;&lt;/br&gt; %s potential threats found</string>
 
     <!-- scan history -->
     <string name="scan_history_all_threats_tab">All</string>
@@ -1170,7 +1170,7 @@
     <string name="threat_ignore_success_message">Threat ignored.</string>
     <string name="threat_ignore_error_message">Error ignoring threat. Please contact support.</string>
     <string name="threat_fix_all_warning_title">Fix all threats</string>
-    <string name="threat_fix_all_warning_message_plural">Please confirm you want to fix all %s active threats.</string>
+    <string name="threat_fix_all_confirmation_message_plural">Please confirm you want to fix all %s active threats.</string>
     <string name="threat_fix_all_confirmation_message_singular">Please confirm you want to fix one active threat.</string>
     <string name="threat_fix_all_error_message">Error fixing threats. Please contact our support.</string>
     <string name="threat_fix_all_status_success_message_plural">Threats were successfully fixed.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -457,10 +457,7 @@ class ScanViewModelTest : BaseUnitTest() {
             with(confirmationDialog) {
                 assertThat(title).isEqualTo(UiStringRes(R.string.threat_fix_all_warning_title))
                 assertThat(message).isEqualTo(
-                    UiStringResWithParams(
-                        R.string.threat_fix_all_warning_message_singular,
-                        listOf(UiStringText("1"))
-                    )
+                    UiStringRes(R.string.threat_fix_all_warning_message_singular)
                 )
                 assertThat(positiveButtonLabel).isEqualTo(R.string.dialog_button_ok)
                 assertThat(negativeButtonLabel).isEqualTo(R.string.dialog_button_cancel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -413,7 +413,7 @@ class ScanViewModelTest : BaseUnitTest() {
             whenever(
                 htmlMessageUtils
                     .getHtmlMessageFromStringFormatResId(
-                        R.string.scan_finished_threats_found_message_plural,
+                        R.string.scan_finished_potential_threats_found_message_plural,
                         "${threats.size}"
                     )
             ).thenReturn(threatsFoundMessage)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/ScanViewModelTest.kt
@@ -47,7 +47,6 @@ import org.wordpress.android.ui.jetpack.scan.usecases.StartScanUseCase.StartScan
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.analytics.ScanTracker
 import org.wordpress.android.viewmodel.Event
@@ -387,7 +386,9 @@ class ScanViewModelTest : BaseUnitTest() {
             val threatFoundMessage = "1 potential threat found"
             whenever(
                 htmlMessageUtils
-                    .getHtmlMessageFromStringFormatResId(R.string.scan_finished_threats_found_message_singular)
+                    .getHtmlMessageFromStringFormatResId(
+                            R.string.scan_finished_potential_threats_found_message_singular
+                    )
             ).thenReturn(threatFoundMessage)
             val fakeScanStateModelWithThreat = fakeScanStateModel.copy(
                 threats = listOf(ThreatTestData.genericThreatModel)
@@ -457,7 +458,7 @@ class ScanViewModelTest : BaseUnitTest() {
             with(confirmationDialog) {
                 assertThat(title).isEqualTo(UiStringRes(R.string.threat_fix_all_warning_title))
                 assertThat(message).isEqualTo(
-                    UiStringRes(R.string.threat_fix_all_warning_message_singular)
+                    UiStringRes(R.string.threat_fix_all_confirmation_message_singular)
                 )
                 assertThat(positiveButtonLabel).isEqualTo(R.string.dialog_button_ok)
                 assertThat(negativeButtonLabel).isEqualTo(R.string.dialog_button_cancel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -208,7 +208,6 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
 
         verify(htmlMessageUtils).getHtmlMessageFromStringFormatResId(
             R.string.scan_idle_with_threats_description_singular,
-            "<b>${threats.size}</b>",
             "<b>${site.name ?: resourceProvider.getString(R.string.scan_this_site)}</b>",
             resourceProvider.getString(R.string.scan_here_to_help)
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -207,7 +207,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         buildScanStateItems(scanStateModelWithThreats)
 
         verify(htmlMessageUtils).getHtmlMessageFromStringFormatResId(
-            R.string.scan_idle_with_threats_description_singular,
+            R.string.scan_idle_threats_description_singular,
             "<b>${site.name ?: resourceProvider.getString(R.string.scan_this_site)}</b>",
             resourceProvider.getString(R.string.scan_here_to_help)
         )


### PR DESCRIPTION
The Romanian translators are having trouble with the string formatting before the singular noun, This PR changes that to explicitly use 1. 

To test: Test that with a single threat it behaves as expected in https://github.com/wordpress-mobile/WordPress-Android/pull/14021

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
