### PR TITLE
Update intent flags for jetpack app

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1283,14 +1283,9 @@ public class ActivityLauncher {
     }
 
     public static void showSignInForResultJetpackOnly(Activity activity) {
-        showSignInForResultJetpackOnly(activity, false);
-    }
-
-    public static void showSignInForResultJetpackOnly(Activity activity, Boolean clearTop) {
         Intent intent = new Intent(activity, LoginActivity.class);
-        if (clearTop) {
-            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        }
+        intent.setFlags(
+                Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         JETPACK_LOGIN_ONLY.putInto(intent);
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesFragment.kt
@@ -118,7 +118,7 @@ class LoginNoSitesFragment : Fragment(R.layout.jetpack_login_empty_view) {
             uiHelpers.setTextOrHide(userContainer.textDisplayName, value)
 
     private fun showSignInForResultJetpackOnly() {
-        ActivityLauncher.showSignInForResultJetpackOnly(requireActivity(), true)
+        ActivityLauncher.showSignInForResultJetpackOnly(requireActivity())
     }
 
     private fun showInstructions(url: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorFragment.kt
@@ -96,7 +96,7 @@ class LoginSiteCheckErrorFragment : Fragment(R.layout.jetpack_login_empty_view) 
     }
 
     private fun showSignInForResultJetpackOnly() {
-        ActivityLauncher.showSignInForResultJetpackOnly(requireActivity(), true)
+        ActivityLauncher.showSignInForResultJetpackOnly(requireActivity())
     }
 
     private fun showInstructions(url: String) {


### PR DESCRIPTION
Fixes #14649 

This PR adds new intent flags when launching LoginActivity for Jetpack. 

To test:
Prep
- Download this branch
- Build a Jetpack flavor

Scenario 1
- Login with an account that doesn't have any Jetpack sites.
- When the No Sites empty screen is show, click the Try with another account button.
- Login with an account that does have at least one Jetpack site.
- Logout from that account.
- Login again with the first account that doesn't have any Jetpack sites.
- Note that the "No Sites empty view" is shown 

Scenario 2
- Login with an account that doesn't have any Jetpack sites.
- When the No Sites empty screen is show, tap the back button or swipe back
- Note that you are taken out of the app and not shown the Me view

## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and reran `LoginViewModelTest` and `LoginNoSitesViewModelTest`
3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
