### PR TITLE
Use view binding in domain registration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -7,9 +7,9 @@ import android.view.MenuItem
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.synthetic.main.domain_suggestions_activity.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.DomainSuggestionsActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
@@ -28,21 +28,30 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: DomainRegistrationMainViewModel
     private lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
+    private var binding: DomainSuggestionsActivityBinding? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
-        setContentView(R.layout.domain_suggestions_activity)
+        with(DomainSuggestionsActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            binding = this
 
-        domainRegistrationPurpose = intent.getSerializableExtra(DOMAIN_REGISTRATION_PURPOSE_KEY)
-                as DomainRegistrationPurpose
+            domainRegistrationPurpose = intent.getSerializableExtra(DOMAIN_REGISTRATION_PURPOSE_KEY)
+                    as DomainRegistrationPurpose
 
-        setSupportActionBar(toolbar_main)
-        supportActionBar?.let {
-            it.setHomeButtonEnabled(true)
-            it.setDisplayHomeAsUpEnabled(true)
+            setSupportActionBar(toolbarMain)
+            supportActionBar?.let {
+                it.setHomeButtonEnabled(true)
+                it.setDisplayHomeAsUpEnabled(true)
+            }
+            setupViewModel()
         }
-        setupViewModel()
+    }
+
+    override fun onDestroy() {
+        binding = null
+        super.onDestroy()
     }
 
     private fun setupViewModel() {
@@ -139,18 +148,20 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
     }
 
     override fun onScrollableViewInitialized(containerId: Int) {
-        if (containerId == R.id.domain_suggestions_list) {
-            appbar_main.post {
-                appbar_main.isLiftOnScroll = false
-                appbar_main.setLifted(false)
-                appbar_main.elevation = 0F
-                appbar_main.requestLayout()
-            }
-        } else {
-            appbar_main.post {
-                appbar_main.isLiftOnScroll = true
-                appbar_main.liftOnScrollTargetViewId = containerId
-                appbar_main.requestLayout()
+        binding?.apply {
+            if (containerId == R.id.domain_suggestions_list) {
+                appbarMain.post {
+                    appbarMain.isLiftOnScroll = false
+                    appbarMain.setLifted(false)
+                    appbarMain.elevation = 0F
+                    appbarMain.requestLayout()
+                }
+            } else {
+                appbarMain.post {
+                    appbarMain.isLiftOnScroll = true
+                    appbarMain.liftOnScrollTargetViewId = containerId
+                    appbarMain.requestLayout()
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -40,7 +40,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
             domainRegistrationPurpose = intent.getSerializableExtra(DOMAIN_REGISTRATION_PURPOSE_KEY)
                     as DomainRegistrationPurpose
 
-            setSupportActionBar(toolbarMain)
+            setSupportActionBar(toolbarDomain)
             supportActionBar?.let {
                 it.setHomeButtonEnabled(true)
                 it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -15,16 +15,15 @@ import android.view.ViewGroup
 import android.widget.EditText
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.domain_registration_details_fragment.*
 import org.apache.commons.lang3.StringEscapeUtils
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.DomainRegistrationDetailsFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SupportedStateResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.SupportedDomainCountry
@@ -46,6 +45,7 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.WPUrlUtils
 import org.wordpress.android.viewmodel.domains.DomainRegistrationDetailsViewModel
 import org.wordpress.android.viewmodel.domains.DomainRegistrationDetailsViewModel.DomainContactFormModel
+import org.wordpress.android.viewmodel.domains.DomainRegistrationDetailsViewModel.DomainRegistrationDetailsUiState
 import javax.inject.Inject
 
 class DomainRegistrationDetailsFragment : Fragment() {
@@ -67,6 +67,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
     private lateinit var mainViewModel: DomainRegistrationMainViewModel
 
     private var loadingProgressDialog: ProgressDialog? = null
+    private var binding: DomainRegistrationDetailsFragmentBinding? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -89,56 +90,64 @@ class DomainRegistrationDetailsFragment : Fragment() {
                 .get(DomainRegistrationMainViewModel::class.java)
         viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(DomainRegistrationDetailsViewModel::class.java)
-        setupObservers()
+        with(DomainRegistrationDetailsFragmentBinding.bind(view)) {
+            binding = this
+            setupObservers()
 
-        val domainProductDetails = requireNotNull(
-                arguments?.getParcelable<DomainProductDetails?>(EXTRA_DOMAIN_PRODUCT_DETAILS)
-        )
-        val site = requireActivity().intent?.getSerializableExtra(WordPress.SITE) as SiteModel
+            val domainProductDetails = requireNotNull(
+                    arguments?.getParcelable<DomainProductDetails?>(EXTRA_DOMAIN_PRODUCT_DETAILS)
+            )
+            val site = requireActivity().intent?.getSerializableExtra(WordPress.SITE) as SiteModel
 
-        viewModel.start(site, domainProductDetails)
+            viewModel.start(site, domainProductDetails)
 
-        domain_privacy_on_radio_button.setOnClickListener {
-            viewModel.togglePrivacyProtection(true)
-        }
-
-        domain_privacy_off_radio_button.setOnClickListener {
-            viewModel.togglePrivacyProtection(false)
-        }
-
-        // Country and State input could only be populated from the dialog
-        country_input.inputType = 0
-        country_input.setOnClickListener {
-            viewModel.onCountrySelectorClicked()
-        }
-
-        state_input.inputType = 0
-        state_input.setOnClickListener {
-            viewModel.onStateSelectorClicked()
-        }
-
-        register_domain_button.setOnClickListener {
-            if (validateForm()) {
-                viewModel.onRegisterDomainButtonClicked()
+            domainPrivacyOnRadioButton.setOnClickListener {
+                viewModel.togglePrivacyProtection(true)
             }
-        }
 
-        setupTosLink()
-        setupInputFieldTextWatchers()
+            domainPrivacyOffRadioButton.setOnClickListener {
+                viewModel.togglePrivacyProtection(false)
+            }
+
+            // Country and State input could only be populated from the dialog
+            countryInput.inputType = 0
+            countryInput.setOnClickListener {
+                viewModel.onCountrySelectorClicked()
+            }
+
+            stateInput.inputType = 0
+            stateInput.setOnClickListener {
+                viewModel.onStateSelectorClicked()
+            }
+
+            registerDomainButton.setOnClickListener {
+                if (validateForm()) {
+                    viewModel.onRegisterDomainButtonClicked()
+                }
+            }
+
+            setupTosLink()
+            setupInputFieldTextWatchers()
+        }
     }
 
-    private fun setupInputFieldTextWatchers() {
+    override fun onDestroyView() {
+        binding = null
+        super.onDestroyView()
+    }
+
+    private fun DomainRegistrationDetailsFragmentBinding.setupInputFieldTextWatchers() {
         arrayOf(
-                first_name_input,
-                last_name_input,
-                organization_input,
-                email_input,
-                country_code_input,
-                phone_number_input,
-                address_first_line_input,
-                address_second_line_input,
-                city_input,
-                postal_code_input
+                firstNameInput,
+                lastNameInput,
+                organizationInput,
+                emailInput,
+                countryCodeInput,
+                phoneNumberInput,
+                addressFirstLineInput,
+                addressSecondLineInput,
+                cityInput,
+                postalCodeInput
         ).forEach {
             it.addTextChangedListener(object : TextWatcher {
                 override fun afterTextChanged(p0: Editable?) {
@@ -155,51 +164,29 @@ class DomainRegistrationDetailsFragment : Fragment() {
     }
 
     // make link to ToS clickable
-    private fun setupTosLink() {
-        tos_explanation.text = Html.fromHtml(
+    private fun DomainRegistrationDetailsFragmentBinding.setupTosLink() {
+        tosExplanation.text = Html.fromHtml(
                 String.format(
                         resources.getString(R.string.domain_registration_privacy_protection_tos),
                         "<u>",
                         "</u>"
                 )
         )
-        tos_explanation.movementMethod = LinkMovementMethod.getInstance()
-        tos_explanation.setOnClickListener {
+        tosExplanation.movementMethod = LinkMovementMethod.getInstance()
+        tosExplanation.setOnClickListener {
             viewModel.onTosLinkClicked()
         }
     }
 
-    private fun setupObservers() {
+    private fun DomainRegistrationDetailsFragmentBinding.setupObservers() {
         viewModel.uiState.observe(viewLifecycleOwner,
-                Observer { uiState ->
-                    uiState?.let {
-                        toggleFormProgressIndictor(uiState.isFormProgressIndicatorVisible)
-                        toggleStateProgressIndicator(uiState.isStateProgressIndicatorVisible)
-                        toggleStateInputEnabledState(uiState.isStateInputEnabled)
-
-                        if (uiState.isRegistrationProgressIndicatorVisible) {
-                            showDomainRegistrationProgressDialog()
-                        } else {
-                            hideDomainRegistrationProgressDialog()
-                        }
-
-                        if (uiState.isPrivacyProtectionEnabled) {
-                            domain_privacy_options_radiogroup.check(R.id.domain_privacy_on_radio_button)
-                        } else {
-                            domain_privacy_options_radiogroup.check(R.id.domain_privacy_off_radio_button)
-                        }
-
-                        register_domain_button.isEnabled = uiState.isDomainRegistrationButtonEnabled
-
-                        // Country and State fields treated as UI state, since we only use them for display purpose
-                        country_input.setText(uiState.selectedCountry?.name)
-                        state_input.setText(uiState.selectedState?.name)
-                    }
+                {
+                    it?.let { uiState -> loadState(uiState) }
                 })
 
         viewModel.domainContactForm.observe(
                 viewLifecycleOwner,
-                Observer<DomainContactFormModel> { domainContactFormModel ->
+                { domainContactFormModel ->
                     val currentModel = getDomainContactFormModel()
                     if (currentModel != domainContactFormModel) {
                         populateContactForm(domainContactFormModel!!)
@@ -207,62 +194,33 @@ class DomainRegistrationDetailsFragment : Fragment() {
                 })
 
         viewModel.showCountryPickerDialog.observe(viewLifecycleOwner,
-                Observer {
+                {
                     if (it != null && it.isNotEmpty()) {
                         showCountryPicker(it)
                     }
                 })
 
         viewModel.showStatePickerDialog.observe(viewLifecycleOwner,
-                Observer {
+                {
                     if (it != null && it.isNotEmpty()) {
                         showStatePicker(it)
                     }
                 })
 
-        viewModel.formError.observe(viewLifecycleOwner,
-                Observer { error ->
-                    var affectedInputFields: Array<TextInputEditText>? = null
-
-                    when (error?.type) {
-                        FIRST_NAME -> affectedInputFields = arrayOf(first_name_input)
-                        LAST_NAME -> affectedInputFields = arrayOf(last_name_input)
-                        ORGANIZATION -> affectedInputFields = arrayOf(organization_input)
-                        ADDRESS_1 -> affectedInputFields = arrayOf(address_first_line_input)
-                        ADDRESS_2 -> affectedInputFields = arrayOf(address_second_line_input)
-                        POSTAL_CODE -> affectedInputFields = arrayOf(postal_code_input)
-                        CITY -> affectedInputFields = arrayOf(city_input)
-                        STATE -> affectedInputFields = arrayOf(state_input)
-                        COUNTRY_CODE -> affectedInputFields = arrayOf(country_input)
-                        EMAIL -> affectedInputFields = arrayOf(email_input)
-                        PHONE -> affectedInputFields = arrayOf(
-                                country_code_input,
-                                phone_number_input
-                        )
-                        else -> {
-                        } // Something else, will just show a Toast with an error message
-                    }
-                    affectedInputFields?.forEach {
-                        showFieldError(
-                                it,
-                                StringEscapeUtils.unescapeHtml4(error?.message)
-                        )
-                    }
-                    affectedInputFields?.firstOrNull { it.requestFocus() }
-                })
+        observeFormError(viewModel)
 
         viewModel.showErrorMessage.observe(viewLifecycleOwner,
-                Observer { errorMessage ->
+                { errorMessage ->
                     ToastUtils.showToast(context, errorMessage)
                 })
 
         viewModel.handleCompletedDomainRegistration.observe(viewLifecycleOwner,
-                Observer { domainRegisteredEvent ->
+                { domainRegisteredEvent ->
                     mainViewModel.completeDomainRegistration(domainRegisteredEvent)
                 })
 
         viewModel.showTos.observe(viewLifecycleOwner,
-                Observer {
+                {
                     ActivityLauncher.openUrlExternal(
                             context,
                             WPUrlUtils.buildTermsOfServiceUrl(context)
@@ -270,33 +228,89 @@ class DomainRegistrationDetailsFragment : Fragment() {
                 })
     }
 
-    private fun populateContactForm(domainContactFormModel: DomainContactFormModel) {
-        first_name_input.setText(domainContactFormModel.firstName)
-        last_name_input.setText(domainContactFormModel.lastName)
-        organization_input.setText(domainContactFormModel.organization)
-        email_input.setText(domainContactFormModel.email)
-        country_code_input.setText(domainContactFormModel.phoneNumberPrefix)
-        phone_number_input.setText(domainContactFormModel.phoneNumber)
-        address_first_line_input.setText(domainContactFormModel.addressLine1)
-        address_second_line_input.setText(domainContactFormModel.addressLine2)
-        city_input.setText(domainContactFormModel.city)
-        postal_code_input.setText(domainContactFormModel.postalCode)
+    private fun DomainRegistrationDetailsFragmentBinding.loadState(uiState: DomainRegistrationDetailsUiState) {
+        toggleFormProgressIndictor(uiState.isFormProgressIndicatorVisible)
+        toggleStateProgressIndicator(uiState.isStateProgressIndicatorVisible)
+        toggleStateInputEnabledState(uiState.isStateInputEnabled)
+
+        if (uiState.isRegistrationProgressIndicatorVisible) {
+            showDomainRegistrationProgressDialog()
+        } else {
+            hideDomainRegistrationProgressDialog()
+        }
+
+        if (uiState.isPrivacyProtectionEnabled) {
+            domainPrivacyOptionsRadiogroup.check(R.id.domain_privacy_on_radio_button)
+        } else {
+            domainPrivacyOptionsRadiogroup.check(R.id.domain_privacy_off_radio_button)
+        }
+
+        registerDomainButton.isEnabled = uiState.isDomainRegistrationButtonEnabled
+
+        // Country and State fields treated as UI state, since we only use them for display purpose
+        countryInput.setText(uiState.selectedCountry?.name)
+        stateInput.setText(uiState.selectedState?.name)
+    }
+
+    private fun DomainRegistrationDetailsFragmentBinding.observeFormError(
+        viewModel: DomainRegistrationDetailsViewModel
+    ) {
+        viewModel.formError.observe(viewLifecycleOwner,
+                { error ->
+                    var affectedInputFields: Array<TextInputEditText>? = null
+
+                    when (error?.type) {
+                        FIRST_NAME -> affectedInputFields = arrayOf(firstNameInput)
+                        LAST_NAME -> affectedInputFields = arrayOf(lastNameInput)
+                        ORGANIZATION -> affectedInputFields = arrayOf(organizationInput)
+                        ADDRESS_1 -> affectedInputFields = arrayOf(addressFirstLineInput)
+                        ADDRESS_2 -> affectedInputFields = arrayOf(addressSecondLineInput)
+                        POSTAL_CODE -> affectedInputFields = arrayOf(postalCodeInput)
+                        CITY -> affectedInputFields = arrayOf(cityInput)
+                        STATE -> affectedInputFields = arrayOf(stateInput)
+                        COUNTRY_CODE -> affectedInputFields = arrayOf(countryInput)
+                        EMAIL -> affectedInputFields = arrayOf(emailInput)
+                        PHONE -> affectedInputFields = arrayOf(
+                                countryCodeInput,
+                                phoneNumberInput
+                        )
+                        else -> {
+                        } // Something else, will just show a Toast with an error message
+                    }
+                    affectedInputFields?.forEach {
+                        showFieldError(it, StringEscapeUtils.unescapeHtml4(error?.message))
+                    }
+                    affectedInputFields?.firstOrNull { it.requestFocus() }
+                })
+    }
+
+    private fun DomainRegistrationDetailsFragmentBinding.populateContactForm(formModel: DomainContactFormModel) {
+        firstNameInput.setText(formModel.firstName)
+        lastNameInput.setText(formModel.lastName)
+        organizationInput.setText(formModel.organization)
+        emailInput.setText(formModel.email)
+        countryCodeInput.setText(formModel.phoneNumberPrefix)
+        phoneNumberInput.setText(formModel.phoneNumber)
+        addressFirstLineInput.setText(formModel.addressLine1)
+        addressSecondLineInput.setText(formModel.addressLine2)
+        cityInput.setText(formModel.city)
+        postalCodeInput.setText(formModel.postalCode)
     }
 
     // local validation
-    private fun validateForm(): Boolean {
+    private fun DomainRegistrationDetailsFragmentBinding.validateForm(): Boolean {
         var formIsCompleted = true
 
         val requiredFields = arrayOf(
-                first_name_input,
-                last_name_input,
-                email_input,
-                country_code_input,
-                phone_number_input,
-                country_input,
-                address_first_line_input,
-                city_input,
-                postal_code_input
+                firstNameInput,
+                lastNameInput,
+                emailInput,
+                countryCodeInput,
+                phoneNumberInput,
+                countryInput,
+                addressFirstLineInput,
+                cityInput,
+                postalCodeInput
         )
 
         var fieldToFocusOn: TextInputEditText? = null
@@ -342,20 +356,20 @@ class DomainRegistrationDetailsFragment : Fragment() {
         editText.error = errorMessage
     }
 
-    private fun getDomainContactFormModel(): DomainContactFormModel {
+    private fun getDomainContactFormModel(): DomainContactFormModel = with(binding!!) {
         return DomainContactFormModel(
-                first_name_input.text.toString(),
-                last_name_input.text.toString(),
-                StringUtils.notNullStr(organization_input.text.toString()),
-                address_first_line_input.text.toString(),
-                address_second_line_input.text.toString(),
-                postal_code_input.text.toString(),
-                city_input.text.toString(),
+                firstNameInput.text.toString(),
+                lastNameInput.text.toString(),
+                StringUtils.notNullStr(organizationInput.text.toString()),
+                addressFirstLineInput.text.toString(),
+                addressSecondLineInput.text.toString(),
+                postalCodeInput.text.toString(),
+                cityInput.text.toString(),
                 null, // state code will be added in ViewModel
                 null, // country code will be added in ViewModel
-                email_input.text.toString(),
-                country_code_input.text.toString(),
-                phone_number_input.text.toString()
+                emailInput.text.toString(),
+                countryCodeInput.text.toString(),
+                phoneNumberInput.text.toString()
         )
     }
 
@@ -375,30 +389,30 @@ class DomainRegistrationDetailsFragment : Fragment() {
         dialogFragment.show(requireFragmentManager(), CountryPickerDialogFragment.TAG)
     }
 
-    private fun toggleFormProgressIndictor(visible: Boolean) {
+    private fun DomainRegistrationDetailsFragmentBinding.toggleFormProgressIndictor(visible: Boolean) {
         if (visible) {
-            form_progress_indicator.visibility = View.VISIBLE
+            formProgressIndicator.visibility = View.VISIBLE
         } else {
-            form_progress_indicator.visibility = View.GONE
+            formProgressIndicator.visibility = View.GONE
         }
     }
 
-    private fun toggleStateProgressIndicator(visible: Boolean) {
+    private fun DomainRegistrationDetailsFragmentBinding.toggleStateProgressIndicator(visible: Boolean) {
         if (visible) {
-            states_loading_progress_indicator.visibility = View.VISIBLE
+            statesLoadingProgressIndicator.visibility = View.VISIBLE
         } else {
-            states_loading_progress_indicator.visibility = View.GONE
+            statesLoadingProgressIndicator.visibility = View.GONE
         }
 
-        state_input_container.isEnabled = !visible
+        stateInputContainer.isEnabled = !visible
     }
 
-    private fun toggleStateInputEnabledState(enabled: Boolean) {
-        state_input_container.isEnabled = enabled
+    private fun DomainRegistrationDetailsFragmentBinding.toggleStateInputEnabledState(enabled: Boolean) {
+        stateInputContainer.isEnabled = enabled
         if (enabled) {
-            state_input_container.hint = getString(R.string.domain_contact_information_state_hint)
+            stateInputContainer.hint = getString(R.string.domain_contact_information_state_hint)
         } else {
-            state_input_container.hint = getString(R.string.domain_contact_information_state_not_available_hint)
+            stateInputContainer.hint = getString(R.string.domain_contact_information_state_not_available_hint)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationResultFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationResultFragment.kt
@@ -3,17 +3,15 @@ package org.wordpress.android.ui.domains
 import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.text.HtmlCompat
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
 import androidx.fragment.app.Fragment
-import kotlinx.android.synthetic.main.domain_registration_result_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.DomainRegistrationResultFragmentBinding
 
-class DomainRegistrationResultFragment : Fragment() {
+class DomainRegistrationResultFragment : Fragment(R.layout.domain_registration_result_fragment) {
     private var domainName: String? = null
     private var email: String? = null
 
@@ -39,28 +37,25 @@ class DomainRegistrationResultFragment : Fragment() {
         email = arguments?.getString(EXTRA_REGISTERED_DOMAIN_EMAIL, "")
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.domain_registration_result_fragment, container, false)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         checkNotNull((activity?.application as WordPress).component())
+        with(DomainRegistrationResultFragmentBinding.bind(view)) {
+            continueButton.setOnClickListener {
+                val intent = Intent()
+                intent.putExtra(RESULT_REGISTERED_DOMAIN_EMAIL, email)
+                val nonNullActivity = requireActivity()
+                nonNullActivity.setResult(RESULT_OK, intent)
+                nonNullActivity.finish()
+            }
 
-        continue_button.setOnClickListener {
-            val intent = Intent()
-            intent.putExtra(RESULT_REGISTERED_DOMAIN_EMAIL, email)
-            val nonNullActivity = requireActivity()
-            nonNullActivity.setResult(RESULT_OK, intent)
-            nonNullActivity.finish()
+            domainRegistrationResultMessage.text = HtmlCompat.fromHtml(
+                    getString(
+                            R.string.domain_registration_result_description,
+                            domainName
+                    ), FROM_HTML_MODE_COMPACT
+            )
         }
-
-        domain_registration_result_message.text = HtmlCompat.fromHtml(
-                getString(
-                        R.string.domain_registration_result_description,
-                        domainName
-                ), FROM_HTML_MODE_COMPACT
-        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -4,17 +4,15 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.TextUtils
 import android.text.TextWatcher
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.domain_suggestions_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.DomainSuggestionsFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse
 import org.wordpress.android.models.networkresource.ListState
@@ -23,7 +21,7 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.viewmodel.domains.DomainSuggestionsViewModel
 import javax.inject.Inject
 
-class DomainSuggestionsFragment : Fragment() {
+class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var mainViewModel: DomainRegistrationMainViewModel
     private lateinit var viewModel: DomainSuggestionsViewModel
@@ -33,14 +31,6 @@ class DomainSuggestionsFragment : Fragment() {
         fun newInstance(): DomainSuggestionsFragment {
             return DomainSuggestionsFragment()
         }
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.domain_suggestions_fragment, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -54,23 +44,24 @@ class DomainSuggestionsFragment : Fragment() {
 
         viewModel = ViewModelProvider(this, viewModelFactory)
                 .get(DomainSuggestionsViewModel::class.java)
+        with(DomainSuggestionsFragmentBinding.bind(view)) {
+            val nonNullIntent = checkNotNull(nonNullActivity.intent)
+            val site = nonNullIntent.getSerializableExtra(WordPress.SITE) as SiteModel
 
-        val nonNullIntent = checkNotNull(nonNullActivity.intent)
-        val site = nonNullIntent.getSerializableExtra(WordPress.SITE) as SiteModel
-
-        setupViews()
-        setupObservers()
-        viewModel.start(site)
+            setupViews()
+            setupObservers()
+            viewModel.start(site)
+        }
     }
 
-    private fun setupViews() {
-        domain_suggestions_list.layoutManager = LinearLayoutManager(
+    private fun DomainSuggestionsFragmentBinding.setupViews() {
+        domainSuggestionsList.layoutManager = LinearLayoutManager(
                 activity,
                 RecyclerView.VERTICAL,
                 false
         )
-        domain_suggestions_list.setEmptyView(actionableEmptyView)
-        chose_domain_button.setOnClickListener {
+        domainSuggestionsList.setEmptyView(actionableEmptyView)
+        choseDomainButton.setOnClickListener {
             val selectedDomain = viewModel.selectedSuggestion.value
 
             mainViewModel.selectDomain(
@@ -80,7 +71,7 @@ class DomainSuggestionsFragment : Fragment() {
                     )
             )
         }
-        domain_suggestion_keyword_input.addTextChangedListener(object : TextWatcher {
+        domainSuggestionKeywordInput.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
 
@@ -88,23 +79,23 @@ class DomainSuggestionsFragment : Fragment() {
                 viewModel.updateSearchQuery(view.toString())
             }
         })
-        val adapter = DomainSuggestionsAdapter(this::onDomainSuggestionSelected)
-        domain_suggestions_list.adapter = adapter
+        val adapter = DomainSuggestionsAdapter(this@DomainSuggestionsFragment::onDomainSuggestionSelected)
+        domainSuggestionsList.adapter = adapter
     }
 
-    private fun setupObservers() {
+    private fun DomainSuggestionsFragmentBinding.setupObservers() {
         viewModel.isIntroVisible.observe(viewLifecycleOwner, Observer {
             it?.let { isIntroVisible ->
-                introduction_container.visibility = if (isIntroVisible) View.VISIBLE else View.GONE
+                introductionContainer.visibility = if (isIntroVisible) View.VISIBLE else View.GONE
             }
         })
         viewModel.suggestionsLiveData.observe(viewLifecycleOwner, Observer { listState ->
             if (listState != null) {
                 val isLoading = listState is ListState.Loading<*>
 
-                domain_suggestions_container.visibility = if (isLoading) View.INVISIBLE else View.VISIBLE
-                suggestion_progress_bar.visibility = if (isLoading) View.VISIBLE else View.GONE
-                suggestion_search_icon.visibility = if (isLoading) View.GONE else View.VISIBLE
+                domainSuggestionsContainer.visibility = if (isLoading) View.INVISIBLE else View.VISIBLE
+                suggestionProgressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
+                suggestionSearchIcon.visibility = if (isLoading) View.GONE else View.VISIBLE
 
                 if (!isLoading) {
                     reloadSuggestions(listState.data)
@@ -121,12 +112,12 @@ class DomainSuggestionsFragment : Fragment() {
             }
         })
         viewModel.choseDomainButtonEnabledState.observe(viewLifecycleOwner, Observer {
-            chose_domain_button.isEnabled = it ?: false
+            choseDomainButton.isEnabled = it ?: false
         })
     }
 
-    private fun reloadSuggestions(domainSuggestions: List<DomainSuggestionResponse>) {
-        val adapter = domain_suggestions_list.adapter as DomainSuggestionsAdapter
+    private fun DomainSuggestionsFragmentBinding.reloadSuggestions(domainSuggestions: List<DomainSuggestionResponse>) {
+        val adapter = domainSuggestionsList.adapter as DomainSuggestionsAdapter
         adapter.selectedPosition = viewModel.selectedPosition.value ?: -1
         adapter.updateSuggestionsList(domainSuggestions)
     }

--- a/WordPress/src/main/res/layout/domain_suggestions_activity.xml
+++ b/WordPress/src/main/res/layout/domain_suggestions_activity.xml
@@ -11,7 +11,7 @@
         android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar_main"
+            android:id="@+id/toolbar_domain"
             app:navigationIcon="@drawable/ic_cross_white_24dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
This is a fairly straightforward change. The only tricky thing was that for some reason when the toolbar has ID `toolbar_main`, the binding crashes in runtime because it's missing `toolbar_text` view. This view is not in the layout so I guess there must be a bug in the view binding generation. Changing the ID of the toolbar fixed the issue.

To test:
- Go to a site with no domain and free credits
- Go through the domain registration and check nothing is out of place

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
