### PR TITLE
Integrate gutenberg-mobile release 1.52.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3494-72a9a3d616b46f4af91768efbe30d66fedface82'
+    ext.gutenbergMobileVersion = 'v1.52.2'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3494-f33aa98132066fbdc75d3170201e464afb2f380a'
+    ext.gutenbergMobileVersion = '3494-72a9a3d616b46f4af91768efbe30d66fedface82'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.30.3-beta.3'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.52.1'
+    ext.gutenbergMobileVersion = '3494-f33aa98132066fbdc75d3170201e464afb2f380a'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 1.52.2 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3494

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.