### PR TITLE
Allow opening header blog by id and site url.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/LikedItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/LikedItemViewHolder.kt
@@ -40,10 +40,7 @@ class LikedItemViewHolder(
 
         imageManager.loadIntoCircle(this.avatar, ImageType.AVATAR_WITH_BACKGROUND, avatarUrl)
 
-        if (
-                !TextUtils.isEmpty(likedItem.authorPreferredSiteUrl) &&
-                likedItem.authorPreferredSiteId > 0 && likedItem.authorUserId > 0
-        ) {
+        if (!TextUtils.isEmpty(likedItem.authorPreferredSiteUrl) || likedItem.authorPreferredSiteId > 0) {
             with(this.avatar) {
                 importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
                 contentDescription = this.context.getString(string.profile_picture, authorName)


### PR DESCRIPTION
This PR allows to open the author site both by url (that is in a webview) or site id (that is in the reader) when tapping on the author avatar in the likers list header.

### To test
- In the reader, open a list of likers and tap on the header avatar. Check the author site is opened in the reader (since it was already fetched in the reader db)
- In the notifications, open a list of likers and tap on the header avatar. Majority of cases should open the author site in a webview (since it was not fetched already in the reader db) where before this patch nothing would have opened (given the site id would have been 0 even if the site url was available)

## Regression Notes
N/A behind feature flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
