### PR TITLE
Add illustration for no network state in comments list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -172,7 +172,9 @@ public class CommentsListFragment extends ViewPagerFragment {
                 mSwipeRefreshLayout,
                 () -> {
                     if (!NetworkUtils.checkConnection(getContext())) {
-                        showEmptyView(EmptyViewMessageType.NETWORK_ERROR);
+                        if (getAdapter().getItemCount() == 0) {
+                            showEmptyView(EmptyViewMessageType.NETWORK_ERROR);
+                        }
                         mSwipeToRefreshHelper.setRefreshing(false);
                         return;
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -10,6 +10,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -229,14 +230,19 @@ public class CommentsListFragment extends ViewPagerFragment {
                     emptyViewMessageStringId = R.string.comments_empty_list;
                     break;
             }
+            mActionableEmptyView.image.setImageResource(R.drawable.img_illustration_empty_results_216dp);
             mActionableEmptyView.image.setVisibility(View.VISIBLE);
         } else {
+            @DrawableRes int emptyViewIllustrationId = 0;
+            int emptyViewIllustrationVisibility = View.GONE;
             switch (messageType) {
                 case LOADING:
                     emptyViewMessageStringId = R.string.comments_fetching;
                     break;
                 case NETWORK_ERROR:
                     emptyViewMessageStringId = R.string.no_network_message;
+                    emptyViewIllustrationId = R.drawable.img_illustration_cloud_off_152dp;
+                    emptyViewIllustrationVisibility = View.VISIBLE;
                     break;
                 case PERMISSION_ERROR:
                     emptyViewMessageStringId = R.string.error_refresh_unauthorized_comments;
@@ -245,8 +251,8 @@ public class CommentsListFragment extends ViewPagerFragment {
                     emptyViewMessageStringId = R.string.error_refresh_comments;
                     break;
             }
-
-            mActionableEmptyView.image.setVisibility(View.GONE);
+            mActionableEmptyView.image.setImageResource(emptyViewIllustrationId);
+            mActionableEmptyView.image.setVisibility(emptyViewIllustrationVisibility);
         }
         mActionableEmptyView.title.setText(emptyViewMessageStringId);
         mActionableEmptyView.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Fixes #14357 

This PR adds an "No Network" illustration to comments list.

[![Image from Gyazo](https://i.gyazo.com/18eb660d18c1dee6a08c4d776a11edb4.png)](https://gyazo.com/18eb660d18c1dee6a08c4d776a11edb4)

To test:
- Turn of internet connection on your device.
- Navigate to Comment list and select a tab without any cached comments.
- Make sure the error message in empty view is accompanied by illustration.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
