### PR TITLE
Fix featured image not displaying for some posts with another image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtils.kt
@@ -19,10 +19,10 @@ class FeaturedImageUtils
     ): Boolean {
         return try {
             val featuredImageUrl = URL(featuredImage)
-            val endIndex = featuredImageUrl.path.lastIndexOf("-", featuredImageUrl.path.lastIndexOf("/"))
+            val endIndex = getLastIndexOfDashInUrl(featuredImageUrl)
             val featuredImageFile = featuredImageUrl.file
             val featuredImagePath = if (endIndex > 0 && !featuredImageFile.startsWith("-")) {
-                featuredImageUrl.path.substring(0, endIndex)
+                featuredImageUrl.path.substring(0, endIndex + 1)
             } else {
                 featuredImageUrl.path
             }
@@ -36,6 +36,10 @@ class FeaturedImageUtils
             false
         }
     }
+
+    private fun getLastIndexOfDashInUrl(url: URL) = url.path.split("/").last()
+            .lastIndexOf("-").takeIf { it > 0 }
+            ?.let { it + url.path.lastIndexOf("/") } ?: -1
 
     /*
      * returns true if the post has a featured image and the featured image is not found in the post body

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/FeaturedImageUtilsTest.kt
@@ -66,6 +66,17 @@ class FeaturedImageUtilsTest {
     }
 
     @Test
+    fun `shows featured image with different name and non-last path segment containing a dash`() {
+        val featuredImage = "https://wordpress.com/wp-content/image1.png"
+        val bodyImage = "https://wordpress.com/wp-content/image2.png"
+        val readerPost = initReaderPost(bodyImage, featuredImage)
+
+        val result = featuredImageUtils.showFeaturedImage(readerPost.featuredImage, readerPost.text)
+
+        assertThat(result).isTrue
+    }
+
+    @Test
     fun `shows featured image with the same name from different host`() {
         val featuredImage = "https://wordpress.com/image.png"
         val bodyImage = "https://wordpress2.com/image.png"


### PR DESCRIPTION
Fixes #13239

**Problem**

Earlier, if the following conditions were met for a "Reader" post:

- post included an image having (non-last) path segment with a dash `-` (E.g. `/wp-content` in `https://wordpress.com/wp-content/image1.png`).
- featured image having the same path but different name (E.g. `https://wordpress.com/wp-content/image2.png`) set on the post. 

the index of the last dash `-` was wrongly calculated resulting in the incorrect substring (`/wp`) getting searched in the post body for the presence of a duplicate featured image. 
Since`/wp` existed in the post body, the featured image was mistaken to be "duplicate" and not displayed on the "Reader" post details screen. 

Before (Featured image not shown on Reader post details)

https://user-images.githubusercontent.com/1405144/111116375-ef7fa380-858b-11eb-9432-31a08fcd090e.mp4|

**Solution**

This PR fixes the calculation of the index of the last dash `-` in the featured image path (uses last path segment to find it).

After (Featured image shown on Reader post details)

https://user-images.githubusercontent.com/1405144/111116631-4eddb380-858c-11eb-8d3b-ba8a1525ddec.mp4

**To test**

1. Select an atomic site from the site picker on "My Sites" tab.
2. Create a post and add an image to it using _Wordpress Media Library_ (this inserts an image with `wp-content` in the file path).
3. Set a featured image to the post (different from the one added in step 2 ) using _Wordpress Media Library_.
4. Follow the site using "Reader Mange Topics and Sites" settings.
5. Select the post created in step 2 from "Reader -> Following tab". 
6. Notice that the "Reader" post details screen displays the feature image in the app bar.

@zwarm I added you as a reviewer since you [reported it here ](https://github.com/wordpress-mobile/WordPress-Android/pull/12931#pullrequestreview-504709956)and it might be easier for you to replicate and test it.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
