### PR TITLE
Update sourcePlatform to reflect Jetpack

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/SupportModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/SupportModule.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.support.SupportHelper
 import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.support.ZendeskPlanFieldHelper
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.CrashLogging
 import javax.inject.Singleton
 
@@ -18,8 +19,9 @@ class SupportModule {
         accountStore: AccountStore,
         siteStore: SiteStore,
         supportHelper: SupportHelper,
-        zendeskPlanFieldHelper: ZendeskPlanFieldHelper
-    ): ZendeskHelper = ZendeskHelper(accountStore, siteStore, supportHelper, zendeskPlanFieldHelper)
+        zendeskPlanFieldHelper: ZendeskPlanFieldHelper,
+        buildConfigWrapper: BuildConfigWrapper
+    ): ZendeskHelper = ZendeskHelper(accountStore, siteStore, supportHelper, zendeskPlanFieldHelper, buildConfigWrapper)
 
     @Singleton
     @Provides

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -339,6 +339,7 @@ class ZendeskHelper(
 /**
  * This is a helper function which builds a `UiConfig` through helpers to be used during ticket creation.
  */
+@Suppress("LongParameterList")
 private fun buildZendeskConfig(
     context: Context,
     allSites: List<SiteModel>?,

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -507,7 +507,6 @@ private object ZendeskConstants {
     const val platformTag = "Android"
     const val jp_sourcePlatform = "mobile_-_jp_android"
     const val wp_sourcePlatform = "mobile_-_wp_android"
-    const val sourcePlatform = "asdf"
     const val wpComTag = "wpcom"
     const val unknownValue = "unknown"
 }

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -507,7 +507,7 @@ private object ZendeskConstants {
     // We rely on this platform tag to filter tickets in Zendesk
     const val platformTag = "Android"
     const val jp_sourcePlatform = "mobile_-_jp_android"
-    const val wp_sourcePlatform = "mobile_-_wp_android"
+    const val wp_sourcePlatform = "mobile_-_android"
     const val wpComTag = "wpcom"
     const val unknownValue = "unknown"
 }

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.util.currentLocale
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DeviceUtils
 import org.wordpress.android.util.LanguageUtils
 import org.wordpress.android.util.NetworkUtils
@@ -48,7 +49,8 @@ class ZendeskHelper(
     private val accountStore: AccountStore,
     private val siteStore: SiteStore,
     private val supportHelper: SupportHelper,
-    private val zendeskPlanFieldHelper: ZendeskPlanFieldHelper
+    private val zendeskPlanFieldHelper: ZendeskPlanFieldHelper,
+    private val buildConfigWrapper: BuildConfigWrapper
 ) {
     private val zendeskInstance: Zendesk
         get() = Zendesk.INSTANCE
@@ -134,7 +136,8 @@ class ZendeskHelper(
                         origin,
                         selectedSite,
                         extraTags,
-                        zendeskPlanFieldHelper
+                        zendeskPlanFieldHelper,
+                        buildConfigWrapper
                     )
                 )
         }
@@ -165,7 +168,8 @@ class ZendeskHelper(
                         origin,
                         selectedSite,
                         extraTags,
-                        zendeskPlanFieldHelper
+                        zendeskPlanFieldHelper,
+                        buildConfigWrapper
                     )
                 )
         }
@@ -341,13 +345,14 @@ private fun buildZendeskConfig(
     origin: Origin?,
     selectedSite: SiteModel? = null,
     extraTags: List<String>? = null,
-    zendeskPlanFieldHelper: ZendeskPlanFieldHelper
+    zendeskPlanFieldHelper: ZendeskPlanFieldHelper,
+    buildConfigWrapper: BuildConfigWrapper
 ): Configuration {
     val ticketSubject = context.getString(R.string.support_ticket_subject)
     return RequestActivity.builder()
         .withTicketForm(
             TicketFieldIds.form,
-            buildZendeskCustomFields(context, allSites, selectedSite, zendeskPlanFieldHelper)
+            buildZendeskCustomFields(context, allSites, selectedSite, zendeskPlanFieldHelper, buildConfigWrapper)
         )
         .withRequestSubject(ticketSubject)
         .withTags(buildZendeskTags(allSites, origin ?: Origin.UNKNOWN, extraTags))
@@ -362,12 +367,19 @@ private fun buildZendeskCustomFields(
     context: Context,
     allSites: List<SiteModel>?,
     selectedSite: SiteModel?,
-    zendeskPlanFieldHelper: ZendeskPlanFieldHelper
+    zendeskPlanFieldHelper: ZendeskPlanFieldHelper,
+    buildConfigWrapper: BuildConfigWrapper
 ): List<CustomField> {
     val currentSiteInformation = if (selectedSite != null) {
         "${SiteUtils.getHomeURLOrHostName(selectedSite)} (${selectedSite.stateLogInformation})"
     } else {
         "not_selected"
+    }
+
+    val sourcePlatform = if (buildConfigWrapper.isJetpackApp) {
+        ZendeskConstants.jp_sourcePlatform
+    } else {
+        ZendeskConstants.wp_sourcePlatform
     }
 
     val customFields = arrayListOf(
@@ -378,7 +390,7 @@ private fun buildZendeskCustomFields(
         CustomField(TicketFieldIds.logs, AppLog.toPlainText(context)),
         CustomField(TicketFieldIds.networkInformation, getNetworkInformation(context)),
         CustomField(TicketFieldIds.appLanguage, LanguageUtils.getPatchedCurrentDeviceLanguage(context)),
-        CustomField(TicketFieldIds.sourcePlatform, ZendeskConstants.sourcePlatform)
+        CustomField(TicketFieldIds.sourcePlatform, sourcePlatform)
     )
     allSites?.let {
         val planIds = it.map { site -> site.planId }.distinct()
@@ -449,6 +461,7 @@ private fun buildZendeskTags(allSites: List<SiteModel>?, origin: Origin, extraTa
     tags.add(origin.toString())
     // Add Android tag to make it easier to filter tickets by platform
     tags.add(ZendeskConstants.platformTag)
+
     extraTags?.let {
         tags.addAll(it)
     }
@@ -492,7 +505,9 @@ private object ZendeskConstants {
     const val noneValue = "none"
     // We rely on this platform tag to filter tickets in Zendesk
     const val platformTag = "Android"
-    const val sourcePlatform = "mobile_-_android"
+    const val jp_sourcePlatform = "mobile_-_jp_android"
+    const val wp_sourcePlatform = "mobile_-_wp_android"
+    const val sourcePlatform = "asdf"
     const val wpComTag = "wpcom"
     const val unknownValue = "unknown"
 }


### PR DESCRIPTION
This PR updates the Zendesk source platform tag so that it properly reflects WordPress or Jetpack.
Ref pbMoDN-2sY-p2#comment-4948 

**To test:**
**Jetpack Test**
- Download this branch
- Build a Jetpack variant
- Navigate to My Site > Me > Help & Support > Contact Support
- Send a test message (It's always a good idea to include text that indicates this is a test message in the request)
- Launch Zendesk and search for the message you just created
- Once the tag is approved the WP Mobile App Platform field should reflect Jetpack as `mobile-_-jp_android`


**WordPress Test**
- Download the APK attached to this PR
- Navigate to My Site > Me > Help & Support > Contact Support
- Send a test message (It's always a good idea to include text that indicates this is a test message in the test)
- Launch Zendesk and search for the message you just created
- Once the tag is approved the WP Mobile App Platform field should reflect Jetpack as `mobile_-_android`

## Regression Notes
1. Potential unintended areas of impact
WordPress source platform tag

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Check the corresponding ticket in Zendesk

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
