### PR TITLE
Update colors in login library to 2.5.0

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/res/values-night/themes.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values-night/themes.xml
@@ -2,10 +2,10 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="Base.Theme.LoginFlow" parent="Base.Theme.LoginFlow.Shared">
-        <item name="colorPrimary">@color/wp_blue_40</item>
-        <item name="colorPrimaryVariant">@color/wp_blue_70</item>
-        <item name="colorSecondary">@color/wp_blue_50</item>
-        <item name="colorSecondaryVariant">@color/wp_blue_70</item>
+        <item name="colorPrimary">@color/wp_blue_30</item>
+        <item name="colorPrimaryVariant">@color/wp_blue_50</item>
+        <item name="colorSecondary">@color/wp_blue_30</item>
+        <item name="colorSecondaryVariant">@color/wp_blue_50</item>
 
         <item name="android:colorBackground">@color/material_black_800</item>
         <item name="colorSurface">@color/material_black_800</item>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/colors.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme Colors -->
-    <color name="wp_blue_40">#1689db</color>
+    <color name="wp_blue_30">#399ce3</color>
     <color name="wp_blue_50">#0675c4</color>
     <color name="wp_blue_70">#044b7a</color>
 

--- a/libs/login/WordPressLoginFlow/src/main/res/values/colors.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/colors.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme Colors -->
-    <color name="wp_blue_40">#3582c4</color>
-    <color name="wp_blue_50">#2271b1</color>
-    <color name="wp_blue_70">#0a4b78</color>
+    <color name="wp_blue_40">#1689db</color>
+    <color name="wp_blue_50">#0675c4</color>
+    <color name="wp_blue_70">#044b7a</color>
 
     <color name="wp_pink_50">#c9356e</color>
     <color name="wp_pink_70">#8c1749</color>


### PR DESCRIPTION
This PR updates blues in the login library to the latest updates in the color palette.

To test:
- Check the colors during login look OK

## Regression Notes
1. Potential unintended areas of impact
- None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Nothing, since there are none

3. What automated tests I added (or what prevented me from doing so)
- Color changes shouldn't be automatically tested

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
