### PR TITLE
Fix comment missing comment timestamp on self hosted sites.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.18.0'
+    fluxCVersion = '0d5bbcb250a5ee4826baf5e0bfec2fc9772ab028'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '0d5bbcb250a5ee4826baf5e0bfec2fc9772ab028'
+    fluxCVersion = '1.19.0-beta-1'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Fixes #14763 

Depends on [this](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2015) Flux-C PR.

We were missing a comment published timestamp on pure self hosted sites, which caused crashes in some cases.

To test:
- Using a self-hosted site (no JP) open a comment list.
- Reply to the topmost comment, and confirm that it appears in the comment list.
- Wait couple of minutes and perform pull to refresh.
- Confirm that comment list is not crashing.

## Regression Notes
1. Potential unintended areas of impact
Should not be any.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
This is legacy code that is not very testable. We are refactoring it at the moment.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
