### PR TITLE
Add missing module to AppComponentTest.kt

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
@@ -34,7 +34,7 @@ import javax.inject.Singleton
             SupportModule::class,
             ThreadModule::class,
             SuggestionSourceModule::class,
-            ExperimentModule::class,
+            ExperimentModule::class
         ]
 )
 interface AppComponentTest : AppComponent {

--- a/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
@@ -14,25 +14,29 @@ import org.wordpress.android.ui.suggestion.SuggestionSourceSubcomponent.Suggesti
 import javax.inject.Singleton
 
 @Singleton
-@Component(modules = [
-    ApplicationModule::class,
-    AppConfigModule::class,
-    OkHttpClientModule::class,
-    InterceptorModuleTest::class,
-    ReleaseNetworkModule::class,
-    LegacyModule::class,
-    ReleaseToolsModule::class,
-    AndroidSupportInjectionModule::class,
-    ViewModelModule::class,
-    StatsModule::class,
-    TrackerTestModule::class,
-    // Login flow library
-    LoginAnalyticsModule::class,
-    LoginFragmentModule::class,
-    LoginServiceModule::class,
-    SupportModule::class,
-    ThreadModule::class,
-    SuggestionSourceModule::class])
+@Component(
+        modules = [
+            ApplicationModule::class,
+            AppConfigModule::class,
+            OkHttpClientModule::class,
+            InterceptorModuleTest::class,
+            ReleaseNetworkModule::class,
+            LegacyModule::class,
+            ReleaseToolsModule::class,
+            AndroidSupportInjectionModule::class,
+            ViewModelModule::class,
+            StatsModule::class,
+            TrackerTestModule::class,
+            // Login flow library
+            LoginAnalyticsModule::class,
+            LoginFragmentModule::class,
+            LoginServiceModule::class,
+            SupportModule::class,
+            ThreadModule::class,
+            SuggestionSourceModule::class,
+            ExperimentModule::class,
+        ]
+)
 interface AppComponentTest : AppComponent {
     @Component.Builder
     interface Builder : AppComponent.Builder {


### PR DESCRIPTION
This PR fixes connected tests by adding the missing experiment module to the AppComponentTest. 

To test:
- Wait for the connected tests to succeed

## Regression Notes
1. Potential unintended areas of impact
- none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
