### PR TITLE
Switch utils library repository to s3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_coroutines_version = '1.3.9'
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
-    ext.wordPressUtilsVersion = '1.30.3-beta.3'
+    ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.52.0'
 


### PR DESCRIPTION
[Bintray is shutting down soon](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), so we will be publishing the [WordPress-Utils-Android](https://github.com/wordpress-mobile/WordPress-Utils-Android) library artifacts to S3 once https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/63 is merged. The only change we need in the clients is to add the new maven repository: `maven { url "https://a8c-libs.s3.amazonaws.com/android" }`

**To test:**

Please follow the testing instructions in https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/63.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
