### PR TITLE
Bug Fix: Manage Topics and Sites Settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.webkit.URLUtil;
 import android.widget.EditText;
@@ -543,6 +544,13 @@ public class ReaderSubsActivity extends LocaleAwareActivity
         @Override
         public int getCount() {
             return mFragments.size();
+        }
+
+        @Override
+        public Object instantiateItem(ViewGroup container, int position) {
+            Object ret = super.instantiateItem(container, position);
+            mFragments.set(position, (Fragment) ret);
+            return ret;
         }
 
         private void refreshFollowedTagFragment() {


### PR DESCRIPTION
Fixes #14162 

This PR fixes a bug with the Manage Topics & Sites setting screen by overriding the `instantiateItem` method so that it returns the same fragment as `getItem(position)`. This fixed the issue in both the Followed Topics and Followed Sites Tabs.

To test:
- Launch the app and navigate to Reader
- Tap on the settings icon to open the Manage Topics & Sites Settings
- Tap on the Followed Topics tab if it is not already focused
- Rotate the device at least once
- Add a topic
- Note the new topic is added to the list.
-----
- Repeat the above steps above for the Followed Sites tab
- Add a URL
- Note the new URL is added to the list (FYI: Followed Sites list is capped at 100 entries)

## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing to ensure that the UI updates when a new topic is added
3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
