### PR TITLE
Jetpack App (Basics): Update magic link scheme

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -82,6 +82,8 @@ android {
         buildConfigField "boolean", "IS_JETPACK_APP", "false"
         buildConfigField "String", "TRACKS_EVENT_PREFIX", '"wpandroid_"'
         buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"org.wordpress.android"'
+
+        manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }
 
     // Gutenberg's dependency - react-native-video is using
@@ -100,6 +102,8 @@ android {
             buildConfigField "boolean", "IS_JETPACK_APP", "false"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"wpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"org.wordpress.android"'
+
+            manifestPlaceholders = [magicLinkScheme:"wordpress"]
         }
 
         jetpack {
@@ -108,6 +112,8 @@ android {
             buildConfigField "boolean", "IS_JETPACK_APP", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
+
+            manifestPlaceholders = [magicLinkScheme:"jetpack"]
         }
 
         vanilla { // used for release and beta

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -10,6 +10,9 @@
     <string name="app_tagline">Site security and performance from your pocket</string>
     <string name="continue_with_wpcom_no_signup">Log in with WordPress.com</string>
 
+    <!-- Login Magic Link -->
+    <string name="login_magic_links_sent_label">Check your email on this device and tap the link in the email you received from Jetpack.com.</string>
+
     <!-- Contact us -->
     <!--Note: Support ticket subject, only visible to the end users of the Zendesk support portal, doesn't need a translation -->
     <string name="support_ticket_subject" translatable="false">Jetpack for Android Support</string>

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -113,7 +113,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:host="magic-login"
-                    android:scheme="wordpress" />
+                    android:scheme="${magicLinkScheme}" />
             </intent-filter>
         </activity>
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -496,7 +496,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
 
     private void showMagicLinkRequestScreen(String email, boolean verifyEmail, boolean allowPassword,
                                             boolean forceRequestAtStart) {
-        AuthEmailPayloadScheme scheme = AuthEmailPayloadScheme.WORDPRESS;
+        AuthEmailPayloadScheme scheme = mViewModel.getMagicLinkScheme();
         String jetpackConnectionSource = mJetpackConnectSource != null ? mJetpackConnectSource.toString() : null;
         LoginMagicLinkRequestFragment loginMagicLinkRequestFragment = LoginMagicLinkRequestFragment
                 .newInstance(email, scheme, mIsJetpackConnect, jetpackConnectionSource, verifyEmail, allowPassword,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginViewModel.kt
@@ -3,14 +3,16 @@ package org.wordpress.android.ui.accounts
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowNoJetpackSites
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowSiteAddressError
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 import kotlin.text.RegexOption.IGNORE_CASE
 
-class LoginViewModel @Inject constructor() : ViewModel() {
+class LoginViewModel @Inject constructor(private val buildConfigWrapper: BuildConfigWrapper) : ViewModel() {
     private val _navigationEvents = MediatorLiveData<Event<LoginNavigationEvents>>()
     val navigationEvents: LiveData<Event<LoginNavigationEvents>> = _navigationEvents
 
@@ -22,5 +24,11 @@ class LoginViewModel @Inject constructor() : ViewModel() {
 
     fun onHandleNoJetpackSites() {
         _navigationEvents.postValue(Event(ShowNoJetpackSites))
+    }
+
+    fun getMagicLinkScheme() = if (buildConfigWrapper.isJetpackApp) {
+        AuthEmailPayloadScheme.JETPACK
+    } else {
+        AuthEmailPayloadScheme.WORDPRESS
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginViewModelTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.accounts
 
 import com.nhaarman.mockitokotlin2.whenever
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -30,7 +29,7 @@ class LoginViewModelTest : BaseUnitTest() {
 
         viewModel.onHandleNoJetpackSites()
 
-        Assertions.assertThat(navigationEvents.last()).isInstanceOf(ShowNoJetpackSites::class.java)
+        assertThat(navigationEvents.last()).isInstanceOf(ShowNoJetpackSites::class.java)
     }
 
     @Test
@@ -41,7 +40,7 @@ class LoginViewModelTest : BaseUnitTest() {
         val connectSiteInfoPayload = getConnectSiteInfoPayload(url)
         viewModel.onHandleSiteAddressError(connectSiteInfoPayload)
 
-        Assertions.assertThat(navigationEvents.last()).isInstanceOf(ShowSiteAddressError::class.java)
+        assertThat(navigationEvents.last()).isInstanceOf(ShowSiteAddressError::class.java)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginViewModelTest.kt
@@ -1,22 +1,27 @@
 package org.wordpress.android.ui.accounts
 
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowNoJetpackSites
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowSiteAddressError
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
 
 class LoginViewModelTest : BaseUnitTest() {
+    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var resourceProvider: ResourceProvider
     private lateinit var viewModel: LoginViewModel
 
     @Before
     fun setUp() {
-        viewModel = LoginViewModel()
+        viewModel = LoginViewModel(buildConfigWrapper)
     }
 
     @Test
@@ -37,6 +42,24 @@ class LoginViewModelTest : BaseUnitTest() {
         viewModel.onHandleSiteAddressError(connectSiteInfoPayload)
 
         Assertions.assertThat(navigationEvents.last()).isInstanceOf(ShowSiteAddressError::class.java)
+    }
+
+    @Test
+    fun `given jetpack app, when magic link scheme is requested, then jetpack scheme is returned`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
+
+        val scheme = viewModel.getMagicLinkScheme()
+
+        assertThat(scheme).isEqualTo(AuthEmailPayloadScheme.JETPACK)
+    }
+
+    @Test
+    fun `given wordpress app, when magic link scheme is requested, then wordpress scheme is returned`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
+
+        val scheme = viewModel.getMagicLinkScheme()
+
+        assertThat(scheme).isEqualTo(AuthEmailPayloadScheme.WORDPRESS)
     }
 
     private fun getConnectSiteInfoPayload(url: String): ConnectSiteInfoPayload =

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = 'df54a9dd'
+    fluxCVersion = '1.17.0-beta-4'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.17.0-beta-3'
+    fluxCVersion = 'df54a9dd'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
SubTask #14620

This PR updates the magic link scheme for the Jetpack app. It is configured using the `build.gradle` based on the selected app.

Corresponding FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2003

To test:

- Install and launch the Jetpack app.
- Select "Login with WordPress.com".
- Enter email and click Continue.
- Click "Get a login link by email".
- Check email (it should be Jetpack-ified via diff `D61257`) and click "Log in to the app".
- Notice that the link opens the Jetpack app and login is successful.

Merge Instructions:

1. Wait for merge till corresponding FluxC PR is merged to develop.
2. Create FluxC tag and update it in the build.gradle (I can take care of it once this PR is approved).
3. Remove Not Ready for Merge.
4. Merge the PR.

## Regression Notes
1. Potential unintended areas of impact
WordPress app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually that "Get a login link by email" uses the `wordpress` scheme and opens the WordPress app from the email.

3. What automated tests I added (or what prevented me from doing so)
Added tests to check the scheme for both WordPress and Jetpack app.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
