### PR TITLE
Update lanes taking into account the new build process

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,7 +65,6 @@ ENV["validate_translations"]="lintVanillaRelease"
   #####################################################################################
   desc "Creates a new release branch from the current develop"
   lane :code_freeze do | options |
-    gutenberg_dep_check()
     old_version = android_codefreeze_prechecks(options)
 
     android_bump_version_release()
@@ -592,40 +591,6 @@ ENV["validate_translations"]="lintVanillaRelease"
       extract_universal_apk(bundle_path:"#{build_dir}#{name}", apk_path:"#{build_dir}#{apk_name}")
     end
     "#{build_dir}#{name}"
-  end
-
-  #####################################################################################
-  # gutenberg_dep_check
-  # -----------------------------------------------------------------------------------
-  # Verifies that Gutenberg is on the last released version
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane gutenberg_dep_check
-  #####################################################################################
-  desc "Verifies that Gutenberg is on the last released version"
-  lane :gutenberg_dep_check do | options |
-    # Pull the latest develop
-    sh("git checkout develop")
-    sh("git pull")
-    sh("git submodule init")
-    sh("git submodule update")
-
-    Dir.chdir("../libs/gutenberg-mobile") do
-      sh("git fetch --tags")
-      last_tag_hash = sh("git rev-list --tags --max-count\=1")
-      submodule_hash = sh("git rev-parse HEAD")
-
-      if (last_tag_hash != submodule_hash)
-        error_message = "Gutenberg submodule hash is not on the last tag!\nSubmodule hash: #{submodule_hash}\nLast tag hash: #{last_tag_hash}"
-        UI.user_error!(error_message) unless UI.interactive?
-
-        if (!UI.confirm("#{error_message}\nDo you want to continue anyway?"))
-          UI.user_error!("Aborted by user request. Please fix Gutenberg reference and try again.")
-        end
-      else
-        UI.message("Gutenberg is on the last tag: #{last_tag_hash}.")
-      end
-    end
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -568,13 +568,11 @@ ENV["validate_translations"]="lintVanillaRelease"
     # Build
     Dir.chdir("..") do
       sh("mkdir -p #{build_dir}")
-      unless is_ci
-        # We pre-build the Gutenberg RN bundle on a different job on CI,
-        # so cleaning here breaks the build
-        UI.message("Cleaning branch...")
-        sh("echo \"Cleaning branch\" >> #{logfile_path}")
-        sh("./gradlew clean >> #{logfile_path} 2>&1")
-      end
+
+      UI.message("Cleaning branch...")
+      sh("echo \"Cleaning branch\" >> #{logfile_path}")
+      sh("./gradlew clean >> #{logfile_path} 2>&1")
+      
       sh("mkdir -p #{build_dir}")
       UI.message("Running lint...")
       sh("echo \"Running lint...\" >> #{logfile_path}")


### PR DESCRIPTION
This PR cleans up the Fastfile removing a couple of checks which aren't required anymore: 
1. removes the `gutenberg_dep_check` lane as it's based on having the submodule available. 
2. removes a check which prevented cleaning up the local build environment before building on CI. 

_About 1_:
I think we should implement an equivalent check based on the version referenced in `build.gradle`. We could mimic what we do on iOS where, during the code freeze, we verify that we don't import libraries referencing random commit hashes or beta versions. At least, we should add a manual check step to the release scenario before merging this feature branch into `develop`.

_About 2_: 
Cleaning up on CI is probably not required most of the times because we start from a clean image. But it shouldn't take a lot of time anyway and it may still help when we build multiple flavours in the same machine. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
