### PR TITLE
Remove Gutenberg mentions flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -72,7 +72,6 @@ android {
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
         buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "10"
         buildConfigField "boolean", "FEATURE_ANNOUNCEMENT_AVAILABLE", "false"
-        buildConfigField "boolean", "GUTENBERG_MENTIONS", "true"
         buildConfigField "boolean", "WP_STORIES_AVAILABLE", "true"
         buildConfigField "boolean", "CONSOLIDATED_MEDIA_PICKER", "false"
         buildConfigField "boolean", "ACTIVITY_LOG_FILTERS", "false"
@@ -105,7 +104,6 @@ android {
             versionCode 1014
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
-            buildConfigField "boolean", "GUTENBERG_MENTIONS", "true"
             buildConfigField "boolean", "WP_STORIES_AVAILABLE", "true"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -211,7 +211,6 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
 import org.wordpress.android.util.config.ConsolidatedMediaPickerFeatureConfig;
-import org.wordpress.android.util.config.GutenbergMentionsFeatureConfig;
 import org.wordpress.android.util.config.WPStoriesFeatureConfig;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
@@ -396,7 +395,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
     @Inject ReblogUtils mReblogUtils;
     @Inject AnalyticsTrackerWrapper mAnalyticsTrackerWrapper;
     @Inject PublishPostImmediatelyUseCase mPublishPostImmediatelyUseCase;
-    @Inject GutenbergMentionsFeatureConfig mGutenbergMentionsFeatureConfig;
     @Inject XPostsCapabilityChecker mXpostsCapabilityChecker;
     @Inject ConsolidatedMediaPickerFeatureConfig mConsolidatedMediaPickerFeatureConfig;
     @Inject CrashLogging mCrashLogging;
@@ -2290,9 +2288,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
         String languageString = LocaleManager.getLanguage(EditPostActivity.this);
         String wpcomLocaleSlug = languageString.replace("_", "-").toLowerCase(Locale.ENGLISH);
 
-        boolean isSiteUsingWpComRestApi = mSite.isUsingWpComRestApi();
-        boolean enableMentions = isSiteUsingWpComRestApi && mGutenbergMentionsFeatureConfig.isEnabled();
-
         // If this.mIsXPostsCapable has not been set, default to allowing xPosts
         boolean enableXPosts = mIsXPostsCapable == null || mIsXPostsCapable;
 
@@ -2308,7 +2303,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
         return new GutenbergPropsBuilder(
                 mWPStoriesFeatureConfig.isEnabled() && SiteUtils.supportsStoriesFeature(mSite),
-                enableMentions,
+                mSite.isUsingWpComRestApi(),
                 enableXPosts,
                 isUnsupportedBlockEditorEnabled,
                 unsupportedBlockEditorSwitch,

--- a/WordPress/src/main/java/org/wordpress/android/util/config/GutenbergMentionsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/GutenbergMentionsFeatureConfig.kt
@@ -1,9 +1,0 @@
-package org.wordpress.android.util.config
-
-import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
-import javax.inject.Inject
-
-@FeatureInDevelopment
-class GutenbergMentionsFeatureConfig
-@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.GUTENBERG_MENTIONS)


### PR DESCRIPTION
Fixes #14260 

Since the GB mentions flag is `true` for everyone for quite some time already, I'm removing it in the current tech project. Is there any reason why we shouldn't do this @mchowning ? 

To test:
- Test the GB mentions are visible as expected

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
