### PR TITLE
Update Dagger components to use `OkHttClientModule`

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import dagger.BindsInstance
 import dagger.Component
 import dagger.android.support.AndroidSupportInjectionModule
-import org.wordpress.android.fluxc.module.DebugOkHttpClientModule
+import org.wordpress.android.fluxc.module.OkHttpClientModule
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule
 import org.wordpress.android.fluxc.module.ReleaseToolsModule
 import org.wordpress.android.login.di.LoginFragmentModule
@@ -17,7 +17,7 @@ import javax.inject.Singleton
 @Component(modules = [
     ApplicationModule::class,
     AppConfigModule::class,
-    DebugOkHttpClientModule::class,
+    OkHttpClientModule::class,
     InterceptorModuleTest::class,
     ReleaseNetworkModule::class,
     LegacyModule::class,

--- a/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/AppComponentDebug.java
@@ -2,7 +2,7 @@ package org.wordpress.android.modules;
 
 import android.app.Application;
 
-import org.wordpress.android.fluxc.module.DebugOkHttpClientModule;
+import org.wordpress.android.fluxc.module.OkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseToolsModule;
 import org.wordpress.android.login.di.LoginFragmentModule;
@@ -20,7 +20,7 @@ import dagger.android.support.AndroidSupportInjectionModule;
 @Component(modules = {
         ApplicationModule.class,
         AppConfigModule.class,
-        DebugOkHttpClientModule.class,
+        OkHttpClientModule.class,
         InterceptorModule.class,
         ReleaseNetworkModule.class,
         LegacyModule.class,

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -3,8 +3,8 @@ package org.wordpress.android.modules;
 import android.app.Application;
 
 import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.module.OkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
-import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
 import org.wordpress.android.fluxc.module.ReleaseToolsModule;
 import org.wordpress.android.login.di.LoginFragmentModule;
 import org.wordpress.android.login.di.LoginServiceModule;
@@ -13,7 +13,6 @@ import org.wordpress.android.push.GCMRegistrationIntentService;
 import org.wordpress.android.push.NotificationsProcessingService;
 import org.wordpress.android.ui.AddQuickPressShortcutActivity;
 import org.wordpress.android.ui.CommentFullScreenDialogFragment;
-import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity;
 import org.wordpress.android.ui.JetpackConnectionResultActivity;
 import org.wordpress.android.ui.JetpackRemoteInstallFragment;
 import org.wordpress.android.ui.ShareIntentReceiverActivity;
@@ -40,6 +39,7 @@ import org.wordpress.android.ui.comments.CommentsActivity;
 import org.wordpress.android.ui.comments.CommentsDetailActivity;
 import org.wordpress.android.ui.comments.CommentsListFragment;
 import org.wordpress.android.ui.comments.EditCommentActivity;
+import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment;
 import org.wordpress.android.ui.domains.DomainSuggestionsFragment;
@@ -232,7 +232,7 @@ import dagger.android.support.AndroidSupportInjectionModule;
 @Component(modules = {
         ApplicationModule.class,
         AppConfigModule.class,
-        ReleaseOkHttpClientModule.class,
+        OkHttpClientModule.class,
         ReleaseNetworkModule.class,
         LegacyModule.class,
         ReleaseToolsModule.class,

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.16.0-beta-3'
+    fluxCVersion = '1.16.0-beta-5'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
### Context

This PR is about syncing with changes introduced in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1976

Testing is not required.

- [ ] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
