### PR TITLE
Adds Analytics event to capture when a category filter is selected

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerTracker.kt
@@ -16,4 +16,6 @@ interface LayoutPickerTracker {
     fun trackNoNetworkErrorShown(message: String)
 
     fun trackErrorShown(message: String)
+
+    fun filterChanged(filter: List<String>)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerTracker.kt
@@ -17,5 +17,7 @@ interface LayoutPickerTracker {
 
     fun trackErrorShown(message: String)
 
-    fun filterChanged(filter: List<String>)
+    fun filterSelected(filter: String, selectedFilters: List<String>)
+
+    fun filterDeselected(filter: String, selectedFilters: List<String>)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
@@ -30,7 +30,7 @@ abstract class LayoutPickerViewModel(
     open val mainDispatcher: CoroutineDispatcher,
     open val bgDispatcher: CoroutineDispatcher,
     open val networkUtils: NetworkUtilsWrapper,
-    val layoutPickerTracker: LayoutPickerTracker
+    private val layoutPickerTracker: LayoutPickerTracker
 ) : ScopedViewModel(bgDispatcher), PreviewModeHandler {
     lateinit var layouts: List<LayoutModel>
     lateinit var categories: List<LayoutCategoryModel>
@@ -108,6 +108,7 @@ abstract class LayoutPickerViewModel(
                         state.copy(selectedCategoriesSlugs = state.selectedCategoriesSlugs.apply { add(categorySlug) })
                 )
             }
+            layoutPickerTracker.filterChanged(state.selectedCategoriesSlugs)
             loadCategories()
             _onCategorySelectionChanged.postValue(Event(Unit))
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
@@ -103,12 +103,13 @@ abstract class LayoutPickerViewModel(
                             remove(categorySlug)
                         })
                 )
+                layoutPickerTracker.filterDeselected(categorySlug, state.selectedCategoriesSlugs)
             } else {
                 updateUiState(
                         state.copy(selectedCategoriesSlugs = state.selectedCategoriesSlugs.apply { add(categorySlug) })
                 )
+                layoutPickerTracker.filterSelected(categorySlug, state.selectedCategoriesSlugs)
             }
