### PR TITLE
Bintray shutdown fixes

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -14,10 +14,11 @@ buildscript {
 repositories {
     google()
     jcenter()
+    mavenCentral()
     maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
     maven { url "https://www.jitpack.io" }
-    maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
     maven { url "https://a8c-libs.s3.amazonaws.com/android" }
+    maven { url "https://a8c-libs.s3.amazonaws.com/android/hermes-mirror" }
 }
 
 apply plugin: 'com.android.application'

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppConfigModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppConfigModule.java
@@ -3,7 +3,7 @@ package org.wordpress.android.modules;
 import android.content.Context;
 import android.util.Base64;
 
-import com.goterl.lazycode.lazysodium.utils.Key;
+import com.goterl.lazysodium.utils.Key;
 
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'com.automattic.android:fetchstyle:1.1'
+        //classpath 'com.automattic.android:fetchstyle:1.1'
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlinVersion"
@@ -25,7 +25,7 @@ buildscript {
     }
 }
 
-apply plugin: 'com.automattic.android.fetchstyle'
+//apply plugin: 'com.automattic.android.fetchstyle'
 
 allprojects {
     apply plugin: 'checkstyle'
@@ -34,7 +34,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url "https://dl.bintray.com/wordpress-mobile/maven" }
         maven { url "https://jitpack.io" }
 
         if (gradle.ext.includedBuildGutenbergMobilePath) {
@@ -43,7 +42,7 @@ allprojects {
                 url "$rootDir/$gradle.ext.includedBuildGutenbergMobilePath/gutenberg/node_modules/react-native/android"
             }
         } else {
-            maven { url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/" }
+            maven { url "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror" }
         }
 
         flatDir {
@@ -134,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.16.0-beta-5'
+    fluxCVersion = '1.16.1'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/libs/editor/example/build.gradle
+++ b/libs/editor/example/build.gradle
@@ -15,7 +15,7 @@ repositories {
     google()
     jcenter()
     maven { url "https://www.jitpack.io" }
-    maven { url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/" }
+    maven { url "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror" }
 }
 
 android {


### PR DESCRIPTION
* Adds `mavenCentral` repository which is necessary for the lazysodium library
* Adds `hermes-mirror` and `react-native-mirror` S3 repositories
* Fixes an import for lazysodium
* Temporarily disables `fetchstyle` plugin (until it's moved to S3)
* Updates FluxC to `1.16.1`: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1988
* Updates stories library to include the Bintray fixes from https://github.com/Automattic/stories-android/pull/674

To test:
* Try various blocks in the Gutenberg editor
* Test encrypted logging using the instructions from #14446

## Regression Notes
1. Potential unintended areas of impact

* Gutenberg editor not working
* Encrypted logging not working

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
