### PR TITLE
Avoid issues with negative site id

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModel.kt
@@ -255,9 +255,9 @@ class EngagedPeopleListViewModel @Inject constructor(
             analyticsUtilsWrapper.trackUserProfileSiteShown()
         }
 
-        if (siteId == 0L && siteUrl.isNotEmpty()) {
+        if (siteId <= 0L && siteUrl.isNotEmpty()) {
             _onNavigationEvent.value = Event(PreviewSiteByUrl(siteUrl, source))
-        } else if (siteId != 0L) {
+        } else if (siteId > 0L) {
             _onNavigationEvent.value = Event(PreviewSiteById(siteId, source))
         }
     }


### PR DESCRIPTION
During testing we found that some reader post author site id could be negative. This PR enforce the logic checks to avoid issues with eventual negative site ids.

### To test
- Logic inspection of the code
- Force condition by debugger (or I can provide a couple of sample posts where this happen as well)

## Regression Notes
N/A behind feature flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
