### PR TITLE
[Tooling] Add check for .env file

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,6 +32,16 @@ SUPPORTED_LOCALES = [
   { glotpress: "zh-tw", google_play: "zh-TW",  promo_config: {} },
 ].freeze
 
+# Env file paths to load
+USER_ENV_FILE_PATH = File.join(Dir.home, '.wpandroid-env.default')
+
+before_all do |lane|
+  # Check that the env file exists
+  unless is_ci || File.file?(USER_ENV_FILE_PATH)
+    UI.user_error!("#{USER_ENV_FILE_PATH} not found: Please copy fastlane/env/user.env-example to #{USER_ENV_FILE_PATH} and fill in the values")
+  end
+end
+
 platform :android do
 ########################################################################
 # Includes
@@ -40,7 +50,7 @@ import "./ScreenshotFastfile"
 
 # Environment
 ########################################################################
-Dotenv.load('~/.wpandroid-env.default')
+Dotenv.load(USER_ENV_FILE_PATH)
 ENV[GHHELPER_REPO="wordpress-mobile/WordPress-Android"]
 ENV["PROJECT_ROOT_FOLDER"]="./"
 ENV["PROJECT_NAME"]="WordPress"


### PR DESCRIPTION
Addresses suggestion from https://github.com/wordpress-mobile/WordPress-Android/pull/14363#issuecomment-809505988

### To test

 - Checkout this branch
 - Temporarily rename the dotenv file: `mv ~/.wpandroid-env.default ~/.wpandroid-env.defaultx`
 - Try to run a lane, e.g. `bundle exec fastlane build_beta`
 - Ensure you get the error message below
 - Rename the dotenv file back: `mv ~/.wpandroid-env.defaultx ~/.wpandroid-env.default`
 - Try to run the same lane again, e.g. `bundle exec fastlane build_beta`
 - Ensure that it does go past the check and starts the lane (e.g. with the lane `build_beta`, it should fail when it detects you're not on a release branch, ensuring that there won't be any side effect when you test this PR)

<details><summary>When the file doesn't exist: Clear error message with instructions</summary>

```
$ mv ~/.wpandroid-env.default ~/.wpandroid-env.defaultx
$ bundle exec fastlane build_beta
$ be fastlane build_beta
[✔] 🚀 
[…plugins info table…]

[19:04:34]: ------------------------------
[19:04:34]: --- Step: default_platform ---
[19:04:34]: ------------------------------
[19:04:34]: ------------------------------
[19:04:34]: --- Step: default_platform ---
[19:04:34]: ------------------------------
[19:04:34]: Driving the lane 'build_beta' 🚀
[19:04:34]: -------------------
[19:04:34]: --- Step: is_ci ---
[19:04:34]: -------------------
+------------------+------------+
|         Lane Context          |
+------------------+------------+
| DEFAULT_PLATFORM | android    |
| PLATFORM_NAME    |            |
| LANE_NAME        | build_beta |
+------------------+------------+
[19:04:34]: /Users/olivier/.wpandroid-env.default not found: Please copy fastlane/env/user.env-example to /Users/olivier/.wpandroid-env.default and fill in the values

+------+------------------+-------------+
|           fastlane summary            |
+------+------------------+-------------+
| Step | Action           | Time (in s) |
+------+------------------+-------------+
| 1    | default_platform | 0           |
| 2    | default_platform | 0           |
| 3    | is_ci            | 0           |
+------+------------------+-------------+

[19:04:34]: fastlane finished with errors

[!] /Users/olivier/.wpandroid-env.default not found: Please copy fastlane/env/user.env-example to /Users/olivier/.wpandroid-env.default and fill in the values
```
</details>

<details><summary>When the file properly exists: OK (fails later, expectedly, for an unrelated reason)</summary>

```
$ mv ~/.wpandroid-env.defaultx ~/.wpandroid-env.default
$ be fastlane build_beta                               
[✔] 🚀 
[…plugins info table…]
[19:04:52]: ------------------------------
[19:04:52]: --- Step: default_platform ---
[19:04:52]: ------------------------------
[19:04:52]: ------------------------------
[19:04:52]: --- Step: default_platform ---
[19:04:52]: ------------------------------
[19:04:52]: Driving the lane 'build_beta' 🚀
[19:04:52]: -------------------
[19:04:52]: --- Step: is_ci ---
[19:04:52]: -------------------
[19:04:52]: -------------------------------------
[19:04:52]: --- Step: android_build_prechecks ---
[19:04:52]: -------------------------------------
[19:04:52]: $ git symbolic-ref -q HEAD
[19:04:52]: ▸ refs/heads/develop
+------------------+------------+
|         Lane Context          |
+------------------+------------+
| DEFAULT_PLATFORM | android    |
| PLATFORM_NAME    |            |
| LANE_NAME        | build_beta |
+------------------+------------+
[19:04:52]: This command works only on release branch

+------+-------------------------+-------------+
|               fastlane summary               |
+------+-------------------------+-------------+
| Step | Action                  | Time (in s) |
+------+-------------------------+-------------+
| 1    | default_platform        | 0           |
| 2    | default_platform        | 0           |
| 3    | is_ci                   | 0           |
| 💥   | android_build_prechecks | 0           |
+------+-------------------------+-------------+

[19:04:52]: fastlane finished with errors

[!] This command works only on release branch
```
</details>