### PR TITLE
Improve firebase syncing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -260,6 +260,7 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
         initDaggerComponent();
         component().inject(this);
         mDispatcher.register(this);
+        mAppConfig.init();
 
         // Start crash logging and upload any encrypted logs that were queued but not yet uploaded
         mCrashLogging.start(getContext());

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -156,7 +156,8 @@ public class AppPrefs {
         MANUAL_FEATURE_CONFIG,
         SITE_JETPACK_CAPABILITIES,
         REMOVED_QUICK_START_CARD_TYPE,
-        PINNED_DYNAMIC_CARD
+        PINNED_DYNAMIC_CARD,
+        FLAGS_FETCHED_SUCCESSFULLY
     }
 
     /**
@@ -1216,6 +1217,14 @@ public class AppPrefs {
 
     @NonNull private static String getManualFeatureConfigKey(String featureKey) {
         return DeletablePrefKey.MANUAL_FEATURE_CONFIG.name() + featureKey;
+    }
+
+    public static Boolean isFlagsFetchedSuccessfully() {
+        return getBoolean(DeletablePrefKey.FLAGS_FETCHED_SUCCESSFULLY, false);
+    }
+
+    public static void setFlagsFetchedSuccessfully(boolean flagsFetchedSuccessfully) {
+        setBoolean(DeletablePrefKey.FLAGS_FETCHED_SUCCESSFULLY, flagsFetchedSuccessfully);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -157,7 +157,7 @@ public class AppPrefs {
         SITE_JETPACK_CAPABILITIES,
         REMOVED_QUICK_START_CARD_TYPE,
         PINNED_DYNAMIC_CARD,
-        FLAGS_FETCHED_SUCCESSFULLY
+        FLAG_FETCHED_SUCCESSFULLY
     }
 
     /**
@@ -1219,12 +1219,16 @@ public class AppPrefs {
         return DeletablePrefKey.MANUAL_FEATURE_CONFIG.name() + featureKey;
     }
 
-    public static Boolean isFlagsFetchedSuccessfully() {
-        return getBoolean(DeletablePrefKey.FLAGS_FETCHED_SUCCESSFULLY, false);
+    public static Boolean isFlagFetchedSuccessfully(String featureKey) {
+        return prefs().getBoolean(getFlagFetchedKey(featureKey), false);
     }
 
-    public static void setFlagsFetchedSuccessfully(boolean flagsFetchedSuccessfully) {
-        setBoolean(DeletablePrefKey.FLAGS_FETCHED_SUCCESSFULLY, flagsFetchedSuccessfully);
+    public static void setFlagFetchedSuccessfully(String featureKey, boolean flagFetched) {
+        prefs().edit().putBoolean(getFlagFetchedKey(featureKey), flagFetched).apply();
+    }
+
+    @NonNull private static String getFlagFetchedKey(String featureKey) {
+        return DeletablePrefKey.FLAG_FETCHED_SUCCESSFULLY.name() + featureKey;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -77,6 +77,10 @@ class AppPrefsWrapper @Inject constructor() {
         get() = AppPrefs.shouldShowStoriesIntro()
         set(shouldShow) = AppPrefs.setShouldShowStoriesIntro(shouldShow)
 
+    var flagsFetchedSuccessfully: Boolean
+        get() = AppPrefs.isFlagsFetchedSuccessfully()
+        set(value) = AppPrefs.setFlagsFetchedSuccessfully(value)
+
     fun getAppWidgetSiteId(appWidgetId: Int) = AppPrefs.getStatsWidgetSelectedSiteId(appWidgetId)
     fun setAppWidgetSiteId(siteId: Long, appWidgetId: Int) = AppPrefs.setStatsWidgetSelectedSiteId(siteId, appWidgetId)
     fun removeAppWidgetSiteId(appWidgetId: Int) = AppPrefs.removeStatsWidgetSelectedSiteId(appWidgetId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -77,10 +77,6 @@ class AppPrefsWrapper @Inject constructor() {
         get() = AppPrefs.shouldShowStoriesIntro()
         set(shouldShow) = AppPrefs.setShouldShowStoriesIntro(shouldShow)
 
-    var flagsFetchedSuccessfully: Boolean
-        get() = AppPrefs.isFlagsFetchedSuccessfully()
-        set(value) = AppPrefs.setFlagsFetchedSuccessfully(value)
-
     fun getAppWidgetSiteId(appWidgetId: Int) = AppPrefs.getStatsWidgetSelectedSiteId(appWidgetId)
     fun setAppWidgetSiteId(siteId: Long, appWidgetId: Int) = AppPrefs.setStatsWidgetSelectedSiteId(siteId, appWidgetId)
     fun removeAppWidgetSiteId(appWidgetId: Int) = AppPrefs.removeStatsWidgetSelectedSiteId(appWidgetId)
@@ -177,6 +173,14 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun getManualFeatureConfig(featureKey: String): Boolean {
         return AppPrefs.getManualFeatureConfig(featureKey)
+    }
+
+    fun setFlagFetched(featureKey: String, flagFetched: Boolean) {
+        AppPrefs.setFlagFetchedSuccessfully(featureKey, flagFetched)
+    }
+
+    fun isFlagFetched(featureKey: String): Boolean {
+        return AppPrefs.isFlagFetchedSuccessfully(featureKey)
     }
 
     fun setSiteJetpackCapabilities(remoteSiteId: Long, capabilities: List<JetpackCapability>) =

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
@@ -31,7 +31,7 @@ class AnalyticsTrackerWrapper
     }
 
     private fun FeatureState.toName(): String {
-        return when(this) {
+        return when (this) {
             is ManuallyOverriden -> "manually_overriden"
             is BuildConfigValue -> "build_config_value"
             is DefaultValue -> "default_value"

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
@@ -4,6 +4,11 @@ import dagger.Reusable
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.config.AppConfig.FeatureState
+import org.wordpress.android.util.config.AppConfig.FeatureState.BuildConfigValue
+import org.wordpress.android.util.config.AppConfig.FeatureState.DefaultValue
+import org.wordpress.android.util.config.AppConfig.FeatureState.ManuallyOverriden
+import org.wordpress.android.util.config.AppConfig.FeatureState.RemoteValue
 import org.wordpress.android.util.config.ExperimentConfig
 import org.wordpress.android.util.config.FeatureConfig
 import javax.inject.Inject
@@ -16,7 +21,22 @@ class AnalyticsTrackerWrapper
     }
 
     fun track(stat: Stat, feature: FeatureConfig) {
-        AnalyticsTracker.track(stat, mapOf(feature.remoteField to feature.isEnabled()))
+        AnalyticsTracker.track(
+                stat,
+                mapOf(
+                        feature.remoteField to feature.isEnabled(),
+                        "${feature.remoteField}_state" to feature.featureState().toName()
+                )
+        )
+    }
+
+    private fun FeatureState.toName(): String {
+        return when(this) {
+            is ManuallyOverriden -> "manually_overriden"
+            is BuildConfigValue -> "build_config_value"
+            is DefaultValue -> "default_value"
+            is RemoteValue -> "remote_value"
+        }
     }
 
     fun track(stat: Stat, experimentConfig: ExperimentConfig) {

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
@@ -30,6 +30,16 @@ class AnalyticsTrackerWrapper
         )
     }
 
+    fun track(stat: Stat, remoteField: String, featureState: FeatureState) {
+        AnalyticsTracker.track(
+                stat,
+                mapOf(
+                        remoteField to featureState.isEnabled,
+                        "${remoteField}_state" to featureState.toName()
+                )
+        )
+    }
+
     private fun FeatureState.toName(): String {
         return when (this) {
             is ManuallyOverriden -> "manually_overriden"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
@@ -65,18 +65,22 @@ class AppConfig
     }
 
     private fun buildFeatureState(feature: FeatureConfig): FeatureState {
-        if (manualFeatureConfig.hasManualSetup(feature)) {
-            return ManuallyOverriden(manualFeatureConfig.isManuallyEnabled(feature))
-        }
-        if (feature.remoteField == null) {
-            return BuildConfigValue(feature.buildConfigValue)
-        }
-        return if (feature.buildConfigValue) {
-            BuildConfigValue(feature.buildConfigValue)
-        } else if (!remoteConfig.isInitialized()) {
-            DefaultValue(remoteConfig.isEnabled(feature.remoteField))
-        } else {
-            RemoteValue(remoteConfig.isEnabled(feature.remoteField))
+        return when {
+            manualFeatureConfig.hasManualSetup(feature) -> {
+                ManuallyOverriden(manualFeatureConfig.isManuallyEnabled(feature))
+            }
+            feature.remoteField == null -> {
+                BuildConfigValue(feature.buildConfigValue)
+            }
+            feature.buildConfigValue -> {
+                BuildConfigValue(feature.buildConfigValue)
+            }
+            !remoteConfig.isInitialized() -> {
+                DefaultValue(remoteConfig.isEnabled(feature.remoteField))
+            }
+            else -> {
+                RemoteValue(remoteConfig.isEnabled(feature.remoteField))
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
@@ -23,11 +23,18 @@ class AppConfig
     private val remoteConfigCheck = RemoteConfigCheck(this)
 
     /**
-     * This method initialized the config and triggers refresh of remote configuration.
+     * This method initialized the config
+     */
+    fun init() {
+        remoteConfig.init()
+        remoteConfigCheck.checkRemoteFields()
+    }
+
+    /**
+     * This method triggers refresh of remote configuration.
      */
     fun refresh() {
         remoteConfig.refresh()
-        remoteConfigCheck.checkRemoteFields()
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
@@ -56,11 +56,14 @@ class AppConfig
      * @param feature feature we're checking remotely
      */
     fun featureState(feature: FeatureConfig): FeatureState {
-        return buildFeatureState(feature).also {
-            analyticsTracker.track(
-                    FEATURE_FLAG_SET,
-                    feature
-            )
+        return buildFeatureState(feature).also { state ->
+            feature.remoteField?.let {
+                analyticsTracker.track(
+                        FEATURE_FLAG_SET,
+                        feature.remoteField,
+                        state
+                )
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/AppConfig.kt
@@ -78,7 +78,7 @@ class AppConfig
             feature.buildConfigValue -> {
                 BuildConfigValue(feature.buildConfigValue)
             }
-            !remoteConfig.isInitialized() -> {
+            !remoteConfig.isInitialized(feature.remoteField) -> {
                 DefaultValue(remoteConfig.isEnabled(feature.remoteField))
             }
             else -> {

--- a/WordPress/src/main/java/org/wordpress/android/util/config/FeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/FeatureConfig.kt
@@ -17,4 +17,6 @@ open class FeatureConfig(
     fun isEnabled(): Boolean {
         return appConfig.isEnabled(this)
     }
+
+    fun featureState() = appConfig.featureState(this)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfig.kt
@@ -13,14 +13,16 @@ import javax.inject.Inject
  */
 class RemoteConfig
 @Inject constructor() {
-    fun refresh() {
+    fun init() {
         val firebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
         val configSettings = Builder()
                 .setMinimumFetchIntervalInSeconds(BuildConfig.REMOTE_CONFIG_FETCH_INTERVAL)
                 .build()
         firebaseRemoteConfig.setConfigSettingsAsync(configSettings)
         firebaseRemoteConfig.setDefaultsAsync(RemoteConfigDefaults.remoteConfigDefaults)
-        firebaseRemoteConfig.fetchAndActivate()
+    }
+    fun refresh() {
+        FirebaseRemoteConfig.getInstance().fetchAndActivate()
                 .addOnCompleteListener { task: Task<Boolean?> ->
                     if (task.isSuccessful) {
                         AppLog.d(

--- a/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfig.kt
@@ -53,11 +53,13 @@ class RemoteConfig
                     }
                 }
         firebaseRemoteConfig.ensureInitialized().addOnSuccessListener {
-            appPrefsWrapper.flagsFetchedSuccessfully = true
+            RemoteConfigDefaults.remoteConfigDefaults.keys.forEach { key ->
+                appPrefsWrapper.setFlagFetched(key, true)
+            }
         }
     }
 
     fun isEnabled(field: String): Boolean = FirebaseRemoteConfig.getInstance().getBoolean(field)
     fun getString(field: String): String = FirebaseRemoteConfig.getInstance().getString(field)
-    fun isInitialized(): Boolean = appPrefsWrapper.flagsFetchedSuccessfully
+    fun isInitialized(remoteField: String): Boolean = appPrefsWrapper.isFlagFetched(remoteField)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfig.kt
@@ -4,6 +4,7 @@ import com.google.android.gms.tasks.Task
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings.Builder
 import org.wordpress.android.BuildConfig
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.UTILS
 import javax.inject.Inject
@@ -12,7 +13,7 @@ import javax.inject.Inject
  * Do not use this class outside of this package. Use [AppConfig] instead
  */
 class RemoteConfig
-@Inject constructor() {
+@Inject constructor(private val appPrefsWrapper: AppPrefsWrapper) {
     fun init() {
         val firebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
         val configSettings = Builder()
@@ -20,14 +21,30 @@ class RemoteConfig
                 .build()
         firebaseRemoteConfig.setConfigSettingsAsync(configSettings)
         firebaseRemoteConfig.setDefaultsAsync(RemoteConfigDefaults.remoteConfigDefaults)
+        firebaseRemoteConfig.activate()
+        firebaseRemoteConfig.fetchAndActivate().addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                AppLog.d(
+                        UTILS,
+                        "Remote config fetched and activated: ${task.result}"
+                )
+            } else {
+                AppLog.e(
+                        UTILS,
+                        "Remote config fetchAndActivate failed"
+                )
+            }
+        }
     }
+
     fun refresh() {
-        FirebaseRemoteConfig.getInstance().fetchAndActivate()
-                .addOnCompleteListener { task: Task<Boolean?> ->
+        val firebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
+        firebaseRemoteConfig.fetch()
+                .addOnCompleteListener { task ->
                     if (task.isSuccessful) {
                         AppLog.d(
                                 UTILS,
-                                "Remote config updated: ${task.result}"
+                                "Remote config fetched: ${task.result}"
                         )
                     } else {
                         AppLog.e(
@@ -36,8 +53,12 @@ class RemoteConfig
                         )
                     }
                 }
+        firebaseRemoteConfig.ensureInitialized().addOnSuccessListener {
+            appPrefsWrapper.flagsFetchedSuccessfully = true
+        }
     }
 
     fun isEnabled(field: String): Boolean = FirebaseRemoteConfig.getInstance().getBoolean(field)
     fun getString(field: String): String = FirebaseRemoteConfig.getInstance().getString(field)
+    fun isInitialized(): Boolean = appPrefsWrapper.flagsFetchedSuccessfully
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfig.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.util.config
 
-import com.google.android.gms.tasks.Task
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings.Builder
 import org.wordpress.android.BuildConfig

--- a/WordPress/src/test/java/org/wordpress/android/util/config/AppConfigParametrizedTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/config/AppConfigParametrizedTest.kt
@@ -65,7 +65,7 @@ class AppConfigParametrizedTest(
         whenever(featureConfig.buildConfigValue).thenReturn(params.buildConfigValue)
         whenever(featureConfig.remoteField).thenReturn(params.remoteField)
         whenever(remoteConfig.isEnabled(REMOTE_FIELD)).thenReturn(params.remoteConfigValue)
-        whenever(remoteConfig.isInitialized()).thenReturn(params.isInitialized)
+        whenever(remoteConfig.isInitialized(REMOTE_FIELD)).thenReturn(params.isInitialized)
     }
 
     companion object {

--- a/WordPress/src/test/java/org/wordpress/android/util/config/AppConfigParametrizedTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/config/AppConfigParametrizedTest.kt
@@ -1,0 +1,160 @@
+package org.wordpress.android.util.config
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.AppConfig.FeatureState
+import org.wordpress.android.util.config.AppConfig.FeatureState.BuildConfigValue
+import org.wordpress.android.util.config.AppConfig.FeatureState.DefaultValue
+import org.wordpress.android.util.config.AppConfig.FeatureState.ManuallyOverriden
+import org.wordpress.android.util.config.AppConfig.FeatureState.RemoteValue
+import org.wordpress.android.util.config.manual.ManualFeatureConfig
+
+@RunWith(Parameterized::class)
+class AppConfigParametrizedTest(
+    private val params: Params
+) {
+    private val remoteConfig: RemoteConfig = mock()
+    private val analyticsTracker: AnalyticsTrackerWrapper = mock()
+    private val featureConfig: FeatureConfig = mock()
+    private val manualFeatureConfig: ManualFeatureConfig = mock()
+    private lateinit var appConfig: AppConfig
+
+    @Before
+    fun setUp() {
+        appConfig = AppConfig(remoteConfig, analyticsTracker, manualFeatureConfig)
+    }
+
+    @Test
+    fun `shows correct value of isEnabled based on params and tracks the decision`() {
+        setupFeatureConfig()
+
+        assertThat(appConfig.isEnabled(featureConfig)).isEqualTo(params.result.isEnabled)
+
+        verify(analyticsTracker).track(Stat.FEATURE_FLAG_SET, featureConfig)
+    }
+
+    @Test
+    fun `shows correct value of feature set based on params and tracks the decision`() {
+        setupFeatureConfig()
+
+        assertThat(appConfig.featureState(featureConfig)).isEqualTo(params.result)
+
+        verify(analyticsTracker).track(Stat.FEATURE_FLAG_SET, featureConfig)
+    }
+
+    private fun setupFeatureConfig() {
+        whenever(manualFeatureConfig.hasManualSetup(featureConfig)).thenReturn(params.hasManualSetup)
+        whenever(manualFeatureConfig.isManuallyEnabled(featureConfig)).thenReturn(params.isManuallyEnabled)
+        whenever(featureConfig.buildConfigValue).thenReturn(params.buildConfigValue)
+        if (params.hasRemoteField) {
+            whenever(featureConfig.remoteField).thenReturn(remoteField)
+        } else {
+            whenever(featureConfig.remoteField).thenReturn(null)
+        }
+        whenever(remoteConfig.isEnabled(remoteField)).thenReturn(params.remoteConfigValue)
+        whenever(remoteConfig.isInitialized()).thenReturn(params.isInitialized)
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun parameters() = listOf(
+                // Manual override shows the flag as enabled
+                arrayOf(
+                        Params(
+                                hasManualSetup = true,
+                                isManuallyEnabled = true,
+                                result = ManuallyOverriden(true)
+                        )
+                ),
+                // Manual override shows the flag as disabled
+                arrayOf(
+                        Params(
+                                hasManualSetup = true,
+                                isManuallyEnabled = false,
+                                result = ManuallyOverriden(false)
+                        )
+                ),
+                // Returns build config value true when remote field is missing
+                arrayOf(
+                        Params(
+                                hasRemoteField = false,
+                                buildConfigValue = true,
+                                result = BuildConfigValue(true)
+                        )
+                ),
+                // Returns build config value false when remote field is missing
+                arrayOf(
+                        Params(
+                                hasRemoteField = false,
+                                buildConfigValue = false,
+                                result = BuildConfigValue(false)
+                        )
+                ),
+                // Returns build config value true if remote field set
+                arrayOf(
+                        Params(
+                                hasRemoteField = true,
+                                buildConfigValue = true,
+                                result = BuildConfigValue(true)
+                        )
+                ),
+                // Returns default value == true from remote field when not initialized
+                arrayOf(
+                        Params(
+                                isInitialized = false,
+                                hasRemoteField = true,
+                                remoteConfigValue = true,
+                                result = DefaultValue(true)
+                        )
+                ),
+                // Returns default value == false from remote field when not initialized
+                arrayOf(
+                        Params(
+                                isInitialized = false,
+                                hasRemoteField = true,
+                                remoteConfigValue = false,
+                                result = DefaultValue(false)
+                        )
+                ),
+                // Returns remote value == true from remote field when initialized
+                arrayOf(
+                        Params(
+                                isInitialized = true,
+                                hasRemoteField = true,
+                                remoteConfigValue = true,
+                                result = RemoteValue(true)
+                        )
+                ),
+                // Returns remote value == false from remote field when initialized
+                arrayOf(
+                        Params(
+                                isInitialized = true,
+                                hasRemoteField = true,
+                                remoteConfigValue = false,
+                                result = RemoteValue(false)
+                        )
+                )
+        )
+
+        private const val remoteField = "remote_field"
+
+        data class Params(
+            val hasManualSetup: Boolean = false,
+            val isManuallyEnabled: Boolean = false,
+            val hasRemoteField: Boolean = false,
+            val buildConfigValue: Boolean = false,
+            val isInitialized: Boolean = false,
+            val remoteConfigValue: Boolean = false,
+            val result: FeatureState
+        )
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/util/config/AppConfigTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/config/AppConfigTest.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.util.config.manual.ManualFeatureConfig
 class AppConfigTest {
     @Mock lateinit var remoteConfig: RemoteConfig
     @Mock lateinit var analyticsTracker: AnalyticsTrackerWrapper
-    @Mock lateinit var featureConfig: FeatureConfig
     @Mock lateinit var experimentConfig: ExperimentConfig
     @Mock lateinit var manualFeatureConfig: ManualFeatureConfig
     private lateinit var appConfig: AppConfig
@@ -30,7 +29,6 @@ class AppConfigTest {
     @Before
     fun setUp() {
         appConfig = AppConfig(remoteConfig, analyticsTracker, manualFeatureConfig)
-        whenever(manualFeatureConfig.hasManualSetup(featureConfig)).thenReturn(false)
     }
 
     @Test
@@ -38,76 +36,6 @@ class AppConfigTest {
         appConfig.refresh()
 
         verify(remoteConfig).refresh()
-    }
-
-    @Test
-    fun `returns feature as enabled when the build config value is enabled and tracks the event`() {
-        setupFeatureConfig(buildConfigValue = true, remoteConfigValue = false)
-
-        assertThat(appConfig.isEnabled(featureConfig)).isTrue()
-        verify(analyticsTracker).track(Stat.FEATURE_FLAG_SET, mapOf(remoteField to true))
-    }
-
-    @Test
-    fun `returns feature as enabled when the remote config value is enabled and tracks the event`() {
-        setupFeatureConfig(buildConfigValue = false, remoteConfigValue = true)
-
-        assertThat(appConfig.isEnabled(featureConfig)).isTrue()
-        verify(analyticsTracker).track(Stat.FEATURE_FLAG_SET, mapOf(remoteField to true))
-    }
-
-    @Test
-    fun `returns feature as disabled when the remote config value is disabled and tracks the event`() {
-        setupFeatureConfig(buildConfigValue = false, remoteConfigValue = false)
-
-        assertThat(appConfig.isEnabled(featureConfig)).isFalse()
-        verify(analyticsTracker).track(Stat.FEATURE_FLAG_SET, mapOf(remoteField to false))
-    }
-
-    @Test
-    fun `returns feature as enabled when the manual config is enabled and does not track the event`() {
-        setupFeatureConfig(buildConfigValue = false, remoteConfigValue = false)
-        whenever(manualFeatureConfig.hasManualSetup(featureConfig)).thenReturn(true)
-        whenever(manualFeatureConfig.isManuallyEnabled(featureConfig)).thenReturn(true)
-
-        assertThat(appConfig.isEnabled(featureConfig)).isTrue()
-        verifyZeroInteractions(analyticsTracker)
-    }
-
-    @Test
-    fun `returns feature as disabled when the manual config is disabled and does not track the event`() {
-        setupFeatureConfig(buildConfigValue = true, remoteConfigValue = false)
-        whenever(manualFeatureConfig.hasManualSetup(featureConfig)).thenReturn(true)
-        whenever(manualFeatureConfig.isManuallyEnabled(featureConfig)).thenReturn(false)
-
-        assertThat(appConfig.isEnabled(featureConfig)).isFalse()
-        verifyZeroInteractions(analyticsTracker)
-    }
-
-    @Test
-    fun `returns cached true value and tracks only once`() {
-        setupFeatureConfig(buildConfigValue = false, remoteConfigValue = true)
-
-        assertThat(appConfig.isEnabled(featureConfig)).isTrue()
-
-        setupFeatureConfig(buildConfigValue = false, remoteConfigValue = false)
-
-        assertThat(appConfig.isEnabled(featureConfig)).isTrue()
-
-        verify(analyticsTracker).track(Stat.FEATURE_FLAG_SET, mapOf(remoteField to true))
-    }
-
-    @Test
-    fun `returns cached false value and tracks only once`() {
-        setupFeatureConfig(buildConfigValue = false, remoteConfigValue = false)
-
-        assertThat(appConfig.isEnabled(featureConfig)).isFalse()
-
-        setupFeatureConfig(buildConfigValue = true, remoteConfigValue = true)
-
-        assertThat(appConfig.isEnabled(featureConfig)).isFalse()
-
-        verify(analyticsTracker).track(Stat.FEATURE_FLAG_SET, mapOf(remoteField to false))
     }
 
     @Test
@@ -150,12 +78,6 @@ class AppConfigTest {
                 Stat.EXPERIMENT_VARIANT_SET,
                 mapOf(remoteField to experimentVariantA)
         )
-    }
-
-    private fun setupFeatureConfig(buildConfigValue: Boolean, remoteConfigValue: Boolean) {
-        whenever(featureConfig.buildConfigValue).thenReturn(buildConfigValue)
-        whenever(featureConfig.remoteField).thenReturn(remoteField)
-        whenever(remoteConfig.isEnabled(remoteField)).thenReturn(remoteConfigValue)
     }
 
     private fun setupExperimentConfig(remoteConfigValue: String, experimentVariants: List<Variant>) {

--- a/WordPress/src/test/java/org/wordpress/android/util/config/AppConfigTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/config/AppConfigTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.util.config
 
 import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException


### PR DESCRIPTION
There were a few issues I'm trying to fix with this PR.
1. We retrieved the `MySiteImprovements` flag value before we initialized firebase with the default values. This caused the the first `isEnabled` call end up with `false` and we were caching this value until the app was restarted. I've added an `init` call to the app `onCreate` method which should fix this issue.
2. I've removed caching and replaced with calling `fetchAndActivate` method in `onCreate`, simply `fetch` on return to foreground and `activate in `onCreate`. The idea here is that the first start of the app will trigger `fetchAndActivate`, this value will not change until the app calls `onCreate` again (so it doesn't change under the user's hands` and we call `fetch` multiple times and `activate` the next time the app is restarted. Let me know if it makes sense.
3. I've added multiple feature states for tracking purposes. This will let us know where the flag value came from if we need to further analyze the data. To make this work I'm checking whether the flag for the given remote field has been initialized before  to see whether we're in the default state.

Before you test:
I recommend overriding the `isEnabled` field in the `MySiteImprovementsFeatureConfig` like this: 
```
override fun isEnabled(): Boolean {
        return super.isEnabled().also { Log.d("my_site_flag", "isEnabled:  ${isEnabled()}") }
    }
```
to see the actual value of the flag.

To test:
- Start with clean installation 
- Notice in Logcat the `my_site_flag` field starts as enabled
- Login/create an account
- The field is assigned and changed based on the AB test
- The My Site screen is correctly loaded based on the updated flag
- You might need to try this several times to get both the AB values

## Regression Notes
1. Potential unintended areas of impact
- This might cause the My Site screen to show the old or the new value for more users than we want

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- The test steps

3. What automated tests I added (or what prevented me from doing so)
- Parametrized unit tests for AppConfig

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
