### PR TITLE
Crash Fix: Replace Instance with Static Reader Tracker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2520,6 +2520,15 @@ public class ReaderPostListFragment extends ViewPagerFragment
         setCurrentTag(tag);
     }
 
+    /**
+     * WARNING: Do not replace the static reader tracker with the corresponding instance reader tracker
+     * as this will result into a {@link NullPointerException} crash on specific scenarios.
+     * <p>
+     * This is because this method is also being triggered through the static
+     * {@link ReaderPostListFragment#newInstanceForTag} method, which means that the
+     * {@link ReaderPostListFragment#mReaderTracker} field instance will not be yet available, and
+     * as thus cannot be used, or else it will result in a {@link NullPointerException}.
+     */
     private void trackTagLoaded(@Nullable ReaderTag tag) {
         if (tag == null) {
             return;
@@ -2534,7 +2543,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
             return;
         }
 
-        mReaderTracker.trackTag(stat, tag.getTagSlug());
+        ReaderTracker.trackTag(stat, tag.getTagSlug());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
@@ -197,16 +197,6 @@ class ReaderTracker @Inject constructor(
 
     fun trackTag(
         stat: AnalyticsTracker.Stat,
-        tag: String
-    ) {
-        val properties = mutableMapOf<String, Any>(
-                TAG_KEY to tag
-        )
-        track(stat, properties)
-    }
-
-    fun trackTag(
-        stat: AnalyticsTracker.Stat,
         tag: String,
         source: String
     ) {
@@ -417,6 +407,17 @@ class ReaderTracker @Inject constructor(
         const val SOURCE_POST_LIST_SAVED_POST_NOTICE = "post_list_saved_post_notice"
 
         private const val UNKNOWN_VALUE = "unknown"
+
+        @JvmStatic
+        fun trackTag(
+            stat: AnalyticsTracker.Stat,
+            tag: String
+        ) {
+            val properties = mutableMapOf<String, Any>(
+                    TAG_KEY to tag
+            )
+            AnalyticsTracker.track(stat, properties)
+        }
     }
 }
 


### PR DESCRIPTION
This crash has been reported today by @yoavf in this https://wp.me/p4a5px-2Jq-p2 post. Also, there are already a few Sentry issues being reported as well (see [Sentry issues here](https://href.li/?https://sentry.io/organizations/a8c/issues/?query=is%3Aunresolved+ReaderPostListFragment&statsPeriod=14d)).

Since the `trackTagLoaded(...)` method is also being triggered through the static `newInstanceForTag(...)` method, this means that the `mReaderTracker` field instance will not be yet available, and as thus cannot be used, or else it will result in a null pointer exception.

This PR fixes this crash by replacing the instance with the static reader tracker equivalent function.

**To Test**
- Launch app and navigate to `Reader` tab.
- Change tabs, from `FOLLOWING`, to `DISCOVER`, to `LIKES`, `SAVED`, `AUTOMATTIC`, etc and verify that app doesn't crash.

**To Replicate The Crash**
- Find the `ReaderPostListFragment.trackTagLoad(...)` method and replace the second `return` with `stat = AnalyticsTracker.Stat.READER_LIST_LOADED;`
- Replace the static `ReaderTracker` with the `mReaderTracker` field instance.
- Rebuild, launch app and navigate to `Reader` tab.
- Change tabs, from `FOLLOWING`, to `DISCOVER`, to `LIKES`, `SAVED`, `AUTOMATTIC`, etc and notice that the app crashes.

## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 
3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
