### PR TITLE
Add missing ID to the progress layout

### DIFF
--- a/WordPress/src/main/res/layout/wpwebview_activity.xml
+++ b/WordPress/src/main/res/layout/wpwebview_activity.xml
@@ -45,10 +45,10 @@
                 android:layout_height="match_parent" />
 
             <include
+                android:id="@+id/progress_layout"
                 layout="@layout/progress_layout"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_above="@+id/navbar_container"
                 android:layout_alignParentTop="true"
                 tools:visibility="gone" />
 


### PR DESCRIPTION
Fixes a crash that happens because of the removed top layout element ID in the progress_layout.

To test:
- Go to reader
- Click on an item
- Click on the overflow menu/Visit site
- The site is opened in the WebView

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
