### PR TITLE
Jetpack App (Basics): Update Toolbar Title Typography

### DIFF
--- a/WordPress/src/jetpack/res/values/styles_toolbar.xml
+++ b/WordPress/src/jetpack/res/values/styles_toolbar.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6">
+        <item name="fontFamily">san-serif</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.App.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline4">
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="fontFamily">san-serif</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.App.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="fontFamily">san-serif</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+</resources>
+

--- a/WordPress/src/jetpack/res/values/styles_toolbar.xml
+++ b/WordPress/src/jetpack/res/values/styles_toolbar.xml
@@ -2,21 +2,15 @@
 <resources>
 
     <!-- TextAppearance -->
-    <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6">
-        <item name="fontFamily">san-serif</item>
-        <item name="android:textStyle">bold</item>
-    </style>
+    <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6"/>
 
     <style name="TextAppearance.App.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline4">
         <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="fontFamily">san-serif</item>
         <item name="android:textStyle">bold</item>
     </style>
 
     <style name="TextAppearance.App.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="fontFamily">san-serif</item>
-        <item name="android:textStyle">bold</item>
     </style>
 
 </resources>

--- a/WordPress/src/jetpack/res/values/styles_toolbar.xml
+++ b/WordPress/src/jetpack/res/values/styles_toolbar.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- Login -->
-    <style name="Widget.LoginFlow.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
-        <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
-        <item name="android:theme">@style/ThemeOverlay.LoginFlow.Toolbar</item>
-    </style>
-
     <!-- TextAppearance -->
     <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="fontFamily">san-serif</item>

--- a/WordPress/src/jetpack/res/values/styles_toolbar.xml
+++ b/WordPress/src/jetpack/res/values/styles_toolbar.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- Login -->
     <style name="Widget.LoginFlow.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
         <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
         <item name="android:theme">@style/ThemeOverlay.LoginFlow.Toolbar</item>
     </style>
 
+    <!-- TextAppearance -->
     <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="fontFamily">san-serif</item>
         <item name="android:textStyle">bold</item>

--- a/WordPress/src/jetpack/res/values/styles_toolbar.xml
+++ b/WordPress/src/jetpack/res/values/styles_toolbar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android">
+<resources>
 
     <style name="Widget.LoginFlow.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
         <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
@@ -24,4 +24,3 @@
     </style>
 
 </resources>
-

--- a/WordPress/src/jetpack/res/values/styles_toolbar.xml
+++ b/WordPress/src/jetpack/res/values/styles_toolbar.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <style name="Widget.LoginFlow.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
+        <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
+        <item name="android:theme">@style/ThemeOverlay.LoginFlow.Toolbar</item>
+    </style>
+
     <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="fontFamily">san-serif</item>
         <item name="android:textStyle">bold</item>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -138,11 +138,6 @@
         <item name="android:navigationBarColor">@android:color/black</item>
     </style>
 
-    <style name="WordPress.ZenDesk.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
-        <item name="titleTextColor">?attr/colorOnSurface</item>
-        <item name="colorControlNormal">?attr/colorOnSurface</item>
-    </style>
-
     <style name="WordPress.SnackbarButton" parent="Widget.MaterialComponents.Button.TextButton.Snackbar">
         <item name="android:textColor">?attr/colorSecondaryVariant</item>
     </style>

--- a/WordPress/src/main/res/values-night/styles_toolbar.xml
+++ b/WordPress/src/main/res/values-night/styles_toolbar.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- Zendesk -->
     <style name="WordPress.ZenDesk.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
         <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
         <item name="titleTextColor">?attr/colorOnSurface</item>

--- a/WordPress/src/main/res/values-night/styles_toolbar.xml
+++ b/WordPress/src/main/res/values-night/styles_toolbar.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <style name="WordPress.ZenDesk.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
+        <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
         <item name="titleTextColor">?attr/colorOnSurface</item>
         <item name="colorControlNormal">?attr/colorOnSurface</item>
     </style>

--- a/WordPress/src/main/res/values-night/styles_toolbar.xml
+++ b/WordPress/src/main/res/values-night/styles_toolbar.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="WordPress.ZenDesk.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
+        <item name="titleTextColor">?attr/colorOnSurface</item>
+        <item name="colorControlNormal">?attr/colorOnSurface</item>
+    </style>
+
+</resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -334,7 +334,7 @@
         <item name="titleTextColor">?attr/colorOnSurface</item>
         <item name="android:background">@null</item>
         <item name="popupTheme">@style/ThemeOverlay.AppCompat.DayNight</item>
-        <item name="titleTextAppearance">@style/WordPress.ToolBar.Title</item>
+        <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
         <item name="android:elevation">0dp</item>
         <item name="colorControlNormal">?attr/colorOnSurface</item>
     </style>
@@ -352,7 +352,7 @@
         <item name="android:textColorHint">?attr/wpColorOnSurfaceMedium</item>
     </style>
 
