### PR TITLE
[WP Stories] Fix stories error snackbar handling

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -1188,7 +1188,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                     allErrorsInResult(event.frameSaveResult).size,
                     errorText
             )
-
             uploadUtilsWrapper.showSnackbarError(
                     requireActivity().findViewById<View>(R.id.coordinator),
                     snackbarMessage,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -20,10 +20,7 @@ import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.snackbar.Snackbar
-import com.wordpress.stories.compose.frame.FrameSaveNotifier.Companion.buildSnackbarErrorMessage
-import com.wordpress.stories.compose.frame.StorySaveEvents.Companion.allErrorsInResult
 import com.wordpress.stories.compose.frame.StorySaveEvents.StorySaveProcessStart
-import com.wordpress.stories.compose.frame.StorySaveEvents.StorySaveResult
 import com.wordpress.stories.compose.story.StoryRepository.getStoryAtIndex
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.UCrop.Options
@@ -62,7 +59,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_REQUEST
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_TASK_DIALOG_NEGATIVE_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_TASK_DIALOG_POSITIVE_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.QUICK_START_TASK_DIALOG_VIEWED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.STORY_SAVE_ERROR_SNACKBAR_MANAGE_TAPPED
 import org.wordpress.android.databinding.MySiteFragmentBinding
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
@@ -1170,41 +1166,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                         requireActivity().findViewById(R.id.coordinator), false,
                         event.mediaModelList, site, event.successMessage
                 )
-            }
-        }
-    }
-
-    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
-    fun onEventMainThread(event: StorySaveResult) {
-        EventBus.getDefault().removeStickyEvent(event)
-        if (!event.isSuccess()) {
-            // note: no tracking added here as we'll perform tracking in StoryMediaSaveUploadBridge
-            val errorText = String.format(
-                    getString(R.string.story_saving_snackbar_finished_with_error),
-                    getStoryAtIndex(event.storyIndex).title
-            )
-            val snackbarMessage = buildSnackbarErrorMessage(
-                    requireActivity(),
-                    allErrorsInResult(event.frameSaveResult).size,
-                    errorText
-            )
-            uploadUtilsWrapper.showSnackbarError(
-                    requireActivity().findViewById<View>(R.id.coordinator),
-                    snackbarMessage,
-                    R.string.story_saving_failed_quick_action_manage
-            ) {
-                // TODO WPSTORIES add TRACKS: the putExtra described here below for NOTIFICATION_TYPE
-                // is meant to be used for tracking purposes. Use it!
-                // TODO add NotificationType.MEDIA_SAVE_ERROR param later when integrating with WPAndroid
-                //        val notificationType = NotificationType.MEDIA_SAVE_ERROR
-                //        notificationIntent.putExtra(ARG_NOTIFICATION_TYPE, notificationType)
-
-                storiesTrackerHelper.trackStorySaveResultEvent(
-                        event,
-                        STORY_SAVE_ERROR_SNACKBAR_MANAGE_TAPPED
-
-                )
-                ActivityLauncher.viewStories(requireActivity(), selectedSite, event)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteStoriesHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteStoriesHandler.kt
@@ -68,21 +68,18 @@ class SiteStoriesHandler
                     Event(
                             SnackbarMessageHolder(
                                     UiStringText(snackbarMessage),
-                                    UiStringRes(R.string.story_saving_failed_quick_action_manage)
-                            ) {
-                                val selectedSite = selectedSiteRepository.getSelectedSite()
-                                        ?: return@SnackbarMessageHolder
-                                _onNavigation.postValue(Event(OpenStories(selectedSite, event)))
-                                // TODO WPSTORIES add TRACKS: the putExtra described here below for NOTIFICATION_TYPE
-                                // is meant to be used for tracking purposes. Use it!
-                                // TODO add NotificationType.MEDIA_SAVE_ERROR param later when integrating with WPAndroid
-                                //        val notificationType = NotificationType.MEDIA_SAVE_ERROR
-                                //        notificationIntent.putExtra(ARG_NOTIFICATION_TYPE, notificationType)
-                                storiesTrackerHelper.trackStorySaveResultEvent(
-                                        event,
-                                        STORY_SAVE_ERROR_SNACKBAR_MANAGE_TAPPED
-                                )
-                            }
+                                    UiStringRes(R.string.story_saving_failed_quick_action_manage),
+                                    buttonAction = {
+                                        val selectedSite = selectedSiteRepository.getSelectedSite()
+                                                ?: return@SnackbarMessageHolder
+                                        _onNavigation.postValue(Event(OpenStories(selectedSite, event)))
+                                        storiesTrackerHelper.trackStorySaveResultEvent(
+                                                event,
+                                                STORY_SAVE_ERROR_SNACKBAR_MANAGE_TAPPED
+                                        )
+                                    },
+                                    onDismissAction = { }
+                            )
                     )
             )
         }


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/13533 that would make the StoryComposerActivity be launched automatically when a Story save process fails, right after presenting the error snackbar in the MySite Fragment as the callback was replicated in its `onDismiss` lambda function.

This PR:
~- removes the remaining code from MySiteFragment that should have been removed as part of https://github.com/wordpress-mobile/WordPress-Android/pull/13533~
- makes the  `onDismissAction` and `buttonAction` parameters to the `SnackbarMessageHolder` class explicit, and defines the behavior correctly on the `buttonAction` instead of letting it be assigned to the `onDismissAction` implicitly. 

**To test:**
1. apply this [patch](https://gist.github.com/mzorz/41d6f80f2395105fff6da6328b190ff5) on the stories library code, which will provoke an error in saving video slides each time.
2. run WPAndroid on this branch, and on the My Site screen tap on the FAB -> Add new Story post
3. record a video or select an existing video with the media picker
4. optionally add a text to it
5. publish it
6. wait on the My site screen until the `Unable to upload <post title> - 1 slide requires action - MANAGE` Snackbar.
7. wait for it to be dismissed, and observe you stay on the main screen, instead of being presented with the Story composer screen, as if you'd have pressed the `MANAGE` button on the snackbar.

## Regression Notes
1. Potential unintended areas of impact
N/A only the Stories actions are affected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
