### PR TITLE
Re-enable shortcuts except for new posts

### DIFF
--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -2,5 +2,4 @@
 <resources>
     <string name="app_name" translatable="false">Jetpack</string>
     <string name="widgets_enabled" translatable="false">false</string>
-    <string name="shortcuts_enabled" translatable="true">false</string>
 </resources>

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <string name="app_name" translatable="false">Jetpack</string>
     <string name="widgets_enabled" translatable="false">false</string>
-    <string name="shortcuts_enabled" translatable="false">false</string>
+    <string name="shortcuts_enabled" translatable="true">false</string>
 </resources>

--- a/WordPress/src/jetpack/res/xml/shortcuts.xml
+++ b/WordPress/src/jetpack/res/xml/shortcuts.xml
@@ -6,7 +6,7 @@
         android:icon="@drawable/ic_shortcut_stats"
         android:shortcutId="stats"
         android:shortcutShortLabel="@string/stats"
-        android:enabled="false">
+        android:enabled="true">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"
@@ -20,7 +20,7 @@
         android:icon="@drawable/ic_shortcut_notifications"
         android:shortcutId="notifications"
         android:shortcutShortLabel="@string/notifications_screen_title"
-        android:enabled="false">
+        android:enabled="true">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"

--- a/WordPress/src/jetpackJalapeno/res/xml/shortcuts.xml
+++ b/WordPress/src/jetpackJalapeno/res/xml/shortcuts.xml
@@ -6,7 +6,7 @@
         android:icon="@drawable/ic_shortcut_stats"
         android:shortcutId="stats"
         android:shortcutShortLabel="@string/stats"
-        android:enabled="false">
+        android:enabled="true">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"
@@ -20,7 +20,7 @@
         android:icon="@drawable/ic_shortcut_notifications"
         android:shortcutId="notifications"
         android:shortcutShortLabel="@string/notifications_screen_title"
-        android:enabled="false">
+        android:enabled="true">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"

--- a/WordPress/src/jetpackWasabi/res/xml/shortcuts.xml
+++ b/WordPress/src/jetpackWasabi/res/xml/shortcuts.xml
@@ -6,7 +6,7 @@
         android:icon="@drawable/ic_shortcut_stats"
         android:shortcutId="stats"
         android:shortcutShortLabel="@string/stats"
-        android:enabled="false">
+        android:enabled="true">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"
@@ -20,7 +20,7 @@
         android:icon="@drawable/ic_shortcut_notifications"
         android:shortcutId="notifications"
         android:shortcutShortLabel="@string/notifications_screen_title"
-        android:enabled="false">
+        android:enabled="true">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="org.wordpress.android.ui.main.WPMainActivity"

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -581,7 +581,7 @@
             android:name=".ui.AddQuickPressShortcutActivity"
             android:label="@string/quickpress_shortcut_activity_label"
             android:theme="@style/WordPress.NoActionBar"
-            android:enabled="@string/shortcuts_enabled">
+            android:enabled="@string/widgets_enabled">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT" />
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3,7 +3,6 @@
 
     <string name="app_name" translatable="false">WordPress</string>
     <string name="widgets_enabled" translatable="false">true</string>
-    <string name="shortcuts_enabled" translatable="false">true</string>
 
     <!-- account setup -->
     <string name="xmlrpc_missing_method_error">Couldn\'t connect. Required XML-RPC methods are missing on the server.</string>


### PR DESCRIPTION
Fixes #14306

This PR reenables the stats and notification shortcuts for the Jetpack App

- Set the shortcuts_enabled to true
- Update the the shortcuts_xml files in jetpack, jetpackJalapeno, and jetpackWasabi and set the stats/notifications to android:enabled=true
 

**Pre test**
You must update your local copy of google-services.json before running the app.
-- Copy existing org.wordress.android, org.wordress.android.prealpha, org.wordress.android.beta sections and replace with com.jetpack.android, com.jetpack.android.prealpha, com.jetpack.android.beta.

**To Test**
Build each product flavor and install on device
wordpressVanillaDebug (Prod)
wordpressWasabiDebug (Beta)
wordpressJalapenoDebug (Alpha)
jetpackVanillaDebug (Prod)
jetpackWasabiDebug (Beta)
jetpackJalapenoDebug (Alpha)

Long press on each app icon
-- Verify that for each Wordpress variation that the stats & notification shortcuts are available
-- Verify that for each Jetpack variation that the stats & notification shortcuts are available


PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
