### PR TITLE
Integrate changes from gutenberg-mobile branch 1.52.1-develop-wp-apps-integration-test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.52.0'
+    ext.gutenbergMobileVersion = '3483-f1b58f6527b8f167fc93f10e760a39bd1a1987da'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 1.52.1-develop-wp-apps-integration-test branch of gutenberg-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3483

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.