### PR TITLE
Fix margins on site info block

### DIFF
--- a/WordPress/src/main/res/layout/my_site_info_block.xml
+++ b/WordPress/src/main/res/layout/my_site_info_block.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
+    android:layout_marginBottom="@dimen/margin_medium"
     android:paddingEnd="@dimen/margin_medium_large"
     tools:ignore="RtlSymmetry">
 
@@ -15,6 +15,7 @@
         android:layout_gravity="center_horizontal"
         android:layout_marginStart="@dimen/content_margin_site_row_start"
         android:layout_marginTop="@dimen/margin_extra_medium_large"
+        android:layout_marginBottom="@dimen/margin_extra_medium_large"
         app:cardCornerRadius="@dimen/my_site_blavatar_container_corner_radius"
         app:cardElevation="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -72,7 +73,6 @@
         android:layout_height="wrap_content"
         android:minHeight="@dimen/my_site_blavatar_sz"
         android:layout_marginStart="@dimen/margin_extra_large"
-        android:layout_marginTop="@dimen/margin_extra_medium_large"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/switch_site"
         app:layout_constraintStart_toEndOf="@id/blavatar_container"


### PR DESCRIPTION
Fixes #14580 

This PR fixes the look of the site info block with the system font set to the largest possible value. In that case the site URL was overflowing the text block. Previously we were using top margin on both the icon and the site title, the bottom margin was set on the parent. This solution moves the 24dp margin to the bottom of the icon and removes all the margin from the title/subtitle. The title/subtitle view is centered so it looks good and has space to grow

To test:
- Make sure `MySiteImprovements` flag is turned on
- Set system font to largest value
- Go to a site with long site title (which wraps 2 lines)
- Make sure the site title and the URL are both visible
- Make sure you test other configurations (font sizes, shorter/longer site titles)

Before:

![Screenshot_1620034376](https://user-images.githubusercontent.com/1079756/116871569-bf13c780-ac14-11eb-919b-fd5f2e6ecdea.png)

After: 

<img width="498" alt="Screenshot 2021-05-03 at 13 38 16" src="https://user-images.githubusercontent.com/1079756/116871620-d5ba1e80-ac14-11eb-9269-3b4235868093.png">



## Regression Notes
1. Potential unintended areas of impact
- Unexpected UI of the site title

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- I've tested with multiple system font sizes/site titles

3. What automated tests I added (or what prevented me from doing so)
- There is no way to test this automatically

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
