### PR TITLE
Integrate changes from gutenberg-mobile branch 1.52.1-develop-ed7a64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.52.0'
+    ext.gutenbergMobileVersion = '3484-c823dbd51f6bb57b954be0e90f084b18bf948001'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 1.52.1-develop-ed7a64 branch of gutenberg-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3484

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.