### PR TITLE
Fixes failed media upload tracking after rotation

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -97,6 +97,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     public static final String ARG_STORY_BLOCK_ID = "story_block_id";
     public static final String ARG_STORY_BLOCK_UPDATED_CONTENT = "story_block_updated_content";
     public static final String ARG_STORY_BLOCK_EXTERNALLY_EDITED_ORIGINAL_HASH = "story_block_original_hash";
+    public static final String ARG_FAILED_MEDIAS = "arg_failed_medias";
 
     private static final int CAPTURE_PHOTO_PERMISSION_REQUEST_CODE = 101;
     private static final int CAPTURE_VIDEO_PERMISSION_REQUEST_CODE = 102;
@@ -124,7 +125,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     GutenbergContainerFragment mRetainedGutenbergContainerFragment;
 
     private ConcurrentHashMap<String, Float> mUploadingMediaProgressMax = new ConcurrentHashMap<>();
-    private Set<String> mFailedMediaIds = new HashSet<>();
+    private HashSet<String> mFailedMediaIds = new HashSet<>();
     private ConcurrentHashMap<String, Date> mCancelledMediaIds = new ConcurrentHashMap<>();
 
     private boolean mIsNewPost;
@@ -200,6 +201,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             mEditorDidMount = savedInstanceState.getBoolean(KEY_EDITOR_DID_MOUNT);
             mExternallyEditedBlockOriginalHash = savedInstanceState.getString(
                     ARG_STORY_BLOCK_EXTERNALLY_EDITED_ORIGINAL_HASH);
+            mFailedMediaIds = (HashSet<String>) savedInstanceState.getSerializable(ARG_FAILED_MEDIAS);
         }
     }
 
@@ -898,6 +900,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         outState.putBoolean(KEY_HTML_MODE_ENABLED, mHtmlModeEnabled);
         outState.putBoolean(KEY_EDITOR_DID_MOUNT, mEditorDidMount);
         outState.putString(ARG_STORY_BLOCK_EXTERNALLY_EDITED_ORIGINAL_HASH, mExternallyEditedBlockOriginalHash);
+        outState.putSerializable(ARG_FAILED_MEDIAS, mFailedMediaIds);
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/24654

### Description

Saves state of failed media upload ids and restores them after rotation

To test:
1. Add a media block such as Image, Media Text or Video
2. Tap on the block to bring up the upload options
3. Tap option ‘Choose from device’ and choose an image or video (a larger one will make testing easier)
4. Turn off internet connection while the upload is in progress
5. You should see the retry message on the image thumbnail
6. Rotate the device
7. Turn on the internet connection
8. Tap on the retry
9. Confirm the retry action
10. **Verify** that the upload resumes and the progress is tracked on the block

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
