### PR TITLE
Make the fragments pre-loaded by the view pager store the already rescued restoredNoteId

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -182,6 +182,11 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
         notification?.let {
             outState.putString(KEY_NOTE_ID, it.id)
             outState.putInt(KEY_LIST_POSITION, listView.firstVisiblePosition)
+        } ?: run {
+            // This is done so the fragments pre-loaded by the view pager can store the already rescued restoredNoteId
+            if (!TextUtils.isEmpty(restoredNoteId)) {
+                outState.putString(KEY_NOTE_ID, restoredNoteId)
+            }
         }
 
         super.onSaveInstanceState(outState)


### PR DESCRIPTION
Fixes #14348 

Quick fix for the linked issue found while working on those screens.

## To test
Reproduce the issue with the below steps in develop and check the issue happens no more after this fix

- In notification screen tap on a notification to open the notification details screen
- swipe between notifications and check no issues happen
- make a double screen rotation
- try to swipe and confirm you get the could not open notification toast message


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
