### PR TITLE
Use viewModelScope instead of casting ViewModel to CoroutineScope

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -22,12 +22,12 @@ import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.GridLayoutManager.SpanSizeLookup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.media_picker_fragment.*
-import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
@@ -496,7 +496,7 @@ class MediaPickerFragment : Fragment() {
         if (recycler.adapter == null) {
             recycler.adapter = MediaPickerAdapter(
                     imageManager,
-                    viewModel as CoroutineScope
+                    viewModel.viewModelScope
             )
         }
         val adapter = recycler.adapter as MediaPickerAdapter

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -15,11 +15,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.android.synthetic.main.photo_picker_fragment.*
 import kotlinx.android.synthetic.main.photo_picker_fragment.view.*
-import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
@@ -224,7 +224,7 @@ class PhotoPickerFragment : Fragment() {
             if (recycler.adapter == null) {
                 recycler.adapter = PhotoPickerAdapter(
                         imageManager,
-                        viewModel as CoroutineScope
+                        viewModel.viewModelScope
                 )
             }
             val adapter = recycler.adapter as PhotoPickerAdapter


### PR DESCRIPTION
The changes introduced by #14186 meant that a `ScopedViewModel` no longer implemented the `CoroutineScope` interface, but we missed a couple of cases where a `ViewModel` was being casted to a `CoroutineScope`, which in turn was causing a `ClassCastException` when trying to opening the photo/media picker. This PR uses the `viewModelScope` to replace those castings.

To test:

1. Open the app.
1. On the My Site screen, tap the Media button.
1. On the Media screen, tap the + button and select "Choose from the device".
1. Make sure the app doesn't crash.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
