### PR TITLE
Change Tracks Event Prefix

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -79,6 +79,7 @@ android {
         buildConfigField "boolean", "CONTACT_INFO_BLOCK_AVAILABLE", "true"
         buildConfigField "boolean", "LIKES_ENHANCEMENTS", "false"
         buildConfigField "boolean", "IS_JETPACK_APP", "false"
+        buildConfigField "String", "TRACKS_EVENT_PREFIX", '"wpandroid_"'
     }
 
     // Gutenberg's dependency - react-native-video is using
@@ -95,12 +96,14 @@ android {
             dimension "app"
             applicationId "org.wordpress.android"
             buildConfigField "boolean", "IS_JETPACK_APP", "false"
+            buildConfigField "String", "TRACKS_EVENT_PREFIX", '"wpandroid_"'
         }
 
         jetpack {
             dimension "app"
             applicationId "com.jetpack.android"
             buildConfigField "boolean", "IS_JETPACK_APP", "true"
+            buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
         }
 
         vanilla { // used for release and beta

--- a/WordPress/src/main/java/org/wordpress/android/modules/TrackerModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/TrackerModule.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.modules
 import android.content.Context
 import dagger.Module
 import dagger.Provides
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.analytics.AnalyticsTrackerNosara
 import org.wordpress.android.analytics.Tracker
 
@@ -10,6 +11,7 @@ import org.wordpress.android.analytics.Tracker
 class TrackerModule {
     @Provides
     fun provideTracker(appContext: Context): Tracker {
-        return AnalyticsTrackerNosara(appContext)
+        val prefix = if (BuildConfig.IS_JETPACK_APP) "jpandroid" else "wpandroid"
+        return AnalyticsTrackerNosara(appContext, prefix)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/modules/TrackerModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/TrackerModule.kt
@@ -11,7 +11,6 @@ import org.wordpress.android.analytics.Tracker
 class TrackerModule {
     @Provides
     fun provideTracker(appContext: Context): Tracker {
-        val prefix = if (BuildConfig.IS_JETPACK_APP) "jpandroid_" else "wpandroid_"
-        return AnalyticsTrackerNosara(appContext, prefix)
+        return AnalyticsTrackerNosara(appContext, BuildConfig.TRACKS_EVENT_PREFIX)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/modules/TrackerModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/TrackerModule.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.analytics.Tracker
 class TrackerModule {
     @Provides
     fun provideTracker(appContext: Context): Tracker {
-        val prefix = if (BuildConfig.IS_JETPACK_APP) "jpandroid" else "wpandroid"
+        val prefix = if (BuildConfig.IS_JETPACK_APP) "jpandroid_" else "wpandroid_"
         return AnalyticsTrackerNosara(appContext, prefix)
     }
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2,7 +2,6 @@ package org.wordpress.android.analytics;
 
 import android.content.Context;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.automattic.android.tracks.TracksClient;
 

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2,6 +2,7 @@ package org.wordpress.android.analytics;
 
 import android.content.Context;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.automattic.android.tracks.TracksClient;
 
@@ -22,12 +23,13 @@ public class AnalyticsTrackerNosara extends Tracker {
     private static final String IS_GUTENBERG_ENABLED = "gutenberg_enabled";
     private static final String APP_SCHEME = "app_scheme";
 
-    private static final String EVENTS_PREFIX = "wpandroid_";
+    private final String mEventsPrefix;
 
     private final TracksClient mNosaraClient;
 
-    public AnalyticsTrackerNosara(Context context) throws IllegalArgumentException {
+    public AnalyticsTrackerNosara(Context context, String eventsPrefix) throws IllegalArgumentException {
         super(context);
+        mEventsPrefix = eventsPrefix;
         mNosaraClient = TracksClient.getClient(context);
     }
 
@@ -534,11 +536,11 @@ public class AnalyticsTrackerNosara extends Tracker {
         }
 
         if (propertiesToJSON.length() > 0) {
-            mNosaraClient.track(EVENTS_PREFIX + eventName, propertiesToJSON, user, userType);
+            mNosaraClient.track(mEventsPrefix + eventName, propertiesToJSON, user, userType);
             String jsonString = propertiesToJSON.toString();
             AppLog.i(T.STATS, "\uD83D\uDD35 Tracked: " + eventName + ", Properties: " + jsonString);
         } else {
-            mNosaraClient.track(EVENTS_PREFIX + eventName, user, userType);
+            mNosaraClient.track(mEventsPrefix + eventName, user, userType);
             AppLog.i(T.STATS, "\uD83D\uDD35 Tracked: " + eventName);
         }
     }


### PR DESCRIPTION
Fixes #14493 

This PR updates how the tracks event prefix is set. The EVENTS_PREFIX was previously hardcoded, but now the value is set by passing the it directly to the `AnalyticsTrackerNosara` constructor within the Dagger module. 

Originally I was using a hardcoded String in the `@Module`; however after some thought I decided to add a new BuildConfig value for the prefix and use that instead. 

To test:
WordPress scenario: 
- Use the APK from CI
- Launch the WordPress app
- Check internal db for presence of **eventname LIKE 'wpandroid_%'** (use the date/time results to narrow to your posts)

Jetpack scenario
- Download this branch
- Build a Jetpack dimension
- Launch the app
- Check internal db for presence of **eventname LIKE 'jpandroid_%'** (use the date/time results to narrow to your posts)


## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 
3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
