### PR TITLE
Handle viewpost deeplink in view model

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -46,6 +46,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose;
 import org.wordpress.android.ui.engagement.EngagedPeopleListActivity;
 import org.wordpress.android.ui.engagement.HeaderData;
+import org.wordpress.android.ui.engagement.ListScenario;
 import org.wordpress.android.ui.engagement.ListScenarioType;
 import org.wordpress.android.ui.history.HistoryDetailActivity;
 import org.wordpress.android.ui.history.HistoryDetailContainerFragment;
@@ -61,7 +62,6 @@ import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
-import org.wordpress.android.ui.engagement.ListScenario;
 import org.wordpress.android.ui.pages.PageParentActivity;
 import org.wordpress.android.ui.pages.PagesActivity;
 import org.wordpress.android.ui.people.PeopleManagementActivity;
@@ -82,6 +82,7 @@ import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
 import org.wordpress.android.ui.prefs.MyProfileActivity;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsActivity;
 import org.wordpress.android.ui.publicize.PublicizeListActivity;
+import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.sitecreation.SiteCreationActivity;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
@@ -314,6 +315,25 @@ public class ActivityLauncher {
         Intent mainActivityIntent = getMainActivityInNewStack(context)
                 .putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_READER);
         Intent viewPostIntent = new Intent(ReaderConstants.ACTION_VIEW_POST, uri);
+        TaskStackBuilder.create(context)
+                        .addNextIntent(mainActivityIntent)
+                        .addNextIntent(viewPostIntent)
+                        .startActivities();
+    }
+
+    public static void viewReaderPostDetailInNewStack(Context context, long blogId, long postId, Uri uri) {
+        Intent mainActivityIntent = getMainActivityInNewStack(context)
+                .putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_READER);
+        Intent viewPostIntent = ReaderActivityLauncher.buildReaderPostDetailIntent(
+                context,
+                false,
+                blogId,
+                postId,
+                null,
+                0,
+                false,
+                uri.toString()
+        );
         TaskStackBuilder.create(context)
                         .addNextIntent(mainActivityIntent)
                         .addNextIntent(viewPostIntent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -3,27 +3,15 @@ package org.wordpress.android.ui.deeplinks;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModelProvider;
 
-import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.analytics.AnalyticsTracker;
-import org.wordpress.android.fluxc.store.AccountStore;
-import org.wordpress.android.fluxc.store.PostStore;
-import org.wordpress.android.fluxc.store.SiteStore;
-import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.RequestCodes;
-import org.wordpress.android.ui.reader.ReaderActivityLauncher;
-import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.AppLog.T;
-import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UriWrapper;
-import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import javax.inject.Inject;
 
@@ -37,15 +25,8 @@ import static org.wordpress.android.WordPress.getContext;
  * Redirects users to the reader activity along with IDs passed in the intent
  */
 public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
-    private static final String DEEP_LINK_HOST_VIEWPOST = "viewpost";
+    private static final String URI_KEY = "uri_key";
 
-    private String mInterceptedUri;
-    private String mBlogId;
-    private String mPostId;
-
-    @Inject AccountStore mAccountStore;
-    @Inject SiteStore mSiteStore;
-    @Inject PostStore mPostStore;
     @Inject DeepLinkNavigator mDeeplinkNavigator;
     @Inject DeepLinkUriUtils mDeepLinkUriUtils;
     @Inject ViewModelProvider.Factory mViewModelFactory;
@@ -56,32 +37,30 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
         mViewModel = new ViewModelProvider(this, mViewModelFactory).get(DeepLinkingIntentReceiverViewModel.class);
-
-        String action = getIntent().getAction();
-        Uri uri = getIntent().getData();
-        String host = "";
-        if (uri != null) {
-            host = uri.getHost();
+        String action = null;
+        Uri uri;
+        if (savedInstanceState == null) {
+            action = getIntent().getAction();
+            uri = getIntent().getData();
+        } else {
+            uri = savedInstanceState.getParcelable(URI_KEY);
         }
-        AnalyticsUtils.trackWithDeepLinkData(AnalyticsTracker.Stat.DEEP_LINKED, action, host, uri);
 
         setupObservers();
 
-        // check if this intent is started via custom scheme link
-        if (Intent.ACTION_VIEW.equals(action) && uri != null) {
-            mInterceptedUri = uri.toString();
-            UriWrapper uriWrapper = new UriWrapper(uri);
-            boolean urlHandledInViewModel = mViewModel.handleUrl(uriWrapper);
-            if (!urlHandledInViewModel) {
-                if (shouldViewPost(host)) {
-                    handleViewPost(uri);
-                } else {
-                    // not handled
-                    finish();
-                }
-            }
-        } else {
-            finish();
+        UriWrapper uriWrapper = null;
+        if (uri != null) {
+            uriWrapper = new UriWrapper(uri);
+        }
+        mViewModel.start(action, uriWrapper);
+    }
+
+    @Override
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        UriWrapper cachedUri = mViewModel.getCachedUri();
+        if (cachedUri != null) {
+            outState.putParcelable(URI_KEY, cachedUri.getUri());
         }
     }
 
@@ -91,28 +70,15 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
                       mDeeplinkNavigator.handleNavigationAction(navigateAction, this);
                       return null;
                   }));