-    <style name="WordPress.ToolBar.Title" parent="TextAppearance.MaterialComponents.Headline6">
+    <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="fontFamily">serif</item>
         <item name="android:textStyle">bold</item>
     </style>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -214,11 +214,6 @@
         <item name="android:navigationBarColor">@android:color/black</item>
     </style>
 
-    <style name="WordPress.ZenDesk.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
-        <item name="titleTextColor">?attr/colorOnPrimary</item>
-        <item name="colorControlNormal">?attr/colorOnPrimary</item>
-    </style>
-
     <style name="WordPress.Stories.Immersive" parent="WordPress.NoActionBar">
         <item name="android:navigationBarColor">@android:color/black</item>
         <item name="android:immersive">true</item>
@@ -330,15 +325,6 @@
         <item name="android:textAppearance">@style/TextAppearance.AppCompat.Title</item>
     </style>
 
-    <style name="WordPress.ToolBar" parent="Widget.MaterialComponents.Toolbar.Surface">
-        <item name="titleTextColor">?attr/colorOnSurface</item>
-        <item name="android:background">@null</item>
-        <item name="popupTheme">@style/ThemeOverlay.AppCompat.DayNight</item>
-        <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
-        <item name="android:elevation">0dp</item>
-        <item name="colorControlNormal">?attr/colorOnSurface</item>
-    </style>
-
     <style name="WordPress.AppBarLayout" parent="Widget.MaterialComponents.AppBarLayout.Surface">
         <item name="android:background">?attr/colorSurface</item>
         <item name="liftOnScroll">true</item>
@@ -350,11 +336,6 @@
         <item name="colorControlNormal">?attr/colorOnSurface</item>
         <item name="android:editTextColor">?attr/colorOnSurface</item>
         <item name="android:textColorHint">?attr/wpColorOnSurfaceMedium</item>
-    </style>
-
-    <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6">
-        <item name="fontFamily">serif</item>
-        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="WordPress.ActionBar.LightDark" parent="Theme.AppCompat.Light">
@@ -1394,31 +1375,6 @@
         <item name="android:drawablePadding">@dimen/margin_medium</item>
         <item name="android:paddingTop">@dimen/margin_small_medium</item>
         <item name="android:paddingBottom">@dimen/margin_small_medium</item>
-    </style>
-
-    <style name="TextAppearance.App.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline4">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="fontFamily">serif</item>
-        <item name="android:textStyle">bold</item>
-    </style>
-
-    <style name="TextAppearance.App.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="fontFamily">serif</item>
-        <item name="android:textStyle">bold</item>
-    </style>
-
-    <style name="WordPress.CollapsedToolbarLayout">
-        <item name="layout_scrollFlags">scroll|exitUntilCollapsed</item>
-        <item name="collapsedTitleTextAppearance">
-            @style/TextAppearance.App.CollapsingToolbar.Collapsed
-        </item>
-        <item name="expandedTitleTextAppearance">
-            @style/TextAppearance.App.CollapsingToolbar.Expanded
-        </item>
-        <item name="expandedTitleMarginBottom">@dimen/collapsible_toolbar_expanded_bottom_margin
-        </item>
-        <item name="expandedTitleMarginStart">16dp</item>
     </style>
 
     <!-- Modal Layout Picker Styles -->

--- a/WordPress/src/main/res/values/styles_toolbar.xml
+++ b/WordPress/src/main/res/values/styles_toolbar.xml
@@ -24,6 +24,7 @@
     </style>
 
     <style name="WordPress.ZenDesk.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
+        <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
         <item name="titleTextColor">?attr/colorOnPrimary</item>
         <item name="colorControlNormal">?attr/colorOnPrimary</item>
     </style>

--- a/WordPress/src/main/res/values/styles_toolbar.xml
+++ b/WordPress/src/main/res/values/styles_toolbar.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Login -->
+    <style name="Widget.LoginFlow.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
+        <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
+        <item name="android:theme">@style/ThemeOverlay.LoginFlow.Toolbar</item>
+    </style>
+
     <!-- App -->
     <style name="WordPress.ToolBar" parent="Widget.MaterialComponents.Toolbar.Surface">
         <item name="titleTextColor">?attr/colorOnSurface</item>

--- a/WordPress/src/main/res/values/styles_toolbar.xml
+++ b/WordPress/src/main/res/values/styles_toolbar.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- App -->
     <style name="WordPress.ToolBar" parent="Widget.MaterialComponents.Toolbar.Surface">
         <item name="titleTextColor">?attr/colorOnSurface</item>
         <item name="android:background">@null</item>
@@ -23,12 +24,14 @@
         <item name="expandedTitleMarginStart">16dp</item>
     </style>
 
+    <!-- Zendesk -->
     <style name="WordPress.ZenDesk.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
         <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
         <item name="titleTextColor">?attr/colorOnPrimary</item>
         <item name="colorControlNormal">?attr/colorOnPrimary</item>
     </style>
 
