### PR TITLE
Use ID to compare SubHeaders on CommentListAdpter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentListItemDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentListItemDiffCallback.kt
@@ -13,7 +13,7 @@ class CommentListItemDiffCallback(
         val newItem = newList[newItemPosition]
 
         return when {
-            oldItem is SubHeader && newItem is SubHeader -> oldItem.label == newItem.label
+            oldItem is SubHeader && newItem is SubHeader -> oldItem.id == newItem.id
             oldItem is Comment && newItem is Comment -> {
                 oldItem.comment.remoteCommentId == newItem.comment.remoteCommentId
             }


### PR DESCRIPTION
Fixes #14598 

This PR fixes the crash in adapter by changing the logic of `areItemsTheSame` to compare SubHeaders by ID instead of label.
The crash is relatively rare (and non-blocking), so I think we are find getting it out in the next release.


To test:
Ideally you would like to reproduce the original issue first:
- Create a comment (you can reply to existing comment) on a minute of an hour (eg. 13:10)
- Wait 30 seconds and create a comment at a 30 seconds of a minute (eg. 13:10:30)
- In the comment list you should see 2 of your comments under one subheader, like this:
[![Image from Gyazo](https://i.gyazo.com/f2e4993fee44010838b8880a5d47ca9e.png)](https://gyazo.com/f2e4993fee44010838b8880a5d47ca9e)
- Wait 35 seconds (5 extra seconds are to account for any network delay when you were creating comments) and refresh the list.
- You should see the first comment you created moving under a different subheader, like this:
[![Image from Gyazo](https://i.gyazo.com/9ad0fdf7946b6c6acef42a0b47b809c5.png)](https://gyazo.com/9ad0fdf7946b6c6acef42a0b47b809c5) 
- Wait another 35 seconds and refresh the list.
- 💥 

Repeat the test with this PR, and at the last step you should see this, instead of 💥 :
[![Image from Gyazo](https://i.gyazo.com/8341f1b59e4f1f85b7f6f1f44e182b31.png)](https://gyazo.com/8341f1b59e4f1f85b7f6f1f44e182b31)

## Regression Notes
1. Potential unintended areas of impact
- Potential issues with Site Comments list.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing.

3. What automated tests I added (or what prevented me from doing so)
- This is a legacy code that is hard to test. We are working on rewriting it at the moment.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
