### PR TITLE
Merges WCAndroid changes to the login library from base repository

### DIFF
--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
-        kotlin_version = '1.3.61'
-        kotlin_ktx_version = '1.2.0'
-        daggerVersion = '2.29.1'
+        kotlin_version = '1.4.32'
+        kotlin_ktx_version = '1.3.2'
+        daggerVersion = '2.33'
         appCompatVersion = '1.0.2'
     }
     repositories {
@@ -21,10 +21,10 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 
 repositories {
+    mavenCentral()
     google()
     jcenter()
     maven { url "https://www.jitpack.io" }
-    maven { url "http://dl.bintray.com/terl/lazysodium-maven" }
 }
 
 android {
@@ -47,14 +47,14 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
-    implementation 'androidx.media:media:1.1.0'
+    implementation 'androidx.media:media:1.2.1'
     implementation 'androidx.legacy:legacy-support-v13:1.0.0'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
+
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation "com.google.android.material:material:1.2.1"
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
     implementation "androidx.core:core-ktx:$kotlin_ktx_version"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     api 'com.google.android.gms:play-services-auth:18.1.0'
 
@@ -65,14 +65,14 @@ dependencies {
             exclude group: "org.wordpress", module: "utils"
         }
     } else {
-        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1.6.22") {
+        implementation("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1.17.0") {
             exclude group: "com.android.support"
             exclude group: "org.wordpress", module: "utils"
         }
     }
 
-    implementation 'com.github.bumptech.glide:glide:4.10.0'
-    kapt 'com.github.bumptech.glide:compiler:4.10.0'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    kapt 'com.github.bumptech.glide:compiler:4.12.0'
 
     // Dagger
     implementation "com.google.dagger:dagger:$daggerVersion"
@@ -81,12 +81,12 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
-    lintChecks 'org.wordpress:lint:1.0.1'
+    lintChecks 'org.wordpress:lint:1.0.2'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:2.28.2'
     testImplementation 'androidx.arch.core:core-testing:2.1.0'
-    testImplementation 'org.robolectric:robolectric:4.4'
+    testImplementation 'org.robolectric:robolectric:4.5.1'
     testImplementation 'org.assertj:assertj-core:3.11.1'
 }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -239,7 +239,9 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
     }
 
     protected void startProgress(boolean cancellable) {
-        mBottomButton.setEnabled(false);
+        if (mBottomButton != null) {
+            mBottomButton.setEnabled(false);
+        }
 
         mProgressDialog =
                 ProgressDialog.show(getActivity(), "", getActivity().getString(getProgressBarText()), true, cancellable,

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -167,8 +167,9 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
                 break;
             case WOO_LOGIN_MODE:
                 if (mOptionalSiteCredsLayout) {
+                    String siteAddressClean = mLoginSiteUrl.replaceFirst("^(http[s]?://)", "");
                     label.setText(Html.fromHtml(
-                            getString(R.string.enter_email_for_site, mLoginSiteUrl)));
+                            getString(R.string.enter_email_for_site, siteAddressClean)));
                 } else {
                     label.setText(getString(R.string.enter_email_wordpress_com));
                 }

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/toolbar_login.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/toolbar_login.xml
@@ -17,9 +17,9 @@
             android:layout_height="24dp"
             android:layout_gravity="center"
             android:contentDescription="@null"
-            android:tint="?attr/colorControlNormal"
             android:visibility="gone"
-            app:srcCompat="@drawable/login_toolbar_icon" />
+            app:srcCompat="@drawable/login_toolbar_icon"
+            app:tint="?attr/colorControlNormal" />
 
     </com.google.android.material.appbar.MaterialToolbar>
 

--- a/libs/login/gradlew.bat
+++ b/libs/login/gradlew.bat
@@ -29,9 +29,6 @@ if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
-@rem Resolve any "." and ".." in APP_HOME to make it shorter.
-for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
-
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 


### PR DESCRIPTION
wordpress-mobile/WordPress-Login-Flow-Android#57 merges changes from both WPAndroid and WCAndroid for login library. This PR brings in those changes so both clients and the base repo is in the same state.

I'll add line comments for where each change has been made in WCAndroid. Note that, this does NOT mean that every WCAndroid change is the right one for WPAndroid. Part of this PR review/testing process is to figure out if there has been any changes to the library that's not valid for either client. Please make sure to pay extra attention to this review.

**To test:**
* This was a very error prone merge, so I think we should test the whole login flow

## Regression Notes
1. Potential unintended areas of impact
* Breaking login flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
* We'll run extensive manual tests for login flow
* The existing login automated tests would also be helpful in ensuring the flow works correctly

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

