### PR TITLE
Fix AztecEditor e2e test broken by deprecation dialog

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
@@ -49,6 +49,7 @@ public class EditorPage {
     public EditorPage() {
         onView(withText("Dismiss")).withFailureHandler(new FailureHandler() {
             @Override public void handle(Throwable error, Matcher<View> viewMatcher) {
+                // Deprecation Dialog only shows up the first time this test is run because of SharedPreference
             }
         }).check(matches(isDisplayed())).perform(click());
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/EditorPage.java
@@ -1,11 +1,15 @@
 package org.wordpress.android.e2e.pages;
 
+import android.view.View;
+
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.FailureHandler;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
 
 import com.google.android.material.snackbar.SnackbarContentLayout;
 
+import org.hamcrest.Matcher;
 import org.wordpress.android.R;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -43,6 +47,11 @@ public class EditorPage {
 
 
     public EditorPage() {
+        onView(withText("Dismiss")).withFailureHandler(new FailureHandler() {
+            @Override public void handle(Throwable error, Matcher<View> viewMatcher) {
+            }
+        }).check(matches(isDisplayed())).perform(click());
+
         editor.check(matches(isDisplayed()));
     }
 


### PR DESCRIPTION
As a result of this PR: https://github.com/wordpress-mobile/WordPress-Android/pull/14205, the following tests failed on develop: https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/21895/workflows/012209eb-f73f-4038-a799-8b4dbec7e49f/jobs/98479/tests#failed-test-0

Basically the new dialog in the screenshot below is blocking the flow of an `EditorPage` test. The change in this PR dismisses the dialog so the test can resume as expected.

More background on the changes that initially broke this test in this issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/3209

### To test:
You should see full suite of passing tests on this PR


### Screenshot:
<img src="https://user-images.githubusercontent.com/1103838/110185088-5223b300-7dc6-11eb-986d-57a3bb5dc597.png" alt="" width="350"> 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
