### PR TITLE
Use view binding in activity log

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailActivity.kt
@@ -3,8 +3,8 @@ package org.wordpress.android.ui.activitylog.detail
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.R
+import org.wordpress.android.databinding.ActivityLogDetailActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface
@@ -15,9 +15,10 @@ class ActivityLogDetailActivity : LocaleAwareActivity(), BasicDialogPositiveClic
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setContentView(R.layout.activity_log_detail_activity)
+        val binding = ActivityLogDetailActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        setSupportActionBar(toolbar_main)
+        setSupportActionBar(binding.toolbarMain)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListActivity.kt
@@ -4,9 +4,9 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
-import kotlinx.android.synthetic.main.activity_log_list_activity.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.ActivityLogListActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailActivity
@@ -30,11 +30,11 @@ class ActivityLogListActivity : LocaleAwareActivity(),
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
+        val binding = ActivityLogListActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        binding.checkAndUpdateUiToBackupScreen()
 
-        setContentView(R.layout.activity_log_list_activity)
-        checkAndUpdateUiToBackupScreen()
-
-        setSupportActionBar(toolbar_main)
+        setSupportActionBar(binding.toolbarMain)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)
@@ -51,10 +51,10 @@ class ActivityLogListActivity : LocaleAwareActivity(),
      * necessity to split those features in separate screens in order not to increase further the complexity of this
      * screen's architecture.
      */
