### PR TITLE
Lint: Changed severity of UseAppTint from warning to ignore

### DIFF
--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -6,7 +6,6 @@
     <!-- WARNING -->
     <issue id="RtlSymmetry" severity="warning" />
     <issue id="UseSparseArrays" severity="warning" />
-    <issue id="UseAppTint" severity="warning" />
 
     <issue id="NewApi">
         <warning path="src/main/res/values/reader_styles.xml" />
@@ -78,7 +77,8 @@
     <issue id="PluralsCandidate" severity="ignore" /> <!-- GlotPress doesn't support plurals -->
     <issue id="LabelFor" severity="ignore" /> <!-- Severity should be increased to error when minSdk >= 17 -->
     <issue id="OldTargetApi" severity="ignore" /> <!-- We are aware of down sides of having an old targetApi -->
-
+    <issue id="UseAppTint" severity="ignore" /> <!-- android:tint attribute had a problem on API<=21, but our minSdk is 21, ignore -->
+    
     <issue id="InvalidPackage">
         <ignore regexp="okio-1.9.0.jar" />
         <ignore regexp="java-common-1.13.jar" />


### PR DESCRIPTION
Originally detected in PR #14212 (see [CI output](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/21932/workflows/1fc74442-4b78-48c9-99ee-b7752b1dfda7/jobs/98606)) and temporarily fixed in https://github.com/wordpress-mobile/WordPress-Android/pull/14212/commits/10d9bf2f278390ee2ef52c89e189f27726ec4569

There was a problem with `android:tint` attribute on API<21 as per [this](https://href.li/?https://stackoverflow.com/questions/64256397/android-imageview-tint), but given we already have a minimum supported SDK (`minSdk`) of 21, we should be safe to ignore this one.

To test:
- verify `./gradlew --stacktrace lintVanillaRelease` does not throw any `UseAppTint` warnings