### PR TITLE
Feature/manage translations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 5c4326ac71c36c7825cd620241db8b08591dcaf4
-  ref: 5c4326ac71c36c7825cd620241db8b08591dcaf4
+  revision: ab8b0dcd6f6f5e21c18d54776266ced36bdca8c0
+  ref: ab8b0dcd6f6f5e21c18d54776266ced36bdca8c0
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.14.0)
       activesupport (~> 5)
@@ -185,7 +185,7 @@ GEM
     octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.11.2)
+    oj (3.11.3)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: ab8b0dcd6f6f5e21c18d54776266ced36bdca8c0
-  ref: ab8b0dcd6f6f5e21c18d54776266ced36bdca8c0
+  revision: 348de22c625922cca9a5060261fa7a0c4005786e
+  tag: 0.16.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.14.0)
+    fastlane-plugin-wpmreleasetoolkit (0.16.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: be2d964972e043fe6d97ca871941f573d8ad2a11
-  ref: be2d964
+  revision: 0375d1a41506b661351f988a46ff8f7c1a642d0b
+  ref: 0375d1a41506b661351f988a46ff8f7c1a642d0b
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.14.0)
       activesupport (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 0093d99f154f5e56bc67a8d1f40e45e5244364e2
-  ref: 0093d99
+  revision: 5c4326ac71c36c7825cd620241db8b08591dcaf4
+  ref: 5c4326ac71c36c7825cd620241db8b08591dcaf4
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.14.0)
       activesupport (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 0375d1a41506b661351f988a46ff8f7c1a642d0b
-  ref: 0375d1a41506b661351f988a46ff8f7c1a642d0b
+  revision: 51b7c0f084e2c4ba6bca6ce180721d9454eb10c8
+  ref: 51b7c0f084e2c4ba6bca6ce180721d9454eb10c8
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.14.0)
       activesupport (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 51b7c0f084e2c4ba6bca6ce180721d9454eb10c8
-  ref: 51b7c0f084e2c4ba6bca6ce180721d9454eb10c8
+  revision: 0093d99f154f5e56bc67a8d1f40e45e5244364e2
+  ref: 0093d99
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.14.0)
       activesupport (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 0ad59f8ad1644b68f8dbe3ebc3e16bb331a24117
-  tag: 0.14.0
+  revision: be2d964972e043fe6d97ca871941f573d8ad2a11
+  ref: be2d964
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.14.0)
       activesupport (~> 5)
@@ -174,7 +174,7 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     multi_json (1.15.0)
     multipart-post (2.0.0)
     nanaimo (0.3.0)
@@ -261,4 +261,4 @@ DEPENDENCIES
   rmagick (~> 4.1)
 
 BUNDLED WITH
-   2.2.10
+   2.2.11

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -507,7 +507,10 @@ ENV["validate_translations"]="lintVanillaRelease"
         github_release_prefix: lib[:github_release_prefix])
 
       if download_path.nil?
-        UI.error "Abort." unless UI.confirm("Can't download strings file for #{lib[:name]}. Do you want to continue?")
+        error_message = "Can't download strings file for #{lib[:name]}.\r\n"
+        error_message += "Strings for this library won't get translated.\r\n"
+        error_message += "Do you want to continue anyway?"
+        UI.user_error! "Abort." unless UI.confirm(error_message)
       else
         UI.message("Strings.xml file downloaded to #{download_path}.")
         sh(merge_strings_tool_file_path, lib[:name], download_path)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -512,7 +512,7 @@ ENV["validate_translations"]="lintVanillaRelease"
         error_message += "Do you want to continue anyway?"
         UI.user_error! "Abort." unless UI.confirm(error_message)
       else
-        UI.message("Strings.xml file downloaded to #{download_path}.")
+        UI.message("Strings.xml file for #{lib[:name]} downloaded to #{download_path}.")
         sh(merge_strings_tool_file_path, lib[:name], download_path)
         File.delete(download_path) if File.exist?(download_path)
       end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,7 +42,7 @@ import "./ScreenshotFastfile"
 ########################################################################
 Dotenv.load('~/.wpandroid-env.default')
 ENV[GHHELPER_REPO="wordpress-mobile/WordPress-Android"]
-ENV["PROJECT_ROOT_FOLDER"]="./"
+ENV["PROJECT_ROOT_FOLDER"]=File.dirname(File.expand_path(__dir__)) + "/"
 ENV["PROJECT_NAME"]="WordPress"
 ENV["HAS_ALPHA_VERSION"]="true"
 ENV["validate_translations"]="lintVanillaRelease"
@@ -70,15 +70,15 @@ ENV["validate_translations"]="lintVanillaRelease"
 
     android_bump_version_release()
     new_version = android_get_app_version()
