### PR TITLE
ExPlat: Handle local Experiment registration

### DIFF
--- a/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
@@ -30,6 +30,7 @@ import dagger.android.support.AndroidSupportInjectionModule;
         StatsModule.class,
         TrackerModule.class,
         SuggestionSourceModule.class,
+        ExperimentModule.class,
         // Login flow library
         LoginAnalyticsModule.class,
         LoginFragmentModule.class,

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -123,6 +123,7 @@ import org.wordpress.android.widgets.AppRatingDialog;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -366,7 +367,7 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
         mStoryMediaSaveUploadBridge.init(this);
         ProcessLifecycleOwner.get().getLifecycle().addObserver(mStoryMediaSaveUploadBridge);
 
-        mExPlat.forceRefresh();
+        mExPlat.start(Collections.emptySet());
     }
 
     protected void initWorkManager() {

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -185,7 +185,6 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
     @Inject AppConfig mAppConfig;
     @Inject ImageEditorFileUtils mImageEditorFileUtils;
     @Inject ExPlat mExPlat;
-    @Inject Set<Experiment> mExperiments;
     @Inject @Named(APPLICATION_SCOPE) CoroutineScope mAppScope;
 
     // For development and production `AnalyticsTrackerNosara`, for testing a mocked `Tracker` will be injected.
@@ -369,7 +368,7 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
         mStoryMediaSaveUploadBridge.init(this);
         ProcessLifecycleOwner.get().getLifecycle().addObserver(mStoryMediaSaveUploadBridge);
 
-        mExPlat.start(mExperiments);
+        mExPlat.forceRefresh();
     }
 
     protected void initWorkManager() {

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -117,16 +117,17 @@ import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.experiments.ExPlat;
 import org.wordpress.android.util.config.AppConfig;
+import org.wordpress.android.util.experiments.Experiment;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.widgets.AppRatingDialog;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -184,6 +185,7 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
     @Inject AppConfig mAppConfig;
     @Inject ImageEditorFileUtils mImageEditorFileUtils;
     @Inject ExPlat mExPlat;
+    @Inject Set<Experiment> mExperiments;
     @Inject @Named(APPLICATION_SCOPE) CoroutineScope mAppScope;
 
     // For development and production `AnalyticsTrackerNosara`, for testing a mocked `Tracker` will be injected.
@@ -367,7 +369,7 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
         mStoryMediaSaveUploadBridge.init(this);
         ProcessLifecycleOwner.get().getLifecycle().addObserver(mStoryMediaSaveUploadBridge);
 
-        mExPlat.start(Collections.emptySet());
+        mExPlat.start(mExperiments);
     }
 
     protected void initWorkManager() {

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -117,7 +117,6 @@ import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.experiments.ExPlat;
 import org.wordpress.android.util.config.AppConfig;
-import org.wordpress.android.util.experiments.Experiment;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.widgets.AppRatingDialog;
 
@@ -127,7 +126,6 @@ import java.lang.reflect.Field;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -243,6 +243,7 @@ import dagger.android.support.AndroidSupportInjectionModule;
         ThreadModule.class,
         TrackerModule.class,
         SuggestionSourceModule.class,
+        ExperimentModule.class,
         // Login flow library
         LoginAnalyticsModule.class,
         LoginFragmentModule.class,

--- a/WordPress/src/main/java/org/wordpress/android/modules/ExperimentModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ExperimentModule.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.modules
+
+import dagger.Module
+import dagger.multibindings.Multibinds
+import org.wordpress.android.util.experiments.Experiment
+
+@Module
+interface ExperimentModule {
+    @Multibinds fun experiments(): Set<Experiment>
+
+    // Copy and paste the line below to add a new experiment.
+    // @Binds @IntoSet fun exampleExperiment(experiment: ExampleExperiment): Experiment
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.util.experiments
 
+import dagger.Lazy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.BuildConfig
@@ -21,20 +22,14 @@ import javax.inject.Singleton
 @Singleton
 class ExPlat
 @Inject constructor(
+    private val experiments: Lazy<Set<Experiment>>,
     private val experimentStore: ExperimentStore,
     private val appLog: AppLogWrapper,
     @Named(APPLICATION_SCOPE) private val coroutineScope: CoroutineScope
 ) {
     private val platform = Platform.WORDPRESS_ANDROID
     private val activeVariations = mutableMapOf<String, Variation>()
-
-    private var experimentNames = emptyList<String>()
-
-    fun start(experiments: Set<Experiment>) {
-        experimentNames = experiments.map { it.name }
-        appLog.d(T.API, "ExPlat: starting with $experimentNames")
-        forceRefresh()
-    }
+    private val experimentNames by lazy { experiments.get().map { it.name } }
 
     fun refreshIfNeeded() {
         refresh(refreshStrategy = IF_STALE)

--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
@@ -58,6 +58,9 @@ class ExPlat
      * is returned from the cached [Assignments] and then set as active. If the cached [Assignments]
      * is stale and [shouldRefreshIfStale] is `true`, then new [Assignments] are fetched and their
      * variations are going to be returned by this method on the next session.
+     *
+     * If the provided [Experiment] was not included in [ExPlat.start], then [Control] is returned.
+     * If [BuildConfig.DEBUG] is `true`, an [IllegalArgumentException] is thrown instead.
      */
     internal fun getVariation(experiment: Experiment, shouldRefreshIfStale: Boolean): Variation {
         if (!experimentNames.contains(experiment.name)) {

--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
@@ -60,7 +60,7 @@ class ExPlat
     internal fun getVariation(experiment: Experiment, shouldRefreshIfStale: Boolean): Variation {
         if (!experimentNames.contains(experiment.name)) {
             val message = "ExPlat: experiment not found: \"${experiment.name}\"! " +
-                    "Make sure to include it when calling ExPlat::start."
+                    "Make sure to include it in the set provided via constructor."
             appLog.e(T.API, message)
             if (BuildConfig.DEBUG) throw IllegalArgumentException(message) else return Control
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
@@ -27,11 +27,11 @@ class ExPlat
     private val activeVariations = mutableMapOf<String, Variation>()
 
     fun refreshIfNeeded() {
-        getAssignments(refreshStrategy = IF_STALE)
+        refresh(refreshStrategy = IF_STALE)
     }
 
     fun forceRefresh() {
-        getAssignments(refreshStrategy = ALWAYS)
+        refresh(refreshStrategy = ALWAYS)
     }
 
     fun clear() {
@@ -51,8 +51,12 @@ class ExPlat
      */
     internal fun getVariation(experiment: Experiment, shouldRefreshIfStale: Boolean) =
             activeVariations.getOrPut(experiment.name) {
-                getAssignments(if (shouldRefreshIfStale) IF_STALE else NEVER).getVariationForExperiment(experiment.name)
-            }
+            getAssignments(if (shouldRefreshIfStale) IF_STALE else NEVER).getVariationForExperiment(experiment.name)
+        }
+
+    private fun refresh(refreshStrategy: RefreshStrategy) {
+        getAssignments(refreshStrategy)
+    }
 
     private fun getAssignments(refreshStrategy: RefreshStrategy): Assignments {
         val cachedAssignments = experimentStore.getCachedAssignments() ?: Assignments()

--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/ExPlat.kt
@@ -30,6 +30,12 @@ class ExPlat
 
     private var experimentNames = emptyList<String>()
 
+    fun start(experiments: Set<Experiment>) {
+        experimentNames = experiments.map { it.name }
+        appLog.d(T.API, "ExPlat: starting with $experimentNames")
+        forceRefresh()
+    }
+
     fun refreshIfNeeded() {
         refresh(refreshStrategy = IF_STALE)
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/experiments/ExampleExperiment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/experiments/ExampleExperiment.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.util.experiments
+
+import javax.inject.Inject
+
+class ExampleExperiment
+@Inject constructor(
+    exPlat: ExPlat
+) : Experiment(
+        "example_experiment",
+        exPlat
+)


### PR DESCRIPTION
This PR is a follow up to #14498 and is related to https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1970.

These changes can be divided into two parts:

- Part 1: Handling `Experiment` registration in the `ExPlat` class.
- Part 2: Providing a set of `Experiment`s to the `ExPlat` class for registration.

I thought about splitting this PR in two, but its changes are not so big overall and I think they make sense together, but let me know what you prefer.

#### Part 1

In this first part, the `ExPlat` class was updated in two ways:
- It now has a `start()` method that replaces the direct call we previously made to `forceRefresh()` once the app started. This method accepts a set of `Experiment`s, maps it to a list of experiment names which is then held internally and then calls `forceRefresh()`.
- The list of experiment names is then used so that we can check when we should retrieve assignments:
    - For `forceRefresh()` and `refreshIfNeeded()`, we check if the list is empty and if so, we prevent any calls to the API from being made.
    - For `getVariation()` we check if the list contains the name of the provided `Experiment` and if it doesn't, we just return `Control` directly (if `BuildConfig.DEBUG` is `true`, we throw a `IllegalArgumentException` instead).
    
#### Part 2

In this part, Dagger is being used to actually provide the set of `Experiment`s to the `ExPlat` class. Since our `Experiment` implementations were already being included in the dependency graph, I just created a `ExperimentModule` where we can add the experiments we want to register and bind them all into a `Set<Experiment>` by using a combination of `@Binds` and `@IntoSet` annotations. It also uses a `@Multibinds` annotation to provide an empty `Set` in case no `Experiment` is currently registered. 

This approach is a bit similar to the one we use to provide a `Map` of `ViewModel`s to the `ViewModelFactory` class and it introduces a similar extra step. To demonstrate, here's how it would work in practice to add a new `Experiment`:

1. We create a new class that extends from the `Experiment` class, and inject the `ExPlat` dependency using Dagger, just like we did before:

```kotlin
class ExampleExperiment @Inject constructor(exPlat: ExPlat) : Experiment("example_experiment", exPlat)
```

2. (new step) We then "register" this `Experiment` in the `ExperimentModule` like so:

```kotlin
@Binds @IntoSet fun exampleExperiment(experiment: ExampleExperiment): Experiment
```

And that's it. I also created an `ExampleExperiment` and left a commented out line in `ExperimentModule` with the code above as an example.

👉 Note: while this approach is pretty safe to use, I don't expect it to be final. Once we start working on adding functionality to list and edit registered experiments locally (as described in #14089), I expect we should be able to replace it with something similar to what we currently have with our remote configs, where we would just need to add an annotation to our `Experiment` class and the generated code would handle the rest for us. For now, other than that extra step, I don't see any major drawbacks that would prevent us from moving forward with this, so please let me know if you do!

### To test

**Without registered experiments**

1. Open the app.
1. On `logcat`, make sure you **don't** see any messages like: `ExPlat: fetching assignments successful with result: ...`.

Try logging in/out and restarting the app and make sure you still don't see the message.

**With registered experiments**

1. Uncomment the commented line in the `ExperimentModule` class and restart the app.
1. Open the app.
1. On `logcat`, notice a message like: `ExPlat: fetching assignments successful with result: ...`.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
Added a few extra unit tests to account for new behaviors.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
