### PR TITLE
Fix string content

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2702,7 +2702,7 @@
     <string name="login_not_a_jetpack_site">To use this app for %1$s you\'ll need to have the Jetpack plugin installed and connected to your WordPress.com account.</string>
     <string name="login_no_jetpack_sites">No Jetpack sites found</string>
     <string name="login_empty_view_avatar_content_description">Your profile photo</string>
-    <string name="login_no_jetpack_sites_error_message">If you already have a site, you\'ll need to install the free Jetpack plugin and connect it to your Wordpress account.</string>
+    <string name="login_no_jetpack_sites_error_message">If you already have a site, you\'ll need to install the free Jetpack plugin and connect it to your WordPress.com account.</string>
     <string name="login_empty_view_see_instructions">See instructions</string>
     <string name="login_empty_view_try_another_account">Try with another account</string>
 


### PR DESCRIPTION
The PR updates the content of `login_no_jetpack_sites_error_message`

**From**:
 If you already have a site, you\'ll need to install the free Jetpack plugin and connect it to your Wordpress account. 

**To**: 
If you already have a site, you\'ll need to install the free Jetpack plugin and connect it to your **WordPress.com** account. 

FYI: This string is only shown in the new Jetpack App, not in WP

## Regression Notes
1. Potential unintended areas of impact None
2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A
3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
