### PR TITLE
Use view binding in jetpack features - part 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadActivity.kt
@@ -3,17 +3,17 @@ package org.wordpress.android.ui.jetpack.backup.download
 import android.R.id
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.backup_download_activity.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.BackupDownloadActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class BackupDownloadActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        with(BackupDownloadActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
 
-        setContentView(R.layout.backup_download_activity)
-
-        setSupportActionBar(toolbar_main)
+            setSupportActionBar(toolbarMain)
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
@@ -10,9 +10,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.jetpack_backup_restore_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.JetpackBackupRestoreFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.jetpack.backup.download.BackupDownloadNavigationEvents.DownloadFile
@@ -44,11 +44,12 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        initDagger()
-        initBackPressHandler()
-        initAdapter()
-        initViewModel(savedInstanceState)
+        with(JetpackBackupRestoreFragmentBinding.bind(view)) {
+            initDagger()
+            initBackPressHandler()
+            initAdapter()
+            initViewModel(savedInstanceState)
+        }
     }
 
     private fun initDagger() {
@@ -71,16 +72,19 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
         viewModel.onBackPressed()
     }
 
-    private fun initAdapter() {
-        recycler_view.adapter = JetpackBackupRestoreAdapter(imageManager, uiHelpers)
-        recycler_view.itemAnimator = null
-        recycler_view.addItemDecoration(
+    private fun JetpackBackupRestoreFragmentBinding.initAdapter() {
+        recyclerView.adapter = JetpackBackupRestoreAdapter(imageManager, uiHelpers)
+        recyclerView.itemAnimator = null
+        recyclerView.addItemDecoration(
                 HorizontalMarginItemDecoration(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
         )
     }
 
-    private fun initViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(this, viewModelFactory).get(BackupDownloadViewModel::class.java)
+    private fun JetpackBackupRestoreFragmentBinding.initViewModel(savedInstanceState: Bundle?) {
+        viewModel = ViewModelProvider(
+                this@BackupDownloadFragment,
+                viewModelFactory
+        ).get(BackupDownloadViewModel::class.java)
 
         val (site, activityId) = when {
             requireActivity().intent?.extras != null -> {
@@ -101,7 +105,7 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
         viewModel.start(site, activityId, savedInstanceState)
     }
 
-    private fun initObservers() {
+    private fun JetpackBackupRestoreFragmentBinding.initObservers() {
         viewModel.uiState.observe(viewLifecycleOwner, {
             updateToolbar(it.toolbarState)
             showView(it)
@@ -151,8 +155,8 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
         })
     }
 
-    private fun showView(state: BackupDownloadUiState) {
-        ((recycler_view.adapter) as JetpackBackupRestoreAdapter).update(state.items)
+    private fun JetpackBackupRestoreFragmentBinding.showView(state: BackupDownloadUiState) {
+        ((recyclerView.adapter) as JetpackBackupRestoreAdapter).update(state.items)
     }
 
     private fun updateToolbar(toolbarState: ToolbarState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreActivity.kt
@@ -2,17 +2,17 @@ package org.wordpress.android.ui.jetpack.restore
 
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.restore_activity.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.RestoreActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class RestoreActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        with(RestoreActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
 
-        setContentView(R.layout.restore_activity)
-
-        setSupportActionBar(toolbar_main)
+            setSupportActionBar(toolbarMain)
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
@@ -10,10 +10,10 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.jetpack_backup_restore_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.R.dimen
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.JetpackBackupRestoreFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.jetpack.common.adapters.JetpackBackupRestoreAdapter
@@ -42,11 +42,12 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        initDagger()
-        initBackPressHandler()
-        initAdapter()
-        initViewModel(savedInstanceState)
+        with(JetpackBackupRestoreFragmentBinding.bind(view)) {
+            initDagger()
+            initBackPressHandler()
+            initAdapter()
+            initViewModel(savedInstanceState)
+        }
     }
 
     private fun initDagger() {
@@ -69,16 +70,16 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
         viewModel.onBackPressed()
     }
 
-    private fun initAdapter() {
-        recycler_view.adapter = JetpackBackupRestoreAdapter(imageManager, uiHelpers)
-        recycler_view.itemAnimator = null
-        recycler_view.addItemDecoration(
+    private fun JetpackBackupRestoreFragmentBinding.initAdapter() {
+        recyclerView.adapter = JetpackBackupRestoreAdapter(imageManager, uiHelpers)
+        recyclerView.itemAnimator = null
+        recyclerView.addItemDecoration(
                 HorizontalMarginItemDecoration(resources.getDimensionPixelSize(dimen.margin_extra_large))
         )
     }
 
-    private fun initViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(this, viewModelFactory).get(RestoreViewModel::class.java)
+    private fun JetpackBackupRestoreFragmentBinding.initViewModel(savedInstanceState: Bundle?) {
+        viewModel = ViewModelProvider(this@RestoreFragment, viewModelFactory).get(RestoreViewModel::class.java)
 
         val (site, activityId) = when {
             requireActivity().intent?.extras != null -> {
@@ -99,7 +100,7 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
         viewModel.start(site, activityId, savedInstanceState)
     }
 
-    private fun initObservers() {
+    private fun JetpackBackupRestoreFragmentBinding.initObservers() {
         viewModel.uiState.observe(viewLifecycleOwner, {
             updateToolbar(it.toolbarState)
             showView(it)
@@ -116,23 +117,23 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
         })
 
         viewModel.wizardFinishedObservable.observeEvent(viewLifecycleOwner, { state ->
-                val intent = Intent()
-                val (restoreCreated, ids) = when (state) {
-                    is RestoreCanceled -> Pair(false, null)
-                    is RestoreInProgress -> Pair(true, Pair(state.rewindId, state.restoreId))
-                    is RestoreCompleted -> Pair(true, null)
-                }
-                intent.putExtra(KEY_RESTORE_REWIND_ID, ids?.first)
-                intent.putExtra(KEY_RESTORE_RESTORE_ID, ids?.second)
-                requireActivity().let { activity ->
-                    activity.setResult(if (restoreCreated) RESULT_OK else RESULT_CANCELED, intent)
-                    activity.finish()
-                }
+            val intent = Intent()
+            val (restoreCreated, ids) = when (state) {
+                is RestoreCanceled -> Pair(false, null)
+                is RestoreInProgress -> Pair(true, Pair(state.rewindId, state.restoreId))
+                is RestoreCompleted -> Pair(true, null)
+            }
+            intent.putExtra(KEY_RESTORE_REWIND_ID, ids?.first)
+            intent.putExtra(KEY_RESTORE_RESTORE_ID, ids?.second)
+            requireActivity().let { activity ->
+                activity.setResult(if (restoreCreated) RESULT_OK else RESULT_CANCELED, intent)
+                activity.finish()
+            }
         })
     }
 
-    private fun showView(state: RestoreUiState) {
-        ((recycler_view.adapter) as JetpackBackupRestoreAdapter).update(state.items)
+    private fun JetpackBackupRestoreFragmentBinding.showView(state: RestoreUiState) {
+        ((recyclerView.adapter) as JetpackBackupRestoreAdapter).update(state.items)
     }
 
     private fun updateToolbar(toolbarState: ToolbarState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
@@ -5,9 +5,9 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.ScanActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 
@@ -18,12 +18,14 @@ class ScanActivity : AppCompatActivity() {
             it.onNewIntent(intent)
         }
     }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        with(ScanActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
 
-        setContentView(R.layout.scan_activity)
-
-        setSupportActionBar(toolbar_main)
+            setSupportActionBar(toolbarMain)
+        }
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -8,9 +8,9 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.scan_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.ScanFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.accounts.HelpActivity.Origin.SCAN_SCREEN_HELP
@@ -38,41 +38,43 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initDagger()
-        initRecyclerView()
-        initViewModel(getSite(savedInstanceState))
+        with(ScanFragmentBinding.bind(view)) {
+            initDagger()
+            initRecyclerView()
+            initViewModel(getSite(savedInstanceState))
+        }
     }
 
     private fun initDagger() {
         (requireActivity().application as WordPress).component()?.inject(this)
     }
 
-    private fun initRecyclerView() {
-        recycler_view.itemAnimator = null
-        recycler_view.addItemDecoration(
+    private fun ScanFragmentBinding.initRecyclerView() {
+        recyclerView.itemAnimator = null
+        recyclerView.addItemDecoration(
                 HorizontalMarginItemDecoration(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
         )
-        recycler_view.setEmptyView(actionable_empty_view)
+        recyclerView.setEmptyView(actionableEmptyView)
         initAdapter()
     }
 
-    private fun initAdapter() {
-        recycler_view.adapter = ScanAdapter(imageManager, uiHelpers)
+    private fun ScanFragmentBinding.initAdapter() {
+        recyclerView.adapter = ScanAdapter(imageManager, uiHelpers)
     }
 
-    private fun initViewModel(site: SiteModel) {
-        viewModel = ViewModelProvider(this, viewModelFactory).get(ScanViewModel::class.java)
+    private fun ScanFragmentBinding.initViewModel(site: SiteModel) {
+        viewModel = ViewModelProvider(this@ScanFragment, viewModelFactory).get(ScanViewModel::class.java)
         setupObservers()
         viewModel.start(site)
     }
 
-    private fun setupObservers() {
+    private fun ScanFragmentBinding.setupObservers() {
         viewModel.uiState.observe(
                 viewLifecycleOwner,
                 { uiState ->
-                    uiHelpers.updateVisibility(progress_bar, uiState.loadingVisible)
-                    uiHelpers.updateVisibility(recycler_view, uiState.contentVisible)
-                    uiHelpers.updateVisibility(actionable_empty_view, uiState.errorVisible)
+                    uiHelpers.updateVisibility(progressBar, uiState.loadingVisible)
+                    uiHelpers.updateVisibility(recyclerView, uiState.contentVisible)
+                    uiHelpers.updateVisibility(actionableEmptyView, uiState.errorVisible)
 
                     when (uiState) {
                         is ContentUiState -> updateContentLayout(uiState)
@@ -108,16 +110,16 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
         )
     }
 
-    private fun updateContentLayout(state: ContentUiState) {
-        ((recycler_view.adapter) as ScanAdapter).update(state.items)
+    private fun ScanFragmentBinding.updateContentLayout(state: ContentUiState) {
+        ((recyclerView.adapter) as ScanAdapter).update(state.items)
     }
 
-    private fun updateErrorLayout(state: ErrorUiState) {
-        uiHelpers.setTextOrHide(actionable_empty_view.title, state.title)
-        uiHelpers.setTextOrHide(actionable_empty_view.subtitle, state.subtitle)
-        uiHelpers.setTextOrHide(actionable_empty_view.button, state.buttonText)
-        actionable_empty_view.image.setImageResource(state.image)
-        actionable_empty_view.button.setOnClickListener { state.action.invoke() }
+    private fun ScanFragmentBinding.updateErrorLayout(state: ErrorUiState) {
+        uiHelpers.setTextOrHide(actionableEmptyView.title, state.title)
+        uiHelpers.setTextOrHide(actionableEmptyView.subtitle, state.subtitle)
+        uiHelpers.setTextOrHide(actionableEmptyView.button, state.buttonText)
+        actionableEmptyView.image.setImageResource(state.image)
+        actionableEmptyView.button.setOnClickListener { state.action.invoke() }
     }
 
     private fun SnackbarMessageHolder.showSnackbar() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsActivity.kt
@@ -3,16 +3,15 @@ package org.wordpress.android.ui.jetpack.scan.details
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.toolbar_main.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.ThreatDetailsActivityBinding
 
 class ThreatDetailsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        setContentView(R.layout.threat_details_activity)
-
-        setSupportActionBar(toolbar_main)
+        with(ThreatDetailsActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            setSupportActionBar(toolbarMain)
+        }
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -7,9 +7,9 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.threat_details_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.ThreatDetailsFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.jetpack.scan.ScanFragment.Companion.ARG_THREAT_ID
@@ -35,27 +35,32 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initDagger()
-        initAdapter()
-        initViewModel()
+        with(ThreatDetailsFragmentBinding.bind(view)) {
+            initDagger()
+            initAdapter()
+            initViewModel()
+        }
     }
 
     private fun initDagger() {
         (requireActivity().application as WordPress).component()?.inject(this)
     }
 
-    private fun initAdapter() {
-        recycler_view.adapter = ThreatDetailsAdapter(imageManager, uiHelpers)
+    private fun ThreatDetailsFragmentBinding.initAdapter() {
+        recyclerView.adapter = ThreatDetailsAdapter(imageManager, uiHelpers)
     }
 
-    private fun initViewModel() {
-        viewModel = ViewModelProvider(this, viewModelFactory).get(ThreatDetailsViewModel::class.java)
+    private fun ThreatDetailsFragmentBinding.initViewModel() {
+        viewModel = ViewModelProvider(
+                this@ThreatDetailsFragment,
+                viewModelFactory
+        ).get(ThreatDetailsViewModel::class.java)
         setupObservers()
         val threatId = requireActivity().intent.getLongExtra(ARG_THREAT_ID, 0)
         viewModel.start(threatId)
     }
 
-    private fun setupObservers() {
+    private fun ThreatDetailsFragmentBinding.setupObservers() {
         viewModel.uiState.observe(
                 viewLifecycleOwner,
                 { uiState ->
@@ -91,8 +96,8 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
         )
     }
 
-    private fun refreshContentScreen(content: Content) {
-        ((recycler_view.adapter) as ThreatDetailsAdapter).update(content.items)
+    private fun ThreatDetailsFragmentBinding.refreshContentScreen(content: Content) {
+        ((recyclerView.adapter) as ThreatDetailsAdapter).update(content.items)
     }
 
     private fun SnackbarMessageHolder.showSnackbar() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/viewholders/ThreatContextLineViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/adapters/viewholders/ThreatContextLineViewHolder.kt
@@ -3,22 +3,21 @@ package org.wordpress.android.ui.jetpack.scan.details.adapters.viewholders
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
-import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.threat_context_lines_list_context_line_item.*
 import org.wordpress.android.R
+import org.wordpress.android.databinding.ThreatContextLinesListContextLineItemBinding
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsListItemState.ThreatContextLinesItemState.ThreatContextLineItemState
 import org.wordpress.android.ui.utils.PaddingBackgroundColorSpan
+import org.wordpress.android.util.viewBinding
 
 class ThreatContextLineViewHolder(
     parent: ViewGroup,
-    override val containerView: View = LayoutInflater.from(parent.context)
-        .inflate(R.layout.threat_context_lines_list_context_line_item, parent, false)
-) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+    val binding: ThreatContextLinesListContextLineItemBinding = parent.viewBinding(
+            ThreatContextLinesListContextLineItemBinding::inflate
+    )
+) : RecyclerView.ViewHolder(binding.root) {
     private val highlightedContentTextPadding = itemView.context.resources.getDimensionPixelSize(R.dimen.margin_small)
 
     fun onBind(itemState: ThreatContextLineItemState) {
@@ -27,14 +26,14 @@ class ThreatContextLineViewHolder(
     }
 
     private fun updateLineNumber(itemState: ThreatContextLineItemState) {
-        with(line_number) {
+        with(binding.lineNumber) {
             setBackgroundColor(ContextCompat.getColor(itemView.context, itemState.lineNumberBackgroundColorRes))
             text = itemState.line.lineNumber.toString()
         }
     }
 
     private fun updateContent(itemState: ThreatContextLineItemState) {
-        with(content) {
+        with(binding.content) {
             setBackgroundColor(ContextCompat.getColor(itemView.context, itemState.contentBackgroundColorRes))
             text = getHighlightedContentText(itemState)
             // Fixes highlighted background clip by the bounds of the TextView
@@ -54,8 +53,8 @@ class ThreatContextLineViewHolder(
 
                 val foregroundSpan = ForegroundColorSpan(ContextCompat.getColor(context, highlightedTextColorRes))
                 val backgroundSpan = PaddingBackgroundColorSpan(
-                    backgroundColor = ContextCompat.getColor(context, highlightedBackgroundColorRes),
-                    padding = highlightedContentTextPadding
+                        backgroundColor = ContextCompat.getColor(context, highlightedBackgroundColorRes),
+                        padding = highlightedContentTextPadding
                 )
 
                 with(spannableText) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -51,6 +51,11 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
         }
     }
 
+    override fun onDestroyView() {
+        binding = null
+        super.onDestroyView()
+    }
+
     private fun initDagger() {
         (requireActivity().application as WordPress).component()?.inject(this)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -39,6 +39,11 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
         }
     }
 
+    override fun onDestroyView() {
+        binding = null
+        super.onDestroyView()
+    }
+
     private fun initDagger() {
         (requireActivity().application as WordPress).component()?.inject(this)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -4,10 +4,9 @@ import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
-import kotlinx.android.synthetic.main.actionable_empty_view.*
-import kotlinx.android.synthetic.main.scan_history_list_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.ScanHistoryListFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.ViewPagerFragment
@@ -29,28 +28,28 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
     private lateinit var viewModel: ScanHistoryListViewModel
     private lateinit var parentViewModel: ScanHistoryViewModel
 
+    private var binding: ScanHistoryListFragmentBinding? = null
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initDagger()
-        initRecyclerView()
-        initViewModel(getSite(savedInstanceState), getTabType())
+        binding = ScanHistoryListFragmentBinding.bind(view).apply {
+            initDagger()
+            initRecyclerView()
+            initViewModel(getSite(savedInstanceState), getTabType())
+        }
     }
 
     private fun initDagger() {
         (requireActivity().application as WordPress).component()?.inject(this)
     }
 
-    private fun initRecyclerView() {
-        initAdapter()
+    private fun ScanHistoryListFragmentBinding.initRecyclerView() {
+        recyclerView.adapter = ScanAdapter(imageManager, uiHelpers)
+        recyclerView.itemAnimator = null
     }
 
-    private fun initAdapter() {
-        recycler_view.adapter = ScanAdapter(imageManager, uiHelpers)
-        recycler_view.itemAnimator = null
-    }
-
-    private fun initViewModel(site: SiteModel, tabType: ScanHistoryTabType) {
-        viewModel = ViewModelProvider(this, viewModelFactory).get(ScanHistoryListViewModel::class.java)
+    private fun ScanHistoryListFragmentBinding.initViewModel(site: SiteModel, tabType: ScanHistoryTabType) {
+        viewModel = ViewModelProvider(this@ScanHistoryListFragment, viewModelFactory).get(ScanHistoryListViewModel::class.java)
         parentViewModel = ViewModelProvider(parentFragment as ViewModelStoreOwner, viewModelFactory).get(
                 ScanHistoryViewModel::class.java
         )
@@ -58,11 +57,11 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
         setupObservers()
     }
 
-    private fun setupObservers() {
+    private fun ScanHistoryListFragmentBinding.setupObservers() {
         viewModel.uiState.observe(viewLifecycleOwner, {
-            uiHelpers.updateVisibility(actionable_empty_view, it.emptyVisibility)
-            uiHelpers.updateVisibility(recycler_view, it.contentVisibility)
-            uiHelpers.updateVisibility(button, false)
+            uiHelpers.updateVisibility(actionableEmptyView, it.emptyVisibility)
+            uiHelpers.updateVisibility(recyclerView, it.contentVisibility)
+            uiHelpers.updateVisibility(actionableEmptyView.button, false)
             when (it) {
                 EmptyHistory -> { // no-op
                 }
@@ -74,8 +73,8 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
         })
     }
 
-    private fun refreshContentScreen(items: List<ScanListItemState>) {
-        ((recycler_view.adapter) as ScanAdapter).update(items)
+    private fun ScanHistoryListFragmentBinding.refreshContentScreen(items: List<ScanListItemState>) {
+        ((recyclerView.adapter) as ScanAdapter).update(items)
     }
 
     private fun getSite(savedInstanceState: Bundle?): SiteModel {
@@ -88,7 +87,7 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
 
     private fun getTabType(): ScanHistoryTabType = requireNotNull(arguments?.getParcelable(ARG_TAB_TYPE))
 
-    override fun getScrollableViewForUniqueIdProvision(): View? = recycler_view
+    override fun getScrollableViewForUniqueIdProvision(): View? = binding?.recyclerView
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putSerializable(WordPress.SITE, viewModel.site)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -54,7 +54,10 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
     }
 
     private fun ScanHistoryListFragmentBinding.initViewModel(site: SiteModel, tabType: ScanHistoryTabType) {
-        viewModel = ViewModelProvider(this@ScanHistoryListFragment, viewModelFactory).get(ScanHistoryListViewModel::class.java)
+        viewModel = ViewModelProvider(
+                this@ScanHistoryListFragment,
+                viewModelFactory
+        ).get(ScanHistoryListViewModel::class.java)
         parentViewModel = ViewModelProvider(parentFragment as ViewModelStoreOwner, viewModelFactory).get(
                 ScanHistoryViewModel::class.java
         )

--- a/WordPress/src/main/res/layout/scan_history_fragment.xml
+++ b/WordPress/src/main/res/layout/scan_history_fragment.xml
@@ -35,6 +35,7 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <include
+        android:id="@+id/fullscreen_error_with_retry"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         layout="@layout/fullscreen_error_with_retry" />


### PR DESCRIPTION
This PR introduces view binding in the rest of the jetpack features - Scan, Scan history, backup, restore and threats. 

To test:
- Make sure to use a Jetpack site with a plan (ping me if you need access to an account with the Jetpack sites)
- Check all the features look as expected (scan, scan history, backup, restore, threats)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
