### PR TITLE
Add content logging to help debug a Story post crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadReadyListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadReadyListener.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.media.services;
 import androidx.annotation.Nullable;
 
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.util.helpers.MediaFile;
 
 /**
@@ -10,7 +11,10 @@ import org.wordpress.android.util.helpers.MediaFile;
  * and mark media failed if could not be uploaded
  */
 public interface MediaUploadReadyListener {
+    // TODO: We're passing a SiteModel parameter here in order to debug a crash on SaveStoryGutenbergBlockUseCase.
+    //  Once that's done, the parameter should be replaced with a site url String, like it was before.
+    //  See: https://git.io/JqfhK
     PostModel replaceMediaFileWithUrlInPost(@Nullable PostModel post, String localMediaId, MediaFile mediaFile,
-                                            String siteUrl);
+                                            @Nullable SiteModel site);
     PostModel markMediaUploadFailedInPost(@Nullable PostModel post, String localMediaId, MediaFile mediaFile);
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -93,6 +93,7 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
 
     fun findAllStoryBlocksInPostAndPerformOnEachMediaFilesJson(
         postModel: PostModel,
+        siteModel: SiteModel?,
         listener: DoWithMediaFilesListener
     ) {
         var content = postModel.content
@@ -124,7 +125,11 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
         postModel.setContent(content)
     }
 
