### PR TITLE
Align wpandroid to fluxc di changes

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
@@ -5,7 +5,6 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.android.support.AndroidSupportInjectionModule
 import org.wordpress.android.fluxc.module.DebugOkHttpClientModule
-import org.wordpress.android.fluxc.module.ReleaseBaseModule
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule
 import org.wordpress.android.fluxc.module.ReleaseToolsModule
 import org.wordpress.android.login.di.LoginFragmentModule
@@ -18,7 +17,6 @@ import javax.inject.Singleton
 @Component(modules = [
     ApplicationModule::class,
     AppConfigModule::class,
-    ReleaseBaseModule::class,
     DebugOkHttpClientModule::class,
     InterceptorModuleTest::class,
     ReleaseNetworkModule::class,

--- a/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
@@ -3,7 +3,6 @@ package org.wordpress.android.modules;
 import android.app.Application;
 
 import org.wordpress.android.fluxc.module.DebugOkHttpClientModule;
-import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseToolsModule;
 import org.wordpress.android.login.di.LoginFragmentModule;
@@ -21,7 +20,6 @@ import dagger.android.support.AndroidSupportInjectionModule;
 @Component(modules = {
         ApplicationModule.class,
         AppConfigModule.class,
-        ReleaseBaseModule.class,
         DebugOkHttpClientModule.class,
         InterceptorModule.class,
         ReleaseNetworkModule.class,

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -3,7 +3,6 @@ package org.wordpress.android.modules;
 import android.app.Application;
 
 import org.wordpress.android.WordPress;
-import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseToolsModule;
@@ -229,7 +228,6 @@ import dagger.android.support.AndroidSupportInjectionModule;
 @Component(modules = {
         ApplicationModule.class,
         AppConfigModule.class,
-        ReleaseBaseModule.class,
         ReleaseOkHttpClientModule.class,
         ReleaseNetworkModule.class,
         LegacyModule.class,
@@ -661,7 +659,7 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(RestoreFragment object);
 
     void inject(EngagedPeopleListFragment object);
-  
+
     void inject(SiteSettingsTimezoneBottomSheet object);
 
     // Allows us to inject the application without having to instantiate any modules, and provides the Application

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '775b0a11cdbb48a7adfd934071f441c66ba3925f'
+    fluxCVersion = '9621372056be33c1a9c28278a192f56c07339786'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
This PR aligns WPAndroid to the latest changes related to DI cleanup introduced with [this PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1946).

I mimic the changes done in a similar alignment in Woo [here](https://github.com/woocommerce/woocommerce-android/pull/3890). 

I'm targeting the `feature/sync-explat-updates` branch since current state of FluxC requires that branch to be merged too.

I think that once approved we can:
- Merge this one into the #14498 keeping the fluxc hash `9621372056be33c1a9c28278a192f56c07339786`
- Review and approve the #14498
- Once approved we can create a new fluxc tag (I think there were already additional PRs merged into develop after the 1.16.0-beta-1 was created, so we need to create a fresh one)
- Update the  #14498 with the newly created fluxc tag and merge

and hopefully we should be ok I think.

### To test:
Check the app builds and smoke test.

## Regression Notes
1. Potential unintended areas of impact
None in theory 😄 .

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Smoke testing and already available CI.

3. What automated tests I added (or what prevented me from doing so)
Current CI should be covering already.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
