### PR TITLE
Test - Use RN Gutenberg bridge built from the gutenberg-mobile CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3230-ea0e970c60e261fdc5e4bb500da144349fd04a11'
+    ext.gutenbergMobileVersion = '3230-ca6390a52d226c3f5b3b23e149bfcdd3d2136295'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3230-98105ead0629a802cbae8771a870bccfd1d800a7'
+    ext.gutenbergMobileVersion = '3230-ea0e970c60e261fdc5e4bb500da144349fd04a11'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'locally-built-by-oguz-63'
+    ext.gutenbergMobileVersion = '3230-98105ead0629a802cbae8771a870bccfd1d800a7'
 
     repositories {
         google()


### PR DESCRIPTION
This is a test PR to verify that the binary that the `gutenberg-mobile` CI uploads to Bintray works. See https://github.com/wordpress-mobile/gutenberg-mobile/pull/3230.