### PR TITLE
Enabling contact info in prod by toggling on feature flag.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,6 @@
 
 17.3
 -----
-* [*] Fixed bug where contact info wasn't showing up in block inserter due to feature flag [https://github.com/wordpress-mobile/WordPress-Android/pull/14499]
 
 
 17.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 17.3
 -----
+* [*] Fixed bug where contact info wasn't showing up in block inserter due to feature flag [https://github.com/wordpress-mobile/WordPress-Android/pull/14499]
 
 
 17.2

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -100,7 +100,7 @@ android {
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"
-            buildConfigField "boolean", "CONTACT_INFO_BLOCK_AVAILABLE", "false"
+            buildConfigField "boolean", "CONTACT_INFO_BLOCK_AVAILABLE", "true"
         }
 
         zalpha { // alpha version - enable experimental features


### PR DESCRIPTION
Fixes [#3395](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3395)

To test:
1. Open block inserter on site with Jetpack >= 8.5.
2. See that contact info is in block inserter.

## Regression Notes
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
