### PR TITLE
Fix keyboard overlapping comment details

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -220,6 +220,7 @@
         <activity
             android:name=".ui.comments.CommentsDetailActivity"
             android:theme="@style/WordPress.NoActionBar"
+            android:windowSoftInputMode="adjustResize"
             android:label="@string/comments"/>
 
         <!-- Posts activities -->


### PR DESCRIPTION
This PR adds a flag to a comment detail activity so the keyboard when expanded in portrait mode will look like this:

[![Image from Gyazo](https://i.gyazo.com/3e8ae6b6581706e4d7e08b3b1f08979d.png)](https://gyazo.com/3e8ae6b6581706e4d7e08b3b1f08979d)

and not like this:

[![Image from Gyazo](https://i.gyazo.com/4da78979b873ba9c04080f48eadc6167.png)](https://gyazo.com/4da78979b873ba9c04080f48eadc6167)

To test:
- Navigate to the Comment details and tap on Reply field to expand the keyboard.
- Make sure layout looks like expected.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