+    <!-- TextAppearance -->
     <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="fontFamily">serif</item>
         <item name="android:textStyle">bold</item>

--- a/WordPress/src/main/res/values/styles_toolbar.xml
+++ b/WordPress/src/main/res/values/styles_toolbar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android">
+<resources>
 
     <!-- Login -->
     <style name="Widget.LoginFlow.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">

--- a/WordPress/src/main/res/values/styles_toolbar.xml
+++ b/WordPress/src/main/res/values/styles_toolbar.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <style name="WordPress.ToolBar" parent="Widget.MaterialComponents.Toolbar.Surface">
+        <item name="titleTextColor">?attr/colorOnSurface</item>
+        <item name="android:background">@null</item>
+        <item name="popupTheme">@style/ThemeOverlay.AppCompat.DayNight</item>
+        <item name="titleTextAppearance">@style/TextAppearance.App.Toolbar.Title</item>
+        <item name="android:elevation">0dp</item>
+        <item name="colorControlNormal">?attr/colorOnSurface</item>
+    </style>
+
+    <style name="WordPress.CollapsedToolbarLayout">
+        <item name="layout_scrollFlags">scroll|exitUntilCollapsed</item>
+        <item name="collapsedTitleTextAppearance">
+            @style/TextAppearance.App.CollapsingToolbar.Collapsed
+        </item>
+        <item name="expandedTitleTextAppearance">
+            @style/TextAppearance.App.CollapsingToolbar.Expanded
+        </item>
+        <item name="expandedTitleMarginBottom">@dimen/collapsible_toolbar_expanded_bottom_margin
+        </item>
+        <item name="expandedTitleMarginStart">16dp</item>
+    </style>
+
+    <style name="WordPress.ZenDesk.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
+        <item name="titleTextColor">?attr/colorOnPrimary</item>
+        <item name="colorControlNormal">?attr/colorOnPrimary</item>
+    </style>
+
+    <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6">
+        <item name="fontFamily">serif</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.App.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline4">
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="fontFamily">serif</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.App.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="fontFamily">serif</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
Fixes #14443

This PR updates the toolbar title font family to `san-serif` in the Jetpack app. There are different toolbar styles for 
- collapsing toolbar (with expanded and collapsed toolbar title)
- default (non-collapsing) toolbar
- toolbar for Login and 
- toolbar for Zendesk

These toolbar styles are extracted to a separate `styles_toolbar.xml` and the toolbar's `titleTextAppearance` is overridden for the Jetpack app. 

Collapsing Toolbar Expanded
WordPress | Jetpack
------------|----------
![wp_toolbar_expanded](https://user-images.githubusercontent.com/1405144/115194761-87345c80-a10b-11eb-948c-06d6f8165984.png)| ![jp_toolbar_expanded](https://user-images.githubusercontent.com/1405144/115194781-8c91a700-a10b-11eb-9e7e-19df49fdecbe.png)

Collapsing Toolbar Collapsed
WordPress | Jetpack
------------|----------
![wp_toolbar_collapsed](https://user-images.githubusercontent.com/1405144/115194802-93201e80-a10b-11eb-959b-3818fa7fa268.png)| ![jp_toolbar_collapsed](https://user-images.githubusercontent.com/1405144/115194818-9915ff80-a10b-11eb-8ca4-6a8afc2f74c2.png)

Default (non-collapsing)
WordPress | Jetpack
------------|----------
![wp_toolbar_title](https://user-images.githubusercontent.com/1405144/115194705-6cfa7e80-a10b-11eb-9624-45d887cff996.png)| ![jp_toolbar_title](https://user-images.githubusercontent.com/1405144/115194729-7683e680-a10b-11eb-83b3-da0066416843.png)

Login
WordPress | Jetpack
------------|----------
![wp_login_toolbar_title](https://user-images.githubusercontent.com/1405144/115194845-a29f6780-a10b-11eb-8e34-d0d4f7fd89a6.png) | ![jp_login_toolbar_title](https://user-images.githubusercontent.com/1405144/115194859-a7641b80-a10b-11eb-9f5a-f1bd3a6d001c.png)

Zendesk
WordPress | Jetpack
------------|----------
![wp_zendesk_toolbar_title](https://user-images.githubusercontent.com/1405144/115194873-adf29300-a10b-11eb-93f3-44b74ada6928.png) | ![jp_zendesk_toolbar_title](https://user-images.githubusercontent.com/1405144/115194933-c662ad80-a10b-11eb-82db-a27bdbd42bb3.png)

Merge Instructions

- Design review by @osullivanchris on the typography of the title.
- Remove Needs Design Review label.
- Remove Not Ready for Merge label.
- Merge the PR.

## Regression Notes
1. Potential unintended areas of impact
N/A - impacts only toolbar styles.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested toolbars on different screens for both WordPress and Jetpack app. 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
