### PR TITLE
Jetpack App (Basics): Update Nav Bar Colors (Bottom Bar)

### DIFF
--- a/WordPress/src/jetpack/res/values-night/colors_base.xml
+++ b/WordPress/src/jetpack/res/values-night/colors_base.xml
@@ -4,4 +4,6 @@
     <color name="colorPrimaryVariant">@color/primary_50</color>
     <color name="colorSecondary">@color/primary_40</color>
     <color name="colorSecondaryVariant">@color/primary_50</color>
+
+    <color name="nav_bar">@color/white</color>
 </resources>

--- a/WordPress/src/jetpack/res/values/colors_base.xml
+++ b/WordPress/src/jetpack/res/values/colors_base.xml
@@ -20,4 +20,6 @@
     <color name="primary_100">@color/jetpack_green_100</color>
     <color name="primary_dark">@color/jetpack_green_80</color>
     <color name="primary_light">@color/jetpack_green_30</color>
+
+    <color name="nav_bar">@color/black</color>
 </resources>

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -185,7 +185,7 @@ class WPMainNavigationView @JvmOverloads constructor(
     private fun setTitleViewSelected(position: Int, isSelected: Boolean) {
         getTitleViewForPosition(position)?.setTextColor(
                 context.getColorStateListFromAttribute(
-                        if (isSelected) R.attr.colorPrimary else R.attr.wpColorOnSurfaceMedium
+                        if (isSelected) R.attr.wpColorNavBar else R.attr.wpColorOnSurfaceMedium
                 )
         )
     }

--- a/WordPress/src/main/res/drawable/nav_bar_button_selector.xml
+++ b/WordPress/src/main/res/drawable/nav_bar_button_selector.xml
@@ -2,7 +2,7 @@
 <selector
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item android:color="?attr/colorPrimary" android:state_selected="true"/>
+    <item android:color="?attr/wpColorNavBar" android:state_selected="true" />
     <item android:color="?attr/colorOnSurface"/>
 
 </selector>

--- a/WordPress/src/main/res/values-night/colors_base.xml
+++ b/WordPress/src/main/res/values-night/colors_base.xml
@@ -4,4 +4,6 @@
     <color name="colorPrimaryVariant">@color/primary_50</color>
     <color name="colorSecondary">@color/primary_30</color>
     <color name="colorSecondaryVariant">@color/primary_50</color>
+
+    <color name="nav_bar">@color/colorPrimary</color>
 </resources>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -22,6 +22,7 @@
         <item name="wpColorSuccess">@color/green_30</item>
         <item name="wpColorWarningDark">@color/warning_50</item>
         <item name="wpColorWarningLight">@color/yellow_20</item>
+        <item name="wpColorNavBar">@color/nav_bar</item>
         <item name="wpColorAppBar">?attr/colorSurface</item>
         <item name="wpColorOnSurfaceMedium">@color/material_on_surface_emphasis_medium</item>
         <item name="wpColorActionModeIcon">?attr/colorOnSurface</item>

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -6,6 +6,7 @@
     <!-- Semantic colors -->
     <attr name="wpColorError" format="reference|color" />
     <attr name="wpColorSuccess" format="reference|color" />
+    <attr name="wpColorNavBar" format="reference|color" />
     <attr name="wpColorAppBar" format="reference|color" />
     <attr name="wpColorOnSurfaceMedium" format="reference|color" />
 

--- a/WordPress/src/main/res/values/colors_base.xml
+++ b/WordPress/src/main/res/values/colors_base.xml
@@ -20,4 +20,6 @@
     <color name="primary_100">@color/blue_100</color>
     <color name="primary_dark">@color/blue_80</color>
     <color name="primary_light">@color/blue_30</color>
+
+    <color name="nav_bar">@color/colorPrimary</color>
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -41,6 +41,7 @@
         <item name="wpColorSuccess">@color/green_50</item>
         <item name="wpColorWarningDark">@color/warning_50</item>
         <item name="wpColorWarningLight">@color/yellow_20</item>
+        <item name="wpColorNavBar">@color/nav_bar</item>
         <item name="wpColorAppBar">?attr/colorSurface</item>
         <item name="wpColorOnSurfaceMedium">@color/material_on_surface_emphasis_medium</item>
         <item name="wpColorActionModeIcon">?attr/colorOnSurface</item>


### PR DESCRIPTION
Fixes #14383

This PR updates the `Jetpack` related nav tar colors based on the latest design feedback.

Theme | WordPress | Jetpack
-----|-----|-----
Light | <img width="250" height="500" alt="wordpress_light" src="https://user-images.githubusercontent.com/9729923/114035203-8be54f00-9887-11eb-9512-27b654c10f6d.png"> | <img width="250" height="500" alt="jetpack_light" src="https://user-images.githubusercontent.com/9729923/114035390-b9ca9380-9887-11eb-84c0-138ab78fdb29.png">
Dark | <img width="250" height="500" alt="wordpress_dark" src="https://user-images.githubusercontent.com/9729923/114035616-ee3e4f80-9887-11eb-8290-a4529bfb6743.png"> | <img width="250" height="500" alt="jetpack_dark" src="https://user-images.githubusercontent.com/9729923/114035691-044c1000-9888-11eb-918e-f0bed2e86a2e.png">

**To Test**
- Build, launch and smoke test the `blue` nav bar colors for the `WordPress` app (e.g. `wordpressWasabiDebug`).
- Build, launch and smoke test the `black/white` nav bar colors for the `Jetpack` app (e.g. `jetpackWasabiDebug`).

**Merge Instructions**
- ~~A quick design review by @osullivanchris on the tab color changes for the Jetpack app.~~ 🟢 
- ~~Remove `Needs Design Review` label~~. 🟢 
- ~~Wait for #14423 to be merged.~~ 🟢 
- ~~Remove `Not Ready for Merge` label.~~ 🟢 
- Merge as normal.

## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢
3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
