### PR TITLE
Replace pink with blue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/CollapseFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/CollapseFullScreenDialogFragment.java
@@ -281,7 +281,7 @@ public class CollapseFullScreenDialogFragment extends DialogFragment {
             mMenuAction = menu.add(0, ID_ACTION, 0, this.mAction);
             mMenuAction.setIcon(R.drawable.ic_send_white_24dp);
             MenuItemCompat.setIconTintList(mMenuAction,
-                    AppCompatResources.getColorStateList(view.getContext(), R.color.accent_neutral_30_selector));
+                    AppCompatResources.getColorStateList(view.getContext(), R.color.primary_neutral_30_selector));
             mMenuAction.setEnabled(false);
             mMenuAction.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
             mMenuAction.setOnMenuItemClickListener(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -672,7 +672,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                     countCustomizeCompleted, countCustomizeCompleted + countCustomizeUncompleted
             )
             if (countGrowUncompleted > 0) {
-                quickStartGrowIcon.setBackgroundResource(R.drawable.bg_oval_pink_50_multiple_users_white_40dp)
+                quickStartGrowIcon.setBackgroundResource(R.drawable.bg_oval_blue_50_multiple_users_white_40dp)
                 quickStartGrowTitle.isEnabled = true
                 quickStartGrowTitle.paintFlags = quickStartGrowTitle.paintFlags and STRIKE_THRU_TEXT_FLAG.inv()
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/MapViewHolder.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.lists.sections.viewholders
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.net.http.SslError
 import android.util.Base64
 import android.view.View
@@ -11,6 +12,8 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.CoroutineScope
@@ -18,6 +21,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.R.attr
+import org.wordpress.android.R.color
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.MapItem
 import org.wordpress.android.util.getColorFromAttribute
 
@@ -27,31 +32,16 @@ class MapViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
 ) {
     private val coroutineScope = CoroutineScope(Dispatchers.Default)
     private val webView: WebView = itemView.findViewById(R.id.web_view)
+
     @SuppressLint("SetJavaScriptEnabled")
     fun bind(item: MapItem) {
         coroutineScope.launch {
             delay(100)
-            val colorLow = Integer.toHexString(
-                    ContextCompat.getColor(
-                            itemView.context,
-                            R.color.stats_map_activity_low
-                    ) and 0xffffff
-            )
-            val colorHigh = Integer.toHexString(
-                    ContextCompat.getColor(
-                            itemView.context,
-                            R.color.stats_map_activity_high
-                    ) and 0xffffff
-            )
-            val backgroundColor = Integer.toHexString(
-                    itemView.context.getColorFromAttribute(R.attr.colorSurface) and 0xffffff
-            )
-            val emptyColor = Integer.toHexString(
-                    ContextCompat.getColor(
-                            itemView.context,
-                            R.color.stats_map_activity_empty
-                    ) and 0xffffff
-            )
+            val context = itemView.context
+            val colorLow = toHexString(color.stats_map_activity_low, context)
+            val colorHigh = toHexString(color.stats_map_activity_high, context)
+            val backgroundColor = toHexString(context.getColorFromAttribute(attr.colorSurface))
+            val emptyColor = toHexString(color.stats_map_activity_empty, context)
             val htmlPage = ("<html>" +
                     "<head>" +
                     "<script type=\"text/javascript\" src=\"https://www.gstatic.com/charts/loader.js\"></script>" +
@@ -120,5 +110,13 @@ class MapViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                 webView.loadData(base64version, "text/html; charset=UTF-8", "base64")
             }
         }
+    }
+
+    private fun toHexString(@ColorRes colorId: Int, context: Context): String {
+        return toHexString(ContextCompat.getColor(context, colorId))
+    }
+
+    private fun toHexString(@ColorInt color: Int): String {
+        return String.format("%06X", (color and 0xffffff))
     }
 }

--- a/WordPress/src/main/res/color/primary_neutral_30_selector.xml
+++ b/WordPress/src/main/res/color/primary_neutral_30_selector.xml
@@ -4,6 +4,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item android:color="@color/neutral_30" android:state_enabled="false" />
-    <item android:color="@color/accent" />
+    <item android:color="@color/primary" />
 
 </selector>

--- a/WordPress/src/main/res/drawable/bg_oval_blue_50_multiple_users_white_40dp.xml
+++ b/WordPress/src/main/res/drawable/bg_oval_blue_50_multiple_users_white_40dp.xml
@@ -8,7 +8,7 @@
             android:shape="oval" >
 
             <solid