-    extract_release_notes_for_version(version: new_version, 
-      release_notes_file_path:"#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt", 
+    extract_release_notes_for_version(version: new_version,
+      release_notes_file_path:"#{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt",
       extracted_notes_file_path:release_notes_path)
     cleanup_release_files(files: [release_note_short_path])
     android_update_release_notes(new_version: new_version)
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
 
-    localize_gutenberg(skip_module_update: true)
+    localize_binary_deps()
     localize_libs()
     send_strings_for_translation()
     ensure_git_status_clean()
@@ -193,7 +193,7 @@ ENV["validate_translations"]="lintVanillaRelease"
   #####################################################################################
   # finalize_hotfix_release
   # -----------------------------------------------------------------------------------
-  # This lane finalizes the hotfix branch. 
+  # This lane finalizes the hotfix branch.
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane finalize_hotfix_release
@@ -247,7 +247,7 @@ ENV["validate_translations"]="lintVanillaRelease"
   # bundle exec fastlane build_and_upload_release
   # bundle exec fastlane build_and_upload_release skip_confirm:true
   # bundle exec fastlane build_and_upload_release skip_prechecks:true
-  # bundle exec fastlane build_and_upload_release create_release:true 
+  # bundle exec fastlane build_and_upload_release create_release:true
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_and_upload_release do | options |
@@ -279,7 +279,7 @@ ENV["validate_translations"]="lintVanillaRelease"
   # Example:
   # bundle exec fastlane build_and_upload_pre_releases
   # bundle exec fastlane build_and_upload_pre_releases skip_confirm:true
-  # bundle exec fastlane build_and_upload_beta create_release:true 
+  # bundle exec fastlane build_and_upload_beta create_release:true
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_and_upload_pre_releases do | options |
@@ -460,6 +460,10 @@ ENV["validate_translations"]="lintVanillaRelease"
     {library: "Stories Creator", strings_path: "./libs/stories-android/stories/src/main/res/values/strings.xml", exclusions: []}
   ]
 
+  binary_imported_libraries = [
+    { name: "Gutenberg Native",   import_key: "gutenbergMobileVersion",   repository: "wordpress-mobile/gutenberg-mobile",   strings_file_path: "bundle/android/strings.xml" },
+  ]
+
   private_lane :send_strings_for_translation do | options |
     sh("cd .. && mkdir -p #{update_strings_path} && cp #{main_strings_path} #{update_strings_path} && git add #{update_strings_path}strings.xml")
     sh("git diff-index --quiet HEAD || git commit -m \"Send strings to translation.\"")
@@ -485,14 +489,24 @@ ENV["validate_translations"]="lintVanillaRelease"
     end
   end
 
-  desc "Import Gutenberg strings"
-  lane :localize_gutenberg do | options |
-    unless options[:skip_module_update] then
-      sh("git submodule init")
-      sh("git submodule update")
-    end
+  desc "Import strings from binary dependencies"
+  lane :localize_binary_deps do | options |
+    merge_strings_tool_file_path = File.join(ENV["PROJECT_ROOT_FOLDER"], 'tools/merge_strings_xml.py')
+    binary_imported_libraries.each do  | lib |
+      download_path = android_download_file_by_version(
+        library_name: lib[:name],
+        import_key: lib[:import_key],
+        repository: lib[:repository],
+        file_path: lib[:strings_file_path])
 
-    sh("cd .. && python ./tools/merge_strings_xml.py")
+      if download_path.nil?
+        UI.error "Abort." unless UI.confirm("Can't download strings file for #{lib[:name]}. Do you want to continue?")
+      else
+        UI.message("Strings.xml file downloaded to #{download_path}.")
+        sh(merge_strings_tool_file_path, lib[:name], download_path)
+        File.delete(download_path) if File.exist?(download_path)
+      end
+    end
 
     is_repo_clean = ("git status --porcelain").empty?
     unless is_repo_clean then
@@ -546,12 +560,12 @@ ENV["validate_translations"]="lintVanillaRelease"
     Dir.chdir("..") do
       sh("mkdir -p #{build_dir}")
       unless is_ci
-        # We pre-build the Gutenberg RN bundle on a different job on CI,  
-        # so cleaning here breaks the build 
+        # We pre-build the Gutenberg RN bundle on a different job on CI,
+        # so cleaning here breaks the build
         UI.message("Cleaning branch...")
         sh("echo \"Cleaning branch\" >> #{logfile_path}")
         sh("./gradlew clean >> #{logfile_path} 2>&1")
-      end 
+      end
       sh("mkdir -p #{build_dir}")
       UI.message("Running lint...")
       sh("echo \"Running lint...\" >> #{logfile_path}")
