### PR TITLE
Add stats email deeplink handling

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -388,7 +388,7 @@ public class ActivityLauncher {
         viewStatsInNewStack(context, site, null);
     }
 
-    public static void viewStatsInNewStack(Context context, SiteModel site,  @Nullable StatsTimeframe statsTimeframe) {
+    public static void viewStatsInNewStack(Context context, SiteModel site, @Nullable StatsTimeframe statsTimeframe) {
         if (site == null) {
             handleMissingSite(context);
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -85,6 +85,7 @@ import org.wordpress.android.ui.publicize.PublicizeListActivity;
 import org.wordpress.android.ui.sitecreation.SiteCreationActivity;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
 import org.wordpress.android.ui.stats.StatsConstants;
+import org.wordpress.android.ui.stats.StatsTimeframe;
 import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.ui.stats.refresh.StatsActivity;
 import org.wordpress.android.ui.stats.refresh.StatsViewAllActivity;
@@ -400,6 +401,29 @@ public class ActivityLauncher {
         Intent mainActivityIntent = getMainActivityInNewStack(context);
 
         Intent statsIntent = StatsActivity.buildIntent(context, site);
+
+        taskStackBuilder.addNextIntent(mainActivityIntent);
+        taskStackBuilder.addNextIntent(statsIntent);
+        taskStackBuilder.startActivities();
+    }
+
+    public static void viewStatsInNewStack(Context context, SiteModel site, StatsTimeframe statsTimeframe) {
+        if (site == null) {
+            AppLog.e(T.STATS, "SiteModel is null when opening the stats from the deeplink.");
+            AnalyticsTracker.track(
+                    STATS_ACCESS_ERROR,
+                    ActivityLauncher.class.getName(),
+                    "NullPointerException",
+                    "Failed to open Stats from the deeplink because of the null SiteModel"
+                                  );
+            ToastUtils.showToast(context, R.string.stats_cannot_be_started, ToastUtils.Duration.SHORT);
+            return;
+        }
+        TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
+
+        Intent mainActivityIntent = getMainActivityInNewStack(context);
+
+        Intent statsIntent = StatsActivity.buildIntent(context, site, statsTimeframe);
 
         taskStackBuilder.addNextIntent(mainActivityIntent);
         taskStackBuilder.addNextIntent(statsIntent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -385,54 +385,55 @@ public class ActivityLauncher {
     }
 
     public static void viewStatsInNewStack(Context context, SiteModel site) {
-        if (site == null) {
-            AppLog.e(T.STATS, "SiteModel is null when opening the stats from the deeplink.");
-            AnalyticsTracker.track(
-                    STATS_ACCESS_ERROR,
-                    ActivityLauncher.class.getName(),
-                    "NullPointerException",
-                    "Failed to open Stats from the deeplink because of the null SiteModel"
-                                  );
-            ToastUtils.showToast(context, R.string.stats_cannot_be_started, ToastUtils.Duration.SHORT);
-            return;
-        }
-        TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
-
-        Intent mainActivityIntent = getMainActivityInNewStack(context);
-
-        Intent statsIntent = StatsActivity.buildIntent(context, site);
-
-        taskStackBuilder.addNextIntent(mainActivityIntent);
-        taskStackBuilder.addNextIntent(statsIntent);
-        taskStackBuilder.startActivities();
+        viewStatsInNewStack(context, site, null);
     }
 
-    public static void viewStatsInNewStack(Context context, SiteModel site, StatsTimeframe statsTimeframe) {
+    public static void viewStatsInNewStack(Context context, SiteModel site,  @Nullable StatsTimeframe statsTimeframe) {
         if (site == null) {
-            AppLog.e(T.STATS, "SiteModel is null when opening the stats from the deeplink.");
-            AnalyticsTracker.track(
-                    STATS_ACCESS_ERROR,
-                    ActivityLauncher.class.getName(),
-                    "NullPointerException",
-                    "Failed to open Stats from the deeplink because of the null SiteModel"
-                                  );
-            ToastUtils.showToast(context, R.string.stats_cannot_be_started, ToastUtils.Duration.SHORT);
+            handleMissingSite(context);
             return;
         }
+        Intent statsIntent;
+        if (statsTimeframe != null) {
+            statsIntent = StatsActivity.buildIntent(context, site, statsTimeframe);
+        } else {
+            statsIntent = StatsActivity.buildIntent(context, site);
+        }
+
+        runIntentOverMainActivityInNewStack(context, statsIntent);
+    }
+
+    private static void handleMissingSite(Context context) {
+        AppLog.e(T.STATS, "SiteModel is null when opening the stats from the deeplink.");
+        AnalyticsTracker.track(
+                STATS_ACCESS_ERROR,
+                ActivityLauncher.class.getName(),
+                "NullPointerException",
+                "Failed to open Stats from the deeplink because of the null SiteModel"
+        );
+        ToastUtils.showToast(context, R.string.stats_cannot_be_started, ToastUtils.Duration.SHORT);
+    }
+
+    private static void runIntentOverMainActivityInNewStack(Context context, Intent intent) {
         TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
 
         Intent mainActivityIntent = getMainActivityInNewStack(context);
 
-        Intent statsIntent = StatsActivity.buildIntent(context, site, statsTimeframe);
-
         taskStackBuilder.addNextIntent(mainActivityIntent);
-        taskStackBuilder.addNextIntent(statsIntent);
+        taskStackBuilder.addNextIntent(intent);
         taskStackBuilder.startActivities();
     }
 
     public static void viewStatsInNewStack(Context context) {
         Intent intent = getMainActivityInNewStack(context);
         intent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_STATS);
+        context.startActivity(intent);
+    }
+
+    public static void viewStatsForTimeframeInNewStack(Context context, StatsTimeframe statsTimeframe) {
+        Intent intent = getMainActivityInNewStack(context);
+        intent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_STATS);
+        intent.putExtra(WPMainActivity.ARG_STATS_TIMEFRAME, statsTimeframe);
         context.startActivity(intent);
     }
 
@@ -464,6 +465,21 @@ public class ActivityLauncher {
             ToastUtils.showToast(context, R.string.stats_cannot_be_started, ToastUtils.Duration.SHORT);
         } else {
             StatsActivity.start(context, site);
+        }
+    }
+
+    public static void viewBlogStatsForTimeframe(Context context, SiteModel site, StatsTimeframe statsTimeframe) {
+        if (site == null) {
+            AppLog.e(T.STATS, "SiteModel is null when opening the stats.");
+            AnalyticsTracker.track(
+                    STATS_ACCESS_ERROR,
+                    ActivityLauncher.class.getName(),
+                    "NullPointerException",
+                    "Failed to open Stats because of the null SiteModel"
+                                  );
+            ToastUtils.showToast(context, R.string.stats_cannot_be_started, ToastUtils.Duration.SHORT);
+        } else {
+            StatsActivity.start(context, site, statsTimeframe);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkNavigator.kt
@@ -7,8 +7,12 @@ import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenEditor
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenEditorForSite
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenInBrowser
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenEditorForPost
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStats
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForSite
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForSiteAndTimeframe
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.ShowSignInFlow
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.StartCreateSiteFlow
+import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
 
@@ -32,6 +36,13 @@ class DeepLinkNavigator
                     navigateAction.site,
                     navigateAction.postId
             )
+            OpenStats -> ActivityLauncher.viewStatsInNewStack(activity)
+            is OpenStatsForSite -> ActivityLauncher.viewStatsInNewStack(activity, navigateAction.site)
+            is OpenStatsForSiteAndTimeframe -> ActivityLauncher.viewStatsInNewStack(
+                    activity,
+                    navigateAction.site,
+                    navigateAction.statsTimeframe
+            )
         }
         activity.finish()
     }
@@ -41,6 +52,11 @@ class DeepLinkNavigator
         data class OpenEditorForPost(val site: SiteModel, val postId: Int) : NavigateAction()
         data class OpenEditorForSite(val site: SiteModel) : NavigateAction()
         object OpenEditor : NavigateAction()
+        data class OpenStatsForSiteAndTimeframe(val site: SiteModel, val statsTimeframe: StatsTimeframe) :
+                NavigateAction()
+
+        data class OpenStatsForSite(val site: SiteModel) : NavigateAction()
+        object OpenStats : NavigateAction()
         object StartCreateSiteFlow : NavigateAction()
         object ShowSignInFlow : NavigateAction()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkNavigator.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenEditorForPo
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStats
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForSite
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForSiteAndTimeframe
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForTimeframe
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.ShowSignInFlow
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.StartCreateSiteFlow
 import org.wordpress.android.ui.stats.StatsTimeframe
@@ -37,6 +38,10 @@ class DeepLinkNavigator
                     navigateAction.postId
             )
             OpenStats -> ActivityLauncher.viewStatsInNewStack(activity)
+            is OpenStatsForTimeframe -> ActivityLauncher.viewStatsForTimeframeInNewStack(
+                    activity,
+                    navigateAction.statsTimeframe
+            )
             is OpenStatsForSite -> ActivityLauncher.viewStatsInNewStack(activity, navigateAction.site)
             is OpenStatsForSiteAndTimeframe -> ActivityLauncher.viewStatsInNewStack(
                     activity,
@@ -56,6 +61,7 @@ class DeepLinkNavigator
                 NavigateAction()
 
         data class OpenStatsForSite(val site: SiteModel) : NavigateAction()
+        data class OpenStatsForTimeframe(val statsTimeframe: StatsTimeframe) : NavigateAction()
         object OpenStats : NavigateAction()
         object StartCreateSiteFlow : NavigateAction()
         object ShowSignInFlow : NavigateAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkUriUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkUriUtils.kt
@@ -12,7 +12,8 @@ class DeepLinkUriUtils
         return site?.url?.let { uriUtilsWrapper.parse(it).host }
     }
 
-    fun getUriFromQueryParameter(uri: UriWrapper, key: String) = uri.getQueryParameter(key)?.let { uriUtilsWrapper.parse(it) }
+    fun getUriFromQueryParameter(uri: UriWrapper, key: String) =
+            uri.getQueryParameter(key)?.let { uriUtilsWrapper.parse(it) }
 
     fun extractTargetHost(uri: UriWrapper): String {
         return uri.lastPathSegment ?: ""

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkUriUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkUriUtils.kt
@@ -1,13 +1,35 @@
 package org.wordpress.android.ui
 
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.util.UriUtilsWrapper
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
 
 class DeepLinkUriUtils
-@Inject constructor() {
-    fun extractHostFromSite(site: SiteModel?): String? {
-        return site?.url?.let { UriWrapper(it).host }
+@Inject constructor(private val siteStore: SiteStore, private val uriUtilsWrapper: UriUtilsWrapper) {
+    private fun extractHostFromSite(site: SiteModel?): String? {
+        return site?.url?.let { uriUtilsWrapper.parse(it).host }
     }
-    fun getUriFromQueryParameter(uri: UriWrapper, key: String) = uri.getQueryParameter(key)?.let { UriWrapper(it) }
+
+    fun getUriFromQueryParameter(uri: UriWrapper, key: String) = uri.getQueryParameter(key)?.let { uriUtilsWrapper.parse(it) }
+
+    fun extractTargetHost(uri: UriWrapper): String {
+        return uri.lastPathSegment ?: ""
+    }
+
+    private fun extractSiteModelFromTargetHost(host: String): SiteModel? {
+        return siteStore.getSitesByNameOrUrlMatching(host).firstOrNull()
+    }
+
+    fun hostToSite(siteUrl: String): SiteModel? {
+        val site = extractSiteModelFromTargetHost(siteUrl)
+        val host = extractHostFromSite(site)
+        // Check if a site is available with given targetHost
+        return if (site != null && host != null && host == siteUrl) {
+            site
+        } else {
+            null
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -79,19 +79,20 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
         if (Intent.ACTION_VIEW.equals(action) && uri != null) {
             mInterceptedUri = uri.toString();
             UriWrapper uriWrapper = new UriWrapper(uri);
-            if (mViewModel.shouldHandleUrl(uriWrapper)) {
-                mViewModel.handleUrl(uriWrapper);
-            } else if (shouldOpenEditorFromDeepLink(host)) {
-                handleOpenEditorFromDeepLink(uri);
-            } else if (isFromAppBanner(host)) {
-                handleAppBanner(host);
-            } else if (shouldViewPost(host)) {
-                handleViewPost(uri);
-            } else if (shouldShowPages(uri)) {
-                handleShowPages(uriWrapper);
-            } else {
-                // not handled
-                finish();
+            boolean urlHandledInViewModel = mViewModel.handleUrl(uriWrapper);
+            if (!urlHandledInViewModel) {
+                if (shouldOpenEditorFromDeepLink(host)) {
+                    handleOpenEditorFromDeepLink(uri);
+                } else if (isFromAppBanner(host)) {
+                    handleAppBanner(host);
+                } else if (shouldViewPost(host)) {
+                    handleViewPost(uri);
+                } else if (shouldShowPages(uri)) {
+                    handleShowPages(uriWrapper);
+                } else {
+                    // not handled
+                    finish();
+                }
             }
         } else {
             finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -45,7 +45,6 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
     private static final String DEEP_LINK_HOST_READ = "read";
     private static final String DEEP_LINK_HOST_VIEWPOST = "viewpost";
     private static final String HOST_WORDPRESS_COM = "wordpress.com";
-    private static final String STATS_PATH = "stats";
     private static final String PAGES_PATH = "pages";
 
     private String mInterceptedUri;

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -6,7 +6,6 @@ import android.os.Bundle;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.wordpress.android.R;

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -90,10 +90,10 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
                 handleAppBanner(host);
             } else if (shouldViewPost(host)) {
                 handleViewPost(uri);
-            } else if (shouldShowStats(uri)) {
-                handleShowStats(uri);
+            } else if (mViewModel.shouldShowStats(uriWrapper)) {
+                mViewModel.handleShowStats(uriWrapper);
             } else if (shouldShowPages(uri)) {
-                handleShowPages(uri);
+                handleShowPages(uriWrapper);
             } else {
                 // not handled
                 finish();
@@ -196,34 +196,15 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
         }
     }
 
-    private boolean shouldShowStats(@NonNull Uri uri) {
-        // Match: https://wordpress.com/stats/
-        return shouldShow(uri, STATS_PATH);
-    }
-
-    private void handleShowStats(@NonNull Uri uri) {
-        String targetHost = extractTargetHost(uri);
-        SiteModel site = extractSiteModelFromTargetHost(targetHost);
-        String host = mDeepLinkUriUtils.extractHostFromSite(site);
-        if (site != null && host != null && StringUtils.equals(host, targetHost)) {
-            ActivityLauncher.viewStatsInNewStack(getContext(), site);
-        } else {
-            // In other cases, launch stats with the current selected site.
-            ActivityLauncher.viewStatsInNewStack(getContext());
-        }
-        finish();
-    }
-
     private boolean shouldShowPages(@NonNull Uri uri) {
         // Match: https://wordpress.com/pages/
         return shouldShow(uri, PAGES_PATH);
     }
 
-    private void handleShowPages(@NonNull Uri uri) {
-        String targetHost = extractTargetHost(uri);
-        SiteModel site = extractSiteModelFromTargetHost(targetHost);
-        String host = mDeepLinkUriUtils.extractHostFromSite(site);
-        if (site != null && host != null && StringUtils.equals(host, targetHost)) {
+    private void handleShowPages(@NonNull UriWrapper uri) {
+        String targetHost = mDeepLinkUriUtils.extractTargetHost(uri);
+        SiteModel site = mDeepLinkUriUtils.hostToSite(targetHost);
+        if (site != null) {
             ActivityLauncher.viewPagesInNewStack(getContext(), site);
         } else {
             // In other cases, launch pages with the current selected site.
@@ -292,15 +273,6 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
     }
 
     // Helper Methods
-    private String extractTargetHost(@NonNull Uri uri) {
-        return uri.getLastPathSegment() == null ? "" : uri.getLastPathSegment();
-    }
-
-    private @Nullable SiteModel extractSiteModelFromTargetHost(String host) {
-        List<SiteModel> matchedSites = mSiteStore.getSitesByNameOrUrlMatching(host);
-        return matchedSites.isEmpty() ? null : matchedSites.get(0);
-    }
-
     private boolean shouldShow(@NonNull Uri uri, @NonNull String path) {
         return StringUtils.equals(uri.getHost(), HOST_WORDPRESS_COM)
                && (!uri.getPathSegments().isEmpty() && StringUtils.equals(uri.getPathSegments().get(0), path));

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -80,18 +80,14 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
         if (Intent.ACTION_VIEW.equals(action) && uri != null) {
             mInterceptedUri = uri.toString();
             UriWrapper uriWrapper = new UriWrapper(uri);
-            if (mViewModel.shouldHandleTrackingUrl(uriWrapper)) {
-                mViewModel.handleTrackingUrl(uriWrapper);
-            } else if (mViewModel.shouldOpenEditor(uriWrapper)) {
-                mViewModel.handleOpenEditor(uriWrapper);
+            if (mViewModel.shouldHandleUrl(uriWrapper)) {
+                mViewModel.handleUrl(uriWrapper);
             } else if (shouldOpenEditorFromDeepLink(host)) {
                 handleOpenEditorFromDeepLink(uri);
             } else if (isFromAppBanner(host)) {
                 handleAppBanner(host);
             } else if (shouldViewPost(host)) {
                 handleViewPost(uri);
-            } else if (mViewModel.shouldShowStats(uriWrapper)) {
-                mViewModel.handleShowStats(uriWrapper);
             } else if (shouldShowPages(uri)) {
                 handleShowPages(uriWrapper);
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
@@ -32,7 +32,7 @@ class DeepLinkingIntentReceiverViewModel
      * `public-api.wordpress.com/mbar`
      * and builds the navigation action based on them
      */
-    fun handleUrl(uriWrapper: UriWrapper) : Boolean {
+    fun handleUrl(uriWrapper: UriWrapper): Boolean {
         return if (shouldHandleUrl(uriWrapper)) {
             _navigateAction.value = Event(buildNavigateAction(uriWrapper))
             true

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
@@ -26,27 +26,32 @@ class DeepLinkingIntentReceiverViewModel
     val toast = editorLinkHandler.toast
 
     /**
-     * This viewmodel handles the following URLs
-     * `wordpress.com/post/...`
-     * `wordpress.com/stats/...`
-     * `public-api.wordpress.com/mbar/`
-     * In these cases this function returns true
-     */
-    fun shouldHandleUrl(uri: UriWrapper): Boolean {
-        return isTrackingUrl(uri) ||
-                editorLinkHandler.isEditorUrl(uri) ||
-                statsLinkHandler.isStatsUrl(uri)
-    }
-
-    /**
      * Handles the following URLs
      * `wordpress.com/post...`
      * `wordpress.com/stats...`
      * `public-api.wordpress.com/mbar`
      * and builds the navigation action based on them
      */
-    fun handleUrl(uriWrapper: UriWrapper) {
-        _navigateAction.value = Event(buildNavigateAction(uriWrapper))
+    fun handleUrl(uriWrapper: UriWrapper) : Boolean {
+        return if (shouldHandleUrl(uriWrapper)) {
+            _navigateAction.value = Event(buildNavigateAction(uriWrapper))
+            true
+        } else {
+            false
+        }
+    }
+
+    /**
+     * This viewmodel handles the following URLs
+     * `wordpress.com/post/...`
+     * `wordpress.com/stats/...`
+     * `public-api.wordpress.com/mbar/`
+     * In these cases this function returns true
+     */
+    private fun shouldHandleUrl(uri: UriWrapper): Boolean {
+        return isTrackingUrl(uri) ||
+                editorLinkHandler.isEditorUrl(uri) ||
+                statsLinkHandler.isStatsUrl(uri)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
@@ -3,12 +3,9 @@ package org.wordpress.android.ui
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenInBrowser
-import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.ShowSignInFlow
-import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.StartCreateSiteFlow
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -20,7 +17,7 @@ class DeepLinkingIntentReceiverViewModel
     @Named(UI_THREAD) private val uiDispatcher: CoroutineDispatcher,
     private val editorLinkHandler: EditorLinkHandler,
     private val statsLinkHandler: StatsLinkHandler,
-    private val accountStore: AccountStore,
+    private val startLinkHandler: StartLinkHandler,
     private val deepLinkUriUtils: DeepLinkUriUtils,
     private val serverTrackingHandler: ServerTrackingHandler
 ) : ScopedViewModel(uiDispatcher) {
@@ -29,101 +26,71 @@ class DeepLinkingIntentReceiverViewModel
     val toast = editorLinkHandler.toast
 
     /**
+     * This viewmodel handles the following URLs
+     * `wordpress.com/post/...`
+     * `wordpress.com/stats/...`
+     * `public-api.wordpress.com/mbar/`
+     * In these cases this function returns true
+     */
+    fun shouldHandleUrl(uri: UriWrapper): Boolean {
+        return isTrackingUrl(uri) ||
+                editorLinkHandler.isEditorUrl(uri) ||
+                statsLinkHandler.isStatsUrl(uri)
+
+    }
+
+    /**
+     * Handles the following URLs
+     * `wordpress.com/post...`
+     * `wordpress.com/stats...`
+     * `public-api.wordpress.com/mbar`
+     * and builds the navigation action based on them
+     */
+    fun handleUrl(uriWrapper: UriWrapper) {
+        _navigateAction.value = Event(buildNavigateAction(uriWrapper))
+    }
+
+    /**
      * Tracking URIs like `public-api.wordpress.com/mbar/...` come from emails and should be handled here
      */
-    fun shouldHandleTrackingUrl(uri: UriWrapper): Boolean {
+    private fun isTrackingUrl(uri: UriWrapper): Boolean {
         // https://public-api.wordpress.com/mbar/
         return uri.host == HOST_API_WORDPRESS_COM &&
                 uri.pathSegments.firstOrNull() == MOBILE_TRACKING_PATH
     }
 
-    /**
-     * URIs like `wordpress.com/post/...` with optional site name and post ID path parameters should be opened in editor
-     */
-    fun shouldOpenEditor(uri: UriWrapper) = shouldShow(uri, POST_PATH)
-
-    /**
-     * URIs like `https://wordpress.com/stats/day/$site` should redirect to the stats screen
-     */
-    fun shouldShowStats(uri: UriWrapper): Boolean {
-        // Match: https://wordpress.com/stats/
-        return shouldShow(uri, STATS_PATH)
+    private fun isWpLoginUrl(uri: UriWrapper): Boolean {
+        // https://wordpress.com/wp-login.php/
+        return uri.host == HOST_WORDPRESS_COM &&
+                uri.pathSegments.firstOrNull() == WP_LOGIN
     }
 
-    /**
-     * Recursively handles URIs that have a redirect_to query parameter set to:
-     * `wordpress.com/post`
-     * `wordpress.com/start`
-     * `wordpress.com/wp-login.php`
-     * The rest of URIs is redirected back to the browser
-     */
-    fun handleTrackingUrl(uri: UriWrapper) {
-        val navigateAction = buildNavigateAction(uri)
-        val event = if (navigateAction != null) {
-            // Make sure we don't miss server tracking on `mbar` URIs
-            if (shouldHandleTrackingUrl(uri)) {
-                serverTrackingHandler.request(uri)
-            }
-            Event(navigateAction)
-        } else {
-            // No need to request the URI with ServerTrackingHandler because the browser will take care of it
-            Event(redirectToBrowser(uri))
-        }
-        _navigateAction.value = event
-    }
-
-    private fun buildNavigateAction(uri: UriWrapper): NavigateAction? {
-        val redirectUri: UriWrapper? = getRedirectUri(uri)
-        return if (redirectUri != null && redirectUri.host == HOST_WORDPRESS_COM) {
-            when (redirectUri.pathSegments.firstOrNull()) {
-                POST_PATH -> editorLinkHandler.buildOpenEditorNavigateAction(redirectUri)
-                STATS_PATH -> statsLinkHandler.buildOpenStatsNavigateAction(redirectUri)
-                START_PATH -> if (accountStore.hasAccessToken()) {
-                    StartCreateSiteFlow
+    private fun buildNavigateAction(uri: UriWrapper, rootUri: UriWrapper = uri): NavigateAction {
+        val trackingUrl = isTrackingUrl(uri)
+        val navigateAction = when {
+            trackingUrl || isWpLoginUrl(uri) -> {
+                val redirectUri = getRedirectUri(uri)
+                if (redirectUri != null) {
+                    buildNavigateAction(redirectUri, rootUri)
                 } else {
-                    ShowSignInFlow
+                    null
                 }
-                WP_LOGIN -> {
-                    buildNavigateAction(redirectUri)
-                }
-                else -> null
             }
-        } else {
-            null
+            editorLinkHandler.isEditorUrl(uri) -> editorLinkHandler.buildOpenEditorNavigateAction(uri)
+            statsLinkHandler.isStatsUrl(uri) -> statsLinkHandler.buildOpenStatsNavigateAction(uri)
+            startLinkHandler.isStartUrl(uri) -> startLinkHandler.buildNavigateAction()
+            else -> null
+        }?.also {
+            // The new URL was build so we need to hit the original `mbar` tracking URL
+            if (trackingUrl) serverTrackingHandler.request(uri)
         }
-    }
-
-    private fun redirectToBrowser(uri: UriWrapper): NavigateAction {
-        return OpenInBrowser(uri.copy(REGULAR_TRACKING_PATH))
-    }
-
-    /**
-     * Opens post editor for provided uri. If uri contains a site and a postId
-     * (e.g. https://wordpress.com/post/example.com/1231/), opens the post for editing, if available.
-     * If the uri only contains a site (e.g. https://wordpress.com/post/example.com/ ), opens a new post
-     * editor for that site, if available.
-     * Else opens the new post editor for currently selected site.
-     */
-    fun handleOpenEditor(uri: UriWrapper) {
-        _navigateAction.value = Event(editorLinkHandler.buildOpenEditorNavigateAction(uri))
-    }
-
-
-    /**
-     * Opens stats screen for provided uri. If uri contains a stats period and site URL
-     * (e.g. https://wordpress.com/stats/day/example.com/)
-     * If the siteURL is not found for the current user, the link opens the stats screen for the current site
-     */
-    fun handleShowStats(uri: UriWrapper) {
-        _navigateAction.value = Event(statsLinkHandler.buildOpenStatsNavigateAction(uri))
+        return navigateAction ?: OpenInBrowser(
+                rootUri.copy(REGULAR_TRACKING_PATH)
+        )
     }
 
     private fun getRedirectUri(uri: UriWrapper): UriWrapper? {
         return deepLinkUriUtils.getUriFromQueryParameter(uri, REDIRECT_TO_PARAM)
-    }
-
-    private fun shouldShow(uri: UriWrapper, path: String): Boolean {
-        return uri.host == HOST_WORDPRESS_COM && uri.pathSegments.firstOrNull() == path
     }
 
     override fun onCleared() {
@@ -132,14 +99,11 @@ class DeepLinkingIntentReceiverViewModel
     }
 
     companion object {
-        private const val HOST_WORDPRESS_COM = "wordpress.com"
+        const val HOST_WORDPRESS_COM = "wordpress.com"
         private const val HOST_API_WORDPRESS_COM = "public-api.wordpress.com"
         private const val MOBILE_TRACKING_PATH = "mbar"
         private const val REGULAR_TRACKING_PATH = "bar"
         private const val REDIRECT_TO_PARAM = "redirect_to"
-        private const val POST_PATH = "post"
-        private const val STATS_PATH = "stats"
-        private const val START_PATH = "start"
         private const val WP_LOGIN = "wp-login.php"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
@@ -36,7 +36,6 @@ class DeepLinkingIntentReceiverViewModel
         return isTrackingUrl(uri) ||
                 editorLinkHandler.isEditorUrl(uri) ||
                 statsLinkHandler.isStatsUrl(uri)
-
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/EditorLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/EditorLinkHandler.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui
 
+import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import org.wordpress.android.R
@@ -11,6 +12,7 @@ import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenEditor
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenEditorForSite
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenEditorForPost
+import org.wordpress.android.ui.DeepLinkingIntentReceiverViewModel.Companion
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
@@ -34,6 +36,15 @@ class EditorLinkHandler
         val targetSite = pathSegments.getOrNull(1)?.toSite()
         val targetPost = pathSegments.getOrNull(2)?.toPost(targetSite)
         return openEditorForSiteAndPost(targetSite, targetPost)
+    }
+
+    /**
+     * Returns true if the URI should be handled by EditorLinkHandler.
+     * The handled links are `wordpress.com/post...1
+     */
+    fun isEditorUrl(uri: UriWrapper): Boolean {
+        return uri.host == DeepLinkingIntentReceiverViewModel.HOST_WORDPRESS_COM &&
+                uri.pathSegments.firstOrNull() == POST_PATH
     }
 
     /**
@@ -76,7 +87,7 @@ class EditorLinkHandler
         }
     }
 
-    private fun extractSiteModelFromTargetHost(host: String): SiteModel? {
-        return siteStore.getSitesByNameOrUrlMatching(host).firstOrNull()
+    companion object {
+        private const val POST_PATH = "post"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/EditorLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/EditorLinkHandler.kt
@@ -1,18 +1,15 @@
 package org.wordpress.android.ui
 
-import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenEditor
-import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenEditorForSite
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenEditorForPost
-import org.wordpress.android.ui.DeepLinkingIntentReceiverViewModel.Companion
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenEditorForSite
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
@@ -20,7 +17,6 @@ import javax.inject.Inject
 class EditorLinkHandler
 @Inject constructor(
     private val deepLinkUriUtils: DeepLinkUriUtils,
-    private val siteStore: SiteStore,
     private val postStore: PostStore
 ) {
     private val _toast = MutableLiveData<Event<Int>>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/EditorLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/EditorLinkHandler.kt
@@ -41,14 +41,7 @@ class EditorLinkHandler
      * to the host.
      */
     private fun String.toSite(): SiteModel? {
-        val site = extractSiteModelFromTargetHost(this)
-        val host = deepLinkUriUtils.extractHostFromSite(site)
-        // Check if a site is available with given targetHost
-        return if (site != null && host != null && host == this) {
-            site
-        } else {
-            null
-        }
+        return deepLinkUriUtils.hostToSite(this)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/StartLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/StartLinkHandler.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.ui
+
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.ShowSignInFlow
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.StartCreateSiteFlow
+import org.wordpress.android.util.UriWrapper
+import javax.inject.Inject
+
+class StartLinkHandler
+@Inject constructor(private val accountStore: AccountStore) {
+    /**
+     * Returns true if the URI looks like `wordpress.com/start`
+     */
+    fun isStartUrl(uri: UriWrapper): Boolean {
+        return uri.host == DeepLinkingIntentReceiverViewModel.HOST_WORDPRESS_COM &&
+                uri.pathSegments.firstOrNull() == START_PATH
+    }
+
+    /**
+     * Returns StartCreateSiteFlow is user logged in and ShowSignInFlow if user is logged out
+     */
+    fun buildNavigateAction(): NavigateAction {
+        return if (accountStore.hasAccessToken()) {
+            StartCreateSiteFlow
+        } else {
+            ShowSignInFlow
+        }
+    }
+
+    companion object {
+        private const val START_PATH = "start"
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/StartLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/StartLinkHandler.kt
@@ -32,4 +32,3 @@ class StartLinkHandler
         private const val START_PATH = "start"
     }
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/StatsLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/StatsLinkHandler.kt
@@ -6,7 +6,6 @@ import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStats
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForSite
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForSiteAndTimeframe
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForTimeframe
-import org.wordpress.android.ui.EditorLinkHandler.Companion
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject

--- a/WordPress/src/main/java/org/wordpress/android/ui/StatsLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/StatsLinkHandler.kt
@@ -5,6 +5,8 @@ import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStats
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForSite
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForSiteAndTimeframe
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForTimeframe
+import org.wordpress.android.ui.EditorLinkHandler.Companion
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
@@ -30,11 +32,23 @@ class StatsLinkHandler
             site != null -> {
                 OpenStatsForSite(site)
             }
+            statsTimeframe != null -> {
+                OpenStatsForTimeframe(statsTimeframe)
+            }
             else -> {
                 // In other cases, launch stats with the current selected site.
                 OpenStats
             }
         }
+    }
+
+    /**
+     * Returns true if the URI should be handled by StatsLinkHandler.
+     * The handled links are `https://wordpress.com/stats/day/$site`
+     */
+    fun isStatsUrl(uri: UriWrapper): Boolean {
+        return uri.host == DeepLinkingIntentReceiverViewModel.HOST_WORDPRESS_COM &&
+                uri.pathSegments.firstOrNull() == STATS_PATH
     }
 
     /**
@@ -46,7 +60,7 @@ class StatsLinkHandler
     }
 
     private fun String.toStatsTimeframe(): StatsTimeframe? {
-        return when(this) {
+        return when (this) {
             "day" -> StatsTimeframe.DAY
             "week" -> StatsTimeframe.WEEK
             "month" -> StatsTimeframe.MONTH
@@ -54,5 +68,8 @@ class StatsLinkHandler
             "insights" -> StatsTimeframe.INSIGHTS
             else -> null
         }
+    }
+    companion object {
+        private const val STATS_PATH = "stats"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/StatsLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/StatsLinkHandler.kt
@@ -1,0 +1,58 @@
+package org.wordpress.android.ui
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStats
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForSite
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.OpenStatsForSiteAndTimeframe
+import org.wordpress.android.ui.stats.StatsTimeframe
+import org.wordpress.android.util.UriWrapper
+import javax.inject.Inject
+
+class StatsLinkHandler
+@Inject constructor(
+    private val deepLinkUriUtils: DeepLinkUriUtils
+) {
+    /**
+     * Builds navigate action from URL like:
+     * https://wordpress.com/stats/$timeframe/$site
+     * where timeframe and site are optional
+     */
+    fun buildOpenStatsNavigateAction(uri: UriWrapper): NavigateAction {
+        val pathSegments = uri.pathSegments
+        val length = pathSegments.size
+        val site = pathSegments.getOrNull(length - 1)?.toSite()
+        val statsTimeframe = pathSegments.getOrNull(length - 2)?.toStatsTimeframe()
+        return when {
+            site != null && statsTimeframe != null -> {
+                OpenStatsForSiteAndTimeframe(site, statsTimeframe)
+            }
+            site != null -> {
+                OpenStatsForSite(site)
+            }
+            else -> {
+                // In other cases, launch stats with the current selected site.
+                OpenStats
+            }
+        }
+    }
+
+    /**
+     * Converts HOST name of a site to SiteModel. It finds the Site in the current local sites and matches the name
+     * to the host.
+     */
+    private fun String.toSite(): SiteModel? {
+        return deepLinkUriUtils.hostToSite(this)
+    }
+
+    private fun String.toStatsTimeframe(): StatsTimeframe? {
+        return when(this) {
+            "day" -> StatsTimeframe.DAY
+            "week" -> StatsTimeframe.WEEK
+            "month" -> StatsTimeframe.MONTH
+            "year" -> StatsTimeframe.YEAR
+            "insights" -> StatsTimeframe.INSIGHTS
+            else -> null
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -106,6 +106,7 @@ import org.wordpress.android.ui.reader.ReaderFragment;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.ui.reader.tracker.ReaderTracker;
+import org.wordpress.android.ui.stats.StatsTimeframe;
 import org.wordpress.android.ui.stories.intro.StoriesIntroDialogFragment;
 import org.wordpress.android.ui.uploads.UploadActionUseCase;
 import org.wordpress.android.ui.uploads.UploadUtils;
@@ -177,6 +178,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     public static final String ARG_EDITOR = "show_editor";
     public static final String ARG_SHOW_ZENDESK_NOTIFICATIONS = "show_zendesk_notifications";
     public static final String ARG_STATS = "show_stats";
+    public static final String ARG_STATS_TIMEFRAME = "stats_timeframe";
     public static final String ARG_PAGES = "show_pages";
 
     // Track the first `onResume` event for the current session so we can use it for Analytics tracking
@@ -651,7 +653,12 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     if (!mSelectedSiteRepository.hasSelectedSite()) {
                         initSelectedSite();
                     }
-                    ActivityLauncher.viewBlogStats(this, mSelectedSiteRepository.getSelectedSite());
+                    if (intent.hasExtra(ARG_STATS_TIMEFRAME)) {
+                        ActivityLauncher.viewBlogStatsForTimeframe(this, mSelectedSiteRepository.getSelectedSite(),
+                                (StatsTimeframe) intent.getSerializableExtra(ARG_STATS_TIMEFRAME));
+                    } else {
+                        ActivityLauncher.viewBlogStats(this, mSelectedSiteRepository.getSelectedSite());
+                    }
                     break;
                 case ARG_PAGES:
                     if (!mSelectedSiteRepository.hasSelectedSite()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -61,6 +61,11 @@ class StatsActivity : LocaleAwareActivity() {
             return buildIntent(context, site.id)
         }
 
+        @JvmStatic
+        fun buildIntent(context: Context, site: SiteModel, statsTimeframe: StatsTimeframe): Intent {
+            return buildIntent(context, site.id, statsTimeframe)
+        }
+
         private fun buildIntent(
             context: Context,
             localSiteId: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -51,6 +51,11 @@ class StatsActivity : LocaleAwareActivity() {
             context.startActivity(buildIntent(context, site))
         }
 
+        @JvmStatic
+        fun start(context: Context, site: SiteModel, statsTimeframe: StatsTimeframe) {
+            context.startActivity(buildIntent(context, site, statsTimeframe))
+        }
+
         fun start(context: Context, localSiteId: Int, statsTimeframe: StatsTimeframe, period: String?) {
             val intent = buildIntent(context, localSiteId, statsTimeframe, period)
             context.startActivity(intent)

--- a/WordPress/src/main/java/org/wordpress/android/util/UriWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/UriWrapper.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 data class UriWrapper(val uri: Uri) {
     constructor(uriString: String) : this(Uri.parse(uriString))
 
+    val lastPathSegment: String? = uri.lastPathSegment
     val pathSegments: List<String> = uri.pathSegments
     val host: String? = uri.host
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/DeepLinkUriUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/DeepLinkUriUtilsTest.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.ui
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.util.UriUtilsWrapper
+
+@RunWith(MockitoJUnitRunner::class)
+class DeepLinkUriUtilsTest {
+    @Mock lateinit var siteStore: SiteStore
+    @Mock lateinit var uriUtilsWrapper: UriUtilsWrapper
+    private lateinit var deepLinkUriUtils: DeepLinkUriUtils
+    private val host = "example.com"
+    lateinit var site: SiteModel
+
+    @Before
+    fun setUp() {
+        deepLinkUriUtils = DeepLinkUriUtils(siteStore, uriUtilsWrapper)
+        site = SiteModel()
+        val buildUri = buildUri("example.com")
+        whenever(uriUtilsWrapper.parse(host)).thenReturn(buildUri)
+    }
+
+    @Test
+    fun `converts host to site when site exists and host matches URL`() {
+        site.url = host
+        whenever(siteStore.getSitesByNameOrUrlMatching(host)).thenReturn(listOf(site))
+
+        val hostToSite = deepLinkUriUtils.hostToSite(host)
+
+        assertThat(hostToSite).isEqualTo(site)
+    }
+
+    @Test
+    fun `returns null when site exists but host doesn't match URL`() {
+        site.url = host
+        val differentUrl = "different_url.com"
+        whenever(siteStore.getSitesByNameOrUrlMatching(differentUrl)).thenReturn(listOf(site))
+
+        val hostToSite = deepLinkUriUtils.hostToSite(differentUrl)
+
+        assertThat(hostToSite).isNull()
+    }
+
+    @Test
+    fun `returns null when site doesnt exist`() {
+        whenever(siteStore.getSitesByNameOrUrlMatching(host)).thenReturn(listOf())
+
+        val hostToSite = deepLinkUriUtils.hostToSite(host)
+
+        assertThat(hostToSite).isNull()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModelTest.kt
@@ -38,23 +38,13 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         )
         whenever(startLinkHandler.isStartUrl(startUrl)).thenReturn(true)
         whenever(editorLinkHandler.isEditorUrl(postUrl)).thenReturn(true)
-        whenever(statsLinkHandler.isStatsUrl(statsUrl)).thenReturn(true)
-    }
-
-    @Test
-    fun `should handle email mbar mobile URL`() {
-        val uri = buildUri("public-api.wordpress.com", "mbar")
-
-        val shouldHandleUri = viewModel.shouldHandleUrl(uri)
-
-        assertThat(shouldHandleUri).isTrue()
     }
 
     @Test
     fun `should not handle WPcom URL`() {
         val uri = buildUri("wordpress.com", "bar")
 
-        val shouldHandleUri = viewModel.shouldHandleUrl(uri)
+        val shouldHandleUri = viewModel.handleUrl(uri)
 
         assertThat(shouldHandleUri).isFalse()
     }
@@ -63,7 +53,7 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
     fun `should not handle bar non-mobile URL`() {
         val uri = buildUri("public-api.wordpress.com", "bar")
 
-        val shouldHandleUri = viewModel.shouldHandleUrl(uri)
+        val shouldHandleUri = viewModel.handleUrl(uri)
 
         assertThat(shouldHandleUri).isFalse()
     }
@@ -78,8 +68,9 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         val barUri = buildUri("public-api.wordpress.com", "bar")
         whenever(uri.copy("bar")).thenReturn(barUri)
 
-        viewModel.handleUrl(uri)
+        val urlHandled = viewModel.handleUrl(uri)
 
+        assertThat(urlHandled).isTrue()
         assertThat(navigateAction).isEqualTo(NavigateAction.OpenInBrowser(barUri))
     }
 
@@ -96,8 +87,9 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
             navigateAction = it?.getContentIfNotHandled()
         }
 
-        viewModel.handleUrl(uri)
+        val urlHandled = viewModel.handleUrl(uri)
 
+        assertThat(urlHandled).isTrue()
         assertThat(navigateAction).isEqualTo(StartCreateSiteFlow)
         verify(serverTrackingHandler).request(uri)
     }
@@ -114,8 +106,9 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         val barUri = buildUri("public-api.wordpress.com", "bar")
         whenever(uri.copy("bar")).thenReturn(barUri)
 
-        viewModel.handleUrl(uri)
+        val urlHandled = viewModel.handleUrl(uri)
 
+        assertThat(urlHandled).isTrue()
         assertThat(navigateAction).isEqualTo(NavigateAction.OpenInBrowser(barUri))
     }
 
@@ -130,31 +123,18 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
             navigateAction = it?.getContentIfNotHandled()
         }
 
-        viewModel.handleUrl(uri)
+        val urlHandled = viewModel.handleUrl(uri)
 
+        assertThat(urlHandled).isTrue()
         assertThat(navigateAction).isEqualTo(expectedAction)
         verify(serverTrackingHandler).request(uri)
-    }
-
-    @Test
-    fun `should handle post url`() {
-        val shouldHandleUri = viewModel.shouldHandleUrl(postUrl)
-
-        assertThat(shouldHandleUri).isTrue()
-    }
-
-    @Test
-    fun `should handle stats url`() {
-        val shouldHandleUri = viewModel.shouldHandleUrl(statsUrl)
-
-        assertThat(shouldHandleUri).isTrue()
     }
 
     @Test
     fun `does not handle pages url`() {
         val uri = buildUri("wordpress.com", "pages")
 
-        val shouldHandleUri = viewModel.shouldHandleUrl(uri)
+        val shouldHandleUri = viewModel.handleUrl(uri)
 
         assertThat(shouldHandleUri).isFalse()
     }
@@ -163,7 +143,7 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
     fun `does not handle app link to posts`() {
         val uri = buildUri("pages", "")
 
-        val shouldHandleUri = viewModel.shouldHandleUrl(uri)
+        val shouldHandleUri = viewModel.handleUrl(uri)
 
         assertThat(shouldHandleUri).isFalse()
     }
@@ -181,8 +161,9 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
             navigateAction = it?.getContentIfNotHandled()
         }
 
-        viewModel.handleUrl(uri)
+        val urlHandled = viewModel.handleUrl(uri)
 
+        assertThat(urlHandled).isTrue()
         assertThat(navigateAction).isEqualTo(expected)
     }
 
@@ -199,8 +180,9 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
             navigateAction = it?.getContentIfNotHandled()
         }
 
-        viewModel.handleUrl(uri)
+        val urlHandled = viewModel.handleUrl(uri)
 
+        assertThat(urlHandled).isTrue()
         assertThat(navigateAction).isEqualTo(expected)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/EditorLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/EditorLinkHandlerTest.kt
@@ -34,6 +34,33 @@ class EditorLinkHandlerTest : BaseUnitTest() {
     }
 
     @Test
+    fun `handles post URI is true`() {
+        val postUri = buildUri("wordpress.com", "post")
+
+        val isEditorUri = editorLinkHandler.isEditorUrl(postUri)
+
+        assertThat(isEditorUri).isTrue()
+    }
+
+    @Test
+    fun `does not handle post URI with different host`() {
+        val postUri = buildUri("wordpress.org", "post")
+
+        val isEditorUri = editorLinkHandler.isEditorUrl(postUri)
+
+        assertThat(isEditorUri).isFalse()
+    }
+
+    @Test
+    fun `does not handle URI with different path`() {
+        val postUri = buildUri("wordpress.com", "stats")
+
+        val isEditorUri = editorLinkHandler.isEditorUrl(postUri)
+
+        assertThat(isEditorUri).isFalse()
+    }
+
+    @Test
     fun `opens editor when site not found`() {
         val uri = buildUri(path1 = "post", path2 = siteUrl)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/EditorLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/EditorLinkHandlerTest.kt
@@ -35,9 +35,7 @@ class EditorLinkHandlerTest : BaseUnitTest() {
 
     @Test
     fun `opens editor when site not found`() {
-        val siteUrl = "site123"
         val uri = buildUri(path1 = "post", path2 = siteUrl)
-        whenever(siteStore.getSitesByNameOrUrlMatching(siteUrl)).thenReturn(listOf())
 
         val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
 
@@ -47,8 +45,7 @@ class EditorLinkHandlerTest : BaseUnitTest() {
     @Test
     fun `opens editor for a site site when post missing in URL`() {
         val uri = buildUri(path1 = "post", path2 = siteUrl)
-        whenever(deepLinkUriUtils.extractHostFromSite(site)).thenReturn(siteUrl)
-        whenever(siteStore.getSitesByNameOrUrlMatching(siteUrl)).thenReturn(listOf(site))
+        whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
 
         val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
 
@@ -58,8 +55,7 @@ class EditorLinkHandlerTest : BaseUnitTest() {
     @Test
     fun `opens editor for a post when both site and post exist`() {
         val uri = buildUri(path1 = "post", path2 = siteUrl, path3 = remotePostId.toString())
-        whenever(deepLinkUriUtils.extractHostFromSite(site)).thenReturn(siteUrl)
-        whenever(siteStore.getSitesByNameOrUrlMatching(siteUrl)).thenReturn(listOf(site))
+        whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
         whenever(postStore.getPostByRemotePostId(remotePostId, site)).thenReturn(post)
 
         val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
@@ -70,8 +66,7 @@ class EditorLinkHandlerTest : BaseUnitTest() {
     @Test
     fun `opens editor for a site site when post not found`() {
         val uri = buildUri(path1 = "post", path2 = siteUrl, path3 = remotePostId.toString())
-        whenever(deepLinkUriUtils.extractHostFromSite(site)).thenReturn(siteUrl)
-        whenever(siteStore.getSitesByNameOrUrlMatching(siteUrl)).thenReturn(listOf(site))
+        whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
         whenever(postStore.getPostByRemotePostId(remotePostId, site)).thenReturn(null)
 
         val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)

--- a/WordPress/src/test/java/org/wordpress/android/ui/EditorLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/EditorLinkHandlerTest.kt
@@ -9,12 +9,10 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction
 
 class EditorLinkHandlerTest : BaseUnitTest() {
     @Mock lateinit var deepLinkUriUtils: DeepLinkUriUtils
-    @Mock lateinit var siteStore: SiteStore
     @Mock lateinit var postStore: PostStore
     private lateinit var editorLinkHandler: EditorLinkHandler
     private lateinit var site: SiteModel
@@ -25,7 +23,7 @@ class EditorLinkHandlerTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        editorLinkHandler = EditorLinkHandler(deepLinkUriUtils, siteStore, postStore)
+        editorLinkHandler = EditorLinkHandler(deepLinkUriUtils, postStore)
         site = SiteModel()
         site.url = siteUrl
         post = PostModel()

--- a/WordPress/src/test/java/org/wordpress/android/ui/StartLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/StartLinkHandlerTest.kt
@@ -1,0 +1,68 @@
+package org.wordpress.android.ui
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.ShowSignInFlow
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction.StartCreateSiteFlow
+
+@RunWith(MockitoJUnitRunner::class)
+class StartLinkHandlerTest {
+    @Mock lateinit var accountStore: AccountStore
+    private lateinit var startLinkHandler: StartLinkHandler
+
+    @Before
+    fun setUp() {
+        startLinkHandler = StartLinkHandler(accountStore)
+    }
+
+    @Test
+    fun `handles start URI is true`() {
+        val startUri = buildUri("wordpress.com", "start")
+
+        val isStartUri = startLinkHandler.isStartUrl(startUri)
+
+        assertThat(isStartUri).isTrue()
+    }
+
+    @Test
+    fun `does not handle start URI with different host`() {
+        val startUri = buildUri("wordpress.org", "start")
+
+        val isStartUri = startLinkHandler.isStartUrl(startUri)
+
+        assertThat(isStartUri).isFalse()
+    }
+
+    @Test
+    fun `does not handle URI with different path`() {
+        val startUri = buildUri("wordpress.com", "stop")
+
+        val isStartUri = startLinkHandler.isStartUrl(startUri)
+
+        assertThat(isStartUri).isFalse()
+    }
+
+    @Test
+    fun `returns site creation flow action when user logged in`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+
+        val navigateAction = startLinkHandler.buildNavigateAction()
+
+        assertThat(navigateAction).isEqualTo(StartCreateSiteFlow)
+    }
+
+    @Test
+    fun `returns sign in action when user not logged in`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+
+        val navigateAction = startLinkHandler.buildNavigateAction()
+
+        assertThat(navigateAction).isEqualTo(ShowSignInFlow)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/StatsLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/StatsLinkHandlerTest.kt
@@ -1,0 +1,84 @@
+package org.wordpress.android.ui
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.stats.StatsTimeframe.DAY
+import org.wordpress.android.ui.stats.StatsTimeframe.INSIGHTS
+import org.wordpress.android.ui.stats.StatsTimeframe.MONTH
+import org.wordpress.android.ui.stats.StatsTimeframe.WEEK
+import org.wordpress.android.ui.stats.StatsTimeframe.YEAR
+
+@RunWith(MockitoJUnitRunner::class)
+class StatsLinkHandlerTest {
+    @Mock lateinit var deepLinkUriUtils: DeepLinkUriUtils
+    @Mock lateinit var site: SiteModel
+    private lateinit var statsLinkHandler: StatsLinkHandler
+
+    @Before
+    fun setUp() {
+        statsLinkHandler = StatsLinkHandler(deepLinkUriUtils)
+    }
+
+    @Test
+    fun `opens stats screen from empty URL`() {
+        val uri = buildUri(path1 = "stats")
+
+        val buildOpenStatsNavigateAction = statsLinkHandler.buildOpenStatsNavigateAction(uri)
+
+        assertThat(buildOpenStatsNavigateAction).isEqualTo(NavigateAction.OpenStats)
+    }
+
+    @Test
+    fun `opens stats screen for a site when URL ends with site URL`() {
+        val siteUrl = "example.com"
+        val uri = buildUri(path1 = "stats", path2 = siteUrl)
+        whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
+
+        val buildOpenStatsNavigateAction = statsLinkHandler.buildOpenStatsNavigateAction(uri)
+
+        assertThat(buildOpenStatsNavigateAction).isEqualTo(NavigateAction.OpenStatsForSite(site))
+    }
+
+    @Test
+    fun `opens stats screen for a stats timeframe and a site when both present in URL`() {
+        val siteUrl = "example.com"
+        val timeframes = mapOf(
+                "day" to DAY,
+                "week" to WEEK,
+                "month" to MONTH,
+                "year" to YEAR,
+                "insights" to INSIGHTS
+        )
+        timeframes.forEach { (key, timeframe) ->
+            val uri = buildUri(path1 = "stats", path2 = key, path3 = siteUrl)
+            whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
+
+            val buildOpenStatsNavigateAction = statsLinkHandler.buildOpenStatsNavigateAction(uri)
+
+            assertThat(buildOpenStatsNavigateAction).isEqualTo(
+                    NavigateAction.OpenStatsForSiteAndTimeframe(
+                            site,
+                            timeframe
+                    )
+            )
+        }
+    }
+
+    @Test
+    fun `opens stats screen for a site when timeframe not valid`() {
+        val siteUrl = "example.com"
+        val uri = buildUri(path1 = "stats", path2 = "invalid", path3 = siteUrl)
+        whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
+
+        val buildOpenStatsNavigateAction = statsLinkHandler.buildOpenStatsNavigateAction(uri)
+
+        assertThat(buildOpenStatsNavigateAction).isEqualTo(NavigateAction.OpenStatsForSite(site))
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/StatsLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/StatsLinkHandlerTest.kt
@@ -27,6 +27,33 @@ class StatsLinkHandlerTest {
     }
 
     @Test
+    fun `handles stats URI is true`() {
+        val statsUri = buildUri("wordpress.com", "stats")
+
+        val isStatsUri = statsLinkHandler.isStatsUrl(statsUri)
+
+        assertThat(isStatsUri).isTrue()
+    }
+
+    @Test
+    fun `does not handle stats URI with different host`() {
+        val statsUri = buildUri("wordpress.org", "stats")
+
+        val isStatsUri = statsLinkHandler.isStatsUrl(statsUri)
+
+        assertThat(isStatsUri).isFalse()
+    }
+
+    @Test
+    fun `does not handle URI with different path`() {
+        val statsUri = buildUri("wordpress.com", "post")
+
+        val isStatsUri = statsLinkHandler.isStatsUrl(statsUri)
+
+        assertThat(isStatsUri).isFalse()
+    }
+
+    @Test
     fun `opens stats screen from empty URL`() {
         val uri = buildUri(path1 = "stats")
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/UriTestHelper.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/UriTestHelper.kt
@@ -4,11 +4,13 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.wordpress.android.util.UriWrapper
 
-fun buildUri(host: String? = null, path1: String, path2: String? = null, path3: String? = null): UriWrapper {
+fun buildUri(host: String? = null, path1: String? = null, path2: String? = null, path3: String? = null): UriWrapper {
     val uri = mock<UriWrapper>()
     if (host != null) {
         whenever(uri.host).thenReturn(host)
     }
-    whenever(uri.pathSegments).thenReturn(listOfNotNull(path1, path2, path3))
+    if (path1 != null || path2 != null || path3 != null) {
+        whenever(uri.pathSegments).thenReturn(listOfNotNull(path1, path2, path3))
+    }
     return uri
 }


### PR DESCRIPTION
Fixes #14449 

This PR adds handling of email links like `public-api.wordpress.com/mbar/...redirect_to=wordpress.com/stats/day/example.com`. As addition I've pulled the logic for simple stats links like `wordpress.com/stats/week/example.com` to be handled by the same `StatsLinkHandler`. One more improvement is that the deeplinks now handle the stats timeframe as well as the site so if there is a link to `day`, it opens the day tab. Let me know if you need links to test this feature out. 

To test:
- Make sure you're logged in with an account that has the `your_site.com` site 
- Open a deeplink like `public-api.wordpress.com/mbar/...redirect_to=wordpress.com/stats/day/your_site.com`
- Notice it's opened in the app
- Notice it opens the Stats screen with the "Day" tab selected for `your_site.com`
- Test this with replacing `day` in the link with `week`, `year`, `insights` for all the screens

To test:
- Make sure you're not logged in with an account that has the `another_site.com` site 
- Open a deeplink like `public-api.wordpress.com/mbar/...redirect_to=wordpress.com/stats/day/another_site.com`
- Notice it's opened in the app
- Notice it opens the Stats screen for the currently selected site

To test:
- Make sure you're logged in with an account that has the `your_site.com` site 
- Open a deeplink like `wordpress.com/stats/day/your_site.com`
- Notice it's opened in the app
- Notice it opens the Stats screen with the "Day" tab selected for `your_site.com`

To test:
- Open a deeplink like `public-api.wordpress.com/bar/...redirect_to=wordpress.com/stats/day/your_site.com`
- Notice it's opened in the browser

## Regression Notes
1. Potential unintended areas of impact
- none 🤞 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
