### PR TITLE
Issue/14004 menu item order

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -93,8 +93,8 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEdito
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBlogPreview
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedSavedOnlyLocallyDialog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowBookmarkedTab
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
-import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType
 import org.wordpress.android.ui.reader.utils.FeaturedImageUtils
 import org.wordpress.android.ui.reader.utils.ReaderUtils
@@ -490,7 +490,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         }
     }
 
-    private fun createMoreMenuPopup(actions: List<SecondaryAction>, v: View) {
+    private fun createMoreMenuPopup(actions: List<ReaderPostCardAction>, v: View) {
         AnalyticsTracker.track(Stat.READER_ARTICLE_DETAIL_MORE_TAPPED)
         moreMenuPopup = ListPopupWindow(v.context)
         moreMenuPopup?.let {
@@ -1002,9 +1002,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                 ReaderPostTable.getFeedPost(blogId, postId, false)
             else
                 ReaderPostTable.getBlogPost(blogId, postId, false)
-            if (post == null) {
-                return false
-            }
+            if (post == null) return false
 
             // "discover" Editor Pick posts should open the original (source) post
             if (post!!.isDiscoverPost) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
@@ -113,11 +113,11 @@ public class ReaderMenuAdapter extends BaseAdapter {
 
         holder.mText.setText(textRes);
         holder.mText.setTextColor(AppCompatResources.getColorStateList(convertView.getContext(), textColorRes));
-        ColorUtils.INSTANCE.setImageResourceWithTint(holder.mIcon, iconRes, iconColorRes);
+        ColorUtils.setImageResourceWithTint(holder.mIcon, iconRes, iconColorRes);
         return convertView;
     }
 
-    class ReaderMenuHolder {
+    static class ReaderMenuHolder {
         private final TextView mText;
         private final ImageView mIcon;
 
@@ -127,7 +127,7 @@ public class ReaderMenuAdapter extends BaseAdapter {
         }
     }
 
-    class ReaderMenuSpacerHolder {
+    static class ReaderMenuSpacerHolder {
         private final Space mSpacer;
         private final LinearLayout mContainer;
         ReaderMenuSpacerHolder(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
@@ -16,7 +16,6 @@ import androidx.appcompat.content.res.AppCompatResources;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction;
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction;
-import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SpacerNoAction;
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType;
 import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.ColorUtils;
@@ -66,20 +65,21 @@ public class ReaderMenuAdapter extends BaseAdapter {
 
     @Override
     public int getItemViewType(int position) {
-        return (mMenuItems.get(position).getType() == ReaderPostCardActionType.SPACER_NO_ACTION) ? 0 : 1;
+        return (mMenuItems.get(position).getType() == ReaderPostCardActionType.SPACER_NO_ACTION)
+                ? TYPE_SPACER : TYPE_CONTENT;
     }
 
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
         ReaderPostCardAction cardAction = mMenuItems.get(position);
         if (getItemViewType(position) == TYPE_SPACER) {
-            return handleSpacer((SpacerNoAction) cardAction, convertView, parent);
+            return handleSpacer(convertView, parent);
         } else {
             return handleSecondaryAction((SecondaryAction) cardAction, convertView, parent);
         }
     }
 
-    private View handleSpacer(SpacerNoAction spacerNoAction, View convertView, ViewGroup parent) {
+    private View handleSpacer(View convertView, ViewGroup parent) {
         ReaderMenuSpacerHolder holder;
         if (convertView == null) {
             convertView = mInflater.inflate(R.layout.reader_popup_menu_spacer_item, parent, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
@@ -6,7 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
+import android.widget.Space;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -15,6 +15,7 @@ import androidx.appcompat.content.res.AppCompatResources;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction;
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction;
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SpacerNoAction;
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType;
 import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.ColorUtils;
@@ -30,6 +31,9 @@ public class ReaderMenuAdapter extends BaseAdapter {
     private final LayoutInflater mInflater;
     private final List<ReaderPostCardAction> mMenuItems = new ArrayList<>();
     private final UiHelpers mUiHelpers;
+
+    private static final int TYPE_SPACER = 0;
+    private static final int TYPE_CONTENT = 1;
 
     public ReaderMenuAdapter(Context context, @NonNull UiHelpers uiHelpers,
                              @NonNull List<ReaderPostCardAction> menuItems) {
@@ -55,7 +59,39 @@ public class ReaderMenuAdapter extends BaseAdapter {
     }
 
     @Override
+    public int getViewTypeCount() {
+        return 2;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        return (mMenuItems.get(position).getType() == ReaderPostCardActionType.SPACER_NO_ACTION) ? 0 : 1;
+    }
+
+    @Override
     public View getView(int position, View convertView, ViewGroup parent) {
+        ReaderPostCardAction cardAction = mMenuItems.get(position);
+        if (getItemViewType(position) == TYPE_SPACER) {
+            return handleSpacer((SpacerNoAction) cardAction, convertView, parent);
+        } else {
+            return handleSecondaryAction((SecondaryAction) cardAction, convertView, parent);
+        }
+    }
+
+    private View handleSpacer(SpacerNoAction spacerNoAction, View convertView, ViewGroup parent) {
+        ReaderMenuSpacerHolder holder;
+        if (convertView == null) {
+            convertView = mInflater.inflate(R.layout.reader_popup_menu_spacer_item, parent, false);
+            holder = new ReaderMenuSpacerHolder(convertView);
+            convertView.setTag(holder);
+        } else {
+            holder = (ReaderMenuSpacerHolder) convertView.getTag();
+        }
+        holder.mSpacer.setVisibility(View.VISIBLE);
+        return convertView;
+    }
+
+    private View handleSecondaryAction(SecondaryAction item, View convertView, ViewGroup parent) {
         ReaderMenuHolder holder;
         if (convertView == null) {
             convertView = mInflater.inflate(R.layout.reader_popup_menu_item, parent, false);
@@ -65,37 +101,33 @@ public class ReaderMenuAdapter extends BaseAdapter {
             holder = (ReaderMenuHolder) convertView.getTag();
         }
 
-        ReaderPostCardAction cardAction = mMenuItems.get(position);
-        if (cardAction.getType() == ReaderPostCardActionType.SPACER_NO_ACTION) {
-            holder.mText.setVisibility(View.INVISIBLE);
-            holder.mIcon.setVisibility(View.INVISIBLE);
-            holder.mContainer.setClickable(false);
-        } else {
-            SecondaryAction item = (SecondaryAction) cardAction;
-            CharSequence textRes = mUiHelpers.getTextOfUiString(convertView.getContext(), item.getLabel());
-            int textColorRes =
-                    ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getLabelColor());
-            int iconColorRes =
-                    ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getIconColor());
-            int iconRes = item.getIconRes();
+        CharSequence textRes = mUiHelpers.getTextOfUiString(convertView.getContext(), item.getLabel());
+        int textColorRes =
+                ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getLabelColor());
+        int iconColorRes =
+                ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getIconColor());
+        int iconRes = item.getIconRes();
 
-            holder.mText.setText(textRes);
-            holder.mText.setTextColor(AppCompatResources.getColorStateList(convertView.getContext(), textColorRes));
-            ColorUtils.INSTANCE.setImageResourceWithTint(holder.mIcon, iconRes, iconColorRes);
-        }
-
+        holder.mText.setText(textRes);
+        holder.mText.setTextColor(AppCompatResources.getColorStateList(convertView.getContext(), textColorRes));
+        ColorUtils.INSTANCE.setImageResourceWithTint(holder.mIcon, iconRes, iconColorRes);
         return convertView;
     }
 
     class ReaderMenuHolder {
         private final TextView mText;
         private final ImageView mIcon;
-        private final LinearLayout mContainer;
 
         ReaderMenuHolder(View view) {
             mText = view.findViewById(R.id.text);
             mIcon = view.findViewById(R.id.image);
-            mContainer = view.findViewById(R.id.reader_popup_menu_item_container);
+        }
+    }
+
+    class ReaderMenuSpacerHolder {
+        private final Space mSpacer;
+        ReaderMenuSpacerHolder(View view) {
+            mSpacer = view.findViewById(R.id.reader_popup_menu_item_spacer);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
@@ -6,13 +6,16 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.content.res.AppCompatResources;
 
 import org.wordpress.android.R;
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction;
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction;
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType;
 import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.ColorUtils;
 import org.wordpress.android.util.ContextExtensionsKt;
@@ -25,10 +28,11 @@ import java.util.List;
  */
 public class ReaderMenuAdapter extends BaseAdapter {
     private final LayoutInflater mInflater;
-    private final List<SecondaryAction> mMenuItems = new ArrayList<>();
+    private final List<ReaderPostCardAction> mMenuItems = new ArrayList<>();
     private final UiHelpers mUiHelpers;
 
-    public ReaderMenuAdapter(Context context, @NonNull UiHelpers uiHelpers, @NonNull List<SecondaryAction> menuItems) {
+    public ReaderMenuAdapter(Context context, @NonNull UiHelpers uiHelpers,
+                             @NonNull List<ReaderPostCardAction> menuItems) {
         super();
         mInflater = LayoutInflater.from(context);
         mMenuItems.addAll(menuItems);
@@ -61,17 +65,24 @@ public class ReaderMenuAdapter extends BaseAdapter {
             holder = (ReaderMenuHolder) convertView.getTag();
         }
 
-        SecondaryAction item = mMenuItems.get(position);
-        CharSequence textRes = mUiHelpers.getTextOfUiString(convertView.getContext(), item.getLabel());
-        int textColorRes =
-                ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getLabelColor());
-        int iconColorRes =
-                ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getIconColor());
-        int iconRes = item.getIconRes();
+        ReaderPostCardAction cardAction = mMenuItems.get(position);
+        if (cardAction.getType() == ReaderPostCardActionType.SPACER_NO_ACTION) {
+            holder.mText.setVisibility(View.INVISIBLE);
+            holder.mIcon.setVisibility(View.INVISIBLE);
+            holder.mContainer.setClickable(false);
+        } else {
+            SecondaryAction item = (SecondaryAction) cardAction;
+            CharSequence textRes = mUiHelpers.getTextOfUiString(convertView.getContext(), item.getLabel());
+            int textColorRes =
+                    ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getLabelColor());
+            int iconColorRes =
+                    ContextExtensionsKt.getColorResIdFromAttribute(convertView.getContext(), item.getIconColor());
+            int iconRes = item.getIconRes();
 
-        holder.mText.setText(textRes);
-        holder.mText.setTextColor(AppCompatResources.getColorStateList(convertView.getContext(), textColorRes));
-        ColorUtils.INSTANCE.setImageResourceWithTint(holder.mIcon, iconRes, iconColorRes);
+            holder.mText.setText(textRes);
+            holder.mText.setTextColor(AppCompatResources.getColorStateList(convertView.getContext(), textColorRes));
+            ColorUtils.INSTANCE.setImageResourceWithTint(holder.mIcon, iconRes, iconColorRes);
+        }
 
         return convertView;
     }
@@ -79,10 +90,12 @@ public class ReaderMenuAdapter extends BaseAdapter {
     class ReaderMenuHolder {
         private final TextView mText;
         private final ImageView mIcon;
+        private final LinearLayout mContainer;
 
         ReaderMenuHolder(View view) {
             mText = view.findViewById(R.id.text);
             mIcon = view.findViewById(R.id.image);
+            mContainer = view.findViewById(R.id.reader_popup_menu_item_container);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.Space;
 import android.widget.TextView;
 
@@ -88,6 +89,8 @@ public class ReaderMenuAdapter extends BaseAdapter {
             holder = (ReaderMenuSpacerHolder) convertView.getTag();
         }
         holder.mSpacer.setVisibility(View.VISIBLE);
+        holder.mContainer.setEnabled(false);
+        holder.mContainer.setClickable(false);
         return convertView;
     }
 
@@ -126,8 +129,10 @@ public class ReaderMenuAdapter extends BaseAdapter {
 
     class ReaderMenuSpacerHolder {
         private final Space mSpacer;
+        private final LinearLayout mContainer;
         ReaderMenuSpacerHolder(View view) {
             mSpacer = view.findViewById(R.id.reader_popup_menu_item_spacer);
+            mContainer = view.findViewById(R.id.reader_popup_menu_item_spacer_container);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -6,7 +6,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
-import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.SPACER_NO_ACTION
 import org.wordpress.android.ui.reader.discover.interests.TagUiState
 import org.wordpress.android.ui.reader.models.ReaderImageList
 import org.wordpress.android.ui.reader.views.uistates.ReaderBlogSectionUiState
@@ -40,7 +40,7 @@ sealed class ReaderCardUiState {
         val likeAction: PrimaryAction,
         val reblogAction: PrimaryAction,
         val commentsAction: PrimaryAction,
-        val moreMenuItems: List<SecondaryAction>? = null,
+        val moreMenuItems: List<ReaderPostCardAction>? = null,
         val onItemClicked: (Long, Long) -> Unit,
         val onItemRendered: (ReaderCardUiState) -> Unit,
         val onMoreButtonClicked: (ReaderPostUiState) -> Unit,
@@ -123,6 +123,12 @@ sealed class ReaderPostCardAction {
         override val type: ReaderPostCardActionType,
         override val onClicked: (Long, Long, ReaderPostCardActionType) -> Unit
     ) : ReaderPostCardAction()
+
+    data class SpacerNoAction(
+        override val isSelected: Boolean = false,
+        override val type: ReaderPostCardActionType = SPACER_NO_ACTION,
+        override val onClicked: ((Long, Long, ReaderPostCardActionType) -> Unit)? = null
+    ) : ReaderPostCardAction()
 }
 
 enum class ReaderPostCardActionType {
@@ -136,5 +142,6 @@ enum class ReaderPostCardActionType {
     REBLOG,
     COMMENTS,
     REPORT_POST,
-    TOGGLE_SEEN_STATUS
+    TOGGLE_SEEN_STATUS,
+    SPACER_NO_ACTION
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -181,6 +181,6 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
                     labelColor = R.attr.wpColorError,
                     iconRes = R.drawable.ic_block_white_24dp,
                     iconColor = R.attr.wpColorError,
-                    onClicked = onButtonClicked,
+                    onClicked = onButtonClicked
             )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -58,7 +58,9 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
         }
 
         if (seenUnseenWithCounterFeatureConfig.isEnabled()) {
-            if (post.isSeenSupported) buildPostSeenUnseen(readerPostTableWrapper.isPostSeen(post), onButtonClicked)
+            if (post.isSeenSupported) {
+                menuItems.add(buildPostSeenUnseen(readerPostTableWrapper.isPostSeen(post), onButtonClicked))
+            }
         }
 
         menuItems.add(buildShare(onButtonClicked))
@@ -83,7 +85,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
     private fun buildSiteNotifications(
         isNotificationsEnabled: Boolean,
         onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
-    ) =
+    ): SecondaryAction =
             if (isNotificationsEnabled) {
                 SecondaryAction(
                         type = SITE_NOTIFICATIONS,
@@ -108,7 +110,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
     private fun buildPostSeenUnseen(
         isPostSeen: Boolean,
         onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
-    ) =
+    ): SecondaryAction =
         if (isPostSeen) {
             SecondaryAction(
                     type = TOGGLE_SEEN_STATUS,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SpacerNoAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.BLOCK_SITE
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.REPORT_POST
@@ -33,7 +34,7 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
     suspend fun buildMoreMenuItems(
         post: ReaderPost,
         onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
-    ): List<SecondaryAction> {
+    ): List<ReaderPostCardAction> {
         return withContext(bgDispatcher) {
             buildMoreMenuItemsBlocking(post, onButtonClicked)
         }
@@ -42,22 +43,22 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
     fun buildMoreMenuItemsBlocking(
         post: ReaderPost,
         onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
-    ): MutableList<SecondaryAction> {
-        val menuItems = mutableListOf<SecondaryAction>()
+    ): MutableList<ReaderPostCardAction> {
+        val menuItems = mutableListOf<ReaderPostCardAction>()
         val isPostFollowed = readerPostTableWrapper.isPostFollowed(post)
 
-        if (isPostFollowed) {
-            menuItems.add(
-                    SecondaryAction(
-                            type = FOLLOW,
-                            label = UiStringRes(R.string.reader_btn_unfollow),
-                            labelColor = R.attr.wpColorOnSurfaceMedium,
-                            iconRes = R.drawable.ic_reader_following_white_24dp,
-                            isSelected = true,
-                            onClicked = onButtonClicked
-                    )
-            )
+        menuItems.add(
+                SecondaryAction(
+                        type = VISIT_SITE,
+                        label = UiStringRes(R.string.reader_label_visit),
+                        labelColor = R.attr.colorOnSurface,
+                        iconRes = R.drawable.ic_globe_white_24dp,
+                        iconColor = R.attr.wpColorOnSurfaceMedium,
+                        onClicked = onButtonClicked
+                )
+        )
 
+        if (isPostFollowed) {
             // When post not from external feed then show notifications option.
             if (!readerUtilsWrapper.isExternalFeed(post.blogId, post.feedId)) {
                 if (readerBlogTableWrapper.isNotificationsEnabled(post.blogId)) {
@@ -85,17 +86,6 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
                     )
                 }
             }
-        } else {
-            menuItems.add(
-                    SecondaryAction(
-                            type = FOLLOW,
-                            label = UiStringRes(R.string.reader_btn_follow),
-                            labelColor = R.attr.colorSecondary,
-                            iconRes = R.drawable.ic_reader_follow_white_24dp,
-                            isSelected = false,
-                            onClicked = onButtonClicked
-                    )
-            )
         }
 
         if (seenUnseenWithCounterFeatureConfig.isEnabled()) {
@@ -138,38 +128,55 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
                         onClicked = onButtonClicked
                 )
         )
-        menuItems.add(
-                SecondaryAction(
-                        type = VISIT_SITE,
-                        label = UiStringRes(R.string.reader_label_visit),
-                        labelColor = R.attr.colorOnSurface,
-                        iconRes = R.drawable.ic_globe_white_24dp,
-                        iconColor = R.attr.wpColorOnSurfaceMedium,
-                        onClicked = onButtonClicked
-                )
-        )
+
+        if (isPostFollowed) {
+            menuItems.add(
+                    SecondaryAction(
+                            type = FOLLOW,
+                            label = UiStringRes(R.string.reader_btn_unfollow),
+                            labelColor = R.attr.wpColorOnSurfaceMedium,
+                            iconRes = R.drawable.ic_reader_following_white_24dp,
+                            isSelected = true,
+                            onClicked = onButtonClicked
+                    )
+            )
+        } else {
+            menuItems.add(
+                    SecondaryAction(
+                            type = FOLLOW,
+                            label = UiStringRes(R.string.reader_btn_follow),
+                            labelColor = R.attr.colorSecondary,
+                            iconRes = R.drawable.ic_reader_follow_white_24dp,
+                            isSelected = false,
+                            onClicked = onButtonClicked
+                    )
+            )
+        }
 
         if (!isPostFollowed) {
+            menuItems.add(SpacerNoAction())
             menuItems.add(
                     SecondaryAction(
                             type = BLOCK_SITE,
                             label = UiStringRes(R.string.reader_menu_block_blog),
-                            labelColor = R.attr.colorOnSurface,
+                            labelColor = R.attr.wpColorError,
                             iconRes = R.drawable.ic_block_white_24dp,
-                            iconColor = R.attr.wpColorOnSurfaceMedium,
+                            iconColor = R.attr.wpColorError,
                             onClicked = onButtonClicked
                     )
             )
+        } else {
+            menuItems.add(SpacerNoAction())
         }
 
         menuItems.add(
                 SecondaryAction(
                         type = REPORT_POST,
                         label = UiStringRes(R.string.reader_menu_report_post),
-                        labelColor = R.attr.colorOnSurface,
+                        labelColor = R.attr.wpColorError,
                         iconRes = R.drawable.ic_block_white_24dp,
-                        iconColor = R.attr.wpColorOnSurfaceMedium,
-                        onClicked = onButtonClicked
+                        iconColor = R.attr.wpColorError,
+                        onClicked = onButtonClicked,
                 )
         )
         return menuItems

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilder.kt
@@ -47,138 +47,138 @@ class ReaderPostMoreButtonUiStateBuilder @Inject constructor(
         val menuItems = mutableListOf<ReaderPostCardAction>()
         val isPostFollowed = readerPostTableWrapper.isPostFollowed(post)
 
-        menuItems.add(
-                SecondaryAction(
-                        type = VISIT_SITE,
-                        label = UiStringRes(R.string.reader_label_visit),
-                        labelColor = R.attr.colorOnSurface,
-                        iconRes = R.drawable.ic_globe_white_24dp,
-                        iconColor = R.attr.wpColorOnSurfaceMedium,
-                        onClicked = onButtonClicked
-                )
-        )
+        menuItems.add(buildVisitSite(onButtonClicked))
 
         if (isPostFollowed) {
             // When post not from external feed then show notifications option.
             if (!readerUtilsWrapper.isExternalFeed(post.blogId, post.feedId)) {
-                if (readerBlogTableWrapper.isNotificationsEnabled(post.blogId)) {
-                    menuItems.add(
-                            SecondaryAction(
-                                    type = SITE_NOTIFICATIONS,
-                                    label = UiStringRes(R.string.reader_btn_notifications_off),
-                                    labelColor = R.attr.wpColorOnSurfaceMedium,
-                                    iconRes = R.drawable.ic_bell_white_24dp,
-                                    isSelected = true,
-                                    onClicked = onButtonClicked
-                            )
-                    )
-                } else {
-                    menuItems.add(
-                            SecondaryAction(
-                                    type = SITE_NOTIFICATIONS,
-                                    label = UiStringRes(R.string.reader_btn_notifications_on),
-                                    labelColor = R.attr.colorOnSurface,
-                                    iconRes = R.drawable.ic_bell_white_24dp,
-                                    iconColor = R.attr.wpColorOnSurfaceMedium,
-                                    isSelected = false,
-                                    onClicked = onButtonClicked
-                            )
-                    )
-                }
+                menuItems.add(buildSiteNotifications(
+                        readerBlogTableWrapper.isNotificationsEnabled(post.blogId), onButtonClicked))
             }
         }
 
         if (seenUnseenWithCounterFeatureConfig.isEnabled()) {
-            if (post.isSeenSupported) {
-                if (readerPostTableWrapper.isPostSeen(post)) {
-                    menuItems.add(
-                            SecondaryAction(
-                                    type = TOGGLE_SEEN_STATUS,
-                                    label = UiStringRes(R.string.reader_menu_mark_as_unseen),
-                                    labelColor = R.attr.colorOnSurface,
-                                    iconRes = R.drawable.ic_not_visible_white_24dp,
-                                    iconColor = R.attr.wpColorOnSurfaceMedium,
-                                    isSelected = false,
-                                    onClicked = onButtonClicked
-                            )
-                    )
-                } else {
-                    menuItems.add(
-                            SecondaryAction(
-                                    type = TOGGLE_SEEN_STATUS,
-                                    label = UiStringRes(R.string.reader_menu_mark_as_seen),
-                                    labelColor = R.attr.colorOnSurface,
-                                    iconRes = R.drawable.ic_visible_white_24dp,
-                                    iconColor = R.attr.wpColorOnSurfaceMedium,
-                                    isSelected = false,
-                                    onClicked = onButtonClicked
-                            )
-                    )
-                }
-            }
+            if (post.isSeenSupported) buildPostSeenUnseen(readerPostTableWrapper.isPostSeen(post), onButtonClicked)
         }
 
-        menuItems.add(
-                SecondaryAction(
-                        type = SHARE,
-                        label = UiStringRes(R.string.reader_btn_share),
-                        labelColor = R.attr.colorOnSurface,
-                        iconRes = R.drawable.ic_share_white_24dp,
-                        iconColor = R.attr.wpColorOnSurfaceMedium,
-                        onClicked = onButtonClicked
-                )
-        )
+        menuItems.add(buildShare(onButtonClicked))
+        menuItems.add(buildFollow(isPostFollowed, onButtonClicked))
+        menuItems.add(SpacerNoAction())
+        if (!isPostFollowed) menuItems.add(buildBlockSite(onButtonClicked))
 
-        if (isPostFollowed) {
-            menuItems.add(
-                    SecondaryAction(
-                            type = FOLLOW,
-                            label = UiStringRes(R.string.reader_btn_unfollow),
-                            labelColor = R.attr.wpColorOnSurfaceMedium,
-                            iconRes = R.drawable.ic_reader_following_white_24dp,
-                            isSelected = true,
-                            onClicked = onButtonClicked
-                    )
-            )
-        } else {
-            menuItems.add(
-                    SecondaryAction(
-                            type = FOLLOW,
-                            label = UiStringRes(R.string.reader_btn_follow),
-                            labelColor = R.attr.colorSecondary,
-                            iconRes = R.drawable.ic_reader_follow_white_24dp,
-                            isSelected = false,
-                            onClicked = onButtonClicked
-                    )
-            )
-        }
-
-        if (!isPostFollowed) {
-            menuItems.add(SpacerNoAction())
-            menuItems.add(
-                    SecondaryAction(
-                            type = BLOCK_SITE,
-                            label = UiStringRes(R.string.reader_menu_block_blog),
-                            labelColor = R.attr.wpColorError,
-                            iconRes = R.drawable.ic_block_white_24dp,
-                            iconColor = R.attr.wpColorError,
-                            onClicked = onButtonClicked
-                    )
-            )
-        } else {
-            menuItems.add(SpacerNoAction())
-        }
-
-        menuItems.add(
-                SecondaryAction(
-                        type = REPORT_POST,
-                        label = UiStringRes(R.string.reader_menu_report_post),
-                        labelColor = R.attr.wpColorError,
-                        iconRes = R.drawable.ic_block_white_24dp,
-                        iconColor = R.attr.wpColorError,
-                        onClicked = onButtonClicked,
-                )
-        )
+        menuItems.add(buildReportPost(onButtonClicked))
         return menuItems
     }
+
+    private fun buildVisitSite(onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit) =
+            SecondaryAction(
+                    type = VISIT_SITE,
+                    label = UiStringRes(R.string.reader_label_visit),
+                    labelColor = R.attr.colorOnSurface,
+                    iconRes = R.drawable.ic_globe_white_24dp,
+                    iconColor = R.attr.wpColorOnSurfaceMedium,
+                    onClicked = onButtonClicked
+            )
+
+    private fun buildSiteNotifications(
+        isNotificationsEnabled: Boolean,
+        onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
+    ) =
+            if (isNotificationsEnabled) {
+                SecondaryAction(
+                        type = SITE_NOTIFICATIONS,
+                        label = UiStringRes(R.string.reader_btn_notifications_off),
+                        labelColor = R.attr.wpColorOnSurfaceMedium,
+                        iconRes = R.drawable.ic_bell_white_24dp,
+                        isSelected = true,
+                        onClicked = onButtonClicked
+                )
+            } else {
+                SecondaryAction(
+                        type = SITE_NOTIFICATIONS,
+                        label = UiStringRes(R.string.reader_btn_notifications_on),
+                        labelColor = R.attr.colorOnSurface,
+                        iconRes = R.drawable.ic_bell_white_24dp,
+                        iconColor = R.attr.wpColorOnSurfaceMedium,
+                        isSelected = false,
+                        onClicked = onButtonClicked
+                )
+            }
+
+    private fun buildPostSeenUnseen(
+        isPostSeen: Boolean,
+        onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit
+    ) =
+        if (isPostSeen) {
+            SecondaryAction(
+                    type = TOGGLE_SEEN_STATUS,
+                    label = UiStringRes(R.string.reader_menu_mark_as_unseen),
+                    labelColor = R.attr.colorOnSurface,
+                    iconRes = R.drawable.ic_not_visible_white_24dp,
+                    iconColor = R.attr.wpColorOnSurfaceMedium,
+                    isSelected = false,
+                    onClicked = onButtonClicked
+            )
+        } else {
+            SecondaryAction(
+                    type = TOGGLE_SEEN_STATUS,
+                    label = UiStringRes(R.string.reader_menu_mark_as_seen),
+                    labelColor = R.attr.colorOnSurface,
+                    iconRes = R.drawable.ic_visible_white_24dp,
+                    iconColor = R.attr.wpColorOnSurfaceMedium,
+                    isSelected = false,
+                    onClicked = onButtonClicked
+            )
+        }
+
+    private fun buildShare(onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit) =
+        SecondaryAction(
+        type = SHARE,
+        label = UiStringRes(R.string.reader_btn_share),
+        labelColor = R.attr.colorOnSurface,
+        iconRes = R.drawable.ic_share_white_24dp,
+        iconColor = R.attr.wpColorOnSurfaceMedium,
+        onClicked = onButtonClicked
+    )
+
+    private fun buildFollow(isPostFollowed: Boolean, onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit) =
+        if (isPostFollowed) {
+            SecondaryAction(
+                    type = FOLLOW,
+                    label = UiStringRes(R.string.reader_btn_unfollow),
+                    labelColor = R.attr.wpColorOnSurfaceMedium,
+                    iconRes = R.drawable.ic_reader_following_white_24dp,
+                    isSelected = true,
+                    onClicked = onButtonClicked
+            )
+        } else {
+            SecondaryAction(
+                    type = FOLLOW,
+                    label = UiStringRes(R.string.reader_btn_follow),
+                    labelColor = R.attr.colorSecondary,
+                    iconRes = R.drawable.ic_reader_follow_white_24dp,
+                    isSelected = false,
+                    onClicked = onButtonClicked
+            )
+        }
+
+    private fun buildBlockSite(onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit) =
+            SecondaryAction(
+                    type = BLOCK_SITE,
+                    label = UiStringRes(R.string.reader_menu_block_blog),
+                    labelColor = R.attr.wpColorError,
+                    iconRes = R.drawable.ic_block_white_24dp,
+                    iconColor = R.attr.wpColorError,
+                    onClicked = onButtonClicked
+            )
+
+    private fun buildReportPost(onButtonClicked: (Long, Long, ReaderPostCardActionType) -> Unit) =
+            SecondaryAction(
+                    type = REPORT_POST,
+                    label = UiStringRes(R.string.reader_menu_report_post),
+                    labelColor = R.attr.wpColorError,
+                    iconRes = R.drawable.ic_block_white_24dp,
+                    iconColor = R.attr.wpColorError,
+                    onClicked = onButtonClicked,
+            )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -119,7 +119,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
         onVideoOverlayClicked: (Long, Long) -> Unit,
         onPostHeaderViewClicked: (Long, Long) -> Unit,
         onTagItemClicked: (String) -> Unit,
-        moreMenuItems: List<SecondaryAction>? = null
+        moreMenuItems: List<ReaderPostCardAction>? = null
     ): ReaderPostUiState {
         return ReaderPostUiState(
                 postId = post.postId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -104,6 +104,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
         }
     }
 
+    @Suppress("LongParameterList")
     fun mapPostToUiStateBlocking(
         post: ReaderPost,
         isDiscover: Boolean = false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostViewHolder.kt
@@ -16,8 +16,8 @@ import org.wordpress.android.datasets.ReaderThumbnailTable
 import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
-import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils.VideoThumbnailUrlListener
 import org.wordpress.android.ui.reader.views.ReaderIconCountView
@@ -201,7 +201,7 @@ class ReaderPostViewHolder(
         }
     }
 
-    private fun renderMoreMenu(uiState: ReaderPostUiState, actions: List<SecondaryAction>, v: View) {
+    private fun renderMoreMenu(uiState: ReaderPostUiState, actions: List<ReaderPostCardAction>, v: View) {
         AnalyticsTracker.track(Stat.POST_CARD_MORE_TAPPED)
         val listPopup = ListPopupWindow(v.context)
         listPopup.width = v.context.resources.getDimensionPixelSize(R.dimen.menu_item_width)
@@ -212,7 +212,7 @@ class ReaderPostViewHolder(
         listPopup.setOnItemClickListener { _, _, position, _ ->
             listPopup.dismiss()
             val item = actions[position]
-            item.onClicked.invoke(uiState.postId, uiState.blogId, item.type)
+            item.onClicked?.invoke(uiState.postId, uiState.blogId, item.type)
         }
         listPopup.setOnDismissListener { uiState.onMoreDismissed.invoke(uiState) }
         listPopup.show()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowSitePickerForResult
 import org.wordpress.android.ui.reader.discover.ReaderPostActions
-import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType.FOLLOW
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionsHandler
@@ -203,7 +203,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         val postId: Long,
         val blogId: Long,
         val headerUiState: ReaderPostDetailsHeaderUiState,
-        val moreMenuItems: List<SecondaryAction>? = null,
+        val moreMenuItems: List<ReaderPostCardAction>? = null,
         val actions: ReaderPostActions
     )
 

--- a/WordPress/src/main/res/layout/reader_popup_menu_item.xml
+++ b/WordPress/src/main/res/layout/reader_popup_menu_item.xml
@@ -1,11 +1,12 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/reader_popup_menu_item_container"
     android:layout_width="match_parent"
     android:layout_height="@dimen/menu_item_height"
     android:gravity="start|center_vertical"
     android:orientation="horizontal"
     android:paddingStart="@dimen/menu_item_margin"
-    android:paddingEnd="@dimen/menu_item_margin">
+    android:paddingEnd="@dimen/menu_item_margin" >
 
     <ImageView
         android:id="@+id/image"

--- a/WordPress/src/main/res/layout/reader_popup_menu_spacer_item.xml
+++ b/WordPress/src/main/res/layout/reader_popup_menu_spacer_item.xml
@@ -1,4 +1,11 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/reader_popup_menu_item_spacer_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="start|center_vertical"
+    android:orientation="horizontal">
     <android.widget.Space xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/reader_popup_menu_item_spacer"
         android:layout_width="match_parent"
         android:layout_height="@dimen/reader_more_menu_spacer_height"/>
+</LinearLayout>

--- a/WordPress/src/main/res/layout/reader_popup_menu_spacer_item.xml
+++ b/WordPress/src/main/res/layout/reader_popup_menu_spacer_item.xml
@@ -1,0 +1,4 @@
+    <android.widget.Space xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/reader_popup_menu_item_spacer"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/reader_more_menu_spacer_height"/>

--- a/WordPress/src/main/res/layout/reader_popup_menu_spacer_item.xml
+++ b/WordPress/src/main/res/layout/reader_popup_menu_spacer_item.xml
@@ -4,7 +4,7 @@
     android:layout_height="wrap_content"
     android:gravity="start|center_vertical"
     android:orientation="horizontal">
-    <android.widget.Space xmlns:android="http://schemas.android.com/apk/res/android"
+    <android.widget.Space
         android:id="@+id/reader_popup_menu_item_spacer"
         android:layout_width="match_parent"
         android:layout_height="@dimen/reader_more_menu_spacer_height"/>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -159,6 +159,8 @@
     <dimen name="reader_follow_button_skeleton_icon_size">14dp</dimen>
     <dimen name="reader_follow_button_skeleton_icon_text_margin">4dp</dimen>
 
+    <!-- reader more menu spacer height -->
+    <dimen name="reader_more_menu_spacer_height">16dp</dimen>
     <!-- collapsing toolbar scrim visible height trigger -->
     <dimen name="scrim_visible_height_trigger">150dp</dimen>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostMoreButtonUiStateBuilderTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.datasets.ReaderBlogTableWrapper
 import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.test
+import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.SecondaryAction
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.config.SeenUnseenWithCounterFeatureConfig
@@ -57,7 +58,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.FOLLOW &&
-                    it.label == UiStringRes(R.string.reader_btn_follow)
+                    (it as SecondaryAction).label == UiStringRes(R.string.reader_btn_follow)
         }).isNotNull
     }
 
@@ -70,7 +71,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.FOLLOW &&
-                    it.label == UiStringRes(R.string.reader_btn_unfollow)
+                    (it as SecondaryAction).label == UiStringRes(R.string.reader_btn_unfollow)
         }).isNotNull
     }
 
@@ -121,7 +122,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.SITE_NOTIFICATIONS &&
-                    it.label == UiStringRes(R.string.reader_btn_notifications_on)
+                    (it as SecondaryAction).label == UiStringRes(R.string.reader_btn_notifications_on)
         }).isNotNull
     }
 
@@ -134,7 +135,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.SITE_NOTIFICATIONS &&
-                    it.label == UiStringRes(R.string.reader_btn_notifications_off)
+                    (it as SecondaryAction).label == UiStringRes(R.string.reader_btn_notifications_off)
         }).isNotNull
     }
 
@@ -187,7 +188,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.FOLLOW &&
-                    it.labelColor == R.attr.colorSecondary
+                    (it as SecondaryAction).labelColor == R.attr.colorSecondary
         }).isNotNull
     }
 
@@ -200,7 +201,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.FOLLOW &&
-                    it.labelColor == R.attr.wpColorOnSurfaceMedium
+                    (it as SecondaryAction).labelColor == R.attr.wpColorOnSurfaceMedium
         }).isNotNull
     }
 
@@ -213,7 +214,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.SITE_NOTIFICATIONS &&
-                    it.labelColor == R.attr.colorOnSurface
+                    (it as SecondaryAction).labelColor == R.attr.colorOnSurface
         }).isNotNull
     }
 
