### PR TITLE
Fetch release toolkit from Ruby Gems with ~> 1.0 requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,8 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: ce59a5e7b4fa75f6bb694bcfa333f85175294c3c
-  tag: 0.18.0
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (0.18.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      progress_bar (~> 1.3)
-      rake (~> 12.3)
-      rake-compiler (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    activesupport (5.2.5)
+    activesupport (5.2.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -64,7 +45,9 @@ GEM
     dotenv (2.7.6)
     emoji_regex (3.2.2)
     excon (0.81.0)
-    faraday (1.4.1)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
@@ -73,6 +56,8 @@ GEM
     faraday-cookie_jar (0.0.7)
       faraday (>= 0.8.0)
       http-cookie (~> 1.0.0)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
@@ -116,6 +101,19 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-wpmreleasetoolkit (1.0.1)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      progress_bar (~> 1.3)
+      rake (~> 12.3)
+      rake-compiler (~> 1.0)
     gh_inspector (1.1.3)
     git (1.8.1)
       rchardet (~> 1.8)
@@ -177,13 +175,13 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.1)
     minitest (5.14.4)
     multi_json (1.15.0)
     multipart-post (2.0.0)
     nanaimo (0.3.0)
     naturally (2.2.1)
-    nokogiri (1.11.3)
+    nokogiri (1.11.5)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.21.0)
@@ -260,9 +258,9 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 1.0)
   nokogiri
   rmagick (~> 4.1)
 
 BUNDLED WITH
-   2.2.15
+   2.2.16

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,5 +6,4 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.18.0'
-
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.0'


### PR DESCRIPTION
On top of moving to the "stable" version and using the SemVer, updating to 1.0.x brings enhancements to the `configure_*` actions to reduce the chances of accidentally tracking unencrypted secrets in Git.

To test, green CI should be enough because all of the changes that went into 1.0.0 and 1.0.1 have been tested individually.

If you want to test the `configure` updates, see [this WordPress iOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/16580) description.

## Regression Notes
1. Potential unintended areas of impact
_None_

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.