### PR TITLE
Set default build variant in build.gradle

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -97,6 +97,7 @@ android {
 
     productFlavors {
         wordpress {
+            isDefault true
             dimension "app"
             applicationId "org.wordpress.android"
             buildConfigField "boolean", "IS_JETPACK_APP", "false"
@@ -141,6 +142,7 @@ android {
         }
 
         jalapeno { // Pre-Alpha version, used for PR builds, can be installed along release, alpha, beta, dev versions
+            isDefault true
             applicationIdSuffix ".prealpha"
             dimension "buildType"
         }


### PR DESCRIPTION
### Description 

After introducing the Jetpack app build variants in the WordPress app `build.gradle`, on the initial project import into the Android Studio, the jetpack jalapeno build variant got selected as the default (based on the alphabetical order).  

This PR sets a WordPress app build variant as the default one.

Slack discussion: p1620858685230200-slack-C02QANACA

CC @ravishanker 

Note: `isDefault` attribute was supported as a fix to this Google issue https://issuetracker.google.com/issues/36988145#comment59 and seems to work for our case.

To test:

1. `git clone --recurse-submodules git@github.com:wordpress-mobile/WordPress-Android.git` in the folder of your preference.
2. `cd WordPress-Android` to enter the working directory.
3. `cp gradle.properties-example gradle.properties`
4. `git checkout issue/default-build-variant`
5. Import this project into Android Studio
6. Wait for the initial build to finish
7. Notice that `wordpressJalapenoDebug` is selected as the active build variant on the Android Studio's "Build Variants" window.

<img width="210" alt="activebuildvariant" src="https://user-images.githubusercontent.com/1405144/118644690-b1a53280-b7fb-11eb-8237-db4e2ea358e5.png">

## Regression Notes
1. Potential unintended areas of impact  🟢

2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢

3. What automated tests I added (or what prevented me from doing so) 🟢

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.