### PR TITLE
Stories: crash fix - allow null value for event.frameId, simply don't process it

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -166,10 +166,14 @@ class StoriesEventListener @Inject constructor(
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     fun onStoryFrameSaveCompleted(event: FrameSaveCompleted) {
         eventBusWrapper.removeStickyEvent(event)
+        // in onStoryFrameSaveCompleted we should always get a frameId that has the TEMPORARY_ID_PREFIX prefix
+        // for Stories being edited only
+        // otherwise we can exit
+        if (event.frameId == null) return
+
         if (!lifecycle.currentState.isAtLeast(CREATED)) {
             return
         }
-        // in onStoryFrameSaveCompleted we should always get a frameId that has the TEMPORARY_ID_PREFIX prefix
         val localMediaId = requireNotNull(event.frameId)
 
         val (frames) = storyRepositoryWrapper.getStoryAtIndex(event.storyIndex)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StoriesEventListener.kt
@@ -174,7 +174,7 @@ class StoriesEventListener @Inject constructor(
         if (!lifecycle.currentState.isAtLeast(CREATED)) {
             return
         }
-        val localMediaId = requireNotNull(event.frameId)
+        val localMediaId = event.frameId
 
         val (frames) = storyRepositoryWrapper.getStoryAtIndex(event.storyIndex)
 


### PR DESCRIPTION
Fixes #13662 

This PR allows null value for event.frameId in StoriesEventListener. It was required to be no null mainly for ediitng existing Story blocks, but a sticky event for a newly created Story (without using the Gutenberg Editor) is perfectly possible, we should just disregard processing those events.

What was happening here was that after creating a Story and after the introduction of this PR https://github.com/Automattic/stories-android/pull/632 all events from Stories are sticky. This makes "old" events come in every now and then but this should be harmless since we're removing as soon as these are first seen.
So, for a new Story we don't really have frame `id`s , so there's no need to process such a new Story frame.
Hope that makes sense!

To test:
1. create a story and publish it
2. create a new Post
3. observe the ~crash~ app doesn't crash anymore 🎉


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
