### PR TITLE
Jetpack App (Basics): Include atomic sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -207,7 +207,8 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
     public RateLimitedTask mUpdateSiteList = new RateLimitedTask(SECONDS_BETWEEN_BLOGLIST_UPDATE) {
         protected boolean run() {
             if (mAccountStore.hasAccessToken()) {
-                mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(SiteUtils.getFetchSitesPayload()));
+                mDispatcher.dispatch(SiteActionBuilder
+                        .newFetchSitesAction(SiteUtils.getFetchSitesPayload(BuildConfig.IS_JETPACK_APP)));
                 mDispatcher.dispatch(AccountActionBuilder.newFetchSubscriptionsAction());
             }
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionResultActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionResultActivity.java
@@ -8,6 +8,7 @@ import android.text.TextUtils;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -133,7 +134,8 @@ public class JetpackConnectionResultActivity extends LocaleAwareActivity {
     private void finishAndGoBackToSource() {
         if (mSource == JetpackConnectionSource.STATS) {
             SiteModel site = (SiteModel) getIntent().getSerializableExtra(SITE);
-            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(SiteUtils.getFetchSitesPayload()));
+            mDispatcher.dispatch(SiteActionBuilder
+                    .newFetchSitesAction(SiteUtils.getFetchSitesPayload(BuildConfig.IS_JETPACK_APP)));
             ActivityLauncher.viewBlogStatsAfterJetpackSetup(this, site);
         }
         finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -355,7 +355,8 @@ public class SitePickerActivity extends LocaleAwareActivity
                         mSwipeToRefreshHelper.setRefreshing(false);
                         return;
                     }
-                    mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(SiteUtils.getFetchSitesPayload()));
+                    mDispatcher.dispatch(SiteActionBuilder
+                            .newFetchSitesAction(SiteUtils.getFetchSitesPayload(BuildConfig.IS_JETPACK_APP)));
                 }
         );
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -6,7 +6,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.jetbrains.annotations.NotNull;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -385,9 +385,9 @@ public class SiteUtils {
     }
 
     @NonNull
-    public static FetchSitesPayload getFetchSitesPayload() {
+    public static FetchSitesPayload getFetchSitesPayload(boolean isJetpackApp) {
         ArrayList<SiteFilter> siteFilters = new ArrayList<>();
-        if (BuildConfig.IS_JETPACK_APP) siteFilters.addAll(Arrays.asList(SiteFilter.JETPACK, SiteFilter.ATOMIC));
+        if (isJetpackApp) siteFilters.addAll(Arrays.asList(SiteFilter.JETPACK, SiteFilter.ATOMIC));
         return new FetchSitesPayload(siteFilters);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -29,6 +29,7 @@ import org.wordpress.android.util.image.BlavatarShape;
 import org.wordpress.android.util.image.ImageType;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class SiteUtils {
@@ -386,7 +387,7 @@ public class SiteUtils {
     @NonNull
     public static FetchSitesPayload getFetchSitesPayload() {
         ArrayList<SiteFilter> siteFilters = new ArrayList<>();
-        if (BuildConfig.IS_JETPACK_APP) siteFilters.add(SiteFilter.JETPACK);
+        if (BuildConfig.IS_JETPACK_APP) siteFilters.addAll(Arrays.asList(SiteFilter.JETPACK, SiteFilter.ATOMIC));
         return new FetchSitesPayload(siteFilters);
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore.SiteFilter
 import org.wordpress.android.ui.plans.PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
 import org.wordpress.android.ui.plans.PlansConstants.BLOGGER_PLAN_TWO_YEARS_ID
 import org.wordpress.android.ui.plans.PlansConstants.FREE_PLAN_ID
@@ -197,6 +198,33 @@ class SiteUtilsTest {
 
         val circularSiteImage = SiteUtils.getSiteImageType(false, CIRCULAR)
         assertThat(circularSiteImage).isEqualTo(BLAVATAR_CIRCULAR)
+    }
+
+    @Test
+    fun `given jetpack app, when sites are fetched, then jetpack and atomic sites are included in the filters`() {
+        val isJetpackApp = true
+
+        val payload = SiteUtils.getFetchSitesPayload(isJetpackApp)
+
+        assertThat(payload.filters).isEqualTo(listOf(SiteFilter.JETPACK, SiteFilter.ATOMIC))
+    }
+
+    @Test
+    fun `given jetpack app, when sites are fetched, then wpcom sites are not included in the filters`() {
+        val isJetpackApp = true
+
+        val payload = SiteUtils.getFetchSitesPayload(isJetpackApp)
+
+        assertThat(payload.filters).doesNotContain(SiteFilter.WPCOM)
+    }
+
+    @Test
+    fun `given wordpress app, when sites are fetched, then no sites are filtered out`() {
+        val isJetpackApp = false
+
+        val payload = SiteUtils.getFetchSitesPayload(isJetpackApp)
+
+        assertThat(payload.filters).isEmpty()
     }
 
     private fun initJetpackSite(): SiteModel {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/util/SiteUtils.java
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteFilter;
 import org.wordpress.android.util.UrlUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class SiteUtils {
@@ -50,7 +51,7 @@ public class SiteUtils {
     @NonNull
     public static FetchSitesPayload getFetchSitesPayload(boolean isJetpackAppLogin) {
         ArrayList<SiteFilter> siteFilters = new ArrayList<>();
-        if (isJetpackAppLogin) siteFilters.add(SiteFilter.JETPACK);
+        if (isJetpackAppLogin) siteFilters.addAll(Arrays.asList(SiteFilter.JETPACK, SiteFilter.ATOMIC));
         return new FetchSitesPayload(siteFilters);
     }
 }


### PR DESCRIPTION
Fixes #14619

This PR includes atomic sites for the Jetpack app.

To test:

1. Install and launch Jetpack app.
2. Login with an account with an atomic site.
3. Notice that login is successful and the site is visible in the site picker.

## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 
3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
