### PR TITLE
Integrate gutenberg-mobile release 1.51.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.51.0'
+    ext.gutenbergMobileVersion = '3424-bc515a265458c98d2fe51bf0cf7c8e6a82f53757'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3424-d5cc3bfb57c86ae94cc976bdce99ffefb43efdc5'
+    ext.gutenbergMobileVersion = 'v1.51.1'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3424-bc515a265458c98d2fe51bf0cf7c8e6a82f53757'
+    ext.gutenbergMobileVersion = '3424-d5cc3bfb57c86ae94cc976bdce99ffefb43efdc5'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 1.51.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3424

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.