### PR TITLE
Rename utils path to make it clear the library comes from S3

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -336,9 +336,9 @@ dependencies {
 
     implementation ('com.github.indexos.media-for-mobile:android:43a9026f0973a2f0a74fa813132f6a16f7499c3a')
 
-    implementation "$gradle.ext.wputilsBinaryPath:$wordPressUtilsVersion"
-    testImplementation "$gradle.ext.wputilsBinaryPath:$wordPressUtilsVersion"
-    debugImplementation "$gradle.ext.wputilsBinaryPath:$wordPressUtilsVersion"
+    implementation "$gradle.ext.wputilsS3Path:$wordPressUtilsVersion"
+    testImplementation "$gradle.ext.wputilsS3Path:$wordPressUtilsVersion"
+    debugImplementation "$gradle.ext.wputilsS3Path:$wordPressUtilsVersion"
     implementation (project(path:':libs:networking:WordPressNetworking')) {
         exclude group: "com.android.volley"
         exclude group: 'org.wordpress', module: 'utils'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_coroutines_version = '1.3.9'
     ext.coroutinesVersion = '1.3.9'
     ext.kotlin_ktx_version = '1.2.0'
-    ext.wordPressUtilsVersion = '1.30.3-beta.3'
+    ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
     ext.gutenbergMobileVersion = 'v1.52.0'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,7 +22,7 @@ include ':WordPressMocks'
 project(':WordPressMocks').projectDir = new File(rootProject.projectDir, properties.getOrDefault('wp.wordpress_mocks_path', 'libs/mocks') + '/WordPressMocks')
 
 gradle.ext.fluxCBinaryPath = "com.github.wordpress-mobile.WordPress-FluxC-Android"
-gradle.ext.wputilsBinaryPath = "org.wordpress:utils"
+gradle.ext.wputilsS3Path = "org.wordpress:utils"
 gradle.ext.gutenbergMobileBinaryPath = "org.wordpress-mobile.gutenberg-mobile:react-native-gutenberg-bridge"
 gradle.ext.includedBuildGutenbergMobilePath = null
 
@@ -54,7 +54,7 @@ if (localBuilds.exists()) {
         includeBuild(ext.localWPUtilsPath) {
             dependencySubstitution {
                 println "Substituting wputils with the local build"
-                substitute module("$gradle.ext.wputilsBinaryPath") with project(':WordPressUtils')
+                substitute module("$gradle.ext.wputilsS3Path") with project(':WordPressUtils')
             }
         }
     }


### PR DESCRIPTION
Title says it all.

@oguzkocer I did know we had #14359 and I tried to update the version on my end. This is the only difference from that PR.

To test: if CI builds the app we're good, as this is just a version change with no extra feature.

## Regression Notes
1. Potential unintended areas of impact
N.A.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.


3. What automated tests I added (or what prevented me from doing so)
N.A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
