### PR TITLE
ExPlat: Sync implementation with latest updates from FluxC

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
@@ -5,7 +5,6 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.android.support.AndroidSupportInjectionModule
 import org.wordpress.android.fluxc.module.DebugOkHttpClientModule
-import org.wordpress.android.fluxc.module.ReleaseBaseModule
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule
 import org.wordpress.android.fluxc.module.ReleaseToolsModule
 import org.wordpress.android.login.di.LoginFragmentModule
@@ -18,7 +17,6 @@ import javax.inject.Singleton
 @Component(modules = [
     ApplicationModule::class,
     AppConfigModule::class,
-    ReleaseBaseModule::class,
     DebugOkHttpClientModule::class,
     InterceptorModuleTest::class,
     ReleaseNetworkModule::class,

--- a/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
@@ -3,7 +3,6 @@ package org.wordpress.android.modules;
 import android.app.Application;
 
 import org.wordpress.android.fluxc.module.DebugOkHttpClientModule;
-import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseToolsModule;
 import org.wordpress.android.login.di.LoginFragmentModule;
@@ -21,7 +20,6 @@ import dagger.android.support.AndroidSupportInjectionModule;
 @Component(modules = {
         ApplicationModule.class,
         AppConfigModule.class,
-        ReleaseBaseModule.class,
         DebugOkHttpClientModule.class,
         InterceptorModule.class,
         ReleaseNetworkModule.class,

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -3,7 +3,6 @@ package org.wordpress.android.modules;
 import android.app.Application;
 
 import org.wordpress.android.WordPress;
-import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseToolsModule;
@@ -229,7 +228,6 @@ import dagger.android.support.AndroidSupportInjectionModule;
 @Component(modules = {
         ApplicationModule.class,
         AppConfigModule.class,
-        ReleaseBaseModule.class,
         ReleaseOkHttpClientModule.class,
         ReleaseNetworkModule.class,
         LegacyModule.class,
@@ -661,7 +659,7 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(RestoreFragment object);
 
     void inject(EngagedPeopleListFragment object);
-  
+
     void inject(SiteSettingsTimezoneBottomSheet object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application

--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.experiments.Assignments
 import org.wordpress.android.fluxc.model.experiments.Variation
 import org.wordpress.android.fluxc.store.ExperimentStore
-import org.wordpress.android.fluxc.store.ExperimentStore.FetchAssignmentsPayload
 import org.wordpress.android.fluxc.store.ExperimentStore.Platform
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.APPLICATION_SCOPE
@@ -63,7 +62,7 @@ class ExPlat
         return cachedAssignments
     }
 
-    private suspend fun fetchAssignments() = experimentStore.fetchAssignments(FetchAssignmentsPayload(platform)).also {
+    private suspend fun fetchAssignments() = experimentStore.fetchAssignments(platform, emptyList()).also {
         if (it.isError) {
             appLog.d(T.API, "ExPlat: fetching assignments failed with result: ${it.error}")
         } else {

--- a/WordPress/src/test/java/org/wordpress/android/util/experiments/ExPlatTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/experiments/ExPlatTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.util.experiments
 
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -42,7 +43,7 @@ class ExPlatTest : BaseUnitTest() {
 
         exPlat.refreshIfNeeded()
 
-        verify(experimentStore, times(1)).fetchAssignments(any())
+        verify(experimentStore, times(1)).fetchAssignments(any(), any(), anyOrNull())
     }
 
     @Test
@@ -51,7 +52,7 @@ class ExPlatTest : BaseUnitTest() {
 
         exPlat.refreshIfNeeded()
 
-        verify(experimentStore, times(1)).fetchAssignments(any())
+        verify(experimentStore, times(1)).fetchAssignments(any(), any(), anyOrNull())
     }
 
     @Test
@@ -60,7 +61,7 @@ class ExPlatTest : BaseUnitTest() {
 
         exPlat.refreshIfNeeded()
 
-        verify(experimentStore, never()).fetchAssignments(any())
+        verify(experimentStore, never()).fetchAssignments(any(), any(), anyOrNull())
     }
 
     @Test
@@ -69,7 +70,7 @@ class ExPlatTest : BaseUnitTest() {
 
         exPlat.forceRefresh()
 
-        verify(experimentStore, times(1)).fetchAssignments(any())
+        verify(experimentStore, times(1)).fetchAssignments(any(), any(), anyOrNull())
     }
 
     @Test
@@ -85,7 +86,7 @@ class ExPlatTest : BaseUnitTest() {
 
         exPlat.getVariation(dummyExperiment, shouldRefreshIfStale = true)
 
-        verify(experimentStore, times(1)).fetchAssignments(any())
+        verify(experimentStore, times(1)).fetchAssignments(any(), any(), anyOrNull())
     }
 
     @Test
@@ -94,7 +95,7 @@ class ExPlatTest : BaseUnitTest() {
 
         exPlat.getVariation(dummyExperiment, shouldRefreshIfStale = true)
 
-        verify(experimentStore, times(1)).fetchAssignments(any())
+        verify(experimentStore, times(1)).fetchAssignments(any(), any(), anyOrNull())
     }
 
     @Test
@@ -103,7 +104,7 @@ class ExPlatTest : BaseUnitTest() {
 
         exPlat.getVariation(dummyExperiment, shouldRefreshIfStale = true)
 
-        verify(experimentStore, never()).fetchAssignments(any())
+        verify(experimentStore, never()).fetchAssignments(any(), any(), anyOrNull())
     }
 
     @Test
@@ -112,7 +113,7 @@ class ExPlatTest : BaseUnitTest() {
 
         exPlat.getVariation(dummyExperiment, shouldRefreshIfStale = false)
 
-        verify(experimentStore, never()).fetchAssignments(any())
+        verify(experimentStore, never()).fetchAssignments(any(), any(), anyOrNull())
     }
 
     @Test
@@ -121,7 +122,7 @@ class ExPlatTest : BaseUnitTest() {
 
         exPlat.getVariation(dummyExperiment, shouldRefreshIfStale = false)
 
-        verify(experimentStore, never()).fetchAssignments(any())
+        verify(experimentStore, never()).fetchAssignments(any(), any(), anyOrNull())
     }
 
     @Test
@@ -146,7 +147,8 @@ class ExPlatTest : BaseUnitTest() {
 
     private suspend fun setupAssignments(cachedAssignments: Assignments?, fetchedAssignments: Assignments) {
         whenever(experimentStore.getCachedAssignments()).thenReturn(cachedAssignments)
-        whenever(experimentStore.fetchAssignments(any())).thenReturn(OnAssignmentsFetched(fetchedAssignments))
+        whenever(experimentStore.fetchAssignments(any(), any(), anyOrNull()))
+                .thenReturn(OnAssignmentsFetched(fetchedAssignments))
     }
 
     private fun buildAssignments(

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '9621372056be33c1a9c28278a192f56c07339786'
+    fluxCVersion = '1.16.0-beta-2'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.15.0'
+    fluxCVersion = '775b0a11cdbb48a7adfd934071f441c66ba3925f'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '775b0a11cdbb48a7adfd934071f441c66ba3925f'
+    fluxCVersion = '9621372056be33c1a9c28278a192f56c07339786'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
The latest ExPlat updates from FluxC introduces some breaking changes, so this PR simply makes sure we handle those so the app doesn't break. Another PR should follow this one introducing actual improvements to the current implementation.

I'll update this PR with a definitive FluxC version once https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1969 and https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1970 are merged.



To test:

Make sure the app builds.

## Regression Notes
1. Potential unintended areas of impact
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
