### PR TITLE
Feature/use view binding in posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -2,18 +2,16 @@ package org.wordpress.android.ui.posts
 
 import android.content.Context
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.annotation.NonNull
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.history_list_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.HistoryListFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.history.HistoryAdapter
 import org.wordpress.android.ui.history.HistoryListItem
@@ -24,7 +22,7 @@ import org.wordpress.android.viewmodel.history.HistoryViewModel
 import org.wordpress.android.viewmodel.history.HistoryViewModel.HistoryListStatus
 import javax.inject.Inject
 
-class HistoryListFragment : Fragment() {
+class HistoryListFragment : Fragment(R.layout.history_list_fragment) {
     private lateinit var swipeToRefreshHelper: SwipeToRefreshHelper
     private lateinit var viewModel: HistoryViewModel
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -45,10 +43,6 @@ class HistoryListFragment : Fragment() {
 
     interface HistoryItemClickInterface {
         fun onHistoryItemClicked(revision: Revision, revisions: List<Revision>)
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.history_list_fragment, container, false)
     }
 
     private fun onItemClicked(item: HistoryListItem) {
@@ -74,53 +68,54 @@ class HistoryListFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val nonNullActivity = requireActivity()
+        with(HistoryListFragmentBinding.bind(view)) {
+            emptyRecyclerView.layoutManager = LinearLayoutManager(nonNullActivity, RecyclerView.VERTICAL, false)
+            emptyRecyclerView.setEmptyView(actionableEmptyView)
+            actionableEmptyView.button.setText(R.string.button_retry)
+            actionableEmptyView.button.setOnClickListener {
+                viewModel.onPullToRefresh()
+            }
 
-        empty_recycler_view.layoutManager = LinearLayoutManager(nonNullActivity, RecyclerView.VERTICAL, false)
-        empty_recycler_view.setEmptyView(actionable_empty_view)
-        actionable_empty_view.button.setText(R.string.button_retry)
-        actionable_empty_view.button.setOnClickListener {
-            viewModel.onPullToRefresh()
+            swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(swipeRefreshLayout) {
+                viewModel.onPullToRefresh()
+            }
+
+            (nonNullActivity.application as WordPress).component()?.inject(this@HistoryListFragment)
+
+            viewModel = ViewModelProvider(this@HistoryListFragment, viewModelFactory).get(HistoryViewModel::class.java)
+            viewModel.create(
+                    localPostId = arguments?.getInt(KEY_POST_LOCAL_ID) ?: 0,
+                    site = arguments?.get(KEY_SITE) as SiteModel
+            )
+            updatePostOrPageEmptyView()
+            setObservers()
         }
-
-        swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(swipe_refresh_layout) {
-            viewModel.onPullToRefresh()
-        }
-
-        (nonNullActivity.application as WordPress).component()?.inject(this)
-
-        viewModel = ViewModelProvider(this, viewModelFactory).get(HistoryViewModel::class.java)
-        viewModel.create(
-                localPostId = arguments?.getInt(KEY_POST_LOCAL_ID) ?: 0,
-                site = arguments?.get(KEY_SITE) as SiteModel
-        )
-        updatePostOrPageEmptyView()
-        setObservers()
     }
 
-    private fun updatePostOrPageEmptyView() {
-        actionable_empty_view.title.text = getString(R.string.history_empty_title)
-        actionable_empty_view.button.visibility = View.GONE
-        actionable_empty_view.subtitle.visibility = View.VISIBLE
+    private fun HistoryListFragmentBinding.updatePostOrPageEmptyView() {
+        actionableEmptyView.title.text = getString(R.string.history_empty_title)
+        actionableEmptyView.button.visibility = View.GONE
+        actionableEmptyView.subtitle.visibility = View.VISIBLE
     }
 
-    private fun reloadList(data: List<HistoryListItem>) {
+    private fun HistoryListFragmentBinding.reloadList(data: List<HistoryListItem>) {
         setList(data)
     }
 
-    private fun setList(list: List<HistoryListItem>) {
+    private fun HistoryListFragmentBinding.setList(list: List<HistoryListItem>) {
         val adapter: HistoryAdapter
 
-        if (empty_recycler_view.adapter == null) {
-            adapter = HistoryAdapter(requireActivity(), this::onItemClicked)
-            empty_recycler_view.adapter = adapter
+        if (emptyRecyclerView.adapter == null) {
+            adapter = HistoryAdapter(requireActivity(), this@HistoryListFragment::onItemClicked)
+            emptyRecyclerView.adapter = adapter
         } else {
-            adapter = empty_recycler_view.adapter as HistoryAdapter
+            adapter = emptyRecyclerView.adapter as HistoryAdapter
         }
 
         adapter.updateList(list)
     }
 
-    private fun setObservers() {
+    private fun HistoryListFragmentBinding.setObservers() {
         viewModel.revisions.observe(viewLifecycleOwner, Observer {
             reloadList(it ?: emptyList())
         })
@@ -135,21 +130,21 @@ class HistoryListFragment : Fragment() {
                         updatePostOrPageEmptyView()
                     }
                     HistoryListStatus.FETCHING -> {
-                        actionable_empty_view.title.setText(R.string.history_fetching_revisions)
-                        actionable_empty_view.subtitle.visibility = View.GONE
-                        actionable_empty_view.button.visibility = View.GONE
+                        actionableEmptyView.title.setText(R.string.history_fetching_revisions)
+                        actionableEmptyView.subtitle.visibility = View.GONE
+                        actionableEmptyView.button.visibility = View.GONE
                     }
                     HistoryListStatus.NO_NETWORK -> {
-                        actionable_empty_view.title.setText(R.string.no_network_title)
-                        actionable_empty_view.subtitle.setText(R.string.no_network_message)
-                        actionable_empty_view.subtitle.visibility = View.VISIBLE
-                        actionable_empty_view.button.visibility = View.VISIBLE
+                        actionableEmptyView.title.setText(R.string.no_network_title)
+                        actionableEmptyView.subtitle.setText(R.string.no_network_message)
+                        actionableEmptyView.subtitle.visibility = View.VISIBLE
+                        actionableEmptyView.button.visibility = View.VISIBLE
                     }
                     HistoryListStatus.ERROR -> {
-                        actionable_empty_view.title.setText(R.string.no_network_title)
-                        actionable_empty_view.subtitle.setText(R.string.error_generic_network)
-                        actionable_empty_view.subtitle.visibility = View.VISIBLE
-                        actionable_empty_view.button.visibility = View.VISIBLE
+                        actionableEmptyView.title.setText(R.string.no_network_title)
+                        actionableEmptyView.subtitle.setText(R.string.error_generic_network)
+                        actionableEmptyView.subtitle.visibility = View.VISIBLE
+                        actionableEmptyView.button.visibility = View.VISIBLE
                     }
                 }
             }
@@ -165,7 +160,7 @@ class HistoryListFragment : Fragment() {
         })
 
         viewModel.post.observe(viewLifecycleOwner, Observer { post ->
-            actionable_empty_view.subtitle.text = if (post?.isPage == true) {
+            actionableEmptyView.subtitle.text = if (post?.isPage == true) {
                 getString(R.string.history_empty_subtitle_page)
             } else {
                 getString(R.string.history_empty_subtitle_post)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListCreateMenuFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListCreateMenuFragment.kt
@@ -6,15 +6,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import kotlinx.android.synthetic.main.add_content_bottom_sheet.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.AddContentBottomSheetBinding
 import org.wordpress.android.ui.main.AddContentAdapter
 import org.wordpress.android.viewmodel.posts.PostListCreateMenuViewModel
 import javax.inject.Inject
@@ -34,25 +33,27 @@ class PostListCreateMenuFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        content_recycler_view.layoutManager = LinearLayoutManager(requireActivity())
-        content_recycler_view.adapter = AddContentAdapter(requireActivity())
+        with(AddContentBottomSheetBinding.bind(view)) {
+            contentRecyclerView.layoutManager = LinearLayoutManager(requireActivity())
+            contentRecyclerView.adapter = AddContentAdapter(requireActivity())
 
-        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(PostListCreateMenuViewModel::class.java)
-        viewModel.mainActions.observe(this, Observer {
-            (dialog?.content_recycler_view?.adapter as? AddContentAdapter)?.update(it ?: listOf())
-        })
+            viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
+                    .get(PostListCreateMenuViewModel::class.java)
+            viewModel.mainActions.observe(this@PostListCreateMenuFragment, {
+                (contentRecyclerView.adapter as? AddContentAdapter)?.update(it ?: listOf())
+            })
 
-        dialog?.setOnShowListener { dialogInterface ->
-            val sheetDialog = dialogInterface as? BottomSheetDialog
+            dialog?.setOnShowListener { dialogInterface ->
+                val sheetDialog = dialogInterface as? BottomSheetDialog
 
-            val bottomSheet = sheetDialog?.findViewById<View>(
-                    com.google.android.material.R.id.design_bottom_sheet
-            ) as? FrameLayout
+                val bottomSheet = sheetDialog?.findViewById<View>(
+                        com.google.android.material.R.id.design_bottom_sheet
+                ) as? FrameLayout
 
-            bottomSheet?.let {
-                val behavior = BottomSheetBehavior.from(it)
-                behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                bottomSheet?.let {
+                    val behavior = BottomSheetBehavior.from(it)
+                    behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -8,10 +8,11 @@ import android.view.View
 import android.widget.AdapterView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.synthetic.main.add_category.*
-import kotlinx.android.synthetic.main.prepublishing_toolbar.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.AddCategoryBinding
+import org.wordpress.android.databinding.PrepublishingAddCategoryFragmentBinding
+import org.wordpress.android.databinding.PrepublishingToolbarBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.CategoryNode
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
@@ -59,29 +60,31 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initBackButton()
-        initSubmitButton()
-        initAdapter()
-        initSpinner()
-        initInputText()
-        initViewModel()
+        with(PrepublishingAddCategoryFragmentBinding.bind(view)) {
+            prepublishingToolbar.initBackButton()
+            addCategory.initSubmitButton()
+            addCategory.initAdapter()
+            addCategory.initSpinner()
+            addCategory.initInputText()
+            initViewModel()
+        }
     }
 
-    private fun initBackButton() {
-        back_button.setOnClickListener {
+    private fun PrepublishingToolbarBinding.initBackButton() {
+        backButton.setOnClickListener {
             viewModel.onBackButtonClick()
         }
     }
 
-    private fun initSubmitButton() {
-        submit_button.setOnClickListener {
+    private fun AddCategoryBinding.initSubmitButton() {
+        submitButton.setOnClickListener {
             viewModel.onSubmitButtonClick()
         }
     }
 
-    private fun initInputText() {
-        category_name.requestFocus()
-        category_name.addTextChangedListener(object : TextWatcher {
+    private fun AddCategoryBinding.initInputText() {
+        categoryName.requestFocus()
+        categoryName.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
             }
 
@@ -93,26 +96,26 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
             }
         })
 
-        ActivityUtils.showKeyboard(category_name)
+        ActivityUtils.showKeyboard(categoryName)
     }
 
-    private fun initAdapter() {
+    private fun AddCategoryBinding.initAdapter() {
         val categoryAdapter = ParentCategorySpinnerAdapter(
                 activity,
                 R.layout.categories_row_parent,
                 arrayListOf<CategoryNode>()
         )
-        parent_category.adapter = categoryAdapter
+        parentCategory.adapter = categoryAdapter
     }
 
-    private fun initSpinner() {
-        parent_category.setOnTouchListener { v, _ ->
+    private fun AddCategoryBinding.initSpinner() {
+        parentCategory.setOnTouchListener { v, _ ->
             spinnerTouched = true
             v.performClick()
             false
         }
 
-        parent_category.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        parentCategory.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(parent: AdapterView<*>?) {
             }
 
@@ -130,8 +133,8 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         }
     }
 
-    private fun initViewModel() {
-        viewModel = ViewModelProvider(this, viewModelFactory)
+    private fun PrepublishingAddCategoryFragmentBinding.initViewModel() {
+        viewModel = ViewModelProvider(this@PrepublishingAddCategoryFragment, viewModelFactory)
                 .get(PrepublishingAddCategoryViewModel::class.java)
         parentViewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
                 .get(PrepublishingViewModel::class.java)
@@ -143,9 +146,9 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         viewModel.start(siteModel, !needsRequestLayout)
     }
 
-    private fun startObserving() {
+    private fun PrepublishingAddCategoryFragmentBinding.startObserving() {
         viewModel.dismissKeyboard.observeEvent(viewLifecycleOwner, {
-            ActivityUtils.hideKeyboardForced(category_name)
+            ActivityUtils.hideKeyboardForced(addCategory.categoryName)
         })
 
         viewModel.navigateBack.observe(viewLifecycleOwner, { bundle ->
@@ -158,7 +161,7 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         })
 
         viewModel.toolbarTitleUiState.observe(viewLifecycleOwner, { uiString ->
-            toolbar_title.text = uiHelpers.getTextOfUiString(requireContext(), uiString)
+            prepublishingToolbar.toolbarTitle.text = uiHelpers.getTextOfUiString(requireContext(), uiString)
         })
 
         viewModel.snackbarEvents.observeEvent(viewLifecycleOwner, {
@@ -166,11 +169,11 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         })
 
         viewModel.uiState.observe(viewLifecycleOwner, { uiState ->
-            loadCategories(uiState.categories)
-            if (uiState.selectedParentCategoryPosition != parent_category.selectedItemPosition) {
-                parent_category.setSelection(uiState.selectedParentCategoryPosition)
+            addCategory.loadCategories(uiState.categories)
+            if (uiState.selectedParentCategoryPosition != addCategory.parentCategory.selectedItemPosition) {
+                addCategory.parentCategory.setSelection(uiState.selectedParentCategoryPosition)
             }
-            updateSubmitButton(uiState.submitButtonUiState)
+            addCategory.updateSubmitButton(uiState.submitButtonUiState)
         })
 
         parentViewModel.triggerOnDeviceBackPressed.observeEvent(viewLifecycleOwner, {
@@ -178,17 +181,17 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         })
     }
 
-    private fun updateSubmitButton(submitButtonUiState: SubmitButtonUiState) {
-        with(submit_button) {
+    private fun AddCategoryBinding.updateSubmitButton(submitButtonUiState: SubmitButtonUiState) {
+        with(submitButton) {
             isEnabled = submitButtonUiState.enabled
         }
         with(uiHelpers) {
-            updateVisibility(submit_button, submitButtonUiState.visibility)
+            updateVisibility(submitButton, submitButtonUiState.visibility)
         }
     }
 
-    private fun loadCategories(categoryLevels: ArrayList<CategoryNode>) {
-        (parent_category.adapter as? ParentCategorySpinnerAdapter)?.replaceItems(categoryLevels)
+    private fun AddCategoryBinding.loadCategories(categoryLevels: ArrayList<CategoryNode>) {
+        (parentCategory.adapter as? ParentCategorySpinnerAdapter)?.replaceItems(categoryLevels)
     }
 
     private fun SnackbarMessageHolder.showToast() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -15,10 +15,10 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import kotlinx.android.synthetic.main.post_prepublishing_bottom_sheet.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.databinding.PostPrepublishingBottomSheetBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.login.widgets.WPBottomSheetDialogFragment
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType
@@ -94,21 +94,23 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initViewModel(savedInstanceState)
-        dialog?.setOnShowListener { dialogInterface ->
-            val sheetDialog = dialogInterface as? BottomSheetDialog
+        with(PostPrepublishingBottomSheetBinding.bind(view)) {
+            initViewModel(savedInstanceState)
+            dialog?.setOnShowListener { dialogInterface ->
+                val sheetDialog = dialogInterface as? BottomSheetDialog
 
-            val bottomSheet = sheetDialog?.findViewById<View>(
-                    com.google.android.material.R.id.design_bottom_sheet
-            ) as? FrameLayout
+                val bottomSheet = sheetDialog?.findViewById<View>(
+                        com.google.android.material.R.id.design_bottom_sheet
+                ) as? FrameLayout
 
-            bottomSheet?.let {
-                val behavior = BottomSheetBehavior.from(it)
-                behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                bottomSheet?.let {
+                    val behavior = BottomSheetBehavior.from(it)
+                    behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                }
             }
+            setupMinimumHeightForFragmentContainer()
+            addWindowInsetToFragmentContainer()
         }
-        setupMinimumHeightForFragmentContainer()
-        addWindowInsetToFragmentContainer()
     }
 
     override fun onDismiss(dialog: DialogInterface) {
@@ -120,26 +122,26 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
      * On Android 10, the bottom sheet is not above the window inset so that leads to the publish button being cut
      * off. To fix this, we add the bottom inset as the margin bottom of the fragment container.
      */
-    private fun addWindowInsetToFragmentContainer() {
+    private fun PostPrepublishingBottomSheetBinding.addWindowInsetToFragmentContainer() {
         if (VERSION.SDK_INT >= VERSION_CODES.Q) {
             activity?.window?.decorView?.rootWindowInsets?.systemWindowInsetBottom?.let { bottomInset ->
-                val param = prepublishing_content_fragment.layoutParams as ViewGroup.MarginLayoutParams
+                val param = prepublishingContentFragment.layoutParams as ViewGroup.MarginLayoutParams
                 param.setMargins(0, 0, 0, bottomInset)
-                prepublishing_content_fragment.layoutParams = param
+                prepublishingContentFragment.layoutParams = param
             }
         }
     }
 
-    private fun setupMinimumHeightForFragmentContainer() {
+    private fun PostPrepublishingBottomSheetBinding.setupMinimumHeightForFragmentContainer() {
         val isPage = checkNotNull(arguments?.getBoolean(IS_PAGE)) {
             "arguments can't be null."
         }
 
         if (isPage) {
-            prepublishing_content_fragment.minimumHeight =
+            prepublishingContentFragment.minimumHeight =
                     resources.getDimensionPixelSize(R.dimen.prepublishing_fragment_container_min_height_for_page)
         } else {
-            prepublishing_content_fragment.minimumHeight =
+            prepublishingContentFragment.minimumHeight =
                     resources.getDimensionPixelSize(R.dimen.prepublishing_fragment_container_min_height)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesAdapter.kt
@@ -9,13 +9,13 @@ import org.wordpress.android.ui.posts.PrepublishingCategoriesViewModel.Prepublis
 import org.wordpress.android.ui.utils.UiHelpers
 
 class PrepublishingCategoriesAdapter(private val uiHelpers: UiHelpers) :
-        RecyclerView.Adapter<PrepublishingCategoriesViewHolder>() {
+        RecyclerView.Adapter<PrepublishingCategoriesViewHolder<*>>() {
     private val items = mutableListOf<PrepublishingCategoriesListItemUiState>()
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
-    ): PrepublishingCategoriesViewHolder {
+    ): PrepublishingCategoriesViewHolder<*> {
         return PrepublishingCategoriesListItemViewHolder(parent, uiHelpers)
     }
 
@@ -25,8 +25,8 @@ class PrepublishingCategoriesAdapter(private val uiHelpers: UiHelpers) :
         return position.toLong()
     }
 
-    override fun onBindViewHolder(holder: PrepublishingCategoriesViewHolder, position: Int) {
-        holder.onBind(items[position])
+    override fun onBindViewHolder(holder: PrepublishingCategoriesViewHolder<*>, position: Int) {
+        holder.onBind(items[position], position)
     }
 
     @MainThread

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -8,12 +8,12 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.prepublishing_categories_fragment.*
-import kotlinx.android.synthetic.main.prepublishing_toolbar.*
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.PrepublishingCategoriesFragmentBinding
+import org.wordpress.android.databinding.PrepublishingToolbarBinding
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded
@@ -74,41 +74,43 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initBackButton()
-        initAddCategoryButton()
-        initRecyclerView()
-        initViewModel()
+        with(PrepublishingCategoriesFragmentBinding.bind(view)) {
+            includePrepublishingToolbar.initBackButton()
+            includePrepublishingToolbar.initAddCategoryButton()
+            initRecyclerView()
+            initViewModel()
+        }
     }
 
-    private fun initBackButton() {
-        back_button.setOnClickListener {
+    private fun PrepublishingToolbarBinding.initBackButton() {
+        backButton.setOnClickListener {
             viewModel.onBackButtonClick()
         }
     }
 
-    private fun initAddCategoryButton() {
-        add_action_button.setOnClickListener {
+    private fun PrepublishingToolbarBinding.initAddCategoryButton() {
+        addActionButton.setOnClickListener {
             viewModel.onAddCategoryClick()
         }
     }
 
-    private fun initRecyclerView() {
-        recycler_view.layoutManager = LinearLayoutManager(
+    private fun PrepublishingCategoriesFragmentBinding.initRecyclerView() {
+        recyclerView.layoutManager = LinearLayoutManager(
                 context,
                 RecyclerView.VERTICAL,
                 false
         )
-        recycler_view.adapter = PrepublishingCategoriesAdapter(uiHelpers)
-        recycler_view.addItemDecoration(
+        recyclerView.adapter = PrepublishingCategoriesAdapter(uiHelpers)
+        recyclerView.addItemDecoration(
                 DividerItemDecoration(
-                        recycler_view.context,
+                        recyclerView.context,
                         DividerItemDecoration.VERTICAL
                 )
         )
     }
 
-    private fun initViewModel() {
-        viewModel = ViewModelProvider(this, viewModelFactory)
+    private fun PrepublishingCategoriesFragmentBinding.initViewModel() {
+        viewModel = ViewModelProvider(this@PrepublishingCategoriesFragment, viewModelFactory)
                 .get(PrepublishingCategoriesViewModel::class.java)
         parentViewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
                 .get(PrepublishingViewModel::class.java)
@@ -122,9 +124,9 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
         viewModel.start(getEditPostRepository(), siteModel, addCategoryRequest, selectedCategoryIds)
     }
 
-    private fun startObserving() {
+    private fun PrepublishingCategoriesFragmentBinding.startObserving() {
         viewModel.navigateToHomeScreen.observeEvent(viewLifecycleOwner, {
-                closeListener?.onBackClicked()
+            closeListener?.onBackClicked()
         })
 
         viewModel.navigateToAddCategoryScreen.observe(viewLifecycleOwner, { bundle ->
@@ -133,21 +135,21 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
         )
 
         viewModel.toolbarTitleUiState.observe(viewLifecycleOwner, { uiString ->
-            toolbar_title.text = uiHelpers.getTextOfUiString(requireContext(), uiString)
+            includePrepublishingToolbar.toolbarTitle.text = uiHelpers.getTextOfUiString(requireContext(), uiString)
         })
 
         viewModel.snackbarEvents.observeEvent(viewLifecycleOwner, {
-                it.showToast()
+            it.showToast()
         })
 
         viewModel.uiState.observe(viewLifecycleOwner, {
-            (recycler_view.adapter as PrepublishingCategoriesAdapter).update(
+            (recyclerView.adapter as PrepublishingCategoriesAdapter).update(
                     it.categoriesListItemUiState
             )
             with(uiHelpers) {
-                updateVisibility(add_action_button, it.addCategoryActionButtonVisibility)
-                updateVisibility(progress_loading, it.progressVisibility)
-                updateVisibility(recycler_view, it.categoryListVisibility)
+                updateVisibility(includePrepublishingToolbar.addActionButton, it.addCategoryActionButtonVisibility)
+                updateVisibility(progressLoading, it.progressVisibility)
+                updateVisibility(recyclerView, it.categoryListVisibility)
             }
         })
         parentViewModel.triggerOnDeviceBackPressed.observeEvent(viewLifecycleOwner, {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesViewHolder.kt
@@ -1,58 +1,46 @@
 package org.wordpress.android.ui.posts
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.annotation.LayoutRes
 import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.prepublishing_categories_row.view.*
+import androidx.viewbinding.ViewBinding
 import org.apache.commons.text.StringEscapeUtils
-import org.wordpress.android.R
+import org.wordpress.android.databinding.PrepublishingCategoriesRowBinding
 import org.wordpress.android.ui.posts.PrepublishingCategoriesViewModel.PrepublishingCategoriesListItemUiState
 import org.wordpress.android.ui.utils.UiDimen.UIDimenRes
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.viewBinding
 
-sealed class PrepublishingCategoriesViewHolder(
-    internal val parent: ViewGroup,
-    @LayoutRes layout: Int
-) : RecyclerView.ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
-    abstract fun onBind(uiState: PrepublishingCategoriesListItemUiState)
+sealed class PrepublishingCategoriesViewHolder<T : ViewBinding>(
+    internal val binding: T
+) : RecyclerView.ViewHolder(binding.root) {
+    abstract fun onBind(uiState: PrepublishingCategoriesListItemUiState, position: Int)
 
     class PrepublishingCategoriesListItemViewHolder(
         parentView: ViewGroup,
         private val uiHelpers: UiHelpers
-    ) : PrepublishingCategoriesViewHolder(
-            parentView,
-            R.layout.prepublishing_categories_row
+    ) : PrepublishingCategoriesViewHolder<PrepublishingCategoriesRowBinding>(
+            parentView.viewBinding(PrepublishingCategoriesRowBinding::inflate)
     ) {
-        private val container = itemView.prepublishing_category_row_layout
-        private val categoryName = itemView.prepublishing_category_text
-        private val categoryCheckBox = itemView.prepublishing_category_check
-        private var onCategorySelected: ((Int) -> Unit)? = null
-
-        init {
-            container.setOnClickListener {
-                onCategorySelected?.invoke(adapterPosition)
+        override fun onBind(uiState: PrepublishingCategoriesListItemUiState, position: Int) = with(binding) {
+            prepublishingCategoryRowLayout.setOnClickListener {
+                uiState.onItemTapped(position)
             }
-            categoryCheckBox.setOnClickListener {
-                onCategorySelected?.invoke(adapterPosition)
+            prepublishingCategoryText.text = StringEscapeUtils.unescapeHtml4(uiState.categoryNode.name)
+            prepublishingCategoryCheck.isChecked = uiState.checked
+            prepublishingCategoryCheck.setOnClickListener {
+                uiState.onItemTapped(position)
             }
-        }
-
-        override fun onBind(uiState: PrepublishingCategoriesListItemUiState) {
-            onCategorySelected = requireNotNull(uiState.onItemTapped) { "OnItemTapped is required" }
-            categoryName.text = StringEscapeUtils.unescapeHtml4(uiState.categoryNode.name)
-            categoryCheckBox.isChecked = uiState.checked
             val verticalPadding: Int = uiHelpers.getPxOfUiDimen(
-                    categoryName.context,
+                    prepublishingCategoryText.context,
                     UIDimenRes(uiState.verticalPaddingResId)
             )
             val horizontalPadding: Int = uiHelpers.getPxOfUiDimen(
-                    categoryName.context,
+                    prepublishingCategoryText.context,
                     UIDimenRes(uiState.horizontalPaddingResId)
             )
             ViewCompat.setPaddingRelative(
-                    categoryName,
+                    prepublishingCategoryText,
                     horizontalPadding * uiState.categoryNode.level,
                     verticalPadding,
                     horizontalPadding,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeFragment.kt
@@ -2,15 +2,13 @@ package org.wordpress.android.ui.posts
 
 import android.content.Context
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.android.synthetic.main.post_prepublishing_home_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.PostPrepublishingHomeFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
 import org.wordpress.android.ui.utils.UiHelpers
@@ -18,7 +16,7 @@ import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
-class PrepublishingHomeFragment : Fragment() {
+class PrepublishingHomeFragment : Fragment(R.layout.post_prepublishing_home_fragment) {
     @Inject lateinit var uiHelpers: UiHelpers
     @Inject lateinit var imageManager: ImageManager
 
@@ -42,21 +40,14 @@ class PrepublishingHomeFragment : Fragment() {
         actionClickedListener = null
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.post_prepublishing_home_fragment, container, false)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        actions_recycler_view.layoutManager = LinearLayoutManager(requireActivity())
-        actions_recycler_view.adapter = PrepublishingHomeAdapter(requireActivity())
+        with(PostPrepublishingHomeFragmentBinding.bind(view)) {
+            actionsRecyclerView.layoutManager = LinearLayoutManager(requireActivity())
+            actionsRecyclerView.adapter = PrepublishingHomeAdapter(requireActivity())
 
-        initViewModel()
+            initViewModel()
+        }
     }
 
     override fun onResume() {
@@ -69,17 +60,17 @@ class PrepublishingHomeFragment : Fragment() {
         super.onResume()
     }
 
-    private fun initViewModel() {
-        viewModel = ViewModelProvider(this, viewModelFactory)
+    private fun PostPrepublishingHomeFragmentBinding.initViewModel() {
+        viewModel = ViewModelProvider(this@PrepublishingHomeFragment, viewModelFactory)
                 .get(PrepublishingHomeViewModel::class.java)
 
         viewModel.storyTitleUiState.observe(viewLifecycleOwner, { storyTitleUiState ->
-            uiHelpers.updateVisibility(story_title_header_view, true)
-            story_title_header_view.init(uiHelpers, imageManager, storyTitleUiState)
+            uiHelpers.updateVisibility(storyTitleHeaderView, true)
+            storyTitleHeaderView.init(uiHelpers, imageManager, storyTitleUiState)
         })
 
         viewModel.uiState.observe(viewLifecycleOwner, { uiState ->
-            (actions_recycler_view.adapter as PrepublishingHomeAdapter).update(uiState)
+            (actionsRecyclerView.adapter as PrepublishingHomeAdapter).update(uiState)
         })
 
         viewModel.onActionClicked.observeEvent(viewLifecycleOwner, { actionType ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingTagsFragment.kt
@@ -4,11 +4,10 @@ import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.synthetic.main.fragment_post_settings_tags.*
-import kotlinx.android.synthetic.main.prepublishing_toolbar.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.databinding.PrepublishingTagsFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
 import org.wordpress.android.ui.utils.UiHelpers
@@ -59,11 +58,13 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        back_button.setOnClickListener {
-            trackTagsChangedEvent()
-            viewModel.onBackButtonClicked()
+        with(PrepublishingTagsFragmentBinding.bind(view)) {
+            prepublishingToolbar.backButton.setOnClickListener {
+                trackTagsChangedEvent()
+                viewModel.onBackButtonClicked()
+            }
+            initViewModel()
         }
-        initViewModel()
         super.onViewCreated(view, savedInstanceState)
     }
 
@@ -81,12 +82,12 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
         super.onResume()
     }
 
-    private fun initViewModel() {
-        viewModel = ViewModelProvider(this, viewModelFactory)
+    private fun PrepublishingTagsFragmentBinding.initViewModel() {
+        viewModel = ViewModelProvider(this@PrepublishingTagsFragment, viewModelFactory)
                 .get(PrepublishingTagsViewModel::class.java)
 
         viewModel.dismissKeyboard.observeEvent(viewLifecycleOwner, {
-            ActivityUtils.hideKeyboardForced(tags_edit_text)
+            ActivityUtils.hideKeyboardForced(fragmentPostSettingsTags.tagsEditText)
         })
 
         viewModel.navigateToHomeScreen.observeEvent(viewLifecycleOwner, {
@@ -94,7 +95,7 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
         })
 
         viewModel.toolbarTitleUiState.observe(viewLifecycleOwner, { uiString ->
-            toolbar_title.text = uiHelpers.getTextOfUiString(requireContext(), uiString)
+            prepublishingToolbar.toolbarTitle.text = uiHelpers.getTextOfUiString(requireContext(), uiString)
         })
 
         val needsRequestLayout = requireArguments().getBoolean(NEEDS_REQUEST_LAYOUT)

--- a/WordPress/src/main/res/layout/prepublishing_add_category_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_add_category_fragment.xml
@@ -5,8 +5,8 @@
     android:orientation="vertical"
     android:id="@+id/add_category_content">
 
-    <include layout="@layout/prepublishing_toolbar" />
+    <include android:id="@+id/prepublishing_toolbar" layout="@layout/prepublishing_toolbar" />
 
-    <include layout="@layout/add_category" />
+    <include android:id="@+id/add_category" layout="@layout/add_category" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
@@ -4,8 +4,6 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/prepublishing_toolbar"/>
-
     <com.google.android.material.textview.MaterialTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -16,5 +14,11 @@
         android:textAppearance="?attr/textAppearanceBody1"
         android:textColor="?wpColorOnSurfaceMedium" />
 
-    <include layout="@layout/fragment_post_settings_tags" />
+    <include
+        android:id="@+id/prepublishing_toolbar"
+        layout="@layout/prepublishing_toolbar" />
+
+    <include
+        android:id="@+id/fragment_post_settings_tags"
+        layout="@layout/fragment_post_settings_tags" />
 </LinearLayout>


### PR DESCRIPTION
This PR introduces view binding in the posts package. This includes the History fragment and prepublishing nudges. Overall it's the same as all the other changes

To test:
- Go to an existing post
- Go to history
- Publish a post
- Check the prepublishing bottom sheet works as expected

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
