### PR TITLE
Rooting the HTTP_AUTH_ERROR to the NOT_AUTHENTICATED case.

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -489,6 +489,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
         switch (error) {
             case INCORRECT_USERNAME_OR_PASSWORD:
             case NOT_AUTHENTICATED: // NOT_AUTHENTICATED is the generic error from XMLRPC response on first call.
+            case HTTP_AUTH_ERROR:
                 showError(getString(R.string.username_or_password_incorrect));
                 break;
             case INVALID_OTP:
@@ -507,7 +508,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseDiscoveryFragment im
                 AppLog.e(T.NUX, "Server response: " + errorMessage);
 
                 ToastUtils.showToast(getActivity(),
-                        errorMessage == null ? getString(R.string.error_generic) : errorMessage);
+                        TextUtils.isEmpty(errorMessage) ? getString(R.string.error_generic) : errorMessage);
                 break;
         }
     }


### PR DESCRIPTION
Fixes #14506

This PR does 2 things:

1. The empty toast message described in the linked issue was due to the fact the generic message was not used for empty messages (as the case we have here) but only for null strings. Added a `TextUtils.isEmpty` check to surface the generic message in case
2. Rooted the `HTTP_AUTH_ERROR` (the one we get in this issue scenario) to the case managed when we get a `NOT_AUTHENTICATED` error

### Notes for reviewer
1. Given the changes, we are using the `showError` function already used for the `NOT_AUTHENTICATED` ; this means we will sum up the following tracking both for `HTTP_AUTH_ERROR` and `NOT_AUTHENTICATED` errors

```
🔵 Tracked: unified_login_failure, Properties: {"source":"default","flow":"login_site_address","step":"username_password","failure":"The username or password you entered is incorrect"}
```
In my understanding this is correct, but reporting in case I'm missing anything

2. Not sure if I need to open a linked PR in the Login lib repo (i see some instructions [here](https://github.com/wordpress-mobile/WordPress-Android/pull/14630#issuecomment-839664547) but not fully sure they still applies), happy to follow advice here after this is merged.

### To test
- On the login screen, select the "Enter your existing site address" option.
- Enter a self-hosted WordPress site address.
- Enter incorrect site credentials (username and/or password).
- Check you get something similar to the below image
 
<p align=center><img src="https://user-images.githubusercontent.com/47797566/117960881-c6765780-b31d-11eb-86fe-849bb491b665.png" width=300/></p>

- Insert correct credentials and check you can login normally

## Regression Notes
We are reusing a user facing notification; in principle no regression expected. Changes verified by manual testing + smoke testing.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
