### PR TITLE
[Tooling] Mute fastlane's CHANGELOG and update check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
           cache_key_prefix: installable-build-v4
       - run:
           name: Copy Secrets
-          command: bundle exec fastlane run configure_apply
+          command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane run configure_apply
       - update-gradle-memory
       - android/restore-gradle-cache
       - restore-gutenberg-bundle-cache
@@ -252,7 +252,7 @@ jobs:
           cache_key_prefix: release-build-v2
       - run:
           name: Copy Secrets
-          command: bundle exec fastlane run configure_apply
+          command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane run configure_apply
       - update-gradle-memory
       - android/restore-gradle-cache
       - restore-gutenberg-bundle-cache
@@ -276,6 +276,8 @@ jobs:
             SLACK_MESSAGE_VERSION=$(./gradlew -q printVersionName | tail -1)
             echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress Android $SLACK_MESSAGE_VERSION failed!'" >> $BASH_ENV
             echo "export SLACK_SUCCESS_MESSAGE=':tada: WordPress Android $SLACK_MESSAGE_VERSION has been deployed!'" >> $BASH_ENV
+            # Prevent fastlane from checking for updates, also removing the verbose fastlane changelog at the end of each invocation.
+            echo "export FASTLANE_SKIP_UPDATE_CHECK=1" >> $BASH_ENV
             bundle check
       - run:
           name: Build Zalpha 
@@ -427,6 +429,7 @@ jobs:
           name: Download Raw Screenshots from Google Storage
           command: |
             TEST_BUCKET=$(cat log.txt | grep -o "gs://test\-lab\-.*/" | head -1)
+            export FASTLANE_SKIP_UPDATE_CHECK=1
             bundle exec fastlane download_raw_screenshots bucket:"$TEST_BUCKET" phone:blueline-28 tenInch:gts3lltevzw-28
       - persist_to_workspace:
           root: .
@@ -468,10 +471,10 @@ jobs:
             bundle install --path vendor/bundle
       - run:
           name: Download Promo Strings
-          command: bundle exec fastlane download_promo_strings
+          command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane download_promo_strings
       - run:
           name: Create Promo Screenshots
-          command: bundle exec fastlane android create_promo_screenshots force:true
+          command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane android create_promo_screenshots force:true
       - run:
           name: ZIP Metadata
           command: cd fastlane/metadata; zip -r Android-Promo-Screenshots.zip android
@@ -536,7 +539,7 @@ jobs:
           cache_key_prefix: strings-check-v2
       - run:
           name: Validate login strings
-          command: bundle exec fastlane validate_login_strings pr_url:$CIRCLE_PULL_REQUEST
+          command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane validate_login_strings pr_url:$CIRCLE_PULL_REQUEST
   translation-review-build:
     executor:
       name: android/default
@@ -551,7 +554,7 @@ jobs:
           cache_key_prefix: translation-review-build-v2
       - run:
           name: Copy Secrets
-          command: bundle exec fastlane run configure_apply
+          command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane run configure_apply
       - update-gradle-memory
       - android/restore-gradle-cache
       - restore-gutenberg-bundle-cache
@@ -568,6 +571,7 @@ jobs:
             TODAY_DATE=$(date +'%Y%m%d')
             VERSION_NAME="${APP_VERSION_PREFIX}-build-${TODAY_DATE}-${CIRCLE_BUILD_NUM}"
             echo "export VERSION_NAME=$VERSION_NAME" >> $BASH_ENV
+            echo "export FASTLANE_SKIP_UPDATE_CHECK=1" >> $BASH_ENV
 
             cp ~/.android/debug_a8c.keystore ~/.android/debug.keystore
             bundle exec fastlane build_for_translation_review custom_version:"$VERSION_NAME"


### PR DESCRIPTION
This adds a magic env var that will prevent fastlane from checking for an update at the end of every invocation, and thus remove the quite verbose fastlane changelog output that gets printed at the end of every fastlane step. This should make logs less spammy especially when debugging CI failures, and show more info even when CircleCI truncates the logs to only the last lines on its UI.

Similar to https://github.com/woocommerce/woocommerce-android/pull/3729.

This skip gets applied to every step invoking `fastlane`:
 * `configure_apply` – even if that will soon be replaced by the Rust version of Gradle and that fastlane invocation will probably get removed soon
 * Steps for validating strings (`validate_login_strings` lane)
 * Steps for generating new screenshots
 * Steps in Release Build job

## To test

Check on CI that the steps invoking `fastlane` don't print the fastlane changelog at the end anymore.

**Before:** (e.g. any CI job that was run on develop)
```
[10:09:12]: -----------------------------
[10:09:12]: --- Step: configure_apply ---
[10:09:12]: -----------------------------
[10:09:12]: Applied configuration
[10:09:12]: Result: true

#######################################################################
# fastlane 2.178.0 is available. You are on 2.174.0.
# You should use the latest version.
# Please update using `bundle update fastlane`.
#######################################################################

2.178.0 Improvements

…[a quite long fastlane changelog here]…
....
....
loooong
....
....
....
....


To see all new releases, open https://github.com/fastlane/fastlane/releases

Please update using `bundle update fastlane`
CircleCI received exit code 0
```

**After:** (see CI on this PR)
```
[17:56:30]: -----------------------------
[17:56:30]: --- Step: configure_apply ---
[17:56:30]: -----------------------------
[17:56:30]: Applied configuration
[17:56:30]: Result: true
CircleCI received exit code 0
```