### PR TITLE
Dont fetch likes for feeds

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -219,6 +219,7 @@ class ReaderPostDetailViewModel @Inject constructor(
 
     fun onRefreshLikersData(post: ReaderPost, expectingToBeThere: CurrentUserInListRequirement = DONT_CARE) {
         if (!likesEnhancementsFeatureConfig.isEnabled()) return
+        if (readerUtilsWrapper.isExternalFeed(post.blogId, post.feedId)) return
         val isLikeDataChanged = lastRenderedLikesData?.isMatchingPost(post) ?: true
 
         if (isLikeDataChanged) {


### PR DESCRIPTION
This PR add a check so that likes endpoint are not fetched in reader post details for feeds.

## To test:
- Place a breakpoint in the `ReaderPostDetailViewModel.onRefreshLikersData` function and check the `getLikesHandler.handleGetLikesForPost` is not called for feeds
- Smoke test to check all works as before for standard blogs

## Regression Notes
N/A Behind feature flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
