### PR TITLE
Add "Move to draft" action to published posts in the post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -61,6 +61,7 @@ import org.wordpress.android.widgets.PostListButtonType.BUTTON_VIEW
 import javax.inject.Inject
 
 private const val MAX_NUMBER_OF_VISIBLE_ACTIONS_STANDARD = 3
+
 /**
  * Helper class which encapsulates logic for creating UiStates for items in the PostsList.
  */
@@ -355,6 +356,7 @@ class PostListItemUiStateHelper @Inject constructor(
         val canShowCopy = postStatus == PUBLISHED || postStatus == DRAFT
         val canShowViewButton = !canRetryUpload && postStatus != PostStatus.TRASHED
         val canShowPublishButton = canRetryUpload || canPublishPost
+        val canMovePostToDraft = postStatus == PUBLISHED || postStatus == TRASHED
         val buttonTypes = ArrayList<PostListButtonType>()
 
         if (postStatus != TRASHED) {
@@ -397,10 +399,13 @@ class PostListItemUiStateHelper @Inject constructor(
             buttonTypes.add(BUTTON_COPY)
         }
 
+        if (canMovePostToDraft) {
+            buttonTypes.add(BUTTON_MOVE_TO_DRAFT)
+        }
+
         when {
             isLocalDraft -> buttonTypes.add(BUTTON_DELETE)
             postStatus == TRASHED -> {
-                buttonTypes.add(BUTTON_MOVE_TO_DRAFT)
                 buttonTypes.add(BUTTON_DELETE_PERMANENTLY)
             }
             postStatus != TRASHED -> buttonTypes.add(BUTTON_TRASH)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -356,7 +356,6 @@ class PostListItemUiStateHelper @Inject constructor(
         val canShowCopy = postStatus == PUBLISHED || postStatus == DRAFT
         val canShowViewButton = !canRetryUpload && postStatus != PostStatus.TRASHED
         val canShowPublishButton = canRetryUpload || canPublishPost
-        val canMovePostToDraft = postStatus == PUBLISHED || postStatus == TRASHED
         val buttonTypes = ArrayList<PostListButtonType>()
 
         if (postStatus != TRASHED) {
@@ -399,9 +398,7 @@ class PostListItemUiStateHelper @Inject constructor(
             buttonTypes.add(BUTTON_COPY)
         }
 
-        if (canMovePostToDraft) {
-            buttonTypes.add(BUTTON_MOVE_TO_DRAFT)
-        }
+        buttonTypes.addMoveToDraftActionIfAvailable(postStatus)
 
         when {
             isLocalDraft -> buttonTypes.add(BUTTON_DELETE)
@@ -412,6 +409,14 @@ class PostListItemUiStateHelper @Inject constructor(
         }
 
         return buttonTypes
+    }
+
+    private fun MutableList<PostListButtonType>.addMoveToDraftActionIfAvailable(postStatus: PostStatus) {
+        val canMovePostToDraft = postStatus == PUBLISHED || postStatus == TRASHED
+
+        if (canMovePostToDraft) {
+            add(BUTTON_MOVE_TO_DRAFT)
+        }
     }
 
     private fun createDefaultViewActions(

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -233,10 +233,12 @@ class PostListItemUiStateHelperTest {
         assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
         assertThat(state.actions).hasSize(3)
 
-        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_STATS)
-        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat((state.actions[2] as MoreItem).actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat((state.actions[2] as MoreItem).actions).hasSize(3)
+        val moreActions = (state.actions[2] as MoreItem).actions
+        assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_STATS)
+        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
+        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(4)
     }
 
     @Test
@@ -250,10 +252,12 @@ class PostListItemUiStateHelperTest {
         assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
         assertThat(state.actions).hasSize(3)
 
-        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
-        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat((state.actions[2] as MoreItem).actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat((state.actions[2] as MoreItem).actions).hasSize(3)
+        val moreActions = (state.actions[2] as MoreItem).actions
+        assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
+        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
+        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(4)
     }
 
     @Test
@@ -270,9 +274,11 @@ class PostListItemUiStateHelperTest {
         assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
         assertThat(state.actions).hasSize(3)
 
-        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+        val moreActions = (state.actions[2] as MoreItem).actions
+        assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
+        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
+        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(3)
     }
 
     @Test
@@ -370,10 +376,12 @@ class PostListItemUiStateHelperTest {
         assertThat(state.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD)
         assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
         assertThat(state.actions).hasSize(3)
-        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
-        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat((state.actions[2] as MoreItem).actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat((state.actions[2] as MoreItem).actions).hasSize(3)
+        val moreActions = (state.actions[2] as MoreItem).actions
+        assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
+        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
+        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(4)
     }
 
     @Test
@@ -455,10 +463,12 @@ class PostListItemUiStateHelperTest {
         assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
         assertThat(state.actions).hasSize(3)
 
-        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
-        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat((state.actions[2] as MoreItem).actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat((state.actions[2] as MoreItem).actions).hasSize(3)
+        val moreActions = (state.actions[2] as MoreItem).actions
+        assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
+        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
+        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(4)
     }
 
     @Test
@@ -569,7 +579,8 @@ class PostListItemUiStateHelperTest {
                 createFailedUploadUiState(uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)))
         )
         val state = createPostListItemUiState(
-                post = createPostModel(isLocallyChanged = true, status = POST_STATE_PRIVATE))
+                post = createPostModel(isLocallyChanged = true, status = POST_STATE_PRIVATE)
+        )
         assertThat(state.data.statuses).containsOnly(UiStringRes(R.string.error_media_recover_post))
     }
 
@@ -591,7 +602,8 @@ class PostListItemUiStateHelperTest {
                 )
         )
         val state = createPostListItemUiState(
-                post = createPostModel(isLocallyChanged = true, status = POST_STATE_PENDING))
+                post = createPostModel(isLocallyChanged = true, status = POST_STATE_PENDING)
+        )
         assertThat(state.data.statuses)
                 .containsOnly(UiStringRes(R.string.error_media_recover_post_not_submitted_retrying))
     }
@@ -602,7 +614,8 @@ class PostListItemUiStateHelperTest {
                 createFailedUploadUiState(
                         uploadError = UploadError(MediaError(AUTHORIZATION_REQUIRED)),
                         isEligibleForAutoUpload = false,
-                        retryWillPushChanges = true)
+                        retryWillPushChanges = true
+                )
         )
         val state = createPostListItemUiState(
                 post = createPostModel(isLocallyChanged = true, status = POST_STATE_PENDING)
@@ -794,9 +807,11 @@ class PostListItemUiStateHelperTest {
         assertThat(state.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MORE)
         assertThat(state.actions).hasSize(3)
 
-        assertThat((state.actions[2] as MoreItem).actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat((state.actions[2] as MoreItem).actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_DELETE)
-        assertThat((state.actions[2] as MoreItem).actions).hasSize(2)
+        val moreActions = (state.actions[2] as MoreItem).actions
+        assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
+        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
+        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_DELETE)
+        assertThat(moreActions).hasSize(3)
     }
 
     @Test


### PR DESCRIPTION
Fixes #14543 

This PR adds the "Move to draft" action to the Published post items more menu. The action should be visible on all the posts in the "Published" tab except the local drafts (posts with local changes that were not published). 

To test:
- Go to the "Posts" screen
- Go to "Published" tab
- Click on the "More" menu on a regular item without local changes
- Notice the "Move to draft" item in the menu
- Click on it
- Notice the post is moved to the "Drafts" tab
- Click on the "More" menu on an item with local changes (there are two states, I'm talking about "This post has local changes", not the "You've made unsaved changes to this post). 
- Notice the "Move to draft" item is not visible.
- Go to the "Trashed" tab
- Notice the items have the "Move to draft" action visible (it's not in the More menu since there are only 2 actions available, it's visible directly on the list item)


![Screenshot_1619684220](https://user-images.githubusercontent.com/1079756/116521676-90c08000-a8d4-11eb-9531-1a47d20b5a86.png)


## Regression Notes
1. Potential unintended areas of impact
- There is a chance I've missed some post state transition

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- I've tested the transitions between the tabs and added unit tests

3. What automated tests I added (or what prevented me from doing so)
- unit tests 
 
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
