### PR TITLE
Integrate gutenberg-mobile release 1.53.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3506-fedbf92ca2c4e93668b0b9c2963447ef26da4f43'
+    ext.gutenbergMobileVersion = 'v1.53.0'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.53.0-alpha1'
+    ext.gutenbergMobileVersion = '3506-8d95c4794245f9284f0fbac10fc0728ae01b7df1'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3506-5be446de4b6bfb71b7958b1f890327d6af768add'
+    ext.gutenbergMobileVersion = '3506-fedbf92ca2c4e93668b0b9c2963447ef26da4f43'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3506-8d95c4794245f9284f0fbac10fc0728ae01b7df1'
+    ext.gutenbergMobileVersion = '3506-5be446de4b6bfb71b7958b1f890327d6af768add'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 1.53.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3506

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.