### PR TITLE
Improves Page Layout Picker implementation using data from the DB

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
@@ -218,6 +218,8 @@ abstract class LayoutPickerViewModel(
         _onThumbnailModeButtonPressed.call()
     }
 
+    open fun getLayout(slug: String?): LayoutModel? = layouts.firstOrNull { it.slug == slug }
+
     /**
      * Retries data fetching
      */
@@ -226,7 +228,7 @@ abstract class LayoutPickerViewModel(
     fun onPreviewLoading() {
         if (networkUtils.isNetworkAvailable()) {
             (uiState.value as? Content)?.let { state ->
-                layouts.firstOrNull { it.slug == state.selectedLayoutSlug }?.let { layout ->
+                getLayout(state.selectedLayoutSlug)?.let { layout ->
                     _previewState.value = PreviewUiState.Loading(layout.demoUrl)
                     layoutPickerTracker.trackPreviewLoading(layout.slug, selectedPreviewMode().key)
                 }
@@ -239,7 +241,7 @@ abstract class LayoutPickerViewModel(
 
     fun onPreviewLoaded() {
         (uiState.value as? Content)?.let { state ->
-            layouts.firstOrNull { it.slug == state.selectedLayoutSlug }?.let { layout ->
+            getLayout(state.selectedLayoutSlug)?.let { layout ->
                 _previewState.value = PreviewUiState.Loaded
                 layoutPickerTracker.trackPreviewLoaded(layout.slug, selectedPreviewMode().key)
             }
@@ -258,7 +260,7 @@ abstract class LayoutPickerViewModel(
 
     fun onPreviewTapped() {
         (uiState.value as? Content)?.let { state ->
-            layouts.firstOrNull { it.slug == state.selectedLayoutSlug }?.let { layout ->
+            getLayout(state.selectedLayoutSlug)?.let { layout ->
                 val template = layout.slug
                 layoutPickerTracker.trackPreviewViewed(template, selectedPreviewMode().key)
                 _onPreviewActionPressed.value = DesignPreviewAction.Show(template, layout.demoUrl)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
@@ -93,7 +93,7 @@ class HomePagePickerViewModel @Inject constructor(
 
     fun onChooseTapped() {
         (uiState.value as? Content)?.let { state ->
-            layouts.firstOrNull { it.slug == state.selectedLayoutSlug }?.let { layout ->
+            getLayout(state.selectedLayoutSlug)?.let { layout ->
                 val template = layout.slug
                 analyticsTracker.trackSiteDesignSelected(template)
                 _onDesignActionPressed.value = DesignSelectionAction.Choose(template)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
@@ -41,6 +41,8 @@ class HomePagePickerViewModel @Inject constructor(
     private val _onBackButtonPressed = SingleLiveEvent<Unit>()
     val onBackButtonPressed: LiveData<Unit> = _onBackButtonPressed
 
+    override val useCachedData: Boolean = false
+
     sealed class DesignSelectionAction(val template: String) {
         object Skip : DesignSelectionAction(defaultTemplateSlug)
         class Choose(template: String) : DesignSelectionAction(template)
@@ -63,7 +65,7 @@ class HomePagePickerViewModel @Inject constructor(
         }
     }
 
-    override fun fetchLayouts() {
+    override fun fetchLayouts(preferCache: Boolean) {
         if (!networkUtils.isNetworkAvailable()) {
             analyticsTracker.trackErrorShown(ERROR_CONTEXT, INTERNET_UNAVAILABLE_ERROR, "Retry error")
             updateUiState(Error(toast = R.string.hpp_retry_error))

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
@@ -92,13 +92,11 @@ class HomePagePickerViewModel @Inject constructor(
     }
 
     fun onChooseTapped() {
-        (uiState.value as? Content)?.let { state ->
-            getLayout(state.selectedLayoutSlug)?.let { layout ->
-                val template = layout.slug
-                analyticsTracker.trackSiteDesignSelected(template)
-                _onDesignActionPressed.value = DesignSelectionAction.Choose(template)
-                return
-            }
+        selectedLayout?.let { layout ->
+            val template = layout.slug
+            analyticsTracker.trackSiteDesignSelected(template)
+            _onDesignActionPressed.value = DesignSelectionAction.Choose(template)
+            return
         }
         analyticsTracker.trackErrorShown(ERROR_CONTEXT, UNKNOWN, "Error choosing design")
         updateUiState(Error(toast = R.string.hpp_choose_error))

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModel.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.store.SiteStore.FetchBlockLayoutsPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnBlockLayoutsFetched
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.layoutpicker.LayoutModel
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Content
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Error
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Loading
@@ -104,6 +105,9 @@ class ModalLayoutPickerViewModel @Inject constructor(
         }
     }
 
+    override fun getLayout(slug: String?): LayoutModel? =
+            slug?.let { siteStore.getBlockLayout(site, it) }?.let { LayoutModel(it) }
+
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onBlockLayoutsFetched(event: OnBlockLayoutsFetched) {
         if (event.isError) {
@@ -163,7 +167,7 @@ class ModalLayoutPickerViewModel @Inject constructor(
      */
     private fun createPage() {
         (uiState.value as? Content)?.let { state ->
-            layouts.firstOrNull { it.slug == state.selectedLayoutSlug }?.let { layout ->
+            getLayout(state.selectedLayoutSlug)?.let { layout ->
                 val content: String = siteStore.getBlockLayoutContent(site, layout.slug) ?: ""
                 _onCreateNewPageRequested.value = PageRequest.Create(layout.slug, content, layout.title)
                 return

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
@@ -62,26 +62,26 @@ class ModalLayoutPickerViewModelTest {
     @Mock lateinit var analyticsTracker: ModalLayoutPickerTracker
     @Mock lateinit var onCreateNewPageRequestedObserver: Observer<Create>
 
+    private val aboutCategory = GutenbergLayoutCategory(
+            slug = "about",
+            title = "About",
+            description = "About pages",
+            emoji = "👋"
+    )
+
+    private val aboutLayout = GutenbergLayout(
+            slug = "about",
+            title = "About",
+            previewTablet = "https://headstartdata.files.wordpress.com/2020/01/about-2.png",
+            previewMobile = "https://headstartdata.files.wordpress.com/2020/01/about-2.png",
+            preview = "https://headstartdata.files.wordpress.com/2020/01/about-2.png",
+            content = "",
+            demoUrl = "",
+            categories = listOf(aboutCategory)
+    )
+
     private val defaultPageLayoutsEvent: OnBlockLayoutsFetched
-        get() {
-            val aboutCategory = GutenbergLayoutCategory(
-                    slug = "about",
-                    title = "About",
-                    description = "About pages",
-                    emoji = "👋"
-            )
-            val aboutLayout = GutenbergLayout(
-                    slug = "about",
-                    title = "About",
-                    previewTablet = "https://headstartdata.files.wordpress.com/2020/01/about-2.png",
-                    previewMobile = "https://headstartdata.files.wordpress.com/2020/01/about-2.png",
-                    preview = "https://headstartdata.files.wordpress.com/2020/01/about-2.png",
-                    content = "",
-                    demoUrl = "",
-                    categories = listOf(aboutCategory)
-            )
-            return OnBlockLayoutsFetched(listOf(aboutLayout), listOf(aboutCategory), null)
-        }
+        get() = OnBlockLayoutsFetched(listOf(aboutLayout), listOf(aboutCategory), null)
 
     @Before
     fun setUp() {
@@ -110,6 +110,7 @@ class ModalLayoutPickerViewModelTest {
             whenever(appPrefsWrapper.getSelectedSite()).thenReturn(siteId)
             whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(site)
             whenever(siteStore.getSiteByLocalId(siteId)).thenReturn(site)
+            whenever(siteStore.getBlockLayout(site, "about")).thenReturn(aboutLayout)
             whenever(supportedBlocksProvider.fromAssets()).thenReturn(SupportedBlocks())
             whenever(thumbDimensionProvider.previewWidth).thenReturn(136)
             whenever(thumbDimensionProvider.scale).thenReturn(1.0)

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.17.0-beta-2'
+    fluxCVersion = '5dafb358da055a7f61732067ead9a726e02be814'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '5dafb358da055a7f61732067ead9a726e02be814'
+    fluxCVersion = '6931c4118a8acb1c40ca2eae6278f1651e29a087'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '6931c4118a8acb1c40ca2eae6278f1651e29a087'
+    fluxCVersion = '1.17.0-beta-3'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #14426

Depends on `WordPress-Fluxc-Android`: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1995

## Description
This PR enhances the Page Layout Picker implementation by using the already available cache instead on the bundle to save the layout models. This is a followup to a [hotfix](https://github.com/wordpress-mobile/WordPress-Android/pull/14422) preventing a `TransactionTooLargeException` crash.
The page layouts are (re)fetched when the Page Layout picker loads and the device is not offline.

## To test

### Device rotation
1. Tap the fab ➕ icon on the My Site screen
2. Select Site page
3. Select some categories and a layout
4. Rotate the device
5. **Verify** that layouts are rendered and the selections haven't changed 

### [Crash](https://github.com/wordpress-mobile/WordPress-Android/issues/14421) regression
1. Tap the fab ➕ icon on the My Site screen
2. Select Site page
3. Put the app to the background
4. Bring the app to the foreground
5. **Verify** that the app does not crash

### Sanity tests

#### Modal Layout Picker

The layout picker for new pages should behave the same as before. Test to make sure no regressions were introduced during the refactoring.

<details>
<summary>Create / preview a page tests</summary>

##### Create a Blank Page
1. Create a new page for a Gutenberg site.
1. Select "Create a Blank Page"
     - **Expect** to see the Editor Load and not present the old Starter Page Template Picker Bar

##### Create a Page from a layout
1. Create a new page for a Gutenberg site.
1. Select a layout
1. Select "Create Page"
     - **Expect** to see the Editor Load with the contents of the layout

##### Preview a layout
1. Create a new page for a Gutenberg site.
1. Select a layout
1. Select "Preview"
     - **Expect** to see a Read-Only Editor load with the contents of the layout
1. Select "Create Page"
     - **Expect** to see the Editor load with the contents of the layout

</details>

<details>
<summary>Filter bar tests</summary>

##### Select Categories
1. Select a category
    - **Expect** to see the sections condensed to be only the selected category filter
1. Select a different category
    - **Expect** to see the new section added to the list
1. Deselect a category
    - **Expect** the list to update again to be only the selected categories
1. Deselect the rest of the categories
    - **Expect** the all of the categories to return

</details>

<details>
<summary>Thumbnail mode</summary>

##### Change to Desktop
1. In the *My Site* screen tap the fab (+) button and select *Site page*
1. Press the **thumbnail mode button**
1. Select **Desktop**
    - **Expect** that desktop thumbnails are displayed

</details>

#### Site Design Picker

Navigate to the Create WordPress.com site - My Sites > ➕ > Create WordPress.com site

<details>
<summary>Create a Site - Selecting a Design</summary>

1. Select a design
1.  **Expect**
    - To see the footer slide in from the bottom
    - To see a border and checkmark animate in place on the selected design.
1. Select Choose
1.  **Expect**
    - To see the analytics event `enhanced_site_creation_site_design_selected` with the property `template` populated with the selected layout's slug
1. Search for and select a domain
1. Select Create Site
1.  **Expect**
    - To see a temporary screen as the site is being created
    - To see the site confirmation screen.

</details>

<details>
<summary>Preview then Create a Site</summary>

1. Select a design
1. Select Preview
1.  **Expect** the preview to show for the selected design
1. Select Choose
1. **Expect** to see the preview modal dismiss and for the Choose a Domain screen to be "pushed" on to the navigation flow.
1. Search for and select a domain
1. Select Create Site
1.  **Expect**
    - To see a temporary screen as the site is being created
    - To see the site confirmation screen.

</details>

#### Known issues:
* There is an [existing issue](https://github.com/wordpress-mobile/WordPress-Android/issues/14364) regarding scroll position accuracy after rotation.

## Regression Notes
1. Potential unintended areas of impact

* New Page creation from template and Site Creation flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)

* Run the sanity tests above and verified that all tests for the above flows are green

3. What automated tests I added (or what prevented me from doing so)

* Some tests where added in the [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1995)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.