### PR TITLE
Update MySiteImprovementsFeatureConfig so it can handle null auth tokens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/MySiteImprovementsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/MySiteImprovementsFeatureConfig.kt
@@ -30,7 +30,7 @@ class MySiteImprovementsFeatureConfig
 
     // Temporary solution until the Firebase bug gets fixed
     override fun isEnabled(): Boolean {
-        return initEnabledValue(accountStore.accessToken.hashCode(), accountStore.hasAccessToken())
+        return initEnabledValue(accountStore.accessToken.orEmpty().hashCode(), accountStore.hasAccessToken())
     }
 
     private fun initEnabledValue(


### PR DESCRIPTION
This PR fixes a crash caused by the authentication code being `null` when the `MySiteImprovementsFeatureConfig` expected it to be empty. This was introduced by #14452 and was first detected when #14472 was merged to `develop` and the optional connected tests started failing. It only happens when we login, logout and try to login again while the app hasn't been finished.

To reproduce the crash:

1. Clear app data.
1. Login using any method.
1. On the My Site screen, tap the Me avatar on the top right corner of the screen.
1. On the Me screen, logout.
1. Press back until you exited the app.
1. Open the app again.
1. Notice the crash.

To test:

Run the optional connected tests and make sure they all pass successfully.

1. Clear app data.
1. Login using any method.
1. On the My Site screen, tap the Me avatar on the top right corner of the screen.
1. On the Me screen, logout.
1. Press back until you exited the app.
1. Open the app again.
1. Notice it doesn't crash.

## Regression Notes
1. Potential unintended areas of impact
Login and Dynamic Cards 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing connected tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
