### PR TITLE
Jetpack App (Emphasis): Remove FAB from My Site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/BuildConfigWrapper.kt
@@ -13,4 +13,6 @@ class BuildConfigWrapper @Inject constructor() {
     }
 
     fun isManualFeatureConfigEnabled(): Boolean = BuildConfig.ENABLE_FEATURE_CONFIGURATION
+
+    val isJetpackApp = BuildConfig.IS_JETPACK_APP
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -216,8 +216,8 @@ class WPMainActivityViewModel @Inject constructor(
         }
     }
 
-    fun onPageChanged(showFab: Boolean, site: SiteModel?) {
-        setMainFabUiState(showFab, site)
+    fun onPageChanged(isOnMySitePageWithValidSite: Boolean, site: SiteModel?) {
+        setMainFabUiState(isOnMySitePageWithValidSite, site)
     }
 
     fun onTooltipTapped(site: SiteModel?) {
@@ -235,8 +235,8 @@ class WPMainActivityViewModel @Inject constructor(
         _switchToMySite.value = Event(Unit)
     }
 
-    fun onResume(site: SiteModel?, showFab: Boolean) {
-        setMainFabUiState(showFab, site)
+    fun onResume(site: SiteModel?, isOnMySitePageWithValidSite: Boolean) {
+        setMainFabUiState(isOnMySitePageWithValidSite, site)
 
         launch {
             val currentVersionCode = buildConfigWrapper.getAppVersionCode()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -217,7 +217,8 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     fun onPageChanged(isOnMySitePageWithValidSite: Boolean, site: SiteModel?) {
-        setMainFabUiState(isOnMySitePageWithValidSite, site)
+        val showFab = if (buildConfigWrapper.isJetpackApp) false else isOnMySitePageWithValidSite
+        setMainFabUiState(showFab, site)
     }
 
     fun onTooltipTapped(site: SiteModel?) {
@@ -236,7 +237,8 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     fun onResume(site: SiteModel?, isOnMySitePageWithValidSite: Boolean) {
-        setMainFabUiState(isOnMySitePageWithValidSite, site)
+        val showFab = if (buildConfigWrapper.isJetpackApp) false else isOnMySitePageWithValidSite
+        setMainFabUiState(showFab, site)
 
         launch {
             val currentVersionCode = buildConfigWrapper.getAppVersionCode()

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -119,7 +119,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     /* FAB VISIBILITY */
 
     @Test
-    fun `when page changed to my site, then fab is visible`() {
+    fun `given wordpress app, when page changed to my site, then fab is visible`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
@@ -128,7 +128,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when page changed away from my site, then fab is hidden`() {
+    fun `given wordpress app, when page changed away from my site, then fab is hidden`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
@@ -137,7 +137,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when my site page is resumed, then fab is visible`() {
+    fun `given wordpress app, when my site page is resumed, then fab is visible`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onResume(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
@@ -146,8 +146,44 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when non my site page is resumed, then fab is hidden`() {
+    fun `given wordpress app, when non my site page is resumed, then fab is hidden`() {
         startViewModelWithDefaultParameters()
+
+        viewModel.onResume(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabVisible).isFalse
+    }
+
+    @Test
+    fun `given jetpack app, when page changed to my site, then fab is hidden`() {
+        startViewModelWithDefaultParameters(isJetpackApp = true)
+
+        viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabVisible).isFalse
+    }
+
+    @Test
+    fun `given jetpack app, when page changed away from my site, then fab is hidden`() {
+        startViewModelWithDefaultParameters(isJetpackApp = true)
+
+        viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabVisible).isFalse
+    }
+
+    @Test
+    fun `given jetpack app, when my site page is resumed, then fab is hidden`() {
+        startViewModelWithDefaultParameters(isJetpackApp = true)
+
+        viewModel.onResume(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabVisible).isFalse
+    }
+
+    @Test
+    fun `given jetpack app, when non my site page is resumed, then fab is hidden`() {
+        startViewModelWithDefaultParameters(isJetpackApp = true)
 
         viewModel.onResume(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
 
@@ -157,7 +193,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     /* FAB TOOLTIP VISIBILITY */
 
     @Test
-    fun `when page changed to my site, then fab tooltip is visible`() {
+    fun `given wordpress app, when page changed to my site, then fab tooltip is visible`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
@@ -166,7 +202,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when page changed away from my site, then fab tooltip is hidden`() {
+    fun `given wordpress app, when page changed away from my site, then fab tooltip is hidden`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
@@ -175,7 +211,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when my site page is resumed, then fab tooltip is visible`() {
+    fun `given wordpress app, when my site page is resumed, then fab tooltip is visible`() {
         startViewModelWithDefaultParameters()
 
         viewModel.onResume(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
@@ -184,8 +220,44 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when non my site page is resumed, then fab tooltip is hidden`() {
+    fun `given wordpress app, when non my site page is resumed, then fab tooltip is hidden`() {
         startViewModelWithDefaultParameters()
+
+        viewModel.onResume(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabTooltipVisible).isFalse
+    }
+
+    @Test
+    fun `given jetpack app, when page changed to my site, then fab tooltip is hidden`() {
+        startViewModelWithDefaultParameters(isJetpackApp = true)
+
+        viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabTooltipVisible).isFalse
+    }
+
+    @Test
+    fun `given jetpack app, when page changed away from my site, then fab tooltip is hidden`() {
+        startViewModelWithDefaultParameters(isJetpackApp = true)
+
+        viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabTooltipVisible).isFalse
+    }
+
+    @Test
+    fun `given jetpack app, when my site page is resumed, then fab tooltip is hidden`() {
+        startViewModelWithDefaultParameters(isJetpackApp = true)
+
+        viewModel.onResume(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabTooltipVisible).isFalse
+    }
+
+    @Test
+    fun `given jetpack app, when non my site page is resumed, then fab tooltip is hidden`() {
+        startViewModelWithDefaultParameters(isJetpackApp = true)
 
         viewModel.onResume(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
 
@@ -556,7 +628,8 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         )
     }
 
-    private fun startViewModelWithDefaultParameters() {
+    private fun startViewModelWithDefaultParameters(isJetpackApp: Boolean = false) {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(isJetpackApp)
         viewModel.start(site = initSite(hasFullAccessToContent = true, supportsStories = true))
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -117,31 +117,31 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `fab visible when asked`() {
+    fun `when page changed to my site, then fab is visible`() {
         startViewModelWithDefaultParameters()
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
-        assertThat(fabUiState?.isFabVisible).isTrue()
+        assertThat(fabUiState?.isFabVisible).isTrue
     }
 
     @Test
-    fun `fab hidden when asked`() {
+    fun `when page changed away from my site, then fab is hidden`() {
         startViewModelWithDefaultParameters()
         viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
-        assertThat(fabUiState?.isFabVisible).isFalse()
+        assertThat(fabUiState?.isFabVisible).isFalse
     }
 
     @Test
-    fun `fab tooltip visible when asked`() {
+    fun `when page changed to my site, then fab tooltip is visible`() {
         startViewModelWithDefaultParameters()
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
-        assertThat(fabUiState?.isFabTooltipVisible).isTrue()
+        assertThat(fabUiState?.isFabTooltipVisible).isTrue
     }
 
     @Test
-    fun `fab tooltip hidden when asked`() {
+    fun `when page changed away from my site, then fab tooltip is hidden`() {
         startViewModelWithDefaultParameters()
         viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
-        assertThat(fabUiState?.isFabTooltipVisible).isFalse()
+        assertThat(fabUiState?.isFabTooltipVisible).isFalse
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -119,28 +119,28 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `fab visible when asked`() {
         startViewModelWithDefaultParameters()
-        viewModel.onPageChanged(showFab = true, site = initSite(hasFullAccessToContent = true))
+        viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
         assertThat(fabUiState?.isFabVisible).isTrue()
     }
 
     @Test
     fun `fab hidden when asked`() {
         startViewModelWithDefaultParameters()
-        viewModel.onPageChanged(showFab = false, site = initSite(hasFullAccessToContent = true))
+        viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
         assertThat(fabUiState?.isFabVisible).isFalse()
     }
 
     @Test
     fun `fab tooltip visible when asked`() {
         startViewModelWithDefaultParameters()
-        viewModel.onPageChanged(showFab = true, site = initSite(hasFullAccessToContent = true))
+        viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
         assertThat(fabUiState?.isFabTooltipVisible).isTrue()
     }
 
     @Test
     fun `fab tooltip hidden when asked`() {
         startViewModelWithDefaultParameters()
-        viewModel.onPageChanged(showFab = false, site = initSite(hasFullAccessToContent = true))
+        viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
         assertThat(fabUiState?.isFabTooltipVisible).isFalse()
     }
 
@@ -182,7 +182,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `fab focus point visible when active task is PUBLISH_POST`() {
         startViewModelWithDefaultParameters()
         activeTask.value = PUBLISH_POST
-        viewModel.onPageChanged(showFab = true, site = initSite(hasFullAccessToContent = true))
+        viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
 
         assertThat(fabUiState?.isFocusPointVisible).isTrue()
     }
@@ -191,7 +191,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `fab focus point gone when active task is different`() {
         startViewModelWithDefaultParameters()
         activeTask.value = UPDATE_SITE_TITLE
-        viewModel.onPageChanged(showFab = true, site = initSite(hasFullAccessToContent = true))
+        viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
 
         assertThat(fabUiState?.isFocusPointVisible).isFalse()
     }
@@ -200,7 +200,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     fun `fab focus point gone when active task is null`() {
         startViewModelWithDefaultParameters()
         activeTask.value = null
-        viewModel.onPageChanged(showFab = true, site = initSite(hasFullAccessToContent = true))
+        viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
 
         assertThat(fabUiState?.isFocusPointVisible).isFalse()
     }
@@ -365,7 +365,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `onResume set expected content message when user has not full access to content`() {
         startViewModelWithDefaultParameters()
-        viewModel.onResume(site = initSite(hasFullAccessToContent = false), showFab = true)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = false), isOnMySitePageWithValidSite = true)
         assertThat(fabUiState!!.CreateContentMessageId)
                 .isEqualTo(R.string.create_post_page_fab_tooltip_contributors_stories_enabled)
     }
@@ -525,7 +525,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     private fun resumeViewModelWithDefaultParameters() {
-        viewModel.onResume(site = initSite(hasFullAccessToContent = true), showFab = true)
+        viewModel.onResume(site = initSite(hasFullAccessToContent = true), isOnMySitePageWithValidSite = true)
     }
 
     private fun initSite(hasFullAccessToContent: Boolean = true, supportsStories: Boolean = true): SiteModel {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -116,33 +116,83 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         switchTabTriggered = false
     }
 
+    /* FAB VISIBILITY */
+
     @Test
     fun `when page changed to my site, then fab is visible`() {
         startViewModelWithDefaultParameters()
+
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
+
         assertThat(fabUiState?.isFabVisible).isTrue
     }
 
     @Test
     fun `when page changed away from my site, then fab is hidden`() {
         startViewModelWithDefaultParameters()
+
         viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
+
         assertThat(fabUiState?.isFabVisible).isFalse
     }
 
     @Test
+    fun `when my site page is resumed, then fab is visible`() {
+        startViewModelWithDefaultParameters()
+
+        viewModel.onResume(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabVisible).isTrue
+    }
+
+    @Test
+    fun `when non my site page is resumed, then fab is hidden`() {
+        startViewModelWithDefaultParameters()
+
+        viewModel.onResume(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabVisible).isFalse
+    }
+
+    /* FAB TOOLTIP VISIBILITY */
+
+    @Test
     fun `when page changed to my site, then fab tooltip is visible`() {
         startViewModelWithDefaultParameters()
+
         viewModel.onPageChanged(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
+
         assertThat(fabUiState?.isFabTooltipVisible).isTrue
     }
 
     @Test
     fun `when page changed away from my site, then fab tooltip is hidden`() {
         startViewModelWithDefaultParameters()
+
         viewModel.onPageChanged(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
+
         assertThat(fabUiState?.isFabTooltipVisible).isFalse
     }
+
+    @Test
+    fun `when my site page is resumed, then fab tooltip is visible`() {
+        startViewModelWithDefaultParameters()
+
+        viewModel.onResume(isOnMySitePageWithValidSite = true, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabTooltipVisible).isTrue
+    }
+
+    @Test
+    fun `when non my site page is resumed, then fab tooltip is hidden`() {
+        startViewModelWithDefaultParameters()
+
+        viewModel.onResume(isOnMySitePageWithValidSite = false, site = initSite(hasFullAccessToContent = true))
+
+        assertThat(fabUiState?.isFabTooltipVisible).isFalse
+    }
+
+    /* FAB TOOLTIP DISABLED */
 
     @Test
     fun `fab tooltip disabled when tapped`() {


### PR DESCRIPTION
Fixes #14509

WordPress | Jetpack
-----------|---------
![wp_fab](https://user-images.githubusercontent.com/1405144/116511576-434c0f00-a8e4-11eb-95fe-458c53147b2e.png)| ![jp_no_fab](https://user-images.githubusercontent.com/1405144/116511586-47782c80-a8e4-11eb-931e-a7b9234edb23.png)

To test:

Jetpack app

- Install and log in to the Jetpack app (build flavor `jetpackJalapenoDebug`).
- Notice that the (create post/page/stories) FAB and corresponding tooltip is not present on the My SIte tab.
- Toggle between bottom tabs or selected another site from the site picker.
- Notice that the FAB and corresponding tooltip is still not present on the My Site tab.

## Regression Notes
1. Potential unintended areas of impact
WordPress app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested WordPress app for the presence of the (create post/page/stories) FAB and corresponding tooltip.

3. What automated tests I added (or what prevented me from doing so)
Updated tests in `WPMainActivityViewModelTest` for FAB and the corresponding tooltip.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
