### PR TITLE
Jetpack App (Basics): Update Zendesk ticket subject

### DIFF
--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -5,4 +5,8 @@
 
     <!-- About View -->
     <string name="app_title">Jetpack for Android</string>
+
+    <!-- Contact us -->
+    <!--Note: Support ticket subject, only visible to the end users of the Zendesk support portal, doesn't need a translation -->
+    <string name="support_ticket_subject" translatable="false">Jetpack for Android Support</string>
 </resources>

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -7,6 +7,7 @@ import androidx.preference.PreferenceManager
 import com.zendesk.logger.Logger
 import com.zendesk.service.ErrorResponse
 import com.zendesk.service.ZendeskCallback
+import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -382,12 +383,13 @@ private fun buildZendeskConfig(
     extraTags: List<String>? = null,
     zendeskPlanFieldHelper: ZendeskPlanFieldHelper
 ): Configuration {
+    val ticketSubject = context.getString(R.string.support_ticket_subject)
     return RequestActivity.builder()
         .withTicketForm(
             TicketFieldIds.form,
             buildZendeskCustomFields(context, allSites, selectedSite, zendeskPlanFieldHelper)
         )
-        .withRequestSubject(ZendeskConstants.ticketSubject)
+        .withRequestSubject(ticketSubject)
         .withTags(buildZendeskTags(allSites, origin ?: Origin.UNKNOWN, extraTags))
         .config()
 }
@@ -533,7 +535,6 @@ private object ZendeskConstants {
     // We rely on this platform tag to filter tickets in Zendesk, so should be kept separate from the `articleLabel`
     const val platformTag = "Android"
     const val sourcePlatform = "mobile_-_android"
-    const val ticketSubject = "WordPress for Android Support"
     const val wpComTag = "wpcom"
     const val unknownValue = "unknown"
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2091,6 +2091,10 @@
     <string name="support_push_notification_message">New message from \'Help &amp; Support\'</string>
     <string name="contact_fragment_title" translatable="false">@string/contact_support</string>
 
+    <!-- Contact us -->
+    <!--Note: Support ticket subject, only visible to the end users of the Zendesk support portal, doesn't need a translation -->
+    <string name="support_ticket_subject" translatable="false">WordPress for Android Support</string>
+
     <!--My Site-->
     <string name="my_site_header_external">External</string>
     <string name="my_site_header_configuration">Configuration</string>


### PR DESCRIPTION
Fixes #14314

To test:

WordPress app 

1. Put a breakpoint inside [ZendeskHelper. buildZendeskConfig](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt#L390) where the Zendesk ticket subject is set.
2. Install and launch the WordPress app
3. Go to My Site -> Me -> Help & Support -> Contact Support
4. Notice that the `ticketSubject` is set to "WordPress for Android Support".

Jetpack app 

1. Repeat above steps 1- 3 for the Jetpack app
2. Notice that the `ticketSubject` is set to "Jetpack for Android Support".

Note: Since the subject is not visible to the app user, the text is not localized (similar to the behaviour earlier), and `translatable` is set to `false` in the strings.xml with a note. Then the string is overridden in the Jetpack app. We can also keep it as a constant in the `BuildConfig`, I can't think of any reason for one approach being better than the other and open to suggestions. 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
