### PR TITLE
Fix stories font first load

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -353,6 +353,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
             }
         }
 
+        // Pre-load the custom story fonts if necessary
+        TextStyleGroupManager.Companion.preloadFonts(getApplicationContext());
+
         // ensure the deep linking activity is enabled. It may have been disabled elsewhere and failed to get re-enabled
         WPActivityUtils.enableReaderDeeplinks(this);
 


### PR DESCRIPTION
Fixes #https://github.com/Automattic/stories-android/issues/676

Related stories-android PR: https://github.com/Automattic/stories-android/pull/700

To test:

1. use WPAndroid and create a Story from the My Site screen -> FAB -> Add new Story post
2. select one back ground image to add to your Story slide
3. once in the composer, add a Text by tapping the "A" button
4. in the Text Editor, choose a font other than the default one. For example, use STRONG.
5. add some text, optionally resize it if you'd like to make it more manageable. Finally tap on the checkmark on the top-right corner of the screen.
6. Now tap on the -> arrow on the top-right of the screen. The pre-publishing bottom sheet will appear. Optionally give your Story post a title, and tap on PUBLISH NOW
7. After your Story is published, go to Posts list (Published) and find it first in the list
8. tap to open
9. once Gutenberg is loaded and shows the Story block, tap on it twice (one to select the block, one to trigger the Story composer)
10. observe the added text does not respect the font you chose in step 4 above.
11. tapping the text to edit will however show the right font selection, and tapping on the checkmark will now correctly update the added view with the originally selected font. 

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
