### PR TITLE
Use view binding in media picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -8,10 +8,10 @@ import android.os.Bundle
 import android.text.TextUtils
 import android.view.MenuItem
 import androidx.fragment.app.FragmentTransaction
-import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.PhotoPickerActivityBinding
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.MediaStore
@@ -102,9 +102,10 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
-        setContentView(R.layout.photo_picker_activity)
-        toolbar_main.setNavigationIcon(R.drawable.ic_close_white_24dp)
-        setSupportActionBar(toolbar_main)
+        val binding = PhotoPickerActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        binding.toolbarMain.setNavigationIcon(R.drawable.ic_close_white_24dp)
+        setSupportActionBar(binding.toolbarMain)
         val actionBar = supportActionBar
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -5,9 +5,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
 import android.text.Html
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.PopupMenu
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AlertDialog.Builder
@@ -18,10 +16,9 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import kotlinx.android.synthetic.main.photo_picker_fragment.*
-import kotlinx.android.synthetic.main.photo_picker_fragment.view.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.PhotoPickerFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.media.MediaBrowserActivity
@@ -55,9 +52,11 @@ import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
-@Deprecated("This class is being refactored, if you implement any change, please also update " +
-        "{@link org.wordpress.android.ui.mediapicker.MediaPickerFragment}")
-class PhotoPickerFragment : Fragment() {
+@Deprecated(
+        "This class is being refactored, if you implement any change, please also update " +
+                "{@link org.wordpress.android.ui.mediapicker.MediaPickerFragment}"
+)
+class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
     enum class PhotoPickerIcon(private val mRequiresUploadPermission: Boolean) {
         ANDROID_CHOOSE_PHOTO(true),
         ANDROID_CHOOSE_VIDEO(true),
@@ -88,23 +87,12 @@ class PhotoPickerFragment : Fragment() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: PhotoPickerViewModel
+    private var binding: PhotoPickerFragmentBinding? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
         viewModel = ViewModelProvider(this, viewModelFactory).get(PhotoPickerViewModel::class.java)
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(
-                R.layout.photo_picker_fragment,
-                container,
-                false
-        )
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -121,105 +109,113 @@ class PhotoPickerFragment : Fragment() {
                 selectedIds = savedInstanceState.getLongArray(KEY_SELECTED_POSITIONS)?.toList()
             }
         }
-        recycler.setEmptyView(actionable_empty_view)
-        recycler.setHasFixedSize(true)
+        with(PhotoPickerFragmentBinding.bind(view)) {
+            binding = this
+            recycler.setEmptyView(actionableEmptyView)
+            recycler.setHasFixedSize(true)
 
-        val layoutManager = GridLayoutManager(
-                activity,
-                NUM_COLUMNS
-        )
-
-        savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
-            layoutManager.onRestoreInstanceState(it)
-        }
-
-        recycler.layoutManager = layoutManager
-
-        var isShowingActionMode = false
-        viewModel.uiState.observe(viewLifecycleOwner, Observer {
-            it?.let { uiState ->
-                setupPhotoList(uiState.photoListUiModel)
-                setupBottomBar(uiState.bottomBarUiModel)
-                setupSoftAskView(uiState.softAskViewUiModel)
-                if (uiState.actionModeUiModel is ActionModeUiModel.Visible && !isShowingActionMode) {
-                    isShowingActionMode = true
-                    (activity as AppCompatActivity).startSupportActionMode(
-                            PhotoPickerActionModeCallback(
-                                    viewModel
-                            )
-                    )
-                } else if (uiState.actionModeUiModel is ActionModeUiModel.Hidden && isShowingActionMode) {
-                    isShowingActionMode = false
-                }
-                uiState.fabUiModel.let(this::setupFab)
-            }
-        })
-
-        viewModel.onNavigateToPreview.observeEvent(viewLifecycleOwner, { uri ->
-            MediaPreviewActivity.showPreview(
-                    requireContext(),
-                    null,
-                    uri.toString()
+            val layoutManager = GridLayoutManager(
+                    activity,
+                    NUM_COLUMNS
             )
-            AccessibilityUtils.setActionModeDoneButtonContentDescription(activity, getString(R.string.cancel))
-        })
 
-        viewModel.onInsert.observeEvent(viewLifecycleOwner, { selectedUris ->
-            listener?.onPhotoPickerMediaChosen(selectedUris.map { it.uri })
-        })
+            savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
+                layoutManager.onRestoreInstanceState(it)
+            }
 
-        viewModel.onIconClicked.observeEvent(viewLifecycleOwner, { (icon, allowMultipleSelection) ->
-            listener?.onPhotoPickerIconClicked(icon, allowMultipleSelection)
-        })
+            recycler.layoutManager = layoutManager
 
-        viewModel.onShowPopupMenu.observeEvent(viewLifecycleOwner, { uiModel ->
-            val popup = PopupMenu(activity, uiModel.view.view)
-            for (popupMenuItem in uiModel.items) {
-                val item = popup.menu
-                        .add(popupMenuItem.title.stringRes)
-                item.setOnMenuItemClickListener {
-                    popupMenuItem.action()
-                    true
+            var isShowingActionMode = false
+            viewModel.uiState.observe(viewLifecycleOwner, Observer {
+                it?.let { uiState ->
+                    setupPhotoList(uiState.photoListUiModel)
+                    setupBottomBar(uiState.bottomBarUiModel)
+                    setupSoftAskView(uiState.softAskViewUiModel)
+                    if (uiState.actionModeUiModel is ActionModeUiModel.Visible && !isShowingActionMode) {
+                        isShowingActionMode = true
+                        (activity as AppCompatActivity).startSupportActionMode(
+                                PhotoPickerActionModeCallback(
+                                        viewModel
+                                )
+                        )
+                    } else if (uiState.actionModeUiModel is ActionModeUiModel.Hidden && isShowingActionMode) {
+                        isShowingActionMode = false
+                    }
+                    setupFab(uiState.fabUiModel)
                 }
-            }
-            popup.show()
-        })
+            })
 
-        viewModel.onPermissionsRequested.observeEvent(viewLifecycleOwner, {
-            when (it) {
-                CAMERA -> requestCameraPermission()
-                STORAGE -> requestStoragePermission()
-            }
-        })
+            viewModel.onNavigateToPreview.observeEvent(viewLifecycleOwner, { uri ->
+                MediaPreviewActivity.showPreview(
+                        requireContext(),
+                        null,
+                        uri.toString()
+                )
+                AccessibilityUtils.setActionModeDoneButtonContentDescription(activity, getString(R.string.cancel))
+            })
 
-        setupProgressDialog()
+            viewModel.onInsert.observeEvent(viewLifecycleOwner, { selectedUris ->
+                listener?.onPhotoPickerMediaChosen(selectedUris.map { it.uri })
+            })
 
-        viewModel.start(selectedIds, browserType, lastTappedIcon, site)
+            viewModel.onIconClicked.observeEvent(viewLifecycleOwner, { (icon, allowMultipleSelection) ->
+                listener?.onPhotoPickerIconClicked(icon, allowMultipleSelection)
+            })
+
+            viewModel.onShowPopupMenu.observeEvent(viewLifecycleOwner, { uiModel ->
+                val popup = PopupMenu(activity, uiModel.view.view)
+                for (popupMenuItem in uiModel.items) {
+                    val item = popup.menu
+                            .add(popupMenuItem.title.stringRes)
+                    item.setOnMenuItemClickListener {
+                        popupMenuItem.action()
+                        true
+                    }
+                }
+                popup.show()
+            })
+
+            viewModel.onPermissionsRequested.observeEvent(viewLifecycleOwner, {
+                when (it) {
+                    CAMERA -> requestCameraPermission()
+                    STORAGE -> requestStoragePermission()
+                }
+            })
+
+            setupProgressDialog()
+
+            viewModel.start(selectedIds, browserType, lastTappedIcon, site)
+        }
     }
 
