### PR TITLE
Jetpack App (Basics): Magic links handle no sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -653,8 +653,11 @@ public class WordPress extends MultiDexApplication implements HasAndroidInjector
         for (SiteModel site : mSiteStore.getSites()) {
             mDispatcher.dispatch(ThemeActionBuilder.newRemoveSiteThemesAction(site));
         }
-        // delete wpcom and jetpack sites
-        mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
+
+        if (!BuildConfig.IS_JETPACK_APP || mSiteStore.hasSite()) {
+            // delete wpcom and jetpack sites
+            mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
+        }
         // remove all lists
         mDispatcher.dispatch(ListActionBuilder.newRemoveAllListsAction());
         // remove all posts

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -3,6 +3,7 @@ package org.wordpress.android.modules;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
+import org.wordpress.android.ui.accounts.LoginEpilogueViewModel;
 import org.wordpress.android.ui.accounts.login.jetpack.LoginSiteCheckErrorViewModel;
 import org.wordpress.android.ui.accounts.login.LoginPrologueViewModel;
 import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverViewModel;
@@ -510,6 +511,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(LoginNoSitesViewModel.class)
     abstract ViewModel loginNoSitesErrorViewModel(LoginNoSitesViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(LoginEpilogueViewModel.class)
+    abstract ViewModel loginEpilogueViewModel(LoginEpilogueViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.accounts;
 
 import android.os.Bundle;
 
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -12,9 +13,11 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.CloseWithResultOk;
+import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowNoJetpackSites;
 import org.wordpress.android.ui.accounts.LoginNavigationEvents.ShowPostSignupInterstitialScreen;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueListener;
+import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesFragment;
 
 import java.util.ArrayList;
 
@@ -62,6 +65,8 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
                 showPostSignupInterstitialScreen();
             } else if (loginEvent instanceof CloseWithResultOk) {
                 closeWithResultOk();
+            } else if (loginEvent instanceof ShowNoJetpackSites) {
+                showNoJetpackSites();
             }
         });
     }
@@ -97,5 +102,21 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
     private void closeWithResultOk() {
         setResult(RESULT_OK);
         finish();
+    }
+
+    private void showNoJetpackSites() {
+        LoginNoSitesFragment fragment = LoginNoSitesFragment.Companion.newInstance();
+        showFragment(fragment, LoginNoSitesFragment.TAG, true);
+    }
+
+    private void showFragment(Fragment fragment, String tag, boolean applySlideAnimation) {
+        FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+        if (applySlideAnimation) {
+            fragmentTransaction
+                    .setCustomAnimations(R.anim.activity_slide_in_from_right, R.anim.activity_slide_out_to_left,
+                            R.anim.activity_slide_in_from_left, R.anim.activity_slide_out_to_right);
+        }
+        fragmentTransaction.replace(R.id.fragment_container, fragment, tag);
+        fragmentTransaction.commit();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -73,10 +73,8 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
 
     protected void addPostLoginFragment(boolean doLoginUpdate, boolean showAndReturn, ArrayList<Integer> oldSitesIds) {
         LoginEpilogueFragment loginEpilogueFragment = LoginEpilogueFragment.newInstance(doLoginUpdate, showAndReturn,
-                                                                                        oldSitesIds);
-        FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
-        fragmentTransaction.replace(R.id.fragment_container, loginEpilogueFragment, LoginEpilogueFragment.TAG);
-        fragmentTransaction.commit();
+                oldSitesIds);
+        showFragment(loginEpilogueFragment, LoginEpilogueFragment.TAG, false);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.accounts;
 import android.os.Bundle;
 
 import androidx.fragment.app.FragmentTransaction;
+import androidx.lifecycle.ViewModelProvider;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -25,6 +26,8 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
+    @Inject ViewModelProvider.Factory mViewModelFactory;
+    @Inject LoginEpilogueViewModel mViewModel;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -42,6 +45,12 @@ public class LoginEpilogueActivity extends LocaleAwareActivity implements LoginE
 
             addPostLoginFragment(doLoginUpdate, showAndReturn, oldSitesIds);
         }
