### PR TITLE
Jetpack App (Basics) - Add About App icon

### DIFF
--- a/WordPress/src/jetpack/res/drawable/ic_about_app_white_24dp.xml
+++ b/WordPress/src/jetpack/res/drawable/ic_about_app_white_24dp.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M12.0001,2C17.523,2 22,6.4771 22,12C22,17.5229 17.523,22 12.0001,22C6.4772,22 2,17.5229 2,12C2,6.4771 6.4772,2 12.0001,2ZM17.495,10.327L12.5071,10.327L12.5071,20.0193L17.495,10.327ZM11.4925,3.9817L6.5046,13.6741L11.4925,13.6741L11.4925,3.9817Z"
+        android:strokeWidth="1"
+        android:fillColor="@color/white"
+        android:fillType="evenOdd"
+        android:strokeColor="@color/transparent"/>
+</vector>

--- a/WordPress/src/main/res/drawable/ic_about_app_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_about_app_white_24dp.xml
@@ -1,0 +1,3 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_my_sites_white_24dp"/>
+</layer-list>

--- a/WordPress/src/main/res/layout/about_activity.xml
+++ b/WordPress/src/main/res/layout/about_activity.xml
@@ -49,7 +49,7 @@
                     android:layout_height="50dp"
                     android:layout_marginTop="@dimen/margin_medium"
                     android:importantForAccessibility="no"
-                    android:src="@drawable/ic_my_sites_white_24dp" />
+                    android:src="@drawable/ic_about_app_white_24dp" />
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/about_first_line"


### PR DESCRIPTION
Fixes #14464 

Adds the Jetpack icon to the About me view.

Note: The WordPress icon has not changed.

Theme | WordPress | Jetpack
-----|-----|-----
Light | <img width="250" height="500" alt="wordpress_light" src="https://user-images.githubusercontent.com/506707/114939615-b5b1ef00-9e0e-11eb-9b1a-7d024cae618c.png"> | <img width="250" height="500" alt="jetpack_light" src="https://user-images.githubusercontent.com/506707/114939626-b9457600-9e0e-11eb-82de-f27c90ccc65f.png">
Dark | <img width="250" height="500" alt="wordpress_dark" src="https://user-images.githubusercontent.com/506707/114939619-b6e31c00-9e0e-11eb-9c4d-8d2ac00ee964.png"> | <img width="250" height="500" alt="jetpack_dark" src="https://user-images.githubusercontent.com/506707/114939629-ba76a300-9e0e-11eb-83ff-7fe7dfa79a85.png">


**To test:**
- Build, launch and smoke test a build flavor for the WordPress app (e.g. wordpressWasabiDebug).
- Navigate to Me -> App Settings -> About WordPress for Android
- Note the Wordpress icon is shown
---------------------------------------
- Build, launch and smoke test a build flavor for the Jetpack app (e.g. jetpackWasabiDebug).
- Navigate to Me -> App Settings -> About Jetpack for Android
- Note the Jetpack icon is shown

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tested for presence of Jetpack and WordPress icon

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
