### PR TITLE
Use view binding in Manual feature configuration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigActivity.kt
@@ -2,22 +2,13 @@ package org.wordpress.android.util.config.manual
 
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.manual_feature_config_fragment.*
 import org.wordpress.android.databinding.ManualFeatureConfigActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class ManualFeatureConfigActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        with(ManualFeatureConfigActivityBinding.inflate(layoutInflater)) {
-            setContentView(root)
-
-            setSupportActionBar(toolbar)
-            supportActionBar?.let {
-                it.setHomeButtonEnabled(true)
-                it.setDisplayHomeAsUpEnabled(true)
-            }
-        }
+        setContentView(ManualFeatureConfigActivityBinding.inflate(layoutInflater).root)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/manual/ManualFeatureConfigFragment.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.util.config.manual
 
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -21,6 +22,13 @@ class ManualFeatureConfigFragment : DaggerFragment(R.layout.manual_feature_confi
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         with(ManualFeatureConfigFragmentBinding.bind(view)) {
+            with(requireActivity() as AppCompatActivity) {
+                setSupportActionBar(toolbar)
+                supportActionBar?.let {
+                    it.setHomeButtonEnabled(true)
+                    it.setDisplayHomeAsUpEnabled(true)
+                }
+            }
             recyclerView.layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
             recyclerView.addItemDecoration(RecyclerItemDecoration(0, DisplayUtils.dpToPx(activity, 1)))
 


### PR DESCRIPTION
This PR introduces view binding to manual feature configuration screen. The change should be quite straightforward.

To test:
- Go to App settings/test feature configuration
- Notice the toolbar looks correct and the back button works

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
