### PR TITLE
Issue/14306 jetpack app disable widgets and shortcuts

### DIFF
--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name" translatable="false">Jetpack</string>
+    <string name="widgets_enabled" translatable="false">false</string>
 </resources>

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="app_name" translatable="false">Jetpack</string>
     <string name="widgets_enabled" translatable="false">false</string>
+    <string name="shortcuts_enabled" translatable="false">false</string>
 </resources>

--- a/WordPress/src/jetpack/res/xml/shortcuts.xml
+++ b/WordPress/src/jetpack/res/xml/shortcuts.xml
@@ -5,7 +5,8 @@
     <shortcut
         android:icon="@drawable/ic_shortcut_stats"
         android:shortcutId="stats"
-        android:shortcutShortLabel="@string/stats">
+        android:shortcutShortLabel="@string/stats"
+        android:enabled="false">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"
@@ -18,7 +19,8 @@
     <shortcut
         android:icon="@drawable/ic_shortcut_notifications"
         android:shortcutId="notifications"
-        android:shortcutShortLabel="@string/notifications_screen_title">
+        android:shortcutShortLabel="@string/notifications_screen_title"
+        android:enabled="false">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"
@@ -31,7 +33,8 @@
     <shortcut
         android:icon="@drawable/ic_shortcut_create_post"
         android:shortcutId="new_post"
-        android:shortcutShortLabel="@string/new_post">
+        android:shortcutShortLabel="@string/new_post"
+        android:enabled="false">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"

--- a/WordPress/src/jetpackJalapeno/res/xml/shortcuts.xml
+++ b/WordPress/src/jetpackJalapeno/res/xml/shortcuts.xml
@@ -5,7 +5,8 @@
     <shortcut
         android:icon="@drawable/ic_shortcut_stats"
         android:shortcutId="stats"
-        android:shortcutShortLabel="@string/stats">
+        android:shortcutShortLabel="@string/stats"
+        android:enabled="false">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"
@@ -18,7 +19,8 @@
     <shortcut
         android:icon="@drawable/ic_shortcut_notifications"
         android:shortcutId="notifications"
-        android:shortcutShortLabel="@string/notifications_screen_title">
+        android:shortcutShortLabel="@string/notifications_screen_title"
+        android:enabled="false">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"
@@ -31,7 +33,8 @@
     <shortcut
         android:icon="@drawable/ic_shortcut_create_post"
         android:shortcutId="new_post"
-        android:shortcutShortLabel="@string/new_post">
+        android:shortcutShortLabel="@string/new_post"
+        android:enabled="false">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"

--- a/WordPress/src/jetpackWasabi/res/xml/shortcuts.xml
+++ b/WordPress/src/jetpackWasabi/res/xml/shortcuts.xml
@@ -5,7 +5,8 @@
     <shortcut
         android:icon="@drawable/ic_shortcut_stats"
         android:shortcutId="stats"
-        android:shortcutShortLabel="@string/stats">
+        android:shortcutShortLabel="@string/stats"
+        android:enabled="false">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"
@@ -18,7 +19,8 @@
     <shortcut
         android:icon="@drawable/ic_shortcut_notifications"
         android:shortcutId="notifications"
-        android:shortcutShortLabel="@string/notifications_screen_title">
+        android:shortcutShortLabel="@string/notifications_screen_title"
+        android:enabled="false">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"
@@ -31,7 +33,8 @@
     <shortcut
         android:icon="@drawable/ic_shortcut_create_post"
         android:shortcutId="new_post"
-        android:shortcutShortLabel="@string/new_post">
+        android:shortcutShortLabel="@string/new_post"
+        android:enabled="false">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -580,7 +580,8 @@
         <activity
             android:name=".ui.AddQuickPressShortcutActivity"
             android:label="@string/quickpress_shortcut_activity_label"
-            android:theme="@style/WordPress.NoActionBar">
+            android:theme="@style/WordPress.NoActionBar"
+            android:enabled="@string/shortcuts_enabled">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT" />
 

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -816,7 +816,8 @@
         <receiver android:name=".ui.notifications.ShareAndDismissNotificationReceiver" />
         <receiver
             android:name=".ui.stats.refresh.lists.widget.views.StatsViewsWidget"
-            android:label="@string/stats_widget_weekly_views_name">
+            android:label="@string/stats_widget_weekly_views_name"
+            android:enabled="@string/widgets_enabled">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
             </intent-filter>
@@ -827,7 +828,8 @@
         </receiver>
         <receiver
             android:name=".ui.stats.refresh.lists.widget.alltime.StatsAllTimeWidget"
-            android:label="@string/stats_widget_all_time_insights_name">
+            android:label="@string/stats_widget_all_time_insights_name"
+            android:enabled="@string/widgets_enabled">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
             </intent-filter>
@@ -838,7 +840,8 @@
         </receiver>
         <receiver
             android:name=".ui.stats.refresh.lists.widget.today.StatsTodayWidget"
-            android:label="@string/stats_widget_today_insights_name">
+            android:label="@string/stats_widget_today_insights_name"
+            android:enabled="@string/widgets_enabled">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
             </intent-filter>
@@ -849,7 +852,8 @@
         </receiver>
         <receiver
             android:name=".ui.stats.refresh.lists.widget.minified.StatsMinifiedWidget"
-            android:label="@string/stats_widget_minified_name">
+            android:label="@string/stats_widget_minified_name"
+            android:enabled="@string/widgets_enabled">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
             </intent-filter>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="app_name" translatable="false">WordPress</string>
+    <string name="widgets_enabled" translatable="false">true</string>
 
     <!-- account setup -->
     <string name="xmlrpc_missing_method_error">Couldn\'t connect. Required XML-RPC methods are missing on the server.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
 
     <string name="app_name" translatable="false">WordPress</string>
     <string name="widgets_enabled" translatable="false">true</string>
+    <string name="shortcuts_enabled" translatable="false">true</string>
 
     <!-- account setup -->
     <string name="xmlrpc_missing_method_error">Couldn\'t connect. Required XML-RPC methods are missing on the server.</string>


### PR DESCRIPTION
Fixes #14306 

This PR disables widgets and shortcuts for Jetpack App

- Two new string values were added `widgets_enabled` and `shortcuts_enabled`
- `AndroidManifest.xml` was updated to use the new strings values to manage enable values
- The `shortcuts_xml` files in `jetpack`, `jetpackJalapeno`, and `jetpackWasabi` were updated to set `android:enabled=false` for each shortcut. 

**Pre test**
- You must update your local copy of `google-services.json` before running the app.
-- Copy existing `org.wordress.android`,  `org.wordress.android.prealpha`, `org.wordress.android.beta` sections and replace with `com.jetpack.android`, `com.jetpack.android.prealpha`, `com.jetpack.android.beta`.

**To Test**
- Build each product flavor and install on device 
- `wordpressVanillaDebug` (Prod)
- `wordpressWasabiDebug` (Beta)
- `wordpressJalapenoDebug` (Alpha)
- `jetpackVanillaDebug` (Prod)
- `jetpackWasabiDebug` (Beta)
- `jetpackJalapenoDebug` (Alpha)

- Long press on each app icon
-- Verify that for each Wordpress variation widgets & shortcuts are available
-- Verify that for each Jetpack variation widgets & shortcuts are unavailable


PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
