### PR TITLE
Adds test verifying that the supported-blocks.json is loading

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/util/SupportedBlocksProviderTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/SupportedBlocksProviderTest.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.util
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.wordpress.android.ui.mlp.SupportedBlocksProvider
+import org.wordpress.android.viewmodel.ContextProvider
+
+@RunWith(AndroidJUnit4::class)
+class SupportedBlocksProviderTest {
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val contextProvider = ContextProvider(context)
+    private val supportedBlocksProvider = SupportedBlocksProvider(contextProvider)
+
+    @Test
+    fun fetchSupportedBlocks() {
+        val supportedBlocks = supportedBlocksProvider.fromAssets().supported
+        assertTrue(supportedBlocks.isNotEmpty())
+    }
+}


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/3417

### Description
This PR enhances https://github.com/wordpress-mobile/WordPress-Android/pull/14528 by adding a test verifying that the supported-blocks.json asset file exists and is not empty.

### To test:
Run the `org.wordpress.android.util.SupportedBlocksProviderTest` test case or check the the CI does not fail

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
