### PR TITLE
Issue/14315 update about the app

### DIFF
--- a/WordPress/src/jetpack/assets/licenses.html
+++ b/WordPress/src/jetpack/assets/licenses.html
@@ -1,0 +1,49 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        margin: 1em;
+      }
+      pre {
+        background: #DDD;
+        padding: 1em;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Jetpack for Android</h2>
+
+    <p>Source code available from
+    <a href="http://android.wordpress.org/">android.wordpress.org</a>.</p>
+
+    <p>Jetpack for Android is released under the terms of the GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>:</p>
+
+    <h2>Additional Libraries</h2>
+
+    <p>Jetpack for Android is made possible with the help of many fantastic open source libraries! The following
+libraries are licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/google/gson">gson</a>: Copyright 2002-2008, Google</li>
+      <li><a href="https://github.com/chrisbanes/PhotoView">PhotoView</a>: Copyright 2011-2012, Chris Banes</li>
+      <li><a href="https://github.com/jukka/tagsoup">TagSoup</a>: Copyright 2002-2008, John Cowan</li>
+      <li><a href="https://github.com/Yalantis/uCrop">uCrop</a>: Copyright 2017, Yalantis</li>
+      <li><a href="https://github.com/xizzhu/simple-tool-tip">Simple Tool Tip</a>: Copyright 2016, Xizhi Zhu</li>
+      <li><a href="https://github.com/square/okio">okio/okhttp</a>: Copyright 2013 Square, Inc.</li>
+      <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Copyright 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/INDExOS/media-for-mobile">Mobile 4 Media</a>: Copyright 2016, INDExOS</li>
+      <li><a href="https://github.com/Tenor-Inc/tenor-android-core">Tenor Android Core</a>: Copyright 2017, Tenor Inc</li>
+    </ul>
+
+    <br>
+    <br>
+    <p>And here's our lone <a href="http://www.gnu.org/licenses/lgpl.html">LGPL v3 licensed dependency</a>:</p>
+
+    <ul>
+      <li><a href="https://github.com/wordpress-mobile/GraphView">GraphView</a>: Copyright 2013, Jonas Gehring</li>
+    </ul>
+
+  </body>
+</html>

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -2,4 +2,7 @@
 <resources>
     <string name="app_name" translatable="false">Jetpack</string>
     <string name="widgets_enabled" translatable="false">false</string>
+
+    <!-- About View -->
+    <string name="app_title">Jetpack for Android</string>
 </resources>

--- a/WordPress/src/main/assets/licenses.html
+++ b/WordPress/src/main/assets/licenses.html
@@ -13,16 +13,16 @@
     </style>
   </head>
   <body>
-    <h2>Jetpack for Android</h2>
+    <h2>WordPress for Android</h2>
 
     <p>Source code available from
     <a href="http://android.wordpress.org/">android.wordpress.org</a>.</p>
 
-    <p>Jetpack for Android is released under the terms of the GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>:</p>
+    <p>WordPress for Android is released under the terms of the GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>:</p>
 
     <h2>Additional Libraries</h2>
 
-    <p>Jetpack for Android is made possible with the help of many fantastic open source libraries! The following
+    <p>WordPress for Android is made possible with the help of many fantastic open source libraries! The following
 libraries are licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
 
     <ul>

--- a/WordPress/src/main/assets/licenses.html
+++ b/WordPress/src/main/assets/licenses.html
@@ -13,16 +13,16 @@
     </style>
   </head>
   <body>
-    <h2>WordPress for Android</h2>
+    <h2>Jetpack for Android</h2>
 
     <p>Source code available from
     <a href="http://android.wordpress.org/">android.wordpress.org</a>.</p>
 
-    <p>WordPress for Android is released under the terms of the GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>:</p>
+    <p>Jetpack for Android is released under the terms of the GNU <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html">GPL v2</a>:</p>
 
     <h2>Additional Libraries</h2>
 
-    <p>WordPress for Android is made possible with the help of many fantastic open source libraries! The following
+    <p>Jetpack for Android is made possible with the help of many fantastic open source libraries! The following
 libraries are licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache v2</a>:</p>
 
     <ul>


### PR DESCRIPTION
Fixes #14315

This PR 
- [x] Updates WordPress for Android
- [x] Updates Open source licenses - N/A (Internal ref: `P1617865067066400-slack-C0180B5PRJ4`)

| App Settings | About the app | Licenses |
| ------------- |  ------------- |  --------- |
|  ![device-2021-04-08-121643](https://user-images.githubusercontent.com/1405144/113993443-1c189980-9872-11eb-99eb-3d4820f6219f.png) |  ![device-2021-04-08-121654](https://user-images.githubusercontent.com/1405144/113993365-099e6000-9872-11eb-9070-96e2a42a3c6a.png)  |  ![licenses](https://user-images.githubusercontent.com/1405144/113993341-00ad8e80-9872-11eb-8b80-e596b5ef876c.png)  |

Note: App version not updated on the About screen, considering it will be covered under `Platform9` tasks.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
