### PR TITLE
Use view binding in stats widgets and the insights

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementActivity.kt
@@ -2,17 +2,18 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.insights.managemen
 
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.R
+import org.wordpress.android.databinding.InsightsManagementActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class InsightsManagementActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        with(InsightsManagementActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
 
-        setContentView(R.layout.insights_management_activity)
-
-        setSupportActionBar(toolbar_main)
+            setSupportActionBar(toolbarMain)
+        }
 
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
@@ -1,48 +1,42 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.insights.management
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import dagger.android.support.DaggerFragment
-import kotlinx.android.synthetic.main.insights_management_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.InsightsManagementFragmentBinding
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.management.InsightsManagementViewModel.InsightListItem
 import javax.inject.Inject
 
-class InsightsManagementFragment : DaggerFragment() {
+class InsightsManagementFragment : DaggerFragment(R.layout.insights_management_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: InsightsManagementViewModel
 
     private var menu: Menu? = null
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        setHasOptionsMenu(true)
-        return inflater.inflate(R.layout.insights_management_fragment, container, false)
-    }
-
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
-
         inflater.inflate(R.menu.menu_insights_management, menu)
         this.menu = menu
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setHasOptionsMenu(true)
         super.onViewCreated(view, savedInstanceState)
-
-        val siteId = activity?.intent?.getIntExtra(WordPress.LOCAL_SITE_ID, 0)
-        initializeViews()
-        initializeViewModels(requireActivity(), siteId)
+        with(InsightsManagementFragmentBinding.bind(view)) {
+            val siteId = activity?.intent?.getIntExtra(WordPress.LOCAL_SITE_ID, 0)
+            initializeViews()
+            initializeViewModels(requireActivity(), siteId)
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -52,11 +46,11 @@ class InsightsManagementFragment : DaggerFragment() {
         return true
     }
 
-    private fun initializeViews() {
+    private fun InsightsManagementFragmentBinding.initializeViews() {
         insightCards.layoutManager = LinearLayoutManager(requireActivity(), RecyclerView.VERTICAL, false)
     }
 
-    private fun initializeViewModels(activity: FragmentActivity, siteId: Int?) {
+    private fun InsightsManagementFragmentBinding.initializeViewModels(activity: FragmentActivity, siteId: Int?) {
         viewModel = ViewModelProvider(activity, viewModelFactory).get(InsightsManagementViewModel::class.java)
 
         viewModel.start(siteId)
@@ -64,7 +58,7 @@ class InsightsManagementFragment : DaggerFragment() {
         setupObservers()
     }
 
-    private fun setupObservers() {
+    private fun InsightsManagementFragmentBinding.setupObservers() {
         viewModel.addedInsights.observe(viewLifecycleOwner, Observer {
             it?.let { items ->
                 updateAddedInsights(items)
@@ -88,7 +82,7 @@ class InsightsManagementFragment : DaggerFragment() {
         })
     }
 
-    private fun updateAddedInsights(insights: List<InsightListItem>) {
+    private fun InsightsManagementFragmentBinding.updateAddedInsights(insights: List<InsightListItem>) {
         var adapter = insightCards.adapter as? InsightsManagementAdapter
         if (adapter == null) {
             adapter = InsightsManagementAdapter()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ActivityViewHolder.kt
@@ -3,62 +3,60 @@ package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.stats_block_single_activity.view.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.databinding.StatsBlockActivityItemBinding
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ActivityItem.Box
 import org.wordpress.android.util.ContentDescriptionListAnnouncer
+import org.wordpress.android.util.viewBinding
 
 private const val SIZE_PADDING = 32
 private const val GAP = 8
 private const val BLOCK_WIDTH = 104
 private const val SPAN_COUNT = 7
 
-class ActivityViewHolder(val parent: ViewGroup) : BlockListItemViewHolder(
-        parent,
-        R.layout.stats_block_activity_item
+class ActivityViewHolder(
+    parent: ViewGroup,
+    val binding: StatsBlockActivityItemBinding = parent.viewBinding(StatsBlockActivityItemBinding::inflate)
+) : BlockListItemViewHolder(
+        binding.root
 ) {
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
-    private val firstBlock = itemView.findViewById<LinearLayout>(R.id.first_activity)
-    private val secondBlock = itemView.findViewById<LinearLayout>(R.id.second_activity)
-    private val thirdBlock = itemView.findViewById<LinearLayout>(R.id.third_activity)
-
     fun bind(
         item: ActivityItem
-    ) {
-        drawBlock(firstBlock.activity, item.blocks[0].boxes)
-        firstBlock.label.text = item.blocks[0].label
+    ) = with(binding) {
+        drawBlock(firstActivity.activity, item.blocks[0].boxes)
+        firstActivity.label.text = item.blocks[0].label
         if (item.blocks.size > 1) {
-            drawBlock(secondBlock.activity, item.blocks[1].boxes)
-            secondBlock.label.text = item.blocks[1].label
+            drawBlock(secondActivity.activity, item.blocks[1].boxes)
+            secondActivity.label.text = item.blocks[1].label
         }
         if (item.blocks.size > 2) {
-            drawBlock(thirdBlock.activity, item.blocks[2].boxes)
-            thirdBlock.label.text = item.blocks[2].label
+            drawBlock(thirdActivity.activity, item.blocks[2].boxes)
+            thirdActivity.label.text = item.blocks[2].label
         }
-        val widthInDp = parent.width / parent.context.resources.displayMetrics.density
+        val widthInDp = root.width / root.context.resources.displayMetrics.density
         if (widthInDp > BLOCK_WIDTH + 2 * GAP) {
             updateVisibility(item, widthInDp)
         } else {
             coroutineScope.launch {
                 delay(50)
-                updateVisibility(item, parent.width / parent.context.resources.displayMetrics.density)
+                updateVisibility(item, root.width / root.context.resources.displayMetrics.density)
             }
         }
 
         setupBlocksForAccessibility(item)
     }
 
-    private fun setupBlocksForAccessibility(item: ActivityItem) {
-        val blocks = listOf(firstBlock, secondBlock, thirdBlock)
+    private fun StatsBlockActivityItemBinding.setupBlocksForAccessibility(item: ActivityItem) {
+        val blocks = listOf(firstActivity, secondActivity, thirdActivity)
 
         blocks.forEachIndexed { index, block ->
             block.label.contentDescription = item.blocks[index].contentDescription
@@ -68,26 +66,26 @@ class ActivityViewHolder(val parent: ViewGroup) : BlockListItemViewHolder(
                     R.string.stats_posting_activity_empty_description,
                     R.string.stats_posting_activity_end_description,
                     R.string.stats_posting_activity_action,
-                    requireNotNull(item.blocks[index].activityContentDescriptions), block
+                    requireNotNull(item.blocks[index].activityContentDescriptions), block.root
             )
         }
     }
 
-    private fun updateVisibility(
+    private fun StatsBlockActivityItemBinding.updateVisibility(
         item: ActivityItem,
         widthInDp: Float
     ) {
         val canFitTwoBlocks = widthInDp > 2 * BLOCK_WIDTH + GAP + SIZE_PADDING
         if (canFitTwoBlocks && item.blocks.size > 1) {
-            secondBlock.visibility = View.VISIBLE
+            secondActivity.root.visibility = View.VISIBLE
         } else {
-            secondBlock.visibility = View.GONE
+            secondActivity.root.visibility = View.GONE
         }
         val canFitThreeBlocks = widthInDp > 3 * BLOCK_WIDTH + 2 * GAP + SIZE_PADDING
         if (canFitThreeBlocks && item.blocks.size > 2) {
-            firstBlock.visibility = View.VISIBLE
+            firstActivity.root.visibility = View.VISIBLE
         } else {
-            firstBlock.visibility = View.GONE
+            firstActivity.root.visibility = View.GONE
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BlockListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BlockListItemViewHolder.kt
@@ -20,9 +20,13 @@ import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
 import org.wordpress.android.util.image.ImageType.ICON
 
 open class BlockListItemViewHolder(
-    parent: ViewGroup,
-    @LayoutRes layout: Int
-) : ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
+    view: View
+) : ViewHolder(view) {
+    constructor(parent: ViewGroup, @LayoutRes layout: Int) : this(
+            LayoutInflater.from(parent.context)
+                    .inflate(layout, parent, false)
+    )
+
     protected fun TextView.setTextOrHide(@StringRes resource: Int?, value: String?) {
         this.visibility = View.VISIBLE
         when {
@@ -83,7 +87,7 @@ open class BlockListItemViewHolder(
                 this.visibility = View.VISIBLE
                 when (item.iconStyle) {
                     NORMAL -> {
-                        findViewById<ImageView>(R.id.avatar).visibility = View.GONE
+                        avatar.visibility = View.GONE
                         icon.setImageOrLoad(item, imageManager)
                     }
                     AVATAR -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/StatsAllTimeWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/alltime/StatsAllTimeWidgetConfigureActivity.kt
@@ -2,17 +2,17 @@ package org.wordpress.android.ui.stats.refresh.lists.widget.alltime
 
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.toolbar_main.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.StatsAllTimeWidgetConfigureActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class StatsAllTimeWidgetConfigureActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        with(StatsAllTimeWidgetConfigureActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
 
-        setContentView(R.layout.stats_all_time_widget_configure_activity)
-
-        setSupportActionBar(toolbar_main)
+            setSupportActionBar(toolbar.toolbarMain)
+        }
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -12,9 +12,9 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import dagger.android.support.DaggerFragment
-import kotlinx.android.synthetic.main.stats_widget_configure_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_WIDGET_ADDED
+import org.wordpress.android.databinding.StatsWidgetConfigureFragmentBinding
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetUpdater
@@ -88,63 +88,64 @@ class StatsWidgetConfigureFragment : DaggerFragment() {
         }
 
         viewModel.start(appWidgetId, widgetType, siteSelectionViewModel, colorSelectionViewModel)
+        with(StatsWidgetConfigureFragmentBinding.bind(view)) {
+            siteContainer.setOnClickListener {
+                siteSelectionViewModel.openSiteDialog()
+            }
+            colorContainer.setOnClickListener {
+                colorSelectionViewModel.openColorDialog()
+            }
 
-        site_container.setOnClickListener {
-            siteSelectionViewModel.openSiteDialog()
-        }
-        color_container.setOnClickListener {
-            colorSelectionViewModel.openColorDialog()
-        }
+            addWidgetButton.setOnClickListener {
+                viewModel.addWidget()
+            }
 
-        add_widget_button.setOnClickListener {
-            viewModel.addWidget()
-        }
+            siteSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
+                StatsWidgetSiteSelectionDialogFragment().show(requireFragmentManager(), "stats_site_selection_fragment")
+            })
 
-        siteSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
-            StatsWidgetSiteSelectionDialogFragment().show(requireFragmentManager(), "stats_site_selection_fragment")
-        })
-
-        colorSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
+            colorSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
                 StatsWidgetColorSelectionDialogFragment().show(
                         requireFragmentManager(),
                         "stats_view_mode_selection_fragment"
                 )
-        })
+            })
 
-        merge(siteSelectionViewModel.notification, colorSelectionViewModel.notification).observeEvent(
-                viewLifecycleOwner,
-                {
-                    ToastUtils.showToast(activity, it)
-                })
+            merge(siteSelectionViewModel.notification, colorSelectionViewModel.notification).observeEvent(
+                    viewLifecycleOwner,
+                    {
+                        ToastUtils.showToast(activity, it)
+                    })
 
-        viewModel.settingsModel.observe(viewLifecycleOwner, { uiModel ->
-            uiModel?.let {
-                if (uiModel.siteTitle != null) {
-                    site_value.text = uiModel.siteTitle
+            viewModel.settingsModel.observe(viewLifecycleOwner, { uiModel ->
+                uiModel?.let {
+                    if (uiModel.siteTitle != null) {
+                        siteValue.text = uiModel.siteTitle
+                    }
+                    colorValue.setText(uiModel.color.title)
+                    addWidgetButton.isEnabled = uiModel.buttonEnabled
                 }
-                color_value.setText(uiModel.color.title)
-                add_widget_button.isEnabled = uiModel.buttonEnabled
-            }
-        })
+            })
 
-        viewModel.widgetAdded.observeEvent(viewLifecycleOwner, {
-            analyticsTrackerWrapper.trackWithWidgetType(STATS_WIDGET_ADDED, it.widgetType)
-            when (it.widgetType) {
-                WEEK_VIEWS -> {
-                    viewsWidgetUpdater.updateAppWidget(requireContext(), appWidgetId = it.appWidgetId)
+            viewModel.widgetAdded.observeEvent(viewLifecycleOwner, {
+                analyticsTrackerWrapper.trackWithWidgetType(STATS_WIDGET_ADDED, it.widgetType)
+                when (it.widgetType) {
+                    WEEK_VIEWS -> {
+                        viewsWidgetUpdater.updateAppWidget(requireContext(), appWidgetId = it.appWidgetId)
+                    }
+                    ALL_TIME_VIEWS -> {
+                        allTimeWidgetUpdater.updateAppWidget(requireContext(), appWidgetId = it.appWidgetId)
+                    }
+                    TODAY_VIEWS -> {
+                        todayWidgetUpdater.updateAppWidget(requireContext(), appWidgetId = it.appWidgetId)
+                    }
                 }
-                ALL_TIME_VIEWS -> {
-                    allTimeWidgetUpdater.updateAppWidget(requireContext(), appWidgetId = it.appWidgetId)
-                }
-                TODAY_VIEWS -> {
-                    todayWidgetUpdater.updateAppWidget(requireContext(), appWidgetId = it.appWidgetId)
-                }
-            }
-            val resultValue = Intent()
-            resultValue.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-            activity?.setResult(RESULT_OK, resultValue)
-            activity?.finish()
-        })
+                val resultValue = Intent()
+                resultValue.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                activity?.setResult(RESULT_OK, resultValue)
+                activity?.finish()
+            })
+        }
     }
 
     enum class WidgetType { WEEK_VIEWS, ALL_TIME_VIEWS, TODAY_VIEWS }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteSelectionDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteSelectionDialogFragment.kt
@@ -10,8 +10,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.android.support.AndroidSupportInjection
-import kotlinx.android.synthetic.main.stats_widget_site_selector.*
 import org.wordpress.android.R
+import org.wordpress.android.databinding.StatsWidgetSiteSelectorBinding
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -20,7 +20,7 @@ class StatsWidgetSiteSelectionDialogFragment : AppCompatDialogFragment() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: StatsSiteSelectionViewModel
-    private fun buildView(): View? {
+    private fun buildView(): View {
         val rootView = requireActivity().layoutInflater.inflate(R.layout.stats_widget_site_selector, null)
         val recyclerView = rootView.findViewById<RecyclerView>(R.id.recycler_view)
         recyclerView.layoutManager = LinearLayoutManager(activity)
@@ -30,7 +30,8 @@ class StatsWidgetSiteSelectionDialogFragment : AppCompatDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val alertDialogBuilder = MaterialAlertDialogBuilder(requireActivity())
-        alertDialogBuilder.setView(buildView())
+        val view = buildView()
+        alertDialogBuilder.setView(view)
         alertDialogBuilder.setTitle(R.string.stats_widget_select_your_site)
         alertDialogBuilder.setNegativeButton(R.string.cancel) { _, _ -> }
         alertDialogBuilder.setCancelable(true)
@@ -38,7 +39,9 @@ class StatsWidgetSiteSelectionDialogFragment : AppCompatDialogFragment() {
         viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(StatsSiteSelectionViewModel::class.java)
         viewModel.sites.observe(this, {
-            (requireDialog().recycler_view.adapter as? StatsWidgetSiteAdapter)?.update(it ?: listOf())
+            with(StatsWidgetSiteSelectorBinding.bind(view)) {
+                (recyclerView.adapter as? StatsWidgetSiteAdapter)?.update(it ?: listOf())
+            }
         })
         viewModel.hideSiteDialog.observeEvent(this, {
             if (dialog?.isShowing == true) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteViewHolder.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import org.wordpress.android.R

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetSiteViewHolder.kt
@@ -3,39 +3,40 @@ package org.wordpress.android.ui.stats.refresh.lists.widget.configuration
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
-import kotlinx.android.synthetic.main.stats_widget_site_selector_item.view.*
 import org.wordpress.android.R
+import org.wordpress.android.databinding.StatsWidgetSiteSelectorItemBinding
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsSiteSelectionViewModel.SiteUiModel
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR
+import org.wordpress.android.util.viewBinding
 
-class StatsWidgetSiteViewHolder(parent: ViewGroup, val imageManager: ImageManager) : ViewHolder(
-        LayoutInflater.from(parent.context).inflate(
-                R.layout.stats_widget_site_selector_item,
-                parent,
-                false
-        )
+class StatsWidgetSiteViewHolder(
+    parent: ViewGroup,
+    val imageManager: ImageManager,
+    val binding: StatsWidgetSiteSelectorItemBinding = parent.viewBinding(StatsWidgetSiteSelectorItemBinding::inflate)
+) : ViewHolder(
+        binding.root
 ) {
-    fun bind(site: SiteUiModel) {
+    fun bind(site: SiteUiModel) = with(binding) {
         if (site.iconUrl != null) {
-            imageManager.load(itemView.site_icon, BLAVATAR, site.iconUrl)
+            imageManager.load(siteIcon, BLAVATAR, site.iconUrl)
         } else {
             imageManager.load(
-                    itemView.site_icon,
+                    siteIcon,
                     R.drawable.ic_placeholder_blavatar_grey_lighten_20_40dp
             )
         }
         if (site.title != null) {
-            itemView.site_title.text = site.title
+            siteTitle.text = site.title
         } else {
-            itemView.site_title.setText(R.string.unknown)
+            siteTitle.setText(R.string.unknown)
         }
         if (site.url != null) {
-            itemView.site_url.text = site.url
+            siteUrl.text = site.url
         } else {
-            itemView.site_url.setText(R.string.unknown)
+            siteUrl.setText(R.string.unknown)
         }
-        itemView.site_container.setOnClickListener {
+        siteContainer.setOnClickListener {
             site.click()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureActivity.kt
@@ -2,17 +2,17 @@ package org.wordpress.android.ui.stats.refresh.lists.widget.minified
 
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.toolbar_main.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.StatsMinifiedWidgetConfigureActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class StatsMinifiedWidgetConfigureActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        with(StatsMinifiedWidgetConfigureActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
 
-        setContentView(R.layout.stats_minified_widget_configure_activity)
-
-        setSupportActionBar(toolbar_main)
+            setSupportActionBar(toolbar.toolbarMain)
+        }
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -10,9 +10,9 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import dagger.android.support.DaggerFragment
-import kotlinx.android.synthetic.main.stats_widget_configure_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_WIDGET_ADDED
+import org.wordpress.android.databinding.StatsWidgetConfigureFragmentBinding
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel
@@ -29,7 +29,7 @@ import org.wordpress.android.util.mergeNotNull
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
-class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
+class StatsMinifiedWidgetConfigureFragment : DaggerFragment(R.layout.stats_widget_configure_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var minifiedWidgetUpdater: MinifiedWidgetUpdater
     @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
@@ -40,10 +40,6 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
     private lateinit var siteSelectionViewModel: StatsSiteSelectionViewModel
     private lateinit var colorSelectionViewModel: StatsColorSelectionViewModel
     private lateinit var dataTypeSelectionViewModel: StatsDataTypeSelectionViewModel
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.stats_widget_configure_fragment, container, false)
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -69,61 +65,61 @@ class StatsMinifiedWidgetConfigureFragment : DaggerFragment() {
         }
 
         viewModel.start(appWidgetId, siteSelectionViewModel, colorSelectionViewModel, dataTypeSelectionViewModel)
-
-        site_container.setOnClickListener {
-            siteSelectionViewModel.openSiteDialog()
-        }
-        color_container.setOnClickListener {
-            colorSelectionViewModel.openColorDialog()
-        }
-        data_type_container.visibility = View.VISIBLE
-        data_type_container.setOnClickListener {
-            dataTypeSelectionViewModel.openDataTypeDialog()
-        }
-
-        add_widget_button.setOnClickListener {
-            viewModel.addWidget()
-        }
-
-        siteSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
-            StatsWidgetSiteSelectionDialogFragment().show(requireFragmentManager(), "stats_site_selection_fragment")
-        })
-
-        colorSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
-            StatsWidgetColorSelectionDialogFragment().show(
-                    requireFragmentManager(),
-                    "stats_view_mode_selection_fragment"
-            )
-        })
-
-        dataTypeSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
-            StatsWidgetDataTypeSelectionDialogFragment().show(
-                    requireFragmentManager(),
-                    "stats_data_type_selection_fragment"
-            )
-        })
-
-        mergeNotNull(
-                siteSelectionViewModel.notification,
-                colorSelectionViewModel.notification,
-                dataTypeSelectionViewModel.notification
-        ).observeEvent(
-                viewLifecycleOwner,
-                {
-                    ToastUtils.showToast(activity, it)
-                })
-
-        viewModel.settingsModel.observe(viewLifecycleOwner, { uiModel ->
-            uiModel?.let {
-                if (uiModel.siteTitle != null) {
-                    site_value.text = uiModel.siteTitle
-                }
-                color_value.setText(uiModel.color.title)
-                data_type_value.setText(uiModel.dataType.title)
-                add_widget_button.isEnabled = uiModel.buttonEnabled
+        with(StatsWidgetConfigureFragmentBinding.bind(view)) {
+            siteContainer.setOnClickListener {
+                siteSelectionViewModel.openSiteDialog()
             }
-        })
+            colorContainer.setOnClickListener {
+                colorSelectionViewModel.openColorDialog()
+            }
+            dataTypeContainer.visibility = View.VISIBLE
+            dataTypeContainer.setOnClickListener {
+                dataTypeSelectionViewModel.openDataTypeDialog()
+            }
 
+            addWidgetButton.setOnClickListener {
+                viewModel.addWidget()
+            }
+
+            siteSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
+                StatsWidgetSiteSelectionDialogFragment().show(requireFragmentManager(), "stats_site_selection_fragment")
+            })
+
+            colorSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
+                StatsWidgetColorSelectionDialogFragment().show(
+                        requireFragmentManager(),
+                        "stats_view_mode_selection_fragment"
+                )
+            })
+
+            dataTypeSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
+                StatsWidgetDataTypeSelectionDialogFragment().show(
+                        requireFragmentManager(),
+                        "stats_data_type_selection_fragment"
+                )
+            })
+
+            mergeNotNull(
+                    siteSelectionViewModel.notification,
+                    colorSelectionViewModel.notification,
+                    dataTypeSelectionViewModel.notification
+            ).observeEvent(
+                    viewLifecycleOwner,
+                    {
+                        ToastUtils.showToast(activity, it)
+                    })
+
+            viewModel.settingsModel.observe(viewLifecycleOwner, { uiModel ->
+                uiModel?.let {
+                    if (uiModel.siteTitle != null) {
+                        siteValue.text = uiModel.siteTitle
+                    }
+                    colorValue.setText(uiModel.color.title)
+                    dataTypeValue.setText(uiModel.dataType.title)
+                    addWidgetButton.isEnabled = uiModel.buttonEnabled
+                }
+            })
+        }
         viewModel.widgetAdded.observeEvent(viewLifecycleOwner, {
             analyticsTrackerWrapper.trackMinifiedWidget(STATS_WIDGET_ADDED)
             minifiedWidgetUpdater.updateAppWidget(requireContext(), appWidgetId = appWidgetId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -4,9 +4,7 @@ import android.app.Activity.RESULT_OK
 import android.appwidget.AppWidgetManager
 import android.content.Intent
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import dagger.android.support.DaggerFragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/StatsTodayWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/StatsTodayWidgetConfigureActivity.kt
@@ -2,17 +2,17 @@ package org.wordpress.android.ui.stats.refresh.lists.widget.today
 
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.toolbar_main.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.StatsTodayWidgetConfigureActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class StatsTodayWidgetConfigureActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        with(StatsTodayWidgetConfigureActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
 
-        setContentView(R.layout.stats_today_widget_configure_activity)
-
-        setSupportActionBar(toolbar_main)
+            setSupportActionBar(toolbar.toolbarMain)
+        }
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/StatsViewsWidgetConfigureActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/StatsViewsWidgetConfigureActivity.kt
@@ -2,17 +2,17 @@ package org.wordpress.android.ui.stats.refresh.lists.widget.views
 
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.toolbar_main.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.StatsViewsWidgetConfigureActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class StatsViewsWidgetConfigureActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        with(StatsViewsWidgetConfigureActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
 
-        setContentView(R.layout.stats_views_widget_configure_activity)
-
-        setSupportActionBar(toolbar_main)
+            setSupportActionBar(toolbar.toolbarMain)
+        }
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/res/layout/stats_all_time_widget_configure_activity.xml
+++ b/WordPress/src/main/res/layout/stats_all_time_widget_configure_activity.xml
@@ -19,7 +19,7 @@
             app:layout_behavior="@string/appbar_scrolling_view_behavior"
             app:viewType="allTime" />
 
-        <include layout="@layout/toolbar_main" />
+        <include android:id="@+id/toolbar" layout="@layout/toolbar_main" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/WordPress/src/main/res/layout/stats_minified_widget_configure_activity.xml
+++ b/WordPress/src/main/res/layout/stats_minified_widget_configure_activity.xml
@@ -18,7 +18,7 @@
             android:layout_below="@id/toolbar"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-        <include layout="@layout/toolbar_main" />
+        <include android:id="@+id/toolbar" layout="@layout/toolbar_main" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/WordPress/src/main/res/layout/stats_today_widget_configure_activity.xml
+++ b/WordPress/src/main/res/layout/stats_today_widget_configure_activity.xml
@@ -19,7 +19,7 @@
             app:layout_behavior="@string/appbar_scrolling_view_behavior"
             app:viewType="today" />
 
-        <include layout="@layout/toolbar_main" />
+        <include android:id="@+id/toolbar" layout="@layout/toolbar_main" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/WordPress/src/main/res/layout/stats_views_widget_configure_activity.xml
+++ b/WordPress/src/main/res/layout/stats_views_widget_configure_activity.xml
@@ -19,7 +19,7 @@
             app:layout_behavior="@string/appbar_scrolling_view_behavior"
             app:viewType="views" />
 
-        <include layout="@layout/toolbar_main" />
+        <include android:id="@+id/toolbar" layout="@layout/toolbar_main" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 


### PR DESCRIPTION
This PR introduces view binding in most of the remaining stats classes. This is mostly the Activity block on the insights screen, insights management and the widgets.

To test:
- Go to Stats of a site with a lot of data
- Go to Insights
- Scroll down
- Go to "Add new stats card"
- Check the screen is loaded correctly
- Add the "Activity" block
- Go back to Insights
- Notice the block is shown correctly


To test 2:
- Go to a site with a lot of data in stats
- Smoke test all 4 types of widgets
- Check you can pick a site, change color, change the type of a widget (not accessible on all the widgets)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
