### PR TITLE
Catch and log exception when the end index of the Story block is out of bounds

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -114,7 +114,7 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
                     )
                     content = listener.doWithMediaFilesJson(content, jsonString)
                     storyBlockStartIndex += HEADING_START.length
-                } catch (exception: IndexOutOfBoundsException) {
+                } catch (exception: StringIndexOutOfBoundsException) {
                     crashLogging.reportException(exception, EDITOR.toString())
                     AppLog.e(EDITOR, exception.message)
                 }
@@ -191,10 +191,11 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
         frames: List<StoryFrameItem>,
         mediaFiles: ArrayList<MediaFile>
     ): List<MediaFile> {
-        return mediaFiles.mapIndexed { index, mediaFile -> run {
-            mediaFile.alt = StoryFrameItem.getAltTextFromFrameAddedViews(frames[index])
-            mediaFile
-        }
+        return mediaFiles.mapIndexed { index, mediaFile ->
+            run {
+                mediaFile.alt = StoryFrameItem.getAltTextFromFrameAddedViews(frames[index])
+                mediaFile
+            }
             mediaFile
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.posts.mediauploadcompletionprocessors.TestConten
 import org.wordpress.android.ui.stories.SaveStoryGutenbergBlockUseCase.Companion.TEMPORARY_ID_PREFIX
 import org.wordpress.android.ui.stories.SaveStoryGutenbergBlockUseCase.StoryMediaFileData
 import org.wordpress.android.ui.stories.prefs.StoriesPrefs
+import org.wordpress.android.util.CrashLogging
 import org.wordpress.android.util.helpers.MediaFile
 
 @RunWith(MockitoJUnitRunner::class)
@@ -30,6 +31,7 @@ class SaveStoryGutenbergBlockUseCaseTest : BaseUnitTest() {
     private lateinit var saveStoryGutenbergBlockUseCase: SaveStoryGutenbergBlockUseCase
     private lateinit var editPostRepository: EditPostRepository
     @Mock lateinit var storiesPrefs: StoriesPrefs
+    @Mock lateinit var crashLogging: CrashLogging
     @Mock lateinit var context: Context
     @Mock lateinit var postStore: PostStore
     @Mock lateinit var mediaFile: MediaFile
@@ -38,7 +40,7 @@ class SaveStoryGutenbergBlockUseCaseTest : BaseUnitTest() {
     @InternalCoroutinesApi
     @Before
     fun setUp() {
-        saveStoryGutenbergBlockUseCase = SaveStoryGutenbergBlockUseCase(storiesPrefs)
+        saveStoryGutenbergBlockUseCase = SaveStoryGutenbergBlockUseCase(storiesPrefs, crashLogging)
         editPostRepository = EditPostRepository(
                 mock(),
                 postStore,


### PR DESCRIPTION
Fixes #13697

This PR wraps part of the `findAllStoryBlocksInPostAndPerformOnEachMediaFilesJson` method in a try/catch block and logs any `IndexOutOfBoundsException` silently to Sentry instead of crashing the app.

I wasn't able to determine the root cause of this crash, but I did share some thoughts about it in the linked issue.

To test:

Not much to test here since we can't reproduce the issue, but you can smoke test the Story feature and make sure nothing looks off.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