@@ -616,7 +630,7 @@ ENV["validate_translations"]="lintVanillaRelease"
   lane :build_for_translation_review do | options |
     cmd_params = ""
     unless options[:custom_version].nil?
-      UI.message("Building custom version: #{options[:custom_version]}") 
+      UI.message("Building custom version: #{options[:custom_version]}")
       cmd_params=" -PversionName=\"#{options[:custom_version]}\""
     end
 
@@ -626,7 +640,7 @@ ENV["validate_translations"]="lintVanillaRelease"
 
     android_merge_translators_strings(strings_folder:"./WordPress/src/main/res/")
     sh("export SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD=1 && cd .. && ./gradlew --stacktrace assembleJalapenoRelease #{cmd_params}")
-  end 
+  end
 
   #####################################################################################
   # trigger_ci
@@ -688,7 +702,7 @@ ENV["validate_translations"]="lintVanillaRelease"
     temp_dir = Dir.mktmpdir()
 
     command = ""
-    if is_ci 
+    if is_ci
       command << "bundletool build-apks --bundle=\"#{bundle_path}\" \\
       --output=\"#{temp_dir}/universal.apks\" \\
       --mode=universal"
@@ -717,8 +731,8 @@ ENV["validate_translations"]="lintVanillaRelease"
     # APKs built on CI are unsigned, so don't upload them until we have a fix
     release_assets = [aab_file_path]
     release_assets.append(apk_file_path) unless is_ci
-    create_release(repository:GHHELPER_REPO, 
-      version: version["name"], 
+    create_release(repository:GHHELPER_REPO,
+      version: version["name"],
       release_notes_file_path:release_notes_path,
       prerelease: set_prerelease_flag,
       release_assets: release_assets.join(',')
@@ -727,7 +741,7 @@ ENV["validate_translations"]="lintVanillaRelease"
 
   private_lane :cleanup_release_files do | options |
     files = options[:files]
-    
+
     files.each do | f |
       File.open(f, "w") {}
       sh("git add #{f}")
@@ -746,7 +760,7 @@ ENV["validate_translations"]="lintVanillaRelease"
   def release_note_short_path
     project_root = File.dirname(File.expand_path(File.dirname(__FILE__)))
     File.join(project_root, "WordPress", "metadata/release_notes_short.txt")
-  end 
+  end
 
   def universal_apk_name(version)
     "wpandroid-#{version["name"]}-universal.apk"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -461,7 +461,7 @@ ENV["validate_translations"]="lintVanillaRelease"
   ]
 
   binary_imported_libraries = [
-    { name: "Gutenberg Native",   import_key: "gutenbergMobileVersion",   repository: "wordpress-mobile/gutenberg-mobile",   strings_file_path: "bundle/android/strings.xml" },
+    { name: "Gutenberg Native",   import_key: "gutenbergMobileVersion",   repository: "wordpress-mobile/gutenberg-mobile",   strings_file_path: "bundle/android/strings.xml", github_release_prefix: "v" },
   ]
 
   private_lane :send_strings_for_translation do | options |
@@ -497,7 +497,8 @@ ENV["validate_translations"]="lintVanillaRelease"
         library_name: lib[:name],
         import_key: lib[:import_key],
         repository: lib[:repository],
-        file_path: lib[:strings_file_path])
+        file_path: lib[:strings_file_path],
+        github_release_prefix: lib[:github_release_prefix])
 
       if download_path.nil?
         UI.error "Abort." unless UI.confirm("Can't download strings file for #{lib[:name]}. Do you want to continue?")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -461,7 +461,13 @@ ENV["validate_translations"]="lintVanillaRelease"
   ]
 
   BINARY_IMPORTED_LIBRARIES = [
-    { name: "Gutenberg Native",   import_key: "gutenbergMobileVersion",   repository: "wordpress-mobile/gutenberg-mobile",   strings_file_path: "bundle/android/strings.xml", github_release_prefix: "v" },
+    {
+      name: "Gutenberg Native",
+      import_key: "gutenbergMobileVersion",
+      repository: "wordpress-mobile/gutenberg-mobile",
+      strings_file_path: "bundle/android/strings.xml",
+      github_release_prefix: "v"
+    },
   ]
 
   private_lane :send_strings_for_translation do | options |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -497,7 +497,7 @@ ENV["validate_translations"]="lintVanillaRelease"
 
   desc "Import strings from binary dependencies"
   lane :localize_binary_deps do | options |
