### PR TITLE
Show only host when displaying URL of a site you are trying to log-in

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -117,8 +117,10 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
     protected void setupLabel(@NonNull TextView label) {
         final boolean isWoo = mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE;
         final int labelResId = isWoo ? R.string.enter_credentials_for_site : R.string.enter_account_info_for_site;
+        final String siteAddress =
+                (mEndpointAddress == null || mEndpointAddress.isEmpty()) ? mInputSiteAddress : mEndpointAddress;
         final String formattedSiteAddress =
-                UrlUtils.getHost(UrlUtils.removeXmlrpcSuffix(StringUtils.notNullStr(mInputSiteAddress)));
+                UrlUtils.removeScheme(UrlUtils.removeXmlrpcSuffix(StringUtils.notNullStr(siteAddress)));
         label.setText(getString(labelResId, formattedSiteAddress));
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -118,7 +118,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
         final boolean isWoo = mLoginListener.getLoginMode() == LoginMode.WOO_LOGIN_MODE;
         final int labelResId = isWoo ? R.string.enter_credentials_for_site : R.string.enter_account_info_for_site;
         final String formattedSiteAddress =
-                UrlUtils.removeScheme(UrlUtils.removeXmlrpcSuffix(StringUtils.notNullStr(mInputSiteAddress)));
+                UrlUtils.getHost(UrlUtils.removeXmlrpcSuffix(StringUtils.notNullStr(mInputSiteAddress)));
         label.setText(getString(labelResId, formattedSiteAddress));
     }
 


### PR DESCRIPTION
Fixes #14319

This PR removes the path component of an URL that is displayed when you enter credentials for a self-hosted site.
[![Image from Gyazo](https://i.gyazo.com/e80b48bf12eb0b9212e840e17058ca96.png)](https://gyazo.com/e80b48bf12eb0b9212e840e17058ca96) 


To test:
- Log out from the app.
- Access self-hosted login flow.
- Use URL that has a path in it (eg. https://testsite.wordpress.com/wp-login.php).
- On the screen where you enter login and password confirm that only the host part of URL is displayed in `Enter your account information for xyz` header.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
