### PR TITLE
Update analytics events to use more inclusive language

### DIFF
--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1541,9 +1541,9 @@ public class AnalyticsTrackerNosara extends Tracker {
             case SITE_SETTINGS_JETPACK_SECURITY_SETTINGS_VIEWED:
                 return "jetpack_settings_viewed";
             case SITE_SETTINGS_JETPACK_ALLOWLISTED_IPS_VIEWED:
-                return "jetpack_whitelisted_ips_viewed";
+                return "jetpack_allowlisted_ips_viewed";
             case SITE_SETTINGS_JETPACK_ALLOWLISTED_IPS_CHANGED:
-                return "jetpack_whitelisted_ips_changed";
+                return "jetpack_allowlisted_ips_changed";
             case ABTEST_START:
                 return "abtest_start";
             case FEATURE_FLAG_SET:


### PR DESCRIPTION
Related to #13619. 

While updating the terms on iOS I've also updated the analytics events names: https://github.com/wordpress-mobile/WordPress-iOS/pull/16025. Seems like it's fine to do update the events as long as iOS and Android are the same.

@malinajirka as the author of [the PR](https://github.com/wordpress-mobile/WordPress-Android/pull/13480) first introducing the changes, can you also please confirm if it's fine to change these event names?

To test:

Can be tested using the same instructions on https://github.com/wordpress-mobile/WordPress-Android/pull/13480 if needed.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
