### PR TITLE
Fixes an issue where Gradle complains about not finding google-services.json file

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -436,7 +436,7 @@ android.buildTypes.all { buildType ->
     }
 
     // Print warning message if example Google services file is used.
-    if ((new File('WordPress/google-services.json').text) == (new File('WordPress/google-services.json-example').text)) {
+    if ((file('google-services.json').text) == (file('google-services.json-example').text)) {
         println("WARNING: You're using the example google-services.json file. Google login will fail.")
     }
 }


### PR DESCRIPTION
I am setting up my M1 computer and I've had this weird error where Gradle complained about missing `WordPress/google-services.json` file and in Android Studio `File` was marked red. We don't need to call `new File` in Groovy, `file` does the same thing and is used just above the line that's changed, so this was a simple fix.

I am not entirely sure if this was necessary or not, but it's a harmless fix that gets me looking at other M1 related issues.

**To test:**
1. Remove `WordPress/google-services.json`
2. Run `./gradlew | grep "WARNING: You're using the example google-services.json file"` and verify that there are 2 warnings.

The reason we remove the `WordPress/google-services.json` is that most of us use the actual `google-services.json` file which would be different from the example one. Our build script copies the example file when there isn't one already and warns the developer. Once you test this, feel free to do `configure apply` again to use the actual file.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
