### PR TITLE
Stories publishing - fix for Untitled posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModel.kt
@@ -133,8 +133,9 @@ class PrepublishingHomeViewModel @Inject constructor(
                         editPostRepository,
                         site
                 )
-                if (categoryString.isNotEmpty())
+                if (categoryString.isNotEmpty()) {
                     UiStringText(categoryString)
+                }
             } else {
                 UiStringRes(R.string.prepublishing_nudges_home_categories_not_set)
             }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
@@ -371,6 +371,26 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
         verify(updateStoryTitleUseCase).updateStoryTitle(eq(storyTitle), any())
     }
 
+    @Test
+    fun `verify story title is correctly updated when title is changed and publish is tapped `() {
+        // arrange
+        var event: Event<PublishPost>? = null
+        val storyTitle = "Story Title"
+        viewModel.onSubmitButtonClicked.observeForever {
+            event = it
+        }
+
+        // act
+        viewModel.start(editPostRepository, site, true)
+        getStoryTitleUiState()?.onStoryTitleChanged?.invoke(storyTitle)
+        val buttonUiState = getButtonUiState()
+        buttonUiState?.onButtonClicked?.invoke(true)
+
+        // assert
+        assertThat(event).isNotNull
+        verify(updateStoryTitleUseCase).updateStoryTitle(eq(storyTitle), any())
+    }
+
     private fun getHeaderUiState() = viewModel.uiState.value?.filterIsInstance(HeaderUiState::class.java)?.first()
     private fun getStoryTitleUiState() = viewModel.storyTitleUiState.value
 


### PR DESCRIPTION

Fixes https://github.com/Automattic/stories-android/issues/683

The original issue would appear when typing a title fast and immediately tapping on the `Publish` button. There's a 500ms delay in between keystrokes that was introduced to avoid performance issues by updating the PostModel on each keystroke, but with this there's a information loss opportunity that lasts at most 500ms.

This PR implements a `join()` call to wait for the delayed keystroke reading job to finish before emiting publishPost event. With this change, the publishPost event is only emited after the latest entered title information is available and set on the EditPostRepository, respecting the MVVM approach and making sure to update it.

To test:
1. create a new Story post, add one slide
2. tap on the ✅ on the right-top corner of the screen
3. when the pre-publishing bottom sheet appears, type a title quickly and quickly tap on the `Publish` button to confirm
4. observe the Post gets correctly uploaded with the right title as entered.

Also test: before merging, use `develop` and perform the same steps listed above, and confirm the Post is uploaded with the "Untitled" title.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added one test to correspond to the action of setting a Story title and then tapping publish uses the rightly set title

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
