### PR TITLE
Reverted materialVersion back to 1.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ ext {
     coreVersion = '1.3.2'
     lifecycleVersion = '2.2.0'
     constraintLayoutVersion = '1.1.3'
-    materialVersion = '1.3.0'
+    materialVersion = '1.2.1'
     preferenceVersion = '1.1.0'
     swipeToRefresh = '1.1.0'
     uCropVersion = '2.2.4'


### PR DESCRIPTION
While working in TimeZone selector we bumped material library version from 1.2.1 to 1.3.0, and looks like this might have caused some issues (potentially related to new version of `ConstraintLayout` that 1.3.0 is using).

I only spotted the issue in reader, but it might appear somewhere else, so until we have more info on how to migrate to 1.3.0 I feel it's better to revert to 1.2.1

To test:
- Open Reader.
- Confirm that posts cards without Feature Images looks ok.

Post Cards should look like this:
[![Image from Gyazo](https://i.gyazo.com/f39651beb9d1885a1dd2df5e51e1b7d0.png)](https://gyazo.com/f39651beb9d1885a1dd2df5e51e1b7d0)

And not like this:
[![Image from Gyazo](https://i.gyazo.com/ebbbd4085598dfae2a6e8a3f77260ca6.png)](https://gyazo.com/ebbbd4085598dfae2a6e8a3f77260ca6)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