-            layoutPickerTracker.filterChanged(state.selectedCategoriesSlugs)
             loadCategories()
             _onCategorySelectionChanged.postValue(Event(Unit))
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerTracker.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.mlp
 
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.ui.layoutpicker.LayoutPickerTracker
+import org.wordpress.android.ui.mlp.ModalLayoutPickerTracker.PROPERTY.FILTER
+import org.wordpress.android.ui.mlp.ModalLayoutPickerTracker.PROPERTY.LOCATION
 import org.wordpress.android.ui.mlp.ModalLayoutPickerTracker.PROPERTY.PREVIEW_MODE
 import org.wordpress.android.ui.mlp.ModalLayoutPickerTracker.PROPERTY.TEMPLATE
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -9,12 +11,15 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val LAYOUT_ERROR_CONTEXT = "layout"
+private const val PAGE_PICKER_LOCATION = "page_picker"
 
 @Singleton
 class ModalLayoutPickerTracker @Inject constructor(val tracker: AnalyticsTrackerWrapper) : LayoutPickerTracker {
     private enum class PROPERTY(val key: String) {
         TEMPLATE("template"),
-        PREVIEW_MODE("preview_mode")
+        PREVIEW_MODE("preview_mode"),
+        LOCATION("location"),
+        FILTER("filter")
     }
 
     override fun trackPreviewModeChanged(mode: String) {
@@ -74,6 +79,13 @@ class ModalLayoutPickerTracker @Inject constructor(val tracker: AnalyticsTracker
                 LAYOUT_ERROR_CONTEXT,
                 "unknown",
                 message
+        )
+    }
+
+    override fun filterChanged(filter: List<String>) {
+        tracker.track(
+                AnalyticsTracker.Stat.FILTER_CHANGED,
+                mapOf(LOCATION.key to PAGE_PICKER_LOCATION, FILTER.key to filter.joinToString())
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerTracker.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.ui.layoutpicker.LayoutPickerTracker
 import org.wordpress.android.ui.mlp.ModalLayoutPickerTracker.PROPERTY.FILTER
 import org.wordpress.android.ui.mlp.ModalLayoutPickerTracker.PROPERTY.LOCATION
 import org.wordpress.android.ui.mlp.ModalLayoutPickerTracker.PROPERTY.PREVIEW_MODE
+import org.wordpress.android.ui.mlp.ModalLayoutPickerTracker.PROPERTY.SELECTED_FILTERS
 import org.wordpress.android.ui.mlp.ModalLayoutPickerTracker.PROPERTY.TEMPLATE
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
@@ -19,7 +20,8 @@ class ModalLayoutPickerTracker @Inject constructor(val tracker: AnalyticsTracker
         TEMPLATE("template"),
         PREVIEW_MODE("preview_mode"),
         LOCATION("location"),
-        FILTER("filter")
+        FILTER("filter"),
+        SELECTED_FILTERS("selected_filters")
     }
 
     override fun trackPreviewModeChanged(mode: String) {
@@ -82,10 +84,25 @@ class ModalLayoutPickerTracker @Inject constructor(val tracker: AnalyticsTracker
         )
     }
 
-    override fun filterChanged(filter: List<String>) {
+    override fun filterSelected(filter: String, selectedFilters: List<String>) {
         tracker.track(
-                AnalyticsTracker.Stat.FILTER_CHANGED,
-                mapOf(LOCATION.key to PAGE_PICKER_LOCATION, FILTER.key to filter.joinToString())
+                AnalyticsTracker.Stat.CATEGORY_FILTER_SELECTED,
+                mapOf(
+                        LOCATION.key to PAGE_PICKER_LOCATION,
+                        FILTER.key to filter,
+                        SELECTED_FILTERS.key to selectedFilters.joinToString()
+                )
+        )
+    }
+
+    override fun filterDeselected(filter: String, selectedFilters: List<String>) {
+        tracker.track(
+                AnalyticsTracker.Stat.CATEGORY_FILTER_DESELECTED,
+                mapOf(
+                        LOCATION.key to PAGE_PICKER_LOCATION,
+                        FILTER.key to filter,
+                        SELECTED_FILTERS.key to selectedFilters.joinToString()
+                )
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
@@ -5,6 +5,8 @@ import org.wordpress.android.ui.layoutpicker.LayoutPickerTracker
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationErrorType.INTERNET_UNAVAILABLE_ERROR
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationErrorType.UNKNOWN
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.CHOSEN_DOMAIN
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.FILTER
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.LOCATION
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.PREVIEW_MODE
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.SEARCH_TERM
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.SEGMENT_ID
@@ -22,6 +24,7 @@ enum class SiteCreationErrorType {
 }
 
 private const val DESIGN_ERROR_CONTEXT = "design"
+private const val SITE_CREATION_LOCATION = "site_creation"
 
 @Singleton
 class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapper) : LayoutPickerTracker {
@@ -32,7 +35,9 @@ class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapp
         CHOSEN_DOMAIN("chosen_domain"),
         SEARCH_TERM("search_term"),
         THUMBNAIL_MODE("thumbnail_mode"),
-        PREVIEW_MODE("preview_mode")
+        PREVIEW_MODE("preview_mode"),
+        LOCATION("location"),
+        FILTER("filter")
     }
 
     private var designSelectionSkipped: Boolean = false
@@ -205,4 +210,11 @@ class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapp
             trackErrorShown(DESIGN_ERROR_CONTEXT, INTERNET_UNAVAILABLE_ERROR, message)
 
     override fun trackErrorShown(message: String) = trackErrorShown(DESIGN_ERROR_CONTEXT, UNKNOWN, message)
+
+    override fun filterChanged(filter: List<String>) {
+        tracker.track(
+                AnalyticsTracker.Stat.FILTER_CHANGED,
+                mapOf(LOCATION.key to SITE_CREATION_LOCATION, FILTER.key to filter.joinToString())
+        )
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.P
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.SEARCH_TERM
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.SEGMENT_ID
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.SEGMENT_NAME
+import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.SELECTED_FILTERS
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.TEMPLATE
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker.PROPERTY.THUMBNAIL_MODE
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -37,7 +38,8 @@ class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapp
         THUMBNAIL_MODE("thumbnail_mode"),
         PREVIEW_MODE("preview_mode"),
         LOCATION("location"),
-        FILTER("filter")
+        FILTER("filter"),
+        SELECTED_FILTERS("selected_filters")
     }
 
     private var designSelectionSkipped: Boolean = false
@@ -211,10 +213,25 @@ class SiteCreationTracker @Inject constructor(val tracker: AnalyticsTrackerWrapp
 
     override fun trackErrorShown(message: String) = trackErrorShown(DESIGN_ERROR_CONTEXT, UNKNOWN, message)
 
-    override fun filterChanged(filter: List<String>) {
+    override fun filterSelected(filter: String, selectedFilters: List<String>) {
         tracker.track(
-                AnalyticsTracker.Stat.FILTER_CHANGED,
-                mapOf(LOCATION.key to SITE_CREATION_LOCATION, FILTER.key to filter.joinToString())
+                AnalyticsTracker.Stat.CATEGORY_FILTER_SELECTED,
+                mapOf(
+                        LOCATION.key to SITE_CREATION_LOCATION,
+                        FILTER.key to filter,
+                        SELECTED_FILTERS.key to selectedFilters.joinToString()
+                )
+        )
+    }
+
+    override fun filterDeselected(filter: String, selectedFilters: List<String>) {
+        tracker.track(
+                AnalyticsTracker.Stat.CATEGORY_FILTER_DESELECTED,
+                mapOf(
+                        LOCATION.key to SITE_CREATION_LOCATION,
+                        FILTER.key to filter,
+                        SELECTED_FILTERS.key to selectedFilters.joinToString()
+                )
         )
     }
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -491,6 +491,7 @@ public final class AnalyticsTracker {
         LAYOUT_PICKER_PREVIEW_LOADED,
         LAYOUT_PICKER_PREVIEW_VIEWED,
         LAYOUT_PICKER_ERROR_SHOWN,
+        FILTER_CHANGED,
         // This stat is part of a funnel that provides critical information.  Before
         // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         SITE_CREATED,

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -491,7 +491,8 @@ public final class AnalyticsTracker {
         LAYOUT_PICKER_PREVIEW_LOADED,
         LAYOUT_PICKER_PREVIEW_VIEWED,
         LAYOUT_PICKER_ERROR_SHOWN,
-        FILTER_CHANGED,
+        CATEGORY_FILTER_SELECTED,
+        CATEGORY_FILTER_DESELECTED,
         // This stat is part of a funnel that provides critical information.  Before
         // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         SITE_CREATED,

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1412,6 +1412,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "layout_picker_preview_viewed";
             case LAYOUT_PICKER_ERROR_SHOWN:
                 return "layout_picker_error_shown";
+            case FILTER_CHANGED:
+                return "filter_changed";
             case SITE_CREATED:
                 // This stat is part of a funnel that provides critical information.  Before
                 // making ANY modification to this stat please refer to: p4qSXL-35X-p2

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1412,8 +1412,10 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "layout_picker_preview_viewed";
             case LAYOUT_PICKER_ERROR_SHOWN:
                 return "layout_picker_error_shown";
-            case FILTER_CHANGED:
-                return "filter_changed";
+            case CATEGORY_FILTER_SELECTED:
+                return "category_filter_selected";
+            case CATEGORY_FILTER_DESELECTED:
+                return "category_filter_deselected";
             case SITE_CREATED:
                 // This stat is part of a funnel that provides critical information.  Before
                 // making ANY modification to this stat please refer to: p4qSXL-35X-p2


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3130

## Description
Adds two new analytics events when selecting/deselecting a category in the Starter Page Picker, or the Home Page Picker.
- Event Name`category_filter_selected`
- Properties 
    - `location` = `site_creation` or `page_picker`
    - `filter` = the selected filter
    - `selected_filters` = the selected filter(s) comma separated 
    
- Event Name`category_filter_deselected`
- Properties 
    - `location` = `site_creation` or `page_picker`
    - `filter` = the deselected filter
    - `selected_filters` = the selected filter(s) comma seperated or empty string

## To test:

### Home page picker
1. Start the site creation flow (e.g. Choose site > Add button)
1. Select the Create WordPress.com site option
1. Verify that the categories and designs are loaded
1. Press on the **Blog** category
1. **Verify** that an event is emitted: `category_filter_selected, Properties: {"location":"site_creation","filter":"blog","selected_filters":"blog"}`
1. Verify that only the blog category designs are displayed
1. Press on the **Business** category
1. **Verify** that an event is emitted: `category_filter_selected, Properties: {"location":"site_creation","filter":"business","selected_filters":"blog, business"}`
1. Verify that only blog and business designs are displayed
1. Press on the **Business** category to deselect
1. **Verify** that an event is emitted: `category_filter_deselected, Properties: {"location":"site_creation","filter":"business","selected_filters":"blog"}`
1. Verify that only the blog category designs are displayed
1. Press on the **Blog** category to deselect
1. **Verify** that an event is emitted: `category_filter_deselected, Properties: {"location":"site_creation","filter":"blog","selected_filters":""}`
1. Verify that all designs are displayed

### Layout page picker
1. Press the fab ➕  icon in the **My Site** screen and select **Site Page**
1. Verify that the categories and layouts are loaded
1. Press on the **Blog** category
1. **Verify** that an event is emitted: `category_filter_selected, Properties: {"location":"page_picker","filter":"blog","selected_filters":"blog"}`
1. Verify that only the blog category layouts are displayed
1. Press on the **Highlights** category
1. **Verify** that an event is emitted: `category_filter_selected, Properties: {"location":"page_picker","filter":"highlights","selected_filters":"blog, highlights"}`
1. Verify that only blog and highlights layouts are displayed
1. Press on the **Highlight** category to deselect
1. **Verify** that an event is emitted: `category_filter_deselected, Properties: {"location":"page_picker","filter":"highlights","selected_filters":"blog"}`
1. Verify that only the blog category layouts are displayed
1. Press on the **Blog** category to deselect
1. **Verify** that an event is emitted: `category_filter_deselected, Properties: {"location":"page_picker","filter":"blog","selected_filters":""}`
1. Verify that all layouts are displayed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