-    fun replaceLocalMediaIdsWithRemoteMediaIdsInPost(postModel: PostModel, mediaFile: MediaFile) {
+    fun replaceLocalMediaIdsWithRemoteMediaIdsInPost(
+        postModel: PostModel,
+        siteModel: SiteModel?,
+        mediaFile: MediaFile
+    ) {
         if (TextUtils.isEmpty(mediaFile.mediaId)) {
             // if for any reason we couldn't obtain a remote mediaId, it's not worth spending time
             // looking to replace anything in the Post. Skip processing for later in error handling.
@@ -133,6 +138,7 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
         val gson = Gson()
         findAllStoryBlocksInPostAndPerformOnEachMediaFilesJson(
                 postModel,
+                siteModel,
                 object : DoWithMediaFilesListener {
                     override fun doWithMediaFilesJson(content: String, mediaFilesJsonString: String): String {
                         var processedContent = content

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -130,11 +130,11 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
     }
 
     // See: https://git.io/JqfhK
-    private fun shouldLogContent(siteModel: SiteModel?, postModel: PostModel) = siteModel != null
-            && siteModel.isWPCom
-            && !siteModel.isPrivate
-            && postModel.password.isEmpty()
-            && postModel.status != PRIVATE.toString()
+    private fun shouldLogContent(siteModel: SiteModel?, postModel: PostModel) = siteModel != null &&
+            siteModel.isWPCom &&
+            !siteModel.isPrivate &&
+            postModel.password.isEmpty() &&
+            postModel.status != PRIVATE.toString()
 
     fun replaceLocalMediaIdsWithRemoteMediaIdsInPost(
         postModel: PostModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -117,16 +117,20 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
                     content = listener.doWithMediaFilesJson(content, jsonString)
                     storyBlockStartIndex += HEADING_START.length
                 } catch (exception: StringIndexOutOfBoundsException) {
-                    AppLog.e(EDITOR, "Error while parsing Story blocks: ${exception.message}")
-                    if (shouldLogContent(siteModel, postModel)) {
-                        AppLog.e(EDITOR, "HTML content of the post before the crash: ${postModel.content}")
-                    }
-                    crashLogging.reportException(exception, EDITOR.toString())
+                    logException(exception, postModel, siteModel)
                 }
             }
         }
 
         postModel.setContent(content)
+    }
+
+    private fun logException(exception: Throwable, postModel: PostModel, siteModel: SiteModel?) {
+        AppLog.e(EDITOR, "Error while parsing Story blocks: ${exception.message}")
+        if (shouldLogContent(siteModel, postModel)) {
+            AppLog.e(EDITOR, "HTML content of the post before the crash: ${postModel.content}")
+        }
+        crashLogging.reportException(exception, EDITOR.toString())
     }
 
     // See: https://git.io/JqfhK

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadReadyProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadReadyProcessor.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.editor.AztecEditorFragment;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.ui.media.services.MediaUploadReadyListener;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -23,15 +24,16 @@ public class MediaUploadReadyProcessor implements MediaUploadReadyListener {
 
     @Override
     public PostModel replaceMediaFileWithUrlInPost(@Nullable PostModel post, String localMediaId, MediaFile mediaFile,
-                                                   String siteUrl) {
+                                                   @Nullable SiteModel site) {
         if (post != null) {
             boolean showAztecEditor = AppPrefs.isAztecEditorEnabled();
             boolean showGutenbergEditor = AppPrefs.isGutenbergEditorEnabled();
 
             if (PostUtils.contentContainsWPStoryGutenbergBlocks(post.getContent())) {
                 mSaveStoryGutenbergBlockUseCase
-                    .replaceLocalMediaIdsWithRemoteMediaIdsInPost(post, mediaFile);
+                    .replaceLocalMediaIdsWithRemoteMediaIdsInPost(post, site, mediaFile);
             } else if (showGutenbergEditor && PostUtils.contentContainsGutenbergBlocks(post.getContent())) {
+                String siteUrl = site != null ? site.getUrl() : "";
                 post.setContent(
                         PostUtils.replaceMediaFileWithUrlInGutenbergPost(post.getContent(), localMediaId, mediaFile,
                                 siteUrl));

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -624,7 +624,7 @@ public class UploadService extends Service {
 
             // actually replace the media ID with the media uri
             processor.replaceMediaFileWithUrlInPost(post, String.valueOf(media.getId()),
-                    FluxCUtils.mediaFileFromMediaModel(media), site.getUrl());
+                    FluxCUtils.mediaFileFromMediaModel(media), site);
 
             // we changed the post, so let’s mark this down
             if (!post.isLocalDraft()) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
@@ -17,6 +17,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.mediauploadcompletionprocessors.TestContent
@@ -140,10 +141,12 @@ class SaveStoryGutenbergBlockUseCaseTest : BaseUnitTest() {
         val mediaFile = getMediaFile(1)
         val postModel = PostModel()
         postModel.setContent(BLOCK_WITH_NON_EMPTY_MEDIA_FILES)
+        val siteModel = SiteModel()
 
         // When
         saveStoryGutenbergBlockUseCase.replaceLocalMediaIdsWithRemoteMediaIdsInPost(
                 postModel,
+                siteModel,
                 mediaFile
         )
 
@@ -178,9 +181,10 @@ class SaveStoryGutenbergBlockUseCaseTest : BaseUnitTest() {
         whenever(mediaFile.fileURL).thenReturn(TestContent.remoteImageUrl)
         val postModel = PostModel()
         postModel.setContent(TestContent.storyBlockWithLocalIdsAndUrls)
+        val siteModel = SiteModel()
 
         // act
-        saveStoryGutenbergBlockUseCase.replaceLocalMediaIdsWithRemoteMediaIdsInPost(postModel, mediaFile)
+        saveStoryGutenbergBlockUseCase.replaceLocalMediaIdsWithRemoteMediaIdsInPost(postModel, siteModel, mediaFile)
 
         // assert
         Assertions.assertThat(postModel.content).isEqualTo(TestContent.storyBlockWithFirstRemoteIdsAndUrlsReplaced)


### PR DESCRIPTION
This PR is a follow up to #14185 and helps to investigate #13697.

It basically adds a `SiteModel` parameter to the `findAllStoryBlocksInPostAndPerformOnEachMediaFilesJson` method which we then use to check if we should also log the Post's content in addition to reporting any caught `StringIndexOutOfBoundsException`. The logic used to determine that is based [on this one](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1868-L1877), which makes sure we only log posts that are not private or password-protected, on WPCom sites that are also not private.

To test:

Again, there's not much to test here since we can't reproduce the issue, but you can smoke test the Story feature and make sure nothing looks off.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
