### PR TITLE
Use view binding in settings and stories

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
@@ -6,8 +6,8 @@ import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
-import kotlinx.android.synthetic.main.prepublishing_story_title_list_item.view.*
 import org.wordpress.android.R
+import org.wordpress.android.databinding.PrepublishingStoryTitleListItemBinding
 import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.StoryTitleUiState
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.focusAndShowKeyboard
@@ -24,34 +24,35 @@ class StoryTitleHeaderView @JvmOverloads constructor(
                     .toInt()
 
     fun init(uiHelpers: UiHelpers, imageManager: ImageManager, uiState: StoryTitleUiState) {
-        LayoutInflater.from(context).inflate(R.layout.prepublishing_story_title_list_item, this, true)
+        with(PrepublishingStoryTitleListItemBinding.inflate(LayoutInflater.from(context), this, true)) {
 
-        imageManager.loadImageWithCorners(
-                story_thumbnail,
-                ImageType.IMAGE,
-                uiState.storyThumbnailUrl,
-                thumbnailCornerRadius
-        )
+            imageManager.loadImageWithCorners(
+                    storyThumbnail,
+                    ImageType.IMAGE,
+                    uiState.storyThumbnailUrl,
+                    thumbnailCornerRadius
+            )
 
-        uiState.storyTitle?.let { title ->
-            story_title.setText(uiHelpers.getTextOfUiString(context, title))
-            story_title.setSelection(title.text.length)
-        }
-
-        story_title.focusAndShowKeyboard()
-
-        story_title_content.setOnClickListener {
-            story_title.focusAndShowKeyboard()
-        }
-
-        story_title.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-            override fun afterTextChanged(view: Editable?) {
-                view?.let {
-                    uiState.onStoryTitleChanged.invoke(it.toString())
-                }
+            uiState.storyTitle?.let { title ->
+                storyTitle.setText(uiHelpers.getTextOfUiString(context, title))
+                storyTitle.setSelection(title.text.length)
             }
-        })
+
+            storyTitle.focusAndShowKeyboard()
+
+            storyTitleContent.setOnClickListener {
+                storyTitle.focusAndShowKeyboard()
+            }
+
+            storyTitle.addTextChangedListener(object : TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+                override fun afterTextChanged(view: Editable?) {
+                    view?.let {
+                        uiState.onStoryTitleChanged.invoke(it.toString())
+                    }
+                }
+            })
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryTitleHeaderView.kt
@@ -25,7 +25,6 @@ class StoryTitleHeaderView @JvmOverloads constructor(
 
     fun init(uiHelpers: UiHelpers, imageManager: ImageManager, uiState: StoryTitleUiState) {
         with(PrepublishingStoryTitleListItemBinding.inflate(LayoutInflater.from(context), this, true)) {
-
             imageManager.loadImageWithCorners(
                     storyThumbnail,
                     ImageType.IMAGE,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
@@ -12,10 +12,10 @@ import android.view.Window
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.synthetic.main.stories_intro_dialog_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.R.attr
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.StoriesIntroDialogFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
@@ -71,13 +71,13 @@ class StoriesIntroDialogFragment : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val site = requireArguments().getSerializable(WordPress.SITE) as SiteModel
+        with(StoriesIntroDialogFragmentBinding.bind(view)) {
+            createStoryIntroButton.setOnClickListener { viewModel.onCreateStoryButtonPressed() }
+            storiesIntroBackButton.setOnClickListener { viewModel.onBackButtonPressed() }
 
-        create_story_intro_button.setOnClickListener { viewModel.onCreateStoryButtonPressed() }
-        stories_intro_back_button.setOnClickListener { viewModel.onBackButtonPressed() }
-
-        story_image_first.setOnClickListener { viewModel.onStoryPreviewTapped1() }
-        story_image_second.setOnClickListener { viewModel.onStoryPreviewTapped2() }
-
+            storyImageFirst.setOnClickListener { viewModel.onStoryPreviewTapped1() }
+            storyImageSecond.setOnClickListener { viewModel.onStoryPreviewTapped2() }
+        }
         viewModel.onCreateButtonClicked.observe(this, Observer {
             activity?.let {
                 mediaPickerLauncher.showStoriesPhotoPickerForResultAndTrack(it, site)

--- a/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigActivity.kt
@@ -3,18 +3,20 @@ package org.wordpress.android.util.config.manual
 import android.os.Bundle
 import android.view.MenuItem
 import kotlinx.android.synthetic.main.manual_feature_config_fragment.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.ManualFeatureConfigActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class ManualFeatureConfigActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.manual_feature_config_activity)
+        with(ManualFeatureConfigActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
 
-        setSupportActionBar(toolbar)
-        supportActionBar?.let {
-            it.setHomeButtonEnabled(true)
-            it.setDisplayHomeAsUpEnabled(true)
+            setSupportActionBar(toolbar)
+            supportActionBar?.let {
+                it.setHomeButtonEnabled(true)
+                it.setDisplayHomeAsUpEnabled(true)
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigFragment.kt
@@ -1,9 +1,7 @@
 package org.wordpress.android.util.config.manual
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView

--- a/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigFragment.kt
@@ -8,49 +8,46 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.android.support.DaggerFragment
-import kotlinx.android.synthetic.main.manual_feature_config_fragment.*
 import org.wordpress.android.R
+import org.wordpress.android.databinding.ManualFeatureConfigFragmentBinding
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
 import kotlin.system.exitProcess
 
-class ManualFeatureConfigFragment : DaggerFragment() {
+class ManualFeatureConfigFragment : DaggerFragment(R.layout.manual_feature_config_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: ManualFeatureConfigViewModel
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.manual_feature_config_fragment, container, false)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        with(ManualFeatureConfigFragmentBinding.bind(view)) {
+            recyclerView.layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
+            recyclerView.addItemDecoration(RecyclerItemDecoration(0, DisplayUtils.dpToPx(activity, 1)))
 
-        recycler_view.layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
-        recycler_view.addItemDecoration(RecyclerItemDecoration(0, DisplayUtils.dpToPx(activity, 1)))
+            viewModel = ViewModelProvider(this@ManualFeatureConfigFragment, viewModelFactory)
+                    .get(ManualFeatureConfigViewModel::class.java)
+            viewModel.uiState.observe(viewLifecycleOwner, {
+                it?.let { uiState ->
+                    val adapter: FeatureAdapter
+                    if (recyclerView.adapter == null) {
+                        adapter = FeatureAdapter()
+                        recyclerView.adapter = adapter
+                    } else {
+                        adapter = recyclerView.adapter as FeatureAdapter
+                    }
 
-        viewModel = ViewModelProvider(this, viewModelFactory)
-                .get(ManualFeatureConfigViewModel::class.java)
-        viewModel.uiState.observe(viewLifecycleOwner, {
-            it?.let { uiState ->
-                val adapter: FeatureAdapter
-                if (recycler_view.adapter == null) {
-                    adapter = FeatureAdapter()
-                    recycler_view.adapter = adapter
-                } else {
-                    adapter = recycler_view.adapter as FeatureAdapter
+                    val layoutManager = recyclerView.layoutManager
+                    val recyclerViewState = layoutManager?.onSaveInstanceState()
+                    adapter.update(uiState.uiItems)
+                    layoutManager?.onRestoreInstanceState(recyclerViewState)
                 }
-
-                val layoutManager = recycler_view?.layoutManager
-                val recyclerViewState = layoutManager?.onSaveInstanceState()
-                adapter.update(uiState.uiItems)
-                layoutManager?.onRestoreInstanceState(recyclerViewState)
-            }
-        })
-        viewModel.restartAction.observeEvent(viewLifecycleOwner, {
-            exitProcess(0)
-        })
-        viewModel.start()
+            })
+            viewModel.restartAction.observeEvent(viewLifecycleOwner, {
+                exitProcess(0)
+            })
+            viewModel.start()
+        }
     }
 }


### PR DESCRIPTION
This PR introduces view binding in two minor places in the app - the manual feature configuration and the stories prologue. The changes are straightforward. 

To test:
- Go to "Test feature configuration" in app settings
- Smoke test it
- Create a story
- Check the "Prologue" works as expected

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
