### PR TITLE
Jetpack App (Basics): Update Stats Colors

### DIFF
--- a/WordPress/src/jetpack/res/values-night/colors_stats.xml
+++ b/WordPress/src/jetpack/res/values-night/colors_stats.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="stats_activity_very_low">@color/gray_80</color>
+    <color name="stats_activity_low">@color/jetpack_green_70</color>
+    <color name="stats_activity_medium">@color/jetpack_green_50</color>
+    <color name="stats_activity_high">@color/jetpack_green_30</color>
+    <color name="stats_activity_very_high">@color/jetpack_green_10</color>
+    <color name="stats_value_bar_color">@color/gray_60</color>
+    <color name="stats_bar_chart_bottom">@color/jetpack_green_30</color>
+    <color name="stats_bar_chart_top">@color/jetpack_green_60</color>
+    <color name="stats_bar_chart_accent_top">@color/pink_60</color>
+    <color name="stats_bar_chart_accent_bottom">@color/pink_30</color>
+    <color name="stats_bar_chart_gridline">@color/gray_80</color>
+    <color name="stats_map_activity_low">@color/jetpack_green_80</color>
+    <color name="stats_map_activity_high">@color/jetpack_green_30</color>
+    <color name="stats_map_activity_empty">@color/gray_80</color>
+</resources>

--- a/WordPress/src/jetpack/res/values/colors_stats.xml
+++ b/WordPress/src/jetpack/res/values/colors_stats.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="stats_activity_very_low">@color/gray_0</color>
+    <color name="stats_activity_low">@color/jetpack_green_5</color>
+    <color name="stats_activity_medium">@color/jetpack_green_20</color>
+    <color name="stats_activity_high">@color/jetpack_green_50</color>
+    <color name="stats_activity_very_high">@color/jetpack_green_70</color>
+    <color name="stats_value_bar_color">@color/gray_10</color>
+    <color name="stats_bar_chart_bottom">@color/jetpack_green_60</color>
+    <color name="stats_bar_chart_top">@color/jetpack_green_30</color>
+    <color name="stats_bar_chart_accent_top">@color/pink_30</color>
+    <color name="stats_bar_chart_accent_bottom">@color/pink_60</color>
+    <color name="stats_bar_chart_gridline">@color/neutral_5</color>
+    <color name="stats_map_activity_low">@color/jetpack_green_5</color>
+    <color name="stats_map_activity_high">@color/jetpack_green</color>
+    <color name="stats_map_activity_empty">@color/neutral_5</color>
+</resources>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -21,23 +21,6 @@
     <color name="placeholder">#1AFFFFFF</color>
     <color name="p2_author_bg_stroke">#1E1E1E</color>
 
-    <!-- Stats -->
-
-    <color name="stats_activity_very_low">@color/gray_80</color>
-    <color name="stats_activity_low">@color/blue_70</color>
-    <color name="stats_activity_medium">@color/blue_50</color>
-    <color name="stats_activity_high">@color/blue_30</color>
-    <color name="stats_activity_very_high">@color/blue_10</color>
-    <color name="stats_value_bar_color">@color/gray_60</color>
-    <color name="stats_bar_chart_bottom">@color/blue_30</color>
-    <color name="stats_bar_chart_top">@color/blue_60</color>
-    <color name="stats_bar_chart_accent_top">@color/pink_60</color>
-    <color name="stats_bar_chart_accent_bottom">@color/pink_30</color>
-    <color name="stats_bar_chart_gridline">@color/gray_80</color>
-    <color name="stats_map_activity_low">@color/blue_80</color>
-    <color name="stats_map_activity_high">@color/blue_30</color>
-    <color name="stats_map_activity_empty">@color/gray_80</color>
-
     <!-- Login Prologue -->
     <color name="promo_indicator_color_default">@color/white_translucent_20</color>
     <color name="login_prologue_background_circle_purple">@color/green_60</color>

