### PR TITLE
Disables the ability to open the editor for Post Pages

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 17.6
 -----
-
+* [*] Disables the ability to open the editor for Post Pages [#14523]
 
 17.5
 -----

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -621,7 +621,13 @@ class PagesViewModel
     }
 
     fun onItemTapped(pageItem: Page) {
-        pageMap[pageItem.remoteId]?.let { checkAndEdit(it) }
+        if (pageItem.remoteId == site.pageForPosts) {
+            launch(defaultDispatcher) {
+                showSnackbar(SnackbarMessageHolder(UiStringRes(R.string.page_is_posts_page_warning)))
+            }
+        } else {
+            pageMap[pageItem.remoteId]?.let { checkAndEdit(it) }
+        }
     }
 
     private fun checkAndEdit(page: PageModel) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -623,7 +622,7 @@ class PagesViewModel
     fun onItemTapped(pageItem: Page) {
         if (pageItem.remoteId == site.pageForPosts) {
             launch(defaultDispatcher) {
-                showSnackbar(SnackbarMessageHolder(UiStringRes(R.string.page_is_posts_page_warning)))
+                _showSnackbarMessage.postValue(SnackbarMessageHolder(UiStringRes(R.string.page_is_posts_page_warning)))
             }
         } else {
             pageMap[pageItem.remoteId]?.let { checkAndEdit(it) }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -250,6 +250,7 @@
     <string name="page_status_change_error">There was a problem changing the page status</string>
     <string name="page_parent_change_error">There was a problem changing the page parent</string>
     <string name="page_delete_dialog_message">Are you sure you want to delete page %s?</string>
+    <string name="page_is_posts_page_warning">The content of your latest posts page is automatically generated and cannot be edited.</string>
     <string name="top_level">Top level</string>
     <string name="page_moved_to_draft">Page has been moved to Drafts</string>
     <string name="page_moved_to_trash">Page has been trashed</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -408,6 +408,7 @@ class PagesViewModelTest {
     ) {
         val site = SiteModel()
         site.showOnFront = showOnFront.value
+        site.pageForPosts = updatedPageForPostsId
         setUpPageStoreWithASinglePage(site)
         viewModel.start(site)
         val settings = StaticPage(updatedPageForPostsId, -1)
@@ -525,5 +526,26 @@ class PagesViewModelTest {
 
         // Assert
         assertThat(viewModel.authorUIState.value?.authorFilterSelection).isEqualTo(EVERYONE)
+    }
+
+    @Test
+    fun `when the user taps on the posts page a warning is shown`() = test {
+        // Arrange
+        val pageForPostsId = 1L
+        val page: PageItem.Page = mock()
+        whenever(page.remoteId).thenReturn(pageForPostsId)
+        val snackbarMessages = mutableListOf<SnackbarMessageHolder>()
+        setupPageForPostsUpdate(
+                snackbarMessages = snackbarMessages,
+                showOnFront = PAGE,
+                updatedPageForPostsId = pageForPostsId
+        )
+
+        // Act
+        viewModel.onItemTapped(page)
+
+        // Assert
+        val message = snackbarMessages[0].message as UiStringRes
+        assertThat(message.stringRes).isEqualTo(R.string.page_is_posts_page_warning)
     }
 }


### PR DESCRIPTION
Fixes #14523

## Desctiption
This PR disables the ability to open the editor for Post Pages and shows a notice when the user tries to do so

## To test:
1. Open *Site Pages*
2. Tap on Actions and set a page as *Posts page*
3. Tap on the page on the list
4. **Verify** that the editor does not open and a notice is presented

## Screenshots
<image width="360" src="https://user-images.githubusercontent.com/304044/120612197-9c680f00-c45d-11eb-8859-9c7120d704d2.png"/>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added [a unit test that](https://github.com/wordpress-mobile/WordPress-Android/pull/14770/files#diff-17604b9dd6a6b2483808f67d8835904eafd3488b2a7385f5599600bd915cd803R531) verifies the warning is shown

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
