### PR TITLE
Jetpack Section: Update scanning state description

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1090,7 +1090,7 @@
     <string name="scan_idle_threats_found_title">Your site may be at risk</string>
     <string name="scan_fixing_threats_title_plural">Fixing Threats</string>
     <string name="scan_fixing_threats_title_singular">Fixing Threat</string>
-    <string name="scan_scanning_description">We will send you a notification once the scan is complete. In the meantime feel free to continue to use your site as normal, you can check the progress at anytime.</string>
+    <string name="scan_scanning_description">We will send you a notification if a threat is found. In the meantime feel free to continue to use your site as normal, you can check the progress at anytime.</string>
     <string name="scan_fixing_threats_description_plural">We\'re hard at work in the background fixing these threats. In the meantime feel free to continue to use your site as normal, you can check the progress at anytime.</string>
     <string name="scan_fixing_threats_description_singular">We\'re hard at work in the background fixing this threat. In the meantime feel free to continue to use your site as normal, you can check the progress at anytime.</string>
     <string name="scan_scanning_is_initial_description">Welcome to Jetpack Scan, we are taking a first look at your site now and the results will be with you soon.</string>


### PR DESCRIPTION
This PR updates the scanning state description to begin with "We will send you a notification once the scan is complete." to "We will send you a notification if a threat is found."  informing the users of the correct notification currently being sent.

To test:
Changes being simple can be reviewed in commit 1af16c7 itself. 

I've tested it and included the screenshot below:

![scanning](https://user-images.githubusercontent.com/1405144/120780706-fd6b1200-c545-11eb-9ae5-d3d779a823fc.png)

## Regression Notes
1. Potential unintended areas of impact 🟢

2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢

3. What automated tests I added (or what prevented me from doing so) 🟢

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
