### PR TITLE
Set zendesk support subject to be translatable

### DIFF
--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -15,7 +15,7 @@
 
     <!-- Contact us -->
     <!--Note: Support ticket subject, only visible to the end users of the Zendesk support portal, doesn't need a translation -->
-    <string name="support_ticket_subject" translatable="false">Jetpack for Android Support</string>
+    <string name="support_ticket_subject">Jetpack for Android Support</string>
 
     <!-- Log out actions in Me -->
     <string name="me_disconnect_from_wordpress_com">Log out of Jetpack</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2097,8 +2097,7 @@
     <string name="contact_fragment_title" translatable="false">@string/contact_support</string>
 
     <!-- Contact us -->
-    <!--Note: Support ticket subject, only visible to the end users of the Zendesk support portal, doesn't need a translation -->
-    <string name="support_ticket_subject" translatable="false">WordPress for Android Support</string>
+    <string name="support_ticket_subject">WordPress for Android Support</string>
 
     <!--My Site-->
     <string name="my_site_header_external">External</string>


### PR DESCRIPTION
This PR removes `translatable=false` from `support_ticket_subject` string resource for Jetpack & WordPress variants.

See `p1622574352151200-slack-C0HTU7HV3` for more detail.

To test:
Nothing to test until after translation occurs.

## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 
3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
