### PR TITLE
Feature/view binding in gif picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/gif/GifMediaViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/gif/GifMediaViewHolder.kt
@@ -3,12 +3,9 @@ package org.wordpress.android.ui.gif
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.ImageView.ScaleType.CENTER_CROP
-import android.widget.TextView
-import androidx.lifecycle.Observer
-import kotlinx.android.synthetic.main.media_picker_thumbnail.view.*
 import org.wordpress.android.R
+import org.wordpress.android.databinding.MediaPickerThumbnailBinding
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.AniUtils.Duration.MEDIUM
 import org.wordpress.android.util.getDistinct
@@ -53,13 +50,12 @@ class GifMediaViewHolder(
 ) : LifecycleOwnerViewHolder<GifMediaViewModel>(itemView) {
     data class ThumbnailViewDimensions(val width: Int, val height: Int)
 
-    private val thumbnailView: ImageView = itemView.image_thumbnail
-    private val selectionNumberTextView: TextView = itemView.text_selection_count
+    private val binding = MediaPickerThumbnailBinding.bind(itemView)
 
     private var mediaViewModel: GifMediaViewModel? = null
 
     init {
-        thumbnailView.apply {
+        binding.imageThumbnail.apply {
             layoutParams.width = thumbnailViewDimensions.width
             layoutParams.height = thumbnailViewDimensions.height
 
@@ -91,7 +87,7 @@ class GifMediaViewHolder(
         updateThumbnailOnSelectionChange(isSelected = isSelected, animated = false)
 
         // When the [isSelected] property changes later, update the selection number and scale the thumbnail
-        mediaViewModel?.isSelected?.observe(this, Observer {
+        mediaViewModel?.isSelected?.observe(this, {
             val selected = it ?: false
 
             updateSelectionIndicatorOnSelectionChange(isSelected = selected, animated = true)
@@ -99,20 +95,20 @@ class GifMediaViewHolder(
         })
 
         // Update selection number text and observe later changes
-        selectionNumberTextView.text = mediaViewModel?.selectionNumber?.value?.toString() ?: ""
-        mediaViewModel?.selectionNumber?.getDistinct()?.observe(this, Observer {
-            selectionNumberTextView.text = it?.toString() ?: ""
+        binding.textSelectionCount.text = mediaViewModel?.selectionNumber?.value?.toString() ?: ""
+        mediaViewModel?.selectionNumber?.getDistinct()?.observe(this, {
+            binding.textSelectionCount.text = it?.toString() ?: ""
         })
 
-        thumbnailView.contentDescription = mediaViewModel?.title
-        imageManager.load(thumbnailView, PHOTO, mediaViewModel?.thumbnailUri.toString(), CENTER_CROP)
+        binding.imageThumbnail.contentDescription = mediaViewModel?.title
+        imageManager.load(binding.imageThumbnail, PHOTO, mediaViewModel?.thumbnailUri.toString(), CENTER_CROP)
     }
 
     private fun updateSelectionIndicatorOnSelectionChange(isSelected: Boolean, animated: Boolean) {
         // The `isSelected` here changes the color of the text. It will be blue when selected.
-        selectionNumberTextView.isSelected = isSelected
+        binding.textSelectionCount.isSelected = isSelected
         if (!isMultiSelectEnabled) {
-            selectionNumberTextView.visibility = if (isSelected) {
+            binding.textSelectionCount.visibility = if (isSelected) {
                 View.VISIBLE
             } else {
                 View.GONE
@@ -122,12 +118,12 @@ class GifMediaViewHolder(
         if (animated) {
             if (!isMultiSelectEnabled) {
                 if (isSelected) {
-                    AniUtils.scaleIn(selectionNumberTextView, MEDIUM)
+                    AniUtils.scaleIn(binding.textSelectionCount, MEDIUM)
                 } else {
-                    AniUtils.scaleOut(selectionNumberTextView, MEDIUM)
+                    AniUtils.scaleOut(binding.textSelectionCount, MEDIUM)
                 }
             } else {
-                AniUtils.startAnimation(selectionNumberTextView, R.anim.pop)
+                AniUtils.startAnimation(binding.textSelectionCount, R.anim.pop)
             }
         }
     }
@@ -139,7 +135,7 @@ class GifMediaViewHolder(
         val scaleStart = if (isSelected) THUMBNAIL_SCALE_NORMAL else THUMBNAIL_SCALE_SELECTED
         val scaleEnd = if (scaleStart == THUMBNAIL_SCALE_SELECTED) THUMBNAIL_SCALE_NORMAL else THUMBNAIL_SCALE_SELECTED
 
-        with(thumbnailView) {
+        with(binding.imageThumbnail) {
             if (animated) {
                 AniUtils.scale(this, scaleStart, scaleEnd, AniUtils.Duration.SHORT)
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerActivity.kt
@@ -13,10 +13,10 @@ import androidx.appcompat.widget.SearchView.OnQueryTextListener
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.GridLayoutManager
-import kotlinx.android.synthetic.main.media_picker_activity.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.databinding.MediaPickerActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActionableEmptyView
 import org.wordpress.android.ui.LocaleAwareActivity
@@ -73,32 +73,34 @@ class GifPickerActivity : LocaleAwareActivity() {
         viewModel.start(site, isMultiSelectEnabled)
 
         // We are intentionally reusing this layout since the UI is very similar.
-        setContentView(R.layout.media_picker_activity)
-
-        initializeToolbar()
-        initializeRecyclerView()
-        initializeSearchView()
-        initializeSearchProgressBar()
-        initializeSelectionBar()
-        initializeEmptyView()
-        initializeRangeLoadErrorEventHandlers()
-        initializePreviewHandlers()
-        initializeDownloadHandlers()
-        initializeStateChangeHandlers()
+        val binding = MediaPickerActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        binding.apply {
+            initializeToolbar()
+            initializeRecyclerView()
+            initializeSearchView()
+            initializeSearchProgressBar()
+            initializeSelectionBar()
+            initializeEmptyView()
+            initializeRangeLoadErrorEventHandlers()
+            initializePreviewHandlers()
+            initializeDownloadHandlers()
+            initializeStateChangeHandlers()
+        }
     }
 
     /**
      * Show the back arrow.
      */
-    private fun initializeToolbar() {
-        setSupportActionBar(toolbar_main)
+    private fun MediaPickerActivityBinding.initializeToolbar() {
+        setSupportActionBar(toolbarMain)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
     /**
      * Configure the RecyclerView to use [GifPickerPagedListAdapter] and display the items in a grid
      */
-    private fun initializeRecyclerView() {
+    private fun MediaPickerActivityBinding.initializeRecyclerView() {
         val pagedListAdapter = GifPickerPagedListAdapter(
                 imageManager = imageManager,
                 thumbnailViewDimensions = thumbnailViewDimensions,
@@ -121,7 +123,7 @@ class GifPickerActivity : LocaleAwareActivity() {
         }
 
         // Update the RecyclerView when new items arrive from the API
-        viewModel.mediaViewModelPagedList.observe(this, Observer {
+        viewModel.mediaViewModelPagedList.observe(this@GifPickerActivity, Observer {
             pagedListAdapter.submitList(it)
         })
     }
@@ -129,12 +131,12 @@ class GifPickerActivity : LocaleAwareActivity() {
     /**
      * Configure the search view to execute search when the keyboard's Done button is pressed.
      */
-    private fun initializeSearchView() {
-        search_view.queryHint = getString(R.string.gif_picker_search_hint)
+    private fun MediaPickerActivityBinding.initializeSearchView() {
+        searchView.queryHint = getString(R.string.gif_picker_search_hint)
 
-        search_view.setOnQueryTextListener(object : OnQueryTextListener {
+        searchView.setOnQueryTextListener(object : OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {
-                search_view.clearFocus()
+                searchView.clearFocus()
                 return true
             }
 
@@ -148,8 +150,8 @@ class GifPickerActivity : LocaleAwareActivity() {
     /**
      * Show the progress bar in the center of the page if we are performing an initial page load.
      */
-    private fun initializeSearchProgressBar() {
-        viewModel.isPerformingInitialLoad.getDistinct().observe(this, Observer {
+    private fun MediaPickerActivityBinding.initializeSearchProgressBar() {
+        viewModel.isPerformingInitialLoad.getDistinct().observe(this@GifPickerActivity, Observer {
             val isPerformingInitialLoad = it ?: return@Observer
             progress.visibility = if (isPerformingInitialLoad) View.VISIBLE else View.GONE
         })
@@ -158,8 +160,8 @@ class GifPickerActivity : LocaleAwareActivity() {
     /**
      * Configure the selection bar and its labels when the [GifPickerViewModel] selected items change
      */
-    private fun initializeSelectionBar() {
-        viewModel.selectionBarUiModel.observe(this, Observer { uiModel ->
+    private fun MediaPickerActivityBinding.initializeSelectionBar() {
+        viewModel.selectionBarUiModel.observe(this@GifPickerActivity, Observer { uiModel ->
             if (uiModel.isMultiselectEnabled) {
                 // Update the "Add" and "Preview" labels to include the number of items. For example, "Add 7" and "Preview 7".
                 //
@@ -168,18 +170,18 @@ class GifPickerActivity : LocaleAwareActivity() {
                 // change to just "Add" and "Preview" too.
                 val selectedCount = uiModel.numberOfSelectedImages
                 if (selectedCount > 0) {
-                    text_preview.text = getString(R.string.preview_count, selectedCount)
-                    text_add.text = getString(R.string.add_count, selectedCount)
+                    textPreview.text = getString(R.string.preview_count, selectedCount)
+                    textAdd.text = getString(R.string.add_count, selectedCount)
                 }
             } else {
                 // When in single selection mode we only show  ADD label
-                text_add.text = getString(R.string.photo_picker_use_gif)
-                text_add.visibility = View.VISIBLE
-                text_preview.visibility = View.GONE
+                textAdd.text = getString(R.string.photo_picker_use_gif)
+                textAdd.visibility = View.VISIBLE
+                textPreview.visibility = View.GONE
             }
 
             val isVisible = uiModel.isVisible
-            val selectionBar: ViewGroup = container_selection_bar
+            val selectionBar: ViewGroup = containerSelectionBar
 
             // Do nothing if the selection bar is already in the visibility state that we want it to be
             if (isVisible && selectionBar.visibility == View.VISIBLE ||
@@ -205,15 +207,15 @@ class GifPickerActivity : LocaleAwareActivity() {
     /**
      * Set up showing and hiding of the empty view depending on the search results
      */
-    private fun initializeEmptyView() {
-        val emptyView: ActionableEmptyView = actionable_empty_view
+    private fun MediaPickerActivityBinding.initializeEmptyView() {
+        val emptyView: ActionableEmptyView = actionableEmptyView
         emptyView.run {
             image.setImageResource(R.drawable.img_illustration_media_105dp)
             bottomImage.setImageResource(R.drawable.img_tenor_100dp)
             bottomImage.contentDescription = getString(R.string.gif_powered_by_tenor)
         }
 
-        viewModel.emptyDisplayMode.getDistinct().observe(this, Observer { emptyDisplayMode ->
+        viewModel.emptyDisplayMode.getDistinct().observe(this@GifPickerActivity, Observer { emptyDisplayMode ->
             when (emptyDisplayMode) {
                 EmptyDisplayMode.HIDDEN -> {
                     emptyView.visibility = View.GONE
@@ -270,8 +272,8 @@ class GifPickerActivity : LocaleAwareActivity() {
     /**
      * Set up listener for the Preview button
      */
-    private fun initializePreviewHandlers() {
-        text_preview.setOnClickListener {
+    private fun MediaPickerActivityBinding.initializePreviewHandlers() {
+        textPreview.setOnClickListener {
             val mediaViewModels = viewModel.selectedMediaViewModelList.value?.values?.toList()
             if (mediaViewModels != null && mediaViewModels.isNotEmpty()) {
                 showPreview(mediaViewModels)
@@ -294,10 +296,10 @@ class GifPickerActivity : LocaleAwareActivity() {
     /**
      * Set up reacting to "Add" button presses and processing the result
      */
-    private fun initializeDownloadHandlers() {
-        text_add.setOnClickListener { viewModel.downloadSelected() }
+    private fun MediaPickerActivityBinding.initializeDownloadHandlers() {
+        textAdd.setOnClickListener { viewModel.downloadSelected() }
 
-        viewModel.downloadResult.observe(this, Observer { result ->
+        viewModel.downloadResult.observe(this@GifPickerActivity, Observer { result ->
             if (result?.mediaModels != null) {
                 val mediaLocalIds = result.mediaModels.map { it.id }.toIntArray()
 
@@ -323,29 +325,29 @@ class GifPickerActivity : LocaleAwareActivity() {
      * - [State.DOWNLOADING] or [State.FINISHED]: "Add", "Preview", searching, and selecting are disabled
      * - [State.DOWNLOADING]: The "Add" button is replaced with a progress bar
      */
-    private fun initializeStateChangeHandlers() {
-        viewModel.state.observe(this, Observer { state ->
+    private fun MediaPickerActivityBinding.initializeStateChangeHandlers() {
+        viewModel.state.observe(this@GifPickerActivity, Observer { state ->
             state ?: return@Observer
 
             val searchClearButton =
-                    search_view.findViewById(androidx.appcompat.R.id.search_close_btn) as ImageView
+                    searchView.findViewById(androidx.appcompat.R.id.search_close_btn) as ImageView
             val searchEditText =
-                    search_view.findViewById(androidx.appcompat.R.id.search_src_text)
+                    searchView.findViewById(androidx.appcompat.R.id.search_src_text)
                             as SearchView.SearchAutoComplete
 
             val isIdle = state == State.IDLE
             val isDownloading = state == State.DOWNLOADING
 
             // Disable all the controls if we are not idle
-            text_add.isEnabled = isIdle
-            text_preview.isEnabled = isIdle
+            textAdd.isEnabled = isIdle
+            textPreview.isEnabled = isIdle
             searchClearButton.isEnabled = isIdle
             searchEditText.isEnabled = isIdle
 
             // Show the progress bar instead of the Add text if we are downloading
-            upload_progress.visibility = if (isDownloading) View.VISIBLE else View.GONE
+            uploadProgress.visibility = if (isDownloading) View.VISIBLE else View.GONE
             // The Add text should not be View.GONE because the progress bar relies on its layout to position itself
-            text_add.visibility = if (isDownloading) View.INVISIBLE else View.VISIBLE
+            textAdd.visibility = if (isDownloading) View.INVISIBLE else View.VISIBLE
         })
     }
 


### PR DESCRIPTION
This PR introduces view bindings in the deprecated gif picker. It mostly serves as a POC. Let me know what you think about this approach. I'm pretty sure this activity is no longer used within our app (it's behind the consolidated media picker flag which is enabled for everyone). 

To test:
- Nothing to test here 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
