### PR TITLE
update proguard rule to not obfuscate MeFragment

### DIFF
--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -90,6 +90,6 @@
 # Proguard is incorrectly removing FragmentContainerView classes
 # Explanation by @renanferrari ->
 # https://github.com/wordpress-mobile/WordPress-Android/issues/14323#issuecomment-805052191
--keep class * extends androidx.fragment.app.FragmentContainerView
+-keep class * extends androidx.fragment.app.Fragment
 
 ###### Main resource class - end

--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -87,6 +87,9 @@
     <fields>;
 }
 
-# Proguard seems to be obfuscating the MeFragment without keeping this
--keep class org.wordpress.android.ui.main.MeFragment
+# Proguard is incorrectly removing FragmentContainerView classes
+# Explanation by @renanferrari ->
+# https://github.com/wordpress-mobile/WordPress-Android/issues/14323#issuecomment-805052191
+-keep class * extends androidx.fragment.app.FragmentContainerView
+
 ###### Main resource class - end

--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -86,4 +86,7 @@
 -keep class org.wordpress.android.R$* {
     <fields>;
 }
+
+# Proguard seems to be obfuscating the MeFragment without keeping this
+-keep class org.wordpress.android.ui.main.MeFragment
 ###### Main resource class - end


### PR DESCRIPTION
Fixes #14323 

Added a simple proguard rule to explicitly ignore MeFragment in obfuscation

To test: Generate a signed build of the app and tap the Me button

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
