### PR TITLE
Prevents TransactionTooLargeException by removing the content from the parcel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutModel.kt
@@ -6,33 +6,34 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayout
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.StarterDesign
 
 @Parcelize
-class LayoutModel(private val starterDesign: StarterDesign? = null, private val blockLayout: GutenbergLayout? = null) :
-        Parcelable {
-    val slug: String
-        get() = starterDesign?.slug ?: blockLayout?.slug ?: ""
-
-    val title: String
-        get() = starterDesign?.title ?: blockLayout?.title ?: ""
-
-    val preview: String
-        get() = starterDesign?.preview ?: blockLayout?.preview ?: ""
-
-    val previewTablet: String
-        get() = starterDesign?.previewTablet ?: blockLayout?.previewTablet ?: ""
-
-    val previewMobile: String
-        get() = starterDesign?.previewMobile ?: blockLayout?.previewMobile ?: ""
-
-    val demoUrl: String
-        get() = starterDesign?.demoUrl ?: blockLayout?.demoUrl ?: ""
-
-    val content: String
-        get() = blockLayout?.content ?: ""
-
+data class LayoutModel(
+    val slug: String,
+    val title: String,
+    val preview: String,
+    val previewTablet: String,
+    val previewMobile: String,
+    val demoUrl: String,
     val categories: List<LayoutCategoryModel>
-        get() = starterDesign?.categories?.toLayoutCategories()
-                ?: blockLayout?.categories?.toLayoutCategories()
-                ?: listOf()
+) : Parcelable {
+    constructor(starterDesign: StarterDesign) : this(
+            starterDesign.slug,
+            starterDesign.title,
+            starterDesign.preview,
+            starterDesign.previewTablet,
+            starterDesign.previewMobile,
+            starterDesign.demoUrl,
+            starterDesign.categories.toLayoutCategories()
+    )
+
+    constructor(blockLayout: GutenbergLayout) : this(
+            blockLayout.slug,
+            blockLayout.title,
+            blockLayout.preview,
+            blockLayout.previewTablet,
+            blockLayout.previewMobile,
+            blockLayout.demoUrl,
+            blockLayout.categories.toLayoutCategories()
+    )
 }
 
 @JvmName("designToLayoutModel") fun List<StarterDesign>.toLayoutModels() = map { LayoutModel(starterDesign = it) }

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.14.0'
+    fluxCVersion = 'a33e4cc331a90d7b206ff96956566f4c93aac4bb'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'a33e4cc331a90d7b206ff96956566f4c93aac4bb'
+    fluxCVersion = '1.14.1'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.2.0'


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/WordPress-Android/issues/14421

Depends on `WordPress-Fluxc-Android`: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1945

## Description
Removes the layout [content](https://github.com/wordpress-mobile/WordPress-Android/pull/14422/files#diff-0d5445d9b365ba00b603fd9b920c2a776ec54e9da6343629a21c1c807b2c5e43L29) from the parcelized model to avoid [`TransactionTooLargeException`](https://developer.android.com/reference/android/os/TransactionTooLargeException). The page layout *content* can get to big and since the number of available layouts grows it is safer to get it from the already available [cache](https://github.com/wordpress-mobile/WordPress-Android/pull/14422/files#diff-c3b5ae18ffb29dec6511f23398992eb0aebf18af2071a25a578155687f81f5a3R162). Till now this cache was used only when the device was offline.

## To test
1. Tap the fab ➕ icon on the My Site screen
2. Select Site page
3. Put the app to the background
4. Bring the app to the foreground
5. **Verify** that the app does not crash

### Sanity tests
#### Create page
1. Follow the **to test** steps above
2. Press the *Create page* button
3. **Verify** that the page is created with the selected layout content
#### Preview and Create page
1. Follow the **to test** steps above
2. Press the *Preview* button
3. Press the *Create page* button
4. **Verify** that the page is created with the selected layout content

## Regression Notes
1. Potential unintended areas of impact

* New Page creation from template

2. What I did to test those areas of impact (or what existing automated tests I relied on)

* Run the sanity tests above

3. What automated tests I added (or what prevented me from doing so)

* There is a [test](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/bc0d7e799bc46d708f45a8ba7be75b5a3f655f9f/example/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java#L743) in place verifying the cached content is retrieved correctly.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
