### PR TITLE
Stories publishing: use SingleLiveEvent for button clicks to show the prepublishing bottom sheet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.PostActionBuilder
@@ -52,11 +53,11 @@ class StoryComposerViewModel @Inject constructor(
     private val _mediaFilesUris = MutableLiveData<List<Uri>>()
     val mediaFilesUris: LiveData<List<Uri>> = _mediaFilesUris
 
-    private val _openPrepublishingBottomSheet = MutableLiveData<Event<Unit>>()
-    val openPrepublishingBottomSheet: LiveData<Event<Unit>> = _openPrepublishingBottomSheet
+    private val _openPrepublishingBottomSheet = SingleLiveEvent<Event<Unit>>()
+    val openPrepublishingBottomSheet = _openPrepublishingBottomSheet
 
-    private val _submitButtonClicked = MutableLiveData<Event<Unit>>()
-    val submitButtonClicked: LiveData<Event<Unit>> = _submitButtonClicked
+    private val _submitButtonClicked = SingleLiveEvent<Event<Unit>>()
+    val submitButtonClicked = _submitButtonClicked
 
     init {
         lifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.CREATED


### PR DESCRIPTION
Fixes #13670

### Description
From the logs in the [related Sentry issue](https://sentry.io/share/issue/47c2547d65554997a142d75e20e342e1/) I can see that the user is creating a Story using the FAB on the My Site screen picking 1 image, publishes it, then goes watch the Web preview once published.
Then they try to go and create a second Story, but this time as soon as the `StoryComposerActivity` gets created, the `PrePublishingFragment` gets created as well, and this triggers the call to [`setupHomeUiState()`](https://github.com/wordpress-mobile/WordPress-Android/blob/9129776d408833315d7e52b0282caf42252e9fd4/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt#L76-L81) which in turn [accesses the StoryRepository](https://github.com/wordpress-mobile/WordPress-Android/blob/9129776d408833315d7e52b0282caf42252e9fd4/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt#L78), which still does not contain the initialized new Story instance, hence the indexes are invalid and the crash occurs.

Here you can see in the logs the `editor_post_created`  event followed by the `prepublishing_bottom_sheet_opened` event:
```
i/WordPress-STATS: 🔵 Tracked: editor_post_created, Properties: {"blog_id":191061185,"site_type":"blog","created_post_source_detail":"story-from-my-site","post_type":"post","created_post_source":"post-list","is_jetpack":false}
i/WordPress-STATS: 🔵 Tracked: prepublishing_bottom_sheet_opened
d/WordPress-API: Dispatching action: TaxonomyAction-FETCH_TAGS
i/WordPress-STATS: 🔵 Tracked: media_photo_optimized
i/WordPress-STATS: 🔵 Tracked: editor_photo_added, Properties: {"ext":"jpg","blog_id":191061185,"site_type":"blog","age_ms":947,"bytes":54184,"mime":"image\/jpeg","megapixels":0,"is_jetpack":false,"via":"device_library"}
IndexOutOfBoundsException: Index: 0, Size: 0

```

### Why is the Prepublishing bottom sheet fragment created

I wonder why this Fragment is created right away, given the [only spot](https://github.com/wordpress-mobile/WordPress-Android/blob/f86f7822fd0ef15dcad15f16bc5109eda9d24dc5/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt#L231-L234) where the Fragment should be created is by means of tapping on the "publish" button (rounded button on the top-right corner of the screen) on the Story Composer:

```
        viewModel.openPrepublishingBottomSheet.observeEvent(this, {
            analyticsTrackerWrapper.track(PREPUBLISHING_BOTTOM_SHEET_OPENED)
            openPrepublishingBottomSheet()
        })
```

So one thing that comes to mind is that as soon as the observable listener is setup, given it contains an event, the event is triggered. This, although I was unable to reproduce, makes sense and concurs with the logs being shown.

### Solution

The solution is to use a [`SingleLiveEvent`](https://github.com/wordpress-mobile/WordPress-Android/blob/a9eeed79f6d85fd3a3a55157ff9b2932248c00cc/WordPress/src/main/java/org/wordpress/android/viewmodel/SingleLiveEvent.kt) instead of [`LiveData`](https://developer.android.com/reference/androidx/lifecycle/LiveData), to make sure the event is consumed only once. We're using this same mechanism elsewhere in [various parts of the app](https://github.com/wordpress-mobile/WordPress-Android/search?q=singleliveevent), and for example this comment [here](https://github.com/wordpress-mobile/WordPress-Android/blob/076c52d869105dcbf8eaa4945e1dde0a336510d5/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/MutableGifMediaViewModel.kt
) explains why.


To test:
1. start the app
2. tap on the FAB, create a new story
3. select one image
4. tap on the rounded button on the top-right corner of the screen to trigger the pre-publishing bottom sheet
5. optionally give the post a title and publish
6. repeat steps 2-5 and confirm the app doesn't crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
