### PR TITLE
Support: Show apps support site instead of zendesk docs.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -110,45 +110,6 @@ class ZendeskHelper(
     }
 
     /**
-     * This function shows the Zendesk Help Center. It doesn't require a valid identity. If the support identity is
-     * available it'll be used and the "New Ticket" button will be available, if not, it'll work with an anonymous
-     * identity. The configuration will only be passed in if the identity is available, as it's only required if
-     * the user contacts us through it.
-     */
-    fun showZendeskHelpCenter(
-        context: Context,
-        origin: Origin?,
-        selectedSite: SiteModel?,
-        extraTags: List<String>? = null
-    ) {
-        require(isZendeskEnabled) {
-            zendeskNeedsToBeEnabledError
-        }
-        val isIdentitySet = isIdentitySet()
-        val builder = HelpCenterActivity.builder()
-                .withArticlesForCategoryIds(ZendeskConstants.mobileCategoryId)
-                .withContactUsButtonVisible(isIdentitySet)
-                .withLabelNames(ZendeskConstants.articleLabel)
-                .withShowConversationsMenuButton(isIdentitySet)
-        AnalyticsTracker.track(Stat.SUPPORT_HELP_CENTER_VIEWED)
-        if (isIdentitySet) {
-            builder.show(
-                context,
-                buildZendeskConfig(
-                    context,
-                    siteStore.sites,
-                    origin,
-                    selectedSite,
-                    extraTags,
-                    zendeskPlanFieldHelper
-                )
-            )
-        } else {
-            builder.show(context)
-        }
-    }
-
-    /**
      * This function creates a new ticket. It'll force a valid identity, so if the user doesn't have one set, a dialog
      * will be shown where the user will need to enter an email and a name. If they cancel the dialog, the ticket
      * creation will be canceled as well. A Zendesk configuration is passed in as it's required for ticket creation.
@@ -522,17 +483,15 @@ private val wpcomPushNotificationDeviceToken: String?
     }
 
 private object ZendeskConstants {
-    const val articleLabel = "Android"
     const val blogSeparator = "\n----------\n"
     const val jetpackTag = "jetpack"
-    const val mobileCategoryId = 360000041586
     const val networkWifi = "WiFi"
     const val networkWWAN = "Mobile"
     const val networkTypeLabel = "Network Type:"
     const val networkCarrierLabel = "Carrier:"
     const val networkCountryCodeLabel = "Country Code:"
     const val noneValue = "none"
-    // We rely on this platform tag to filter tickets in Zendesk, so should be kept separate from the `articleLabel`
+    // We rely on this platform tag to filter tickets in Zendesk
     const val platformTag = "Android"
     const val sourcePlatform = "mobile_-_android"
     const val wpComTag = "wpcom"

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -36,7 +36,6 @@ import zendesk.core.PushRegistrationProvider
 import zendesk.core.Zendesk
 import zendesk.support.CustomField
 import zendesk.support.Support
-import zendesk.support.guide.HelpCenterActivity
 import zendesk.support.request.RequestActivity
 import zendesk.support.requestlist.RequestListActivity
 import java.util.Timer

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.accounts
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
 import org.wordpress.android.R
@@ -56,7 +57,7 @@ class HelpActivity : LocaleAwareActivity() {
             }
 
             contactUsButton.setOnClickListener { createNewZendeskTicket() }
-            faqButton.setOnClickListener { showZendeskFaq() }
+            faqButton.setOnClickListener { showFaq() }
             myTicketsButton.setOnClickListener { showZendeskTickets() }
             applicationVersion.text = getString(R.string.version_with_name_param, WordPress.versionName)
             applicationLogButton.setOnClickListener { v ->
@@ -133,14 +134,10 @@ class HelpActivity : LocaleAwareActivity() {
         )
     }
 
-    private fun showZendeskFaq() {
-        zendeskHelper
-                .showZendeskHelpCenter(
-                        this,
-                        originFromExtras,
-                        selectedSiteFromExtras,
-                        extraTagsFromExtras
-                )
+    private fun showFaq() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("http://apps.wordpress.com/mobile-app-support/"))
+        startActivity(intent)
+        AnalyticsTracker.track(Stat.SUPPORT_HELP_CENTER_VIEWED)
     }
 
     private fun HelpActivityBinding.refreshContactEmailText() {


### PR DESCRIPTION
Closes #14661 

This PR shows the support docs hosted at https://apps.wordpress.com/mobile-app-support/ rather than the Zendesk hosted support pages when a user tap the `Browse our FAQ` option in the help activity. The related Zendesk code is removed.

Example:
![Screen Recording 2021-05-17 at 5 18 55 PM 2021-05-17 18_50_41](https://user-images.githubusercontent.com/1435271/118570011-ccff3780-b740-11eb-9b35-01085341a415.gif)

To test:
View the FAQ. Confirm the support site is shown and you can navigate to different articles.

@khaykov would you be game for a review?

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
