### PR TITLE
Hotfix - Consolidated Media Picker : Resolve issue where site is null during the avatar picker flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,9 @@
 17.4
 -----
 
+17.3.2
+-----
+* [***] Me Screen: Fixed an issue with the Change Photo flow that was causing a crash. [https://github.com/wordpress-mobile/WordPress-Android/pull/14701]
 
 17.3
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceListBuilder.kt
@@ -103,8 +103,16 @@ class DeviceListBuilder(
         val deviceMediaList = deviceMediaLoader.loadMedia(mediaType, filter, pageSize, lastDateModified)
         val result = deviceMediaList.items.mapNotNull {
             val mimeType = deviceMediaLoader.getMimeType(it.uri)
-            if (mimeType != null && MediaUtils.isSupportedMimeType(mimeType) &&
-                    mediaUtilsWrapper.isMimeTypeSupportedBySitePlan(site, mimeType)) {
+            val isMimeTypeSupported = mimeType != null && site?.let {
+                mediaUtilsWrapper.isMimeTypeSupportedBySitePlan(
+                        site,
+                        mimeType
+                )
+            } ?: true && MediaUtils.isSupportedMimeType(
+                    mimeType
+            )
+
+            if (isMimeTypeSupported) {
                 MediaItem(LocalUri(it.uri), it.uri.toString(), it.title, mediaType, mimeType, it.dateModified)
             } else {
                 null
@@ -123,8 +131,17 @@ class DeviceListBuilder(
 
         val filteredPage = documentsList.items.mapNotNull { document ->
             val mimeType = deviceMediaLoader.getMimeType(document.uri)
-            if (mimeType != null && mimeTypes.isSupportedApplicationType(mimeType) &&
-                    mediaUtilsWrapper.isMimeTypeSupportedBySitePlan(site, mimeType)) {
+            val isMimeTypeSupported = mimeType != null && site?.let {
+                mediaUtilsWrapper.isMimeTypeSupportedBySitePlan(
+                        site,
+                        mimeType
+                )
+            } ?: true && MediaUtils.isSupportedMimeType(
+                    mimeType
+            )
+            val isSupportedApplicationType = mimeType != null && mimeTypes.isSupportedApplicationType(mimeType)
+
+            if (isSupportedApplicationType && isMimeTypeSupported) {
                 MediaItem(
                         LocalUri(document.uri),
                         document.uri.toString(),


### PR DESCRIPTION
Fixes #14699

## Description 
This PR resolves a crash that was being caused when the `Consolidated Media Picker` was being utilized to select an avatar via the `Me` screen. 

The issue was that for most flows, a site is available so the `mediaUtilsWrapper.isMimeTypeSupportedBySitePlan(
                                site,
                                mimeType
                        )` would work as expected but in this case, when selecting an avatar, the site can be empty, so this PR adds null-safety to the usage of the `SiteModel` within the `DeviceListBuilder`. 
                        
With this in place, all mime types are automatically supported once a site is not available since the site plan's logic wouldn't be required.
                        
## Testing 

### Verify the bug has been resolved. 

1. Go to the Me screen. 
2. Click `Change Photo`. 
3. Notice the app does not crash. 

### Smoke Testing

Smoke test the media browser https://github.com/wordpress-mobile/WordPress-Android/pull/14353 The existing behavior is fine since this null-safety change just ensures the functionality works as it would without a site. 

## Regression Notes
1. Potential unintended areas of impact
The potential areas of impact by this change would be other behavior that relies on the `MediaPicker`. Since the code modifications here are related to enabling the support of a mime type when a site isn't available, the remaining logic functions as is, before these changes were introduced in #14353

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- I tested the "Change Photo" flow in the Me screen. 
- I verified that on a free site I wasn't able to upload a `key`, `zip` file and on a premium one I was able to do that. 
- I verified that on a free site, I am not able to upload audio files, but on a premium plan I am able to. 
- I verified that the File, Audio, Video, Image Block all work as expected with the Media Picker.

3. What automated tests I added (or what prevented me from doing so)
In this case, no automated tests were added for this flow. Pre-existing `MediaPicker` related tests verify that the changes did not break the existing functionality.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
