### PR TITLE
Jetpack App Basics: Initial project configuration

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -190,23 +190,6 @@ android {
     buildFeatures {
         viewBinding true
     }
-    sourceSets {
-        jetpack {
-            res {
-                srcDirs 'src/jetpack/res'
-            }
-        }
-        jetpackJalapeno {
-            res {
-                srcDirs 'src/jetpackJalapeno/res'
-            }
-        }
-        jetpackWasabi {
-            res {
-                srcDirs 'src/jetpackWasabi/res'
-            }
-        }
-    }
 }
 
 // allows us to use cool things like @Parcelize annotations

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -190,6 +190,23 @@ android {
     buildFeatures {
         viewBinding true
     }
+    sourceSets {
+        jetpack {
+            res {
+                srcDirs 'src/jetpack/res'
+            }
+        }
+        jetpackJalapeno {
+            res {
+                srcDirs 'src/jetpackJalapeno/res'
+            }
+        }
+        jetpackWasabi {
+            res {
+                srcDirs 'src/jetpackWasabi/res'
+            }
+        }
+    }
 }
 
 // allows us to use cool things like @Parcelize annotations

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -92,9 +92,19 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    flavorDimensions "buildType"
+    flavorDimensions "app", "buildType"
 
     productFlavors {
+        wordpress {
+            dimension "app"
+            applicationId "org.wordpress.android"
+        }
+
+        jetpack {
+            dimension "app"
+            applicationId "com.jetpack.android"
+        }
+
         vanilla { // used for release and beta
             dimension "buildType"
             // Only set the release version if one isn't provided

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -119,21 +119,20 @@ android {
         }
 
         zalpha { // alpha version - enable experimental features
-            applicationId "org.wordpress.android"
             dimension "buildType"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
-            applicationId "org.wordpress.android.beta"
+            applicationIdSuffix ".beta"
             dimension "buildType"
             // Enable this for testing consolidated media picker
             // buildConfigField "boolean", "CONSOLIDATED_MEDIA_PICKER", "true"
         }
 
         jalapeno { // Pre-Alpha version, used for PR builds, can be installed along release, alpha, beta, dev versions
-            applicationId "org.wordpress.android.prealpha"
+            applicationIdSuffix ".prealpha"
             dimension "buildType"
         }
     }

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">Jetpack</string>
+</resources>

--- a/WordPress/src/jetpackJalapeno/res/values/strings.xml
+++ b/WordPress/src/jetpackJalapeno/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">Jetpack Pre-Alpha</string>
+</resources>

--- a/WordPress/src/jetpackWasabi/res/values/strings.xml
+++ b/WordPress/src/jetpackWasabi/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">Jetpack Beta</string>
+</resources>


### PR DESCRIPTION
Fixes #14296 

This PR sets up the initial configuration for the Jetpack App
- Created the new `app` product flavor dimensions
- Set the Jetpack App application id: `com.jetpack.android`
- Swapped out `applicationId` with `applicationIdSuffix` in the `buildType` dimensions
- Added source set folder structure
- Added values/strings file to force the directory structure to show in the IDE

**Notes**
- This PR will be merged into the JetpackApp Basics feature branch: `feature/jetpack-app-basics`
- The milestone is set for 17.1, but I suspect this might be too optimistic. 

**Pre test**
- You must update your local copy of `google-services.json` before running the app.
-- Copy existing `org.wordress.android`,  `org.wordress.android.prealpha`, `org.wordress.android.beta` sections and replace with `com.jetpack.android`, `com.jetpack.android.prealpha`, `com.jetpack.android.beta`.

**To Test**
- Build and launch each product flavor. Verify the build variant launches.
- `wordpressVanillaDebug` (Prod)
- `wordpressWasabiDebug` (Beta)
- `wordpressJalapenoDebug` (Alpha)
- `jetpackVanillaDebug` (Prod)
- `jetpackWasabiDebug` (Beta)
- `jetpackJalapenoDebug` (Alpha)

Note that:
- `jetpackDebug` should build all `debug` product flavors related to the `jetpack` dimension.
- `jetpackJalapeno` should build both, the `debug` and `release`, `jalapeno` product flavor for `jetpack` dimension.
- `jetpackWasabi` should build both, the `debug` and `release`, `wasabi` product flavor for `jetpack` dimension.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
