### PR TITLE
Check if Activity is destroyed before attempting to use context

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -130,6 +130,7 @@ class ImageManager @Inject constructor(
         videoLoader?.runIfMediaNotTooBig(scope,
                 videoUrl,
                 loadAction = {
+                    if (!context.isAvailable()) return@runIfMediaNotTooBig
                     GlideApp.with(context)
                             .load(videoUrl)
                             .addFallback(imageType)
@@ -141,6 +142,7 @@ class ImageManager @Inject constructor(
                             .clearOnDetach()
                 },
                 fallbackAction = {
+                    if (!context.isAvailable()) return@runIfMediaNotTooBig
                     GlideApp.with(context)
                             .load(placeholderManager.getErrorResource(imageType))
                             .addPlaceholder(imageType)


### PR DESCRIPTION
Fixes #14329 

This one here [`runIfMediaNotTooBig`](https://github.com/wordpress-mobile/WordPress-Android/pull/14085/files#diff-21205c7dd80fe9080443ba728a41422d6d1e45dc968289d7ffd1c808189d6235R24-R28) performs a network request to check whether a specific video is too big or not. This then uses Glide to load the thumbnail from it or a fallback, passing in the context which is the Activity that was on the foreground at first.
The context being used is the parent of the viewHolder's view in `loadThumbnailFromVideoUrl()` as needed. By the time the adapter finishes up performing the network requests to check if media is not too big, the user may have already left the Activity and it may have been destroyed, hence the context is not valid anymore and when Glide is called it throws the aforementioned exception.

This was introduced last month here https://github.com/wordpress-mobile/WordPress-Android/commit/602a8d1be9674cdf527c81e5ea5a48f9749f5388 in PR https://github.com/wordpress-mobile/WordPress-Android/pull/14085

There is actually a check in place here https://github.com/wordpress-mobile/WordPress-Android/commit/602a8d1be9674cdf527c81e5ea5a48f9749f5388#diff-9e9bb051dea794d926d61427f20715cf36bda5fccf389437d477aa5cce005333R128

```
        if (!context.isAvailable()) return
        videoLoader?.runIfMediaNotTooBig(scope,
[...]
```

But the check is performed right before the network call, so with the change introduced in https://github.com/wordpress-mobile/WordPress-Android/commit/602a8d1be9674cdf527c81e5ea5a48f9749f5388 the check and the actual Glide call are now deferred by an amount of time that makes the bug (that would otherwise have been prevented by [this check](https://github.com/wordpress-mobile/WordPress-Android/commit/602a8d1be9674cdf527c81e5ea5a48f9749f5388#diff-9e9bb051dea794d926d61427f20715cf36bda5fccf389437d477aa5cce005333R128)) appear again.

To test:
1. Load a self hosted site with several videos in its media section, set your emulator / device to a slow network
2. go to the Media section of the app, wait for the thumbnails to start appearing (so the adapter loaded the list) and exit the Activity
3. observe no crashes
4. Repeat 1-3 with a jetpack site / .com site
5. Test the cases in https://github.com/wordpress-mobile/WordPress-Android/pull/14085

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
