### PR TITLE
Use view binding in stats detail, view all and list fragments

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -215,7 +215,7 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
         })
 
         viewModel.dateSelectorData.observe(viewLifecycleOwner, { dateSelectorUiModel ->
-            drawDateSelector(dateSelectorUiModel)
+            statsListFragment.drawDateSelector(dateSelectorUiModel)
         })
 
         viewModel.navigationTarget.observeEvent(viewLifecycleOwner, { target ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -44,7 +44,7 @@ abstract class StatsListViewModel(
     defaultDispatcher: CoroutineDispatcher,
     private val statsUseCase: BaseListUseCase,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val dateSelector: StatsDateSelector,
+    protected val dateSelector: StatsDateSelector,
     popupMenuHandler: ItemPopupMenuHandler? = null,
     private val newsCardHandler: NewsCardHandler? = null
 ) : ScopedViewModel(defaultDispatcher) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/DetailListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/DetailListViewModel.kt
@@ -17,4 +17,9 @@ class DetailListViewModel
     @Named(BLOCK_DETAIL_USE_CASE) private val detailUseCase: BaseListUseCase,
     analyticsTracker: AnalyticsTrackerWrapper,
     dateSelectorFactory: StatsDateSelector.Factory
-) : StatsListViewModel(mainDispatcher, detailUseCase, analyticsTracker, dateSelectorFactory.build(DETAIL))
+) : StatsListViewModel(mainDispatcher, detailUseCase, analyticsTracker, dateSelectorFactory.build(DETAIL)) {
+    override fun onCleared() {
+        super.onCleared()
+        dateSelector.clear()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.StatsDetailFragmentBinding
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
-import org.wordpress.android.ui.stats.refresh.utils.drawDateSelector
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import javax.inject.Inject
@@ -32,20 +31,21 @@ class StatsDetailFragment : DaggerFragment(R.layout.stats_detail_fragment) {
         super.onViewCreated(view, savedInstanceState)
 
         val nonNullActivity = requireActivity()
-        val binding = StatsDetailFragmentBinding.bind(view)
-        with(nonNullActivity as AppCompatActivity) {
-            setSupportActionBar(binding.toolbar)
-            supportActionBar?.let {
-                it.setHomeButtonEnabled(true)
-                it.setDisplayHomeAsUpEnabled(true)
+        with(StatsDetailFragmentBinding.bind(view)) {
+            with(nonNullActivity as AppCompatActivity) {
+                setSupportActionBar(toolbar)
+                supportActionBar?.let {
+                    it.setHomeButtonEnabled(true)
+                    it.setDisplayHomeAsUpEnabled(true)
+                }
             }
+            initializeViewModels(nonNullActivity)
+            initializeViews()
         }
-        initializeViewModels(nonNullActivity)
-        initializeViews(binding)
     }
 
-    private fun initializeViews(binding: StatsDetailFragmentBinding) {
-        swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(binding.pullToRefresh) {
+    private fun StatsDetailFragmentBinding.initializeViews() {
+        swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
             viewModel.onPullToRefresh()
         }
     }
@@ -76,16 +76,6 @@ class StatsDetailFragment : DaggerFragment(R.layout.stats_detail_fragment) {
             it?.let { isRefreshing ->
                 swipeToRefreshHelper.isRefreshing = isRefreshing
             }
-        })
-
-        viewModel.selectedDateChanged.observe(viewLifecycleOwner, Observer { event ->
-            if (event != null) {
-                viewModel.onDateChanged(event.selectedSection)
-            }
-        })
-
-        viewModel.showDateSelector.observe(viewLifecycleOwner, Observer { dateSelectorUiModel ->
-            drawDateSelector(dateSelectorUiModel)
         })
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailViewModel.kt
@@ -3,15 +3,11 @@ package org.wordpress.android.ui.stats.refresh.lists.detail
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.stats.refresh.BLOCK_DETAIL_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.BaseListUseCase
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DETAIL
-import org.wordpress.android.ui.stats.refresh.utils.StatsDateSelector
 import org.wordpress.android.ui.stats.refresh.utils.StatsPostProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -27,13 +23,10 @@ class StatsDetailViewModel
     @Named(BLOCK_DETAIL_USE_CASE) private val detailUseCase: BaseListUseCase,
     private val statsSiteProvider: StatsSiteProvider,
     private val statsPostProvider: StatsPostProvider,
-    private val networkUtilsWrapper: NetworkUtilsWrapper,
-    dateSelectorFactory: StatsDateSelector.Factory
+    private val networkUtilsWrapper: NetworkUtilsWrapper
 ) : ScopedViewModel(mainDispatcher) {
-    private val dateSelector = dateSelectorFactory.build(DETAIL)
     private val _isRefreshing = MutableLiveData<Boolean>()
     val isRefreshing: LiveData<Boolean> = _isRefreshing
-    val selectedDateChanged = dateSelector.selectedDate
 
     private val _showSnackbarMessage = mergeNotNull(
             detailUseCase.snackbarMessage,
@@ -41,7 +34,6 @@ class StatsDetailViewModel
             singleEvent = true
     )
     val showSnackbarMessage: LiveData<SnackbarMessageHolder> = _showSnackbarMessage
-    val showDateSelector = dateSelector.dateSelectorData
 
     fun init(
         postId: Long,
@@ -50,12 +42,6 @@ class StatsDetailViewModel
         postUrl: String?
     ) {
         statsPostProvider.init(postId, postType, postTitle, postUrl)
-    }
-
-    fun onDateChanged(selectedSection: StatsSection) {
-        launch {
-            detailUseCase.onDateChanged(selectedSection)
-        }
     }
 
     fun refresh() {
@@ -67,7 +53,6 @@ class StatsDetailViewModel
 
     override fun onCleared() {
         super.onCleared()
-        dateSelector.clear()
         detailUseCase.onCleared()
         statsPostProvider.clear()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateSelectorViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateSelectorViewUtils.kt
@@ -1,30 +1,30 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
 import android.view.View
-import androidx.fragment.app.Fragment
-import kotlinx.android.synthetic.main.stats_date_selector.*
-import kotlinx.android.synthetic.main.stats_list_fragment.*
+import org.wordpress.android.databinding.StatsListFragmentBinding
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 
-fun Fragment.drawDateSelector(dateSelectorUiModel: DateSelectorUiModel?) {
+fun StatsListFragmentBinding.drawDateSelector(dateSelectorUiModel: DateSelectorUiModel?) {
     val dateSelectorVisibility = if (dateSelectorUiModel?.isVisible == true) View.VISIBLE else View.GONE
-    if (date_selection_toolbar.visibility != dateSelectorVisibility) {
-        date_selection_toolbar.visibility = dateSelectorVisibility
+    if (dateSelectionToolbar.visibility != dateSelectorVisibility) {
+        dateSelectionToolbar.visibility = dateSelectorVisibility
     }
-    selectedDateTextView.text = dateSelectorUiModel?.date ?: ""
-    val timeZone = dateSelectorUiModel?.timeZone
-    if (currentSiteTimeZone.visibility == View.GONE && timeZone != null) {
-        currentSiteTimeZone.visibility = View.VISIBLE
-        currentSiteTimeZone.text = timeZone
-    } else if (currentSiteTimeZone.visibility == View.VISIBLE && timeZone == null) {
-        currentSiteTimeZone.visibility = View.GONE
-    }
-    val enablePreviousButton = dateSelectorUiModel?.enableSelectPrevious == true
-    if (previousDateButton.isEnabled != enablePreviousButton) {
-        previousDateButton.isEnabled = enablePreviousButton
-    }
-    val enableNextButton = dateSelectorUiModel?.enableSelectNext == true
-    if (nextDateButton.isEnabled != enableNextButton) {
-        nextDateButton.isEnabled = enableNextButton
+    with(dateSelector) {
+        selectedDateTextView.text = dateSelectorUiModel?.date ?: ""
+        val timeZone = dateSelectorUiModel?.timeZone
+        if (currentSiteTimeZone.visibility == View.GONE && timeZone != null) {
+            currentSiteTimeZone.visibility = View.VISIBLE
+            currentSiteTimeZone.text = timeZone
+        } else if (currentSiteTimeZone.visibility == View.VISIBLE && timeZone == null) {
+            currentSiteTimeZone.visibility = View.GONE
+        }
+        val enablePreviousButton = dateSelectorUiModel?.enableSelectPrevious == true
+        if (previousDateButton.isEnabled != enablePreviousButton) {
+            previousDateButton.isEnabled = enablePreviousButton
+        }
+        val enableNextButton = dateSelectorUiModel?.enableSelectNext == true
+        if (nextDateButton.isEnabled != enableNextButton) {
+            nextDateButton.isEnabled = enableNextButton
+        }
     }
 }

--- a/WordPress/src/main/res/layout/stats_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_detail_fragment.xml
@@ -16,7 +16,7 @@
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <fragment
+            <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/fragment_container"
                 android:name="org.wordpress.android.ui.stats.refresh.lists.StatsListFragment"
                 android:layout_width="match_parent"


### PR DESCRIPTION
This PR contains view binding changes and one thing that I've noticed while trying to access the nested stats list fragment in the stats detail fragment. 

I'm pretty sure that the date selector handling in the Stats detail fragment was redundant. The detail fragment contains the list fragment (initialized with the Detail type). This list fragment is already handling the date selection and updates the data based on the selected date. The only thing that the detail fragment was doing in addition was the dateSelector.clear method which I've moved to the `DetailListViewModel`. The `DetailListViewModel` and the detail use case are used only in the detail activity/fragment. I've tested the stats detail and it seems to work as expected. I think that this change removes duplicate data loading.  

To test:
- Go to a site with a lot of data
- Go to blog posts
- Click on an overflow menu on a new post
- Click on "Stats"
- Notice the Stats detail screen
- Try going back and forward to switch dates with "<" and ">"
- Notice the date is changing the bar chart correctly
- Try selecting the date in the bar chart
- Notice it updates the date selector
- Select an older date
- Leave the screen
- Go to a different post stats
- Notice the previously selected older date is NOT selected
- Notice Today's date is selected

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
