### PR TITLE
Removes Preview mode from Gutenberg editor 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3219,10 +3219,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
         mPostEditorAnalyticsSession.applyTemplate(template);
     }
 
-    @Override public void onGutenbergEditorSessionTemplateApplyTracked(String template) {
-        mPostEditorAnalyticsSession.applyTemplate(template);
-    }
-
     @Override public void showUserSuggestions(Consumer<String> onResult) {
         showSuggestions(SuggestionType.Users, onResult);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3223,10 +3223,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
         mPostEditorAnalyticsSession.applyTemplate(template);
     }
 
-    @Override public void onGutenbergEditorSessionTemplatePreviewTracked(String template) {
-        // Preview mode is deprecated. See: https://github.com/wordpress-mobile/gutenberg-mobile/issues/3217
-    }
-
     @Override public void showUserSuggestions(Consumer<String> onResult) {
         showSuggestions(SuggestionType.Users, onResult);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'develop-2d631f6d9b2d928759696d07ac8e4ae910c38c69'
+    ext.gutenbergMobileVersion = 'develop-4469dda6a4539ce371cad3e3340edc2d14a2c207'
 
     repositories {
         google()

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -204,7 +204,6 @@ public abstract class EditorFragmentAbstract extends Fragment {
         void onAddFileClicked(boolean allowMultipleSelection);
         void onAddAudioFileClicked(boolean allowMultipleSelection);
         void onPerformFetch(String path, Consumer<String> onResult, Consumer<Bundle> onError);
-        void onGutenbergEditorSessionTemplateApplyTracked(String template);
         void showUserSuggestions(Consumer<String> onResult);
         void showXpostSuggestions(Consumer<String> onResult);
         void onGutenbergEditorSetFocalPointPickerTooltipShown(boolean tooltipShown);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -205,7 +205,6 @@ public abstract class EditorFragmentAbstract extends Fragment {
         void onAddAudioFileClicked(boolean allowMultipleSelection);
         void onPerformFetch(String path, Consumer<String> onResult, Consumer<Bundle> onError);
         void onGutenbergEditorSessionTemplateApplyTracked(String template);
-        void onGutenbergEditorSessionTemplatePreviewTracked(String template);
         void showUserSuggestions(Consumer<String> onResult);
         void showXpostSuggestions(Consumer<String> onResult);
         void onGutenbergEditorSetFocalPointPickerTooltipShown(boolean tooltipShown);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -23,7 +23,6 @@ import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGetContentTimeout;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGutenbergDidRequestUnsupportedBlockFallbackListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGutenbergDidSendButtonPressedActionListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnImageFullscreenPreviewListener;
-import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnLogGutenbergUserEventListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnReattachMediaSavingQueryListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnReattachMediaUploadQueryListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnFocalPointPickerTooltipShownEventListener;
@@ -63,7 +62,6 @@ public class GutenbergContainerFragment extends Fragment {
                                   RequestExecutor fetchExecutor,
                                   OnImageFullscreenPreviewListener onImageFullscreenPreviewListener,
                                   OnMediaEditorListener onMediaEditorListener,
-                                  OnLogGutenbergUserEventListener onLogGutenbergUserEventListener,
                                   OnGutenbergDidRequestUnsupportedBlockFallbackListener
                                           onGutenbergDidRequestUnsupportedBlockFallbackListener,
                                   OnGutenbergDidSendButtonPressedActionListener
@@ -84,7 +82,6 @@ public class GutenbergContainerFragment extends Fragment {
                     fetchExecutor,
                     onImageFullscreenPreviewListener,
                     onMediaEditorListener,
-                    onLogGutenbergUserEventListener,
                     onGutenbergDidRequestUnsupportedBlockFallbackListener,
                     onGutenbergDidSendButtonPressedActionListener,
                     showSuggestionsUtil,

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -54,7 +54,6 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.aztec.IHistoryListener;
-import org.wordpress.mobile.ReactNativeGutenbergBridge.GutenbergBridgeJS2Parent.GutenbergUserEvent;
 import org.wordpress.mobile.WPAndroidGlue.Media;
 import org.wordpress.mobile.WPAndroidGlue.MediaOption;
 import org.wordpress.mobile.WPAndroidGlue.ShowSuggestionsUtil;
@@ -65,7 +64,6 @@ import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnFocalPointPickerTo
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGetContentTimeout;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGutenbergDidRequestUnsupportedBlockFallbackListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnGutenbergDidSendButtonPressedActionListener;
-import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnLogGutenbergUserEventListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaFilesCollectionBasedBlockEditorListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnMediaLibraryButtonListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnReattachMediaSavingQueryListener;
@@ -358,17 +356,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 mEditorFragmentListener::onPerformFetch,
                 mEditorImagePreviewListener::onImagePreviewRequested,
                 mEditorEditMediaListener::onMediaEditorRequested,
-                new OnLogGutenbergUserEventListener() {
-                    @Override
-                    public void onGutenbergUserEvent(GutenbergUserEvent event, Map<String, Object> properties) {
-                        switch (event) {
-                            case EDITOR_SESSION_TEMPLATE_APPLY:
-                                mEditorFragmentListener.onGutenbergEditorSessionTemplateApplyTracked((String)
-                                        properties.get(USER_EVENT_KEY_TEMPLATE));
-                                break;
-                        }
-                    }
-                },
                 new OnGutenbergDidRequestUnsupportedBlockFallbackListener() {
                     @Override
                     public void gutenbergDidRequestUnsupportedBlockFallback(UnsupportedBlock unsupportedBlock) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -362,10 +362,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                     @Override
                     public void onGutenbergUserEvent(GutenbergUserEvent event, Map<String, Object> properties) {
                         switch (event) {
-                            case EDITOR_SESSION_TEMPLATE_PREVIEW:
-                                mEditorFragmentListener.onGutenbergEditorSessionTemplatePreviewTracked((String)
-                                        properties.get(USER_EVENT_KEY_TEMPLATE));
-                                break;
                             case EDITOR_SESSION_TEMPLATE_APPLY:
                                 mEditorFragmentListener.onGutenbergEditorSessionTemplateApplyTracked((String)
                                         properties.get(USER_EVENT_KEY_TEMPLATE));


### PR DESCRIPTION
This should be merged after https://github.com/wordpress-mobile/gutenberg-mobile/issues/2980 is complete on both platforms

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3217

**`gutenberg-mobile` PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/3268
**`gutenberg` PR:** https://github.com/WordPress/gutenberg/pull/29896

## Description
This PR removes the [editor preview mode introduced for the layout picker preview functionality]( https://github.com/wordpress-mobile/gutenberg-mobile/issues/2452) that is being [replaced with a webview implementation](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2980).
**See:** https://github.com/WordPress/gutenberg/pull/29896

## To test:
Quick sanity of the editor to validate that no functionality is unintentionally broken

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
