### PR TITLE
Remove libs/gutenberg-mobile submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "libs/gutenberg-mobile"]
-	path = libs/gutenberg-mobile
-	url = ../../wordpress-mobile/gutenberg-mobile.git
-	shallow = true
 [submodule "libs/stories-android"]
 	path = libs/stories-android
 	url = ../../Automattic/stories-android.git


### PR DESCRIPTION
This PR removes `libs/gutenberg-mobile` from `.gitmodules`. Unfortunately developers still may need to do some cleanup in their local repository since the submodule is initialized for most of us. Since we removed the `libs/gutenberg-mobile`, it's probably not going to be necessary, but if it is, this Stackoverflow discussion may prove helpful: https://stackoverflow.com/questions/1260748/how-do-i-remove-a-submodule

**To test:**
* Nothing to test

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
