### PR TITLE
Decreases the preview WebView initial scale

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -129,6 +129,8 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
     public static final String ACTION_BAR_TITLE = "action_bar_title";
     public static final String SHOW_PREVIEW_MODE_TOGGLE = "SHOW_PREVIEW_MODE_TOGGLE";
     public static final String PRIVATE_AT_SITE_ID = "PRIVATE_AT_SITE_ID";
+    private static final int PREVIEW_INITIAL_SCALE = 90;
+    private static final long PREVIEW_JS_EVALUATION_DELAY = 250L;
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -640,7 +642,7 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
 
         if (mPreviewModeChangeAllowed) {
             mWebView.getSettings().setUseWideViewPort(true);
-            mWebView.setInitialScale(100);
+            mWebView.setInitialScale(PREVIEW_INITIAL_SCALE);
         }
 
         WebViewClient webViewClient = createWebViewClient(allowedURL);
@@ -693,7 +695,7 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
             public void run() {
                 mWebView.evaluateJavascript(script, value -> mViewModel.onUrlLoaded());
             }
-        }, 250);
+        }, PREVIEW_JS_EVALUATION_DELAY);
     }
 
     private void setWebViewWidth(int previewWidth) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
@@ -31,7 +31,7 @@ import org.wordpress.android.util.setVisible
 import org.wordpress.android.util.skip
 import javax.inject.Inject
 
-private const val INITIAL_SCALE = 100
+private const val INITIAL_SCALE = 90
 private const val JS_EVALUATION_DELAY = 250L
 
 abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {


### PR DESCRIPTION
Fixes #14327

### Description
Decreases the preview WebView initial scale for better rendering in devices with tall aspect ratio.
i tested other approaches to evaluate the scale dynamically based on the screen dimensions. Since I did not notice any differences in devices with "normal"(18:9 or less) aspect ratio I chose to simplify the solution and just decrease the scale to 90% in all devices.

### To test:

1. Start the site creation flow in a device with a "tall" screen
1. Select a design
1. Press preview
1. Choose Desktop from the preview mode button (top-right)
1. Notice that the screen does not allow horizontal scrolling

#### Note:
The fixed issue was reported to occur only on device with aspect ration bigger than 18:9:
* Pixel 2 XL (18:9) was ok
* Pixel 3a (18.5:9) exhibited the issue and should be fixed
* Pixel 5 (19.5:9) exhibited the issue and should be fixed
* Tested to work up to 20:9 aspect ratio on an emulator

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
