### PR TITLE
Scan History: Add show/hide scrolling behaviour to toolbar

### DIFF
--- a/WordPress/src/main/res/layout/scan_history_fragment.xml
+++ b/WordPress/src/main/res/layout/scan_history_fragment.xml
@@ -15,7 +15,8 @@
             android:id="@+id/toolbar_main"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:theme="@style/WordPress.ActionBar" />
+            app:theme="@style/WordPress.ActionBar"
+            app:layout_scrollFlags="scroll|enterAlways" />
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"
@@ -23,7 +24,6 @@
             android:layout_height="?attr/actionBarSize"
             android:layout_gravity="bottom"
             android:visibility="visible"
-            app:layout_scrollFlags="scroll|enterAlways"
             app:tabMode="scrollable" />
 
     </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
Fixes #14418

This PR adds show/ hide scrolling behavior to the toolbar on the Scan History screen. 

To test:

1. Log in to the app with a WordPress.com account having a site with a scan plan (e.g. Test site:  [pressable-jetpack-daily-scan](https://pressable-jetpack-daily-scan.mystagingwebsite.com/)).
2. Select the site and go to Scan History.
3. Notice that on scrolling the screen:
    - Toolbar is shown/ hidden.
    - Tab bar is retained to show the selected threat status filter.

**Before**

https://user-images.githubusercontent.com/1405144/114032380-e1c2f280-9899-11eb-91d1-3a82233ef567.mp4

**After** 

https://user-images.githubusercontent.com/1405144/114028842-8cd1ad00-9896-11eb-8fdc-ea8e461c0667.mp4| 

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None - The PR changes only one property in the layout xml, it doesn't impact the rest of the app.

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
