### PR TITLE
Update related posts title  + header style

### DIFF
--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -177,9 +177,8 @@
         <item name="android:textAppearance">?attr/textAppearanceBody1</item>
         <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:lineSpacingMultiplier">1.3</item>
-        <item name="android:textStyle">bold</item>
         <item name="android:maxLines">3</item>
-        <item name="android:fontFamily">serif</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:ellipsize">end</item>
     </style>
 

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -121,6 +121,7 @@
         <item name="android:textAllCaps">true</item>
         <item name="android:textAlignment">viewStart</item>
         <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="ReaderTextView.Date" parent="ReaderTextView">


### PR DESCRIPTION
This PR updates below  related posts styles: 
- Title style (`noto-serif` `bold` to `sans-serif-medium`). Ref: `p5T066-21h#comment-7561`
(Note that we used `noto-serif` `bold` instead of `noto-serif` `semi-bold` specified in Figma design earlier as `semi-bold` / `medium` text style for `noto-serif` was not available. `medium` style is available for `sans-serif`.)
- "More from ..." header text style from normal to bold. Ref: `p5T066-21h#comment-7560`

Before | After
-------|------
![style_before](https://user-images.githubusercontent.com/1405144/111110945-7714e480-8583-11eb-8dbf-c728373915bb.png) | ![style_after](https://user-images.githubusercontent.com/1405144/111111367-32d61400-8584-11eb-88d4-c416648fb143.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