+
+        initViewModel();
+    }
+
+    private void initViewModel() {
+        mViewModel = new ViewModelProvider(this, mViewModelFactory).get(LoginEpilogueViewModel.class);
     }
 
     protected void addPostLoginFragment(boolean doLoginUpdate, boolean showAndReturn, ArrayList<Integer> oldSitesIds) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
@@ -1,6 +1,33 @@
 package org.wordpress.android.ui.accounts
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.viewmodel.Event
+
 import javax.inject.Inject
 
-class LoginEpilogueViewModel @Inject constructor() : ViewModel()
+class LoginEpilogueViewModel @Inject constructor(
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val siteStore: SiteStore
+) : ViewModel() {
+    private val _navigationEvents = MediatorLiveData<Event<LoginNavigationEvents>>()
+    val navigationEvents: LiveData<Event<LoginNavigationEvents>> = _navigationEvents
+
+    fun onContinue() {
+        if (!siteStore.hasSite()) handleNoSitesFound() else handleSitesFound()
+    }
+
+    private fun handleNoSitesFound() {
+        if (appPrefsWrapper.shouldShowPostSignupInterstitial) {
+            _navigationEvents.postValue(Event(LoginNavigationEvents.ShowPostSignupInterstitialScreen))
+        }
+        _navigationEvents.postValue(Event(LoginNavigationEvents.CloseWithResultOk))
+    }
+
+    private fun handleSitesFound() {
+        _navigationEvents.postValue(Event(LoginNavigationEvents.CloseWithResultOk))
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.accounts
+
+import androidx.lifecycle.ViewModel
+import javax.inject.Inject
+
+class LoginEpilogueViewModel @Inject constructor() : ViewModel()

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModel.kt
@@ -5,12 +5,14 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.viewmodel.Event
 
 import javax.inject.Inject
 
 class LoginEpilogueViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
+    private val buildConfigWrapper: BuildConfigWrapper,
     private val siteStore: SiteStore
 ) : ViewModel() {
     private val _navigationEvents = MediatorLiveData<Event<LoginNavigationEvents>>()
@@ -21,10 +23,14 @@ class LoginEpilogueViewModel @Inject constructor(
     }
 
     private fun handleNoSitesFound() {
-        if (appPrefsWrapper.shouldShowPostSignupInterstitial) {
-            _navigationEvents.postValue(Event(LoginNavigationEvents.ShowPostSignupInterstitialScreen))
+        if (buildConfigWrapper.isJetpackApp) {
+            _navigationEvents.postValue(Event(LoginNavigationEvents.ShowNoJetpackSites))
+        } else {
+            if (appPrefsWrapper.shouldShowPostSignupInterstitial) {
+                _navigationEvents.postValue(Event(LoginNavigationEvents.ShowPostSignupInterstitialScreen))
+            }
+            _navigationEvents.postValue(Event(LoginNavigationEvents.CloseWithResultOk))
         }
-        _navigationEvents.postValue(Event(LoginNavigationEvents.CloseWithResultOk))
     }
 
     private fun handleSitesFound() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginNavigationEvents.kt
@@ -7,6 +7,8 @@ sealed class LoginNavigationEvents {
     object ShowNoJetpackSites : LoginNavigationEvents()
     object ShowSignInForResultJetpackOnly : LoginNavigationEvents()
     data class ShowInstructions(val url: String = INSTRUCTIONS_URL) : LoginNavigationEvents()
+    object ShowPostSignupInterstitialScreen : LoginNavigationEvents()
+    object CloseWithResultOk : LoginNavigationEvents()
     object ShowEmailLoginScreen : LoginNavigationEvents()
     object ShowLoginViaSiteAddressScreen : LoginNavigationEvents()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.main.SitePickerAdapter;
 import org.wordpress.android.ui.main.SitePickerAdapter.SiteList;
 import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode;
 import org.wordpress.android.ui.main.SitePickerAdapter.ViewHolderHandler;
+import org.wordpress.android.util.BuildConfigWrapper;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.image.ImageManager;
@@ -56,6 +57,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
     @Inject ImageManager mImageManager;
     @Inject UnifiedLoginTracker mUnifiedLoginTracker;
+    @Inject BuildConfigWrapper mBuildConfigWrapper;
 
     public static LoginEpilogueFragment newInstance(boolean doLoginUpdate, boolean showAndReturn,
                                                     ArrayList<Integer> oldSitesIds) {
@@ -213,7 +215,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
     @Override
     protected boolean isJetpackAppLogin() {
-        return mDoLoginUpdate && BuildConfig.IS_JETPACK_APP;
+        return mDoLoginUpdate && mBuildConfigWrapper.isJetpackApp();
     }
 
     private void bindHeaderViewHolder(LoginHeaderViewHolder holder, SiteList sites) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -211,6 +211,11 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         }
     }
 
+    @Override
+    protected boolean isJetpackAppLogin() {
+        return mDoLoginUpdate && BuildConfig.IS_JETPACK_APP;
+    }
+
     private void bindHeaderViewHolder(LoginHeaderViewHolder holder, SiteList sites) {
         if (!isAdded()) {
             return;

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
@@ -1,0 +1,14 @@
+package org.wordpress.android.ui.accounts
+
+import org.junit.Before
+
+import org.wordpress.android.BaseUnitTest
+
+class LoginEpilogueViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: LoginEpilogueViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = LoginEpilogueViewModel()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
@@ -72,8 +72,30 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given wp app with sites present, when continued from epilogue, then epilogue closes with ok result`() {
+    fun `given wp app with sites, when continued from epilogue, then epilogue closes with ok result`() {
         init(isJetpackApp = false, hasSite = true)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onContinue()
+
+        assertThat(navigationEvents.last()).isInstanceOf(LoginNavigationEvents.CloseWithResultOk::class.java)
+    }
+
+    /* Jetpack app - No Jetpack Sites Screen */
+    @Test
+    fun `given jetpack app with no sites, when continued from epilogue, then no jetpack sites is shown`() {
+        init(isJetpackApp = true, hasSite = false)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onContinue()
+
+        assertThat(navigationEvents.last()).isInstanceOf(LoginNavigationEvents.ShowNoJetpackSites::class.java)
+    }
+
+    /* Jetpack app - Eplilogue Screen Close */
+    @Test
+    fun `given jetpack app with sites, when continued from epilogue, then screen closes with ok result`() {
+        init(isJetpackApp = true, hasSite = true)
         val navigationEvents = initObservers().navigationEvents
 
         viewModel.onContinue()

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
@@ -1,14 +1,100 @@
 package org.wordpress.android.ui.accounts
 
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 
+import org.junit.Test
+import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 
 class LoginEpilogueViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: LoginEpilogueViewModel
 
+    @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock lateinit var siteStore: SiteStore
+
     @Before
     fun setUp() {
-        viewModel = LoginEpilogueViewModel()
+        viewModel = LoginEpilogueViewModel(appPrefsWrapper, siteStore)
+    }
+
+    /* Post Signup Interstitial Screen */
+    @Test
+    fun `given no sites, when continued from epilogue first time, then signup interstitial shown`() {
+        init(hasSite = false, postSignupInterstitialShownEarlier = false)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onContinue()
+
+        assertThat(navigationEvents.first())
+                .isInstanceOf(LoginNavigationEvents.ShowPostSignupInterstitialScreen::class.java)
+    }
+
+    @Test
+    fun `given no sites, when continued from epilogue next time, then signup interstitial not shown`() {
+        init(hasSite = false, postSignupInterstitialShownEarlier = true)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onContinue()
+
+        assertThat(
+                navigationEvents.filterIsInstance(LoginNavigationEvents.ShowPostSignupInterstitialScreen::class.java)
+        ).isEmpty()
+    }
+
+    @Test
+    fun `given sites present, when continued from epilogue, then signup interstitial not shown`() {
+        init(hasSite = true)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onContinue()
+
+        assertThat(
+                navigationEvents.filterIsInstance(LoginNavigationEvents.ShowPostSignupInterstitialScreen::class.java)
+        ).isEmpty()
+    }
+
+    /* Eplilogue Screen Close */
+    @Test
+    fun `given no sites, when continued from epilogue, then epilogue closes with ok result`() {
+        init(hasSite = false)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onContinue()
+
+        assertThat(navigationEvents.last())
+                .isInstanceOf(LoginNavigationEvents.CloseWithResultOk::class.java)
+    }
+
+    @Test
+    fun `given sites present, when continued from epilogue, then screen closes with ok result`() {
+        init(hasSite = true)
+        val navigationEvents = initObservers().navigationEvents
+
+        viewModel.onContinue()
+
+        assertThat(navigationEvents.last()).isInstanceOf(LoginNavigationEvents.CloseWithResultOk::class.java)
+    }
+
+    private data class Observers(
+        val navigationEvents: List<LoginNavigationEvents>,
+    )
+
+    private fun initObservers(): Observers {
+        val navigationEvents = mutableListOf<LoginNavigationEvents>()
+        viewModel.navigationEvents.observeForever { navigationEvents.add(it.peekContent()) }
+
+        return Observers(navigationEvents)
+    }
+
+    fun init(
+        hasSite: Boolean = false,
+        postSignupInterstitialShownEarlier: Boolean = false
+    ) {
+        whenever(siteStore.hasSite()).thenReturn(hasSite)
+        whenever(appPrefsWrapper.shouldShowPostSignupInterstitial).thenReturn(!postSignupInterstitialShownEarlier)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/LoginEpilogueViewModelTest.kt
@@ -9,22 +9,24 @@ import org.mockito.Mock
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.BuildConfigWrapper
 
 class LoginEpilogueViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: LoginEpilogueViewModel
 
     @Mock lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Mock lateinit var buildConfigWrapper: BuildConfigWrapper
     @Mock lateinit var siteStore: SiteStore
 
     @Before
     fun setUp() {
-        viewModel = LoginEpilogueViewModel(appPrefsWrapper, siteStore)
+        viewModel = LoginEpilogueViewModel(appPrefsWrapper, buildConfigWrapper, siteStore)
     }
 
-    /* Post Signup Interstitial Screen */
+    /* WordPress app - Post Signup Interstitial Screen */
     @Test
-    fun `given no sites, when continued from epilogue first time, then signup interstitial shown`() {
-        init(hasSite = false, postSignupInterstitialShownEarlier = false)
+    fun `given wp app with no sites, when continued from epilogue first time, then signup interstitial shown`() {
+        init(isJetpackApp = false, hasSite = false, postSignupInterstitialShownEarlier = false)
         val navigationEvents = initObservers().navigationEvents
 
         viewModel.onContinue()
@@ -34,8 +36,8 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given no sites, when continued from epilogue next time, then signup interstitial not shown`() {
-        init(hasSite = false, postSignupInterstitialShownEarlier = true)
+    fun `given wp app with no sites, when continued from epilogue next time, then signup interstitial not shown`() {
+        init(isJetpackApp = false, hasSite = false, postSignupInterstitialShownEarlier = true)
         val navigationEvents = initObservers().navigationEvents
 
         viewModel.onContinue()
@@ -46,8 +48,8 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given sites present, when continued from epilogue, then signup interstitial not shown`() {
-        init(hasSite = true)
+    fun `given wp app with sites, when continued from epilogue, then signup interstitial not shown`() {
+        init(isJetpackApp = false, hasSite = true)
         val navigationEvents = initObservers().navigationEvents
 
         viewModel.onContinue()
@@ -57,10 +59,10 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
         ).isEmpty()
     }
 
-    /* Eplilogue Screen Close */
+    /* WordPress app - Eplilogue Screen Close */
     @Test
-    fun `given no sites, when continued from epilogue, then epilogue closes with ok result`() {
-        init(hasSite = false)
+    fun `given wp app with no sites, when continued from epilogue, then epilogue closes with ok result`() {
+        init(isJetpackApp = false, hasSite = false)
         val navigationEvents = initObservers().navigationEvents
 
         viewModel.onContinue()
@@ -70,8 +72,8 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given sites present, when continued from epilogue, then screen closes with ok result`() {
-        init(hasSite = true)
+    fun `given wp app with sites present, when continued from epilogue, then epilogue closes with ok result`() {
+        init(isJetpackApp = false, hasSite = true)
         val navigationEvents = initObservers().navigationEvents
 
         viewModel.onContinue()
@@ -79,9 +81,7 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
         assertThat(navigationEvents.last()).isInstanceOf(LoginNavigationEvents.CloseWithResultOk::class.java)
     }
 
-    private data class Observers(
-        val navigationEvents: List<LoginNavigationEvents>,
-    )
+    private data class Observers(val navigationEvents: List<LoginNavigationEvents>)
 
     private fun initObservers(): Observers {
         val navigationEvents = mutableListOf<LoginNavigationEvents>()
@@ -91,9 +91,11 @@ class LoginEpilogueViewModelTest : BaseUnitTest() {
     }
 
     fun init(
+        isJetpackApp: Boolean,
         hasSite: Boolean = false,
         postSignupInterstitialShownEarlier: Boolean = false
     ) {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(isJetpackApp)
         whenever(siteStore.hasSite()).thenReturn(hasSite)
         whenever(appPrefsWrapper.shouldShowPostSignupInterstitial).thenReturn(!postSignupInterstitialShownEarlier)
     }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -340,7 +340,7 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
         }
     }
 
-    private boolean isJetpackAppLogin() {
+    protected boolean isJetpackAppLogin() {
         return (mLoginListener instanceof LoginListener)
                && ((LoginListener) mLoginListener).getLoginMode() == LoginMode.JETPACK_LOGIN_ONLY;
     }


### PR DESCRIPTION
SubTask #14620

### Description

When no sites are found after login via a magic link, the WordPress app displays a post-signup interstitial screen (see Epilogue Screen FieldGuide: `PCYsg-wY8`). 

> If the user doesn’t have any sites, they might see the Post-Signup Interstitial screen at the end of the flow, instead of the Epilogue screen (or after it, in some cases). This screen is only shown once and is only shown at the end of the primary flow. Despite its name, it is shown at the end of both the Signup and Login flows.

Once this screen is dismissed (using NOT RIGHT NOW option), the "My Site" tab for empty sites gets displayed. 

Similar behavior was seen for the Jetpack app (see: https://github.com/wordpress-mobile/WordPress-Android/pull/14644#pullrequestreview-659663043). 

This PR fixes this behavior and displays no jetpack sites screen for this scenario.

**Before** 

Post Login Interstitial | Add Site
----------------------|--------
![post insterstitial](https://user-images.githubusercontent.com/1405144/118488253-2ebba380-b739-11eb-8e84-3d00c2934073.png) | ![add new site](https://user-images.githubusercontent.com/1405144/118488270-324f2a80-b739-11eb-9f48-eda743d62ae9.png)

**After**
![nosites](https://user-images.githubusercontent.com/1405144/118488555-79d5b680-b739-11eb-8c3f-c5c7fa9c336f.png)

To test:

Jetpack App

1. Install and launch the Jetpack app.
2. Select "Login with WordPress.com".
3. Enter email (for an account with no jetpack sites) and click Continue.
4. Click "Get a login link by email".
5. Check email and click "Log in to the app".
6. Notice that the link opens the Jetpack app and no jetpack sites screen is shown.

WordPress App

1. Install and launch the WordPress app.
2. Select "Log in or sign up with WordPress.com".
3. Enter email (for an account with no sites) and click Continue.
4. Click "Get a login link by email".
5. Check email and click "Log in to the app".
6. Notice that the link opens the WordPress app and the post-login interstitial screen is displayed.

## Regression Notes
1. Potential unintended areas of impact
WordPress app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested WordPress app manually for magic link login (for accounts with sites and without sites)

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for both WordPress app and Jetpack app for no site scenario on magic link login.


### Other Notes

1. ~~A flashing issue on the `LoginNoSitesFragment` screen is handled in PR #14651. This PR is not merged yet and you might see the issue in this PR.~~ Fixed with 9bc8471
2. Noticed a WordPress logo notification on the login Epilogue screen (after login with password for an account with no jetpack sites). On clicking this notification while the app is minimized, the "My Site" tab for empty sites gets displayed. Adding it as a known issue in the main task.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
