### PR TITLE
Jetpack App (Basics): Update Tab Bar Colors (Top Bar)

### DIFF
--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -99,12 +99,6 @@
         <item name="android:navigationBarColor">?attr/colorSurface</item>
     </style>
 
-    <style name="WordPress.TabLayout" parent="Widget.MaterialComponents.TabLayout">
-        <item name="android:elevation">0dp</item>
-        <item name="android:background">@drawable/tab_layout_background</item>
-        <item name="android:duplicateParentState">true</item>
-    </style>
-
     <style name="WordPress.FloatingActionButton" parent="Widget.MaterialComponents.FloatingActionButton">
         <item name="android:backgroundTint">?attr/colorSecondaryVariant</item>
         <item name="tint">?attr/colorOnSurface</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -383,7 +383,7 @@
         <item name="actionTextColorAlpha">1.0</item>
     </style>
 
-    <style name="WordPress.TabLayout" parent="Widget.MaterialComponents.TabLayout.Colored">
+    <style name="WordPress.TabLayout" parent="Widget.MaterialComponents.TabLayout">
         <item name="android:background">@drawable/tab_layout_background</item>
         <item name="android:elevation">0dp</item>
         <item name="android:duplicateParentState">true</item>


### PR DESCRIPTION
Fixes #14435

This PR updates the `Jetpack`, but also `WordPress`, related tab bar colors based on the latest design feedback.

App | Light Theme | Dark Theme (Before) | Dark Theme (After)
-----|-----|-----|-----
WordPress | <img width="250" height="500" alt="wordpress_light_theme" src="https://user-images.githubusercontent.com/9729923/114379048-04525580-9b91-11eb-9a49-3708e527cb99.png"> | <img width="250" height="500" alt="wordpress_dark_theme_before" src="https://user-images.githubusercontent.com/9729923/114379103-10d6ae00-9b91-11eb-84db-c575fdd669ba.png"> | <img width="250" height="500" alt="wordpress_dark_theme_after" src="https://user-images.githubusercontent.com/9729923/114379145-1cc27000-9b91-11eb-98a4-eb5e6aca52b4.png">
Jetpack | <img width="250" height="500" alt="jetpack_light_theme" src="https://user-images.githubusercontent.com/9729923/114378765-b2113480-9b90-11eb-95b1-79e6c2f3f9e0.png"> | <img width="250" height="500" alt="jetpack_light_theme_before" src="https://user-images.githubusercontent.com/9729923/114378845-c81ef500-9b90-11eb-9a66-c2f96397d3db.png"> | <img width="250" height="500" alt="jetpack_light_theme_after" src="https://user-images.githubusercontent.com/9729923/114378927-e258d300-9b90-11eb-819f-dad06a2ea448.png">

**To Test**
- Build, launch and smoke test the `white/blue` tab bar colors (text and line) for the `WordPress` app (e.g. `wordpressWasabiDebug`).
- Build, launch and smoke test the `white/green` tab bar colors (text and line) for the `Jetpack` app (e.g. `jetpackWasabiDebug`).

**Merge Instructions**
- ~~A quick design review by @osullivanchris on the tab color changes for the Jetpack app.~~ 🟢 
- ~~Remove `Needs Design Review` label.~~ 🟢 
- A quick review by @khaykov on why the `android:layout_marginBottom` is needed on the light theme. And, why the difference with the dark theme. #12675
- Remove `Not Ready for Merge` label.
- Merge as normal.

## Regression Notes
1. Potential unintended areas of impact 🟢
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢
3. What automated tests I added (or what prevented me from doing so) 🟢

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