--- a/WordPress/src/main/res/values-night/colors_stats.xml
+++ b/WordPress/src/main/res/values-night/colors_stats.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="stats_activity_very_low">@color/gray_80</color>
+    <color name="stats_activity_low">@color/blue_70</color>
+    <color name="stats_activity_medium">@color/blue_50</color>
+    <color name="stats_activity_high">@color/blue_30</color>
+    <color name="stats_activity_very_high">@color/blue_10</color>
+    <color name="stats_value_bar_color">@color/gray_60</color>
+    <color name="stats_bar_chart_bottom">@color/blue_30</color>
+    <color name="stats_bar_chart_top">@color/blue_60</color>
+    <color name="stats_bar_chart_accent_top">@color/pink_60</color>
+    <color name="stats_bar_chart_accent_bottom">@color/pink_30</color>
+    <color name="stats_bar_chart_gridline">@color/gray_80</color>
+    <color name="stats_map_activity_low">@color/blue_80</color>
+    <color name="stats_map_activity_high">@color/blue_30</color>
+    <color name="stats_map_activity_empty">@color/gray_80</color>
+</resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -16,23 +16,6 @@
     <color name="placeholder">#1A000000</color>
     <color name="p2_author_bg_stroke">#FFF</color>
 
-    <!-- Stats -->
-
-    <color name="stats_activity_very_low">@color/gray_0</color>
-    <color name="stats_activity_low">@color/blue_5</color>
-    <color name="stats_activity_medium">@color/blue_20</color>
-    <color name="stats_activity_high">@color/blue_50</color>
-    <color name="stats_activity_very_high">@color/blue_70</color>
-    <color name="stats_value_bar_color">@color/gray_10</color>
-    <color name="stats_bar_chart_bottom">@color/blue_60</color>
-    <color name="stats_bar_chart_top">@color/blue_30</color>
-    <color name="stats_bar_chart_accent_top">@color/pink_30</color>
-    <color name="stats_bar_chart_accent_bottom">@color/pink_60</color>
-    <color name="stats_bar_chart_gridline">@color/neutral_5</color>
-    <color name="stats_map_activity_low">@color/blue_5</color>
-    <color name="stats_map_activity_high">@color/blue</color>
-    <color name="stats_map_activity_empty">@color/neutral_5</color>
-
     <!-- Post History -->
 
     <color name="post_history_underlying_background">@color/neutral_0</color>

--- a/WordPress/src/main/res/values/colors_stats.xml
+++ b/WordPress/src/main/res/values/colors_stats.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="stats_activity_very_low">@color/gray_0</color>
+    <color name="stats_activity_low">@color/blue_5</color>
+    <color name="stats_activity_medium">@color/blue_20</color>
+    <color name="stats_activity_high">@color/blue_50</color>
+    <color name="stats_activity_very_high">@color/blue_70</color>
+    <color name="stats_value_bar_color">@color/gray_10</color>
+    <color name="stats_bar_chart_bottom">@color/blue_60</color>
+    <color name="stats_bar_chart_top">@color/blue_30</color>
+    <color name="stats_bar_chart_accent_top">@color/pink_30</color>
+    <color name="stats_bar_chart_accent_bottom">@color/pink_60</color>
+    <color name="stats_bar_chart_gridline">@color/neutral_5</color>
+    <color name="stats_map_activity_low">@color/blue_5</color>
+    <color name="stats_map_activity_high">@color/blue</color>
+    <color name="stats_map_activity_empty">@color/neutral_5</color>
+</resources>


### PR DESCRIPTION
Fixes #14300

This PR updates the `Jetpack` related stats colors based on the latest design feedback.

