### PR TITLE
Use ConstraintLayout in quick actions block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickActionsViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/QuickActionsViewHolder.kt
@@ -16,8 +16,8 @@ class QuickActionsViewHolder(
         quickActionPagesButton.setOnClickListener { item.onPagesClick.click() }
 
         val pagesVisibility = if (item.showPages) View.VISIBLE else View.GONE
-        quickActionPagesContainer.visibility = pagesVisibility
-        middleQuickActionSpacing.visibility = pagesVisibility
+        quickActionPagesButton.visibility = pagesVisibility
+        quickActionPagesLabel.visibility = pagesVisibility
 
         quickStartStatsFocusPoint.setVisibleOrGone(item.showStatsFocusPoint)
         quickStartPagesFocusPoint.setVisibleOrGone(item.showPagesFocusPoint)

--- a/WordPress/src/main/res/layout/quick_actions_block.xml
+++ b/WordPress/src/main/res/layout/quick_actions_block.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/quick_actions_container"
@@ -10,104 +11,117 @@
     android:paddingStart="@dimen/content_margin_site_row_start"
     android:paddingTop="@dimen/margin_extra_small"
     android:clipChildren="false"
-    android:clipToPadding="false"
-    android:orientation="horizontal">
+    android:clipToPadding="false">
 
-    <RelativeLayout style="@style/MySiteQuickActionButtonContainer">
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/quick_action_posts_button"
+        app:layout_constraintBottom_toTopOf="@+id/quick_actions_stats_label"
+        android:id="@+id/quick_action_stats_button"
+        app:layout_constraintHorizontal_chainStyle="spread_inside"
+        style="@style/MySiteQuickActionButton"
+        android:src="@drawable/ic_stats_alt_white_24dp"
+        android:contentDescription="@string/stats"/>
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/quick_action_stats_button"
-            style="@style/MySiteQuickActionButton"
-            android:src="@drawable/ic_stats_alt_white_24dp"
-            android:contentDescription="@string/stats"/>
+    <org.wordpress.android.widgets.WPTextView
+        app:layout_constraintTop_toBottomOf="@+id/quick_action_stats_button"
+        app:layout_constraintStart_toStartOf="@+id/quick_action_stats_button"
+        app:layout_constraintEnd_toEndOf="@+id/quick_action_stats_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:id="@+id/quick_actions_stats_label"
+        style="@style/ImprovedMySiteQuickActionButtonLabel"
+        android:layout_below="@+id/quick_action_stats_button"
+        android:text="@string/stats" />
 
-        <org.wordpress.android.widgets.WPTextView
-            style="@style/MySiteQuickActionButtonLabel"
-            android:layout_below="@+id/quick_action_stats_button"
-            android:text="@string/stats" />
-
-        <org.wordpress.android.widgets.QuickStartFocusPoint
-            android:id="@+id/quick_start_stats_focus_point"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentEnd="true"
-            android:layout_gravity="center_vertical|center"
-            android:contentDescription="@string/quick_start_focus_point_description"
-            android:elevation="@dimen/quick_start_focus_point_elevation"
-            app:size="small"
-            tools:ignore="RtlSymmetry" />
-    </RelativeLayout>
-
-    <Space
+    <org.wordpress.android.widgets.QuickStartFocusPoint
+        android:id="@+id/quick_start_stats_focus_point"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_weight="1" />
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/quick_start_focus_point_description"
+        android:elevation="@dimen/quick_start_focus_point_elevation"
+        app:layout_constraintBottom_toBottomOf="@+id/quick_action_stats_button"
+        app:layout_constraintEnd_toEndOf="@+id/quick_action_stats_button"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="@+id/quick_action_stats_button"
+        app:layout_constraintTop_toTopOf="@+id/quick_action_stats_button"
+        app:layout_constraintVertical_bias="0.0"
+        app:size="small"
+        tools:ignore="RtlSymmetry" />
 
-    <RelativeLayout style="@style/MySiteQuickActionButtonContainer">
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        app:layout_constraintStart_toEndOf="@+id/quick_action_stats_button"
+        app:layout_constraintEnd_toStartOf="@+id/quick_action_media_button"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/quick_action_posts_label"
+        android:id="@+id/quick_action_posts_button"
+        style="@style/MySiteQuickActionButton"
+        android:src="@drawable/ic_posts_white_24dp"
+        android:contentDescription="@string/posts"/>
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/quick_action_posts_button"
-            style="@style/MySiteQuickActionButton"
-            android:src="@drawable/ic_posts_white_24dp"
-            android:contentDescription="@string/posts"/>
+    <org.wordpress.android.widgets.WPTextView
+        app:layout_constraintTop_toBottomOf="@+id/quick_action_posts_button"
+        app:layout_constraintStart_toStartOf="@+id/quick_action_posts_button"
+        app:layout_constraintEnd_toEndOf="@+id/quick_action_posts_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:id="@+id/quick_action_posts_label"
+        style="@style/ImprovedMySiteQuickActionButtonLabel"
+        android:ellipsize="end"
+        android:layout_below="@+id/quick_action_posts_button"
+        android:text="@string/posts" />
 
-        <org.wordpress.android.widgets.WPTextView
-            style="@style/MySiteQuickActionButtonLabel"
-            android:layout_below="@+id/quick_action_posts_button"
-            android:text="@string/posts" />
-    </RelativeLayout>
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        app:layout_constraintStart_toEndOf="@+id/quick_action_posts_button"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/quick_action_pages_button"
+        app:layout_constraintBottom_toTopOf="@+id/quick_action_media_label"
+        android:id="@+id/quick_action_media_button"
+        style="@style/MySiteQuickActionButton"
+        android:src="@drawable/ic_media_white_24dp"
+        android:contentDescription="@string/media"/>
 
-    <Space
+    <org.wordpress.android.widgets.WPTextView
+        app:layout_constraintTop_toBottomOf="@+id/quick_action_media_button"
+        app:layout_constraintStart_toStartOf="@+id/quick_action_media_button"
+        app:layout_constraintEnd_toEndOf="@+id/quick_action_media_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:id="@+id/quick_action_media_label"
+        style="@style/ImprovedMySiteQuickActionButtonLabel"
+        android:layout_below="@+id/quick_action_media_button"
+        android:text="@string/media" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/quick_action_media_button"
+        app:layout_constraintBottom_toTopOf="@+id/quick_action_pages_label"
+        android:id="@+id/quick_action_pages_button"
+        style="@style/MySiteQuickActionButton"
+        android:src="@drawable/ic_pages_white_24dp"
+        android:contentDescription="@string/pages"/>
+
+    <org.wordpress.android.widgets.WPTextView
+        app:layout_constraintTop_toBottomOf="@+id/quick_action_pages_button"
+        app:layout_constraintStart_toStartOf="@+id/quick_action_pages_button"
+        app:layout_constraintEnd_toEndOf="@+id/quick_action_pages_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:id="@+id/quick_action_pages_label"
+        style="@style/ImprovedMySiteQuickActionButtonLabel"
+        android:layout_below="@+id/quick_action_pages_button"
+        android:text="@string/pages" />
+
+    <org.wordpress.android.widgets.QuickStartFocusPoint
+        android:id="@+id/quick_start_pages_focus_point"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_weight="1" />
-
-    <RelativeLayout style="@style/MySiteQuickActionButtonContainer">
-
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/quick_action_media_button"
-            style="@style/MySiteQuickActionButton"
-            android:src="@drawable/ic_media_white_24dp"
-            android:contentDescription="@string/media"/>
-
-        <org.wordpress.android.widgets.WPTextView
-            style="@style/MySiteQuickActionButtonLabel"
-            android:layout_below="@+id/quick_action_media_button"
-            android:text="@string/media" />
-    </RelativeLayout>
-
-    <Space
-        android:id="@+id/middle_quick_action_spacing"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_weight="1" />
-
-    <RelativeLayout
-        android:id="@+id/quick_action_pages_container"
-        style="@style/MySiteQuickActionButtonContainer">
-
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/quick_action_pages_button"
-            style="@style/MySiteQuickActionButton"
-            android:src="@drawable/ic_pages_white_24dp"
-            android:contentDescription="@string/pages"/>
-
-        <org.wordpress.android.widgets.WPTextView
-            style="@style/MySiteQuickActionButtonLabel"
-            android:layout_below="@+id/quick_action_pages_button"
-            android:text="@string/pages" />
-
-        <org.wordpress.android.widgets.QuickStartFocusPoint
-            android:id="@+id/quick_start_pages_focus_point"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical|center"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentTop="true"
-            android:contentDescription="@string/quick_start_focus_point_description"
-            android:elevation="@dimen/quick_start_focus_point_elevation"
-            app:size="small"
-            tools:ignore="RtlSymmetry" />
-    </RelativeLayout>
-</LinearLayout>
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="@+id/quick_action_pages_button"
+        app:layout_constraintEnd_toEndOf="@+id/quick_action_pages_button"
+        app:layout_constraintStart_toStartOf="@+id/quick_action_pages_button"
+        app:layout_constraintBottom_toBottomOf="@+id/quick_action_pages_button"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintVertical_bias="0.0"
+        android:contentDescription="@string/quick_start_focus_point_description"
+        android:elevation="@dimen/quick_start_focus_point_elevation"
+        app:size="small"
+        tools:ignore="RtlSymmetry" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -312,6 +312,7 @@
     <dimen name="my_site_name_label_double_line_text_size">16sp</dimen>
     <dimen name="my_site_content_area">500dp</dimen>
     <dimen name="my_site_quick_action_button_container_width">64dp</dimen>
+    <dimen name="my_site_quick_action_button_text_max_width">84dp</dimen>
 
     <!--me-->
     <dimen name="me_list_row_icon_size">24dp</dimen>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -486,6 +486,13 @@
         <item name="android:layout_centerHorizontal">true</item>
     </style>
 
+    <style name="ImprovedMySiteQuickActionButtonLabel" parent="MySiteQuickActionButtonLabel">
+        <item name="android:maxLines">1</item>
+        <item name="android:textSize">@dimen/text_sz_small</item>
+        <item name="android:ellipsize">end</item>
+        <item name="maxWidth">@dimen/my_site_quick_action_button_text_max_width</item>
+    </style>
+
     <style name="MySiteListRowLayout">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
Fixes #14591 

This fix is a little bit tricky. The main thing that fixes the overlap with largest font is that the the label now has maxWidth 20dp wider than the icon. This causes the font sometimes overlap the icon and the quick actions block padding. However, I think this is ok since it only happens with the largest system font and the result looks really good. In order to implement this I've converted the quick actions block to constraint layout.

To test:
- Make sure the my site improvements flag is turned on
- Change system font to "Largest"
- Switch to a site with all of 4 actions 
- Check the font is not overlapping to the second line
- Switch to a site with all of 3 actions (where you're not an admin)
- Check the actions look as expected
- Change the system font back to standard
- Check the quick actions labels look like they did before both with 4 and 3 actions


Before: 

<img width="498" alt="Screenshot 2021-05-05 at 11 31 29" src="https://user-images.githubusercontent.com/1079756/117121940-95ce7500-ad95-11eb-991a-e42cc361ca0d.png">
<img width="499" alt="Screenshot 2021-05-05 at 11 31 17" src="https://user-images.githubusercontent.com/1079756/117121946-96670b80-ad95-11eb-8f8c-3cb6b8bf099f.png">
<img width="498" alt="Screenshot 2021-05-05 at 11 30 41" src="https://user-images.githubusercontent.com/1079756/117121947-96ffa200-ad95-11eb-9769-80b42fba6456.png">
<img width="498" alt="Screenshot 2021-05-05 at 11 30 17" src="https://user-images.githubusercontent.com/1079756/117121949-97983880-ad95-11eb-9617-caa9ee8be4db.png">


After: 

<img width="498" alt="Screenshot 2021-05-05 at 11 32 20" src="https://user-images.githubusercontent.com/1079756/117121963-9c5cec80-ad95-11eb-8093-194f50c42bfa.png">
<img width="498" alt="Screenshot 2021-05-05 at 11 32 11" src="https://user-images.githubusercontent.com/1079756/117121969-9d8e1980-ad95-11eb-8de7-3d9cefa45c78.png">
<img width="499" alt="Screenshot 2021-05-05 at 11 31 54" src="https://user-images.githubusercontent.com/1079756/117121970-9d8e1980-ad95-11eb-9b63-0d76f846b8e2.png">
<img width="498" alt="Screenshot 2021-05-05 at 11 31 42" src="https://user-images.githubusercontent.com/1079756/117121973-9e26b000-ad95-11eb-9b32-32128f26e116.png">


## Regression Notes
1. Potential unintended areas of impact
- I think there are no unintended areas of impact 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- I've tested everything mentioned in "To test" block and compared to the current develop

3. What automated tests I added (or what prevented me from doing so)
- N/A
 
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
