### PR TITLE
Feature/use view binding in pages

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -69,6 +69,11 @@ class PageListFragment : ViewPagerFragment(R.layout.pages_list_fragment) {
         }
     }
 
+    override fun onDestroyView() {
+        binding = null
+        super.onDestroyView()
+    }
+
     override fun onSaveInstanceState(outState: Bundle) {
         linearLayoutManager?.let {
             outState.putParcelable(listStateKey, it.onSaveInstanceState())

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -63,7 +63,7 @@ class PageListFragment : ViewPagerFragment(R.layout.pages_list_fragment) {
 
         val nonNullActivity = requireActivity()
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
-        with (PagesListFragmentBinding.bind(view)) {
+        with(PagesListFragmentBinding.bind(view)) {
             initializeViews(savedInstanceState)
             initializeViewModels(nonNullActivity)
         }
@@ -125,7 +125,11 @@ class PageListFragment : ViewPagerFragment(R.layout.pages_list_fragment) {
         })
     }
 
-    private fun PagesListFragmentBinding.setPages(pages: List<PageItem>, isSitePhotonCapable: Boolean, isSitePrivateAt: Boolean) {
+    private fun PagesListFragmentBinding.setPages(
+        pages: List<PageItem>,
+        isSitePhotonCapable: Boolean,
+        isSitePrivateAt: Boolean
+    ) {
         val adapter: PageListAdapter
         if (recyclerView.adapter == null) {
             adapter = PageListAdapter(
@@ -170,18 +174,18 @@ class PageListFragment : ViewPagerFragment(R.layout.pages_list_fragment) {
     }
 
     fun showSnackbar() {
-            view?.post {
-                val title = quickStartUtilsWrapper.stylizeQuickStartPrompt(
-                        requireContext(),
-                        R.string.quick_start_dialog_edit_homepage_message_pages_short,
-                        R.drawable.ic_homepage_16dp
-                )
+        view?.post {
+            val title = quickStartUtilsWrapper.stylizeQuickStartPrompt(
+                    requireContext(),
+                    R.string.quick_start_dialog_edit_homepage_message_pages_short,
+                    R.drawable.ic_homepage_16dp
+            )
 
-                snackbar = WPDialogSnackbar.make(
-                        requireView().findViewById(R.id.page_list_layout), title,
-                        resources.getInteger(R.integer.quick_start_snackbar_duration_ms)
-                )
-                snackbar?.show()
-            }
+            snackbar = WPDialogSnackbar.make(
+                    requireView().findViewById(R.id.page_list_layout), title,
+                    resources.getInteger(R.integer.quick_start_snackbar_duration_ms)
+            )
+            snackbar?.show()
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -2,21 +2,19 @@ package org.wordpress.android.ui.pages
 
 import android.os.Bundle
 import android.os.Parcelable
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.pages_list_fragment.*
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.PagesListFragmentBinding
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.ui.ViewPagerFragment
 import org.wordpress.android.ui.quickstart.QuickStartEvent
@@ -31,7 +29,7 @@ import org.wordpress.android.widgets.RecyclerItemDecoration
 import org.wordpress.android.widgets.WPDialogSnackbar
 import javax.inject.Inject
 
-class PageListFragment : ViewPagerFragment() {
+class PageListFragment : ViewPagerFragment(R.layout.pages_list_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject internal lateinit var imageManager: ImageManager
     @Inject internal lateinit var uiHelper: UiHelpers
@@ -40,6 +38,7 @@ class PageListFragment : ViewPagerFragment() {
     private lateinit var viewModel: PageListViewModel
     private var linearLayoutManager: LinearLayoutManager? = null
     private var snackbar: WPDialogSnackbar? = null
+    private var binding: PagesListFragmentBinding? = null
 
     private val listStateKey = "list_state"
 
@@ -55,12 +54,8 @@ class PageListFragment : ViewPagerFragment() {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.pages_list_fragment, container, false)
-    }
-
     override fun getScrollableViewForUniqueIdProvision(): View? {
-        return recyclerView
+        return binding?.recyclerView
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -68,9 +63,10 @@ class PageListFragment : ViewPagerFragment() {
 
         val nonNullActivity = requireActivity()
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
-
-        initializeViews(savedInstanceState)
-        initializeViewModels(nonNullActivity)
+        with (PagesListFragmentBinding.bind(view)) {
+            initializeViews(savedInstanceState)
+            initializeViewModels(nonNullActivity)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -80,11 +76,11 @@ class PageListFragment : ViewPagerFragment() {
         super.onSaveInstanceState(outState)
     }
 
-    private fun initializeViewModels(activity: FragmentActivity) {
+    private fun PagesListFragmentBinding.initializeViewModels(activity: FragmentActivity) {
         val pagesViewModel = ViewModelProvider(activity, viewModelFactory).get(PagesViewModel::class.java)
 
         val listType = arguments?.getSerializable(typeKey) as PageListType
-        viewModel = ViewModelProvider(this, viewModelFactory)
+        viewModel = ViewModelProvider(this@PageListFragment, viewModelFactory)
                 .get(listType.name, PageListViewModel::class.java)
 
         viewModel.start(listType, pagesViewModel)
@@ -92,7 +88,7 @@ class PageListFragment : ViewPagerFragment() {
         setupObservers()
     }
 
-    private fun initializeViews(savedInstanceState: Bundle?) {
+    private fun PagesListFragmentBinding.initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
@@ -103,7 +99,7 @@ class PageListFragment : ViewPagerFragment() {
         recyclerView.addItemDecoration(RecyclerItemDecoration(0, DisplayUtils.dpToPx(activity, 1)))
     }
 
-    private fun setupObservers() {
+    private fun PagesListFragmentBinding.setupObservers() {
         viewModel.pages.observe(viewLifecycleOwner, Observer { data ->
             data?.let { setPages(data.first, data.second, data.third) }
         })
@@ -129,7 +125,7 @@ class PageListFragment : ViewPagerFragment() {
         })
     }
 
-    private fun setPages(pages: List<PageItem>, isSitePhotonCapable: Boolean, isSitePrivateAt: Boolean) {
+    private fun PagesListFragmentBinding.setPages(pages: List<PageItem>, isSitePhotonCapable: Boolean, isSitePrivateAt: Boolean) {
         val adapter: PageListAdapter
         if (recyclerView.adapter == null) {
             adapter = PageListAdapter(

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentActivity.kt
@@ -1,17 +1,16 @@
 package org.wordpress.android.ui.pages
 
 import android.os.Bundle
-import kotlinx.android.synthetic.main.toolbar_main.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.PagesParentActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class PageParentActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val binding = PagesParentActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        setContentView(R.layout.pages_parent_activity)
-
-        setSupportActionBar(toolbar_main)
+        setSupportActionBar(binding.toolbar.toolbarMain)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
@@ -2,21 +2,19 @@ package org.wordpress.android.ui.pages
 
 import android.os.Bundle
 import android.os.Parcelable
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.pages_list_fragment.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.PagesListFragmentBinding
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.viewmodel.pages.PageParentSearchViewModel
 import org.wordpress.android.viewmodel.pages.PageParentViewModel
@@ -24,7 +22,7 @@ import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
-class PageParentSearchFragment : Fragment(), CoroutineScope {
+class PageParentSearchFragment : Fragment(R.layout.pages_list_fragment), CoroutineScope {
     protected var job: Job = Job()
 
     override val coroutineContext: CoroutineContext
@@ -42,21 +40,14 @@ class PageParentSearchFragment : Fragment(), CoroutineScope {
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.pages_list_fragment, container, false)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val nonNullActivity = requireActivity()
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
-
-        initializeViews(savedInstanceState)
-        initializeViewModels(nonNullActivity)
+        with(PagesListFragmentBinding.bind(view)) {
+            initializeViews(savedInstanceState)
+            initializeViewModels(nonNullActivity)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -66,18 +57,18 @@ class PageParentSearchFragment : Fragment(), CoroutineScope {
         super.onSaveInstanceState(outState)
     }
 
-    private fun initializeViewModels(activity: FragmentActivity) {
+    private fun PagesListFragmentBinding.initializeViewModels(activity: FragmentActivity) {
         val pageParentViewModel = ViewModelProvider(activity, viewModelFactory)
                 .get(PageParentViewModel::class.java)
 
-        viewModel = ViewModelProvider(this, viewModelFactory)
+        viewModel = ViewModelProvider(this@PageParentSearchFragment, viewModelFactory)
                 .get(PageParentSearchViewModel::class.java)
         viewModel.start(pageParentViewModel)
 
         setupObservers()
     }
 
-    private fun initializeViews(savedInstanceState: Bundle?) {
+    private fun PagesListFragmentBinding.initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
@@ -88,17 +79,18 @@ class PageParentSearchFragment : Fragment(), CoroutineScope {
         recyclerView.addItemDecoration(RecyclerItemDecoration(0, DisplayUtils.dpToPx(activity, 1)))
     }
 
-    private fun setupObservers() {
+    private fun PagesListFragmentBinding.setupObservers() {
         viewModel.searchResult.observe(viewLifecycleOwner, Observer { data ->
             data?.let { setSearchResult(data) }
         })
     }
 
-    private fun setSearchResult(pages: List<PageItem>) {
+    private fun PagesListFragmentBinding.setSearchResult(pages: List<PageItem>) {
         val adapter: PageParentSearchAdapter
         if (recyclerView.adapter == null) {
             adapter = PageParentSearchAdapter(
-                    { page -> viewModel.onParentSelected(page) }, this)
+                    { page -> viewModel.onParentSelected(page) }, this@PageParentSearchFragment
+            )
             recyclerView.adapter = adapter
         } else {
             adapter = recyclerView.adapter as PageParentSearchAdapter

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
@@ -3,9 +3,9 @@ package org.wordpress.android.ui.pages
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.pages_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.PagesActivityBinding
 import org.wordpress.android.push.NotificationType
 import org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE
 import org.wordpress.android.ui.LocaleAwareActivity
@@ -25,14 +25,7 @@ class PagesActivity : LocaleAwareActivity(),
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
-
-        setContentView(R.layout.pages_activity)
-
-        setSupportActionBar(toolbar)
-        supportActionBar?.let {
-            it.setHomeButtonEnabled(true)
-            it.setDisplayHomeAsUpEnabled(true)
-        }
+        setContentView(PagesActivityBinding.inflate(layoutInflater).root)
 
         handleIntent(intent)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -1,22 +1,22 @@
 package org.wordpress.android.ui.pages
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.ProgressDialog
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.HapticFeedbackConstants
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.MenuItem.OnActionExpandListener
 import android.view.MotionEvent
 import android.view.View
-import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.LinearLayout
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -26,9 +26,9 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.pages_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.PagesFragmentBinding
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -70,12 +70,13 @@ import org.wordpress.android.widgets.WPSnackbar
 import java.lang.ref.WeakReference
 import javax.inject.Inject
 
-class PagesFragment : Fragment(), ScrollableViewInitializedListener {
+class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializedListener {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: PagesViewModel
     private lateinit var mlpViewModel: ModalLayoutPickerViewModel
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
     private lateinit var actionMenuItem: MenuItem
+    private var binding: PagesFragmentBinding? = null
 
     /**
      * PostStore needs to be injected here as otherwise FluxC doesn't accept emitted events.
@@ -107,18 +108,28 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         setHasOptionsMenu(true)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.pages_fragment, container, false)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val nonNullActivity = requireActivity()
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
+        with(PagesFragmentBinding.bind(view)) {
+            binding = this
+            with(nonNullActivity as AppCompatActivity) {
+                setSupportActionBar(toolbar)
+                supportActionBar?.let {
+                    it.setHomeButtonEnabled(true)
+                    it.setDisplayHomeAsUpEnabled(true)
+                }
+            }
+            initializeViews(nonNullActivity)
+            initializeViewModels(nonNullActivity, savedInstanceState)
+        }
+    }
 
-        initializeViews(nonNullActivity)
-        initializeViewModels(nonNullActivity, savedInstanceState)
+    override fun onDestroyView() {
+        binding = null
+        super.onDestroyView()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -162,7 +173,8 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         viewModel.onPageParentSet(pageId, parentId)
     }
 
-    private fun initializeViews(activity: FragmentActivity) {
+    @SuppressLint("ClickableViewAccessibility")
+    private fun PagesFragmentBinding.initializeViews(activity: FragmentActivity) {
         pagesPager.adapter = PagesPagerAdapter(activity, childFragmentManager)
         tabLayout.setupWithViewPager(pagesPager)
 
@@ -211,8 +223,8 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         }
 
         authorSelectionAdapter = AuthorSelectionAdapter(activity)
-        pages_author_selection.adapter = authorSelectionAdapter
-        pages_author_selection.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        pagesAuthorSelection.adapter = authorSelectionAdapter
+        pagesAuthorSelection.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(parent: AdapterView<*>) {}
 
             override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
@@ -221,7 +233,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         }
     }
 
-    private fun initializeSearchView() {
+    private fun PagesFragmentBinding.initializeSearchView() {
         actionMenuItem.setOnActionExpandListener(object : OnActionExpandListener {
             override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
                 viewModel.onSearchExpanded(restorePreviousSearch)
@@ -257,7 +269,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         (searchEditFrame.layoutParams as LinearLayout.LayoutParams)
                 .apply { this.leftMargin = DisplayUtils.dpToPx(activity, -8) }
 
-        viewModel.isSearchExpanded.observe(this, Observer {
+        viewModel.isSearchExpanded.observe(this@PagesFragment, Observer {
             if (it == true) {
                 showSearchList(actionMenuItem)
             } else {
@@ -266,7 +278,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         })
     }
 
-    private fun initializeViewModels(activity: FragmentActivity, savedInstanceState: Bundle?) {
+    private fun PagesFragmentBinding.initializeViewModels(activity: FragmentActivity, savedInstanceState: Bundle?) {
         viewModel = ViewModelProvider(activity, viewModelFactory).get(PagesViewModel::class.java)
         mlpViewModel = ViewModelProvider(activity, viewModelFactory).get(ModalLayoutPickerViewModel::class.java)
 
@@ -282,8 +294,8 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
 
         viewModel.authorUIState.observe(activity, Observer { state ->
             state?.let {
-                uiHelpers.updateVisibility(pages_author_selection, state.isAuthorFilterVisible)
-                uiHelpers.updateVisibility(pages_tab_layout_fading_edge, state.isAuthorFilterVisible)
+                uiHelpers.updateVisibility(pagesAuthorSelection, state.isAuthorFilterVisible)
+                uiHelpers.updateVisibility(pagesTabLayoutFadingEdge, state.isAuthorFilterVisible)
 
                 val tabLayoutPaddingStart =
                         if (state.isAuthorFilterVisible)
@@ -294,7 +306,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
                 authorSelectionAdapter.updateItems(state.authorFilterItems)
 
                 authorSelectionAdapter.getIndexOfSelection(state.authorFilterSelection)?.let { selectionIndex ->
-                    pages_author_selection.setSelection(selectionIndex)
+                    pagesAuthorSelection.setSelection(selectionIndex)
                 }
             }
         })
@@ -326,7 +338,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         )
     }
 
-    private fun setupObservers(activity: FragmentActivity) {
+    private fun PagesFragmentBinding.setupObservers(activity: FragmentActivity) {
         viewModel.listState.observe(viewLifecycleOwner, {
             refreshProgressBars(it)
         })
@@ -373,7 +385,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
 
         viewModel.editPage.observe(viewLifecycleOwner, { (site, page, loadAutoRevision) ->
             page?.let {
-                ActivityLauncher.editPageForResult(this, site, page.id, loadAutoRevision)
+                ActivityLauncher.editPageForResult(this@PagesFragment, site, page.id, loadAutoRevision)
             }
         })
 
@@ -399,7 +411,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         })
 
         viewModel.setPageParent.observe(viewLifecycleOwner, { page ->
-            page?.let { ActivityLauncher.viewPageParentForResult(this, page) }
+            page?.let { ActivityLauncher.viewPageParentForResult(this@PagesFragment, page) }
         })
 
         viewModel.isNewPageButtonVisible.observe(viewLifecycleOwner, { isVisible ->
@@ -444,7 +456,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
             }
         })
 
-        viewModel.publishAction.observe(this, {
+        viewModel.publishAction.observe(this@PagesFragment, {
             it?.let {
                 uploadUtilsWrapper.publishPost(activity, it.post, it.site)
             }
@@ -496,7 +508,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
             "Menu does not contain mandatory search item"
         }
 
-        initializeSearchView()
+        binding!!.initializeSearchView()
     }
 
     private fun refreshProgressBars(listState: PageListState?) {
@@ -507,7 +519,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         swipeToRefreshHelper.isRefreshing = listState == FETCHING
     }
 
-    private fun hideSearchList(myActionMenuItem: MenuItem) {
+    private fun PagesFragmentBinding.hideSearchList(myActionMenuItem: MenuItem) {
         pagesPager.visibility = View.VISIBLE
         tabLayout.visibility = View.VISIBLE
         tabContainer.visibility = View.VISIBLE
@@ -515,12 +527,12 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         if (myActionMenuItem.isActionViewExpanded) {
             myActionMenuItem.collapseActionView()
         }
-        appbar_main.getTag(R.id.pages_non_search_recycler_view_id_tag_key)?.let {
-            appbar_main.setLiftOnScrollTargetViewIdAndRequestLayout(it as Int)
+        appbarMain.getTag(R.id.pages_non_search_recycler_view_id_tag_key)?.let {
+            appbarMain.setLiftOnScrollTargetViewIdAndRequestLayout(it as Int)
         }
     }
 
-    private fun showSearchList(myActionMenuItem: MenuItem) {
+    private fun PagesFragmentBinding.showSearchList(myActionMenuItem: MenuItem) {
         pagesPager.visibility = View.GONE
         tabLayout.visibility = View.GONE
         tabContainer.visibility = View.GONE
@@ -528,7 +540,7 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
         if (!myActionMenuItem.isActionViewExpanded) {
             myActionMenuItem.expandActionView()
         }
-        appbar_main.setLiftOnScrollTargetViewIdAndRequestLayout(R.id.pages_search_recycler_view_id)
+        appbarMain.setLiftOnScrollTargetViewIdAndRequestLayout(R.id.pages_search_recycler_view_id)
     }
 
     fun onPositiveClickedForBasicDialog(instanceTag: String) {
@@ -540,8 +552,10 @@ class PagesFragment : Fragment(), ScrollableViewInitializedListener {
     }
 
     override fun onScrollableViewInitialized(containerId: Int) {
-        appbar_main.setLiftOnScrollTargetViewIdAndRequestLayout(containerId)
-        appbar_main.setTag(R.id.pages_non_search_recycler_view_id_tag_key, containerId)
+        with(binding!!) {
+            appbarMain.setLiftOnScrollTargetViewIdAndRequestLayout(containerId)
+            appbarMain.setTag(R.id.pages_non_search_recycler_view_id_tag_key, containerId)
+        }
     }
 }
 

--- a/WordPress/src/main/res/layout/pages_activity.xml
+++ b/WordPress/src/main/res/layout/pages_activity.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:name="org.wordpress.android.ui.pages.PagesFragment"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/pages_parent_activity.xml
+++ b/WordPress/src/main/res/layout/pages_parent_activity.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/toolbar_main" />
+    <include android:id="@+id/toolbar" layout="@layout/toolbar_main" />
 
     <fragment
         android:id="@+id/fragment_container"


### PR DESCRIPTION
This PR introduces view bindings in pages activity/fragment, page parent activity/fragment and page parent search.
The changes are quite straightforward

To test:
- Go to Site pages
- Check it looks as expected
- Click on an overflow menu on a page -> "Set parent"
- Check the "Page parent" screen looks as expected
- Click on "Search"
- Check everything works

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