@@ -226,7 +227,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.SITE_NOTIFICATIONS &&
-                    it.labelColor == R.attr.wpColorOnSurfaceMedium
+                    (it as SecondaryAction).labelColor == R.attr.wpColorOnSurfaceMedium
         }).isNotNull
     }
 
@@ -249,7 +250,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.TOGGLE_SEEN_STATUS &&
-                    it.label == UiStringRes(R.string.reader_menu_mark_as_seen)
+                    (it as SecondaryAction).label == UiStringRes(R.string.reader_menu_mark_as_seen)
         }).isNotNull
     }
 
@@ -262,7 +263,7 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         // Assert
         assertThat(menuItems.find {
             it.type == ReaderPostCardActionType.TOGGLE_SEEN_STATUS &&
-                    it.label == UiStringRes(R.string.reader_menu_mark_as_unseen)
+                    (it as SecondaryAction).label == UiStringRes(R.string.reader_menu_mark_as_unseen)
         }).isNotNull
     }
 
@@ -284,6 +285,16 @@ class ReaderPostMoreButtonUiStateBuilderTest {
         val menuItems = builder.buildMoreMenuItems(post, dummyOnClick)
         // Assert
         assertThat(menuItems.find { it.type == ReaderPostCardActionType.TOGGLE_SEEN_STATUS }).isNull()
+    }
+
+    @Test
+    fun `given post list card actions created, then list contains spacer no action`() = test {
+        // Arrange
+        val post = init()
+        // Act
+        val menuItems = builder.buildMoreMenuItems(post, dummyOnClick)
+        // Assert
+        assertThat(menuItems.find { it.type == ReaderPostCardActionType.SPACER_NO_ACTION }).isNotNull
     }
 
     private fun init(

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -128,7 +128,6 @@
     <ID>LongMethod:ReaderDiscoverFragment.kt$ReaderDiscoverFragment$private fun initViewModel()</ID>
     <ID>LongMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment$private fun initViewModel()</ID>
     <ID>LongMethod:ReaderPostDetailFragment.kt$ReaderPostDetailFragment.ShowPostTask$override fun onPostExecute(result: Boolean)</ID>
-    <ID>LongMethod:ReaderPostMoreButtonUiStateBuilder.kt$ReaderPostMoreButtonUiStateBuilder$fun buildMoreMenuItemsBlocking( post: ReaderPost, onButtonClicked: (Long, Long, ReaderPostCardActionType) -&gt; Unit ): MutableList&lt;SecondaryAction&gt;</ID>
     <ID>LongMethod:ReferrersUseCase.kt$ReferrersUseCase$override fun buildUiModel(domainModel: ReferrersModel, uiState: SelectedGroup): List&lt;BlockListItem&gt;</ID>
     <ID>LongMethod:SearchListViewModel.kt$SearchListViewModel$private fun PageModel.toPageItem(areActionsEnabled: Boolean): PageItem</ID>
     <ID>LongMethod:StatsFragment.kt$StatsFragment$private fun setupObservers(activity: FragmentActivity)</ID>


### PR DESCRIPTION
Fixes #14004 

This PR changes the More menu on the ReaderPost card
- The menu item order has changed
- The block site/report this post test/icon have changed color to red
- There is an empty row between share and the block/report actions

|current |light|dark
|---|---|--|
|![current](https://user-images.githubusercontent.com/506707/109880558-13b2ba80-7c45-11eb-9ecc-c7d58b8dd5f3.jpg)|![light](https://user-images.githubusercontent.com/506707/109880798-5f656400-7c45-11eb-977e-a51b5099c7ad.png)|![dark](https://user-images.githubusercontent.com/506707/109880595-21684000-7c45-11eb-8b36-0c4083650cea.png)

**To test:**
Scenario One
- Launch the app
- Navigate to discover
- Tap the more menu on a card.
- Note that following:
-- The item order has changed
-- There is a space before the block this site and/or report this site
-------------------
Scenario Two
- Launch the app
- Navigate to following
- Tap the more menu on a card.
- Note that following:
-- The item order has changed
-- There is a space before the block this site and/or report this site
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
