### PR TITLE
Deeplinks improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -25,6 +25,7 @@ import javax.inject.Inject
 
 class DeepLinkNavigator
 @Inject constructor() {
+    @Suppress("ComplexMethod")
     fun handleNavigationAction(navigateAction: NavigateAction, activity: AppCompatActivity) {
         when (navigateAction) {
             StartCreateSiteFlow -> ActivityLauncher.showMainActivityAndSiteCreationActivity(activity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -10,6 +10,8 @@ import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenE
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInBrowser
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInReader
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenNotifications
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenPages
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenPagesForSite
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenReader
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenStats
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenStatsForSite
@@ -55,6 +57,8 @@ class DeepLinkNavigator
             OpenReader -> ActivityLauncher.viewReaderInNewStack(activity)
             is OpenInReader -> ActivityLauncher.viewPostDeeplinkInNewStack(activity, navigateAction.uri.uri)
             OpenNotifications -> ActivityLauncher.viewNotificationsInNewStack(activity)
+            is OpenPagesForSite -> ActivityLauncher.viewPagesInNewStack(activity, navigateAction.site)
+            OpenPages -> ActivityLauncher.viewPagesInNewStack(activity)
         }
         activity.finish()
     }
@@ -75,5 +79,7 @@ class DeepLinkNavigator
         object StartCreateSiteFlow : NavigateAction()
         object ShowSignInFlow : NavigateAction()
         object OpenNotifications : NavigateAction()
+        data class OpenPagesForSite(val site: SiteModel) : NavigateAction()
+        object OpenPages : NavigateAction()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkUriUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkUriUtils.kt
@@ -15,22 +15,19 @@ class DeepLinkUriUtils
     fun getUriFromQueryParameter(uri: UriWrapper, key: String) =
             uri.getQueryParameter(key)?.let { uriUtilsWrapper.parse(it) }
 
-    fun extractTargetHost(uri: UriWrapper): String {
-        return uri.lastPathSegment ?: ""
-    }
-
-    private fun extractSiteModelFromTargetHost(host: String): SiteModel? {
-        return siteStore.getSitesByNameOrUrlMatching(host).firstOrNull()
+    private fun extractSiteModelFromTargetHost(host: String): List<SiteModel> {
+        return siteStore.getSitesByNameOrUrlMatching(host)
     }
 
     fun hostToSite(siteUrl: String): SiteModel? {
-        val site = extractSiteModelFromTargetHost(siteUrl)
-        val host = extractHostFromSite(site)
-        // Check if a site is available with given targetHost
-        return if (site != null && host != null && host == siteUrl) {
-            site
-        } else {
-            null
+        return extractSiteModelFromTargetHost(siteUrl).find { site ->
+            // Check if a site is available with given targetHost
+            val host = extractHostFromSite(site)
+            host != null && host == siteUrl
         }
+    }
+
+    fun blogIdToSite(blogId: String): SiteModel? {
+        return blogId.toLongOrNull()?.let { siteStore.getSiteBySiteId(it) }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -11,8 +11,6 @@ import androidx.lifecycle.ViewModelProvider;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
-import org.wordpress.android.fluxc.model.PostModel;
-import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.SiteStore;
@@ -26,8 +24,6 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UriWrapper;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
-
-import java.util.List;
 
 import javax.inject.Inject;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -84,8 +84,6 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
                     handleOpenEditorFromDeepLink(uri);
                 } else if (shouldViewPost(host)) {
                     handleViewPost(uri);
-                } else if (shouldShowPages(uri)) {
-                    handleShowPages(uriWrapper);
                 } else {
                     // not handled
                     finish();
@@ -187,23 +185,6 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
         } else {
             ActivityLauncher.loginForDeeplink(this);
         }
-    }
-
-    private boolean shouldShowPages(@NonNull Uri uri) {
-        // Match: https://wordpress.com/pages/
-        return shouldShow(uri, PAGES_PATH);
-    }
-
-    private void handleShowPages(@NonNull UriWrapper uri) {
-        String targetHost = mDeepLinkUriUtils.extractTargetHost(uri);
-        SiteModel site = mDeepLinkUriUtils.hostToSite(targetHost);
-        if (site != null) {
-            ActivityLauncher.viewPagesInNewStack(getContext(), site);
-        } else {
-            // In other cases, launch pages with the current selected site.
-            ActivityLauncher.viewPagesInNewStack(getContext());
-        }
-        finish();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -44,7 +44,6 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
     private static final String DEEP_LINK_HOST_POST = "post";
     private static final String DEEP_LINK_HOST_VIEWPOST = "viewpost";
     private static final String HOST_WORDPRESS_COM = "wordpress.com";
-    private static final String PAGES_PATH = "pages";
 
     private String mInterceptedUri;
     private String mBlogId;

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -37,9 +37,7 @@ import static org.wordpress.android.WordPress.getContext;
  * Redirects users to the reader activity along with IDs passed in the intent
  */
 public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
-    private static final String DEEP_LINK_HOST_POST = "post";
     private static final String DEEP_LINK_HOST_VIEWPOST = "viewpost";
-    private static final String HOST_WORDPRESS_COM = "wordpress.com";
 
     private String mInterceptedUri;
     private String mBlogId;
@@ -151,23 +149,5 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
     public void onBackPressed() {
         super.onBackPressed();
         finish();
-    }
-
-    // Helper Methods
-    private boolean shouldShow(@NonNull Uri uri, @NonNull String path) {
-        return StringUtils.equals(uri.getHost(), HOST_WORDPRESS_COM)
-               && (!uri.getPathSegments().isEmpty() && StringUtils.equals(uri.getPathSegments().get(0), path));
-    }
-
-    private Long parseAsLongOrNull(String longAsString) {
-        if (longAsString == null || longAsString.isEmpty()) {
-            return null;
-        }
-
-        try {
-            return Long.valueOf(longAsString);
-        } catch (NumberFormatException nfe) {
-            return null;
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -19,6 +19,7 @@ class DeepLinkingIntentReceiverViewModel
     private val statsLinkHandler: StatsLinkHandler,
     private val startLinkHandler: StartLinkHandler,
     private val readerLinkHandler: ReaderLinkHandler,
+    private val pagesLinkHandler: PagesLinkHandler,
     private val notificationsLinkHandler: NotificationsLinkHandler,
     private val deepLinkUriUtils: DeepLinkUriUtils,
     private val serverTrackingHandler: ServerTrackingHandler
@@ -67,6 +68,7 @@ class DeepLinkingIntentReceiverViewModel
             statsLinkHandler.isStatsUrl(uri) -> statsLinkHandler.buildOpenStatsNavigateAction(uri)
             startLinkHandler.isStartUrl(uri) -> startLinkHandler.buildNavigateAction()
             notificationsLinkHandler.isNotificationsUrl(uri) -> notificationsLinkHandler.buildNavigateAction()
+            pagesLinkHandler.isPagesUrl(uri) -> pagesLinkHandler.buildNavigateAction(uri)
             else -> null
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/EditorLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/EditorLinkHandler.kt
@@ -26,12 +26,24 @@ class EditorLinkHandler
      * Builds navigate action from URL like:
      * https://wordpress.com/post/siteNameOrUrl/postId
      * where siteNameOrUrl and postID are optional
+     * or App links like wordpress://post?blogId=798&postId=1231
      */
     fun buildOpenEditorNavigateAction(uri: UriWrapper): NavigateAction {
-        val pathSegments = uri.pathSegments
-        val targetSite = pathSegments.getOrNull(1)?.toSite()
-        val targetPost = pathSegments.getOrNull(2)?.toPost(targetSite)
-        return openEditorForSiteAndPost(targetSite, targetPost)
+        var hasSiteParam = false
+        var hasPostParam = false
+        val (targetSite, targetPost) = if (uri.host == POST_PATH) {
+            // Handles wordpress://post?blogId=798&postId=1231
+            val targetSite = uri.getQueryParameter(BLOG_ID).also { hasSiteParam = it != null }?.blogIdToSite()
+            val targetPost = uri.getQueryParameter(POST_ID).also { hasPostParam = it != null }?.toPost(targetSite)
+            targetSite to targetPost
+        } else {
+            // Handles https://wordpress.com/post/siteNameOrUrl/postId
+            val pathSegments = uri.pathSegments
+            val targetSite = pathSegments.getOrNull(1).also { hasSiteParam = it != null }?.hostNameToSite()
+            val targetPost = pathSegments.getOrNull(2).also { hasPostParam = it != null }?.toPost(targetSite)
+            targetSite to targetPost
+        }
+        return openEditorForSiteAndPost(hasSiteParam, hasPostParam, targetSite, targetPost)
     }
 
     /**
@@ -39,15 +51,22 @@ class EditorLinkHandler
      * The handled links are `wordpress.com/post...1
      */
     fun isEditorUrl(uri: UriWrapper): Boolean {
-        return uri.host == DeepLinkingIntentReceiverViewModel.HOST_WORDPRESS_COM &&
-                uri.pathSegments.firstOrNull() == POST_PATH
+        return (uri.host == DeepLinkingIntentReceiverViewModel.HOST_WORDPRESS_COM &&
+                uri.pathSegments.firstOrNull() == POST_PATH) || uri.host == POST_PATH
+    }
+
+    /**
+     * Converts BlogID if long or Site URL for other cases to a SiteModel
+     */
+    private fun String.blogIdToSite(): SiteModel? {
+        return deepLinkUriUtils.blogIdToSite(this) ?: this.hostNameToSite()
     }
 
     /**
      * Converts HOST name of a site to SiteModel. It finds the Site in the current local sites and matches the name
      * to the host.
      */
-    private fun String.toSite(): SiteModel? {
+    private fun String.hostNameToSite(): SiteModel? {
         return deepLinkUriUtils.hostToSite(this)
     }
 
@@ -67,15 +86,21 @@ class EditorLinkHandler
         }
     }
 
-    private fun openEditorForSiteAndPost(site: SiteModel?, post: PostModel?): NavigateAction {
+    private fun openEditorForSiteAndPost(hasSiteParam: Boolean, hasPostParam: Boolean, site: SiteModel?, post: PostModel?): NavigateAction {
         return when {
             site == null -> {
-                // Site not found, or host of site doesn't match the host in url
-                _toast.value = Event(R.string.blog_not_found)
+                if (hasSiteParam) {
+                    // Site not found, or host of site doesn't match the host in url
+                    _toast.value = Event(R.string.blog_not_found)
+                }
                 // Open a new post editor with current selected site
                 OpenEditor
             }
             post == null -> {
+                if (hasPostParam) {
+                    // Post not found. Open new post editor for given site.
+                    _toast.value = Event(R.string.post_not_found)
+                }
                 // Open new post editor for given site
                 OpenEditorForSite(site)
             }
@@ -85,5 +110,7 @@ class EditorLinkHandler
 
     companion object {
         private const val POST_PATH = "post"
+        private const val BLOG_ID = "blogId"
+        private const val POST_ID = "postId"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/EditorLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/EditorLinkHandler.kt
@@ -86,7 +86,12 @@ class EditorLinkHandler
         }
     }
 
-    private fun openEditorForSiteAndPost(hasSiteParam: Boolean, hasPostParam: Boolean, site: SiteModel?, post: PostModel?): NavigateAction {
+    private fun openEditorForSiteAndPost(
+        hasSiteParam: Boolean,
+        hasPostParam: Boolean,
+        site: SiteModel?,
+        post: PostModel?
+    ): NavigateAction {
         return when {
             site == null -> {
                 if (hasSiteParam) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/PagesLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/PagesLinkHandler.kt
@@ -1,0 +1,37 @@
+package org.wordpress.android.ui.deeplinks
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenPages
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenPagesForSite
+import org.wordpress.android.util.UriWrapper
+import javax.inject.Inject
+
+class PagesLinkHandler
+@Inject constructor(private val deepLinkUriUtils: DeepLinkUriUtils) {
+    /**
+     * Returns true if the URI looks like `wordpress.com/pages`
+     */
+    fun isPagesUrl(uri: UriWrapper): Boolean {
+        return uri.host == DeepLinkingIntentReceiverViewModel.HOST_WORDPRESS_COM &&
+                uri.pathSegments.firstOrNull() == PAGES_PATH
+    }
+
+    /**
+     * Returns StartCreateSiteFlow is user logged in and ShowSignInFlow if user is logged out
+     */
+    fun buildNavigateAction(uri: UriWrapper): NavigateAction {
+        val targetHost: String = deepLinkUriUtils.extractTargetHost(uri)
+        val site: SiteModel? = deepLinkUriUtils.hostToSite(targetHost)
+        return if (site != null) {
+            OpenPagesForSite(site)
+        } else {
+            // In other cases, launch pages with the current selected site.
+            OpenPages
+        }
+    }
+
+    companion object {
+        private const val PAGES_PATH = "pages"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/PagesLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/PagesLinkHandler.kt
@@ -21,7 +21,7 @@ class PagesLinkHandler
      * Returns StartCreateSiteFlow is user logged in and ShowSignInFlow if user is logged out
      */
     fun buildNavigateAction(uri: UriWrapper): NavigateAction {
-        val targetHost: String = deepLinkUriUtils.extractTargetHost(uri)
+        val targetHost: String = uri.lastPathSegment ?: ""
         val site: SiteModel? = deepLinkUriUtils.hostToSite(targetHost)
         return if (site != null) {
             OpenPagesForSite(site)

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
@@ -27,7 +27,6 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: DeepLinkingIntentReceiverViewModel
     private val startUrl = buildUri("wordpress.com", "start")
     private val postUrl = buildUri("wordpress.com", "post")
-    private val statsUrl = buildUri("wordpress.com", "stats")
 
     @InternalCoroutinesApi
     @Before

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
@@ -20,6 +20,7 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
     @Mock lateinit var startLinkHandler: StartLinkHandler
     @Mock lateinit var readerLinkHandler: ReaderLinkHandler
     @Mock lateinit var notificationsLinkHandler: NotificationsLinkHandler
+    @Mock lateinit var pagesLinkHandler: PagesLinkHandler
     @Mock lateinit var accountStore: AccountStore
     @Mock lateinit var deepLinkUriUtils: DeepLinkUriUtils
     @Mock lateinit var serverTrackingHandler: ServerTrackingHandler
@@ -37,6 +38,7 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
                 statsLinkHandler,
                 startLinkHandler,
                 readerLinkHandler,
+                pagesLinkHandler,
                 notificationsLinkHandler,
                 deepLinkUriUtils,
                 serverTrackingHandler

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/EditorLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/EditorLinkHandlerTest.kt
@@ -6,6 +6,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore
@@ -18,8 +19,10 @@ class EditorLinkHandlerTest : BaseUnitTest() {
     private lateinit var site: SiteModel
     private lateinit var post: PostModel
     private val siteUrl = "site123"
+    private val blogId = "321"
     private val remotePostId = 123L
     private val localPostId = 1
+    private lateinit var toasts: MutableList<Int>
 
     @Before
     fun setUp() {
@@ -29,11 +32,22 @@ class EditorLinkHandlerTest : BaseUnitTest() {
         post = PostModel()
         post.setRemotePostId(remotePostId)
         post.setId(localPostId)
+        toasts = mutableListOf()
+        editorLinkHandler.toast.observeForever { it?.getContentIfNotHandled()?.let { toast -> toasts.add(toast) } }
     }
 
     @Test
-    fun `handles post URI is true`() {
-        val postUri = buildUri("wordpress.com", "post")
+    fun `handles post URI`() {
+        val postUri = buildUri(host = "wordpress.com", path1 = "post")
+
+        val isEditorUri = editorLinkHandler.isEditorUrl(postUri)
+
+        assertThat(isEditorUri).isTrue()
+    }
+
+    @Test
+    fun `handles post app link`() {
+        val postUri = buildUri(host = "post")
 
         val isEditorUri = editorLinkHandler.isEditorUrl(postUri)
 
@@ -42,7 +56,7 @@ class EditorLinkHandlerTest : BaseUnitTest() {
 
     @Test
     fun `does not handle post URI with different host`() {
-        val postUri = buildUri("wordpress.org", "post")
+        val postUri = buildUri(host = "wordpress.org", path1 = "post")
 
         val isEditorUri = editorLinkHandler.isEditorUrl(postUri)
 
@@ -51,7 +65,7 @@ class EditorLinkHandlerTest : BaseUnitTest() {
 
     @Test
     fun `does not handle URI with different path`() {
-        val postUri = buildUri("wordpress.com", "stats")
+        val postUri = buildUri(host = "wordpress.com", path1 = "stats")
 
         val isEditorUri = editorLinkHandler.isEditorUrl(postUri)
 
@@ -59,26 +73,28 @@ class EditorLinkHandlerTest : BaseUnitTest() {
     }
 
     @Test
-    fun `opens editor when site not found`() {
+    fun `deeplink - opens editor and shows toast when site not found`() {
         val uri = buildUri(path1 = "post", path2 = siteUrl)
 
         val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
 
         assertThat(navigateAction).isEqualTo(NavigateAction.OpenEditor)
+        assertThat(toasts.last()).isEqualTo(R.string.blog_not_found)
     }
 
     @Test
-    fun `opens editor for a site site when post missing in URL`() {
+    fun `deeplink - opens editor for a site when post missing in URL`() {
         val uri = buildUri(path1 = "post", path2 = siteUrl)
         whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
 
         val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
 
         assertThat(navigateAction).isEqualTo(NavigateAction.OpenEditorForSite(site))
+        assertThat(toasts).isEmpty()
     }
 
     @Test
-    fun `opens editor for a post when both site and post exist`() {
+    fun `deeplink - opens editor for a post when both site and post exist`() {
         val uri = buildUri(path1 = "post", path2 = siteUrl, path3 = remotePostId.toString())
         whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
         whenever(postStore.getPostByRemotePostId(remotePostId, site)).thenReturn(post)
@@ -86,10 +102,11 @@ class EditorLinkHandlerTest : BaseUnitTest() {
         val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
 
         assertThat(navigateAction).isEqualTo(NavigateAction.OpenEditorForPost(site, localPostId))
+        assertThat(toasts).isEmpty()
     }
 
     @Test
-    fun `opens editor for a site site when post not found`() {
+    fun `deeplink - opens editor for a site and shows toast when post not found`() {
         val uri = buildUri(path1 = "post", path2 = siteUrl, path3 = remotePostId.toString())
         whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
         whenever(postStore.getPostByRemotePostId(remotePostId, site)).thenReturn(null)
@@ -97,5 +114,79 @@ class EditorLinkHandlerTest : BaseUnitTest() {
         val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
 
         assertThat(navigateAction).isEqualTo(NavigateAction.OpenEditorForSite(site))
+        assertThat(toasts.last()).isEqualTo(R.string.post_not_found)
+    }
+
+    @Test
+    fun `applink - opens editor and shows toast when site not found`() {
+        val uri = buildUri(
+                host = "post",
+                queryParam1 = "blogId" to blogId
+        )
+
+        val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenEditor)
+        assertThat(toasts.last()).isEqualTo(R.string.blog_not_found)
+    }
+
+    @Test
+    fun `applink - opens editor for a site from ID when post missing in URL`() {
+        val uri = buildUri(
+                host = "post",
+                queryParam1 = "blogId" to blogId
+        )
+        whenever(deepLinkUriUtils.blogIdToSite(blogId)).thenReturn(site)
+
+        val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenEditorForSite(site))
+        assertThat(toasts).isEmpty()
+    }
+
+    @Test
+    fun `applink - opens editor for a site from URL`() {
+        val uri = buildUri(
+                host = "post",
+                queryParam1 = "blogId" to siteUrl
+        )
+        whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
+
+        val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenEditorForSite(site))
+        assertThat(toasts).isEmpty()
+    }
+
+    @Test
+    fun `applink - opens editor for a post when both site and post exist`() {
+        val uri = buildUri(
+                host = "post",
+                queryParam1 = "blogId" to blogId,
+                queryParam2 = "postId" to remotePostId.toString()
+        )
+        whenever(deepLinkUriUtils.blogIdToSite(blogId)).thenReturn(site)
+        whenever(postStore.getPostByRemotePostId(remotePostId, site)).thenReturn(post)
+
+        val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenEditorForPost(site, localPostId))
+        assertThat(toasts).isEmpty()
+    }
+
+    @Test
+    fun `applink - opens editor for a site and shows toast when post not found`() {
+        val uri = buildUri(
+                host = "post",
+                queryParam1 = "blogId" to blogId,
+                queryParam2 = "postId" to remotePostId.toString()
+        )
+        whenever(deepLinkUriUtils.blogIdToSite(blogId)).thenReturn(site)
+        whenever(postStore.getPostByRemotePostId(remotePostId, site)).thenReturn(null)
+
+        val navigateAction = editorLinkHandler.buildOpenEditorNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenEditorForSite(site))
+        assertThat(toasts.last()).isEqualTo(R.string.post_not_found)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/PagesLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/PagesLinkHandlerTest.kt
@@ -1,0 +1,70 @@
+package org.wordpress.android.ui.deeplinks
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+
+@RunWith(MockitoJUnitRunner::class)
+class PagesLinkHandlerTest {
+    @Mock lateinit var deepLinkUriUtils: DeepLinkUriUtils
+    @Mock lateinit var site: SiteModel
+    private lateinit var pagesLinkHandler: PagesLinkHandler
+
+    @Before
+    fun setUp() {
+        pagesLinkHandler = PagesLinkHandler(deepLinkUriUtils)
+    }
+
+    @Test
+    fun `handles pages URI`() {
+        val pagesUri = buildUri(host = "wordpress.com", path1 = "pages")
+
+        val isPagesUri = pagesLinkHandler.isPagesUrl(pagesUri)
+
+        assertThat(isPagesUri).isTrue()
+    }
+
+    @Test
+    fun `does not handle pages URI with different host`() {
+        val pagesUri = buildUri(host = "wordpress.org", path1 = "pages")
+
+        val isPagesUri = pagesLinkHandler.isPagesUrl(pagesUri)
+
+        assertThat(isPagesUri).isFalse()
+    }
+
+    @Test
+    fun `does not handle URI with different path`() {
+        val pagesUri = buildUri(host = "wordpress.com", path1 = "post")
+
+        val isPagesUri = pagesLinkHandler.isPagesUrl(pagesUri)
+
+        assertThat(isPagesUri).isFalse()
+    }
+
+    @Test
+    fun `opens pages screen from empty URL`() {
+        val uri = buildUri(path1 = "pages")
+
+        val navigateAction = pagesLinkHandler.buildNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenPages)
+    }
+
+    @Test
+    fun `opens pages screen for a site when URL ends with site URL`() {
+        val siteUrl = "example.com"
+        val uri = buildUri(path1 = "pages", path2 = siteUrl)
+        whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
+
+        val navigateAction = pagesLinkHandler.buildNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenPagesForSite(site))
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/PagesLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/PagesLinkHandlerTest.kt
@@ -61,6 +61,7 @@ class PagesLinkHandlerTest {
     fun `opens pages screen for a site when URL ends with site URL`() {
         val siteUrl = "example.com"
         val uri = buildUri(path1 = "pages", path2 = siteUrl)
+        whenever(uri.lastPathSegment).thenReturn(siteUrl)
         whenever(deepLinkUriUtils.hostToSite(siteUrl)).thenReturn(site)
 
         val navigateAction = pagesLinkHandler.buildNavigateAction(uri)

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/UriTestHelper.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/UriTestHelper.kt
@@ -14,3 +14,21 @@ fun buildUri(host: String? = null, path1: String? = null, path2: String? = null,
     }
     return uri
 }
+
+fun buildUri(
+    host: String? = null,
+    queryParam1: Pair<String, String>? = null,
+    queryParam2: Pair<String, String>? = null
+): UriWrapper {
+    val uri = mock<UriWrapper>()
+    if (host != null) {
+        whenever(uri.host).thenReturn(host)
+    }
+    if (queryParam1 != null) {
+        whenever(uri.getQueryParameter(queryParam1.first)).thenReturn(queryParam1.second)
+    }
+    if (queryParam2 != null) {
+        whenever(uri.getQueryParameter(queryParam2.first)).thenReturn(queryParam2.second)
+    }
+    return uri
+}


### PR DESCRIPTION
This PR introduces two changes:
- moves handling of the `wordpress.com/pages` links to the view model
- moves handling of the `wordpress://post...` links to the view model

I've also fixed two bugs that were previously in the code
- the `hostToSite` method in the `DeepLinkUriUtils` was checking just the first site that matched the URL pattern. However, if you have multiple similar sites, it wasn't necessarily the site that you wanted (and that matched the `host`). This would cause and error and a toast. I've fixed that by iterating over all the found sites and comparing the host
- I've added a missing toast when to the `wordpress.com/post` links when the post ID is present but the post is not found.

To test:
- Make sure you're logged in with a site `example.com`
- Click on link `wordpress.com/pages/example.com` 
- Notice the app is opened on the Pages screen for site `example.com`


To test:
- Make sure you're not logged in with a site `example.com`
- Click on link `wordpress.com/pages/example.com` 
- Notice the app is opened on the Pages screen for the currently selected site


To test:
- Make sure you're logged in with a site with remote id X and a post with remote ID Y
- Click on link `wordpress://post?blogId=X&postId=Y` 
- Notice the post for the site is opened in the editor


To test:
- Make sure you're logged in with a site with remote id X
- Click on link `wordpress://post?blogId=X&postId=123` 
- Notice the editor is opened for the given site with a new post


To test:
- Make sure you're logged in with a site with remote id X
- Click on link `wordpress://post?blogId=X` 
- Notice the editor is opened for the given site with a new post


To test:
- Make sure you're logged in with a site with url `example.com`
- Click on link `wordpress://post?blogId=example.com` 
- Notice the editor is opened for the given site with a new post


To test:
- Make sure you're logged in with any site
- Click on link `wordpress://post` 
- Notice the editor is opened for the selected site with a new post

## Regression Notes
1. Potential unintended areas of impact
- the other post deeplinks

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- I've tested it manually and wrote additional unit tests

3. What automated tests I added (or what prevented me from doing so)
- unit tests 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
