### PR TITLE
Merge 17.4-rc-3 to develop

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,9 @@
 17.4
 -----
 
+17.3.2
+-----
+* [***] Me Screen: Fixed an issue with the Change Photo flow that was causing a crash. [https://github.com/wordpress-mobile/WordPress-Android/pull/14701]
 
 17.3
 -----

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -120,7 +120,7 @@ android {
             dimension "buildType"
             // Only set the release version if one isn't provided
             if (!project.hasProperty("versionName")) {
-                versionName "17.4.2-rc-3"
+                versionName "17.4-rc-3"
             }
             versionCode 1053
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -122,7 +122,7 @@ android {
             if (!project.hasProperty("versionName")) {
                 versionName "17.3.2"
             }
-            versionCode 1052
+            versionCode 1053
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -62,7 +62,7 @@ android {
         } else {
             versionName "alpha-295"
         }
-        versionCode 1051
+        versionCode 1052
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
@@ -122,7 +122,7 @@ android {
             if (!project.hasProperty("versionName")) {
                 versionName "17.3.2"
             }
-            versionCode 1053
+            versionCode 1052
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -120,7 +120,7 @@ android {
             dimension "buildType"
             // Only set the release version if one isn't provided
             if (!project.hasProperty("versionName")) {
-                versionName "17.3.2-rc-1"
+                versionName "17.4.2-rc-3"
             }
             versionCode 1053
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -60,9 +60,9 @@ android {
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "alpha-295"
+            versionName "alpha-296"
         }
-        versionCode 1053
+        versionCode 1055
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
@@ -120,9 +120,9 @@ android {
             dimension "buildType"
             // Only set the release version if one isn't provided
             if (!project.hasProperty("versionName")) {
-                versionName "17.3.2"
+                versionName "17.3.2-rc-1"
             }
-            versionCode 1053
+            versionCode 1054
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -120,9 +120,9 @@ android {
             dimension "buildType"
             // Only set the release version if one isn't provided
             if (!project.hasProperty("versionName")) {
-                versionName "17.3.1"
+                versionName "17.3.2"
             }
-            versionCode 1049
+            versionCode 1052
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -62,7 +62,7 @@ android {
         } else {
             versionName "alpha-296"
         }
-        versionCode 1055
+        versionCode 1054
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
@@ -122,7 +122,7 @@ android {
             if (!project.hasProperty("versionName")) {
                 versionName "17.3.2-rc-1"
             }
-            versionCode 1054
+            versionCode 1053
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -62,7 +62,7 @@ android {
         } else {
             versionName "alpha-295"
         }
-        versionCode 1052
+        versionCode 1053
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
@@ -122,7 +122,7 @@ android {
             if (!project.hasProperty("versionName")) {
                 versionName "17.3.2"
             }
-            versionCode 1052
+            versionCode 1053
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceListBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/DeviceListBuilder.kt
@@ -103,8 +103,16 @@ class DeviceListBuilder(
         val deviceMediaList = deviceMediaLoader.loadMedia(mediaType, filter, pageSize, lastDateModified)
         val result = deviceMediaList.items.mapNotNull {
             val mimeType = deviceMediaLoader.getMimeType(it.uri)
-            if (mimeType != null && MediaUtils.isSupportedMimeType(mimeType) &&
-                    mediaUtilsWrapper.isMimeTypeSupportedBySitePlan(site, mimeType)) {
+            val isMimeTypeSupported = mimeType != null && site?.let {
+                mediaUtilsWrapper.isMimeTypeSupportedBySitePlan(
+                        site,
+                        mimeType
+                )
+            } ?: true && MediaUtils.isSupportedMimeType(
+                    mimeType
+            )
+
+            if (isMimeTypeSupported) {
                 MediaItem(LocalUri(it.uri), it.uri.toString(), it.title, mediaType, mimeType, it.dateModified)
             } else {
                 null
@@ -123,8 +131,17 @@ class DeviceListBuilder(
 
         val filteredPage = documentsList.items.mapNotNull { document ->
             val mimeType = deviceMediaLoader.getMimeType(document.uri)
-            if (mimeType != null && mimeTypes.isSupportedApplicationType(mimeType) &&
-                    mediaUtilsWrapper.isMimeTypeSupportedBySitePlan(site, mimeType)) {
+            val isMimeTypeSupported = mimeType != null && site?.let {
+                mediaUtilsWrapper.isMimeTypeSupportedBySitePlan(
+                        site,
+                        mimeType
+                )
+            } ?: true && MediaUtils.isSupportedMimeType(
+                    mimeType
+            )
+            val isSupportedApplicationType = mimeType != null && mimeTypes.isSupportedApplicationType(mimeType)
+
+            if (isSupportedApplicationType && isMimeTypeSupported) {
                 MediaItem(
                         LocalUri(document.uri),
                         document.uri.toString(),

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.53.0'
+    ext.gutenbergMobileVersion = '3535-c869ec0f18d34ecc618d218ca2e2172eafbc556b'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3535-857c9aae20473671da2700ae1d4fe1f7f6cd6f2f'
+    ext.gutenbergMobileVersion = '3535-cd8eee699f4ab0cd64dc2dada40a3cd4f8610899'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '857c9aae20473671da2700ae1d4fe1f7f6cd6f2f'
+    ext.gutenbergMobileVersion = '3535-857c9aae20473671da2700ae1d4fe1f7f6cd6f2f'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3535-c869ec0f18d34ecc618d218ca2e2172eafbc556b'
+    ext.gutenbergMobileVersion = '857c9aae20473671da2700ae1d4fe1f7f6cd6f2f'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_ktx_version = '1.2.0'
     ext.wordPressUtilsVersion = '1.40.0'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3535-cd8eee699f4ab0cd64dc2dada40a3cd4f8610899'
+    ext.gutenbergMobileVersion = 'v1.53.1'
 
     repositories {
         google()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -216,7 +216,7 @@ REPOSITORY_NAME="WordPress-Android"
   lane :new_beta_release do | options |
     android_betabuild_prechecks(options)
     send_strings_for_translation()
-    # download_translations(options)
+    download_translations(options)
     android_bump_version_beta()
     new_version = android_get_app_version()
     trigger_release_build(branch_to_build: "release/#{new_version}")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -216,7 +216,7 @@ REPOSITORY_NAME="WordPress-Android"
   lane :new_beta_release do | options |
     android_betabuild_prechecks(options)
     send_strings_for_translation()
-    download_translations(options)
+    # download_translations(options)
     android_bump_version_beta()
     new_version = android_get_app_version()
     trigger_release_build(branch_to_build: "release/#{new_version}")


### PR DESCRIPTION
Includes the hotfix #14701 and `gutenbergMobileVersion` change. I've had to temporarily disable downloading translations due to en-dash lint issue, but re-enabled it after the new beta was submitted. I was also not my best self today and did a few extra commits trying to get the release script pickup the correct `versionCode` and still ended up fixing it manually. Sorry about that!