### PR TITLE
Remove steps to install buldletool and install new jdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,16 +172,16 @@ jobs:
           name: Build Zalpha
           command: |
             if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-              bundle exec fastlane build_alpha skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+              bundle exec fastlane build_alpha skip_confirm:true skip_prechecks:true create_release:false upload_to_play_store:false
             fi
           no_output_timeout: 15m
       - run:
           name: Build Vanilla
           command: |
             if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-              bundle exec fastlane build_beta skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+              bundle exec fastlane build_beta skip_confirm:true skip_prechecks:true create_release:false upload_to_play_store:false
             else
-              bundle exec fastlane build_and_upload_release skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
+              # bundle exec fastlane build_and_upload_release skip_confirm:true skip_prechecks:true create_release:false upload_to_play_store:false
             fi
           no_output_timeout: 15m
       - android/save-gradle-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,14 +159,6 @@ jobs:
       - update-gradle-memory
       - android/restore-gradle-cache
       - run:
-          name: Install other tools
-          command: |
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-            eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-            brew install openjdk
-            brew install bundletool
-            echo "export PATH='/home/linuxbrew/.linuxbrew/Cellar/bundletool/1.2.0/bin:$PATH'" >> $BASH_ENV
-      - run:
           name: Prepare build
           command: |
             echo "export APP_VERSION=$(./gradlew -q printVersionName | tail -1)" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,16 +172,16 @@ jobs:
           name: Build Zalpha
           command: |
             if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-              bundle exec fastlane build_alpha skip_confirm:true skip_prechecks:true create_release:false upload_to_play_store:false
+              bundle exec fastlane build_alpha skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
             fi
           no_output_timeout: 15m
       - run:
           name: Build Vanilla
           command: |
             if [[ ${APP_VERSION} == *"-rc-"* ]]; then
-              bundle exec fastlane build_beta skip_confirm:true skip_prechecks:true create_release:false upload_to_play_store:false
+              bundle exec fastlane build_beta skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
             else
-              # bundle exec fastlane build_and_upload_release skip_confirm:true skip_prechecks:true create_release:false upload_to_play_store:false
+              bundle exec fastlane build_and_upload_release skip_confirm:true skip_prechecks:true create_release:true upload_to_play_store:true
             fi
           no_output_timeout: 15m
       - android/save-gradle-cache

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -623,7 +623,6 @@ REPOSITORY_NAME="WordPress-Android"
       sh("cp -v #{bundle_path} #{build_dir}#{name} | tee -a #{logfile_path}")
       UI.message("Bundle ready: #{name}")
       sh("echo \"Bundle ready: #{name}\" >> #{logfile_path}")
-      extract_universal_apk(bundle_path:"#{build_dir}#{name}", apk_path:"#{build_dir}#{apk_name}")
     end
     "#{build_dir}#{name}"
   end
@@ -704,33 +703,6 @@ REPOSITORY_NAME="WordPress-Android"
         File.delete(file) if Integer(File.basename(file, ".*")) < Integer(options[:build]) rescue puts "Cannot delete file #{file}"
       end
     end
-  end
-
-  private_lane :extract_universal_apk do | options |
-    bundle_path=options[:bundle_path]
-    apk_path=options[:apk_path]
-    temp_dir = Dir.mktmpdir()
-
-    command = ""
-    if is_ci
-      command << "bundletool build-apks --bundle=\"#{bundle_path}\" \\
-      --output=\"#{temp_dir}/universal.apks\" \\
-      --mode=universal"
-    else
-      command = "source ./tools/gradle-functions.sh"
-      command << "&& bundletool build-apks --bundle=\"#{bundle_path}\" \\
-      --output=\"#{temp_dir}/universal.apks\" \\
-      --mode=universal \\
-      --ks=\"$(get_gradle_property gradle.properties storeFile)\" \\
-      --ks-pass=\"pass:$(get_gradle_property gradle.properties storePassword)\" \\
-      --ks-key-alias=\"$(get_gradle_property gradle.properties keyAlias)\" \\
-      --key-pass=\"pass:$(get_gradle_property gradle.properties keyPassword)\""
-    end
-    sh(command)
-
-    sh("unzip \"#{temp_dir}/universal.apks\" -d \"#{temp_dir}\"")
-    FileUtils.cp_r("#{temp_dir}/universal.apk", "#{apk_path}", remove_destination: true)
-    FileUtils.rm_rf("#{temp_dir}")
   end
 
   private_lane :create_gh_release do | options |


### PR DESCRIPTION
Per discussion in Slack(p1618410985357000), we shouldn't need to install bundletool and the openjdk anymore and we can save ourselves some time in CI by not doing this. This PR removes that step in CI for the release build job. 