### PR TITLE
Jetpack App (Basics): Disable login signup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -143,9 +143,13 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
             switch (getLoginMode()) {
                 case FULL:
-                case JETPACK_LOGIN_ONLY:
                     mUnifiedLoginTracker.setSource(Source.DEFAULT);
                     mIsSignupFromLoginEnabled = true;
+                    loginFromPrologue();
+                    break;
+                case JETPACK_LOGIN_ONLY:
+                    mUnifiedLoginTracker.setSource(Source.DEFAULT);
+                    mIsSignupFromLoginEnabled = false;
                     loginFromPrologue();
                     break;
                 case WPCOM_LOGIN_ONLY:
@@ -206,7 +210,6 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-
         outState.putString(KEY_SMARTLOCK_HELPER_STATE, mSmartLockHelperState.name());
         outState.putBoolean(KEY_SIGNUP_FROM_LOGIN_ENABLED, mIsSignupFromLoginEnabled);
         outState.putBoolean(KEY_SITE_LOGIN_AVAILABLE_FROM_PROLOGUE, mIsSiteLoginAvailableFromPrologue);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.kt
@@ -9,6 +9,7 @@ import androidx.annotation.FloatRange
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayoutMediator
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -54,6 +55,12 @@ class LoginPrologueFragment : Fragment(R.layout.login_signup_screen) {
         val binding = LoginSignupScreenBinding.bind(view)
 
         with(binding.bottomButtonsContainer) {
+            if (BuildConfig.IS_JETPACK_APP) {
+                continueWithWpcomButton.setText(R.string.continue_with_wpcom_no_signup)
+            } else {
+                continueWithWpcomButton.setText(R.string.continue_with_wpcom)
+            }
+
             continueWithWpcomButton.setOnClickListener {
                 unifiedLoginTracker.trackClick(Click.CONTINUE_WITH_WORDPRESS_COM)
                 loginPrologueListener.showEmailLoginScreen()

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1366,7 +1366,11 @@ public class WPMainActivity extends LocaleAwareActivity implements
             // Reset site selection
             setSelectedSite(null);
             // Show the sign in screen
-            ActivityLauncher.showSignInForResult(this);
+            if (BuildConfig.IS_JETPACK_APP) {
+                ActivityLauncher.showSignInForResultJetpackOnly(this);
+            } else {
+                ActivityLauncher.showSignInForResult(this);
+            }
         } else {
             SiteModel site = getSelectedSite();
             if (site == null && mSiteStore.hasSite()) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2724,6 +2724,7 @@
     <string name="signup_confirmation_title">Signup confirmation</string>
 
     <string name="continue_with_wpcom">Log in or sign up with WordPress.com</string>
+    <string name="continue_with_wpcom_no_signup">Log in with WordPress.com</string>
     <string name="enter_your_site_address">Enter your existing site address</string>
 
     <string name="username_changer_action">Save</string>


### PR DESCRIPTION
Parent #14303 

This PR disables the Sign Up option during login for Jetpack App builds.

|Wordpress|Jetpack
|---|---
|![WP](https://user-images.githubusercontent.com/506707/112050334-1d825c00-8b27-11eb-9686-d568631b2926.png)|![JP](https://user-images.githubusercontent.com/506707/114587927-219c2800-9c54-11eb-9d44-ddce1f011bd1.png)

|Wordpress SignUp|Jetpack Error
|---|---
|![WP](https://user-images.githubusercontent.com/506707/114588358-9a9b7f80-9c54-11eb-8ad1-0a38a69e9bea.png)|![JP](https://user-images.githubusercontent.com/506707/114588377-9ec79d00-9c54-11eb-86ab-53f785487c0e.png)

To test
- Download this branch

Scenario 1: Jetpack (No need to test all flavors, one will do)
- Launch a jetpack flavor
- The Login prologue button text should match the above Jetpack screenshot
- Login as normal (NOTE:  There is an issue with jetpack logins filtering/not filtering jetpack sites properly - this is not addressed in this PR)
- Logout as normal
- The Login prologue button text should match the above Jetpack screenshot
- Tap the Log in with WordPress.com button
- Enter an email address that is not a WP.com account IE: blahblah.blah@gmail.com
- Note that you remain on the email entry view and be shown an error as in Jetpack Error above

Scenario 2: WordPress (No need to test all flavors, one will do)
- Launch a WordPress flavor
- The Login prologue button text should match the above WordPress screenshot
- Login as normal 
- Logout as normal
- The Login prologue button text should match the above WordPress screenshot
- Tap the Log in with WordPress.com button
- Enter an email address that is not a WP.com account IE: blahblah.blah@gmail.com
- Note that you see the Sign Up email sent view as seen in WordPress Signup above

## Regression Notes
1. Potential unintended areas of impact
The WordPress login flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested using the same accounts on the WordPress scheme to verify the login flow still works correctly.

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
