### PR TITLE
Jetpack App (Basics): Update MySite Tab Icon

### DIFF
--- a/WordPress/src/jetpack/res/drawable/ic_jetpack_white_24dp.xml
+++ b/WordPress/src/jetpack/res/drawable/ic_jetpack_white_24dp.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-</selector>

--- a/WordPress/src/jetpack/res/drawable/ic_jetpack_white_24dp.xml
+++ b/WordPress/src/jetpack/res/drawable/ic_jetpack_white_24dp.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+</selector>

--- a/WordPress/src/jetpack/res/drawable/ic_my_sites_white_24dp.xml
+++ b/WordPress/src/jetpack/res/drawable/ic_my_sites_white_24dp.xml
@@ -1,14 +1,9 @@
-<!-- This asset is a copy of ic_plans_white_24dp from WordPress. It is the jetpack grid icon -->
-<vector
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:height="24dp"
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0"
-    tools:ignore="UnusedResources">
-
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
     <path
         android:fillColor="@android:color/white"
-        android:pathData="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm-1 12H6l5-10v10zm2 6V10h5l-5 10z" />
+        android:pathData="M22,9L12,1 2,9v2h2v10h5v-4c0,-1.657 1.343,-3 3,-3s3,1.343 3,3v4h5V11h2V9z"/>
 </vector>


### PR DESCRIPTION
Fixes #14301

This PR changes the My Site icon from the Jetpack Icon to Home icon.

@osullivanchris - One open question on text: Should it be "My Site" or "Home"? Thanks

Light | Dark
-----|-----
<img width="250" height="500" alt="light" src="https://user-images.githubusercontent.com/506707/117212776-c4b20e80-adc8-11eb-88d4-fc1a311f840e.png"> | <img width="250" height="500" alt="dark" src="https://user-images.githubusercontent.com/506707/117212783-c67bd200-adc8-11eb-8715-392f6eacb95b.png">

To test:
- Checkout this branch
- Build a Jetpack variant
- Launch the app and login 
- Note that the My Site icon is shown as a home icon (see screenshots) 
-- Test both light and dark mode

## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 
3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
