### PR TITLE
Remove switch to classic from gutenberg 

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.java
@@ -10,7 +10,6 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.wordpress.android.e2e.pages.BlockEditorPage;
-import org.wordpress.android.e2e.pages.EditorPage;
 import org.wordpress.android.e2e.pages.MySitesPage;
 import org.wordpress.android.e2e.pages.PostPreviewPage;
 import org.wordpress.android.e2e.pages.SiteSettingsPage;

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.java
@@ -58,12 +58,7 @@ public class BlockEditorTests extends BaseTest {
 
         blockEditorPage.enterTitle(title);
 
-        blockEditorPage.switchToClassic();
-
-        EditorPage editorPage = new EditorPage();
-        editorPage.hasTitle(title);
-
-        editorPage.previewPost();
+        blockEditorPage.previewPost();
         sleep();
 
         new PostPreviewPage();

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/BlockEditorPage.java
@@ -13,6 +13,7 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 
@@ -34,8 +35,8 @@ public class BlockEditorPage {
         titleField.perform(typeText(postTitle), ViewActions.closeSoftKeyboard());
     }
 
-    public void switchToClassic() {
+    public void previewPost() {
         openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
-        clickOn("Switch to classic editor");
+        clickOn(onView(withText(R.string.menu_preview)));
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1213,21 +1213,17 @@ public class EditPostActivity extends LocaleAwareActivity implements
             }
         }
 
-        MenuItem switchToAztecMenuItem = menu.findItem(R.id.menu_switch_to_aztec);
         MenuItem switchToGutenbergMenuItem = menu.findItem(R.id.menu_switch_to_gutenberg);
 
         // The following null checks should basically be redundant but were added to manage
         // an odd behaviour recorded with Android 8.0.0
         // (see https://github.com/wordpress-mobile/WordPress-Android/issues/9748 for more information)
-        if (switchToAztecMenuItem != null && switchToGutenbergMenuItem != null) {
+        if (switchToGutenbergMenuItem != null) {
             if (mShowGutenbergEditor) {
                 // we're showing Gutenberg so, just offer the Aztec switch
-                switchToAztecMenuItem.setVisible(true);
                 switchToGutenbergMenuItem.setVisible(false);
             } else {
                 // we're showing Aztec so, hide the "Switch to Aztec" menu
-                switchToAztecMenuItem.setVisible(false);
-
                 switchToGutenbergMenuItem.setVisible(
                         shouldSwitchToGutenbergBeVisible(mEditorFragment, mSite)
                 );
@@ -1417,19 +1413,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     ((AztecEditorFragment) mEditorFragment).onToolbarHtmlButtonClicked();
                 } else if (mEditorFragment instanceof GutenbergEditorFragment) {
                     ((GutenbergEditorFragment) mEditorFragment).onToggleHtmlMode();
-                }
-            } else if (itemId == R.id.menu_switch_to_aztec) {
-                // The following boolean check should be always redundant but was added to manage
-                // an odd behaviour recorded with Android 8.0.0
-                // (see https://github.com/wordpress-mobile/WordPress-Android/issues/9748 for more information)
-                if (mShowGutenbergEditor) {
-                    // let's finish this editing instance and start again, but not letting Gutenberg be used
-                    mRestartEditorOption = RestartEditorOptions.RESTART_SUPPRESS_GUTENBERG;
-                    mPostEditorAnalyticsSession.switchEditor(Editor.CLASSIC);
-                    mPostEditorAnalyticsSession.setOutcome(Outcome.SAVE);
-                    mViewModel.finish(ActivityFinishState.SAVED_LOCALLY);
-                } else {
-                    logWrongMenuState("Wrong state in menu_switch_to_aztec: menu should not be visible.");
                 }
             } else if (itemId == R.id.menu_switch_to_gutenberg) {
                 // The following boolean check should be always redundant but was added to manage

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1219,15 +1219,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
         // an odd behaviour recorded with Android 8.0.0
         // (see https://github.com/wordpress-mobile/WordPress-Android/issues/9748 for more information)
         if (switchToGutenbergMenuItem != null) {
-            if (mShowGutenbergEditor) {
-                // we're showing Gutenberg so, just offer the Aztec switch
-                switchToGutenbergMenuItem.setVisible(false);
-            } else {
-                // we're showing Aztec so, hide the "Switch to Aztec" menu
-                switchToGutenbergMenuItem.setVisible(
-                        shouldSwitchToGutenbergBeVisible(mEditorFragment, mSite)
-                );
-            }
+            boolean switchToGutenbergVisibility = mShowGutenbergEditor ? false
+                    : shouldSwitchToGutenbergBeVisible(mEditorFragment, mSite);
+            switchToGutenbergMenuItem.setVisible(switchToGutenbergVisibility);
         }
 
         MenuItem contentInfo = menu.findItem(R.id.menu_content_info);

--- a/WordPress/src/main/res/menu/edit_post.xml
+++ b/WordPress/src/main/res/menu/edit_post.xml
@@ -14,11 +14,6 @@
         android:orderInCategory="1" >
 
         <item
-            android:id="@+id/menu_switch_to_aztec"
-            android:title="@string/menu_switch_to_aztec_editor">
-        </item>
-
-        <item
             android:id="@+id/menu_switch_to_gutenberg"
             android:title="@string/menu_switch_to_gutenberg_editor">
         </item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1613,7 +1613,6 @@
     <string name="menu_undo">Undo</string>
     <string name="menu_redo">Redo</string>
     <string name="menu_debug">Debug Menu</string>
-    <string name="menu_switch_to_aztec_editor">Switch to classic editor</string>
     <string name="menu_switch_to_gutenberg_editor">Switch to block editor</string>
     <string name="menu_content_info">Content structure</string>
 


### PR DESCRIPTION
Addresses: https://github.com/wordpress-mobile/gutenberg-mobile/issues/3048 (for Android)
See WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16131


**Relevant info Borrowed from WPiOS PR:**
In discussion with @kyleaparker, we decided that it's best to fast-track the removal of the "switch to classic" option in the block editor. This PR will be scheduled for release in v17.1 alongside a matching change for iOS.

I think this change doesn't warrant inclusion in `RELEASE-NOTES.txt`, but if anyone thinks differently I'd love to hear.

## To test

1. Select a Simple site
2. Open a new post in the block editor
3. Tap the ellipsis button to reveal the options bottom sheet
4. Verify that there is no longer an option to switch to classic
5. Repeat Steps 2-4 for Atomic, Jetpack, self-hosted sites

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
