### PR TITLE
Jetpack App (Basics): Log out language

### DIFF
--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -13,4 +13,8 @@
     <!-- Contact us -->
     <!--Note: Support ticket subject, only visible to the end users of the Zendesk support portal, doesn't need a translation -->
     <string name="support_ticket_subject" translatable="false">Jetpack for Android Support</string>
+
+    <!-- Log out actions in Me -->
+    <string name="me_disconnect_from_wordpress_com">Log out of Jetpack</string>
+    <string name="sign_out_wpcom_confirm_with_no_changes">Log out of Jetpack?</string>
 </resources>


### PR DESCRIPTION
Fixes #14611 

This PR adds two strings to `jetpack/res/values/strings.xml ` and changes the verbiage to reflect Jetpack for separate builds.

To test:
- Create a local copy of this branch
- Build a Jetpack variant
- Log into the app with a Jetpack /WP account
- Tap Me 
- The log out text shows as: "Log out of Jetpack"

- Build a WordPress variant
- Log into the app with a WP account
- Tap Me
- The log out text shows: "Log out of WordPress.com"

## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 
3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
