### PR TITLE
Like enhancements unit testing 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.engagement
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -275,7 +276,8 @@ class EngagedPeopleListViewModel @Inject constructor(
         )
     }
 
-    override fun onCleared() {
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public override fun onCleared() {
         super.onCleared()
         getLikesJob?.cancel()
         getLikesHandler.clear()

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModelTest.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.engagement
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
@@ -9,12 +8,10 @@ import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.test
 import org.wordpress.android.ui.engagement.AuthorName.AuthorNameString
@@ -51,11 +48,7 @@ import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.viewmodel.Event
 
 @InternalCoroutinesApi
-@RunWith(MockitoJUnitRunner::class)
-class EngagedPeopleListViewModelTest {
-    @Rule
-    @JvmField val rule = InstantTaskExecutorRule()
-
+class EngagedPeopleListViewModelTest : BaseUnitTest() {
     @Mock lateinit var getLikesHandler: GetLikesHandler
     @Mock lateinit var readerUtilsWrapper: ReaderUtilsWrapper
     @Mock lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModelTest.kt
@@ -88,7 +88,6 @@ class EngagedPeopleListViewModelTest {
         whenever(getLikesHandler.snackbarEvents).thenReturn(snackbarEvents)
         whenever(getLikesHandler.likesStatusUpdate).thenReturn(getLikesState)
 
-
         viewModel = EngagedPeopleListViewModel(
                 TEST_DISPATCHER,
                 TEST_DISPATCHER,
@@ -484,7 +483,6 @@ class EngagedPeopleListViewModelTest {
                 whenever(listScenario.commentPostId).thenReturn(postId)
                 whenever(listScenario.headerData).thenReturn(headerData)
                 whenever(listScenario.source).thenReturn(LIKE_NOTIFICATION_LIST)
-
             }
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModelTest.kt
@@ -1,0 +1,520 @@
+package org.wordpress.android.ui.engagement
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.InternalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.test
+import org.wordpress.android.ui.engagement.AuthorName.AuthorNameString
+import org.wordpress.android.ui.engagement.EngageItem.LikedItem
+import org.wordpress.android.ui.engagement.EngageItem.Liker
+import org.wordpress.android.ui.engagement.EngageItem.NextLikesPageLoader
+import org.wordpress.android.ui.engagement.EngagedListNavigationEvent.OpenUserProfileBottomSheet
+import org.wordpress.android.ui.engagement.EngagedListNavigationEvent.PreviewCommentInReader
+import org.wordpress.android.ui.engagement.EngagedListNavigationEvent.PreviewPostInReader
+import org.wordpress.android.ui.engagement.EngagedListNavigationEvent.PreviewSiteById
+import org.wordpress.android.ui.engagement.EngagedListNavigationEvent.PreviewSiteByUrl
+import org.wordpress.android.ui.engagement.EngagedListServiceRequestEvent.RequestBlogPost
+import org.wordpress.android.ui.engagement.EngagedListServiceRequestEvent.RequestComment
+import org.wordpress.android.ui.engagement.EngagedPeopleListViewModel.EngagedPeopleListUiState
+import org.wordpress.android.ui.engagement.EngagementNavigationSource.LIKE_NOTIFICATION_LIST
+import org.wordpress.android.ui.engagement.EngagementNavigationSource.LIKE_READER_LIST
+import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState
+import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
+import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.LikesData
+import org.wordpress.android.ui.engagement.GetLikesUseCase.LikeGroupFingerPrint
+import org.wordpress.android.ui.engagement.ListScenarioType.LOAD_COMMENT_LIKES
+import org.wordpress.android.ui.engagement.ListScenarioType.LOAD_POST_LIKES
+import org.wordpress.android.ui.engagement.utils.GetLikesTestConfig.TEST_CONFIG_1
+import org.wordpress.android.ui.engagement.utils.GetLikesTestConfig.TEST_CONFIG_2
+import org.wordpress.android.ui.engagement.utils.GetLikesTestConfig.TEST_CONFIG_3
+import org.wordpress.android.ui.engagement.utils.GetLikesTestConfig.TEST_CONFIG_4
+import org.wordpress.android.ui.engagement.utils.GetLikesTestConfig.TEST_CONFIG_5
+import org.wordpress.android.ui.engagement.utils.generatesEquivalentLikedItem
+import org.wordpress.android.ui.engagement.utils.getGetLikesState
+import org.wordpress.android.ui.engagement.utils.isEqualTo
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.viewmodel.Event
+
+@InternalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class EngagedPeopleListViewModelTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    @Mock lateinit var getLikesHandler: GetLikesHandler
+    @Mock lateinit var readerUtilsWrapper: ReaderUtilsWrapper
+    @Mock lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
+    @Mock lateinit var listScenario: ListScenario
+    @Mock lateinit var headerData: HeaderData
+
+    private lateinit var viewModel: EngagedPeopleListViewModel
+
+    private val engagementUtils = EngagementUtils()
+
+    private val snackbarEvents = MutableLiveData<Event<SnackbarMessageHolder>>()
+    private val getLikesState = MutableLiveData<GetLikesState>()
+
+    private var uiState: EngagedPeopleListUiState? = null
+    private var navigationEvent: EngagedListNavigationEvent? = null
+    private var serviceRequestEvent: MutableList<EngagedListServiceRequestEvent> = mutableListOf()
+    private var holder: SnackbarMessageHolder? = null
+
+    private val siteId = 100L
+    private val postId = 1000L
+    private val commentId = 10000L
+    private val expectedNumLikes = 6
+    private val defaultPageLenght = 20
+    private val noLikesLimit = -1
+
+    @Before
+    fun setup() {
+        setupMocksForPostOrComment(LOAD_POST_LIKES)
+
+        whenever(getLikesHandler.snackbarEvents).thenReturn(snackbarEvents)
+        whenever(getLikesHandler.likesStatusUpdate).thenReturn(getLikesState)
+
+
+        viewModel = EngagedPeopleListViewModel(
+                TEST_DISPATCHER,
+                TEST_DISPATCHER,
+                getLikesHandler,
+                readerUtilsWrapper,
+                engagementUtils,
+                analyticsUtilsWrapper
+        )
+
+        setupObservers()
+    }
+
+    @Test
+    fun `onCleared call clear on likes handler`() {
+        viewModel.onCleared()
+
+        verify(getLikesHandler, times(1)).clear()
+    }
+
+    @Test
+    fun `data refresh is requested on start`() = test {
+        viewModel.start(listScenario)
+
+        verify(getLikesHandler, times(1)).handleGetLikesForPost(
+                LikeGroupFingerPrint(
+                        siteId,
+                        postId,
+                        expectedNumLikes
+                ),
+                false
+        )
+    }
+
+    @Test
+    fun `post is requested for reader when post does not exist`() {
+        whenever(readerUtilsWrapper.postExists(siteId, postId)).thenReturn(false)
+
+        viewModel.start(listScenario)
+
+        assertThat(serviceRequestEvent).isNotEmpty
+        assertThat(serviceRequestEvent).isEqualTo(listOf(RequestBlogPost(siteId, postId)))
+    }
+
+    @Test
+    fun `comment is requested for reader when comment does not exist`() {
+        setupMocksForPostOrComment(LOAD_COMMENT_LIKES)
+
+        whenever(readerUtilsWrapper.postExists(siteId, postId)).thenReturn(true)
+        whenever(readerUtilsWrapper.commentExists(siteId, postId, commentId)).thenReturn(false)
+
+        viewModel.start(listScenario)
+
+        assertThat(serviceRequestEvent).isNotEmpty
+        assertThat(serviceRequestEvent).isEqualTo(listOf(RequestComment(siteId, postId, commentId)))
+    }
+
+    @Test
+    fun `post and comment are requested for reader when they do not exist`() {
+        setupMocksForPostOrComment(LOAD_COMMENT_LIKES)
+
+        whenever(readerUtilsWrapper.postExists(siteId, postId)).thenReturn(false)
+        whenever(readerUtilsWrapper.commentExists(siteId, postId, commentId)).thenReturn(false)
+
+        viewModel.start(listScenario)
+
+        assertThat(serviceRequestEvent).isNotEmpty
+        assertThat(serviceRequestEvent).isEqualTo(
+                listOf(
+                        RequestBlogPost(siteId, postId),
+                        RequestComment(siteId, postId, commentId)
+                )
+        )
+    }
+
+    @Test
+    fun `likes are requested for post`() = test {
+        viewModel.start(listScenario)
+
+        verify(getLikesHandler, times(1)).handleGetLikesForPost(
+                LikeGroupFingerPrint(
+                        siteId,
+                        postId,
+                        expectedNumLikes
+                ),
+                false
+        )
+    }
+
+    @Test
+    fun `likes are requested for comment`() = test {
+        setupMocksForPostOrComment(LOAD_COMMENT_LIKES)
+
+        viewModel.start(listScenario)
+
+        verify(getLikesHandler, times(1)).handleGetLikesForComment(
+                LikeGroupFingerPrint(
+                        siteId,
+                        commentId,
+                        expectedNumLikes
+                ),
+                false
+        )
+    }
+
+    @Test
+    fun `uiState is updated with post liked item, likers and no page loader`() = test {
+        val likesState = getGetLikesState(TEST_CONFIG_1)
+
+        viewModel.start(listScenario)
+
+        getLikesState.value = likesState
+
+        requireNotNull(uiState).let {
+            assertThat(it.showLikeFacesTrain).isFalse
+            assertThat(it.showLoading).isFalse
+            with(it.engageItemsList) {
+                val likedItem = this.filterIsInstance<LikedItem>()
+                val likerItems = this.filterIsInstance<Liker>()
+                val pageLoader = this.filterIsInstance<NextLikesPageLoader>()
+
+                assertThat(likedItem.size).isEqualTo(1)
+                assertThat(listScenario.generatesEquivalentLikedItem(likedItem.first()))
+                assertThat((likesState as LikesData).likes.isEqualTo(likerItems)).isTrue
+                assertThat(pageLoader).isEmpty()
+            }
+        }
+    }
+
+    @Test
+    fun `uiState is updated with post liked item, likers and page loader`() = test {
+        val likesState = getGetLikesState(TEST_CONFIG_2)
+
+        viewModel.start(listScenario)
+
+        getLikesState.value = likesState
+
+        requireNotNull(uiState).let {
+            assertThat(it.showLikeFacesTrain).isFalse
+            assertThat(it.showLoading).isFalse
+            with(it.engageItemsList) {
+                val likedItem = this.filterIsInstance<LikedItem>()
+                val likerItems = this.filterIsInstance<Liker>()
+                val pageLoader = this.filterIsInstance<NextLikesPageLoader>()
+
+                assertThat(likedItem.size).isEqualTo(1)
+                assertThat(listScenario.generatesEquivalentLikedItem(likedItem.first()))
+                assertThat((likesState as LikesData).likes.isEqualTo(likerItems)).isTrue
+                assertThat(pageLoader.size).isEqualTo(1)
+            }
+        }
+    }
+
+    @Test
+    fun `uiState is updated with comment liked item, likers and no page loader`() = test {
+        val likesState = getGetLikesState(TEST_CONFIG_3)
+
+        setupMocksForPostOrComment(LOAD_COMMENT_LIKES)
+
+        viewModel.start(listScenario)
+
+        getLikesState.value = likesState
+
+        requireNotNull(uiState).let {
+            assertThat(it.showLikeFacesTrain).isFalse
+            assertThat(it.showLoading).isFalse
+            with(it.engageItemsList) {
+                val likedItem = this.filterIsInstance<LikedItem>()
+                val likerItems = this.filterIsInstance<Liker>()
+                val pageLoader = this.filterIsInstance<NextLikesPageLoader>()
+
+                assertThat(likedItem.size).isEqualTo(1)
+                assertThat(listScenario.generatesEquivalentLikedItem(likedItem.first()))
+                assertThat((likesState as LikesData).likes.isEqualTo(likerItems)).isTrue
+                assertThat(pageLoader).isEmpty()
+            }
+        }
+    }
+
+    @Test
+    fun `uiState is updated with comment liked item, likers and page loader`() = test {
+        val likesState = getGetLikesState(TEST_CONFIG_4)
+
+        setupMocksForPostOrComment(LOAD_COMMENT_LIKES)
+
+        viewModel.start(listScenario)
+
+        getLikesState.value = likesState
+
+        requireNotNull(uiState).let {
+            assertThat(it.showLikeFacesTrain).isFalse
+            assertThat(it.showLoading).isFalse
+            with(it.engageItemsList) {
+                val likedItem = this.filterIsInstance<LikedItem>()
+                val likerItems = this.filterIsInstance<Liker>()
+                val pageLoader = this.filterIsInstance<NextLikesPageLoader>()
+
+                assertThat(likedItem.size).isEqualTo(1)
+                assertThat(listScenario.generatesEquivalentLikedItem(likedItem.first()))
+                assertThat((likesState as LikesData).likes.isEqualTo(likerItems)).isTrue
+                assertThat(pageLoader.size).isEqualTo(1)
+            }
+        }
+    }
+
+    @Test
+    fun `uiState shows empty state on failure with no values in cache`() = test {
+        val likesState = getGetLikesState(TEST_CONFIG_5)
+
+        viewModel.start(listScenario)
+
+        getLikesState.value = likesState
+
+        requireNotNull(uiState).let {
+            assertThat(it.showLikeFacesTrain).isFalse
+            assertThat(it.showLoading).isFalse
+            with(it.engageItemsList) {
+                val likedItem = this.filterIsInstance<LikedItem>()
+                val likerItems = this.filterIsInstance<Liker>()
+                val pageLoader = this.filterIsInstance<NextLikesPageLoader>()
+
+                assertThat(likedItem.size).isEqualTo(1)
+                assertThat(listScenario.generatesEquivalentLikedItem(likedItem.first()))
+                assertThat((likesState as Failure).cachedLikes.isEqualTo(likerItems)).isTrue
+                assertThat(pageLoader.size).isEqualTo(0)
+            }
+            assertThat(it.showEmptyState).isTrue
+        }
+    }
+
+    @Test
+    fun `when user profile holder is clicked, sheet is opened`() {
+        val likesState = getGetLikesState(TEST_CONFIG_1)
+
+        viewModel.start(listScenario)
+
+        getLikesState.value = likesState
+
+        requireNotNull(uiState).let {
+            (it.engageItemsList[1] as Liker).onClick!!.invoke(mock(), listScenario.source)
+
+            requireNotNull(navigationEvent).let {
+                assertThat(navigationEvent is OpenUserProfileBottomSheet).isTrue
+            }
+        }
+    }
+
+    @Test
+    fun `when site holder with site id is clicked, the site is previewed in reader`() {
+        val likesState = getGetLikesState(TEST_CONFIG_1)
+
+        viewModel.start(listScenario)
+
+        getLikesState.value = likesState
+
+        requireNotNull(uiState).let {
+            val likedItem = it.engageItemsList[0] as LikedItem
+            likedItem.onGravatarClick.invoke(
+                    likedItem.authorPreferredSiteId,
+                    likedItem.authorPreferredSiteUrl,
+                    likedItem.blogPreviewSource
+            )
+
+            requireNotNull(navigationEvent).let {
+                assertThat(navigationEvent is PreviewSiteById).isTrue
+            }
+        }
+    }
+
+    @Test
+    fun `when site holder with zero site id is clicked, the site is previewed in webview`() {
+        val likesState = getGetLikesState(TEST_CONFIG_1)
+
+        viewModel.start(listScenario)
+
+        getLikesState.value = likesState
+
+        requireNotNull(uiState).let {
+            val likedItem = it.engageItemsList[0] as LikedItem
+            likedItem.onGravatarClick.invoke(
+                    0,
+                    likedItem.authorPreferredSiteUrl,
+                    likedItem.blogPreviewSource
+            )
+
+            requireNotNull(navigationEvent).let {
+                assertThat(navigationEvent is PreviewSiteByUrl).isTrue
+            }
+        }
+    }
+
+    @Test
+    fun `when header holder for comment is clicked, reader is opened if data is available`() {
+        setupMocksForPostOrComment(LOAD_COMMENT_LIKES)
+
+        val likesState = getGetLikesState(TEST_CONFIG_2)
+
+        whenever(readerUtilsWrapper.postAndCommentExists(anyLong(), anyLong(), anyLong())).thenReturn(true)
+
+        viewModel.start(listScenario)
+
+        getLikesState.value = likesState
+
+        requireNotNull(uiState).let {
+            val likedItem = it.engageItemsList[0] as LikedItem
+            likedItem.onHeaderClicked.invoke(
+                    likedItem.likedItemSiteId,
+                    likedItem.likedItemSiteUrl,
+                    likedItem.likedItemId,
+                    likedItem.likedItemPostId
+            )
+
+            requireNotNull(navigationEvent).let {
+                assertThat(navigationEvent is PreviewCommentInReader).isTrue
+            }
+        }
+    }
+
+    @Test
+    fun `when header holder for comment is clicked, webview is opened if data is not available`() {
+        setupMocksForPostOrComment(LOAD_COMMENT_LIKES)
+
+        val likesState = getGetLikesState(TEST_CONFIG_2)
+
+        whenever(readerUtilsWrapper.postAndCommentExists(anyLong(), anyLong(), anyLong())).thenReturn(false)
+
+        viewModel.start(listScenario)
+
+        getLikesState.value = likesState
+
+        requireNotNull(uiState).let {
+            val likedItem = it.engageItemsList[0] as LikedItem
+            likedItem.onHeaderClicked.invoke(
+                    likedItem.likedItemSiteId,
+                    likedItem.likedItemSiteUrl,
+                    likedItem.likedItemId,
+                    likedItem.likedItemPostId
+            )
+
+            requireNotNull(navigationEvent).let {
+                assertThat(navigationEvent is PreviewSiteByUrl).isTrue
+            }
+        }
+    }
+
+    @Test
+    fun `when header holder for post is clicked, reader is opened`() {
+        val likesState = getGetLikesState(TEST_CONFIG_1)
+
+        viewModel.start(listScenario)
+
+        getLikesState.value = likesState
+
+        requireNotNull(uiState).let {
+            val likedItem = it.engageItemsList[0] as LikedItem
+            likedItem.onHeaderClicked.invoke(
+                    likedItem.likedItemSiteId,
+                    likedItem.likedItemSiteUrl,
+                    likedItem.likedItemId,
+                    likedItem.likedItemPostId
+            )
+
+            requireNotNull(navigationEvent).let {
+                assertThat(navigationEvent is PreviewPostInReader).isTrue
+            }
+        }
+    }
+
+    private fun setupMocksForPostOrComment(type: ListScenarioType) {
+        whenever(headerData.authorName).thenReturn(AuthorNameString("authorName"))
+        whenever(headerData.snippetText).thenReturn("snippetText")
+        whenever(headerData.authorAvatarUrl).thenReturn("authorAvatarUrl")
+        whenever(headerData.numLikes).thenReturn(expectedNumLikes)
+        whenever(headerData.authorUserId).thenReturn(100)
+
+        whenever(headerData.authorPreferredSiteId).thenReturn(1000)
+        whenever(headerData.authorPreferredSiteUrl).thenReturn("authorPreferredSiteUrl")
+
+        whenever(listScenario.commentSiteUrl).thenReturn("commentSiteUrl")
+
+        when (type) {
+            LOAD_POST_LIKES -> {
+                whenever(listScenario.type).thenReturn(LOAD_POST_LIKES)
+                whenever(listScenario.siteId).thenReturn(siteId)
+                whenever(listScenario.postOrCommentId).thenReturn(postId)
+                whenever(listScenario.commentPostId).thenReturn(0L)
+                whenever(listScenario.headerData).thenReturn(headerData)
+                whenever(listScenario.source).thenReturn(LIKE_READER_LIST)
+            }
+            LOAD_COMMENT_LIKES -> {
+                whenever(listScenario.type).thenReturn(LOAD_COMMENT_LIKES)
+                whenever(listScenario.siteId).thenReturn(siteId)
+                whenever(listScenario.postOrCommentId).thenReturn(commentId)
+                whenever(listScenario.commentPostId).thenReturn(postId)
+                whenever(listScenario.headerData).thenReturn(headerData)
+                whenever(listScenario.source).thenReturn(LIKE_NOTIFICATION_LIST)
+
+            }
+        }
+    }
+
+    private fun setupObservers() {
+        uiState = null
+        navigationEvent = null
+        serviceRequestEvent.clear()
+        holder = null
+
+        viewModel.uiState.observeForever {
+            uiState = it
+        }
+
+        viewModel.onNavigationEvent.observeForever {
+            it.applyIfNotHandled {
+                navigationEvent = this
+            }
+        }
+
+        viewModel.onServiceRequestEvent.observeForever {
+            it.applyIfNotHandled {
+                serviceRequestEvent.add(this)
+            }
+        }
+
+        viewModel.onSnackbarMessage.observeForever {
+            it.applyIfNotHandled {
+                holder = this
+            }
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/UserProfileViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/UserProfileViewModelTest.kt
@@ -71,7 +71,6 @@ class UserProfileViewModelTest {
 
         requireNotNull(sheetAction).let {
             assertThat(it is ShowBottomSheet).isTrue
-
         }
     }
 
@@ -89,7 +88,6 @@ class UserProfileViewModelTest {
 
         requireNotNull(sheetAction).let {
             assertThat(it is HideBottomSheet).isTrue
-
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/UserProfileViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/UserProfileViewModelTest.kt
@@ -1,16 +1,13 @@
 package org.wordpress.android.ui.engagement
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.ui.engagement.BottomSheetAction.HideBottomSheet
 import org.wordpress.android.ui.engagement.BottomSheetAction.ShowBottomSheet
 import org.wordpress.android.ui.engagement.BottomSheetUiState.UserProfileUiState
@@ -20,11 +17,7 @@ import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
 
-@RunWith(MockitoJUnitRunner::class)
-class UserProfileViewModelTest {
-    @Rule
-    @JvmField val rule = InstantTaskExecutorRule()
-
+class UserProfileViewModelTest : BaseUnitTest() {
     @Mock lateinit var resourceProvider: ResourceProvider
     @Mock lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/UserProfileViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/UserProfileViewModelTest.kt
@@ -1,0 +1,125 @@
+package org.wordpress.android.ui.engagement
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.ui.engagement.BottomSheetAction.HideBottomSheet
+import org.wordpress.android.ui.engagement.BottomSheetAction.ShowBottomSheet
+import org.wordpress.android.ui.engagement.BottomSheetUiState.UserProfileUiState
+import org.wordpress.android.ui.engagement.EngagedListNavigationEvent.OpenUserProfileBottomSheet.UserProfile
+import org.wordpress.android.ui.engagement.EngagementNavigationSource.LIKE_NOTIFICATION_LIST
+import org.wordpress.android.ui.reader.tracker.ReaderTracker
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.viewmodel.ResourceProvider
+
+@RunWith(MockitoJUnitRunner::class)
+class UserProfileViewModelTest {
+    @Rule
+    @JvmField val rule = InstantTaskExecutorRule()
+
+    @Mock lateinit var resourceProvider: ResourceProvider
+    @Mock lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
+
+    private lateinit var viewModel: UserProfileViewModel
+
+    private var sheetAction: BottomSheetAction? = null
+    private var sheetUiState: BottomSheetUiState? = null
+
+    @Before
+    fun setup() {
+        viewModel = UserProfileViewModel(
+                resourceProvider,
+                analyticsUtilsWrapper
+        )
+
+        setupObservers()
+    }
+
+    @Test
+    fun `bottom sheet ui state is updated when user clicks on a liker`() {
+        val userProfile = getDefaultUserProfile()
+        viewModel.onBottomSheetOpen(userProfile, ::onClickDummy, LIKE_NOTIFICATION_LIST)
+
+        requireNotNull(sheetUiState).let {
+            assertThat(it is UserProfileUiState).isTrue
+            with(it as UserProfileUiState) {
+                assertThat(userAvatarUrl).isEqualTo(userProfile.userAvatarUrl)
+                assertThat(blavatarUrl).isEqualTo(userProfile.blavatarUrl)
+                assertThat(userName).isEqualTo(userProfile.userName)
+                assertThat(userLogin).isEqualTo(userProfile.userLogin)
+                assertThat(userBio).isEqualTo(userProfile.userBio)
+                assertThat(siteTitle).isEqualTo(userProfile.siteTitle)
+                assertThat(siteUrl).isEqualTo(userProfile.siteUrl)
+                assertThat(siteId).isEqualTo(userProfile.siteId)
+                assertThat(blogPreviewSource).isEqualTo(ReaderTracker.SOURCE_NOTIF_LIKE_LIST_USER_PROFILE)
+            }
+        }
+    }
+
+    @Test
+    fun `bottom sheet is opened when user clicks on a liker`() {
+        val userProfile = getDefaultUserProfile()
+        viewModel.onBottomSheetOpen(userProfile, ::onClickDummy, LIKE_NOTIFICATION_LIST)
+
+        requireNotNull(sheetAction).let {
+            assertThat(it is ShowBottomSheet).isTrue
+
+        }
+    }
+
+    @Test
+    fun `bottom sheet opening is tracked`() {
+        val userProfile = getDefaultUserProfile()
+        viewModel.onBottomSheetOpen(userProfile, ::onClickDummy, LIKE_NOTIFICATION_LIST)
+
+        verify(analyticsUtilsWrapper, times(1)).trackUserProfileShown(anyString())
+    }
+
+    @Test
+    fun `bottom sheet is closed on cancel`() {
+        viewModel.onBottomSheetCancelled()
+
+        requireNotNull(sheetAction).let {
+            assertThat(it is HideBottomSheet).isTrue
+
+        }
+    }
+
+    private fun getDefaultUserProfile(): UserProfile {
+        return UserProfile(
+                userAvatarUrl = "userAvatarUrl",
+                blavatarUrl = "blavatarUrl",
+                userName = "userName",
+                userLogin = "userLogin",
+                userBio = "userBio",
+                siteTitle = "siteTitle",
+                siteUrl = "siteUrl",
+                siteId = 100L
+        )
+    }
+
+    private fun onClickDummy(siteId: Long, siteUrl: String, source: String) {}
+
+    private fun setupObservers() {
+        sheetUiState = null
+        sheetAction = null
+
+        viewModel.bottomSheetUiState.observeForever {
+            sheetUiState = it
+        }
+
+        viewModel.onBottomSheetAction.observeForever {
+            it.applyIfNotHandled {
+                sheetAction = this
+            }
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/utils/GetLikesTestUtils.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/utils/GetLikesTestUtils.kt
@@ -58,7 +58,7 @@ enum class GetLikesTestConfig {
 }
 
 fun getGetLikesState(testConfig: GetLikesTestConfig): GetLikesState {
-    return when(testConfig) {
+    return when (testConfig) {
         TEST_CONFIG_1 -> {
             LikesData(
                     getDefaultLikers(10, POST_LIKE, 10, 100),

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/utils/GetLikesTestUtils.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/utils/GetLikesTestUtils.kt
@@ -59,6 +59,7 @@ enum class GetLikesTestConfig {
 
 fun getGetLikesState(testConfig: GetLikesTestConfig): GetLikesState {
     return when (testConfig) {
+        // Like Data available for post and fetched from API; no more data available
         TEST_CONFIG_1 -> {
             LikesData(
                     getDefaultLikers(10, POST_LIKE, 10, 100),
@@ -66,6 +67,7 @@ fun getGetLikesState(testConfig: GetLikesTestConfig): GetLikesState {
                     false
             )
         }
+        // Like Data available for post and fetched from API, more data available
         TEST_CONFIG_2 -> {
             LikesData(
                     getDefaultLikers(10, COMMENT_LIKE, 10, 100),
@@ -73,6 +75,7 @@ fun getGetLikesState(testConfig: GetLikesTestConfig): GetLikesState {
                     true
             )
         }
+        // Like Data available for comment and fetched from API, no more data available
         TEST_CONFIG_3 -> {
             LikesData(
                     getDefaultLikers(10, COMMENT_LIKE, 10, 100),
@@ -80,6 +83,7 @@ fun getGetLikesState(testConfig: GetLikesTestConfig): GetLikesState {
                     false
             )
         }
+        // Like Data available for comment and fetched from API, more data available
         TEST_CONFIG_4 -> {
             LikesData(
                     getDefaultLikers(10, COMMENT_LIKE, 10, 100),
@@ -87,6 +91,7 @@ fun getGetLikesState(testConfig: GetLikesTestConfig): GetLikesState {
                     true
             )
         }
+        // Failure getting like data from API, and no cached data available
         TEST_CONFIG_5 -> {
             val cachedData = listOf<LikeModel>()
             Failure(

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -238,7 +238,7 @@ class ReaderPostDetailViewModelTest {
         whenever(getLikesHandler.snackbarEvents).thenReturn(snackbarEvents)
         whenever(getLikesHandler.likesStatusUpdate).thenReturn(getLikesState)
         val context = mock<Context>()
-        whenever(context.getString(anyInt(),anyInt())).thenReturn("10 bloggers like this.")
+        whenever(context.getString(anyInt(), anyInt())).thenReturn("10 bloggers like this.")
         whenever(contextProvider.getContext()).thenReturn(context)
     }
 
@@ -829,28 +829,28 @@ class ReaderPostDetailViewModelTest {
 
     @Test
     fun `ui state shows empty state on failure and no cached data`() {
-       val likesState = getGetLikesState(TEST_CONFIG_5) as Failure
-       val likers = listOf<Liker>()
+        val likesState = getGetLikesState(TEST_CONFIG_5) as Failure
+        val likers = listOf<Liker>()
 
-       getLikesState.value = likesState
-       whenever(engagementUtils.likesToEngagedPeople(anyList(), eq(null), eq(null))).thenReturn(likers)
-       val post = mock<ReaderPost>()
-       whenever(post.isWP).thenReturn(true)
-       viewModel.post = post
-       val likeObserver = init().likesUiState
+        getLikesState.value = likesState
+        whenever(engagementUtils.likesToEngagedPeople(anyList(), eq(null), eq(null))).thenReturn(likers)
+        val post = mock<ReaderPost>()
+        whenever(post.isWP).thenReturn(true)
+        viewModel.post = post
+        val likeObserver = init().likesUiState
 
-       getLikesState.value = likesState
+        getLikesState.value = likesState
 
-       assertThat(likeObserver).isNotEmpty
-       with(likeObserver.first()) {
-           assertThat(showLikeFacesTrain).isTrue
-           assertThat(showLoading).isFalse
-           assertThat(engageItemsList).isEqualTo(likers)
-           assertThat(numLikes).isEqualTo(likesState.expectedNumLikes)
-           assertThat(showEmptyState).isTrue
-           assertThat(emptyStateTitle is UiStringRes).isTrue
-           assertThat(likersFacesText).isNull()
-       }
+        assertThat(likeObserver).isNotEmpty
+        with(likeObserver.first()) {
+            assertThat(showLikeFacesTrain).isTrue
+            assertThat(showLoading).isFalse
+            assertThat(engageItemsList).isEqualTo(likers)
+            assertThat(numLikes).isEqualTo(likesState.expectedNumLikes)
+            assertThat(showEmptyState).isTrue
+            assertThat(emptyStateTitle is UiStringRes).isTrue
+            assertThat(likersFacesText).isNull()
+        }
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.viewmodels
 
+import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.any
@@ -18,6 +19,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyList
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
@@ -30,14 +33,23 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.test
+import org.wordpress.android.ui.engagement.EngageItem.Liker
+import org.wordpress.android.ui.engagement.EngagedPeopleListViewModel.EngagedPeopleListUiState
 import org.wordpress.android.ui.engagement.EngagementUtils
 import org.wordpress.android.ui.engagement.GetLikesHandler
+import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState
+import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
+import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.LikesData
+import org.wordpress.android.ui.engagement.utils.GetLikesTestConfig.TEST_CONFIG_1
+import org.wordpress.android.ui.engagement.utils.GetLikesTestConfig.TEST_CONFIG_5
+import org.wordpress.android.ui.engagement.utils.getGetLikesState
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.ReaderPostDetailUiStateBuilder
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenEditorForReblog
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.OpenUrl
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ReplaceRelatedPostDetailsWithHistory
+import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowEngagedPeopleList
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowMediaPreview
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostInWebView
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents.ShowPostsByTag
@@ -73,7 +85,6 @@ import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiSt
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState.RelatedPostsUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel.UiState.ReaderPostDetailsUiState.RelatedPostsUiState.ReaderRelatedPostUiState
-
 import org.wordpress.android.ui.reader.views.uistates.FollowButtonUiState
 import org.wordpress.android.ui.reader.views.uistates.ReaderBlogSectionUiState
 import org.wordpress.android.ui.reader.views.uistates.ReaderBlogSectionUiState.ReaderBlogSectionClickData
@@ -131,6 +142,9 @@ class ReaderPostDetailViewModelTest {
     private val fakeRefreshPostFeed = MutableLiveData<Event<Unit>>()
     private val fakeNavigationFeed = MutableLiveData<Event<ReaderNavigationEvents>>()
     private val fakeSnackBarFeed = MutableLiveData<Event<SnackbarMessageHolder>>()
+    private val getLikesState = MutableLiveData<GetLikesState>()
+
+    private val snackbarEvents = MutableLiveData<Event<SnackbarMessageHolder>>()
 
     private val readerPost = createDummyReaderPost(2)
     private val site = SiteModel().apply { siteId = readerPost.blogId }
@@ -220,7 +234,12 @@ class ReaderPostDetailViewModelTest {
         whenever(reblogUseCase.onReblogSiteSelected(ArgumentMatchers.anyInt(), anyOrNull())).thenReturn(mock())
         whenever(reblogUseCase.convertReblogStateToNavigationEvent(anyOrNull())).thenReturn(mock<OpenEditorForReblog>())
 
-        whenever(likesEnhancementsFeatureConfig.isEnabled()).thenReturn(false)
+        whenever(likesEnhancementsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(getLikesHandler.snackbarEvents).thenReturn(snackbarEvents)
+        whenever(getLikesHandler.likesStatusUpdate).thenReturn(getLikesState)
+        val context = mock<Context>()
+        whenever(context.getString(anyInt(),anyInt())).thenReturn("10 bloggers like this.")
+        whenever(contextProvider.getContext()).thenReturn(context)
     }
 
     /* SHOW POST - LOADING */
@@ -772,6 +791,80 @@ class ReaderPostDetailViewModelTest {
         )
     }
 
+    @Test
+    fun `likes for post are refreshed on request`() = test {
+        val likesState = getGetLikesState(TEST_CONFIG_1) as LikesData
+
+        getLikesState.value = likesState
+        init()
+        viewModel.onRefreshLikersData(viewModel.post!!)
+        verify(getLikesHandler, times(1)).handleGetLikesForPost(anyOrNull(), anyBoolean(), anyInt(), anyInt())
+    }
+
+    @Test
+    fun `ui state show likers faces when data available`() {
+        val likesState = getGetLikesState(TEST_CONFIG_1) as LikesData
+        val likers = MutableList(5) { mock<Liker>() }
+
+        getLikesState.value = likesState
+        whenever(engagementUtils.likesToEngagedPeople(anyList(), eq(null), eq(null))).thenReturn(likers)
+        val post = mock<ReaderPost>()
+        whenever(post.isWP).thenReturn(true)
+        viewModel.post = post
+        val likeObserver = init().likesUiState
+
+        getLikesState.value = likesState
+
+        assertThat(likeObserver).isNotEmpty
+        with(likeObserver.first()) {
+            assertThat(showLikeFacesTrain).isTrue
+            assertThat(showLoading).isFalse
+            assertThat(engageItemsList).isEqualTo(likers)
+            assertThat(numLikes).isEqualTo(likesState.expectedNumLikes)
+            assertThat(showEmptyState).isFalse
+            assertThat(emptyStateTitle).isNull()
+            assertThat(likersFacesText is UiStringText).isTrue
+        }
+    }
+
+    @Test
+    fun `ui state shows empty state on failure and no cached data`() {
+       val likesState = getGetLikesState(TEST_CONFIG_5) as Failure
+       val likers = listOf<Liker>()
+
+       getLikesState.value = likesState
+       whenever(engagementUtils.likesToEngagedPeople(anyList(), eq(null), eq(null))).thenReturn(likers)
+       val post = mock<ReaderPost>()
+       whenever(post.isWP).thenReturn(true)
+       viewModel.post = post
+       val likeObserver = init().likesUiState
+
+       getLikesState.value = likesState
+
+       assertThat(likeObserver).isNotEmpty
+       with(likeObserver.first()) {
+           assertThat(showLikeFacesTrain).isTrue
+           assertThat(showLoading).isFalse
+           assertThat(engageItemsList).isEqualTo(likers)
+           assertThat(numLikes).isEqualTo(likesState.expectedNumLikes)
+           assertThat(showEmptyState).isTrue
+           assertThat(emptyStateTitle is UiStringRes).isTrue
+           assertThat(likersFacesText).isNull()
+       }
+    }
+
+    @Test
+    fun `likers list is shown when like faces are clicked`() {
+        val post = mock<ReaderPost>()
+        viewModel.post = post
+
+        val navigation = init().navigation
+
+        viewModel.onLikeFacesClicked()
+
+        assertThat(navigation.last().peekContent()).isInstanceOf(ShowEngagedPeopleList::class.java)
+    }
+
     private fun <T> testWithoutLocalPost(block: suspend CoroutineScope.() -> T) {
         test {
             whenever(readerGetPostUseCase.get(any(), any(), any())).thenReturn(Pair(null, false))
@@ -877,6 +970,10 @@ class ReaderPostDetailViewModelTest {
         viewModel.snackbarEvents.observeForever {
             msgs.add(it)
         }
+        val likesUiStates = mutableListOf<EngagedPeopleListUiState>()
+        viewModel.likesUiState.observeForever {
+            likesUiStates.add(it)
+        }
 
         val interceptedUri = INTERCEPTED_URI.takeIf { interceptedUrPresent }
 
@@ -896,13 +993,15 @@ class ReaderPostDetailViewModelTest {
         return Observers(
                 uiStates,
                 navigation,
-                msgs
+                msgs,
+                likesUiStates
         )
     }
 
     private data class Observers(
         val uiStates: List<UiState>,
         val navigation: List<Event<ReaderNavigationEvents>>,
-        val snackbarMsgs: List<Event<SnackbarMessageHolder>>
+        val snackbarMsgs: List<Event<SnackbarMessageHolder>>,
+        val likesUiState: List<EngagedPeopleListUiState>
     )
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.reader.viewmodels
 
 import android.content.Context
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
@@ -14,9 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.ArgumentMatchers.anyInt
@@ -24,7 +21,7 @@ import org.mockito.ArgumentMatchers.anyList
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
@@ -111,11 +108,7 @@ private const val ON_RELATED_POST_ITEM_CLICKED_PARAM_POSITION = 3
 private const val INTERCEPTED_URI = "intercepted uri"
 
 @InternalCoroutinesApi
-@RunWith(MockitoJUnitRunner::class)
-class ReaderPostDetailViewModelTest {
-    @Rule
-    @JvmField val rule = InstantTaskExecutorRule()
-
+class ReaderPostDetailViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: ReaderPostDetailViewModel
 
     @Mock private lateinit var readerPostCardActionsHandler: ReaderPostCardActionsHandler


### PR DESCRIPTION
This is a second part PR to the #14532. Adding unit testing to view model layers for likes enhancements.

## To test
To test it should be enough to check the CI is green.

## Regression Notes
N/A; behind feature flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
