### PR TITLE
Use View Binding in Notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -6,12 +6,10 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.text.Html
 import android.text.TextUtils
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -19,13 +17,13 @@ import androidx.fragment.app.FragmentPagerAdapter
 import com.google.android.material.appbar.AppBarLayout.LayoutParams
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.google.android.material.tabs.TabLayout.Tab
-import kotlinx.android.synthetic.main.notifications_list_fragment.*
 import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL
+import org.wordpress.android.databinding.NotificationsListFragmentBinding
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.JetpackConnectionSource.NOTIFICATIONS
@@ -52,16 +50,18 @@ import org.wordpress.android.util.setLiftOnScrollTargetViewIdAndRequestLayout
 import java.util.HashMap
 import javax.inject.Inject
 
-class NotificationsListFragment : Fragment(), ScrollableViewInitializedListener {
+class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment), ScrollableViewInitializedListener {
     private var shouldRefreshNotifications = false
     private var lastTabPosition = 0
 
     @Inject lateinit var accountStore: AccountStore
 
+    private var binding: NotificationsListFragmentBinding? = null
+
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            setSelectedTab(savedInstanceState.getInt(KEY_LAST_TAB_POSITION, TAB_POSITION_ALL))
+            binding?.setSelectedTab(savedInstanceState.getInt(KEY_LAST_TAB_POSITION, TAB_POSITION_ALL))
         }
     }
 
@@ -71,46 +71,44 @@ class NotificationsListFragment : Fragment(), ScrollableViewInitializedListener 
         shouldRefreshNotifications = true
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.notifications_list_fragment, container, false)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)
-        toolbar_main.setTitle(R.string.notifications_screen_title)
-        (requireActivity() as AppCompatActivity).setSupportActionBar(toolbar_main)
+        binding = NotificationsListFragmentBinding.bind(view).apply {
+            toolbarMain.setTitle(R.string.notifications_screen_title)
+            (requireActivity() as AppCompatActivity).setSupportActionBar(toolbarMain)
 
-        tab_layout.addOnTabSelectedListener(object : OnTabSelectedListener {
-            override fun onTabSelected(tab: Tab) {
-                val properties: MutableMap<String, String?> = HashMap(1)
-                when (tab.position) {
-                    TAB_POSITION_ALL -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_ALL.toString()
-                    TAB_POSITION_COMMENT -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_COMMENT.toString()
-                    TAB_POSITION_FOLLOW -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_FOLLOW.toString()
-                    TAB_POSITION_LIKE -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_LIKE.toString()
-                    TAB_POSITION_UNREAD -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_UNREAD.toString()
-                    else -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_ALL.toString()
+            tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
+                override fun onTabSelected(tab: Tab) {
+                    val properties: MutableMap<String, String?> = HashMap(1)
+                    when (tab.position) {
+                        TAB_POSITION_ALL -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_ALL.toString()
+                        TAB_POSITION_COMMENT -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_COMMENT.toString()
+                        TAB_POSITION_FOLLOW -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_FOLLOW.toString()
+                        TAB_POSITION_LIKE -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_LIKE.toString()
+                        TAB_POSITION_UNREAD -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_UNREAD.toString()
+                        else -> properties[NOTIFICATIONS_SELECTED_FILTER] = FILTER_ALL.toString()
+                    }
+                    AnalyticsTracker.track(NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties)
+                    lastTabPosition = tab.position
                 }
-                AnalyticsTracker.track(NOTIFICATION_TAPPED_SEGMENTED_CONTROL, properties)
-                lastTabPosition = tab.position
+
+                override fun onTabUnselected(tab: Tab) {}
+                override fun onTabReselected(tab: Tab) {}
+            })
+            viewPager.adapter = NotificationsFragmentAdapter(childFragmentManager, buildTitles())
+            viewPager.pageMargin = resources.getDimensionPixelSize(R.dimen.margin_extra_large)
+            tabLayout.setupWithViewPager(viewPager)
+
+            jetpackTermsAndConditions.text = Html.fromHtml(
+                    String.format(resources.getString(R.string.jetpack_connection_terms_and_conditions), "<u>", "</u>")
+            )
+            jetpackTermsAndConditions.setOnClickListener {
+                WPWebViewActivity.openURL(requireContext(), WPUrlUtils.buildTermsOfServiceUrl(context))
             }
-
-            override fun onTabUnselected(tab: Tab) {}
-            override fun onTabReselected(tab: Tab) {}
-        })
-        view_pager.adapter = NotificationsFragmentAdapter(childFragmentManager, buildTitles())
-        view_pager.pageMargin = resources.getDimensionPixelSize(R.dimen.margin_extra_large)
-        tab_layout.setupWithViewPager(view_pager)
-
-        jetpack_terms_and_conditions.text = Html.fromHtml(
-                String.format(resources.getString(R.string.jetpack_connection_terms_and_conditions), "<u>", "</u>")
-        )
-        jetpack_terms_and_conditions.setOnClickListener {
-            WPWebViewActivity.openURL(requireContext(), WPUrlUtils.buildTermsOfServiceUrl(context))
-        }
-        jetpack_faq.setOnClickListener {
-            WPWebViewActivity.openURL(requireContext(), StatsConnectJetpackActivity.FAQ_URL)
+            jetpackFaq.setOnClickListener {
+                WPWebViewActivity.openURL(requireContext(), StatsConnectJetpackActivity.FAQ_URL)
+            }
         }
     }
 
