### PR TITLE
Fixing issue with multiple tap on same liker.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
@@ -100,8 +100,8 @@ class EngagedPeopleListFragment : Fragment() {
                     ShowBottomSheet -> {
                         if (bottomSheet == null) {
                             bottomSheet = UserProfileBottomSheetFragment.newInstance(USER_PROFILE_VM_KEY)
+                            bottomSheet.show(fragmentManager, USER_PROFILE_BOTTOM_SHEET_TAG)
                         }
-                        bottomSheet.show(fragmentManager, USER_PROFILE_BOTTOM_SHEET_TAG)
                     }
                     HideBottomSheet -> {
                         bottomSheet?.apply { this.dismiss() }


### PR DESCRIPTION
This is a quick PR to fix a possible crash when a user taps very quickly and multiple times on a liker in the list of likers. This is due since the show on the bottom sheet should not be actually called when the bottom sheet isn't null.

### To test
- Try to tap multiple times on the same liker and check the logcat for the following crash `java.lang.IllegalStateException: Fragment already added: UserProfileBottomSheetFragment`
- Smoke test to check the standard expected behaviour of the user profile bottom sheet is kept.


## Regression Notes
N/A behind feature flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
