### PR TITLE
Add retry to get expected like state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
@@ -100,8 +100,8 @@ class EngagedPeopleListFragment : Fragment() {
                     ShowBottomSheet -> {
                         if (bottomSheet == null) {
                             bottomSheet = UserProfileBottomSheetFragment.newInstance(USER_PROFILE_VM_KEY)
+                            bottomSheet.show(fragmentManager, USER_PROFILE_BOTTOM_SHEET_TAG)
                         }
-                        bottomSheet.show(fragmentManager, USER_PROFILE_BOTTOM_SHEET_TAG)
                     }
                     HideBottomSheet -> {
                         bottomSheet?.apply { this.dismiss() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/GetLikesHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/GetLikesHandler.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
 import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.DON_T_CARE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement.DONT_CARE
 import org.wordpress.android.ui.engagement.GetLikesUseCase.FailureType.NO_NETWORK
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
@@ -35,7 +35,7 @@ class GetLikesHandler @Inject constructor(
         requestNextPage: Boolean,
         pageLength: Int = LIKES_PER_PAGE_DEFAULT,
         limit: Int = LIKES_RESULT_NO_LIMITS,
-        expectingToBeThere: BeInListRequirement = DON_T_CARE
+        expectingToBeThere: CurrentUserInListRequirement = DONT_CARE
     ) {
         getLikesUseCase.getLikesForPost(
                 fingerPrint,

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/GetLikesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/GetLikesUseCase.kt
@@ -21,9 +21,9 @@ import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.PostStore.FetchPostLikesPayload
 import org.wordpress.android.fluxc.store.PostStore.OnPostLikesChanged
 import org.wordpress.android.fluxc.store.Store.OnChanged
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.DON_T_CARE
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.REQUIRE_TO_BE_THERE
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.REQUIRE_TO_NOT_BE_THERE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement.DONT_CARE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement.REQUIRE_TO_BE_THERE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement.REQUIRE_TO_NOT_BE_THERE
 import org.wordpress.android.ui.engagement.GetLikesUseCase.FailureType.GENERIC
 import org.wordpress.android.ui.engagement.GetLikesUseCase.FailureType.NO_NETWORK
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
@@ -68,7 +68,7 @@ class GetLikesUseCase @Inject constructor(
     suspend fun getLikesForPost(
         fingerPrint: LikeGroupFingerPrint,
         paginationParams: PaginationParams,
-        expectingToBeThere: BeInListRequirement
+        expectingToBeThere: CurrentUserInListRequirement
     ): Flow<GetLikesState> = flow {
         getLikes(POST_LIKE, this, fingerPrint, paginationParams, expectingToBeThere)
     }
@@ -86,7 +86,7 @@ class GetLikesUseCase @Inject constructor(
         flow: FlowCollector<GetLikesState>,
         fingerPrint: LikeGroupFingerPrint,
         paginationParams: PaginationParams,
-        expectingToBeThere: BeInListRequirement = DON_T_CARE
+        expectingToBeThere: CurrentUserInListRequirement = DONT_CARE
     ) {
         if (!paginationParams.requestNextPage) {
             flow.emit(Loading)
@@ -142,19 +142,19 @@ class GetLikesUseCase @Inject constructor(
     }
 
     private fun shouldRetry(
-        expectingToBeThere: BeInListRequirement,
+        expectingToBeThere: CurrentUserInListRequirement,
         retry: Int,
         result: OnChanged<*>,
         likes: List<LikeModel>
     ): Boolean {
-        val shouldCheck = expectingToBeThere != DON_T_CARE &&
+        val shouldCheck = expectingToBeThere != DONT_CARE &&
                 retry < NUM_RETRY &&
                 !result.isError &&
                 accountStore.hasAccessToken()
 
         return if (shouldCheck) {
             when (expectingToBeThere) {
-                DON_T_CARE -> {
+                DONT_CARE -> {
                     false
                 }
                 REQUIRE_TO_BE_THERE -> {
@@ -308,8 +308,8 @@ class GetLikesUseCase @Inject constructor(
     data class LikeGroupFingerPrint(val siteId: Long, val postOrCommentId: Long, val expectedNumLikes: Int)
     data class PaginationParams(val requestNextPage: Boolean, val pageLength: Int, val limit: Int)
 
-    enum class BeInListRequirement {
-        DON_T_CARE,
+    enum class CurrentUserInListRequirement {
+        DONT_CARE,
         REQUIRE_TO_BE_THERE,
         REQUIRE_TO_NOT_BE_THERE
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/GetLikesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/GetLikesUseCase.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.generated.CommentActionBuilder
 import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.FetchPostLikes
 import org.wordpress.android.fluxc.model.LikeModel
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.CommentStore
 import org.wordpress.android.fluxc.store.CommentStore.FetchCommentLikesPayload
 import org.wordpress.android.fluxc.store.CommentStore.OnCommentLikesChanged
@@ -20,6 +21,9 @@ import org.wordpress.android.fluxc.store.PostStore
 import org.wordpress.android.fluxc.store.PostStore.FetchPostLikesPayload
 import org.wordpress.android.fluxc.store.PostStore.OnPostLikesChanged
 import org.wordpress.android.fluxc.store.Store.OnChanged
+import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.DON_T_CARE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.REQUIRE_TO_BE_THERE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.REQUIRE_TO_NOT_BE_THERE
 import org.wordpress.android.ui.engagement.GetLikesUseCase.FailureType.GENERIC
 import org.wordpress.android.ui.engagement.GetLikesUseCase.FailureType.NO_NETWORK
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
@@ -48,7 +52,8 @@ class GetLikesUseCase @Inject constructor(
     @SuppressWarnings("Unused")
     val commentStore: CommentStore,
     @SuppressWarnings("Unused")
-    val postStore: PostStore
+    val postStore: PostStore,
+    val accountStore: AccountStore
 ) {
     private var getLikesContinuations = mutableMapOf<String, Continuation<OnChanged<*>>>()
 
@@ -62,9 +67,10 @@ class GetLikesUseCase @Inject constructor(
 
     suspend fun getLikesForPost(
         fingerPrint: LikeGroupFingerPrint,
-        paginationParams: PaginationParams
+        paginationParams: PaginationParams,
+        expectingToBeThere: BeInListRequirement
     ): Flow<GetLikesState> = flow {
-        getLikes(POST_LIKE, this, fingerPrint, paginationParams)
+        getLikes(POST_LIKE, this, fingerPrint, paginationParams, expectingToBeThere)
     }
 
     suspend fun getLikesForComment(
@@ -74,20 +80,101 @@ class GetLikesUseCase @Inject constructor(
         getLikes(COMMENT_LIKE, this, fingerPrint, paginationParams)
     }
 
+    @SuppressWarnings("ComplexMethod", "NestedBlockDepth", "LoopWithTooManyJumpStatements")
     private suspend fun getLikes(
         category: LikeCategory,
         flow: FlowCollector<GetLikesState>,
         fingerPrint: LikeGroupFingerPrint,
-        paginationParams: PaginationParams
+        paginationParams: PaginationParams,
+        expectingToBeThere: BeInListRequirement = DON_T_CARE
     ) {
         if (!paginationParams.requestNextPage) {
             flow.emit(Loading)
             delay(PROGRESS_DELAY_MS)
         }
 
-        val noNetworkDetected = !networkUtilsWrapper.isNetworkAvailable()
+        for (retry in 1..NUM_RETRY) {
+            val noNetworkDetected = !networkUtilsWrapper.isNetworkAvailable()
 
-        val event = suspendCoroutine<OnChanged<*>> {
+            val result = makeRequest(category, fingerPrint, paginationParams)
+
+            val isPostLikeEvent = category == POST_LIKE && result is OnPostLikesChanged
+            val isCommentLikeEvent = category == COMMENT_LIKE && result is OnCommentLikesChanged
+
+            if (isPostLikeEvent || isCommentLikeEvent) {
+                var likes = listOf<LikeModel>()
+                var errorMessage: String? = null
+                var hasMore = false
+
+                if (result is OnPostLikesChanged) {
+                    likes = result.postLikes
+                    if (result.isError) errorMessage = result.error.message
+                    hasMore = result.hasMore
+                }
+
+                if (result is OnCommentLikesChanged) {
+                    likes = result.commentLikes
+                    if (result.isError) errorMessage = result.error.message
+                }
+
+                if (shouldRetry(expectingToBeThere, retry, result, likes)) {
+                    delay(PROGRESS_DELAY_MS)
+                    continue
+                }
+
+                likes = if (paginationParams.limit > 0) {
+                    likes.take(paginationParams.limit)
+                } else {
+                    likes
+                }
+
+                flow.emit(
+                    if (result.isError) {
+                        getFailureState(noNetworkDetected, likes, errorMessage, fingerPrint.expectedNumLikes)
+                    } else {
+                        LikesData(likes, fingerPrint.expectedNumLikes, hasMore)
+                    }
+                )
+
+                break
+            }
+        }
+    }
+
+    private fun shouldRetry(
+        expectingToBeThere: BeInListRequirement,
+        retry: Int,
+        result: OnChanged<*>,
+        likes: List<LikeModel>
+    ): Boolean {
+        val shouldCheck = expectingToBeThere != DON_T_CARE &&
+                retry < NUM_RETRY &&
+                !result.isError &&
+                accountStore.hasAccessToken()
+
+        return if (shouldCheck) {
+            when (expectingToBeThere) {
+                DON_T_CARE -> {
+                    false
+                }
+                REQUIRE_TO_BE_THERE -> {
+                    !likes.any { it.likerId == accountStore.account.userId }
+                }
+                REQUIRE_TO_NOT_BE_THERE -> {
+                    likes.any { it.likerId == accountStore.account.userId }
+                }
+            }
+        } else {
+            false
+        }
+    }
+
+    private suspend fun makeRequest(
+        category: LikeCategory,
+        fingerPrint: LikeGroupFingerPrint,
+        paginationParams: PaginationParams
+    ): OnChanged<*> {
+        return suspendCoroutine {
             getLikesContinuations[category.getActionKey(fingerPrint.siteId, fingerPrint.postOrCommentId)] = it
             when (category) {
                 POST_LIKE -> {
@@ -109,40 +196,6 @@ class GetLikesUseCase @Inject constructor(
                     dispatcher.dispatch(CommentActionBuilder.newFetchCommentLikesAction(payload))
                 }
             }
-        }
-
-        val isPostLikeEvent = category == POST_LIKE && event is OnPostLikesChanged
-        val isCommentLikeEvent = category == COMMENT_LIKE && event is OnCommentLikesChanged
-
-        if (isPostLikeEvent || isCommentLikeEvent) {
-            var likes = listOf<LikeModel>()
-            var errorMessage: String? = null
-            var hasMore = false
-
-            if (event is OnPostLikesChanged) {
-                likes = event.postLikes
-                if (event.isError) errorMessage = event.error.message
-                hasMore = event.hasMore
-            }
-
-            if (event is OnCommentLikesChanged) {
-                likes = event.commentLikes
-                if (event.isError) errorMessage = event.error.message
-            }
-
-            likes = if (paginationParams.limit > 0) {
-                likes.take(paginationParams.limit)
-            } else {
-                likes
-            }
-
-            flow.emit(
-                    if (event.isError) {
-                        getFailureState(noNetworkDetected, likes, errorMessage, fingerPrint.expectedNumLikes)
-                    } else {
-                        LikesData(likes, fingerPrint.expectedNumLikes, hasMore)
-                    }
-            )
         }
     }
 
@@ -255,8 +308,17 @@ class GetLikesUseCase @Inject constructor(
     data class LikeGroupFingerPrint(val siteId: Long, val postOrCommentId: Long, val expectedNumLikes: Int)
     data class PaginationParams(val requestNextPage: Boolean, val pageLength: Int, val limit: Int)
 
+    enum class BeInListRequirement {
+        DON_T_CARE,
+        REQUIRE_TO_BE_THERE,
+        REQUIRE_TO_NOT_BE_THERE
+    }
+
     companion object {
         // Pretty arbitrary amount to allow the loading state to appear to the user
         private const val PROGRESS_DELAY_MS = 600L
+
+        // Num of retries for post likes when BeInListRequirement is not DON_T_CARE
+        private const val NUM_RETRY = 6
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/LikedItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/LikedItemViewHolder.kt
@@ -40,10 +40,7 @@ class LikedItemViewHolder(
 
         imageManager.loadIntoCircle(this.avatar, ImageType.AVATAR_WITH_BACKGROUND, avatarUrl)
 
-        if (
-                !TextUtils.isEmpty(likedItem.authorPreferredSiteUrl) &&
-                likedItem.authorPreferredSiteId > 0 && likedItem.authorUserId > 0
-        ) {
+        if (!TextUtils.isEmpty(likedItem.authorPreferredSiteUrl) || likedItem.authorPreferredSiteId > 0) {
             with(this.avatar) {
                 importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
                 contentDescription = this.context.getString(string.profile_picture, authorName)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -219,6 +219,7 @@ class ReaderPostDetailViewModel @Inject constructor(
 
     fun onRefreshLikersData(post: ReaderPost, expectingToBeThere: CurrentUserInListRequirement = DONT_CARE) {
         if (!likesEnhancementsFeatureConfig.isEnabled()) return
+        if (readerUtilsWrapper.isExternalFeed(post.blogId, post.feedId)) return
         val isLikeDataChanged = lastRenderedLikesData?.isMatchingPost(post) ?: true
 
         if (isLikeDataChanged) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -20,6 +20,10 @@ import org.wordpress.android.ui.engagement.EngageItem
 import org.wordpress.android.ui.engagement.EngagedPeopleListViewModel.EngagedPeopleListUiState
 import org.wordpress.android.ui.engagement.EngagementUtils
 import org.wordpress.android.ui.engagement.GetLikesHandler
+import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement
+import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.DON_T_CARE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.REQUIRE_TO_BE_THERE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.REQUIRE_TO_NOT_BE_THERE
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.LikesData
@@ -174,7 +178,14 @@ class ReaderPostDetailViewModel @Inject constructor(
             currentUiState?.let {
                 findPost(currentUiState.postId, currentUiState.blogId)?.let { post ->
                     if (likesEnhancementsFeatureConfig.isEnabled()) {
-                        onRefreshLikersData(post)
+                        onRefreshLikersData(
+                                post,
+                                if (post.isLikedByCurrentUser) {
+                                    REQUIRE_TO_BE_THERE
+                                } else {
+                                    REQUIRE_TO_NOT_BE_THERE
+                                }
+                        )
                     }
                     updatePostActions(post)
                 }
@@ -206,7 +217,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         }
     }
 
-    fun onRefreshLikersData(post: ReaderPost) {
+    fun onRefreshLikersData(post: ReaderPost, expectingToBeThere: BeInListRequirement = DON_T_CARE) {
         if (!likesEnhancementsFeatureConfig.isEnabled()) return
         val isLikeDataChanged = lastRenderedLikesData?.isMatchingPost(post) ?: true
 
@@ -222,7 +233,8 @@ class ReaderPostDetailViewModel @Inject constructor(
                         ),
                         requestNextPage = false,
                         pageLength = MAX_NUM_LIKES_FACES,
-                        limit = MAX_NUM_LIKES_FACES
+                        limit = MAX_NUM_LIKES_FACES,
+                        expectingToBeThere = expectingToBeThere
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -20,10 +20,10 @@ import org.wordpress.android.ui.engagement.EngageItem
 import org.wordpress.android.ui.engagement.EngagedPeopleListViewModel.EngagedPeopleListUiState
 import org.wordpress.android.ui.engagement.EngagementUtils
 import org.wordpress.android.ui.engagement.GetLikesHandler
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.DON_T_CARE
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.REQUIRE_TO_BE_THERE
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.REQUIRE_TO_NOT_BE_THERE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement.DONT_CARE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement.REQUIRE_TO_BE_THERE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement.REQUIRE_TO_NOT_BE_THERE
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.LikesData
@@ -217,7 +217,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         }
     }
 
-    fun onRefreshLikersData(post: ReaderPost, expectingToBeThere: BeInListRequirement = DON_T_CARE) {
+    fun onRefreshLikersData(post: ReaderPost, expectingToBeThere: CurrentUserInListRequirement = DONT_CARE) {
         if (!likesEnhancementsFeatureConfig.isEnabled()) return
         val isLikeDataChanged = lastRenderedLikesData?.isMatchingPost(post) ?: true
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/GetLikesHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/GetLikesHandlerTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.LikeModel.LikeType.COMMENT_LIKE
 import org.wordpress.android.fluxc.model.LikeModel.LikeType.POST_LIKE
 import org.wordpress.android.test
+import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.DON_T_CARE
 import org.wordpress.android.ui.engagement.GetLikesUseCase.FailureType
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
@@ -64,7 +65,7 @@ class GetLikesHandlerTest {
                 hasMore = false
         )
 
-        whenever(getLikesUseCase.getLikesForPost(fingerPrint, paginationParams)).thenReturn(
+        whenever(getLikesUseCase.getLikesForPost(fingerPrint, paginationParams, DON_T_CARE)).thenReturn(
                 flow { emit(state) }
         )
 
@@ -100,7 +101,7 @@ class GetLikesHandlerTest {
                 hasMore = false
         )
 
-        whenever(getLikesUseCase.getLikesForPost(fingerPrint, paginationParams)).thenReturn(
+        whenever(getLikesUseCase.getLikesForPost(fingerPrint, paginationParams, DON_T_CARE)).thenReturn(
                 flow { emit(state) }
         )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/GetLikesHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/GetLikesHandlerTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.fluxc.model.LikeModel.LikeType.COMMENT_LIKE
 import org.wordpress.android.fluxc.model.LikeModel.LikeType.POST_LIKE
 import org.wordpress.android.test
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.DON_T_CARE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement.DONT_CARE
 import org.wordpress.android.ui.engagement.GetLikesUseCase.FailureType
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
@@ -65,7 +65,7 @@ class GetLikesHandlerTest {
                 hasMore = false
         )
 
-        whenever(getLikesUseCase.getLikesForPost(fingerPrint, paginationParams, DON_T_CARE)).thenReturn(
+        whenever(getLikesUseCase.getLikesForPost(fingerPrint, paginationParams, DONT_CARE)).thenReturn(
                 flow { emit(state) }
         )
 
@@ -101,7 +101,7 @@ class GetLikesHandlerTest {
                 hasMore = false
         )
 
-        whenever(getLikesUseCase.getLikesForPost(fingerPrint, paginationParams, DON_T_CARE)).thenReturn(
+        whenever(getLikesUseCase.getLikesForPost(fingerPrint, paginationParams, DONT_CARE)).thenReturn(
                 flow { emit(state) }
         )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/usecases/GetLikesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/usecases/GetLikesUseCaseTest.kt
@@ -27,7 +27,7 @@ import org.wordpress.android.fluxc.store.PostStore.OnPostLikesChanged
 import org.wordpress.android.fluxc.store.PostStore.PostError
 import org.wordpress.android.test
 import org.wordpress.android.ui.engagement.GetLikesUseCase
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.DON_T_CARE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement.DONT_CARE
 import org.wordpress.android.ui.engagement.GetLikesUseCase.FailureType.GENERIC
 import org.wordpress.android.ui.engagement.GetLikesUseCase.FailureType.NO_NETWORK
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
@@ -98,7 +98,7 @@ class GetLikesUseCaseTest {
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
                 PaginationParams(false, defaultPageLenght, defaultLikesLimit),
-                DON_T_CARE
+                DONT_CARE
         )
 
         assertThat(flow.toList().firstOrNull() is Loading).isTrue
@@ -120,7 +120,7 @@ class GetLikesUseCaseTest {
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
                 PaginationParams(true, defaultPageLenght, defaultLikesLimit),
-                DON_T_CARE
+                DONT_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty
@@ -146,7 +146,7 @@ class GetLikesUseCaseTest {
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
                 PaginationParams(false, defaultPageLenght, defaultLikesLimit),
-                DON_T_CARE
+                DONT_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty
@@ -187,7 +187,7 @@ class GetLikesUseCaseTest {
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
                 PaginationParams(false, defaultPageLenght, noLikesLimit),
-                DON_T_CARE
+                DONT_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty
@@ -228,7 +228,7 @@ class GetLikesUseCaseTest {
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
                 PaginationParams(false, defaultPageLenght, noLikesLimit),
-                DON_T_CARE
+                DONT_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty
@@ -270,7 +270,7 @@ class GetLikesUseCaseTest {
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
                 PaginationParams(false, defaultPageLenght, noLikesLimit),
-                DON_T_CARE
+                DONT_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty
@@ -306,7 +306,7 @@ class GetLikesUseCaseTest {
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
                 PaginationParams(false, defaultPageLenght, defaultLikesLimit),
-                DON_T_CARE
+                DONT_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/usecases/GetLikesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/usecases/GetLikesUseCaseTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.action.CommentAction.FETCHED_COMMENT_LIKES
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged.FetchPostLikes
 import org.wordpress.android.fluxc.model.LikeModel.LikeType.COMMENT_LIKE
 import org.wordpress.android.fluxc.model.LikeModel.LikeType.POST_LIKE
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.CommentStore
 import org.wordpress.android.fluxc.store.CommentStore.CommentError
 import org.wordpress.android.fluxc.store.CommentStore.CommentErrorType
@@ -26,6 +27,7 @@ import org.wordpress.android.fluxc.store.PostStore.OnPostLikesChanged
 import org.wordpress.android.fluxc.store.PostStore.PostError
 import org.wordpress.android.test
 import org.wordpress.android.ui.engagement.GetLikesUseCase
+import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.DON_T_CARE
 import org.wordpress.android.ui.engagement.GetLikesUseCase.FailureType.GENERIC
 import org.wordpress.android.ui.engagement.GetLikesUseCase.FailureType.NO_NETWORK
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
@@ -45,6 +47,7 @@ class GetLikesUseCaseTest {
     @Mock private lateinit var dispatcher: Dispatcher
     @Mock private lateinit var commentStore: CommentStore
     @Mock private lateinit var postStore: PostStore
+    @Mock private lateinit var accountStore: AccountStore
 
     private lateinit var getLikesUseCase: GetLikesUseCase
     private val siteId = 100L
@@ -63,7 +66,8 @@ class GetLikesUseCaseTest {
                 networkUtilsWrapper,
                 dispatcher,
                 commentStore,
-                postStore
+                postStore,
+                accountStore
         )
     }
 
@@ -93,7 +97,8 @@ class GetLikesUseCaseTest {
 
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
-                PaginationParams(false, defaultPageLenght, defaultLikesLimit)
+                PaginationParams(false, defaultPageLenght, defaultLikesLimit),
+                DON_T_CARE
         )
 
         assertThat(flow.toList().firstOrNull() is Loading).isTrue
@@ -114,7 +119,8 @@ class GetLikesUseCaseTest {
 
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
-                PaginationParams(true, defaultPageLenght, defaultLikesLimit)
+                PaginationParams(true, defaultPageLenght, defaultLikesLimit),
+                DON_T_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty
@@ -139,7 +145,8 @@ class GetLikesUseCaseTest {
 
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
-                PaginationParams(false, defaultPageLenght, defaultLikesLimit)
+                PaginationParams(false, defaultPageLenght, defaultLikesLimit),
+                DON_T_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty
@@ -179,7 +186,8 @@ class GetLikesUseCaseTest {
 
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
-                PaginationParams(false, defaultPageLenght, noLikesLimit)
+                PaginationParams(false, defaultPageLenght, noLikesLimit),
+                DON_T_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty
@@ -219,7 +227,8 @@ class GetLikesUseCaseTest {
 
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
-                PaginationParams(false, defaultPageLenght, noLikesLimit)
+                PaginationParams(false, defaultPageLenght, noLikesLimit),
+                DON_T_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty
@@ -260,7 +269,8 @@ class GetLikesUseCaseTest {
 
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
-                PaginationParams(false, defaultPageLenght, noLikesLimit)
+                PaginationParams(false, defaultPageLenght, noLikesLimit),
+                DON_T_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty
@@ -295,7 +305,8 @@ class GetLikesUseCaseTest {
 
         val flow = getLikesUseCase.getLikesForPost(
                 LikeGroupFingerPrint(siteId, postId, expectedNumLikes),
-                PaginationParams(false, defaultPageLenght, defaultLikesLimit)
+                PaginationParams(false, defaultPageLenght, defaultLikesLimit),
+                DON_T_CARE
         )
 
         assertThat(flow.toList()).isNotEmpty

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.ui.engagement.EngageItem.Liker
 import org.wordpress.android.ui.engagement.EngagedPeopleListViewModel.EngagedPeopleListUiState
 import org.wordpress.android.ui.engagement.EngagementUtils
 import org.wordpress.android.ui.engagement.GetLikesHandler
+import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.DON_T_CARE
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.LikesData
@@ -791,7 +792,10 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
         getLikesState.value = likesState
         init()
         viewModel.onRefreshLikersData(viewModel.post!!)
-        verify(getLikesHandler, times(1)).handleGetLikesForPost(anyOrNull(), anyBoolean(), anyInt(), anyInt())
+        verify(
+                getLikesHandler,
+                times(1)
+        ).handleGetLikesForPost(anyOrNull(), anyBoolean(), anyInt(), anyInt(), eq(DON_T_CARE))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModelTest.kt
@@ -34,7 +34,7 @@ import org.wordpress.android.ui.engagement.EngageItem.Liker
 import org.wordpress.android.ui.engagement.EngagedPeopleListViewModel.EngagedPeopleListUiState
 import org.wordpress.android.ui.engagement.EngagementUtils
 import org.wordpress.android.ui.engagement.GetLikesHandler
-import org.wordpress.android.ui.engagement.GetLikesUseCase.BeInListRequirement.DON_T_CARE
+import org.wordpress.android.ui.engagement.GetLikesUseCase.CurrentUserInListRequirement.DONT_CARE
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.Failure
 import org.wordpress.android.ui.engagement.GetLikesUseCase.GetLikesState.LikesData
@@ -795,7 +795,7 @@ class ReaderPostDetailViewModelTest : BaseUnitTest() {
         verify(
                 getLikesHandler,
                 times(1)
-        ).handleGetLikesForPost(anyOrNull(), anyBoolean(), anyInt(), anyInt(), eq(DON_T_CARE))
+        ).handleGetLikesForPost(anyOrNull(), anyBoolean(), anyInt(), anyInt(), eq(DONT_CARE))
     }
 
     @Test


### PR DESCRIPTION
This PR adds a retry mechanism in the getLikes function. This is currently used in the reader post details when a user is liking/unliking a post and should appear/disappear from the likers train of faces. I'll add some more unit testing in a separate PR (also trying to see if we can even more simplify the getLikes function 🙃 ).

### To test
- Use the debugger to check there can be cases where one or more retry is attempted (especially when liking to get the user included in the likers response)
- Bring the NUM_RETRY to 1 and check there are cases when the user liked but it's not included in the list of likers. This tests that in case the NUM_RETRY is reached the logic still present a result in the end (showing what is possible to show)
- Smoke test both notifications and reader

## Regression Notes
N/A still behind feature flag

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
