### PR TITLE
Stories: add bounds check in saving, don't process an empty Story block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -105,12 +105,14 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
         // --> remove mediaFiles entirely
         // set start index and go up.
         var storyBlockStartIndex = 0
-        while (storyBlockStartIndex > -1 && storyBlockStartIndex < content.length) {
+        var hasMediaFiles = true
+        while (storyBlockStartIndex > -1 && storyBlockStartIndex < content.length && hasMediaFiles) {
             storyBlockStartIndex = content.indexOf(HEADING_START, storyBlockStartIndex)
             if (storyBlockStartIndex > -1) {
                 val storyBlockEndIndex = content.indexOf(HEADING_END, storyBlockStartIndex)
                 val mediaFilesStartIndex = storyBlockStartIndex + HEADING_START.length
-                if (mediaFilesStartIndex < storyBlockEndIndex) {
+                hasMediaFiles = mediaFilesStartIndex < storyBlockEndIndex
+                if (hasMediaFiles) {
                     try {
                         val jsonString: String = content.substring(
                                 mediaFilesStartIndex,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -112,17 +112,18 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
                 val storyBlockEndIndex = content.indexOf(HEADING_END, storyBlockStartIndex)
                 val mediaFilesStartIndex = storyBlockStartIndex + HEADING_START.length
                 hasMediaFiles = mediaFilesStartIndex < storyBlockEndIndex
-                if (hasMediaFiles) {
-                    try {
-                        val jsonString: String = content.substring(
-                                mediaFilesStartIndex,
-                                storyBlockEndIndex
-                        )
-                        content = listener.doWithMediaFilesJson(content, jsonString)
-                        storyBlockStartIndex += HEADING_START.length
-                    } catch (exception: StringIndexOutOfBoundsException) {
-                        logException(exception, postModel, siteModel)
-                    }
+                if (!hasMediaFiles) {
+                    break
+                }
+                try {
+                    val jsonString: String = content.substring(
+                            mediaFilesStartIndex,
+                            storyBlockEndIndex
+                    )
+                    content = listener.doWithMediaFilesJson(content, jsonString)
+                    storyBlockStartIndex += HEADING_START.length
+                } catch (exception: StringIndexOutOfBoundsException) {
+                    logException(exception, postModel, siteModel)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCase.kt
@@ -109,15 +109,18 @@ class SaveStoryGutenbergBlockUseCase @Inject constructor(
             storyBlockStartIndex = content.indexOf(HEADING_START, storyBlockStartIndex)
             if (storyBlockStartIndex > -1) {
                 val storyBlockEndIndex = content.indexOf(HEADING_END, storyBlockStartIndex)
-                try {
-                    val jsonString: String = content.substring(
-                            storyBlockStartIndex + HEADING_START.length,
-                            storyBlockEndIndex
-                    )
-                    content = listener.doWithMediaFilesJson(content, jsonString)
-                    storyBlockStartIndex += HEADING_START.length
-                } catch (exception: StringIndexOutOfBoundsException) {
-                    logException(exception, postModel, siteModel)
+                val mediaFilesStartIndex = storyBlockStartIndex + HEADING_START.length
+                if (mediaFilesStartIndex < storyBlockEndIndex) {
+                    try {
+                        val jsonString: String = content.substring(
+                                mediaFilesStartIndex,
+                                storyBlockEndIndex
+                        )
+                        content = listener.doWithMediaFilesJson(content, jsonString)
+                        storyBlockStartIndex += HEADING_START.length
+                    } catch (exception: StringIndexOutOfBoundsException) {
+                        logException(exception, postModel, siteModel)
+                    }
                 }
             }
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/SaveStoryGutenbergBlockUseCaseTest.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.mediauploadcompletionprocessors.TestContent
 import org.wordpress.android.ui.stories.SaveStoryGutenbergBlockUseCase.Companion.TEMPORARY_ID_PREFIX
+import org.wordpress.android.ui.stories.SaveStoryGutenbergBlockUseCase.DoWithMediaFilesListener
 import org.wordpress.android.ui.stories.SaveStoryGutenbergBlockUseCase.StoryMediaFileData
 import org.wordpress.android.ui.stories.prefs.StoriesPrefs
 import org.wordpress.android.util.CrashLogging
@@ -217,6 +218,25 @@ class SaveStoryGutenbergBlockUseCaseTest : BaseUnitTest() {
         Assertions.assertThat(postModel.content).isEqualTo(TestContent.storyBlockWithLocalIdsAndUrls)
     }
 
+    @Test
+    fun `post with a Story block with no mediaFiles is not taken into account for processing`() {
+        // Given
+        val siteModel = SiteModel()
+        val postModel = PostModel()
+        val listener: DoWithMediaFilesListener = mock()
+        postModel.setContent(BLOCK_LACKING_MEDIA_FILES_ARRAY)
+
+        // When
+        saveStoryGutenbergBlockUseCase.findAllStoryBlocksInPostAndPerformOnEachMediaFilesJson(
+                postModel,
+                siteModel,
+                mock()
+        )
+
+        // Then
+        verify(listener, times(0)).doWithMediaFilesJson(any(), any())
+    }
+
     private fun setupFluxCMediaFiles(
         emptyList: Boolean
     ): ArrayList<MediaFile> {
@@ -280,6 +300,9 @@ class SaveStoryGutenbergBlockUseCaseTest : BaseUnitTest() {
     }
 
     companion object {
+        private const val BLOCK_LACKING_MEDIA_FILES_ARRAY = "<!-- wp:jetpack/story -->\n" +
+                "<div class=\"wp-story wp-block-jetpack-story\"></div>\n" +
+                "<!-- /wp:jetpack/story -->"
         private const val BLOCK_WITH_EMPTY_MEDIA_FILES = "<!-- wp:jetpack/story {\"mediaFiles\":[]} -->\n" +
                 "<div class=\"wp-story wp-block-jetpack-story\"></div>\n" +
                 "<!-- /wp:jetpack/story -->"


### PR DESCRIPTION
Fixes #13678 

The problem is there seem to be Posts with empty Story blocks in their content:

```
    <!-- wp:jetpack/story -->
    <div class="wp-block-jetpack-story wp-story"></div>
    <!-- /wp:jetpack/story -->
```

Therefore, when the `findAllStoryBlocksInPostAndPerformOnEachMediaFilesJson` iterator tries to find the `mediaFiles` attribute within the block, it fails to do so (the code is not really prepared to expect a non-existent `mediaFiles` attribute).

This PR adds a check to avoid processing `mediaFiles` for a block that simply doesn't contain any (that is, an empty block that hasn't been assigned any media files yet).

To test:

1. create a new Post
2. add a Story block, but don't do anything with it to it's left empty
3. add a media block (image block, video block)
4. add a media item to it
5. while it's uploading, exit the editor
6. observe it doesn't crash and finalizes uploads correctly
7. check on your site and observe the Post renders correctly

Note: I noticed once the post may be uploaded containing a local path to the media file, but I haven't been able to reproduce, and is unrelated to this particular change.

## Regression Notes
1. Potential unintended areas of impact

Uploads of media when a Story block is also on the same Post.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Tried uploading media (Image block) manually.

3. What automated tests I added (or what prevented me from doing so)

Added a unit test to check that if a Story block contains no `mediaFiles` array (as is the case for a Story block that has been added through the Block Picker on Gutenberg mobile), then do not try to process the array.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
