### PR TITLE
Use View Binding in My Site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -107,6 +107,7 @@ import org.wordpress.android.ui.main.WPMainActivity.OnScrollToTopListener
 import org.wordpress.android.ui.main.utils.MeGravatarLoader
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
+import org.wordpress.android.ui.photopicker.MediaPickerConstants.EXTRA_MEDIA_SOURCE
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource.ANDROID_CAMERA
@@ -176,8 +177,10 @@ import java.util.TimeZone
 import javax.inject.Inject
 import javax.inject.Named
 
-@Deprecated("This class is being refactored, if you implement any change, please also update " +
-        "{@link org.wordpress.android.ui.mysite.ImprovedMySiteFragment}")
+@Deprecated(
+        "This class is being refactored, if you implement any change, please also update " +
+                "{@link org.wordpress.android.ui.mysite.ImprovedMySiteFragment}"
+)
 class MySiteFragment : Fragment(R.layout.my_site_fragment),
         OnScrollToTopListener,
         BasicDialogPositiveClickInterface,
@@ -426,90 +429,34 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             viewPages()
         }
         rowPages.setOnClickListener { viewPages() }
-        rowComments.setOnClickListener {
-            ActivityLauncher.viewCurrentBlogComments(
-                    activity,
-                    selectedSite
-            )
-        }
+        rowComments.setOnClickListener { ActivityLauncher.viewCurrentBlogComments(activity, selectedSite) }
         rowThemes.setOnClickListener {
             if (themeBrowserUtils.isAccessible(selectedSite)) {
                 ActivityLauncher.viewCurrentBlogThemes(activity, selectedSite)
             }
         }
-        rowPeople.setOnClickListener {
-            ActivityLauncher.viewCurrentBlogPeople(
-                    activity,
-                    selectedSite
-            )
-        }
-        rowPlugins.setOnClickListener {
-            ActivityLauncher.viewPluginBrowser(
-                    activity,
-                    selectedSite
-            )
-        }
-        rowActivityLog.setOnClickListener {
-            ActivityLauncher.viewActivityLogList(
-                    activity,
-                    selectedSite
-            )
-        }
-        rowBackup.setOnClickListener {
-            ActivityLauncher.viewBackupList(
-                    activity,
-                    selectedSite
-            )
-        }
-        rowScan.setOnClickListener {
-            ActivityLauncher.viewScan(
-                    activity,
-                    selectedSite
-            )
-        }
-        rowSettings.setOnClickListener {
-            ActivityLauncher.viewBlogSettingsForResult(
-                    activity,
-                    selectedSite
-            )
-        }
+        rowPeople.setOnClickListener { ActivityLauncher.viewCurrentBlogPeople(activity, selectedSite) }
+        rowPlugins.setOnClickListener { ActivityLauncher.viewPluginBrowser(activity, selectedSite) }
+        rowActivityLog.setOnClickListener { ActivityLauncher.viewActivityLogList(activity, selectedSite) }
+        rowBackup.setOnClickListener { ActivityLauncher.viewBackupList(activity, selectedSite) }
+        rowScan.setOnClickListener { ActivityLauncher.viewScan(activity, selectedSite) }
+        rowSettings.setOnClickListener { ActivityLauncher.viewBlogSettingsForResult(activity, selectedSite) }
         rowSharing.setOnClickListener {
-            if (isQuickStartTaskActive(ENABLE_POST_SHARING)) {
-                requestNextStepOfActiveQuickStartTask()
-            }
+            if (isQuickStartTaskActive(ENABLE_POST_SHARING)) requestNextStepOfActiveQuickStartTask()
             ActivityLauncher.viewBlogSharing(activity, selectedSite)
         }
-        rowAdmin.setOnClickListener {
-            ActivityLauncher.viewBlogAdmin(
-                    activity,
-                    selectedSite
-            )
-        }
+        rowAdmin.setOnClickListener { ActivityLauncher.viewBlogAdmin(activity, selectedSite) }
         actionableEmptyView.button.setOnClickListener {
-            SitePickerActivity.addSite(
-                    activity,
-                    accountStore.hasAccessToken()
-            )
+            SitePickerActivity.addSite(activity, accountStore.hasAccessToken())
         }
