### PR TITLE
Removes github release prefix for gutenberg mobile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -475,7 +475,7 @@ ENV["validate_translations"]="lintVanillaRelease"
       import_key: "gutenbergMobileVersion",
       repository: "wordpress-mobile/gutenberg-mobile",
       strings_file_path: "bundle/android/strings.xml",
-      github_release_prefix: "v"
+      github_release_prefix: ""
     },
   ]
 


### PR DESCRIPTION
Gutenberg mobile's tag name and the Bintray version number match each other at `v1.50.0`. So, the extra `v` for the `github_release_prefix` is causing the url to download the release files from github to be wrong. Removing this prefix seems to fix the issue.

**To test:**
* Run `bundle exec fastlane localize_binary_deps` before this change and verify that it returns an error `Can't download strings file ...`
* Run `bundle exec fastlane localize_binary_deps` after the change to confirm the download works as expected

cc @loremattei 

P.S: This may not be the best solution, but it should be good enough to unblock the code freeze.