### PR TITLE
Replaces ConstraintLayout with RelativeLayout to bypass RTL rendering issue

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 17.2
 -----
 * [*] Timezone: Timezone selection dialog in site settings is updated with grouping by continents, manual offsets and additional timezone information. [https://github.com/wordpress-mobile/WordPress-Android/pull/14198]
+* [*] My Site: Fixes a bug in rendering the menu in RTL interface languages
 
 17.1
 -----

--- a/WordPress/src/main/res/layout/my_site_item_block.xml
+++ b/WordPress/src/main/res/layout/my_site_item_block.xml
@@ -15,10 +15,11 @@
         android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/my_site_item_primary_text"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:src="@drawable/ic_plans_white_24dp" />
-
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/my_site_item_primary_text"
         style="@style/UpdatedMySiteListRowTextView"
@@ -29,7 +30,6 @@
         app:layout_constraintStart_toEndOf="@+id/my_site_item_primary_icon"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="@string/plan" />
-
     <ImageView
         android:id="@+id/my_site_item_secondary_icon"
         style="@style/MySiteListRowSecondaryIcon"
@@ -38,8 +38,8 @@
         android:src="@drawable/ic_external_white_24dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/guideline2"
         app:layout_constraintStart_toEndOf="@+id/my_site_item_primary_text"/>
-
     <org.wordpress.android.widgets.QuickStartFocusPoint
         android:id="@+id/my_site_item_quick_start_focus_point"
         android:layout_width="wrap_content"
@@ -53,22 +53,25 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:size="small"
-        tools:ignore="RtlSymmetry" />
+        app:size="small" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" />
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/my_site_item_secondary_text"
         style="@style/MySiteListRowSecondaryTextView"
         android:layout_marginEnd="32dp"
-        android:gravity="end"
         android:paddingEnd="0dp"
         android:paddingStart="0dp"
         android:textAlignment="viewEnd"
-        app:layout_constraintStart_toEndOf="@+id/my_site_item_primary_text"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/guideline2"
         app:layout_constraintTop_toTopOf="parent"
-        tools:ignore="RtlSymmetry"
         tools:text="@string/plan" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -586,7 +586,7 @@
     </style>
 
     <style name="MySiteListRowSecondaryTextView" parent="MySiteListRowSecondaryElement">
-        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_alignParentEnd">true</item>
         <item name="android:ellipsize">end</item>


### PR DESCRIPTION
Fixes #14438

## Description
~The original `my_site_item_block.xml` structure worked as expected in LTR languages and there is no structural reason to break in RTL. Thus the observed UI bug is most probably due to a [`ConstraintLayout` bug](https://issuetracker.google.com/issues?q=ConstraintLayout%20RTL) ([e.g.](https://issuetracker.google.com/issues/146535404)).
Note that we are using version `1.1.3` of `ContraintLayout`. I tested with `2.0.4`(stable) and `2.1.0-beta1` and the issue is still reproduced. 
As a workaround the layout was transformed to `RelativeLayout`.~
A fix using ConstraintLayout was cherrypicked from @planarvoid's solution 4a51f62afa29d618a8f02da05287cdbc6abd44de

To test:
1. Set the Interface to an RTL (e.g. Hebrew or Arabic) language (Avatar>App Settings> Interface Language)
2. Browse to **My Site** screen
3. Verify that the options list is rendered correctly

|Hebrew Before|Hebrew with the Fix|
|---|---|
|![device-2021-04-14-151741](https://user-images.githubusercontent.com/304044/114708938-a9f1fa00-9d34-11eb-84fe-4a9609c222dd.png)|![device-2021-04-14-151602](https://user-images.githubusercontent.com/304044/114708922-a65e7300-9d34-11eb-8974-e7a45134125a.png)|

|Arabic|English|
|---|---|
![device-2021-04-14-151645](https://user-images.githubusercontent.com/304044/114709084-d3ab2100-9d34-11eb-8e2a-b318e8c2a340.png)|![device-2021-04-14-151513](https://user-images.githubusercontent.com/304044/114709049-c7bf5f00-9d34-11eb-8b18-b41937fa04f9.png)|

## Regression Notes
1. Potential unintended areas of impact
None identified

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