-    private fun checkAndUpdateUiToBackupScreen() {
+    private fun ActivityLogListActivityBinding.checkAndUpdateUiToBackupScreen() {
         if (intent.getBooleanExtra(ACTIVITY_LOG_REWINDABLE_ONLY_KEY, false)) {
             setTitle(R.string.backup)
-            activity_type_filter.visibility = View.GONE
+            activityTypeFilter.visibility = View.GONE
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -153,7 +153,11 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
         }
     }
 
-    private fun ActivityLogTypeFilterFragmentBinding.addMenuItem(action: ActivityLogTypeFilterViewModel.Action, order: Int, showAlways: Boolean) {
+    private fun ActivityLogTypeFilterFragmentBinding.addMenuItem(
+        action: ActivityLogTypeFilterViewModel.Action,
+        order: Int,
+        showAlways: Boolean
+    ) {
         val actionLabel = uiHelpers.getTextOfUiString(requireContext(), action.label)
         toolbarMain.menu.add(ACTIONS_MENU_GROUP, Menu.NONE, order, actionLabel).let {
             if (showAlways) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/filter/ActivityLogTypeFilterFragment.kt
@@ -13,10 +13,10 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.activity_log_type_filter_fragment.*
-import kotlinx.android.synthetic.main.progress_layout.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.ActivityLogTypeFilterFragmentBinding
+import org.wordpress.android.databinding.ProgressLayoutBinding
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.UiState.Content
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel.UiState.Error
@@ -38,6 +38,7 @@ private const val ACTIONS_MENU_GROUP = 1
  */
 private const val PRIMARY_ACTION_ORDER = 2
 private const val SECONDARY_ACTION_ORDER = 1
+
 /**
  * Always show the primary action no matter the screen size.
  */
@@ -63,39 +64,41 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initToolbar()
-        initRecyclerView()
-        initViewModel()
+        with(ActivityLogTypeFilterFragmentBinding.bind(view)) {
+            initToolbar()
+            initRecyclerView()
+            initViewModel()
+        }
     }
 
-    private fun initToolbar() {
-        toolbar_main.navigationIcon = ColorUtils.applyTintToDrawable(
-                toolbar_main.context, R.drawable.ic_close_white_24dp,
-                toolbar_main.context.getColorResIdFromAttribute(R.attr.colorOnSurface)
+    private fun ActivityLogTypeFilterFragmentBinding.initToolbar() {
+        toolbarMain.navigationIcon = ColorUtils.applyTintToDrawable(
+                toolbarMain.context, R.drawable.ic_close_white_24dp,
+                toolbarMain.context.getColorResIdFromAttribute(R.attr.colorOnSurface)
         )
-        toolbar_main.setNavigationContentDescription(R.string.close_dialog_button_desc)
-        toolbar_main.setNavigationOnClickListener { dismiss() }
+        toolbarMain.setNavigationContentDescription(R.string.close_dialog_button_desc)
+        toolbarMain.setNavigationOnClickListener { dismiss() }
     }
 
-    private fun initRecyclerView() {
-        recycler_view.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+    private fun ActivityLogTypeFilterFragmentBinding.initRecyclerView() {
+        recyclerView.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
         initAdapter()
     }
 
-    private fun initViewModel() {
-        viewModel = ViewModelProvider(this, viewModelFactory)
+    private fun ActivityLogTypeFilterFragmentBinding.initViewModel() {
+        viewModel = ViewModelProvider(this@ActivityLogTypeFilterFragment, viewModelFactory)
                 .get(ActivityLogTypeFilterViewModel::class.java)
 
         val parentViewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
                 .get(ActivityLogViewModel::class.java)
 
         viewModel.uiState.observe(viewLifecycleOwner, Observer { uiState ->
-            uiHelpers.updateVisibility(actionable_empty_view, uiState.errorVisibility)
-            uiHelpers.updateVisibility(recycler_view, uiState.contentVisibility)
-            uiHelpers.updateVisibility(progress_layout, uiState.loadingVisibility)
+            uiHelpers.updateVisibility(actionableEmptyView, uiState.errorVisibility)
+            uiHelpers.updateVisibility(recyclerView, uiState.contentVisibility)
+            uiHelpers.updateVisibility(progress.root, uiState.loadingVisibility)
             refreshMenuItems(uiState)
             when (uiState) {
-                is FullscreenLoading -> refreshLoadingScreen(uiState)
+                is FullscreenLoading -> progress.refreshLoadingScreen(uiState)
                 is Error -> refreshErrorScreen(uiState)
                 is Content -> refreshContentScreen(uiState)
             }
@@ -124,24 +127,24 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
         )
     }
 
-    private fun refreshLoadingScreen(uiState: FullscreenLoading) {
-        uiHelpers.setTextOrHide(progress_text, uiState.loadingText)
+    private fun ProgressLayoutBinding.refreshLoadingScreen(uiState: FullscreenLoading) {
+        uiHelpers.setTextOrHide(progressText, uiState.loadingText)
     }
 
-    private fun refreshErrorScreen(uiState: Error) {
-        actionable_empty_view.image.setImageResource(uiState.image)
-        uiHelpers.setTextOrHide(actionable_empty_view.title, uiState.title)
-        uiHelpers.setTextOrHide(actionable_empty_view.subtitle, uiState.subtitle)
-        uiHelpers.setTextOrHide(actionable_empty_view.button, uiState.buttonText)
-        actionable_empty_view.button.setOnClickListener { uiState.retryAction?.action?.invoke() }
+    private fun ActivityLogTypeFilterFragmentBinding.refreshErrorScreen(uiState: Error) {
+        actionableEmptyView.image.setImageResource(uiState.image)
+        uiHelpers.setTextOrHide(actionableEmptyView.title, uiState.title)
+        uiHelpers.setTextOrHide(actionableEmptyView.subtitle, uiState.subtitle)
+        uiHelpers.setTextOrHide(actionableEmptyView.button, uiState.buttonText)
+        actionableEmptyView.button.setOnClickListener { uiState.retryAction?.action?.invoke() }
     }
 
-    private fun refreshContentScreen(uiState: Content) {
-        (recycler_view.adapter as ActivityLogTypeFilterAdapter).update(uiState.items)
+    private fun ActivityLogTypeFilterFragmentBinding.refreshContentScreen(uiState: Content) {
+        (recyclerView.adapter as ActivityLogTypeFilterAdapter).update(uiState.items)
     }
 
-    private fun refreshMenuItems(uiState: ActivityLogTypeFilterViewModel.UiState) {
-        val menu = toolbar_main.menu
+    private fun ActivityLogTypeFilterFragmentBinding.refreshMenuItems(uiState: ActivityLogTypeFilterViewModel.UiState) {
+        val menu = toolbarMain.menu
         menu.removeGroup(ACTIONS_MENU_GROUP)
 
         if (uiState is Content) {
@@ -150,9 +153,9 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
         }
     }
 
-    private fun addMenuItem(action: ActivityLogTypeFilterViewModel.Action, order: Int, showAlways: Boolean) {
+    private fun ActivityLogTypeFilterFragmentBinding.addMenuItem(action: ActivityLogTypeFilterViewModel.Action, order: Int, showAlways: Boolean) {
         val actionLabel = uiHelpers.getTextOfUiString(requireContext(), action.label)
-        toolbar_main.menu.add(ACTIONS_MENU_GROUP, Menu.NONE, order, actionLabel).let {
+        toolbarMain.menu.add(ACTIONS_MENU_GROUP, Menu.NONE, order, actionLabel).let {
             if (showAlways) {
                 it.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
             } else {
@@ -165,8 +168,8 @@ class ActivityLogTypeFilterFragment : DialogFragment() {
         }
     }
 
-    private fun initAdapter() {
-        recycler_view.adapter = ActivityLogTypeFilterAdapter(uiHelpers)
+    private fun ActivityLogTypeFilterFragmentBinding.initAdapter() {
+        recyclerView.adapter = ActivityLogTypeFilterAdapter(uiHelpers)
     }
 
     companion object {

--- a/WordPress/src/main/res/layout/activity_log_detail_activity.xml
+++ b/WordPress/src/main/res/layout/activity_log_detail_activity.xml
@@ -20,7 +20,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:name="org.wordpress.android.ui.activitylog.detail.ActivityLogDetailFragment"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
+++ b/WordPress/src/main/res/layout/activity_log_type_filter_fragment.xml
@@ -36,7 +36,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <include layout="@layout/progress_layout" />
+    <include android:id="@+id/progress" layout="@layout/progress_layout" />
 
     <org.wordpress.android.ui.ActionableEmptyView
         android:id="@+id/actionable_empty_view"

--- a/WordPress/src/main/res/layout/progress_layout.xml
+++ b/WordPress/src/main/res/layout/progress_layout.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/progress_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center"


### PR DESCRIPTION
This PR replaces synth accessors with view bindings in the activity log classes (list, detail and the filters). In several places I've used `findViewById` to reach a view in the parent activity. I think it's the cleanest way forward at the moment but it's not a great approach. Changing it would require the activity to use the view model instead of the fragment. 

This line `requireActivity().findViewById<View>(R.id.progress)` is IMO incorrect. We're trying to show/hide an item in a viewholder. However, changing that is out of scope of this PR.

To test:
- Go to activity log
- Check it looks OK
- Go to an item detail
- Try several filters
- Check everything works as expected

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
