### PR TITLE
Show Date selector on the stats view all screen

### DIFF
--- a/WordPress/src/main/res/layout/stats_view_all_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_view_all_fragment.xml
@@ -13,13 +13,14 @@
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fillViewport="true">
+            android:fillViewport="true"
+            android:layout_below="@id/toolbar"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
             <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
                 android:id="@+id/pullToRefresh"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                app:layout_behavior="@string/appbar_scrolling_view_behavior">
+                android:layout_height="match_parent">
 
                 <include
                     android:id="@+id/stats_list_fragment"


### PR DESCRIPTION
Fixes #14582 

This PR fixes the invisible date selector on the stats View all screen.

To test:
- Go to a site with a lot of data
- Go to Stats/Year
- Go to one block that has the "View all" button
- Click on it
- Notice the date selector is now visible under the toolbar
- Change date
- Notice the new data is loaded


After the fix: 

<img width="501" alt="Screenshot 2021-05-03 at 14 07 53" src="https://user-images.githubusercontent.com/1079756/116874066-fa17fa00-ac18-11eb-9c06-81be8b2695cc.png">


## Regression Notes
1. Potential unintended areas of impact
- All the stats View all screens

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- I've tested the view all screens on period views and insights and the stats details

3. What automated tests I added (or what prevented me from doing so)
- this can't be automatically tested

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
