### PR TITLE
Jetpack App (Emphasis): Hide quick actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -141,6 +140,7 @@ import org.wordpress.android.util.AppLog.T.DOMAIN_REGISTRATION
 import org.wordpress.android.util.AppLog.T.EDITOR
 import org.wordpress.android.util.AppLog.T.MAIN
 import org.wordpress.android.util.AppLog.T.UTILS
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.FluxCUtils
@@ -213,6 +213,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     @Inject lateinit var siteUtilsWrapper: SiteUtilsWrapper
     @Inject lateinit var quickStartUtilsWrapper: QuickStartUtilsWrapper
     @Inject lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Inject lateinit var buildConfigWrapper: BuildConfigWrapper
     @Inject @Named(UI_THREAD) lateinit var uiDispatcher: CoroutineDispatcher
     @Inject @Named(BG_THREAD) lateinit var bgDispatcher: CoroutineDispatcher
     lateinit var uiScope: CoroutineScope
@@ -428,7 +429,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     private fun MySiteFragmentBinding.setupQuickActionsIfNecessary() {
-        if (BuildConfig.IS_JETPACK_APP) {
+        if (buildConfigWrapper.isJetpackApp) {
             quickActionButtonsContainer.visibility = View.GONE
             return
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -391,10 +392,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         switchSite.setOnClickListener { showSitePicker() }
         rowViewSite.setOnClickListener { viewSite() }
         mySiteRegisterDomainCta.setOnClickListener { registerDomain() }
-        quickActionStatsButton.setOnClickListener {
-            AnalyticsTracker.track(QUICK_ACTION_STATS_TAPPED)
-            viewStats()
-        }
         rowStats.setOnClickListener { viewStats() }
         mySiteBlavatar.setOnClickListener { updateBlavatar() }
         rowPlan.setOnClickListener {
@@ -402,20 +399,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             ActivityLauncher.viewBlogPlans(activity, selectedSite)
         }
         rowJetpackSettings.setOnClickListener { ActivityLauncher.viewJetpackSecuritySettings(activity, selectedSite) }
-        quickActionPostsButton.setOnClickListener {
-            AnalyticsTracker.track(QUICK_ACTION_POSTS_TAPPED)
-            viewPosts()
-        }
         rowBlogPosts.setOnClickListener { viewPosts() }
-        quickActionMediaButton.setOnClickListener {
-            AnalyticsTracker.track(QUICK_ACTION_MEDIA_TAPPED)
-            viewMedia()
-        }
         rowMedia.setOnClickListener { viewMedia() }
-        quickActionPagesButton.setOnClickListener {
-            AnalyticsTracker.track(QUICK_ACTION_PAGES_TAPPED)
-            viewPages()
-        }
         rowPages.setOnClickListener { viewPages() }
         rowComments.setOnClickListener { ActivityLauncher.viewCurrentBlogComments(activity, selectedSite) }
         rowThemes.setOnClickListener {
@@ -440,6 +425,30 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         quickStartCustomize.setOnClickListener { showQuickStartList(CUSTOMIZE) }
         quickStartGrow.setOnClickListener { showQuickStartList(GROW) }
         quickStartMore.setOnClickListener { showQuickStartCardMenu() }
+    }
+
+    private fun MySiteFragmentBinding.setupQuickActionsIfNecessary() {
+        if (BuildConfig.IS_JETPACK_APP) {
+            quickActionButtonsContainer.visibility = View.GONE
+            return
+        }
+
+        quickActionStatsButton.setOnClickListener {
+            AnalyticsTracker.track(QUICK_ACTION_STATS_TAPPED)
+            viewStats()
+        }
+        quickActionPostsButton.setOnClickListener {
+            AnalyticsTracker.track(QUICK_ACTION_POSTS_TAPPED)
+            viewPosts()
+        }
+        quickActionMediaButton.setOnClickListener {
+            AnalyticsTracker.track(QUICK_ACTION_MEDIA_TAPPED)
+            viewMedia()
+        }
+        quickActionPagesButton.setOnClickListener {
+            AnalyticsTracker.track(QUICK_ACTION_PAGES_TAPPED)
+            viewPages()
+        }
     }
 
     private fun registerDomain() {
@@ -561,6 +570,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     private fun MySiteFragmentBinding.onBind() {
+        setupQuickActionsIfNecessary()
         setupClickListeners()
         collapsingToolbar.title = getString(R.string.my_site_section_screen_title)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
@@ -102,6 +101,7 @@ import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Neg
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Positive
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.MediaUtilsWrapper
@@ -143,7 +143,8 @@ class MySiteViewModel
     private val quickStartRepository: QuickStartRepository,
     private val quickStartItemBuilder: QuickStartItemBuilder,
     private val currentAvatarSource: CurrentAvatarSource,
-    private val dynamicCardsSource: DynamicCardsSource
+    private val dynamicCardsSource: DynamicCardsSource,
+    private val buildConfigWrapper: BuildConfigWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val _onTechInputDialogShown = MutableLiveData<Event<TextInputDialogModel>>()
@@ -206,7 +207,7 @@ class MySiteViewModel
                             activeTask == UPLOAD_SITE_ICON
                     )
             )
-            if (!BuildConfig.IS_JETPACK_APP) {
+            if (!buildConfigWrapper.isJetpackApp) {
                 siteItems.add(
                         QuickActionsBlock(
                                 ListItemInteraction.create(this::quickActionStatsClick),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_PROMPT_SHOWN
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS
@@ -205,17 +206,19 @@ class MySiteViewModel
                             activeTask == UPLOAD_SITE_ICON
                     )
             )
-            siteItems.add(
-                    QuickActionsBlock(
-                            ListItemInteraction.create(this::quickActionStatsClick),
-                            ListItemInteraction.create(this::quickActionPagesClick),
-                            ListItemInteraction.create(this::quickActionPostsClick),
-                            ListItemInteraction.create(this::quickActionMediaClick),
-                            site.isSelfHostedAdmin || site.hasCapabilityEditPages,
-                            activeTask == CHECK_STATS,
-                            activeTask == EDIT_HOMEPAGE || activeTask == REVIEW_PAGES
-                    )
-            )
+            if (!BuildConfig.IS_JETPACK_APP) {
+                siteItems.add(
+                        QuickActionsBlock(
+                                ListItemInteraction.create(this::quickActionStatsClick),
+                                ListItemInteraction.create(this::quickActionPagesClick),
+                                ListItemInteraction.create(this::quickActionPostsClick),
+                                ListItemInteraction.create(this::quickActionMediaClick),
+                                site.isSelfHostedAdmin || site.hasCapabilityEditPages,
+                                activeTask == CHECK_STATS,
+                                activeTask == EDIT_HOMEPAGE || activeTask == REVIEW_PAGES
+                        )
+                )
+            }
             if (isDomainCreditAvailable) {
                 analyticsTrackerWrapper.track(DOMAIN_CREDIT_PROMPT_SHOWN)
                 siteItems.add(DomainRegistrationBlock(ListItemInteraction.create(this::domainRegistrationClick)))

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -99,6 +99,7 @@ import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringResWithParams
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.FluxCUtilsWrapper
 import org.wordpress.android.util.MediaUtilsWrapper
@@ -129,6 +130,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock lateinit var scanAndBackupSource: ScanAndBackupSource
     @Mock lateinit var currentAvatarSource: CurrentAvatarSource
     @Mock lateinit var dynamicCardsSource: DynamicCardsSource
+    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<UiModel>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -197,7 +199,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 quickStartRepository,
                 quickStartItemBuilder,
                 currentAvatarSource,
-                dynamicCardsSource
+                dynamicCardsSource,
+                buildConfigWrapper
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()
@@ -954,6 +957,17 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         verify(analyticsTrackerWrapper).track(Stat.QUICK_START_REMOVE_CARD_TAPPED)
         verify(quickStartRepository).refresh()
+    }
+
+    @Test
+    fun `given build is Jetpack, then quick action block is not built`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
+
+        initSelectedSite()
+
+        val quickActionsBlock = findQuickActionsBlock()
+
+        assertThat(quickActionsBlock).isNull()
     }
 
     private fun findQuickActionsBlock() = getLastItems().find { it is QuickActionsBlock } as QuickActionsBlock?

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -960,7 +960,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given build is Jetpack, then quick action block is not built`() {
+    fun `when build is Jetpack, then quick action block is not built`() {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
 
         initSelectedSite()
@@ -968,6 +968,17 @@ class MySiteViewModelTest : BaseUnitTest() {
         val quickActionsBlock = findQuickActionsBlock()
 
         assertThat(quickActionsBlock).isNull()
+    }
+
+    @Test
+    fun `when build is WordPress, then quick action block is built`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
+
+        initSelectedSite()
+
+        val quickActionsBlock = findQuickActionsBlock()
+
+        assertThat(quickActionsBlock).isNotNull
     }
 
     private fun findQuickActionsBlock() = getLastItems().find { it is QuickActionsBlock } as QuickActionsBlock?


### PR DESCRIPTION
Fixes #14510 

This PR hides the Quick Action Buttons when the build is Jetpack.
Both the old and improved My Site logic have been updated.

To test:
Scenario 1
- Checkout this branch
- Build Jetpack variant
- Launch the app and login
- The Quick Action buttons are not shown on the My Site tab

Scenario 2
- Use the PR APK (Wordpress) variant
- Launch the app and login
- Observe the Quick Action buttons are shown on the My Site tab

## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Ran MySiteViewModelTest
3. What automated tests I added (or what prevented me from doing so)
- Added new test to MySiteViewModelTest
PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
