### PR TITLE
Jetpack App (Emphasis): Hide Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1236,20 +1236,20 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (prompts == null) return;
         final ViewGroup parentView = findViewById(prompts.getParentContainerId());
         final View targetView = findViewById(prompts.getFocusedContainerId());
-        if (parentView != null && targetView != null) {
+        if (parentView != null) {
             int size = getResources().getDimensionPixelOffset(R.dimen.quick_start_focus_point_size);
             int horizontalOffset;
             int verticalOffset;
             switch (activeTask) {
                 case FOLLOW_SITE:
-                    horizontalOffset = targetView.getWidth() / 2 - size + getResources()
-                            .getDimensionPixelOffset(R.dimen.quick_start_focus_point_bottom_nav_offset);
+                    horizontalOffset = targetView != null ? ((targetView.getWidth() / 2 - size + getResources()
+                            .getDimensionPixelOffset(R.dimen.quick_start_focus_point_bottom_nav_offset))) : 0;
                     verticalOffset = 0;
                     break;
                 case PUBLISH_POST:
                     horizontalOffset = getResources()
                             .getDimensionPixelOffset(R.dimen.quick_start_focus_point_my_site_right_offset);
-                    verticalOffset = (targetView.getHeight() - size) / 2;
+                    verticalOffset = targetView != null ? ((targetView.getHeight() - size) / 2) : 0;
                     break;
                 default:
                     horizontalOffset = 0;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1236,7 +1236,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (prompts == null) return;
         final ViewGroup parentView = findViewById(prompts.getParentContainerId());
         final View targetView = findViewById(prompts.getFocusedContainerId());
-        if (parentView != null) {
+        if (parentView != null && targetView != null) {
             int size = getResources().getDimensionPixelOffset(R.dimen.quick_start_focus_point_size);
             int horizontalOffset;
             int verticalOffset;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -19,6 +19,7 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomnavigation.BottomNavigationView.OnNavigationItemReselectedListener
 import com.google.android.material.bottomnavigation.BottomNavigationView.OnNavigationItemSelectedListener
 import com.google.android.material.bottomnavigation.LabelVisibilityMode
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.main.WPMainActivity.OnScrollToTopListener
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType.MY_SITE
@@ -78,6 +79,8 @@ class WPMainNavigationView @JvmOverloads constructor(
 
         // overlay each item with our custom view
         val menuView = getChildAt(0) as BottomNavigationMenuView
+        if (BuildConfig.IS_JETPACK_APP) hideReaderTab()
+
         val inflater = LayoutInflater.from(context)
         for (i in 0 until menu.size()) {
             val itemView = menuView.getChildAt(i) as BottomNavigationItemView
@@ -96,6 +99,10 @@ class WPMainNavigationView @JvmOverloads constructor(
         }
 
         currentPosition = AppPrefs.getMainPageIndex(numPages() - 1)
+    }
+
+    private fun hideReaderTab() {
+        menu.removeItem(R.id.nav_reader)
     }
 
     private fun disableShiftMode() {
@@ -310,7 +317,7 @@ class WPMainNavigationView @JvmOverloads constructor(
     }
 
     companion object {
-        private val pages = listOf(MY_SITE, READER, NOTIFS)
+        private val pages = if (BuildConfig.IS_JETPACK_APP) listOf(MY_SITE, NOTIFS) else listOf(MY_SITE, READER, NOTIFS)
 
         private const val TAG_MY_SITE = "tag-mysite"
         private const val TAG_READER = "tag-reader"

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.RecyclerView.OnScrollListener
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.APP_REVIEWS_EVENT_INCREMENTED_BY_CHECKING_NOTIFICATION
@@ -322,37 +323,45 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         if (!accountStore.hasAccessToken()) {
             return
         }
+        val titleResId: Int
+        var descriptionResId = 0
+        var buttonResId = 0
         when (tabPosition) {
-            NotificationsListFragment.TAB_POSITION_ALL -> showEmptyView(
-                    R.string.notifications_empty_all,
-                    R.string.notifications_empty_action_all,
-                    R.string.notifications_empty_view_reader
-            )
-            NotificationsListFragment.TAB_POSITION_COMMENT -> showEmptyView(
-                    R.string.notifications_empty_comments,
-                    R.string.notifications_empty_action_comments,
-                    R.string.notifications_empty_view_reader
-            )
-            NotificationsListFragment.TAB_POSITION_FOLLOW -> showEmptyView(
-                    R.string.notifications_empty_followers,
-                    R.string.notifications_empty_action_followers_likes,
-                    R.string.notifications_empty_view_reader
-            )
-            NotificationsListFragment.TAB_POSITION_LIKE -> showEmptyView(
-                    R.string.notifications_empty_likes,
-                    R.string.notifications_empty_action_followers_likes,
-                    R.string.notifications_empty_view_reader
-            )
-            NotificationsListFragment.TAB_POSITION_UNREAD -> if (selectedSite == null) {
-                showEmptyView(R.string.notifications_empty_unread)
-            } else {
-                showEmptyView(
-                        R.string.notifications_empty_unread,
-                        R.string.notifications_empty_action_unread,
-                        R.string.posts_empty_list_button
-                )
+            NotificationsListFragment.TAB_POSITION_ALL -> {
+                titleResId = R.string.notifications_empty_all
+                descriptionResId = R.string.notifications_empty_action_all
+                buttonResId = R.string.notifications_empty_view_reader
             }
-            else -> showEmptyView(R.string.notifications_empty_list)
+            NotificationsListFragment.TAB_POSITION_COMMENT -> {
+                titleResId = R.string.notifications_empty_comments
+                descriptionResId = R.string.notifications_empty_action_comments
+                buttonResId = R.string.notifications_empty_view_reader
+            }
+            NotificationsListFragment.TAB_POSITION_FOLLOW -> {
+                titleResId = R.string.notifications_empty_followers
+                descriptionResId = R.string.notifications_empty_action_followers_likes
+                buttonResId = R.string.notifications_empty_view_reader
+            }
+            NotificationsListFragment.TAB_POSITION_LIKE -> {
+                titleResId = R.string.notifications_empty_likes
+                descriptionResId = R.string.notifications_empty_action_followers_likes
+                buttonResId = R.string.notifications_empty_view_reader
+            }
+            NotificationsListFragment.TAB_POSITION_UNREAD -> {
+                if (selectedSite == null) {
+                    titleResId = R.string.notifications_empty_unread
+                } else {
+                    titleResId = R.string.notifications_empty_unread
+                    descriptionResId = R.string.notifications_empty_action_unread
+                    buttonResId = R.string.posts_empty_list_button
+                }
+            }
+            else -> titleResId = R.string.notifications_empty_list
+        }
+        if (BuildConfig.IS_JETPACK_APP) {
+            showEmptyView(titleResId)
+        } else {
+            showEmptyView(titleResId, descriptionResId, buttonResId)
         }
         actionableEmptyView.image.visibility = if (DisplayUtils.isLandscape(context)) View.GONE else View.VISIBLE
     }


### PR DESCRIPTION
Fixes #14508

This PR 
- hides the Reader tab for the Jetpack app (based on the "Hide Reader" requirement of the `pcdRpT-iP` P2 post).
- only displays the title for the empty view on the Notifications tab and hides actions to go to the Reader or create a post (based on https://github.com/wordpress-mobile/WordPress-iOS/pull/16339#issuecomment-823407368).


To test:
- Comment out condition to `hideEmptyView()` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt#L150-L154) so that `showEmptyViewForCurrentFilter() `gets called for the notifications tab **.
- Install and log in to the Jetpack app `jetpackJalapenoDebug`. 
- Notice that the Reader tab is not visible in the bottom bar.
- Go to the Notifications tab.
- Notice that the empty view is visible without the description and action button.

![jp](https://user-images.githubusercontent.com/1405144/116033297-cc620c80-a67e-11eb-9a64-7693c41de6c5.png)

------

- Repeat the above steps for the WordPress app `wordpressJalapenoDebug`
- Notice that 
    - the Reader tab is visible in the bottom bar.
    - the empty view is visible on the Notifications tab with the description and action button.

![wp](https://user-images.githubusercontent.com/1405144/116033288-c9671c00-a67e-11eb-9d2d-5c3455ceeb54.png)

** Revert commented out code after testing the apps.

## Regression Notes
1. Potential unintended areas of impact
WordPress app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested WordPress app for the presence of the Reader tab and empty view on the Notifications tab.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
