### PR TITLE
Add notes about color updates

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,10 +9,9 @@
 * [**] Comments: added an Unreplied comments filter [https://github.com/wordpress-mobile/WordPress-Android/pull/14373]
 * [***] Block Editor: Improved the accessibility of range and step-type block settings. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3255]
 * [**] Updated the app icon to match the new color scheme within the app. [#14391]
-* [*] Colors: Replaced pink with blue as the accent color of the app [https://github.com/wordpress-mobile/WordPress-Android/pull/14376]
+* [**] Colors: Replaced pink with blue as the accent color of the app [https://github.com/wordpress-mobile/WordPress-Android/pull/14376]
 * [*] Colors: Updated color palette to 2.5.0 [https://github.com/wordpress-mobile/WordPress-Android/pull/14370]
 * [*] Colors: Replaced wordpress_blue with blue color [https://github.com/wordpress-mobile/WordPress-Android/pull/14369]
-* [*] Colors: Updated app icons with the new colors [https://github.com/wordpress-mobile/WordPress-Android/pull/14391]
 
 17.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,10 @@
 * [**] Comments: added an Unreplied comments filter [https://github.com/wordpress-mobile/WordPress-Android/pull/14373]
 * [***] Block Editor: Improved the accessibility of range and step-type block settings. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3255]
 * [**] Updated the app icon to match the new color scheme within the app. [#14391]
+* [*] Colors: Replaced pink with blue as the accent color of the app [https://github.com/wordpress-mobile/WordPress-Android/pull/14376]
+* [*] Colors: Updated color palette to 2.5.0 [https://github.com/wordpress-mobile/WordPress-Android/pull/14370]
+* [*] Colors: Replaced wordpress_blue with blue color [https://github.com/wordpress-mobile/WordPress-Android/pull/14369]
+* [*] Colors: Updated app icons with the new colors [https://github.com/wordpress-mobile/WordPress-Android/pull/14391]
 
 17.0
 -----


### PR DESCRIPTION
This PR adds missing release notes about color updates

To test:
- nothing to test here

## Regression Notes
1. Potential unintended areas of impact
- none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