Section/Theme | WordPress | Jetpack
-----|-----|-----
Latest Post Summary/Light | <img width="250" height="500" alt="latest_post_summary_light_wordpress" src="https://user-images.githubusercontent.com/9729923/115890426-972aa400-a45d-11eb-9ea0-9a7662372fa1.png"> | <img width="250" height="500" alt="latest_post_summary_light_jetpack" src="https://user-images.githubusercontent.com/9729923/115890440-9b56c180-a45d-11eb-80a9-702d2ac3cbf0.png">
Latest Post Summary/Dark | <img width="250" height="500" alt="latest_post_summary_dark_wordpress" src="https://user-images.githubusercontent.com/9729923/115888677-d9eb7c80-a45b-11eb-9b2d-471829871f5d.png"> | <img width="250" height="500" alt="latest_post_summary_dark_jetpack" src="https://user-images.githubusercontent.com/9729923/115888690-df48c700-a45b-11eb-9089-fc52cdffa2bc.png">
Posting Activity/Light | <img width="250" height="500" alt="posting_activity_light_wordpress" src="https://user-images.githubusercontent.com/9729923/115890514-ae699180-a45d-11eb-9358-ebf3f8501087.png"> | <img width="250" height="500" alt="posting_activity_light_jetpack" src="https://user-images.githubusercontent.com/9729923/115890522-b32e4580-a45d-11eb-838f-398dddbba0f8.png">
Posting Activity/Dark | <img width="250" height="500" alt="posting_activity_dark_wordpress" src="https://user-images.githubusercontent.com/9729923/115888776-f982a500-a45b-11eb-9774-2c6e04fa32f8.png"> | <img width="250" height="500" alt="posting_activity_dark_jetpack" src="https://user-images.githubusercontent.com/9729923/115888791-fdaec280-a45b-11eb-8ada-eb06349ce15d.png">
Years Views/Light | <img width="250" height="500" alt="years_views_light_wordpress" src="https://user-images.githubusercontent.com/9729923/115890603-c80ad900-a45d-11eb-8eda-b196dba29de3.png"> | <img width="250" height="500" alt="years_views_light_jetpack" src="https://user-images.githubusercontent.com/9729923/115890615-cc36f680-a45d-11eb-8b0a-bbf04eae103b.png">
Years Views/Dark | <img width="250" height="500" alt="years_views_dark_wordpress" src="https://user-images.githubusercontent.com/9729923/115888924-2040db80-a45c-11eb-9d80-67673199d7f0.png"> | <img width="250" height="500" alt="years_views_dark_jetpack" src="https://user-images.githubusercontent.com/9729923/115888942-25058f80-a45c-11eb-882b-d431c21f3bd2.png">
Years Countries/Light | <img width="250" height="500" alt="years_countries_light_wordpress" src="https://user-images.githubusercontent.com/9729923/115890705-e2dd4d80-a45d-11eb-99a8-259f61687a10.png"> | <img width="250" height="500" alt="years_countries_light_jetpack" src="https://user-images.githubusercontent.com/9729923/115890717-e7096b00-a45d-11eb-9808-b860db0002cd.png">
Years Countries/Dark | <img width="250" height="500" alt="years_countries_dark_wordpress" src="https://user-images.githubusercontent.com/9729923/115889056-45cde500-a45c-11eb-9176-e299166207ca.png"> | <img width="250" height="500" alt="years_countries_dark_jetpack" src="https://user-images.githubusercontent.com/9729923/115889080-49fa0280-a45c-11eb-9ed9-3c1cd7e23d9c.png">

**To Test**
- Build, launch and smoke test the `blue/pink` stats colors for the WordPress app (e.g. wordpressWasabiDebug).
- Build, launch and smoke test the `jetpack_green/pink` stats colors for the Jetpack app (e.g. wordpressWasabiDebug).

**Merge Instructions**
- A quick design review by @osullivanchris on the stats color changes for the Jetpack app.
- Remove `Needs Design Review` label.
- Merge as normal.

## Regression Notes
1. Potential unintended areas of impact ⚪ N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 Manual Testing
3. What automated tests I added (or what prevented me from doing so) ⚪ N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