-                android:color="@color/pink_50" >
+                android:color="@color/blue_50" >
             </solid>
 
         </shape>

--- a/WordPress/src/main/res/drawable/bg_oval_blue_50_multiple_users_white_40dp_selector.xml
+++ b/WordPress/src/main/res/drawable/bg_oval_blue_50_multiple_users_white_40dp_selector.xml
@@ -4,6 +4,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item android:drawable="@drawable/bg_oval_neutral_30_multiple_users_white_40dp" android:state_enabled="false" />
-    <item android:drawable="@drawable/bg_oval_pink_50_multiple_users_white_40dp" />
+    <item android:drawable="@drawable/bg_oval_blue_50_multiple_users_white_40dp" />
 
 </selector>

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -313,7 +313,7 @@
                                 <ImageView
                                     android:id="@+id/quick_start_grow_icon"
                                     style="@style/QuickStartTypeIcon"
-                                    android:background="@drawable/bg_oval_pink_50_multiple_users_white_40dp_selector"
+                                    android:background="@drawable/bg_oval_blue_50_multiple_users_white_40dp_selector"
                                     android:importantForAccessibility="no" />
 
                                 <com.google.android.material.textview.MaterialTextView

--- a/WordPress/src/main/res/layout/reader_include_comment_box.xml
+++ b/WordPress/src/main/res/layout/reader_include_comment_box.xml
@@ -66,7 +66,7 @@
             android:contentDescription="@string/send"
             android:enabled="false"
             android:padding="@dimen/margin_medium"
-            app:tint="@color/accent_neutral_30_selector"
+            app:tint="@color/primary_neutral_30_selector"
             android:src="@drawable/ic_send_white_24dp" />
     </LinearLayout>
 

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -34,8 +34,8 @@
     <color name="stats_bar_chart_accent_top">@color/pink_60</color>
     <color name="stats_bar_chart_accent_bottom">@color/pink_30</color>
     <color name="stats_bar_chart_gridline">@color/gray_80</color>
-    <color name="stats_map_activity_low">@color/pink_80</color>
-    <color name="stats_map_activity_high">@color/pink_30</color>
+    <color name="stats_map_activity_low">@color/blue_80</color>
+    <color name="stats_map_activity_high">@color/blue_30</color>
     <color name="stats_map_activity_empty">@color/gray_80</color>
 
     <!-- Login Prologue -->

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -4,8 +4,8 @@
     <style name="Base.Wordpress" parent="Theme.MaterialComponents.DayNight.Bridge">
         <item name="colorPrimary">@color/blue_30</item>
         <item name="colorPrimaryVariant">@color/blue_50</item>
-        <item name="colorSecondary">@color/pink_30</item>
-        <item name="colorSecondaryVariant">@color/pink_50</item>
+        <item name="colorSecondary">@color/blue_30</item>
+        <item name="colorSecondaryVariant">@color/blue_50</item>
         <item name="android:colorBackground">@color/background_dark</item>
         <item name="colorSurface">@color/background_dark</item>
         <item name="colorError">@color/red_30</item>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -31,8 +31,8 @@
     <color name="stats_bar_chart_accent_top">@color/pink_30</color>
     <color name="stats_bar_chart_accent_bottom">@color/pink_60</color>
     <color name="stats_bar_chart_gridline">@color/neutral_5</color>
-    <color name="stats_map_activity_low">@color/accent_5</color>
-    <color name="stats_map_activity_high">@color/accent</color>
+    <color name="stats_map_activity_low">@color/blue_5</color>
+    <color name="stats_map_activity_high">@color/blue</color>
     <color name="stats_map_activity_empty">@color/neutral_5</color>
 
     <!-- Post History -->

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -324,7 +324,7 @@
     <color name="reader_following_empty_view_upper_right_plus">@color/yellow_0</color>
     <color name="reader_following_empty_view_mid_left_plus">@color/green_0</color>
     <color name="reader_following_empty_view_center_circle">@color/blue_0</color>
-    <color name="reader_following_empty_view_left_lower_plus">@color/pink_0</color>
+    <color name="reader_following_empty_view_left_lower_plus">@color/blue_0</color>
     <color name="reader_following_empty_view_outline">@color/gray_10</color>
     <color name="reader_following_empty_view_middle_plus">@android:color/white</color>
     <color name="reader_following_empty_view_background">@color/background_default</color>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -5,8 +5,8 @@
         <!-- Material theme -->
         <item name="colorPrimary">@color/blue_50</item>
         <item name="colorPrimaryVariant">@color/blue_70</item>
