### PR TITLE
Do not show [Whats new] feature announcement if Jetpack build

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -282,7 +282,9 @@ public class AppSettingsFragment extends PreferenceFragment
         WhatsNewAnnouncementModel latestAnnouncement = event.getWhatsNewItems().get(0);
         mWhatsNew.setSummary(getString(R.string.version_with_name_param, latestAnnouncement.getAppVersionName()));
         mWhatsNew.setOnPreferenceClickListener(this);
-        addWhatsNewPreference();
+        if (!BuildConfig.IS_JETPACK_APP) {
+            addWhatsNewPreference();
+        }
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Fixes #14755 

This PR prevents the App Settings -> What's New item from showing if the app variant is Jetpack.

**To test:**
**Setup**
Follow the instructions [here](https://fieldguide.automattic.com/mobile-feature-announcements/mobile-feature-announcements-mc-tool/) on how to set up the MC tool to create a feature announcement (Use alpha wording, so not to accidentally release to public).

**WordPress test**
- Remove any pre-existing versions on your device
- Install the APK attached to this device
- Login and navigate to Me -> App Settings
- Scroll to the bottom and note that the "What's New" row is visible

**Jetpack test**
- Remove any pre-existing versions on your device
- Pull this branch & build a Jetpack variant
- Login and navigate to Me -> App Settings
- Scroll to the bottom and note that the "What's New" row is not visible


## Regression Notes
1. Potential unintended areas of impact
2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
