### PR TITLE
Stories - update init order

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -142,7 +142,6 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         setMediaPickerProvider(this)
         (application as WordPress).component().inject(this)
         initSite(savedInstanceState)
-        super.onCreate(savedInstanceState)
         setSnackbarProvider(this)
         setAuthenticationProvider(this)
         setNotificationExtrasLoader(this)
@@ -153,9 +152,11 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         setPrepublishingEventProvider(this)
         setPermissionDialogProvider(this)
         setGenericAnnouncementDialogProvider(this)
-        setUseTempCaptureFile(false) // we need to keep the captured files for later Story editing
 
         initViewModel(savedInstanceState)
+        super.onCreate(savedInstanceState)
+
+        setUseTempCaptureFile(false) // we need to keep the captured files for later Story editing
     }
 
     private fun initSite(savedInstanceState: Bundle?) {


### PR DESCRIPTION
Fixes a crash identified in https://github.com/Automattic/stories-android/pull/681#issuecomment-839388382

Was able to reproduce on a fresh install (delete application data), and fixed in https://github.com/wordpress-mobile/WordPress-Android/commit/5ca542c07d4c47dc9ce27b7ae55c798b43067624 by moving `super.onCreate()` all the way down (actually just below `initViewModel()`) to make sure any Story library listeners instantiated in the ViewModel would be available before calling ComposeLoopFrameActivity's `onCreate()`. I also had to move the initialization call order of `setUseTempCaptureFile()` given it internally accesses the `storyViewModel` (and it can only exist after initializing the ViewModel itself).

Note this PR also updates the Stories library hash to point to the PR in Stories repo where the issue was noticed.

To test:
1. delete app's data
2. login to WP (a .com or jetpack site)
3. tap FAB to create a story
4. select one or two items from the media picker
5. observe the app doesn't crash with the `uninitialized prop` exception (it will fall back to the My Site screen the first run which is fixed in https://github.com/Automattic/stories-android/pull/684, but will work following tries)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
