### PR TITLE
Improve handling of tracking URLs for deeplinks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
@@ -34,13 +34,7 @@ class DeepLinkingIntentReceiverViewModel
      * and builds the navigation action based on them
      */
     fun handleUrl(uriWrapper: UriWrapper): Boolean {
-        val navigateAction = buildNavigateAction(uriWrapper)
-        return if (navigateAction != null) {
-            _navigateAction.value = Event(navigateAction)
-            true
-        } else {
-            false
-        }
+        return buildNavigateAction(uriWrapper)?.also { _navigateAction.value = Event(it) } != null
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
@@ -38,19 +38,6 @@ class DeepLinkingIntentReceiverViewModel
     }
 
     /**
-     * This viewmodel handles the following URLs
-     * `wordpress.com/post/...`
-     * `wordpress.com/stats/...`
-     * `public-api.wordpress.com/mbar/`
-     * In these cases this function returns true
-     */
-    private fun shouldHandleUrl(uri: UriWrapper): Boolean {
-        return isTrackingUrl(uri) ||
-                editorLinkHandler.isEditorUrl(uri) ||
-                statsLinkHandler.isStatsUrl(uri)
-    }
-
-    /**
      * Tracking URIs like `public-api.wordpress.com/mbar/...` come from emails and should be handled here
      */
     private fun isTrackingUrl(uri: UriWrapper): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
@@ -73,14 +73,7 @@ class DeepLinkingIntentReceiverViewModel
     private fun buildNavigateAction(uri: UriWrapper, rootUri: UriWrapper = uri): NavigateAction {
         val trackingUrl = isTrackingUrl(uri)
         val navigateAction = when {
-            trackingUrl || isWpLoginUrl(uri) -> {
-                val redirectUri = getRedirectUri(uri)
-                if (redirectUri != null) {
-                    buildNavigateAction(redirectUri, rootUri)
-                } else {
-                    null
-                }
-            }
+            trackingUrl || isWpLoginUrl(uri) -> getRedirectUri(uri)?.let { buildNavigateAction(it, rootUri) }
             readerLinkHandler.isReaderUrl(uri) -> readerLinkHandler.buildOpenInReaderNavigateAction(uri)
             editorLinkHandler.isEditorUrl(uri) -> editorLinkHandler.buildOpenEditorNavigateAction(uri)
             statsLinkHandler.isStatsUrl(uri) -> statsLinkHandler.buildOpenStatsNavigateAction(uri)

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModel.kt
@@ -73,7 +73,7 @@ class DeepLinkingIntentReceiverViewModel
     private fun buildNavigateAction(uri: UriWrapper, rootUri: UriWrapper = uri): NavigateAction {
         val trackingUrl = isTrackingUrl(uri)
         val navigateAction = when {
-            trackingUrl || isWpLoginUrl(uri) -> getRedirectUri(uri)?.let { buildNavigateAction(it, rootUri) }
+            trackingUrl || isWpLoginUrl(uri) -> getRedirectUriAndBuildNavigateAction(uri, rootUri)
             readerLinkHandler.isReaderUrl(uri) -> readerLinkHandler.buildOpenInReaderNavigateAction(uri)
             editorLinkHandler.isEditorUrl(uri) -> editorLinkHandler.buildOpenEditorNavigateAction(uri)
             statsLinkHandler.isStatsUrl(uri) -> statsLinkHandler.buildOpenStatsNavigateAction(uri)
@@ -86,6 +86,10 @@ class DeepLinkingIntentReceiverViewModel
         return navigateAction ?: OpenInBrowser(
                 rootUri.copy(REGULAR_TRACKING_PATH)
         )
+    }
+
+    private fun getRedirectUriAndBuildNavigateAction(uri: UriWrapper, rootUri: UriWrapper): NavigateAction? {
+        return getRedirectUri(uri)?.let { buildNavigateAction(it, rootUri) }
     }
 
     private fun getRedirectUri(uri: UriWrapper): UriWrapper? {

--- a/WordPress/src/test/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModelTest.kt
@@ -210,8 +210,6 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         verify(serverTrackingHandler).request(uri)
     }
 
-    // TODO Fix this test
-    @Ignore("Temporarily ignoring this test as it will be fixed later on")
     @Test
     fun `view post mbar URL triggers the browser when it can't be resolved`() {
         val uri = buildUri("public-api.wordpress.com", "mbar", "redirect_to=...")

--- a/WordPress/src/test/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/DeepLinkingIntentReceiverViewModelTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest


### PR DESCRIPTION
This PR introduces a few improvements to the way we handle `mbar` links in `DeepLinkingIntentReceiverViewModel`. 

The changes should be straightforward and easy to follow through commit history, but in summary, they try to simplify the code inside `buildNavigateAction` and use the value returned by it in `handleUrl` to check if we can handle a given URL, which in turn makes `shouldHandleUrl` unnecessary. This also makes the behavior to open a URL in the browser a bit more explicit.

Let me know if I missed something or if you have any questions!

Note that this is targeting #14461.

To test:

I'd just trust the unit tests with this one, unless you can think of a scenario that is not covered by them. 

## Regression Notes
1. Potential unintended areas of impact
General deeplinking handling.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
No tests added, but I re-enabled a previously disabled test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
