### PR TITLE
Use View Binding in Reader ViewHolders

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
@@ -23,16 +23,12 @@ private const val recommendedBlogsViewType: Int = 4
 class ReaderDiscoverAdapter(
     private val uiHelpers: UiHelpers,
     private val imageManager: ImageManager
-) : Adapter<ReaderViewHolder>() {
+) : Adapter<ReaderViewHolder<*>>() {
     private val items = mutableListOf<ReaderCardUiState>()
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReaderViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReaderViewHolder<*> {
         return when (viewType) {
             welcomeBannerViewType -> WelcomeBannerViewHolder(parent)
-            postViewType -> ReaderPostViewHolder(
-                    uiHelpers,
-                    imageManager,
-                    parent
-            )
+            postViewType -> ReaderPostViewHolder(uiHelpers, imageManager, parent)
             interestViewType -> ReaderInterestsCardViewHolder(uiHelpers, parent)
             recommendedBlogsViewType -> ReaderRecommendedBlogsCardViewHolder(parent, imageManager, uiHelpers)
             else -> throw NotImplementedError("Unknown ViewType")
@@ -41,7 +37,7 @@ class ReaderDiscoverAdapter(
 
     override fun getItemCount(): Int = items.size
 
-    override fun onBindViewHolder(holder: ReaderViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: ReaderViewHolder<*>, position: Int) {
         holder.onBind(items[position])
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestViewHolder.kt
@@ -1,23 +1,19 @@
 package org.wordpress.android.ui.reader.discover.viewholders
 
-import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.content.res.AppCompatResources.getColorStateList
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.reader_interest_item.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.ReaderInterestItemBinding
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ReaderInterestUiState
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.viewBinding
 
 class ReaderInterestViewHolder(
     private val uiHelpers: UiHelpers,
-    internal val parent: ViewGroup,
-    override val containerView: View = LayoutInflater.from(parent.context)
-            .inflate(R.layout.reader_interest_item, parent, false)
-) : RecyclerView.ViewHolder(containerView), LayoutContainer {
-    fun onBind(uiState: ReaderInterestUiState) {
+    parent: ViewGroup,
+    private val binding: ReaderInterestItemBinding = parent.viewBinding(ReaderInterestItemBinding::inflate)
+) : RecyclerView.ViewHolder(binding.root) {
+    fun onBind(uiState: ReaderInterestUiState) = with(binding) {
         uiHelpers.setTextOrHide(interest, uiState.interest)
         interest.setOnClickListener { uiState.onClicked.invoke(uiState.interest) }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardViewHolder.kt
@@ -6,36 +6,38 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.OnItemTouchListener
-import kotlinx.android.synthetic.main.reader_interest_card.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.ReaderInterestCardBinding
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderInterestAdapter
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.viewBinding
 
 private const val Y_BUFFER = 10
 
 class ReaderInterestsCardViewHolder(
     uiHelpers: UiHelpers,
     parentView: ViewGroup
-) : ReaderViewHolder(parentView, R.layout.reader_interest_card) {
+) : ReaderViewHolder<ReaderInterestCardBinding>(parentView.viewBinding(ReaderInterestCardBinding::inflate)) {
     init {
-        if (interests_list.adapter == null) {
-            interests_list.layoutManager = LinearLayoutManager(interests_list.context, RecyclerView.HORIZONTAL, false)
-            val readerInterestAdapter = ReaderInterestAdapter(uiHelpers)
-            interests_list.adapter = readerInterestAdapter
+        with(binding.interestsList) {
+            if (adapter == null) {
+                layoutManager = LinearLayoutManager(context, RecyclerView.HORIZONTAL, false)
+                val readerInterestAdapter = ReaderInterestAdapter(uiHelpers)
+                adapter = readerInterestAdapter
+            }
         }
     }
 
-    override fun onBind(uiState: ReaderCardUiState) {
+    override fun onBind(uiState: ReaderCardUiState) = with(binding) {
         uiState as ReaderInterestsCardUiState
         setOnTouchItemListener()
-        (interests_list.adapter as ReaderInterestAdapter).update(uiState.interest)
+        (interestsList.adapter as ReaderInterestAdapter).update(uiState.interest)
     }
 
-    private fun setOnTouchItemListener() {
-        val gestureDetector = GestureDetector(interests_list.context, GestureListener())
-        interests_list.addOnItemTouchListener(object : OnItemTouchListener {
+    private fun setOnTouchItemListener() = with(binding) {
+        val gestureDetector = GestureDetector(interestsList.context, GestureListener())
+        interestsList.addOnItemTouchListener(object : OnItemTouchListener {
             override fun onInterceptTouchEvent(recyclerView: RecyclerView, e: MotionEvent): Boolean {
                 return gestureDetector.onTouchEvent(e)
             }
@@ -56,18 +58,23 @@ class ReaderInterestsCardViewHolder(
          * We need to do this immediately, because if we don't, then the next move event could potentially
          * trigger the viewPager to switch tabs
          */
-        override fun onDown(e: MotionEvent?): Boolean {
-            interests_list.parent.requestDisallowInterceptTouchEvent(true)
+        override fun onDown(e: MotionEvent?): Boolean = with(binding) {
+            interestsList.parent.requestDisallowInterceptTouchEvent(true)
             return super.onDown(e)
         }
 
-        override fun onScroll(e1: MotionEvent?, e2: MotionEvent?, distanceX: Float, distanceY: Float): Boolean {
+        override fun onScroll(
+            e1: MotionEvent?,
+            e2: MotionEvent?,
+            distanceX: Float,
+            distanceY: Float
+        ): Boolean = with(binding) {
             if (kotlin.math.abs(distanceX) > kotlin.math.abs(distanceY)) {
                 // Detected a horizontal scroll, prevent the viewpager from switching tabs
-                interests_list.parent.requestDisallowInterceptTouchEvent(true)
+                interestsList.parent.requestDisallowInterceptTouchEvent(true)
             } else if (kotlin.math.abs(distanceY) > Y_BUFFER) {
                 // Detected a vertical scroll allow the viewpager to switch tabs
-                interests_list.parent.requestDisallowInterceptTouchEvent(false)
+                interestsList.parent.requestDisallowInterceptTouchEvent(false)
             }
             return super.onScroll(e1, e2, distanceX, distanceY)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogViewHolder.kt
@@ -1,30 +1,27 @@
 package org.wordpress.android.ui.reader.discover.viewholders
 
-import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.reader_recommended_blog_item.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.ReaderRecommendedBlogItemBinding
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommendedBlogsCardUiState.ReaderRecommendedBlogUiState
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR_CIRCULAR
+import org.wordpress.android.util.viewBinding
 
 class ReaderRecommendedBlogViewHolder(
-    internal val parent: ViewGroup,
+    parent: ViewGroup,
     private val imageManager: ImageManager,
     private val uiHelpers: UiHelpers,
-    override val containerView: View = LayoutInflater.from(parent.context)
-            .inflate(R.layout.reader_recommended_blog_item, parent, false)
-) : RecyclerView.ViewHolder(containerView), LayoutContainer {
-    fun onBind(uiState: ReaderRecommendedBlogUiState) {
+    private val binding: ReaderRecommendedBlogItemBinding =
+            parent.viewBinding(ReaderRecommendedBlogItemBinding::inflate)
+) : RecyclerView.ViewHolder(binding.root) {
+    fun onBind(uiState: ReaderRecommendedBlogUiState) = with(binding) {
         with(uiState) {
-            site_name.text = name
-            site_url.text = url
-            uiHelpers.setTextOrHide(site_description, description)
-            site_follow_icon.apply {
+            siteName.text = name
+            siteUrl.text = url
+            uiHelpers.setTextOrHide(siteDescription, description)
+            siteFollowIcon.apply {
                 setIsFollowed(isFollowed)
                 contentDescription = context.getString(followContentDescription.stringRes)
                 setOnClickListener {
@@ -32,21 +29,21 @@ class ReaderRecommendedBlogViewHolder(
                 }
             }
             updateBlogImage(iconUrl)
-            containerView.setOnClickListener {
+            root.setOnClickListener {
                 onItemClicked(blogId, feedId)
             }
         }
     }
 
-    private fun updateBlogImage(iconUrl: String?) {
+    private fun updateBlogImage(iconUrl: String?) = with(binding) {
         if (iconUrl != null) {
             imageManager.loadIntoCircle(
-                    imageView = site_icon,
+                    imageView = siteIcon,
                     imageType = BLAVATAR_CIRCULAR,
                     imgUrl = iconUrl
             )
         } else {
-            imageManager.cancelRequestAndClearImageView(site_icon)
+            imageManager.cancelRequestAndClearImageView(siteIcon)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogsCardViewHolder.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.reader.discover.viewholders
 
 import android.view.ViewGroup
-import kotlinx.android.synthetic.main.reader_recommended_blogs_card.*
 import org.wordpress.android.R
+import org.wordpress.android.databinding.ReaderRecommendedBlogsCardBinding
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommendedBlogsCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderRecommendedBlogsAdapter
@@ -10,19 +10,24 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.addItemDivider
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.viewBinding
 
 class ReaderRecommendedBlogsCardViewHolder(
     parentView: ViewGroup,
     imageManager: ImageManager,
     uiHelpers: UiHelpers
-) : ReaderViewHolder(parentView, R.layout.reader_recommended_blogs_card) {
+) : ReaderViewHolder<ReaderRecommendedBlogsCardBinding>(
+        parentView.viewBinding(ReaderRecommendedBlogsCardBinding::inflate)
+) {
     private val recommendedBlogsAdapter = ReaderRecommendedBlogsAdapter(imageManager, uiHelpers)
 
     init {
-        recommended_blogs.adapter = recommendedBlogsAdapter
-        parentView.context.getDrawable(R.drawable.default_list_divider)?.let {
-            recommended_blogs.addItemDivider(it)
-        } ?: AppLog.w(AppLog.T.READER, "Discover list divider null")
+        with(binding) {
+            recommendedBlogs.adapter = recommendedBlogsAdapter
+            parentView.context.getDrawable(R.drawable.default_list_divider)?.let {
+                recommendedBlogs.addItemDivider(it)
+            } ?: AppLog.w(AppLog.T.READER, "Discover list divider null")
+        }
     }
 
     override fun onBind(uiState: ReaderCardUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRelatedPostViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRelatedPostViewHolder.kt
@@ -1,43 +1,36 @@
 package org.wordpress.android.ui.reader.discover.viewholders
 
-import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.reader_cardview_related_post.*
-import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.ReaderCardviewRelatedPostBinding
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.ReaderPostDetailsUiState.RelatedPostsUiState.ReaderRelatedPostUiState
-
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.PHOTO
+import org.wordpress.android.util.viewBinding
 
 class ReaderRelatedPostViewHolder(
     private val uiHelpers: UiHelpers,
     private val imageManager: ImageManager,
-    private val parent: ViewGroup,
-    override val containerView: View = LayoutInflater.from(parent.context).inflate(
-            R.layout.reader_cardview_related_post,
-            parent,
-            false
-    )
-) : RecyclerView.ViewHolder(containerView), LayoutContainer {
-    fun onBind(state: ReaderRelatedPostUiState) {
+    parent: ViewGroup,
+    private val binding: ReaderCardviewRelatedPostBinding =
+            parent.viewBinding(ReaderCardviewRelatedPostBinding::inflate)
+) : RecyclerView.ViewHolder(binding.root) {
+    fun onBind(state: ReaderRelatedPostUiState) = with(binding) {
         updateFeaturedImage(state)
-        uiHelpers.setTextOrHide(text_title, state.title)
-        uiHelpers.setTextOrHide(text_excerpt, state.excerpt)
+        uiHelpers.setTextOrHide(textTitle, state.title)
+        uiHelpers.setTextOrHide(textExcerpt, state.excerpt)
         itemView.setOnClickListener { state.onItemClicked.invoke(state.postId, state.blogId, state.isGlobal) }
     }
 
-    private fun updateFeaturedImage(state: ReaderRelatedPostUiState) {
-        uiHelpers.updateVisibility(image_featured, state.featuredImageVisibility)
+    private fun updateFeaturedImage(state: ReaderRelatedPostUiState) = with(binding) {
+        uiHelpers.updateVisibility(imageFeatured, state.featuredImageVisibility)
         if (state.featuredImageUrl == null) {
-            imageManager.cancelRequestAndClearImageView(image_featured)
+            imageManager.cancelRequestAndClearImageView(imageFeatured)
         } else {
             imageManager.loadImageWithCorners(
-                    image_featured,
+                    imageFeatured,
                     PHOTO,
                     state.featuredImageUrl,
                     uiHelpers.getPxOfUiDimen(WordPress.getContext(), state.featuredImageCornerRadius)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderViewHolder.kt
@@ -1,18 +1,9 @@
 package org.wordpress.android.ui.reader.discover.viewholders
 
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import androidx.annotation.LayoutRes
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.extensions.LayoutContainer
+import androidx.viewbinding.ViewBinding
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState
 
-abstract class ReaderViewHolder(
-    internal val parent: ViewGroup,
-    @LayoutRes private val layout: Int,
-    override val containerView: View = LayoutInflater.from(parent.context).inflate(layout, parent, false)
-) : RecyclerView.ViewHolder(containerView),
-        LayoutContainer {
+abstract class ReaderViewHolder<T : ViewBinding>(protected val binding: T) : RecyclerView.ViewHolder(binding.root) {
     abstract fun onBind(uiState: ReaderCardUiState)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/WelcomeBannerViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/WelcomeBannerViewHolder.kt
@@ -1,16 +1,18 @@
 package org.wordpress.android.ui.reader.discover.viewholders
 
 import android.view.ViewGroup
-import kotlinx.android.synthetic.main.reader_cardview_welcome_banner.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.ReaderCardviewWelcomeBannerBinding
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderWelcomeBannerCardUiState
+import org.wordpress.android.util.viewBinding
 
 class WelcomeBannerViewHolder(
     parentView: ViewGroup
-) : ReaderViewHolder(parentView, R.layout.reader_cardview_welcome_banner) {
-    override fun onBind(uiState: ReaderCardUiState) {
+) : ReaderViewHolder<ReaderCardviewWelcomeBannerBinding>(
+        parentView.viewBinding(ReaderCardviewWelcomeBannerBinding::inflate)
+) {
+    override fun onBind(uiState: ReaderCardUiState) = with(binding) {
         val state = uiState as ReaderWelcomeBannerCardUiState
-        welcome_title.setText(state.titleRes)
+        welcomeTitle.setText(state.titleRes)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/ViewBindingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ViewBindingUtils.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.util
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.viewbinding.ViewBinding
+
+inline fun <T : ViewBinding> ViewGroup.viewBinding(inflateBinding: (LayoutInflater, ViewGroup, Boolean) -> T) =
+        inflateBinding(LayoutInflater.from(context), this, false)


### PR DESCRIPTION
This PR introduces View Bindings for the Reader ViewHolders. The approach is a bit similar to #14211, except it delegates the layout inflation to an extension function (see 91bc58f). I believe this makes abstract ViewHolders like the `ReaderViewHolder` [a lot cleaner](https://github.com/wordpress-mobile/WordPress-Android/pull/14225/files#diff-cbef3240e5a7f026946cea2fb45debec28306677afb06c2321063c8e8ac1d1f7) and doesn't add much more complexity to its subclasses or concrete implementations like the [`ReaderInterestViewHolder`](https://github.com/wordpress-mobile/WordPress-Android/pull/14225/files#diff-e7ea8e780247dda3e6c846155f2fb7aadb3eaa281ac5c82b7eba4e6c89679e15).

To test:

Smoke test the Reader, with special attention for the Discover section and the Interests screen, and make sure everything is working as expected and nothing looks out of place.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
