### PR TITLE
Integrate gutenberg-mobile release 1.52.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.52.0'
+    ext.gutenbergMobileVersion = '3467-e95b5144cf4cd6d9566f3b6f484f14754ce32f48'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3467-55a0cbfa4698a9d6c6c753f1348f7d73a6327f76'
+    ext.gutenbergMobileVersion = 'v1.52.1'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3467-e95b5144cf4cd6d9566f3b6f484f14754ce32f48'
+    ext.gutenbergMobileVersion = '3467-55a0cbfa4698a9d6c6c753f1348f7d73a6327f76'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 1.52.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3467

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.