### PR TITLE
Use View Binding in Me screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MainBottomSheetFragment.kt
@@ -6,16 +6,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import kotlinx.android.synthetic.main.add_content_bottom_sheet.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.AddContentBottomSheetBinding
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel
 import javax.inject.Inject
 
@@ -34,26 +32,26 @@ class MainBottomSheetFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val recyclerView = view.findViewById<RecyclerView>(R.id.content_recycler_view)
-        recyclerView.layoutManager = LinearLayoutManager(requireActivity())
-        recyclerView.adapter = AddContentAdapter(requireActivity())
+        with(AddContentBottomSheetBinding.bind(view)) {
+            contentRecyclerView.layoutManager = LinearLayoutManager(requireActivity())
+            contentRecyclerView.adapter = AddContentAdapter(requireActivity())
 
-        viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(WPMainActivityViewModel::class.java)
+            viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(WPMainActivityViewModel::class.java)
+            viewModel.mainActions.observe(this@MainBottomSheetFragment) {
+                (contentRecyclerView.adapter as? AddContentAdapter)?.update(it ?: listOf())
+            }
 
-        viewModel.mainActions.observe(this, Observer {
-            (dialog?.content_recycler_view?.adapter as? AddContentAdapter)?.update(it ?: listOf())
-        })
+            dialog?.setOnShowListener { dialogInterface ->
+                val sheetDialog = dialogInterface as? BottomSheetDialog
 
-        dialog?.setOnShowListener { dialogInterface ->
-            val sheetDialog = dialogInterface as? BottomSheetDialog
+                val bottomSheet = sheetDialog?.findViewById<View>(
+                        com.google.android.material.R.id.design_bottom_sheet
+                ) as? FrameLayout
 
-            val bottomSheet = sheetDialog?.findViewById<View>(
-                    com.google.android.material.R.id.design_bottom_sheet
-            ) as? FrameLayout
-
-            bottomSheet?.let {
-                val behavior = BottomSheetBehavior.from(it)
-                behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                bottomSheet?.let {
+                    val behavior = BottomSheetBehavior.from(it)
+                    behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeActivity.kt
@@ -1,10 +1,8 @@
 package org.wordpress.android.ui.main
 
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.R
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.RequestCodes
@@ -14,17 +12,6 @@ class MeActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.me_activity)
-
-        setSupportActionBar(toolbar_main)
-        supportActionBar?.let {
-            it.setHomeButtonEnabled(true)
-            it.setDisplayHomeAsUpEnabled(true)
-            val activityInfo = packageManager.getActivityInfo(
-                    componentName,
-                    PackageManager.GET_META_DATA
-            )
-            it.setTitle(activityInfo.labelRes)
-        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.main
 import android.app.Activity
 import android.app.ProgressDialog
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
@@ -12,6 +13,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.View.OnClickListener
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -90,6 +92,16 @@ class MeFragment : Fragment(), OnScrollToTopListener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        with(requireActivity() as AppCompatActivity) {
+            setSupportActionBar(toolbar_main)
+            supportActionBar?.apply {
+                setHomeButtonEnabled(true)
+                setDisplayHomeAsUpEnabled(true)
+                // We need to set the title this way so it can be updated on locale change
+                setTitle(packageManager.getActivityInfo(componentName, PackageManager.GET_META_DATA).labelRes)
+            }
+        }
+
         val showPickerListener = OnClickListener {
             AnalyticsTracker.track(ME_GRAVATAR_TAPPED)
             showPhotoPickerForGravatar()
@@ -138,10 +150,10 @@ class MeFragment : Fragment(), OnScrollToTopListener {
 
         viewModel = ViewModelProvider(this, viewModelFactory).get(MeViewModel::class.java)
         viewModel.showDisconnectDialog.observeEvent(viewLifecycleOwner, {
-                when (it) {
-                    true -> showDisconnectDialog()
-                    false -> hideDisconnectDialog()
-                }
+            when (it) {
+                true -> showDisconnectDialog()
+                false -> hideDisconnectDialog()
+            }
         })
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -9,10 +9,8 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
 import android.text.TextUtils
-import android.view.LayoutInflater
 import android.view.View
 import android.view.View.OnClickListener
-import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -20,7 +18,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
 import com.yalantis.ucrop.UCropActivity
-import kotlinx.android.synthetic.main.me_fragment.*
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -33,6 +30,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.ME_GRAVATAR_GALLERY
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.ME_GRAVATAR_SHOT_NEW
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.ME_GRAVATAR_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.ME_GRAVATAR_UPLOADED
+import org.wordpress.android.databinding.MeFragmentBinding
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
@@ -65,9 +63,10 @@ import org.wordpress.android.viewmodel.observeEvent
 import java.io.File
 import javax.inject.Inject
 
-class MeFragment : Fragment(), OnScrollToTopListener {
+class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     private var disconnectProgressDialog: ProgressDialog? = null
     private var isUpdatingGravatar = false
+    private var binding: MeFragmentBinding? = null
 
     @Inject lateinit var dispatcher: Dispatcher
     @Inject lateinit var accountStore: AccountStore
@@ -86,14 +85,14 @@ class MeFragment : Fragment(), OnScrollToTopListener {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.me_fragment, container, false) as ViewGroup
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding = MeFragmentBinding.bind(view).apply { onBind(savedInstanceState) }
+    }
+
+    private fun MeFragmentBinding.onBind(savedInstanceState: Bundle?) {
         with(requireActivity() as AppCompatActivity) {
-            setSupportActionBar(toolbar_main)
+            setSupportActionBar(toolbarMain)
             supportActionBar?.apply {
                 setHomeButtonEnabled(true)
                 setDisplayHomeAsUpEnabled(true)
@@ -106,33 +105,21 @@ class MeFragment : Fragment(), OnScrollToTopListener {
             AnalyticsTracker.track(ME_GRAVATAR_TAPPED)
             showPhotoPickerForGravatar()
         }
-        avatar_container.setOnClickListener(showPickerListener)
-        change_photo.setOnClickListener(showPickerListener)
-        row_my_profile.setOnClickListener {
-            ActivityLauncher.viewMyProfile(
-                    activity
-            )
+        avatarContainer.setOnClickListener(showPickerListener)
+        changePhoto.setOnClickListener(showPickerListener)
+        rowMyProfile.setOnClickListener {
+            ActivityLauncher.viewMyProfile(activity)
         }
-        row_account_settings.setOnClickListener {
-            ActivityLauncher.viewAccountSettings(
-                    activity
-            )
+        rowAccountSettings.setOnClickListener {
+            ActivityLauncher.viewAccountSettings(activity)
         }
-        row_app_settings.setOnClickListener {
-            ActivityLauncher.viewAppSettingsForResult(
-                    activity
-            )
+        rowAppSettings.setOnClickListener {
+            ActivityLauncher.viewAppSettingsForResult(activity)
         }
-        row_support.setOnClickListener {
-            ActivityLauncher
-                    .viewHelpAndSupport(
-                            requireContext(),
-                            ME_SCREEN_HELP,
-                            selectedSite,
-                            null
-                    )
+        rowSupport.setOnClickListener {
+            ActivityLauncher.viewHelpAndSupport(requireContext(), ME_SCREEN_HELP, selectedSite, null)
         }
-        row_logout.setOnClickListener {
+        rowLogout.setOnClickListener {
             if (accountStore.hasAccessToken()) {
                 signOutWordPressComWithConfirmation()
             } else {
@@ -148,7 +135,7 @@ class MeFragment : Fragment(), OnScrollToTopListener {
             }
         }
 
-        viewModel = ViewModelProvider(this, viewModelFactory).get(MeViewModel::class.java)
+        viewModel = ViewModelProvider(this@MeFragment, viewModelFactory).get(MeViewModel::class.java)
         viewModel.showDisconnectDialog.observeEvent(viewLifecycleOwner, {
             when (it) {
                 true -> showDisconnectDialog()
@@ -167,7 +154,7 @@ class MeFragment : Fragment(), OnScrollToTopListener {
 
     override fun onScrollToTop() {
         if (isAdded) {
-            scroll_view.smoothScrollTo(0, 0)
+            binding?.scrollView?.smoothScrollTo(0, 0)
         }
     }
 
@@ -185,7 +172,7 @@ class MeFragment : Fragment(), OnScrollToTopListener {
 
     override fun onResume() {
         super.onResume()
-        refreshAccountDetails()
+        binding?.refreshAccountDetails()
     }
 
     override fun onDestroy() {
@@ -194,50 +181,50 @@ class MeFragment : Fragment(), OnScrollToTopListener {
         super.onDestroy()
     }
 
-    private fun refreshAccountDetails() {
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+
+    private fun MeFragmentBinding.refreshAccountDetails() {
         if (!FluxCUtils.isSignedInWPComOrHasWPOrgSite(accountStore, siteStore)) {
             return
         }
         // we only want to show user details for WordPress.com users
         if (accountStore.hasAccessToken()) {
             val defaultAccount = accountStore.account
-            me_display_name.visibility = View.VISIBLE
-            me_username.visibility = View.VISIBLE
-            card_avatar.visibility = View.VISIBLE
-            row_my_profile.visibility = View.VISIBLE
+            meDisplayName.visibility = View.VISIBLE
+            meUsername.visibility = View.VISIBLE
+            cardAvatar.visibility = View.VISIBLE
+            rowMyProfile.visibility = View.VISIBLE
             loadAvatar(null)
-            me_username.text = getString(R.string.at_username, defaultAccount.userName)
-            me_login_logout_text_view.setText(R.string.me_disconnect_from_wordpress_com)
-            val displayName = defaultAccount.displayName
-            if (!TextUtils.isEmpty(displayName)) {
-                me_display_name.text = displayName
-            } else {
-                me_display_name.text = defaultAccount.userName
-            }
+            meUsername.text = getString(R.string.at_username, defaultAccount.userName)
+            meLoginLogoutTextView.setText(R.string.me_disconnect_from_wordpress_com)
+            meDisplayName.text = defaultAccount.displayName.ifEmpty { defaultAccount.userName }
         } else {
-            me_display_name.visibility = View.GONE
-            me_username.visibility = View.GONE
-            card_avatar.visibility = View.GONE
-            avatar_progress.visibility = View.GONE
-            row_my_profile.visibility = View.GONE
-            row_account_settings.visibility = View.GONE
-            me_login_logout_text_view.setText(R.string.me_connect_to_wordpress_com)
+            meDisplayName.visibility = View.GONE
+            meUsername.visibility = View.GONE
+            cardAvatar.visibility = View.GONE
+            avatarProgress.visibility = View.GONE
+            rowMyProfile.visibility = View.GONE
+            rowAccountSettings.visibility = View.GONE
+            meLoginLogoutTextView.setText(R.string.me_connect_to_wordpress_com)
         }
     }
 
-    private fun showGravatarProgressBar(isUpdating: Boolean) {
-        avatar_progress.visibility = if (isUpdating) View.VISIBLE else View.GONE
+    private fun MeFragmentBinding.showGravatarProgressBar(isUpdating: Boolean) {
+        avatarProgress.visibility = if (isUpdating) View.VISIBLE else View.GONE
         isUpdatingGravatar = isUpdating
     }
 
-    private fun loadAvatar(injectFilePath: String?) {
+    private fun MeFragmentBinding.loadAvatar(injectFilePath: String?) {
         val newAvatarUploaded = injectFilePath != null && injectFilePath.isNotEmpty()
         val avatarUrl = meGravatarLoader.constructGravatarUrl(accountStore.account.avatarUrl)
         meGravatarLoader.load(
                 newAvatarUploaded,
                 avatarUrl,
                 injectFilePath,
-                me_avatar,
+                meAvatar,
                 AVATAR_WITHOUT_BACKGROUND,
                 object : RequestListener<Drawable> {
                     override fun onLoadFailed(e: Exception?, model: Any?) {
@@ -419,7 +406,7 @@ class MeFragment : Fragment(), OnScrollToTopListener {
             )
             return
         }
-        showGravatarProgressBar(true)
+        binding?.showGravatarProgressBar(true)
         GravatarApi.uploadGravatar(file, accountStore.account.email, accountStore.accessToken,
                 object : GravatarUploadListener {
                     override fun onSuccess() {
@@ -436,10 +423,10 @@ class MeFragment : Fragment(), OnScrollToTopListener {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: GravatarUploadFinished) {
-        showGravatarProgressBar(false)
+        binding?.showGravatarProgressBar(false)
         if (event.success) {
             AnalyticsTracker.track(ME_GRAVATAR_UPLOADED)
-            loadAvatar(event.filePath)
+            binding?.loadAvatar(event.filePath)
         } else {
             ToastUtils.showToast(
                     activity,
@@ -451,7 +438,7 @@ class MeFragment : Fragment(), OnScrollToTopListener {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAccountChanged(event: OnAccountChanged?) {
-        refreshAccountDetails()
+        binding?.refreshAccountDetails()
     }
 
     private val selectedSite: SiteModel?

--- a/WordPress/src/main/res/layout/me_activity.xml
+++ b/WordPress/src/main/res/layout/me_activity.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:name="org.wordpress.android.ui.main.MeFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent" />
 
 </FrameLayout>


### PR DESCRIPTION
This PR introduces View Bindings for the Me screen. Most of the changes introduced here are pretty similar to what we have already done in other classes. Like in #14217, a toolbar setup that was in an Activity had to be moved to a Fragment. 

Other than the Me activity and fragment, I'm also including changes to the `MainBottomSheetFragment` here, just because it was in the same package and it was pretty small.

To test:

Smoke test the Me screen and make sure everything is working as expected and nothing looks out of place. Main points of attention:

1. Try to upload a new avatar and make sure the progress bar shows up correctly and the process completes successfully.
1. Try to logout and make sure it works as expected.
1. Login with a self-hosted site and make sure the screen looks as expected.
1. Change the device language via system settings while the Me screen is open and make sure everything is updated, including the toolbar title. Repeat this but changing the language via app settings.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