-        quickStartCustomize.setOnClickListener {
-            showQuickStartList(
-                    CUSTOMIZE
-            )
-        }
-        quickStartGrow.setOnClickListener {
-            showQuickStartList(
-                    GROW
-            )
-        }
+        quickStartCustomize.setOnClickListener { showQuickStartList(CUSTOMIZE) }
+        quickStartGrow.setOnClickListener { showQuickStartList(GROW) }
         quickStartMore.setOnClickListener { showQuickStartCardMenu() }
     }
 
     private fun registerDomain() {
         AnalyticsUtils.trackWithSiteDetails(DOMAIN_CREDIT_REDEMPTION_TAPPED, selectedSite)
-        ActivityLauncher.viewDomainRegistrationActivityForResult(
-                activity, selectedSite,
-                CTA_DOMAIN_CREDIT_REDEMPTION
-        )
+        ActivityLauncher.viewDomainRegistrationActivityForResult(activity, selectedSite, CTA_DOMAIN_CREDIT_REDEMPTION)
     }
 
     private fun viewMedia() {
@@ -860,40 +807,30 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             }
             RequestCodes.PHOTO_PICKER -> if (resultCode == Activity.RESULT_OK && data != null) {
                 if (!storiesMediaPickerResultHandler.handleMediaPickerResultForStories(
-                                data, activity, selectedSite, STORY_FROM_MY_SITE)) {
+                                data, activity, selectedSite, STORY_FROM_MY_SITE
+                        )
+                ) {
                     if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_ID)) {
                         val mediaId = data.getLongExtra(MediaPickerConstants.EXTRA_MEDIA_ID, 0).toInt()
                         updateSiteIconMediaId(mediaId, true)
                     } else {
-                        val mediaUriStringsArray = data.getStringArrayExtra(
-                                MediaPickerConstants.EXTRA_MEDIA_URIS
-                        )
+                        val mediaUriStringsArray = data.getStringArrayExtra(MediaPickerConstants.EXTRA_MEDIA_URIS)
                         if (mediaUriStringsArray.isNullOrEmpty()) {
-                            AppLog.e(
-                                    UTILS,
-                                    "Can't resolve picked or captured image"
-                            )
+                            AppLog.e(UTILS, "Can't resolve picked or captured image")
                             return
                         }
 
-                        val source = PhotoPickerMediaSource.fromString(
-                                data.getStringExtra(MediaPickerConstants.EXTRA_MEDIA_SOURCE)
-                        )
+                        val source = PhotoPickerMediaSource.fromString(data.getStringExtra(EXTRA_MEDIA_SOURCE))
                         val stat = if (source == ANDROID_CAMERA) MY_SITE_ICON_SHOT_NEW else MY_SITE_ICON_GALLERY_PICKED
                         AnalyticsTracker.track(stat)
                         val imageUri = Uri.parse(mediaUriStringsArray[0])
                         if (imageUri != null) {
-                            val didGoWell = WPMediaUtils.fetchMediaAndDoNext(
-                                    activity, imageUri
-                            ) { uri: Uri ->
+                            val didGoWell = WPMediaUtils.fetchMediaAndDoNext(activity, imageUri) { uri: Uri ->
                                 selectedSiteRepository.showSiteIconProgressBar(true)
                                 startCropActivity(uri)
                             }
                             if (!didGoWell) {
-                                AppLog.e(
-                                        UTILS,
-                                        "Can't download picked or captured image"
-                                )
+                                AppLog.e(UTILS, "Can't download picked or captured image")
                             }
                         }
                     }
@@ -909,24 +846,12 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             }
             UCrop.REQUEST_CROP -> if (resultCode == Activity.RESULT_OK) {
                 AnalyticsTracker.track(MY_SITE_ICON_CROPPED)
-                WPMediaUtils.fetchMediaAndDoNext(
-                        activity, UCrop.getOutput(data!!)
-                ) { uri: Uri? ->
-                    startSiteIconUpload(
-                            MediaUtils.getRealPathFromURI(activity, uri)
-                    )
+                WPMediaUtils.fetchMediaAndDoNext(activity, UCrop.getOutput(data!!)) { uri: Uri? ->
+                    startSiteIconUpload(MediaUtils.getRealPathFromURI(activity, uri))
                 }
             } else if (resultCode == UCrop.RESULT_ERROR) {
-                AppLog.e(
-                        MAIN,
-                        "Image cropping failed!",
-                        UCrop.getError(data!!)
-                )
-                ToastUtils.showToast(
-                        activity,
-                        R.string.error_cropping_image,
-                        SHORT
-                )
+                AppLog.e(MAIN, "Image cropping failed!", UCrop.getError(data!!))
+                ToastUtils.showToast(activity, R.string.error_cropping_image, SHORT)
             }
             RequestCodes.DOMAIN_REGISTRATION -> if (resultCode == Activity.RESULT_OK && isAdded && data != null) {
                 AnalyticsTracker.track(DOMAIN_CREDIT_REDEMPTION_SUCCESS)
@@ -1038,27 +963,27 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             return
         }
         if (site == null) {
-            scrollView.visibility = View.GONE
-            actionableEmptyView.visibility = View.VISIBLE
-
-            // Hide actionable empty view image when screen height is under 600 pixels.
-            if (DisplayUtils.getDisplayPixelHeight(activity) >= 600) {
-                actionableEmptyView.image.visibility = View.VISIBLE
-            } else {
-                actionableEmptyView.image.visibility = View.GONE
-            }
-            return
-        }
-        if (SiteUtils.onFreePlan(site) || SiteUtils.hasCustomDomain(
-                        site
-                )) {
-            isDomainCreditAvailable = false
-            toggleDomainRegistrationCtaVisibility()
-        } else if (!isDomainCreditChecked) {
-            fetchSitePlans(site)
+            showEmptyView()
         } else {
-            toggleDomainRegistrationCtaVisibility()
+            showContent(site)
         }
+    }
+
+    private fun MySiteFragmentBinding.showEmptyView() {
+        scrollView.visibility = View.GONE
+        actionableEmptyView.visibility = View.VISIBLE
+
+        // Hide actionable empty view image when screen height is under 600 pixels.
+        if (DisplayUtils.getDisplayPixelHeight(activity) >= 600) {
+            actionableEmptyView.image.visibility = View.VISIBLE
+        } else {
+            actionableEmptyView.image.visibility = View.GONE
+        }
+    }
+
+    private fun MySiteFragmentBinding.showContent(site: SiteModel) {
+        showDomainRegistrationIfNeeded(site)
+
         scrollView.visibility = View.VISIBLE
         actionableEmptyView.visibility = View.GONE
         toggleAdminVisibility(site)
@@ -1071,9 +996,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         rowSharing.visibility = sharingVisibility
 
         // show settings for all self-hosted to expose Delete Site
-        val isAdminOrSelfHosted = site.hasCapabilityManageOptions || !SiteUtils.isAccessedViaWPComRest(
-                site
-        )
+        val isAdminOrSelfHosted = site.hasCapabilityManageOptions || !SiteUtils.isAccessedViaWPComRest(site)
         rowSettings.visibility = if (isAdminOrSelfHosted) View.VISIBLE else View.GONE
         rowPeople.visibility = if (site.hasCapabilityListUsers) View.VISIBLE else View.GONE
         rowPlugins.visibility = if (PluginUtils.isPluginFeatureAvailable(site)) View.VISIBLE else View.GONE
@@ -1092,18 +1015,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         siteInfoContainer.subtitle.text = homeUrl
 
         // Hide the Plan item if the Plans feature is not available for this blog
-        val planShortName = site.planShortName
-        if (!TextUtils.isEmpty(planShortName) && site.hasCapabilityManageOptions && !site.isWpForTeamsSite) {
-            if (site.isWPCom || site.isAutomatedTransfer) {
-                mySiteCurrentPlanTextView.text = planShortName
-                rowPlan.visibility = View.VISIBLE
-            } else {
-                // TODO: Support Jetpack plans
-                rowPlan.visibility = View.GONE
-            }
-        } else {
-            rowPlan.visibility = View.GONE
-        }
+        showPlanIfNeeded(site)
 
         val jetpackSectionVisible = site.isJetpackConnected && // jetpack is installed and connected
                 !site.isWPComAtomic // isn't atomic site
@@ -1120,6 +1032,32 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         rowPages.visibility = pageVisibility
         quickActionPagesContainer.visibility = pageVisibility
         middleQuickActionSpacing.visibility = pageVisibility
+    }
+
+    private fun MySiteFragmentBinding.showDomainRegistrationIfNeeded(site: SiteModel) {
+        if (SiteUtils.onFreePlan(site) || SiteUtils.hasCustomDomain(site)) {
+            isDomainCreditAvailable = false
+            toggleDomainRegistrationCtaVisibility()
+        } else if (!isDomainCreditChecked) {
+            fetchSitePlans(site)
+        } else {
+            toggleDomainRegistrationCtaVisibility()
+        }
+    }
+
+    private fun MySiteFragmentBinding.showPlanIfNeeded(site: SiteModel) {
+        val planShortName = site.planShortName
+        if (!TextUtils.isEmpty(planShortName) && site.hasCapabilityManageOptions && !site.isWpForTeamsSite) {
+            if (site.isWPCom || site.isAutomatedTransfer) {
+                mySiteCurrentPlanTextView.text = planShortName
+                rowPlan.visibility = View.VISIBLE
+            } else {
+                // TODO: Support Jetpack plans
+                rowPlan.visibility = View.GONE
+            }
+        } else {
+            rowPlan.visibility = View.GONE
+        }
     }
 
     private fun MySiteFragmentBinding.toggleAdminVisibility(site: SiteModel?) {
@@ -1213,39 +1151,37 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         EventBus.getDefault().removeStickyEvent(event)
         val site = selectedSite
         if (site != null) {
-            if (isMediaUploadInProgress) {
-                if (event.mediaModelList.size > 0) {
-                    binding?.apply {
-                        val media = event.mediaModelList[0]
-                        imageManager.load(
-                                mySiteBlavatar,
-                                BLAVATAR,
-                                PhotonUtils
-                                        .getPhotonImageUrl(
-                                                media.url,
-                                                blavatarSz,
-                                                blavatarSz,
-                                                HIGH,
-                                                site.isPrivateWPComAtomic
-                                        )
+            binding?.handleUploadMediaSuccessEvent(site, event)
+        }
+    }
+
+    private fun MySiteFragmentBinding.handleUploadMediaSuccessEvent(site: SiteModel, event: UploadMediaSuccessEvent) {
+        if (isMediaUploadInProgress) {
+            if (event.mediaModelList.size > 0) {
+                val media = event.mediaModelList[0]
+                imageManager.load(
+                        mySiteBlavatar,
+                        BLAVATAR,
+                        PhotonUtils.getPhotonImageUrl(
+                                media.url,
+                                blavatarSz,
+                                blavatarSz,
+                                HIGH,
+                                site.isPrivateWPComAtomic
                         )
-                        updateSiteIconMediaId(media.mediaId.toInt(), false)
-                    }
-                } else {
-                    AppLog.w(
-                            MAIN,
-                            "Site icon upload completed, but mediaList is empty."
-                    )
-                }
-                selectedSiteRepository.showSiteIconProgressBar(false)
+                )
+                updateSiteIconMediaId(media.mediaId.toInt(), false)
             } else {
-                if (event.mediaModelList != null && event.mediaModelList.isNotEmpty()) {
-                    uploadUtilsWrapper.onMediaUploadedSnackbarHandler(
-                            activity,
-                            requireActivity().findViewById(R.id.coordinator), false,
-                            event.mediaModelList, site, event.successMessage
-                    )
-                }
+                AppLog.w(MAIN, "Site icon upload completed, but mediaList is empty.")
+            }
+            selectedSiteRepository.showSiteIconProgressBar(false)
+        } else {
+            if (event.mediaModelList != null && event.mediaModelList.isNotEmpty()) {
+                uploadUtilsWrapper.onMediaUploadedSnackbarHandler(
+                        activity,
+                        requireActivity().findViewById(R.id.coordinator), false,
+                        event.mediaModelList, site, event.successMessage
+                )
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/DomainRegistrationViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/DomainRegistrationViewHolder.kt
@@ -1,14 +1,14 @@
 package org.wordpress.android.ui.mysite
 
 import android.view.ViewGroup
-import kotlinx.android.synthetic.main.domain_registration_block.view.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.DomainRegistrationBlockBinding
 import org.wordpress.android.ui.mysite.MySiteItem.DomainRegistrationBlock
+import org.wordpress.android.util.viewBinding
 
 class DomainRegistrationViewHolder(
     parent: ViewGroup
-) : MySiteItemViewHolder(parent, R.layout.domain_registration_block) {
-    fun bind(item: DomainRegistrationBlock) = itemView.apply {
-        my_site_register_domain_cta.setOnClickListener { item.onClick.click() }
+) : MySiteItemViewHolder<DomainRegistrationBlockBinding>(parent.viewBinding(DomainRegistrationBlockBinding::inflate)) {
+    fun bind(item: DomainRegistrationBlock) = with(binding) {
+        mySiteRegisterDomainCta.setOnClickListener { item.onClick.click() }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/ImprovedMySiteFragment.kt
@@ -5,9 +5,8 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.appcompat.widget.TooltipCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -17,12 +16,10 @@ import com.google.android.material.snackbar.Snackbar
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity
-import kotlinx.android.synthetic.main.main_activity.*
-import kotlinx.android.synthetic.main.me_action_layout.*
-import kotlinx.android.synthetic.main.new_my_site_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.R.attr
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.NewMySiteFragmentBinding
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.TextInputDialogFragment
@@ -91,7 +88,7 @@ import org.wordpress.android.viewmodel.observeEvent
 import java.io.File
 import javax.inject.Inject
 
-class ImprovedMySiteFragment : Fragment(),
+class ImprovedMySiteFragment : Fragment(R.layout.new_my_site_fragment),
         TextInputDialogFragment.Callback {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var imageManager: ImageManager
@@ -105,6 +102,8 @@ class ImprovedMySiteFragment : Fragment(),
     private lateinit var dialogViewModel: BasicDialogViewModel
     private lateinit var dynamicCardMenuViewModel: DynamicCardMenuViewModel
 
+    private var binding: NewMySiteFragmentBinding? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
@@ -115,27 +114,34 @@ class ImprovedMySiteFragment : Fragment(),
                 .get(DynamicCardMenuViewModel::class.java)
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(
-                R.layout.new_my_site_fragment,
-                container,
-                false
-        )
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding = NewMySiteFragmentBinding.bind(view).apply {
+            setupToolbar()
+            setupContentViews(savedInstanceState)
+            setupObservers()
+        }
+    }
 
-        appbar_main.addOnOffsetChangedListener(OnOffsetChangedListener { appBarLayout, verticalOffset ->
+    private fun NewMySiteFragmentBinding.setupToolbar() {
+        toolbarMain.let { toolbar ->
+            toolbar.inflateMenu(R.menu.my_site_menu)
+            toolbar.menu.findItem(R.id.me_item)?.let { meMenu ->
+                meMenu.actionView.let { actionView ->
+                    actionView.setOnClickListener { viewModel.onAvatarPressed() }
+                    TooltipCompat.setTooltipText(actionView, meMenu.title)
+                }
+            }
+        }
+
+        val avatar = root.findViewById<ImageView>(R.id.avatar)
+
+        appbarMain.addOnOffsetChangedListener(OnOffsetChangedListener { appBarLayout, verticalOffset ->
             val maxOffset = appBarLayout.totalScrollRange
             val currentOffset = maxOffset + verticalOffset
 
             val percentage = ((currentOffset.toFloat() / maxOffset.toFloat()) * 100).toInt()
-            avatar?.let {
+            avatar?.let { avatar ->
                 val minSize = avatar.minimumHeight
                 val maxSize = avatar.maxHeight
                 val modifierPx = (minSize.toFloat() - maxSize.toFloat()) * (percentage.toFloat() / 100) * -1
@@ -146,18 +152,10 @@ class ImprovedMySiteFragment : Fragment(),
                 avatar.scaleY = newScale
             }
         })
+    }
 
-        toolbar_main.let { toolbar ->
-            toolbar.inflateMenu(R.menu.my_site_menu)
-            toolbar.menu.findItem(R.id.me_item)?.let { meMenu ->
-                meMenu.actionView.let { actionView ->
-                    actionView.setOnClickListener { viewModel.onAvatarPressed() }
-                    TooltipCompat.setTooltipText(actionView, meMenu.title)
-                }
-            }
-        }
-
-        actionable_empty_view.button.setOnClickListener { viewModel.onAddSitePressed() }
+    private fun NewMySiteFragmentBinding.setupContentViews(savedInstanceState: Bundle?) {
+        actionableEmptyView.button.setOnClickListener { viewModel.onAddSitePressed() }
 
         val layoutManager = LinearLayoutManager(activity)
 
@@ -165,7 +163,7 @@ class ImprovedMySiteFragment : Fragment(),
             layoutManager.onRestoreInstanceState(it)
         }
 
-        recycler_view.layoutManager = layoutManager
+        recyclerView.layoutManager = layoutManager
 
         val adapter = MySiteAdapter(imageManager, uiHelpers)
 
@@ -173,8 +171,10 @@ class ImprovedMySiteFragment : Fragment(),
             adapter.onRestoreInstanceState(it)
         }
 
-        recycler_view.adapter = adapter
+        recyclerView.adapter = adapter
+    }
 
+    private fun NewMySiteFragmentBinding.setupObservers() {
         viewModel.uiModel.observe(viewLifecycleOwner, {
             it?.let { uiModel ->
                 loadGravatar(uiModel.accountAvatarUrl)
@@ -185,7 +185,7 @@ class ImprovedMySiteFragment : Fragment(),
             }
         })
         viewModel.onScrollTo.observeEvent(viewLifecycleOwner, {
-            (recycler_view.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(it, 0)
+            (recyclerView.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(it, 0)
         })
         viewModel.onBasicDialogShown.observeEvent(viewLifecycleOwner, { model ->
             dialogViewModel.showDialog(requireActivity().supportFragmentManager,
@@ -207,7 +207,7 @@ class ImprovedMySiteFragment : Fragment(),
                     model.isInputEnabled,
                     model.callbackId
             )
-            inputDialog.setTargetFragment(this, 0)
+            inputDialog.setTargetFragment(this@ImprovedMySiteFragment, 0)
             inputDialog.show(parentFragmentManager, TextInputDialogFragment.TAG)
         })
         viewModel.onDynamicCardMenuShown.observeEvent(viewLifecycleOwner, { dynamicCardMenuModel ->
@@ -223,7 +223,7 @@ class ImprovedMySiteFragment : Fragment(),
                 is OpenMeScreen -> ActivityLauncher.viewMeActivityForResult(activity)
                 is OpenSitePicker -> ActivityLauncher.showSitePickerForResult(activity, action.site)
                 is OpenSite -> ActivityLauncher.viewCurrentSite(activity, action.site, true)
-                is OpenMediaPicker -> mediaPickerLauncher.showSiteIconPicker(this, action.site)
+                is OpenMediaPicker -> mediaPickerLauncher.showSiteIconPicker(this@ImprovedMySiteFragment, action.site)
                 is OpenCropActivity -> startCropActivity(action.imageUri)
                 is OpenActivityLog -> ActivityLauncher.viewActivityLogList(activity, action.site)
                 is OpenBackup -> ActivityLauncher.viewBackupList(activity, action.site)
@@ -241,7 +241,7 @@ class ImprovedMySiteFragment : Fragment(),
                 is OpenComments -> ActivityLauncher.viewCurrentBlogComments(activity, action.site)
                 is OpenStats -> ActivityLauncher.viewBlogStats(activity, action.site)
                 is ConnectJetpackForStats -> ActivityLauncher.viewConnectJetpackForStats(activity, action.site)
-                is StartWPComLoginForJetpackStats -> ActivityLauncher.loginForJetpackStats(this)
+                is StartWPComLoginForJetpackStats -> ActivityLauncher.loginForJetpackStats(this@ImprovedMySiteFragment)
                 is OpenJetpackSettings -> ActivityLauncher.viewJetpackSecuritySettings(activity, action.site)
                 is OpenStories -> ActivityLauncher.viewStories(activity, action.site, action.event)
                 is AddNewStory ->
@@ -343,24 +343,30 @@ class ImprovedMySiteFragment : Fragment(),
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        recycler_view?.layoutManager?.let {
+        binding?.recyclerView?.layoutManager?.let {
             outState.putParcelable(KEY_LIST_STATE, it.onSaveInstanceState())
         }
-        (recycler_view?.adapter as? MySiteAdapter)?.let {
+        (binding?.recyclerView?.adapter as? MySiteAdapter)?.let {
             outState.putBundle(KEY_NESTED_LISTS_STATES, it.onSaveInstanceState())
         }
     }
 
-    private fun loadGravatar(avatarUrl: String) = avatar?.let {
-        meGravatarLoader.load(
-                false,
-                meGravatarLoader.constructGravatarUrl(avatarUrl),
-                null,
-                it,
-                USER,
-                null
-        )
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
     }
+
+    private fun NewMySiteFragmentBinding.loadGravatar(avatarUrl: String) =
+            root.findViewById<ImageView>(R.id.avatar)?.let {
+                meGravatarLoader.load(
+                        false,
+                        meGravatarLoader.constructGravatarUrl(avatarUrl),
+                        null,
+                        it,
+                        USER,
+                        null
+                )
+            }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
@@ -427,16 +433,16 @@ class ImprovedMySiteFragment : Fragment(),
         }
     }
 
-    private fun loadData(items: List<MySiteItem>) {
-        recycler_view.setVisible(true)
-        actionable_empty_view.setVisible(false)
-        (recycler_view.adapter as? MySiteAdapter)?.loadData(items)
+    private fun NewMySiteFragmentBinding.loadData(items: List<MySiteItem>) {
+        recyclerView.setVisible(true)
+        actionableEmptyView.setVisible(false)
+        (recyclerView.adapter as? MySiteAdapter)?.loadData(items)
     }
 
-    private fun loadEmptyView(shouldShowEmptyViewImage: Boolean) {
-        recycler_view.setVisible(false)
-        actionable_empty_view.setVisible(true)
-        actionable_empty_view.image.setVisible(shouldShowEmptyViewImage)
+    private fun NewMySiteFragmentBinding.loadEmptyView(shouldShowEmptyViewImage: Boolean) {
+        recyclerView.setVisible(false)
+        actionableEmptyView.setVisible(true)
+        actionableEmptyView.image.setVisible(shouldShowEmptyViewImage)
     }
 
     private fun showSnackbar(holder: SnackbarMessageHolder) {
@@ -444,7 +450,7 @@ class ImprovedMySiteFragment : Fragment(),
             snackbarSequencer.enqueue(
                     SnackbarItem(
                             Info(
-                                    view = parent.coordinator,
+                                    view = parent.findViewById(R.id.coordinator),
                                     textRes = holder.message,
                                     duration = Snackbar.LENGTH_LONG
                             ),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -20,7 +20,7 @@ import org.wordpress.android.ui.mysite.MySiteItem.Type.SITE_INFO_BLOCK
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 
-class MySiteAdapter(val imageManager: ImageManager, val uiHelpers: UiHelpers) : Adapter<MySiteItemViewHolder>() {
+class MySiteAdapter(val imageManager: ImageManager, val uiHelpers: UiHelpers) : Adapter<MySiteItemViewHolder<*>>() {
     private var items = listOf<MySiteItem>()
     private val quickStartViewPool = RecycledViewPool()
     private var nestedScrollStates = Bundle()
@@ -33,7 +33,7 @@ class MySiteAdapter(val imageManager: ImageManager, val uiHelpers: UiHelpers) : 
         diffResult.dispatchUpdatesTo(this)
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MySiteItemViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MySiteItemViewHolder<*> {
         return when (viewType) {
             SITE_INFO_BLOCK.ordinal -> MySiteInfoViewHolder(parent, imageManager)
             QUICK_ACTIONS_BLOCK.ordinal -> QuickActionsViewHolder(parent)
@@ -50,7 +50,7 @@ class MySiteAdapter(val imageManager: ImageManager, val uiHelpers: UiHelpers) : 
         }
     }
 
-    override fun onBindViewHolder(holder: MySiteItemViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: MySiteItemViewHolder<*>, position: Int) {
         when (holder) {
             is MySiteInfoViewHolder -> holder.bind(items[position] as SiteInfoBlock)
             is QuickActionsViewHolder -> holder.bind(items[position] as QuickActionsBlock)
@@ -61,7 +61,7 @@ class MySiteAdapter(val imageManager: ImageManager, val uiHelpers: UiHelpers) : 
         }
     }
 
-    override fun onViewRecycled(holder: MySiteItemViewHolder) {
+    override fun onViewRecycled(holder: MySiteItemViewHolder<*>) {
         super.onViewRecycled(holder)
         if (holder is QuickStartCardViewHolder) {
             holder.onRecycled()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCategoryViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCategoryViewHolder.kt
@@ -1,17 +1,18 @@
 package org.wordpress.android.ui.mysite
 
 import android.view.ViewGroup
-import android.widget.TextView
-import org.wordpress.android.R
+import org.wordpress.android.databinding.MySiteCategoryHeaderBlockBinding
 import org.wordpress.android.ui.mysite.MySiteItem.CategoryHeader
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.viewBinding
 
-class MySiteCategoryViewHolder(parent: ViewGroup, private val uiHelpers: UiHelpers) : MySiteItemViewHolder(
-        parent,
-        R.layout.my_site_category_header_block
+class MySiteCategoryViewHolder(
+    parent: ViewGroup,
+    private val uiHelpers: UiHelpers
+) : MySiteItemViewHolder<MySiteCategoryHeaderBlockBinding>(
+        parent.viewBinding(MySiteCategoryHeaderBlockBinding::inflate)
 ) {
-    private val category = itemView.findViewById<TextView>(R.id.category)
-    fun bind(item: CategoryHeader) {
+    fun bind(item: CategoryHeader) = with(binding) {
         uiHelpers.setTextOrHide(category, item.title)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteInfoViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteInfoViewHolder.kt
@@ -2,32 +2,18 @@ package org.wordpress.android.ui.mysite
 
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageButton
-import android.widget.ImageView
-import android.widget.ProgressBar
-import org.wordpress.android.R
+import org.wordpress.android.databinding.MySiteInfoBlockBinding
 import org.wordpress.android.ui.mysite.MySiteItem.SiteInfoBlock
 import org.wordpress.android.ui.mysite.MySiteItem.SiteInfoBlock.IconState
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR
-import org.wordpress.android.widgets.MySiteTitleAndSubtitleLabelView
-import org.wordpress.android.widgets.QuickStartFocusPoint
+import org.wordpress.android.util.viewBinding
 
-class MySiteInfoViewHolder(parent: ViewGroup, private val imageManager: ImageManager) : MySiteItemViewHolder(
-        parent,
-        R.layout.my_site_info_block
-) {
-    private val mySiteBlavatar = itemView.findViewById<ImageView>(R.id.my_site_blavatar)
-    private val mySiteIconProgress = itemView.findViewById<ProgressBar>(R.id.my_site_icon_progress)
-    private val siteInfoContainer = itemView.findViewById<MySiteTitleAndSubtitleLabelView>(R.id.site_info_container)
-    private val switchSite = itemView.findViewById<ImageButton>(R.id.switch_site)
-    private val quickStartIconFocusPoint = itemView.findViewById<QuickStartFocusPoint>(
-            R.id.quick_start_icon_focus_point
-    )
-    private val quickStartTitleFocusPoint = itemView.findViewById<QuickStartFocusPoint>(
-            R.id.quick_start_title_focus_point
-    )
-    fun bind(item: SiteInfoBlock) {
+class MySiteInfoViewHolder(
+    parent: ViewGroup,
+    private val imageManager: ImageManager
+) : MySiteItemViewHolder<MySiteInfoBlockBinding>(parent.viewBinding(MySiteInfoBlockBinding::inflate)) {
+    fun bind(item: SiteInfoBlock) = with(binding) {
         if (item.iconState is IconState.Visible) {
             mySiteBlavatar.visibility = View.VISIBLE
             imageManager.load(mySiteBlavatar, BLAVATAR, item.iconState.url ?: "")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteItemViewHolder.kt
@@ -1,9 +1,6 @@
 package org.wordpress.android.ui.mysite
 
-import android.view.LayoutInflater
-import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import androidx.viewbinding.ViewBinding
 
-open class MySiteItemViewHolder(parent: ViewGroup, layout: Int) : ViewHolder(
-        LayoutInflater.from(parent.context).inflate(layout, parent, false)
-)
+open class MySiteItemViewHolder<T : ViewBinding>(protected val binding: T) : ViewHolder(binding.root)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteListItemViewHolder.kt
@@ -1,27 +1,20 @@
 package org.wordpress.android.ui.mysite
 
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
-import org.wordpress.android.R
+import org.wordpress.android.databinding.MySiteItemBlockBinding
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.widgets.QuickStartFocusPoint
+import org.wordpress.android.util.viewBinding
 
-class MySiteListItemViewHolder(parent: ViewGroup, private val uiHelpers: UiHelpers) : MySiteItemViewHolder(
-        parent,
-        R.layout.my_site_item_block
-) {
-    private val primaryIcon = itemView.findViewById<ImageView>(R.id.my_site_item_primary_icon)
-    private val primaryText = itemView.findViewById<TextView>(R.id.my_site_item_primary_text)
-    private val secondaryIcon = itemView.findViewById<ImageView>(R.id.my_site_item_secondary_icon)
-    private val secondaryText = itemView.findViewById<TextView>(R.id.my_site_item_secondary_text)
-    private val focusPoint = itemView.findViewById<QuickStartFocusPoint>(R.id.my_site_item_quick_start_focus_point)
-    fun bind(item: MySiteItem.ListItem) {
-        uiHelpers.setImageOrHide(primaryIcon, item.primaryIcon)
-        uiHelpers.setImageOrHide(secondaryIcon, item.secondaryIcon)
-        uiHelpers.setTextOrHide(primaryText, item.primaryText)
-        uiHelpers.setTextOrHide(secondaryText, item.secondaryText)
+class MySiteListItemViewHolder(
+    parent: ViewGroup,
+    private val uiHelpers: UiHelpers
+) : MySiteItemViewHolder<MySiteItemBlockBinding>(parent.viewBinding(MySiteItemBlockBinding::inflate)) {
+    fun bind(item: MySiteItem.ListItem) = with(binding) {
+        uiHelpers.setImageOrHide(mySiteItemPrimaryIcon, item.primaryIcon)
+        uiHelpers.setImageOrHide(mySiteItemSecondaryIcon, item.secondaryIcon)
+        uiHelpers.setTextOrHide(mySiteItemPrimaryText, item.primaryText)
+        uiHelpers.setTextOrHide(mySiteItemSecondaryText, item.secondaryText)
         itemView.setOnClickListener { item.onClick.click() }
-        focusPoint.setVisibleOrGone(item.showFocusPoint)
+        mySiteItemQuickStartFocusPoint.setVisibleOrGone(item.showFocusPoint)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickActionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickActionsViewHolder.kt
@@ -2,22 +2,24 @@ package org.wordpress.android.ui.mysite
 
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.android.synthetic.main.quick_actions_block.view.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.QuickActionsBlockBinding
 import org.wordpress.android.ui.mysite.MySiteItem.QuickActionsBlock
+import org.wordpress.android.util.viewBinding
 
-class QuickActionsViewHolder(parent: ViewGroup) : MySiteItemViewHolder(parent, R.layout.quick_actions_block) {
-    fun bind(item: QuickActionsBlock) = itemView.apply {
-        quick_action_stats_button.setOnClickListener { item.onStatsClick.click() }
-        quick_action_posts_button.setOnClickListener { item.onPostsClick.click() }
-        quick_action_media_button.setOnClickListener { item.onMediaClick.click() }
-        quick_action_pages_button.setOnClickListener { item.onPagesClick.click() }
+class QuickActionsViewHolder(
+    parent: ViewGroup
+) : MySiteItemViewHolder<QuickActionsBlockBinding>(parent.viewBinding(QuickActionsBlockBinding::inflate)) {
+    fun bind(item: QuickActionsBlock) = with(binding) {
+        quickActionStatsButton.setOnClickListener { item.onStatsClick.click() }
+        quickActionPostsButton.setOnClickListener { item.onPostsClick.click() }
+        quickActionMediaButton.setOnClickListener { item.onMediaClick.click() }
+        quickActionPagesButton.setOnClickListener { item.onPagesClick.click() }
 
         val pagesVisibility = if (item.showPages) View.VISIBLE else View.GONE
-        quick_action_pages_container.visibility = pagesVisibility
-        middle_quick_action_spacing.visibility = pagesVisibility
+        quickActionPagesContainer.visibility = pagesVisibility
+        middleQuickActionSpacing.visibility = pagesVisibility
 
-        quick_start_stats_focus_point.setVisibleOrGone(item.showStatsFocusPoint)
-        quick_start_pages_focus_point.setVisibleOrGone(item.showPagesFocusPoint)
+        quickStartStatsFocusPoint.setVisibleOrGone(item.showStatsFocusPoint)
+        quickStartPagesFocusPoint.setVisibleOrGone(item.showPagesFocusPoint)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartCardViewHolder.kt
@@ -17,25 +17,26 @@ import androidx.recyclerview.widget.LinearLayoutManager.HORIZONTAL
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener
 import androidx.recyclerview.widget.RecyclerView.RecycledViewPool
-import kotlinx.android.synthetic.main.quick_start_card.view.*
 import org.wordpress.android.R
+import org.wordpress.android.databinding.QuickStartCardBinding
 import org.wordpress.android.ui.mysite.MySiteItem.DynamicCard.QuickStartCard
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ColorUtils
+import org.wordpress.android.util.viewBinding
 
 class QuickStartCardViewHolder(
     parent: ViewGroup,
     private val viewPool: RecycledViewPool,
     private val nestedScrollStates: Bundle,
     private val uiHelpers: UiHelpers
-) : MySiteItemViewHolder(parent, R.layout.quick_start_card) {
+) : MySiteItemViewHolder<QuickStartCardBinding>(parent.viewBinding(QuickStartCardBinding::inflate)) {
     private var currentItem: QuickStartCard? = null
     private val lowEmphasisAlpha = ResourcesCompat.getFloat(itemView.resources, R.dimen.emphasis_low)
 
     init {
-        itemView.apply {
-            quick_start_card_more_button.let { TooltipCompat.setTooltipText(it, it.contentDescription) }
-            quick_start_card_recycler_view.apply {
+        with(binding) {
+            quickStartCardMoreButton.let { TooltipCompat.setTooltipText(it, it.contentDescription) }
+            quickStartCardRecyclerView.apply {
                 adapter = QuickStartTaskCardAdapter(uiHelpers)
                 layoutManager = LinearLayoutManager(context, HORIZONTAL, false)
                 setRecycledViewPool(viewPool)
@@ -56,34 +57,34 @@ class QuickStartCardViewHolder(
         }
     }
 
-    fun bind(item: QuickStartCard) = itemView.apply {
+    fun bind(item: QuickStartCard) = with(binding) {
         currentItem = item
 
-        ObjectAnimator.ofInt(quick_start_card_progress, "progress", item.progress).setDuration(600).start()
+        ObjectAnimator.ofInt(quickStartCardProgress, "progress", item.progress).setDuration(600).start()
 
-        val progressIndicatorColor = ContextCompat.getColor(context, item.accentColor)
+        val progressIndicatorColor = ContextCompat.getColor(root.context, item.accentColor)
         val progressTrackColor = ColorUtils.applyEmphasisToColor(progressIndicatorColor, lowEmphasisAlpha)
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
-            quick_start_card_progress.progressBackgroundTintList = ColorStateList.valueOf(progressTrackColor)
-            quick_start_card_progress.progressTintList = ColorStateList.valueOf(progressIndicatorColor)
+            quickStartCardProgress.progressBackgroundTintList = ColorStateList.valueOf(progressTrackColor)
+            quickStartCardProgress.progressTintList = ColorStateList.valueOf(progressIndicatorColor)
         } else {
             // Workaround for Lollipop
-            val progressDrawable = quick_start_card_progress.progressDrawable.mutate() as LayerDrawable
+            val progressDrawable = quickStartCardProgress.progressDrawable.mutate() as LayerDrawable
             val backgroundLayer = progressDrawable.findDrawableByLayerId(android.R.id.background)
             val progressLayer = progressDrawable.findDrawableByLayerId(android.R.id.progress)
             backgroundLayer.colorFilter = createBlendModeColorFilterCompat(progressTrackColor, SRC_IN)
             progressLayer.colorFilter = createBlendModeColorFilterCompat(progressIndicatorColor, SRC_IN)
-            quick_start_card_progress.progressDrawable = progressDrawable
+            quickStartCardProgress.progressDrawable = progressDrawable
         }
 
-        quick_start_card_title.text = uiHelpers.getTextOfUiString(context, item.title)
-        (quick_start_card_recycler_view.adapter as? QuickStartTaskCardAdapter)?.loadData(item.taskCards)
-        restoreScrollState(quick_start_card_recycler_view, item.id.toString())
-        quick_start_card_more_button.setOnClickListener { item.onMoreClick.click() }
+        quickStartCardTitle.text = uiHelpers.getTextOfUiString(root.context, item.title)
+        (quickStartCardRecyclerView.adapter as? QuickStartTaskCardAdapter)?.loadData(item.taskCards)
+        restoreScrollState(quickStartCardRecyclerView, item.id.toString())
+        quickStartCardMoreButton.setOnClickListener { item.onMoreClick.click() }
     }
 
     fun onRecycled() {
-        currentItem?.let { saveScrollState(itemView.quick_start_card_recycler_view, it.id.toString()) }
+        currentItem?.let { saveScrollState(binding.quickStartCardRecyclerView, it.id.toString()) }
         currentItem = null
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartTaskCardAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickStartTaskCardAdapter.kt
@@ -1,17 +1,15 @@
 package org.wordpress.android.ui.mysite
 
-import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
-import kotlinx.android.synthetic.main.quick_start_task_card.view.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.QuickStartTaskCardBinding
 import org.wordpress.android.ui.mysite.MySiteItem.DynamicCard.QuickStartCard.QuickStartTaskCard
 import org.wordpress.android.ui.mysite.QuickStartTaskCardAdapter.QuickStartTaskCardViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.viewBinding
 
 class QuickStartTaskCardAdapter(private val uiHelpers: UiHelpers) : Adapter<QuickStartTaskCardViewHolder>() {
     private var items = listOf<QuickStartTaskCard>()
@@ -23,7 +21,7 @@ class QuickStartTaskCardAdapter(private val uiHelpers: UiHelpers) : Adapter<Quic
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = QuickStartTaskCardViewHolder(
-            LayoutInflater.from(parent.context).inflate(R.layout.quick_start_task_card, parent, false)
+            parent.viewBinding(QuickStartTaskCardBinding::inflate)
     )
 
     override fun onBindViewHolder(holder: QuickStartTaskCardViewHolder, position: Int) {
@@ -32,14 +30,14 @@ class QuickStartTaskCardAdapter(private val uiHelpers: UiHelpers) : Adapter<Quic
 
     override fun getItemCount() = items.size
 
-    inner class QuickStartTaskCardViewHolder(itemView: View) : ViewHolder(itemView) {
-        fun bind(taskCard: QuickStartTaskCard) = itemView.apply {
-            task_card_title.text = uiHelpers.getTextOfUiString(context, taskCard.title)
-            task_card_description.text = uiHelpers.getTextOfUiString(context, taskCard.description)
-            task_card_illustration.setImageResource(taskCard.illustration)
+    inner class QuickStartTaskCardViewHolder(val binding: QuickStartTaskCardBinding) : ViewHolder(binding.root) {
+        fun bind(taskCard: QuickStartTaskCard) = with(binding) {
+            taskCardTitle.text = uiHelpers.getTextOfUiString(root.context, taskCard.title)
+            taskCardDescription.text = uiHelpers.getTextOfUiString(root.context, taskCard.description)
+            taskCardIllustration.setImageResource(taskCard.illustration)
 
-            task_card_view.apply {
-                checkedIconTint = ContextCompat.getColorStateList(context, taskCard.accentColor)
+            taskCardView.apply {
+                checkedIconTint = ContextCompat.getColorStateList(root.context, taskCard.accentColor)
                 isChecked = taskCard.done
                 setOnClickListener(if (taskCard.done) null else ({ taskCard.onClick.click() }))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardMenuFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/DynamicCardMenuFragment.kt
@@ -9,9 +9,9 @@ import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import kotlinx.android.synthetic.main.quick_start_menu_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.QuickStartMenuFragmentBinding
 import org.wordpress.android.fluxc.model.DynamicCardType
 import org.wordpress.android.util.image.ImageManager
 import javax.inject.Inject
@@ -40,15 +40,17 @@ class DynamicCardMenuFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val quickStartCardMenuPin = if (viewModel.isPinned) {
-            R.string.quick_start_card_menu_unpin
-        } else {
-            R.string.quick_start_card_menu_pin
+        with(QuickStartMenuFragmentBinding.bind(view)) {
+            val quickStartCardMenuPin = if (viewModel.isPinned) {
+                R.string.quick_start_card_menu_unpin
+            } else {
+                R.string.quick_start_card_menu_pin
+            }
+            quickStartPinText.setText(quickStartCardMenuPin)
+            pinAction.setOnClickListener { invokeAndDismiss { viewModel.onPinActionClicked() } }
+            hideAction.setOnClickListener { invokeAndDismiss { viewModel.onHideActionClicked() } }
+            removeAction.setOnClickListener { invokeAndDismiss { viewModel.onRemoveActionClicked() } }
         }
-        quick_start_pin_text.setText(quickStartCardMenuPin)
-        pin_action.setOnClickListener { invokeAndDismiss { viewModel.onPinActionClicked() } }
-        hide_action.setOnClickListener { invokeAndDismiss { viewModel.onHideActionClicked() } }
-        remove_action.setOnClickListener { invokeAndDismiss { viewModel.onRemoveActionClicked() } }
 
         dialog?.setOnShowListener { dialogInterface ->
             val sheetDialog = dialogInterface as? BottomSheetDialog


### PR DESCRIPTION
This PR introduces View Bindings for the Fragments and ViewHolders in the My Site section of the app. Most of the changes are pretty similar to what we've done so far in the other PRs. One exception is the `ImprovedMySiteFragment`, where it was necessary to resort to a couple of `findViewById`s (let me know if you have any suggestions for better alternatives).

Note: I've added a `@Suppress("ComplexMethod")` to the method that handles navigation events, as I can't think of a way to simplify it any further. Let me know if you any suggestions.

To test:

Smoke test the My Site screen and make sure everything is working as expected and nothing looks out of place. Some additional checks:

1. Make sure the account avatar is loaded correctly and that it correctly resizes on scroll.
1. Create a new site and make sure completing a Quick Start task correctly shows a Snackbar. Also try to pin/unpin/hide/remove a card and make sure it works as expected.
1. Enable/disable the `my_site_improvements_enabled` flag and repeat.

👉 I know the PR seems pretty big, but most of it is due to formatting. Selecting the "Hide whitespace changes" should make the review a lot easier.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
