### PR TITLE
Add wildcard ignore for .configure-files folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,8 @@ WordPress/*.jks
 
 local-builds.gradle
 
-# All secrets should be stored under .configure-files
-# Everything without a .enc extension is ignored
+# Currently, the configure tool stores the encrypted files under
+# .configure-files. Everything in that folder without a .enc extension should
+# be ignored.
 .configure-files/*
 !.configure-files/*.enc

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,8 @@ WordPress/debug.keystore
 WordPress/*.jks
 
 local-builds.gradle
+
+# All secrets should be stored under .configure-files
+# Everything without a .enc extension is ignored
+.configure-files/*
+!.configure-files/*.enc


### PR DESCRIPTION
Makes sure that all the non-encrypted files in the `.configure-files` folder are ignored, for future proofing.

To test: Add a file the folder and verify it doesn't appear in the `git status` output.


## Regression Notes
N.A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
