### PR TITLE
Integrate gutenberg-mobile release 1.50.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3361-b431ada95e2519aa1e535ef25a98b52a4a96ab32'
+    ext.gutenbergMobileVersion = 'v1.50.1'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.50.0'
+    ext.gutenbergMobileVersion = '3361-c334ea9867fc445f8ef8a9ce94c1f307af758a56'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3361-c334ea9867fc445f8ef8a9ce94c1f307af758a56'
+    ext.gutenbergMobileVersion = '3361-b431ada95e2519aa1e535ef25a98b52a4a96ab32'
 
     repositories {
         google()


### PR DESCRIPTION
This PR incorporates the 1.50.1 release of gutenberg-mobile.  
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: 
https://github.com/wordpress-mobile/gutenberg-mobile/pull/3361

Release Submission Checklist
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary."