### PR TITLE
Change order of comment filters to align with iOS

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.kt
@@ -63,7 +63,7 @@ class CommentsActivity : LocaleAwareActivity(),
     private lateinit var appBar: AppBarLayout
     private lateinit var site: SiteModel
 
-    private val commentListFilters = listOf(ALL, UNAPPROVED, UNREPLIED, APPROVED, TRASH, SPAM)
+    private val commentListFilters = listOf(ALL, UNAPPROVED, UNREPLIED, APPROVED, SPAM, TRASH)
 
     private var disabledTabsOpacity: Float = 0F
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.kt
@@ -63,7 +63,7 @@ class CommentsActivity : LocaleAwareActivity(),
     private lateinit var appBar: AppBarLayout
     private lateinit var site: SiteModel
 
-    private val commentListFilters = listOf(ALL, UNAPPROVED, APPROVED, UNREPLIED, SPAM, TRASH)
+    private val commentListFilters = listOf(ALL, UNAPPROVED, UNREPLIED, APPROVED, TRASH, SPAM)
 
     private var disabledTabsOpacity: Float = 0F
 


### PR DESCRIPTION
This PR changes the order of Unreplied comment filter Comment List to align with iOS.

Before:
[![Image from Gyazo](https://i.gyazo.com/79b44cccecd5570f4e7ef2401cebe95e.png)](https://gyazo.com/79b44cccecd5570f4e7ef2401cebe95e)

After:
[![Image from Gyazo](https://i.gyazo.com/1f36b615ecc0fa0407f0100b929775e5.png)](https://gyazo.com/1f36b615ecc0fa0407f0100b929775e5)


To test:
- Make sure the Comment List filters looks like "After".

## Regression Notes
1. Potential unintended areas of impact
- Don't believe there are any.

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
