### PR TITLE
Stories: updated stories library with new crop/zoom/pan functionality

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] Comments: Switched comments filter from dropdown to tabs. [https://github.com/wordpress-mobile/WordPress-Android/pull/14140]
 * [*] [Block Editor] Remove the cancel button from settings options [https://github.com/WordPress/gutenberg/pull/29599]
+* [**] Stories: enabled pinch to zoom on your slides background images! [https://github.com/wordpress-mobile/WordPress-Android/pull/14284]
 
 16.9
 -----


### PR DESCRIPTION
This PR brings WordPress Android all the joy of pan/zoom functionality implemented in the Stories library in the following PRs:

https://github.com/Automattic/stories-android/pull/650
https://github.com/Automattic/stories-android/pull/651
https://github.com/Automattic/stories-android/pull/649
https://github.com/Automattic/stories-android/pull/648
https://github.com/Automattic/stories-android/pull/647

To test:

1. Create a new Story Post in WPAndroid
2. Follow the test cases described in https://github.com/Automattic/stories-android/pull/651
3. Also observe the blurriness is added for images not matching the screen size (see https://github.com/Automattic/stories-android/pull/650)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