-    merge_strings_tool_file_path = File.join(ENV["PROJECT_ROOT_FOLDER"], 'tools/merge_strings_xml.py')
+    merge_strings_tool_file_path = File.join(ENV["PROJECT_ROOT_FOLDER"], 'tools', 'merge_strings_xml.py')
     binary_imported_libraries.each do  | lib |
       download_path = android_download_file_by_version(
         library_name: lib[:name],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -460,7 +460,7 @@ ENV["validate_translations"]="lintVanillaRelease"
     {library: "Stories Creator", strings_path: "./libs/stories-android/stories/src/main/res/values/strings.xml", exclusions: []}
   ]
 
-  binary_imported_libraries = [
+  BINARY_IMPORTED_LIBRARIES = [
     { name: "Gutenberg Native",   import_key: "gutenbergMobileVersion",   repository: "wordpress-mobile/gutenberg-mobile",   strings_file_path: "bundle/android/strings.xml", github_release_prefix: "v" },
   ]
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '51b7c0f084e2c4ba6bca6ce180721d9454eb10c8'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '0093d99'
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '0093d99'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '5c4326ac71c36c7825cd620241db8b08591dcaf4'
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: 'ab8b0dcd6f6f5e21c18d54776266ced36bdca8c0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.16.0'
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: 'be2d964'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '0375d1a41506b661351f988a46ff8f7c1a642d0b'
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.14.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: 'be2d964'
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '0375d1a41506b661351f988a46ff8f7c1a642d0b'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '51b7c0f084e2c4ba6bca6ce180721d9454eb10c8'
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '5c4326ac71c36c7825cd620241db8b08591dcaf4'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: 'ab8b0dcd6f6f5e21c18d54776266ced36bdca8c0'
 

--- a/tools/merge_strings_xml.py
+++ b/tools/merge_strings_xml.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import logging, sys
+import logging, sys, os
 import xml.etree.ElementTree as ET
 from xml.dom import minidom
 import json
@@ -98,16 +98,23 @@ def merge_strings(main_xml, extra_sections):
         add_section(main_root, insertion_point_index, section_name, new_elements)
     # make sure xml file ends with a newline
     main_root.tail = '\n'
-    xml_string = ('<?xml version="1.0" encoding="UTF-8"?>' + '\n' + 
+    xml_string = ('<?xml version="1.0" encoding="UTF-8"?>' + '\n' +
         ET.tostring(main_root, encoding='utf8').split('\n',1)[1])
     with open(main_xml, 'wb') as xml_file:
         xml_file.write(xml_string)
 
 def main():
+    if len(sys.argv) != 3:
+        print 'Usage: merge_strings_xml.py <section name> <strings.xml file path>'
+        sys.exit(1)
+
+    project_root_path = os.path.dirname(os.path.dirname(__file__))
+    main_strings_file = os.path.join(project_root_path, 'WordPress/src/main/res/values/strings.xml')
+    print('Merging strings for: ', sys.argv[1])
     merge_strings(
-        './WordPress/src/main/res/values/strings.xml',
+        main_strings_file,
         [
-            { 'name': 'Gutenberg Native', 'file': './libs/gutenberg-mobile/bundle/android/strings.xml' },
+            { 'name': sys.argv[1], 'file': sys.argv[2] },
         ]
     )
 

--- a/tools/merge_strings_xml.py
+++ b/tools/merge_strings_xml.py
@@ -110,11 +110,13 @@ def main():
 
     project_root_path = os.path.dirname(os.path.dirname(__file__))
     main_strings_file = os.path.join(project_root_path, 'WordPress/src/main/res/values/strings.xml')
-    print('Merging strings for: ', sys.argv[1])
+    library_name = sys.argv[1]
+    input_file = sys.argv[2]
+    print('Merging strings for: ', library_name)
     merge_strings(
         main_strings_file,
         [
-            { 'name': sys.argv[1], 'file': sys.argv[2] },
+            { 'name': library_name, 'file': input_file },
         ]
     )
 


### PR DESCRIPTION
This PR adds support for translating `strings.xml` files which belong to internal libraries which are imported as binary dependencies. 
This PR only covers `mobile-gutenberg`, but the flow can be easily used for other libraries by adding them to the `binary_imported_libraries` array. 

`localize_binary_deps` downloads the `strings.xml` file from the GitHub release which is referred in `build.gradle` as the imported one. 

**To test:**
1. Checkout a new branch from this one. 
2. Update `ext.gutenbergMobileVersion` in `build.gradle` to a released version.
3. `bundle install`
4. Run `bundle exec fastlane localize_binary_deps` and verify that the main `strings.xml` gets updated. 

Related `release-toolkit` PR: https://github.com/wordpress-mobile/release-toolkit/pull/222

**Note:** Before merging this PR, I'll need to release a new version of `release-toolkit` and update the reference in this PR.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
