### PR TITLE
Reader: Respect src tag when tapping a Story preview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -193,13 +193,18 @@ public class ReaderWebView extends WPWebView {
     }
 
     /***
-     * isValidInstagramImageClick checks if this is an embedded instragram situation.
-     * If so, we want to ignore image click so that the iframe src gets handled
-     * The additional URL grab is an additional check for the instagram.com host
+     * Checks if the tapped image is a child of an anchor tag we want to respect.
+     * If so, we want to ignore the image click so that the wrapping src gets handled.
+     * The additional URL grab is an additional check for the appropriate host or URL structure.
+     *
+     * Cases:
+     * 1. Instagram
+     * 2. The Story block
+     *
      * @param hr - the HitTestResult
-     * @return true if is instagram or false otherwise
+     * @return true if the image click should be ignored and deferred to the parent anchor tag
      */
-    private boolean isValidInstagramImageClick(HitTestResult hr) {
+    private boolean isValidEmbeddedImageClick(HitTestResult hr) {
         // Referenced https://pacheco.dev/posts/android/webview-image-anchor/
         if (hr.getType() == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE) {
             Handler handler = new Handler();
@@ -211,7 +216,7 @@ public class ReaderWebView extends WPWebView {
                 return false;
             }
 
-            return url.contains("ig_embed");
+            return url.contains("ig_embed") || url.contains("wp-story");
         } else {
             return false;
         }
@@ -228,7 +233,7 @@ public class ReaderWebView extends WPWebView {
             if (hr != null) {
                 if (isValidClickedUrl(hr.getExtra())) {
                     if (UrlUtils.isImageUrl(hr.getExtra())) {
-                        if (isValidInstagramImageClick(hr)) {
+                        if (isValidEmbeddedImageClick(hr)) {
                             return super.onTouchEvent(event);
                         } else {
                             return mUrlClickListener.onImageUrlClick(


### PR DESCRIPTION
Fixes a recent issue where tapping a Story in the Reader detail view would open the photo viewer instead of opening the story in a browser for fullscreen playback.

The cause was a change to the structure of the rendered block, which moved the anchor tag further outside the nested HTML structure. This changed how taps were being registered by the WebView on Android. It looks like we've already had to solve a similar problem for Instagram embeds, so I just extended that solution to recognize story block URLs as well.

_Note: There's a [relevant Calypso PR](https://github.com/Automattic/wp-calypso/pull/52892) unmerged as of this writing that makes some CSS changes required by the same change that broke what this PR is fixing. However, the CSS changes are needed for fixes to the Calypso and WPiOS readers - the WPAndroid reader is unaffected, probably due to some customizations we have about `display: block` and such._

To test:

1. Follow a WP.com site with stories (wpstories DOT wordpress DOT com works)
2. Open a story post from that site in the Reader
3. Observe that the story preview loads correctly in the Reader detail view (should look like this):
![device-2020-09-22-122031](https://user-images.githubusercontent.com/9613966/93841318-2b693880-fcce-11ea-88e4-8d0d4a0aaa51.png)
4. Tap the story preview, and verify that it opens the device browser and plays the story in fullscreen mode

## Regression Notes
1. Potential unintended areas of impact

There should be none - this change specifically targets Story blocks in the Reader, identifying those by their URL structure.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
