### PR TITLE
Integrate gutenberg-mobile release 1.53.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.53.0'
+    ext.gutenbergMobileVersion = '3535-c869ec0f18d34ecc618d218ca2e2172eafbc556b'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3535-857c9aae20473671da2700ae1d4fe1f7f6cd6f2f'
+    ext.gutenbergMobileVersion = '3535-cd8eee699f4ab0cd64dc2dada40a3cd4f8610899'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '857c9aae20473671da2700ae1d4fe1f7f6cd6f2f'
+    ext.gutenbergMobileVersion = '3535-857c9aae20473671da2700ae1d4fe1f7f6cd6f2f'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3535-c869ec0f18d34ecc618d218ca2e2172eafbc556b'
+    ext.gutenbergMobileVersion = '857c9aae20473671da2700ae1d4fe1f7f6cd6f2f'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3535-cd8eee699f4ab0cd64dc2dada40a3cd4f8610899'
+    ext.gutenbergMobileVersion = 'v1.53.1'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 1.53.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3535

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.