-    private fun setupSoftAskView(uiModel: SoftAskViewUiModel) {
+    override fun onDestroyView() {
+        binding = null
+        super.onDestroyView()
+    }
+
+    private fun PhotoPickerFragmentBinding.setupSoftAskView(uiModel: SoftAskViewUiModel) {
         when (uiModel) {
             is SoftAskViewUiModel.Visible -> {
-                soft_ask_view.title.text = Html.fromHtml(uiModel.label)
-                soft_ask_view.button.setText(uiModel.allowId.stringRes)
-                soft_ask_view.button.setOnClickListener {
+                softAskView.title.text = Html.fromHtml(uiModel.label)
+                softAskView.button.setText(uiModel.allowId.stringRes)
+                softAskView.button.setOnClickListener {
                     if (uiModel.isAlwaysDenied) {
                         WPPermissionUtils.showAppSettings(requireActivity())
                     } else {
                         requestStoragePermission()
                     }
                 }
-                soft_ask_view.visibility = View.VISIBLE
+                softAskView.visibility = View.VISIBLE
             }
             is SoftAskViewUiModel.Hidden -> {
-                if (soft_ask_view.visibility == View.VISIBLE) {
-                    AniUtils.fadeOut(soft_ask_view, MEDIUM)
+                if (softAskView.visibility == View.VISIBLE) {
+                    AniUtils.fadeOut(softAskView, MEDIUM)
                 }
             }
         }
     }
 
-    private fun setupPhotoList(uiModel: PhotoListUiModel) {
+    private fun PhotoPickerFragmentBinding.setupPhotoList(uiModel: PhotoListUiModel) {
         if (uiModel is PhotoListUiModel.Data) {
             if (recycler.adapter == null) {
                 recycler.adapter = PhotoPickerAdapter(
@@ -234,43 +230,42 @@ class PhotoPickerFragment : Fragment() {
         }
     }
 
-    private fun setupFab(fabUiModel: FabUiModel) {
+    private fun PhotoPickerFragmentBinding.setupFab(fabUiModel: FabUiModel) {
         if (fabUiModel.show) {
-            wp_stories_take_picture.visibility = View.VISIBLE
-            wp_stories_take_picture.setOnClickListener {
+            wpStoriesTakePicture.visibility = View.VISIBLE
+            wpStoriesTakePicture.setOnClickListener {
                 fabUiModel.action()
             }
         } else {
-            wp_stories_take_picture.visibility = View.GONE
+            wpStoriesTakePicture.visibility = View.GONE
         }
     }
 
-    private fun setupBottomBar(uiModel: BottomBarUiModel) {
+    private fun PhotoPickerFragmentBinding.setupBottomBar(uiModel: BottomBarUiModel) {
         if (!canShowMediaSourceBottomBar(uiModel.hideMediaBottomBarInPortrait)) {
-            hideBottomBar(container_media_source_bar)
+            hideBottomBar(containerMediaSourceBar)
         } else {
             if (!uiModel.showCameraButton) {
-                container_media_source_bar.icon_camera.visibility = View.GONE
+                iconCamera.visibility = View.GONE
             } else {
-                container_media_source_bar.icon_camera.setOnClickListener {
+                iconCamera.setOnClickListener {
                     viewModel.onCameraClicked(ViewWrapper(it))
                 }
             }
-            container_media_source_bar.icon_picker
-                    ?.setOnClickListener {
+            iconPicker.setOnClickListener {
                         uiModel.onIconPickerClicked(ViewWrapper(it))
                     }
 
             if (uiModel.showWPMediaIcon) {
-                container_media_source_bar.icon_wpmedia.setOnClickListener {
+                iconWpmedia.setOnClickListener {
                     viewModel.clickIcon(WP_MEDIA)
                 }
             } else {
-                container_media_source_bar.icon_wpmedia.visibility = View.GONE
+                iconWpmedia.visibility = View.GONE
             }
         }
         if (uiModel.canShowInsertEditBottomBar) {
-            container_insert_edit_bar.text_edit
+            textEdit
                     .setOnClickListener {
                         val inputData = WPMediaUtils.createListOfEditImageInputData(
                                 requireContext(),
@@ -278,26 +273,26 @@ class PhotoPickerFragment : Fragment() {
                         )
                         ActivityLauncher.openImageEditor(activity, inputData)
                     }
-            container_insert_edit_bar.text_insert.setOnClickListener { viewModel.performInsertAction() }
+            textInsert.setOnClickListener { viewModel.performInsertAction() }
         }
         val editTextVisible = if (uiModel.insertEditTextBarVisible) View.VISIBLE else View.GONE
-        container_insert_edit_bar.text_edit.visibility = editTextVisible
+        textEdit.visibility = editTextVisible
         when (uiModel.type) {
             INSERT_EDIT -> {
-                hideBottomBar(container_media_source_bar)
-                showBottomBar(container_insert_edit_bar)
+                hideBottomBar(containerMediaSourceBar)
+                showBottomBar(containerInsertEditBar)
             }
             MEDIA_SOURCE -> {
                 if (canShowMediaSourceBottomBar(uiModel.hideMediaBottomBarInPortrait)) {
-                    showBottomBar(container_media_source_bar)
+                    showBottomBar(containerMediaSourceBar)
                 } else {
-                    hideBottomBar(container_media_source_bar)
+                    hideBottomBar(containerMediaSourceBar)
                 }
-                hideBottomBar(container_insert_edit_bar)
+                hideBottomBar(containerInsertEditBar)
             }
             NONE -> {
-                hideBottomBar(container_insert_edit_bar)
-                hideBottomBar(container_media_source_bar)
+                hideBottomBar(containerInsertEditBar)
+                hideBottomBar(containerMediaSourceBar)
             }
         }
     }
@@ -347,7 +342,7 @@ class PhotoPickerFragment : Fragment() {
         if (selectedIds != null && selectedIds.isNotEmpty()) {
             outState.putLongArray(KEY_SELECTED_POSITIONS, selectedIds.toLongArray())
         }
-        recycler.layoutManager?.let {
+        binding!!.recycler.layoutManager?.let {
             outState.putParcelable(KEY_LIST_STATE, it.onSaveInstanceState())
         }
     }
@@ -383,10 +378,6 @@ class PhotoPickerFragment : Fragment() {
 
     private fun isBottomBarShowing(bottomBar: View): Boolean {
         return bottomBar.visibility == View.VISIBLE
-    }
-
-    private fun hasAdapter(): Boolean {
-        return recycler.adapter != null
     }
 
     /*


### PR DESCRIPTION
Fairly straightforward change - introduces view binding in media picker and photo picker (the new and deprecated code).

To test:
- Go to media 
- Choose "Choose from device"
- Check the screen looks OK
- Add a story
- Choose "Choose from device"
- Check the screen looks OK

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
