### PR TITLE
[TEST] Gutenberg - Disable featured image banner on iOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3474-4519c31bdc0d9ccdec47cb4a98034e90c0741418'
+    ext.gutenbergMobileVersion = '3474-640d2cd58cb624e5b87a276da200493eec31dc76'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.52.0'
+    ext.gutenbergMobileVersion = '3474-4519c31bdc0d9ccdec47cb4a98034e90c0741418'
 
     repositories {
         google()


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/pull/3474

To test:
1. Create a new post. 
2. Tap the three icons to the upper right of the post editor to access Post Settings and set a featured image.
3. Tap the back button. If the new featured image hasn't already been added to the editor via an image block, add it.
4. Confirm that the Featured banner display overlays the correct image block.
5. Return to Post Settings. Tap the existing featured image and then Remove.
6. Tap the back button to confirm that the Featured banner has been removed from the image block, as expected.

## Regression Notes
The only regression that could take is if the functionality on Android stopped working, hence this PR verifies that does not occur.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing. 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
