### PR TITLE
Run image-editor unit tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,6 @@ jobs:
           command: ./gradlew :libs:WordPressProcessors:test --stacktrace
       - run:
           name: Test ImageEditor
-          environment:
-            SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
           command: ./gradlew :libs:image-editor:ImageEditor:test --stacktrace
       - android/save-gradle-cache
       - android/save-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
           name: Test ImageEditor
           environment:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
-          command: ./gradlew :libs:ImageEditor:test --stacktrace
+          command: ./gradlew :libs:image-editor:ImageEditor:test --stacktrace
       - android/save-gradle-cache
       - android/save-test-results
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,11 @@ jobs:
           environment:
             SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
           command: ./gradlew :libs:WordPressProcessors:test --stacktrace
+      - run:
+          name: Test ImageEditor
+          environment:
+            SUPPRESS_GUTENBERG_MOBILE_JS_BUNDLE_BUILD: 1
+          command: ./gradlew :libs:ImageEditor:test --stacktrace
       - android/save-gradle-cache
       - android/save-test-results
   lint:

--- a/libs/image-editor/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/crop/CropViewModelTest.kt
+++ b/libs/image-editor/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/crop/CropViewModelTest.kt
@@ -80,7 +80,7 @@ class CropViewModelTest {
     @Test
     fun `navigate back action not triggered on crop failure`() {
         viewModel.onCropFinish(cropFailedResultCode, cropResultData)
-        assertNull(viewModel.navigateBackWithCropResult.value)
+        assertNull("break test")
     }
 
     @Test

--- a/libs/image-editor/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/crop/CropViewModelTest.kt
+++ b/libs/image-editor/ImageEditor/src/test/kotlin/org/wordpress/android/imageeditor/crop/CropViewModelTest.kt
@@ -80,7 +80,7 @@ class CropViewModelTest {
     @Test
     fun `navigate back action not triggered on crop failure`() {
         viewModel.onCropFinish(cropFailedResultCode, cropResultData)
-        assertNull("break test")
+        assertNull(viewModel.navigateBackWithCropResult.value)
     }
 
     @Test


### PR DESCRIPTION
This PR updates the CI config so even unit tests located in CardReaderModule run on each build.


Notice [all CI checks pass](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/22610/workflows/9c49d1fd-e47f-4f56-83f8-bb449b4d9916/jobs/101316) after 502cbff commit even though the commit obviously breaks the unit tests.
Notice [CI fails](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/22611/workflows/89f5b1f0-8832-4e49-82b9-8c531eb8190d/jobs/101320) after the CI config gets updated in commit 8ab7291
Notice CI succeeds after the issues introduced in 502cbff is fixed in commit 20a6794


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
