### PR TITLE
Update eventbus version to v3.2.0

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -241,7 +241,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-auth:18.1.0'
     implementation 'com.android.installreferrer:installreferrer:2.2'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
-    implementation 'org.greenrobot:eventbus:3.1.1'
+    implementation 'org.greenrobot:eventbus:3.2.0'
     implementation ('com.automattic:rest:1.0.8') {
         exclude group: 'com.mcxiaoke.volley'
     }


### PR DESCRIPTION
Update eventBus to v3.2.0

The release notes can be found [here](https://greenrobot.org/release/eventbus-3-2/). There are no breaking changes. The new version should be more performant (measuring the difference is IMO not worth it).

Gradle will use "latest" conflict resolution strategy when it founds two different version of the library (one in WPAndroid and the other one in FluxC). So the new version will be used even if we don't manually reference [the updated version of FluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1928).

To test:
Smoke test the app

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

@mzorz Could you please update event bus version in stories repo. Thanks!
