### PR TITLE
Improve how s3 repositories are defined and define which dependencies they serve

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -12,13 +12,40 @@ buildscript {
 }
 
 repositories {
+    maven {
+        url "https://a8c-libs.s3.amazonaws.com/android"
+        content {
+            includeGroup "org.wordpress"
+            includeGroup "org.wordpress-mobile.gutenberg-mobile"
+        }
+    }
+    maven {
+        url "https://a8c-libs.s3.amazonaws.com/android/hermes-mirror"
+        content {
+            includeGroup "org.wordpress-mobile"
+        }
+    }
+    def reactNativeUrl = gradle.ext.includedBuildGutenbergMobilePath != null ?
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        "$rootDir/$gradle.ext.includedBuildGutenbergMobilePath/gutenberg/node_modules/react-native/android"
+        : "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror"
+    maven {
+        url reactNativeUrl
+        content {
+            includeGroup "com.facebook.react"
+        }
+    }
+    maven {
+        url 'https://zendesk.jfrog.io/zendesk/repo'
+        content {
+            includeGroup "com.zendesk"
+            includeGroup "com.zendesk.belvedere2"
+        }
+    }
     google()
     jcenter()
     mavenCentral()
-    maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
     maven { url "https://www.jitpack.io" }
-    maven { url "https://a8c-libs.s3.amazonaws.com/android" }
-    maven { url "https://a8c-libs.s3.amazonaws.com/android/hermes-mirror" }
 }
 
 apply plugin: 'com.android.application'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -25,10 +25,10 @@ repositories {
             includeGroup "org.wordpress-mobile"
         }
     }
-    def reactNativeUrl = gradle.ext.includedBuildGutenbergMobilePath != null ?
-        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        "$rootDir/$gradle.ext.includedBuildGutenbergMobilePath/gutenberg/node_modules/react-native/android"
-        : "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror"
+    // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+    def localRNUrl = "$rootDir/$gradle.ext.includedBuildGutenbergMobilePath/gutenberg/node_modules/react-native/android"
+    def remoteRNUrl ="https://a8c-libs.s3.amazonaws.com/android/react-native-mirror"
+    def reactNativeUrl = gradle.ext.includedBuildGutenbergMobilePath != null ? localRNUrl : remoteRNUrl
     maven {
         url reactNativeUrl
         content {

--- a/build.gradle
+++ b/build.gradle
@@ -36,15 +36,6 @@ allprojects {
         jcenter()
         maven { url "https://jitpack.io" }
 
-        if (gradle.ext.includedBuildGutenbergMobilePath) {
-            maven {
-                // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-                url "$rootDir/$gradle.ext.includedBuildGutenbergMobilePath/gutenberg/node_modules/react-native/android"
-            }
-        } else {
-            maven { url "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror" }
-        }
-
         flatDir {
             dirs '../aars'
         }

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -15,10 +15,21 @@ buildscript {
 }
 
 repositories {
+    maven {
+        url "https://a8c-libs.s3.amazonaws.com/android"
+        content {
+            includeGroup "org.wordpress-mobile.gutenberg-mobile"
+        }
+    }
+    maven {
+        url "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror"
+        content {
+            includeGroup "com.facebook.react"
+        }
+    }
     google()
     jcenter()
     maven { url "https://www.jitpack.io" }
-    maven { url "https://a8c-libs.s3.amazonaws.com/android" }
 }
 
 apply plugin: 'com.android.library'

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -27,6 +27,12 @@ repositories {
             includeGroup "com.facebook.react"
         }
     }
+    maven {
+        url "https://a8c-libs.s3.amazonaws.com/android/hermes-mirror"
+        content {
+            includeGroup "org.wordpress-mobile"
+        }
+    }
     google()
     jcenter()
     maven { url "https://www.jitpack.io" }

--- a/libs/editor/example/build.gradle
+++ b/libs/editor/example/build.gradle
@@ -12,10 +12,15 @@ buildscript {
 apply plugin: 'com.android.application'
 
 repositories {
+    maven {
+        url "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror"
+        content {
+            includeGroup "com.facebook.react"
+        }
+    }
     google()
     jcenter()
     maven { url "https://www.jitpack.io" }
-    maven { url "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror" }
 }
 
 android {


### PR DESCRIPTION
As part of moving some of our dependencies to S3, we have added maven repositories for it to our build files. It turns out Gradle kept checking if a new version is published to these custom repositories for every variant. This meant a lot of time was being spent in configuration phase. In a cached build, it takes me 33 seconds to do `/gradlew buildWordPressVanillaDebug` in current develop and 22 seconds for a dry-run: `./gradlew buildWordPressVanillaDebug --dry-run` which is way too much.

This PR tells Gradle which dependencies it should look for in the custom repositories and moves these repositories to the top of the build file to make dependency resolution more secure.

With these changes same commands takes me 3 & 1 seconds respectively.

**To test:**
* As long as the project builds & runs, I don't think there is anything to test

## Regression Notes
1. Potential unintended areas of impact
Build failures - apps should not be affected as long as it builds

2. What I did to test those areas of impact (or what existing automated tests I relied on)
CI builds

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