+        mViewModel.getFinish()
+                  .observe(this, finishEvent -> finishEvent.applyIfNotHandled(unit -> {
+                      finish();
+                      return null;
+                  }));
         mViewModel.getToast().observe(this, toastEvent -> toastEvent.applyIfNotHandled(toastMessage -> {
             ToastUtils.showToast(getContext(), toastMessage);
             return null;
         }));
-    }
-
-    private boolean shouldViewPost(String host) {
-        return StringUtils.equals(host, DEEP_LINK_HOST_VIEWPOST);
-    }
-
-    private void handleViewPost(@NonNull Uri uri) {
-        mBlogId = uri.getQueryParameter("blogId");
-        mPostId = uri.getQueryParameter("postId");
-
-        // if user is signed in wpcom show the post right away - otherwise show welcome activity
-        // and then show the post once the user has signed in
-        if (mAccountStore.hasAccessToken()) {
-            showPost();
-            finish();
-        } else {
-            ActivityLauncher.loginForDeeplink(this);
-        }
     }
 
     @Override
@@ -120,28 +86,9 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
         super.onActivityResult(requestCode, resultCode, data);
         // show the post if user is returning from successful login
         if (requestCode == RequestCodes.DO_LOGIN && resultCode == RESULT_OK) {
-            showPost();
-        }
-
-        finish();
-    }
-
-    private void showPost() {
-        if (!TextUtils.isEmpty(mBlogId) && !TextUtils.isEmpty(mPostId)) {
-            try {
-                final long blogId = Long.parseLong(mBlogId);
-                final long postId = Long.parseLong(mPostId);
-
-                AnalyticsUtils.trackWithBlogPostDetails(AnalyticsTracker.Stat.READER_VIEWPOST_INTERCEPTED,
-                        blogId, postId);
-
-                ReaderActivityLauncher.showReaderPostDetail(this, false, blogId, postId, null, 0, false,
-                        mInterceptedUri);
-            } catch (NumberFormatException e) {
-                AppLog.e(T.READER, e);
-            }
+            mViewModel.onSuccessfulLogin();
         } else {
-            ToastUtils.showToast(this, R.string.error_generic);
+            finish();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -29,7 +29,7 @@ class DeepLinkingIntentReceiverViewModel
     private val deepLinkUriUtils: DeepLinkUriUtils,
     private val accountStore: AccountStore,
     private val serverTrackingHandler: ServerTrackingHandler,
-        private val analyticsUtilsWrapper: AnalyticsUtilsWrapper
+    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper
 ) : ScopedViewModel(uiDispatcher) {
     private val _navigateAction = MutableLiveData<Event<NavigateAction>>()
     val navigateAction = _navigateAction as LiveData<Event<NavigateAction>>

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -3,10 +3,15 @@ package org.wordpress.android.ui.deeplinks
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.DEEP_LINKED
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.LoginForResult
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInBrowser
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.ShowSignInFlow
 import org.wordpress.android.util.UriWrapper
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -22,11 +27,31 @@ class DeepLinkingIntentReceiverViewModel
     private val pagesLinkHandler: PagesLinkHandler,
     private val notificationsLinkHandler: NotificationsLinkHandler,
     private val deepLinkUriUtils: DeepLinkUriUtils,
-    private val serverTrackingHandler: ServerTrackingHandler
+    private val accountStore: AccountStore,
+    private val serverTrackingHandler: ServerTrackingHandler,
+        private val analyticsUtilsWrapper: AnalyticsUtilsWrapper
 ) : ScopedViewModel(uiDispatcher) {
     private val _navigateAction = MutableLiveData<Event<NavigateAction>>()
     val navigateAction = _navigateAction as LiveData<Event<NavigateAction>>
+    private val _finish = MutableLiveData<Event<Unit>>()
+    val finish = _finish as LiveData<Event<Unit>>
     val toast = editorLinkHandler.toast
+    var cachedUri: UriWrapper? = null
+
+    fun start(action: String?, uri: UriWrapper?) {
+        if (action != null) {
+            analyticsUtilsWrapper.trackWithDeepLinkData(DEEP_LINKED, action, uri?.host ?: "", uri?.uri)
+        }
+        if (uri == null || !handleUrl(uri)) {
+            _finish.value = Event(Unit)
+        }
+    }
+
+    fun onSuccessfulLogin() {
+        cachedUri?.let {
+            handleUrl(it)
+        }
+    }
 
     /**
      * Handles the following URLs
@@ -35,8 +60,15 @@ class DeepLinkingIntentReceiverViewModel
      * `public-api.wordpress.com/mbar`
      * and builds the navigation action based on them
      */
-    fun handleUrl(uriWrapper: UriWrapper): Boolean {
-        return buildNavigateAction(uriWrapper)?.also { _navigateAction.value = Event(it) } != null
+    private fun handleUrl(uriWrapper: UriWrapper): Boolean {
+        cachedUri = uriWrapper
+        return buildNavigateAction(uriWrapper)?.also {
+            if (accountStore.hasAccessToken() || it is OpenInBrowser || it is ShowSignInFlow) {
+                _navigateAction.value = Event(it)
+            } else {
+                _navigateAction.value = Event(LoginForResult)
+            }
+        } != null
     }
 
     /**
@@ -83,6 +115,7 @@ class DeepLinkingIntentReceiverViewModel
 
     override fun onCleared() {
         serverTrackingHandler.clear()
+        cachedUri = null
         super.onCleared()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/ReaderLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/ReaderLinkHandler.kt
@@ -1,33 +1,63 @@
 package org.wordpress.android.ui.deeplinks
 
 import android.content.Intent
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_VIEWPOST_INTERCEPTED
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInReader
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenReader
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.ViewPostInReader
 import org.wordpress.android.ui.reader.ReaderConstants
 import org.wordpress.android.ui.utils.IntentUtils
 import org.wordpress.android.util.UriWrapper
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
 class ReaderLinkHandler
-@Inject constructor(private val intentUtils: IntentUtils) {
+@Inject constructor(
+    private val intentUtils: IntentUtils,
+    private val analyticsUtilsWrapper: AnalyticsUtilsWrapper
+) {
+    private val _toast = MutableLiveData<Event<Int>>()
+    val toast = _toast as LiveData<Event<Int>>
+
     /**
      * URIs supported by the Reader are already defined as intent filters in the manifest. Instead of replicating
      * that logic here, we simply check if we can resolve an [Intent] that uses [ReaderConstants.ACTION_VIEW_POST].
      * Since that's a custom action that is only handled by the Reader, we can then assume it supports this URI.
-     * In addition we also handle the Reader app links `wordpress://read` here.
+     * Other deeplinks handled:
+     * `wordpress://read`
+     * `wordpress://viewpost?blogId={blogId}&postId={postId}`
      */
     fun isReaderUrl(uri: UriWrapper) =
-            DEEP_LINK_HOST_READ == uri.host || intentUtils.canResolveWith(ReaderConstants.ACTION_VIEW_POST, uri)
+            DEEP_LINK_HOST_READ == uri.host || DEEP_LINK_HOST_VIEWPOST == uri.host || intentUtils.canResolveWith(
+                    ReaderConstants.ACTION_VIEW_POST,
+                    uri
+            )
 
     fun buildOpenInReaderNavigateAction(uri: UriWrapper): NavigateAction {
         return when (uri.host) {
             DEEP_LINK_HOST_READ -> OpenReader
+            DEEP_LINK_HOST_VIEWPOST -> {
+                val blogId = uri.getQueryParameter("blogId")?.toLongOrNull()
+                val postId = uri.getQueryParameter("postId")?.toLongOrNull()
+                if (blogId != null && postId != null) {
+                    analyticsUtilsWrapper.trackWithBlogPostDetails(READER_VIEWPOST_INTERCEPTED, blogId, postId)
+                    ViewPostInReader(blogId, postId, uri)
+                } else {
+                    _toast.value = Event(R.string.error_generic)
+                    OpenReader
+                }
+            }
             else -> OpenInReader(uri)
         }
     }
 
     companion object {
         private const val DEEP_LINK_HOST_READ = "read"
+        private const val DEEP_LINK_HOST_VIEWPOST = "viewpost"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -12,6 +12,7 @@ import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.ActivityOptionsCompat;
 
+import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.ReaderPost;
@@ -48,6 +49,16 @@ public class ReaderActivityLauncher {
                                             int commentId,
                                             boolean isRelatedPost,
                                             String interceptedUri) {
+        Intent intent =
+                buildReaderPostDetailIntent(context, isFeed, blogId, postId, directOperation, commentId, isRelatedPost,
+                        interceptedUri);
+        context.startActivity(intent);
+    }
+
+    @NotNull
+    public static Intent buildReaderPostDetailIntent(Context context, boolean isFeed, long blogId, long postId,
+                                                      DirectOperation directOperation, int commentId,
+                                                      boolean isRelatedPost, String interceptedUri) {
         Intent intent = new Intent(context, ReaderPostPagerActivity.class);
         intent.putExtra(ReaderConstants.ARG_IS_FEED, isFeed);
         intent.putExtra(ReaderConstants.ARG_BLOG_ID, blogId);
@@ -57,7 +68,7 @@ public class ReaderActivityLauncher {
         intent.putExtra(ReaderConstants.ARG_IS_SINGLE_POST, true);
         intent.putExtra(ReaderConstants.ARG_IS_RELATED_POST, isRelatedPost);
         intent.putExtra(ReaderConstants.ARG_INTERCEPTED_URI, interceptedUri);
-        context.startActivity(intent);
+        return intent;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtilsWrapper.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import dagger.Reusable
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.ReaderPost
@@ -66,4 +67,7 @@ class AnalyticsUtilsWrapper @Inject constructor(
     fun trackRailcarRender(
         railcarJson: String
     ) = AnalyticsUtils.trackRailcarRender(railcarJson)
+
+    fun trackWithBlogPostDetails(stat: Stat, blogId: Long, postId: Long) =
+            AnalyticsUtils.trackWithBlogPostDetails(stat, blogId, postId)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModelTest.kt
@@ -1,5 +1,9 @@
 package org.wordpress.android.ui.deeplinks
 
+import android.net.Uri
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.isNull
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
@@ -10,9 +14,14 @@ import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.TEST_DISPATCHER
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.DEEP_LINKED
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.LoginForResult
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenEditor
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.StartCreateSiteFlow
+import org.wordpress.android.util.UriWrapper
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 
 class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
     @Mock lateinit var editorLinkHandler: EditorLinkHandler
@@ -24,9 +33,12 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
     @Mock lateinit var accountStore: AccountStore
     @Mock lateinit var deepLinkUriUtils: DeepLinkUriUtils
     @Mock lateinit var serverTrackingHandler: ServerTrackingHandler
+    @Mock lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
     private lateinit var viewModel: DeepLinkingIntentReceiverViewModel
     private val startUrl = buildUri("wordpress.com", "start")
     private val postUrl = buildUri("wordpress.com", "post")
+    private var isFinished = false
+    private lateinit var navigateActions: MutableList<NavigateAction>
 
     @InternalCoroutinesApi
     @Before
@@ -40,44 +52,54 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
                 pagesLinkHandler,
                 notificationsLinkHandler,
                 deepLinkUriUtils,
-                serverTrackingHandler
+                accountStore,
+                serverTrackingHandler,
+                analyticsUtilsWrapper
         )
         whenever(startLinkHandler.isStartUrl(startUrl)).thenReturn(true)
         whenever(editorLinkHandler.isEditorUrl(postUrl)).thenReturn(true)
+        isFinished = false
+        viewModel.finish.observeForever {
+            it?.getContentIfNotHandled()?.let {
+                isFinished = true
+            }
+        }
+        navigateActions = mutableListOf()
+        viewModel.navigateAction.observeForever {
+            it?.getContentIfNotHandled()?.let {
+                navigateActions.add(it)
+            }
+        }
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
     }
 
     @Test
-    fun `should not handle WPcom URL`() {
+    fun `does not navigate and finishes on WPcom URL`() {
         val uri = buildUri("wordpress.com", "bar")
 
-        val shouldHandleUri = viewModel.handleUrl(uri)
+        viewModel.start(null, uri)
 
-        assertThat(shouldHandleUri).isFalse()
+        assertUriNotHandled()
     }
 
     @Test
-    fun `should not handle bar non-mobile URL`() {
+    fun `does not navigate and finishes on non-mobile URL`() {
         val uri = buildUri("public-api.wordpress.com", "bar")
 
-        val shouldHandleUri = viewModel.handleUrl(uri)
+        viewModel.start(null, uri)
 
-        assertThat(shouldHandleUri).isFalse()
+        assertUriNotHandled()
     }
 
     @Test
-    fun `magic login URL opens the URI in the browser without redirect parameter`() {
+    fun `mbar URL without redirect parameter replaced mbar to bar and opened in browser`() {
         val uri = buildUri("public-api.wordpress.com", "mbar")
-        var navigateAction: NavigateAction? = null
-        viewModel.navigateAction.observeForever {
-            navigateAction = it?.getContentIfNotHandled()
-        }
         val barUri = buildUri("public-api.wordpress.com", "bar")
         whenever(uri.copy("bar")).thenReturn(barUri)
 
-        val urlHandled = viewModel.handleUrl(uri)
+        viewModel.start(null, uri)
 
-        assertThat(urlHandled).isTrue()
-        assertThat(navigateAction).isEqualTo(NavigateAction.OpenInBrowser(barUri))
+        assertUriHandled(NavigateAction.OpenInBrowser(barUri))
     }
 
     @Test
@@ -88,15 +110,10 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         whenever(deepLinkUriUtils.getUriFromQueryParameter(uri, "redirect_to")).thenReturn(firstRedirect)
         whenever(deepLinkUriUtils.getUriFromQueryParameter(firstRedirect, "redirect_to")).thenReturn(startUrl)
         whenever(startLinkHandler.buildNavigateAction()).thenReturn(StartCreateSiteFlow)
-        var navigateAction: NavigateAction? = null
-        viewModel.navigateAction.observeForever {
-            navigateAction = it?.getContentIfNotHandled()
-        }
 
-        val urlHandled = viewModel.handleUrl(uri)
+        viewModel.start(null, uri)
 
-        assertThat(urlHandled).isTrue()
-        assertThat(navigateAction).isEqualTo(StartCreateSiteFlow)
+        assertUriHandled(StartCreateSiteFlow)
         verify(serverTrackingHandler).request(uri)
     }
 
@@ -105,17 +122,12 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         val uri = buildUri("public-api.wordpress.com", "mbar", "redirect_to=...")
         val redirect = buildUri("wordpress.com", "wp-login.php")
         whenever(deepLinkUriUtils.getUriFromQueryParameter(uri, "redirect_to")).thenReturn(redirect)
-        var navigateAction: NavigateAction? = null
-        viewModel.navigateAction.observeForever {
-            navigateAction = it?.getContentIfNotHandled()
-        }
         val barUri = buildUri("public-api.wordpress.com", "bar")
         whenever(uri.copy("bar")).thenReturn(barUri)
 
-        val urlHandled = viewModel.handleUrl(uri)
+        viewModel.start(null, uri)
 
-        assertThat(urlHandled).isTrue()
-        assertThat(navigateAction).isEqualTo(NavigateAction.OpenInBrowser(barUri))
+        assertUriHandled(NavigateAction.OpenInBrowser(barUri))
     }
 
     @Test
@@ -124,15 +136,10 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         whenever(deepLinkUriUtils.getUriFromQueryParameter(uri, "redirect_to")).thenReturn(postUrl)
         val expectedAction = NavigateAction.OpenEditor
         whenever(editorLinkHandler.buildOpenEditorNavigateAction(postUrl)).thenReturn(expectedAction)
-        var navigateAction: NavigateAction? = null
-        viewModel.navigateAction.observeForever {
-            navigateAction = it?.getContentIfNotHandled()
-        }
 
-        val urlHandled = viewModel.handleUrl(uri)
+        viewModel.start(null, uri)
 
-        assertThat(urlHandled).isTrue()
-        assertThat(navigateAction).isEqualTo(expectedAction)
+        assertUriHandled(expectedAction)
         verify(serverTrackingHandler).request(uri)
     }
 
@@ -140,37 +147,37 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
     fun `does not handle pages url`() {
         val uri = buildUri("wordpress.com", "pages")
 
-        val shouldHandleUri = viewModel.handleUrl(uri)
+        viewModel.start(null, uri)
 
-        assertThat(shouldHandleUri).isFalse()
+        assertUriNotHandled()
     }
 
     @Test
-    fun `does not handle app link to posts`() {
+    fun `does not handle app link to pages`() {
         val uri = buildUri("pages", "")
 
-        val shouldHandleUri = viewModel.handleUrl(uri)
+        viewModel.start(null, uri)
 
-        assertThat(shouldHandleUri).isFalse()
+        assertUriNotHandled()
     }
 
     @Test
     fun `opens navigate action from editor link handler`() {
-        val siteUrl = "site123"
-        val uri = buildUri("wordpress.com", "post", siteUrl)
-        whenever(editorLinkHandler.isEditorUrl(uri)).thenReturn(true)
-        val expected = NavigateAction.OpenEditor
-        whenever(editorLinkHandler.buildOpenEditorNavigateAction(uri)).thenReturn(expected)
+        val (uri, expected) = initEditorLinkHandler()
 
-        var navigateAction: NavigateAction? = null
-        viewModel.navigateAction.observeForever {
-            navigateAction = it?.getContentIfNotHandled()
-        }
+        viewModel.start(null, uri)
 
-        val urlHandled = viewModel.handleUrl(uri)
+        assertUriHandled(expected)
+    }
 
-        assertThat(urlHandled).isTrue()
-        assertThat(navigateAction).isEqualTo(expected)
+    @Test
+    fun `opens login when user logged out`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        val (uri, _) = initEditorLinkHandler()
+
+        viewModel.start(null, uri)
+
+        assertUriHandled(LoginForResult)
     }
 
     @Test
@@ -181,15 +188,9 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         val expected = NavigateAction.OpenStats
         whenever(statsLinkHandler.buildOpenStatsNavigateAction(uri)).thenReturn(expected)
 
-        var navigateAction: NavigateAction? = null
-        viewModel.navigateAction.observeForever {
-            navigateAction = it?.getContentIfNotHandled()
-        }
+        viewModel.start(null, uri)
 
-        val urlHandled = viewModel.handleUrl(uri)
-
-        assertThat(urlHandled).isTrue()
-        assertThat(navigateAction).isEqualTo(expected)
+        assertUriHandled(expected)
     }
 
     @Test
@@ -200,34 +201,24 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         val expected = NavigateAction.OpenNotifications
         whenever(notificationsLinkHandler.buildNavigateAction()).thenReturn(expected)
 
-        var navigateAction: NavigateAction? = null
-        viewModel.navigateAction.observeForever {
-            navigateAction = it?.getContentIfNotHandled()
-        }
+        viewModel.start(null, uri)
 
-        val urlHandled = viewModel.handleUrl(uri)
-
-        assertThat(urlHandled).isTrue()
-        assertThat(navigateAction).isEqualTo(expected)
+        assertUriHandled(expected)
     }
 
     @Test
     fun `view post mbar URL triggers the reader when it can be resolved`() {
         val uri = buildUri("public-api.wordpress.com", "mbar", "redirect_to=...")
         val redirect = buildUri("wordpress.com", "read")
-        var navigateAction: NavigateAction? = null
         val expectedAction = NavigateAction.OpenInReader(redirect)
 
         whenever(deepLinkUriUtils.getUriFromQueryParameter(uri, "redirect_to")).thenReturn(redirect)
         whenever(readerLinkHandler.isReaderUrl(redirect)).thenReturn(true)
         whenever(readerLinkHandler.buildOpenInReaderNavigateAction(redirect)).thenReturn(expectedAction)
 
-        viewModel.navigateAction.observeForever { navigateAction = it?.getContentIfNotHandled() }
+        viewModel.start(null, uri)
 
-        val urlHandled = viewModel.handleUrl(uri)
-
-        assertThat(urlHandled).isTrue
-        assertThat(navigateAction).isEqualTo(expectedAction)
+        assertUriHandled(expectedAction)
         verify(serverTrackingHandler).request(uri)
     }
 
@@ -236,19 +227,67 @@ class DeepLinkingIntentReceiverViewModelTest : BaseUnitTest() {
         val uri = buildUri("public-api.wordpress.com", "mbar", "redirect_to=...")
         val redirect = buildUri("wordpress.com", "read")
         val barUri = buildUri("public-api.wordpress.com", "bar")
-        var navigateAction: NavigateAction? = null
         val expectedAction = NavigateAction.OpenInBrowser(barUri)
 
         whenever(deepLinkUriUtils.getUriFromQueryParameter(uri, "redirect_to")).thenReturn(redirect)
         whenever(readerLinkHandler.isReaderUrl(redirect)).thenReturn(false)
         whenever(uri.copy("bar")).thenReturn(barUri)
 
-        viewModel.navigateAction.observeForever { navigateAction = it?.getContentIfNotHandled() }
+        viewModel.start(null, uri)
 
-        val urlHandled = viewModel.handleUrl(uri)
-
-        assertThat(urlHandled).isTrue
-        assertThat(navigateAction).isEqualTo(expectedAction)
+        assertUriHandled(expectedAction)
         verifyZeroInteractions(serverTrackingHandler)
+    }
+
+    @Test
+    fun `tracks deeplink when action not null and URL null`() {
+        val action = "VIEW"
+
+        viewModel.start(action, null)
+
+        verify(analyticsUtilsWrapper).trackWithDeepLinkData(eq(DEEP_LINKED), eq(action), eq(""), isNull())
+    }
+
+    @Test
+    fun `tracks deeplink when action not null and URL not null`() {
+        val action = "VIEW"
+        val host = "wordpress.com"
+        val uriWrapper = buildUri(host, "read")
+        val mockedUri = mock<Uri>()
+        whenever(uriWrapper.uri).thenReturn(mockedUri)
+
+        viewModel.start(action, uriWrapper)
+
+        verify(analyticsUtilsWrapper).trackWithDeepLinkData(DEEP_LINKED, action, host, mockedUri)
+    }
+
+    @Test
+    fun `on successful login rehandles the cached URL`() {
+        whenever(accountStore.hasAccessToken()).thenReturn(false, true)
+        val (uri, expected) = initEditorLinkHandler()
+        viewModel.start(null, uri)
+
+        viewModel.onSuccessfulLogin()
+
+        assertThat(navigateActions).containsExactly(LoginForResult, expected)
+    }
+
+    private fun assertUriNotHandled() {
+        assertThat(isFinished).isTrue()
+        assertThat(navigateActions).isEmpty()
+    }
+
+    private fun assertUriHandled(navigateAction: NavigateAction) {
+        assertThat(isFinished).isFalse()
+        assertThat(navigateActions.last()).isEqualTo(navigateAction)
+    }
+
+    private fun initEditorLinkHandler(): Pair<UriWrapper, OpenEditor> {
+        val siteUrl = "site123"
+        val uri = buildUri("wordpress.com", "post", siteUrl)
+        whenever(editorLinkHandler.isEditorUrl(uri)).thenReturn(true)
+        val expected = OpenEditor
+        whenever(editorLinkHandler.buildOpenEditorNavigateAction(uri)).thenReturn(expected)
+        return Pair(uri, expected)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/ReaderLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/ReaderLinkHandlerTest.kt
@@ -1,0 +1,121 @@
+package org.wordpress.android.ui.deeplinks
+
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.READER_VIEWPOST_INTERCEPTED
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenInReader
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenReader
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.ViewPostInReader
+import org.wordpress.android.ui.reader.ReaderConstants
+import org.wordpress.android.ui.utils.IntentUtils
+import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+
+class ReaderLinkHandlerTest: BaseUnitTest() {
+    @Mock lateinit var intentUtils: IntentUtils
+    @Mock lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
+    private lateinit var readerLinkHandler: ReaderLinkHandler
+
+    @Before
+    fun setUp() {
+        readerLinkHandler = ReaderLinkHandler(intentUtils, analyticsUtilsWrapper)
+    }
+
+    @Test
+    fun `handles URI with host == read`() {
+        val uri = buildUri(host = "read")
+
+        val isReaderUri = readerLinkHandler.isReaderUrl(uri)
+
+        assertThat(isReaderUri).isTrue()
+    }
+
+    @Test
+    fun `handles URI with host == viewpost`() {
+        val uri = buildUri(host = "viewpost")
+
+        val isReaderUri = readerLinkHandler.isReaderUrl(uri)
+
+        assertThat(isReaderUri).isTrue()
+    }
+
+    @Test
+    fun `handles URI when intent utils can resolve it`() {
+        val uri = buildUri(host = "reader")
+        whenever(intentUtils.canResolveWith(ReaderConstants.ACTION_VIEW_POST, uri)).thenReturn(true)
+
+        val isReaderUri = readerLinkHandler.isReaderUrl(uri)
+
+        assertThat(isReaderUri).isTrue()
+    }
+
+    @Test
+    fun `does not handle URI when intent utils cannot resolve it`() {
+        val uri = buildUri(host = "reader")
+        whenever(intentUtils.canResolveWith(ReaderConstants.ACTION_VIEW_POST, uri)).thenReturn(false)
+
+        val isReaderUri = readerLinkHandler.isReaderUrl(uri)
+
+        assertThat(isReaderUri).isFalse()
+    }
+
+    @Test
+    fun `URI with read host opens reader`() {
+        val uri = buildUri(host = "read")
+
+        val navigateAction = readerLinkHandler.buildOpenInReaderNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(OpenReader)
+    }
+
+    @Test
+    fun `URI with viewpost host without query params opens reader`() {
+        val uri = buildUri(host = "viewpost")
+
+        val navigateAction = readerLinkHandler.buildOpenInReaderNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(OpenReader)
+    }
+
+    @Test
+    fun `URI with viewpost host with non-number query params opens reader`() {
+        val uri = buildUri(
+                host = "viewpost",
+                queryParam1 = "blogId" to "abc",
+                queryParam2 = "postId" to "cba"
+        )
+
+        val navigateAction = readerLinkHandler.buildOpenInReaderNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(OpenReader)
+    }
+
+    @Test
+    fun `URI with viewpost host with query params opens post in reader`() {
+        val blogId: Long = 123
+        val postId: Long = 321
+        val uri = buildUri(
+                host = "viewpost",
+                queryParam1 = "blogId" to blogId.toString(),
+                queryParam2 = "postId" to postId.toString()
+        )
+
+        val navigateAction = readerLinkHandler.buildOpenInReaderNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(ViewPostInReader(blogId, postId, uri))
+        verify(analyticsUtilsWrapper).trackWithBlogPostDetails(READER_VIEWPOST_INTERCEPTED, blogId, postId)
+    }
+
+    @Test
+    fun `opens URI in reader when host is neither read nor viewpost`() {
+        val uri = buildUri(host = "openInReader")
+
+        val navigateAction = readerLinkHandler.buildOpenInReaderNavigateAction(uri)
+
+        assertThat(navigateAction).isEqualTo(OpenInReader(uri))
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/ReaderLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/ReaderLinkHandlerTest.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.ui.reader.ReaderConstants
 import org.wordpress.android.ui.utils.IntentUtils
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 
-class ReaderLinkHandlerTest: BaseUnitTest() {
+class ReaderLinkHandlerTest : BaseUnitTest() {
     @Mock lateinit var intentUtils: IntentUtils
     @Mock lateinit var analyticsUtilsWrapper: AnalyticsUtilsWrapper
     private lateinit var readerLinkHandler: ReaderLinkHandler


### PR DESCRIPTION
This PR introduces 2 changes:
- moves handling of the `wordpress://viewpost` links to the viewmodel. They're now handled by the `ReaderLinkHandler` since they are opened in the Reader post detail. In addition to this I've changed the behaviour a little bit. Previously if the blog ID and post ID were not present/parsed, the app just finished. I've changed the behaviour to open default reader instead. I think this is better.
- Adds check whether the user is logged in before opening a link. If the user is not logged in, the URI is cached and the login is triggered for a result. Once we get the result, we retrigger the cached URL. This is a very generic approach and works for all the use cases. 

To test:
- Make sure you're logged in with a blog with remote ID X and post with remote ID Y
- open a `wordpress://viewpost?blogId=X&postId=Y` deeplink
- Notice the post detail is opened in the reader post detail
- Go back
- Notice you go to the main activity instead of closing the app

To test:
- Make sure you're logged out
- open a `wordpress://viewpost?blogId=X&postId=Y` deeplink
- Notice you're redirected to Login process
- Log in with a blog with remote ID X and post with remote ID Y
- Finish login
- Notice the post detail is opened in the reader post detail
- Go back
- Notice you go to the main activity instead of closing the app


To test:
- Make sure you're logged in
- open a `wordpress://viewpost` deeplink
- Notice the reader is opened

To test
- Test other links (stats, pages, read) without the user being logged in
- Notice the user is redirected to the desired link once login ends
- Notice the links work as expected when the user is logged in


## Regression Notes
1. Potential unintended areas of impact
- all the deeplinks

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- I've tested multiple flows and everything is unit tested

3. What automated tests I added (or what prevented me from doing so)
- unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
