### PR TITLE
Jetpack App (Emphasis): Remove "Followed Sites" from notifications settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -62,6 +62,7 @@ import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.Prefer
 import org.wordpress.android.ui.prefs.notifications.FollowedBlogsProvider.PreferenceModel.ClickHandler;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.BuildConfigWrapper;
 import org.wordpress.android.util.ContextExtensionsKt;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -117,6 +118,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     @Inject SiteStore mSiteStore;
     @Inject Dispatcher mDispatcher;
     @Inject FollowedBlogsProvider mFollowedBlogsProvider;
+    @Inject BuildConfigWrapper mBuildConfigWrapper;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -126,6 +128,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         addPreferencesFromResource(R.xml.notifications_settings);
         setHasOptionsMenu(true);
         removeSightAndSoundsForAPI26();
+        if (mBuildConfigWrapper.isJetpackApp()) removeFollowedBlogsPreference();
 
         // Bump Analytics
         if (savedInstanceState == null) {
@@ -147,6 +150,14 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         }
     }
 
+    private void removeFollowedBlogsPreference() {
+        PreferenceScreen preferenceScreen =
+                (PreferenceScreen) findPreference(getActivity().getString(R.string.wp_pref_notifications_root));
+
+        PreferenceCategory categoryFollowedBlogs = (PreferenceCategory) preferenceScreen
+                .findPreference(getActivity().getString(R.string.pref_notification_blogs_followed));
+        preferenceScreen.removePreference(categoryFollowedBlogs);
+    }
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
@@ -567,7 +578,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     }
 
     private void configureFollowedBlogsSettings(PreferenceCategory blogsCategory, final boolean showAll) {
-        if (!isAdded()) {
+        if (!isAdded() || blogsCategory == null) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -112,7 +112,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
 
     private final List<PreferenceCategory> mTypePreferenceCategories = new ArrayList<>();
     private PreferenceCategory mBlogsCategory;
-    private PreferenceCategory mFollowedBlogsCategory;
+    @Nullable private PreferenceCategory mFollowedBlogsCategory;
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -579,7 +579,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         updateSearchMenuVisibility();
     }
 
-    private void configureFollowedBlogsSettings(PreferenceCategory blogsCategory, final boolean showAll) {
+    private void configureFollowedBlogsSettings(@Nullable PreferenceCategory blogsCategory, final boolean showAll) {
         if (!isAdded() || blogsCategory == null) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -128,7 +128,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         addPreferencesFromResource(R.xml.notifications_settings);
         setHasOptionsMenu(true);
         removeSightAndSoundsForAPI26();
-        if (mBuildConfigWrapper.isJetpackApp()) removeFollowedBlogsPreference();
+        removeFollowedBlogsPreferenceForJetpackApp();
 
         // Bump Analytics
         if (savedInstanceState == null) {
@@ -150,13 +150,15 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         }
     }
 
-    private void removeFollowedBlogsPreference() {
-        PreferenceScreen preferenceScreen =
+    private void removeFollowedBlogsPreferenceForJetpackApp() {
+        if (mBuildConfigWrapper.isJetpackApp()) {
+            PreferenceScreen preferenceScreen =
                 (PreferenceScreen) findPreference(getActivity().getString(R.string.wp_pref_notifications_root));
 
-        PreferenceCategory categoryFollowedBlogs = (PreferenceCategory) preferenceScreen
-                .findPreference(getActivity().getString(R.string.pref_notification_blogs_followed));
-        preferenceScreen.removePreference(categoryFollowedBlogs);
+            PreferenceCategory categoryFollowedBlogs = (PreferenceCategory) preferenceScreen
+                    .findPreference(getActivity().getString(R.string.pref_notification_blogs_followed));
+            preferenceScreen.removePreference(categoryFollowedBlogs);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #14512 

This PR removes the "Followed Sites" section from the notifications settings for the Jetpack app. 

To test:

1. Install the Jetpack app.
2. Go to the "Notifications" tab.
3. Click the gear icon on the top right corner to go to the "Notifications Settings" screen.
4. Notice that the followed sites are not displayed on the screen. 

Jetpack | WordPress
---------|-----------
![notifs_settings](https://user-images.githubusercontent.com/1405144/120068444-58ac8880-c09e-11eb-8e36-171188c3ec16.png) | ![notifs_settings_wp](https://user-images.githubusercontent.com/1405144/120069854-ad9fcd00-c0a5-11eb-9136-7d7df24c3de3.png)

## Regression Notes
1. Potential unintended areas of impact 
 WordPress Notification Settings

2. What I did to test those areas of impact (or what existing automated tests I relied on) 
I tested the WordPress app and made sure the Followed Sites section is displayed

3. What automated tests I added (or what prevented me from doing so) 
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
