### PR TITLE
Replace ic_my_sites icon with ic_app icon

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
@@ -610,7 +610,7 @@ public class GCMMessageHandler {
             // Build the new notification, add group to support wearable stacking
             return new NotificationCompat.Builder(context,
                     context.getString(R.string.notification_channel_normal_id))
-                    .setSmallIcon(R.drawable.ic_my_sites_white_24dp)
+                    .setSmallIcon(R.drawable.ic_app_white_24dp)
                     .setColor(context.getResources().getColor(R.color.primary_50))
                     .setContentTitle(title)
                     .setContentText(message)


### PR DESCRIPTION
This PR replaces the `ic_my_sites_white_24dp` icon with `ic_app_white_24dp` in the `GCMMessageHandler`. 

To test:
- Download this branch
- Build a Jetpack Variant
- Perform an action on another device that will cause a notification in the Jetpack App
- Note that the icon shows as Jetpack

------------
- Using the WP APK attached to this PR
- Perform an action on another device that will cause a notification in the WordPress App
- Note that the icon shows as WordPress

## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 
3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