@@ -129,23 +127,30 @@ class NotificationsListFragment : Fragment(), ScrollableViewInitializedListener 
         shouldRefreshNotifications = true
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+
     override fun onResume() {
         super.onResume()
         EventBus.getDefault().post(NotificationsUnseenStatus(false))
-        if (!accountStore.hasAccessToken()) {
-            showConnectJetpackView()
-            connect_jetpack.visibility = View.VISIBLE
-            tab_layout.visibility = View.GONE
-            view_pager.visibility = View.GONE
-        } else {
-            connect_jetpack.visibility = View.GONE
-            tab_layout.visibility = View.VISIBLE
-            view_pager.visibility = View.VISIBLE
-            if (shouldRefreshNotifications) {
-                fetchNotesFromRemote()
+        binding?.apply {
+            if (!accountStore.hasAccessToken()) {
+                showConnectJetpackView()
+                connectJetpack.visibility = View.VISIBLE
+                tabLayout.visibility = View.GONE
+                viewPager.visibility = View.GONE
+            } else {
+                connectJetpack.visibility = View.GONE
+                tabLayout.visibility = View.VISIBLE
+                viewPager.visibility = View.VISIBLE
+                if (shouldRefreshNotifications) {
+                    fetchNotesFromRemote()
+                }
             }
+            setSelectedTab(lastTabPosition)
         }
-        setSelectedTab(lastTabPosition)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -153,9 +158,9 @@ class NotificationsListFragment : Fragment(), ScrollableViewInitializedListener 
         super.onSaveInstanceState(outState)
     }
 
-    private fun clearToolbarScrollFlags() {
-        if (toolbar_main.layoutParams is LayoutParams) {
-            val params = toolbar_main.layoutParams as LayoutParams
+    private fun NotificationsListFragmentBinding.clearToolbarScrollFlags() {
+        if (toolbarMain.layoutParams is LayoutParams) {
+            val params = toolbarMain.layoutParams as LayoutParams
             params.scrollFlags = 0
         }
     }
@@ -167,20 +172,20 @@ class NotificationsListFragment : Fragment(), ScrollableViewInitializedListener 
         NotificationsUpdateServiceStarter.startService(activity)
     }
 
-    private fun setSelectedTab(position: Int) {
+    private fun NotificationsListFragmentBinding.setSelectedTab(position: Int) {
         lastTabPosition = position
-        tab_layout.getTabAt(lastTabPosition)?.select()
+        tabLayout.getTabAt(lastTabPosition)?.select()
     }
 
-    private fun showConnectJetpackView() {
+    private fun NotificationsListFragmentBinding.showConnectJetpackView() {
         clearToolbarScrollFlags()
-        jetpack_setup.setOnClickListener {
+        jetpackSetup.setOnClickListener {
             val siteModel = (requireActivity() as? WPMainActivity)?.selectedSite
             JetpackConnectionWebViewActivity.startJetpackConnectionFlow(activity, NOTIFICATIONS, siteModel, false)
         }
     }
 
-    private class NotificationsFragmentAdapter internal constructor(
+    private class NotificationsFragmentAdapter(
         fragmentManager: FragmentManager,
         private val titles: List<String>
     ) : FragmentPagerAdapter(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
@@ -281,6 +286,6 @@ class NotificationsListFragment : Fragment(), ScrollableViewInitializedListener 
     }
 
     override fun onScrollableViewInitialized(containerId: Int) {
-        app_bar.setLiftOnScrollTargetViewIdAndRequestLayout(containerId)
+        binding?.appBar?.setLiftOnScrollTargetViewIdAndRequestLayout(containerId)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -4,9 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.animation.Animation
 import android.view.animation.Animation.AnimationListener
 import androidx.annotation.StringRes
@@ -14,13 +12,13 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener
-import kotlinx.android.synthetic.main.notifications_list_fragment_page.*
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.APP_REVIEWS_EVENT_INCREMENTED_BY_CHECKING_NOTIFICATION
+import org.wordpress.android.databinding.NotificationsListFragmentPageBinding
 import org.wordpress.android.datasets.NotificationsTable
 import org.wordpress.android.fluxc.model.CommentStatus
 import org.wordpress.android.fluxc.model.SiteModel
@@ -57,7 +55,9 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.widgets.AppRatingDialog.incrementInteractions
 import javax.inject.Inject
 
-class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener, DataLoadedListener {
+class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_list_fragment_page),
+        OnScrollToTopListener,
+        DataLoadedListener {
     private var notesAdapter: NotesAdapter? = null
     private var swipeToRefreshHelper: SwipeToRefreshHelper? = null
     private var isAnimatingOutNewNotificationsBar = false
@@ -69,9 +69,11 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
 
     private val showNewUnseenNotificationsRunnable = Runnable {
         if (isAdded) {
-            notifications_list?.addOnScrollListener(mOnScrollListener)
+            binding?.notificationsList?.addOnScrollListener(mOnScrollListener)
         }
     }
+
+    private var binding: NotificationsListFragmentPageBinding? = null
 
     interface OnNoteClickListener {
         fun onClickNote(noteId: String?)
@@ -80,7 +82,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         val adapter = createOrGetNotesAdapter()
-        notifications_list.adapter = adapter
+        binding?.notificationsList?.adapter = adapter
         if (savedInstanceState != null) {
             tabPosition = savedInstanceState.getInt(KEY_TAB_POSITION, NotificationsListFragment.TAB_POSITION_ALL)
         }
@@ -113,30 +115,29 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
         shouldRefreshNotifications = true
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.notifications_list_fragment_page, container, false)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         arguments?.let {
             tabPosition = it.getInt(KEY_TAB_POSITION, NotificationsListFragment.TAB_POSITION_ALL)
         }
-        notifications_list.layoutManager = LinearLayoutManager(activity)
-        swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(notifications_refresh) {
-            hideNewNotificationsBar()
-            fetchNotesFromRemote()
+        binding = NotificationsListFragmentPageBinding.bind(view).apply {
+            notificationsList.layoutManager = LinearLayoutManager(activity)
+            swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(notificationsRefresh) {
+                hideNewNotificationsBar()
+                fetchNotesFromRemote()
+            }
+            layoutNewNotificatons.visibility = View.GONE
+            layoutNewNotificatons.setOnClickListener { onScrollToTop() }
         }
-        layout_new_notificatons.visibility = View.GONE
-        layout_new_notificatons.setOnClickListener { onScrollToTop() }
     }
 
     override fun onDestroyView() {
         notesAdapter!!.cancelReloadNotesTask()
         swipeToRefreshHelper = null
-        notifications_list.adapter = null
-        notifications_list.removeCallbacks(showNewUnseenNotificationsRunnable)
+        binding?.notificationsList?.adapter = null
+        binding?.notificationsList?.removeCallbacks(showNewUnseenNotificationsRunnable)
         notesAdapter = null
+        binding = null
         super.onDestroyView()
     }
 
@@ -145,10 +146,12 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
             AppLog.d(T.NOTIFS,
                     "NotificationsListFragmentPage.onDataLoaded occurred when fragment is not attached.")
         }
-        if (itemsCount > 0) {
-            hideEmptyView()
-        } else {
-            showEmptyViewForCurrentFilter()
+        binding?.apply {
+            if (itemsCount > 0) {
+                hideEmptyView()
+            } else {
+                showEmptyViewForCurrentFilter()
+            }
         }
     }
 
@@ -158,12 +161,12 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
     }
 
     override fun getScrollableViewForUniqueIdProvision(): View? {
-        return notifications_list
+        return binding?.notificationsList
     }
 
     override fun onResume() {
         super.onResume()
-        hideNewNotificationsBar()
+        binding?.hideNewNotificationsBar()
         EventBus.getDefault().post(NotificationsUnseenStatus(false))
         if (accountStore.hasAccessToken()) {
             notesAdapter!!.reloadNotesFromDBAsync()
@@ -182,10 +185,12 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
         if (!isAdded) {
             return
         }
-        clearPendingNotificationsItemsOnUI()
-        val layoutManager = notifications_list.layoutManager as LinearLayoutManager
-        if (layoutManager.findFirstCompletelyVisibleItemPosition() > 0) {
-            layoutManager.smoothScrollToPosition(notifications_list, null, 0)
+        binding?.apply {
+            clearPendingNotificationsItemsOnUI()
+            val layoutManager = notificationsList.layoutManager as LinearLayoutManager
+            if (layoutManager.findFirstCompletelyVisibleItemPosition() > 0) {
+                layoutManager.smoothScrollToPosition(notificationsList, null, 0)
+            }
         }
     }
 
@@ -217,16 +222,16 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
     private val mOnScrollListener: OnScrollListener = object : OnScrollListener() {
         override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
             super.onScrolled(recyclerView, dx, dy)
-            notifications_list.removeOnScrollListener(this)
-            clearPendingNotificationsItemsOnUI()
+            binding?.notificationsList?.removeOnScrollListener(this)
+            binding?.clearPendingNotificationsItemsOnUI()
         }
     }
 
-    private fun clearPendingNotificationsItemsOnUI() {
+    private fun NotificationsListFragmentPageBinding.clearPendingNotificationsItemsOnUI() {
         hideNewNotificationsBar()
         EventBus.getDefault().post(NotificationsUnseenStatus(false))
         NotificationsActions.updateNotesSeenTimestamp()
-        Thread(Runnable { gcmMessageHandler.removeAllNotifications(activity) }).start()
+        Thread { gcmMessageHandler.removeAllNotifications(activity) }.start()
     }
 
     private fun fetchNotesFromRemote() {
@@ -243,14 +248,14 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
     val selectedSite: SiteModel?
         get() = (activity as? WPMainActivity)?.selectedSite
 
-    private fun hideEmptyView() {
+    private fun NotificationsListFragmentPageBinding.hideEmptyView() {
         if (isAdded) {
-            actionable_empty_view.visibility = View.GONE
-            notifications_list.visibility = View.VISIBLE
+            actionableEmptyView.visibility = View.GONE
+            notificationsList.visibility = View.VISIBLE
         }
     }
 
-    private fun hideNewNotificationsBar() {
+    private fun NotificationsListFragmentPageBinding.hideNewNotificationsBar() {
         if (!isAdded || !isNewNotificationsBarShowing || isAnimatingOutNewNotificationsBar) {
             return
         }
@@ -259,18 +264,18 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
             override fun onAnimationStart(animation: Animation) {}
             override fun onAnimationEnd(animation: Animation) {
                 if (isAdded) {
-                    layout_new_notificatons.visibility = View.GONE
+                    layoutNewNotificatons.visibility = View.GONE
                     isAnimatingOutNewNotificationsBar = false
                 }
             }
 
             override fun onAnimationRepeat(animation: Animation) {}
         }
-        AniUtils.startAnimation(layout_new_notificatons, R.anim.notifications_bottom_bar_out, listener)
+        AniUtils.startAnimation(layoutNewNotificatons, R.anim.notifications_bottom_bar_out, listener)
     }
 
     private val isNewNotificationsBarShowing: Boolean
-        get() = layout_new_notificatons != null && layout_new_notificatons.visibility == View.VISIBLE
+        get() = binding?.layoutNewNotificatons?.visibility == View.VISIBLE
 
     private fun performActionForActiveFilter() {
         if (!isAdded) {
@@ -287,33 +292,33 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
         }
     }
 
-    private fun showEmptyView(
+    private fun NotificationsListFragmentPageBinding.showEmptyView(
         @StringRes titleResId: Int,
         @StringRes descriptionResId: Int = 0,
         @StringRes buttonResId: Int = 0
     ) {
         if (isAdded) {
-            actionable_empty_view.visibility = View.VISIBLE
-            notifications_list.visibility = View.GONE
-            actionable_empty_view.title.setText(titleResId)
+            actionableEmptyView.visibility = View.VISIBLE
+            notificationsList.visibility = View.GONE
+            actionableEmptyView.title.setText(titleResId)
             if (descriptionResId != 0) {
-                actionable_empty_view.subtitle.setText(descriptionResId)
-                actionable_empty_view.subtitle.visibility = View.VISIBLE
+                actionableEmptyView.subtitle.setText(descriptionResId)
+                actionableEmptyView.subtitle.visibility = View.VISIBLE
             } else {
-                actionable_empty_view.subtitle.visibility = View.GONE
+                actionableEmptyView.subtitle.visibility = View.GONE
             }
             if (buttonResId != 0) {
-                actionable_empty_view.button.setText(buttonResId)
-                actionable_empty_view.button.visibility = View.VISIBLE
+                actionableEmptyView.button.setText(buttonResId)
+                actionableEmptyView.button.visibility = View.VISIBLE
             } else {
-                actionable_empty_view.button.visibility = View.GONE
+                actionableEmptyView.button.visibility = View.GONE
             }
-            actionable_empty_view.button.setOnClickListener { performActionForActiveFilter() }
+            actionableEmptyView.button.setOnClickListener { performActionForActiveFilter() }
         }
     }
 
     // Show different empty view message and action button based on selected tab.
-    private fun showEmptyViewForCurrentFilter() {
+    private fun NotificationsListFragmentPageBinding.showEmptyViewForCurrentFilter() {
         if (!accountStore.hasAccessToken()) {
             return
         }
@@ -349,27 +354,27 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
             }
             else -> showEmptyView(R.string.notifications_empty_list)
         }
-        actionable_empty_view.image.visibility = if (DisplayUtils.isLandscape(context)) View.GONE else View.VISIBLE
+        actionableEmptyView.image.visibility = if (DisplayUtils.isLandscape(context)) View.GONE else View.VISIBLE
     }
 
-    private fun showNewNotificationsBar() {
+    private fun NotificationsListFragmentPageBinding.showNewNotificationsBar() {
         if (!isAdded || isNewNotificationsBarShowing) {
             return
         }
-        AniUtils.startAnimation(layout_new_notificatons, R.anim.notifications_bottom_bar_in)
-        layout_new_notificatons.visibility = View.VISIBLE
+        AniUtils.startAnimation(layoutNewNotificatons, R.anim.notifications_bottom_bar_in)
+        layoutNewNotificatons.visibility = View.VISIBLE
     }
 
-    private fun showNewUnseenNotificationsUI() {
-        if (!isAdded || notifications_list.layoutManager == null) {
+    private fun NotificationsListFragmentPageBinding.showNewUnseenNotificationsUI() {
+        if (!isAdded || notificationsList.layoutManager == null) {
             return
         }
-        notifications_list.clearOnScrollListeners()
-        notifications_list.removeCallbacks(showNewUnseenNotificationsRunnable)
-        notifications_list.postDelayed(showNewUnseenNotificationsRunnable, 1000L)
-        val first = notifications_list.layoutManager!!.getChildAt(0)
+        notificationsList.clearOnScrollListeners()
+        notificationsList.removeCallbacks(showNewUnseenNotificationsRunnable)
+        notificationsList.postDelayed(showNewUnseenNotificationsRunnable, 1000L)
+        val first = notificationsList.layoutManager!!.getChildAt(0)
         // Show new notifications bar if first item is not visible on the screen.
-        if (first != null && notifications_list.layoutManager!!.getPosition(first) > 0) {
+        if (first != null && notificationsList.layoutManager!!.getPosition(first) > 0) {
             showNewNotificationsBar()
         }
     }
@@ -414,7 +419,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
         }
         notesAdapter!!.reloadNotesFromDBAsync()
         if (event.hasUnseenNotes) {
-            showNewUnseenNotificationsUI()
+            binding?.showNewUnseenNotificationsUI()
         }
     }
 
@@ -439,10 +444,12 @@ class NotificationsListFragmentPage : ViewPagerFragment(), OnScrollToTopListener
         if (!isAdded) {
             return
         }
-        if (event.hasUnseenNotes) {
-            showNewUnseenNotificationsUI()
-        } else {
-            hideNewNotificationsBar()
+        binding?.apply {
+            if (event.hasUnseenNotes) {
+                showNewUnseenNotificationsUI()
+            } else {
+                hideNewNotificationsBar()
+            }
         }
     }
 


### PR DESCRIPTION
This PR introduces View Bindings for the Notifications screen. Changes are mostly straightforward. 

To test:

Smoke test the Notifications screen and make sure everything is working as expected and nothing looks out of place. Main points of attention:

1. Make sure all tabs loaded correctly.
1. Send a notification to your site and make sure the screen updates accordingly.
1. Login with a self-hosted site and make sure the screen shows the Jetpack connect view.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