-        <item name="colorSecondary">@color/pink_50</item>
-        <item name="colorSecondaryVariant">@color/pink_70</item>
+        <item name="colorSecondary">@color/blue_50</item>
+        <item name="colorSecondaryVariant">@color/blue_70</item>
         <item name="android:colorBackground">@android:color/white</item>
         <item name="colorSurface">@android:color/white</item>
         <item name="colorError">@color/red_50</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -375,7 +375,7 @@
     </style>
 
     <style name="WordPress.SnackbarButton" parent="Widget.MaterialComponents.Button.TextButton.Snackbar">
-        <item name="android:textColor">@color/pink_30</item>
+        <item name="android:textColor">@color/blue_30</item>
     </style>
 
     <style name="WordPress.SnackbarText" parent="@style/Widget.MaterialComponents.Snackbar.TextView">

--- a/libs/login/WordPressLoginFlow/src/main/res/values-night/themes.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values-night/themes.xml
@@ -4,8 +4,8 @@
     <style name="Base.Theme.LoginFlow" parent="Base.Theme.LoginFlow.Shared">
         <item name="colorPrimary">@color/wp_blue_40</item>
         <item name="colorPrimaryVariant">@color/wp_blue_70</item>
-        <item name="colorSecondary">@color/wp_pink_50</item>
-        <item name="colorSecondaryVariant">@color/wp_pink_70</item>
+        <item name="colorSecondary">@color/wp_blue_50</item>
+        <item name="colorSecondaryVariant">@color/wp_blue_70</item>
 
         <item name="android:colorBackground">@color/material_black_800</item>
         <item name="colorSurface">@color/material_black_800</item>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/themes.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/themes.xml
@@ -47,8 +47,8 @@
     <style name="Base.Theme.LoginFlow" parent="Base.Theme.LoginFlow.Shared">
         <item name="colorPrimary">@color/wp_blue_50</item>
         <item name="colorPrimaryVariant">@color/wp_blue_70</item>
-        <item name="colorSecondary">@color/wp_pink_50</item>
-        <item name="colorSecondaryVariant">@color/wp_pink_70</item>
+        <item name="colorSecondary">@color/wp_blue_50</item>
+        <item name="colorSecondaryVariant">@color/wp_blue_70</item>
 
         <item name="android:colorBackground">@color/material_white_50</item>
         <item name="colorSurface">@color/material_white_50</item>


### PR DESCRIPTION
Fixes #14027 

This PR replaces the pink color with blue in most of the app. This is done by:
- Replacing colorSecondary value with blue
- Replacing colorSecondaryVariant value with blue
- In the rest of the places I've manually updated the values where it makes sense.

I was considering another approach - instead of changing the value of colorSecondary replacing colorSecondary in code with colorPrimary. In the end I've decided to not follow this approach because keeping both primary and secondary set allows us to easily change the value in the future (if we ever decide the secondary color is still required). 

Exceptions to this change are:
- Stats bar chart - the accent still needs to be pink
- The bottom bar notifications badge - since the icon is blue, the badge remains pink


To test: 
- Go through the main flows - Login, Create a site, Quick start
- Check the buttons and the links are all blue now
- Check nothing is out of place
- Be cautious about dialogs

To test 2:
- Go to stats with a lot of data
- Go to Year view
- Notice the selected day in the bar chart is still pink
- Scroll to the Countries block
- Notice the countries are now in blue

To test 3: 
- Go to a site with a new notification
- Notice the bottom bar notifications badge is pink

**Updated countries map** 
![map](https://user-images.githubusercontent.com/1079756/113136368-90748c80-9223-11eb-9083-2cd7cbb1d8ec.png)

**Bar chart with pink selected bars**
![bar_chart](https://user-images.githubusercontent.com/1079756/113136377-936f7d00-9223-11eb-9df4-8d8c8604c60f.png)

**Blue dialog buttons**
![dialog_buttons](https://user-images.githubusercontent.com/1079756/113136379-94081380-9223-11eb-87f1-1c514453d757.png)

**Updated signup button**
![signup_button](https://user-images.githubusercontent.com/1079756/113136383-94081380-9223-11eb-8328-adfbc4b2aa21.png)

**Notifications badge still pink with blue FAB**
![notifications_badge](https://user-images.githubusercontent.com/1079756/113136384-94081380-9223-11eb-8738-00ce80a66bcb.png)



## Regression Notes
1. Potential unintended areas of impact
- the whole app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- I went through the login/create a site flow, smoke tested stats, notifications, comments and whatever I could think of

3. What automated tests I added (or what prevented me from doing so)
- color changes shouldn't be automatically tested

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
