### PR TITLE
Fixes Page Layout Picker not filtering layouts based on supported blocks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'develop-73b8188472ec71b23befdfdfe175784164b0be99'
+    ext.gutenbergMobileVersion = 'develop-8efdc5bc5715f352cde72741b01b503399bf42c7'
 
     repositories {
         google()


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/3417

`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3418
`gutenberg`: https://github.com/WordPress/gutenberg/pull/31184

To test:
* Follow testing steps on https://github.com/WordPress/gutenberg/pull/31184

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
