### PR TITLE
Use view binding in the WPEditTextWithChipsOutlined.kt

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/WPEditTextWithChipsOutlined.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/WPEditTextWithChipsOutlined.kt
@@ -29,10 +29,8 @@ import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textview.MaterialTextView
-import kotlinx.android.synthetic.main.reader_gap_marker_view.view.*
-import kotlinx.android.synthetic.main.stats_block_list_item.view.*
-import kotlinx.android.synthetic.main.wp_edit_text_with_chips_outlined.view.*
 import org.wordpress.android.R
+import org.wordpress.android.databinding.WpEditTextWithChipsOutlinedBinding
 import org.wordpress.android.util.RtlUtils
 import org.wordpress.android.util.getColorResIdFromAttribute
 import java.util.LinkedHashMap
@@ -198,9 +196,11 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
         val chips = getChipsMap()
 
         chips[item]?.let {
-            flexbox.removeView(it)
-            if (flexbox.childCount == 1) {
-                styleView(isEditorFocused(), hasItemsOrText(), true)
+            withBinding {
+                flexbox.removeView(it)
+                if (flexbox.childCount == 1) {
+                    styleView(isEditorFocused(), hasItemsOrText(), true)
+                }
             }
         }
     }
@@ -219,6 +219,12 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
     fun containsChip(item: String): Boolean {
         throwExceptionIfChipifyNotEnabled()
         return getChipsMap().containsKey(item)
+    }
+
+    private fun <T> withBinding(block: WpEditTextWithChipsOutlinedBinding.() -> T): T {
+        return with(WpEditTextWithChipsOutlinedBinding.bind(this)) {
+            block()
+        }
     }
 
     private fun loadOutlineDrawable() {
@@ -329,7 +335,11 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
         }
     }
 
-    private fun canAddMoreChips() = flexbox.childCount < maxChips + 1 || maxChips == 0
+    private fun canAddMoreChips(): Boolean {
+        return withBinding {
+            flexbox.childCount < maxChips + 1 || maxChips == 0
+        }
+    }
 
     private fun addItem(item: String) {
         if (!canAddMoreChips() && item.isNotBlank()) {
@@ -375,12 +385,13 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
         if (!isAlreadyInGroup) {
             chip.setOnCloseIconClickListener { chipView ->
                 val itemName = chip.text.toString()
+                withBinding {
+                    flexbox.removeView(chipView)
+                    itemsManager?.onRemoveItem(itemName)
 
-                flexbox.removeView(chipView)
-                itemsManager?.onRemoveItem(itemName)
-
-                if (flexbox.childCount == 1) {
-                    styleView(isEditorFocused(), hasItemsOrText(), true)
+                    if (flexbox.childCount == 1) {
+                        styleView(isEditorFocused(), hasItemsOrText(), true)
+                    }
                 }
             }
 
@@ -418,11 +429,12 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
     // This should be fast enough for our use case, so we get fresh data always
     private fun getChipsMap(): MutableMap<String, Chip> {
         val chips: MutableMap<String, Chip> = LinkedHashMap()
-
-        for (i in 0 until flexbox.childCount) {
-            val v: View = flexbox.getChildAt(i)
-            if (v is Chip) {
-                chips[v.text.toString()] = v
+        withBinding {
+            for (i in 0 until flexbox.childCount) {
+                val v: View = flexbox.getChildAt(i)
+                if (v is Chip) {
+                    chips[v.text.toString()] = v
+                }
             }
         }
 
@@ -434,15 +446,18 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
             return false
         }
 
-        // try and remove the last entered username
-        if (flexbox.childCount > 1) {
-            val chipToRemove = flexBox.getChildAt(flexbox.childCount - 2) as Chip
-            val itemName = chipToRemove.text.toString()
-            flexBox.removeViewAt(flexbox.childCount - 2)
-            itemsManager?.onRemoveItem(itemName)
-            return true
+        return withBinding {
+            // try and remove the last entered username
+            if (flexbox.childCount > 1) {
+                val chipToRemove = flexBox.getChildAt(flexbox.childCount - 2) as Chip
+                val itemName = chipToRemove.text.toString()
+                flexBox.removeViewAt(flexbox.childCount - 2)
+                itemsManager?.onRemoveItem(itemName)
+                true
+            } else {
+                false
+            }
         }
-        return false
     }
 
     private fun endsWithDelimiter(string: String): Boolean {
@@ -602,7 +617,7 @@ class WPEditTextWithChipsOutlined @JvmOverloads constructor(
     }
 
     private fun hasItemsOrText() = hasItems() || hasText()
-    private fun hasItems() = flexbox.childCount > 1
+    private fun hasItems() = withBinding { flexbox.childCount > 1 }
     private fun hasText() = (editor.text?.length ?: 0) > 0
     private fun isEditorFocused() = editor.isFocused
     private fun hasHint() = hintResourceId != 0


### PR DESCRIPTION
This PR introduces view bindings in the people invite fragment in the WPEditTextWithChipsOutlined view

To test:
- Go to My Site/People
- Click on "+" to invite more people
- Start adding emails
- Notice the emails are correctly shown in the chips

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
