### PR TITLE
Import strings from binary dependencies

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -526,7 +526,6 @@ REPOSITORY_NAME="WordPress-Android"
   main_strings_path = "./WordPress/src/main/res/values/strings.xml"
   update_strings_path = "./fastlane/resources/values/"
   libraries_strings_path = [
-    {library: "Login Library", strings_path: "./libs/login/WordPressLoginFlow/src/main/res/values/strings.xml", exclusions: ["default_web_client_id"]},
     {library: "Image Editor", strings_path: "./libs/image-editor/ImageEditor/src/main/res/values/strings.xml", exclusions: []},
     {library: "Stories Creator", strings_path: "./libs/stories-android/stories/src/main/res/values/strings.xml", exclusions: []}
   ]
@@ -537,7 +536,17 @@ REPOSITORY_NAME="WordPress-Android"
       import_key: "gutenbergMobileVersion",
       repository: "wordpress-mobile/gutenberg-mobile",
       strings_file_path: "bundle/android/strings.xml",
-      github_release_prefix: ""
+      github_release_prefix: "",
+      exclusions: [],
+      merge_tool: File.join(ENV["PROJECT_ROOT_FOLDER"], 'tools', 'merge_strings_xml.py')
+    },
+    {
+      name: "Login Library",
+      import_key: "wordPressLoginVersion",
+      repository: "wordpress-mobile/WordPress-Login-Flow-Android",
+      strings_file_path: "WordPressLoginFlow/src/main/res/values/strings.xml",
+      github_release_prefix: "",
+      exclusions: ["default_web_client_id"]
     },
   ]
 
@@ -568,7 +577,6 @@ REPOSITORY_NAME="WordPress-Android"
 
   desc "Import strings from binary dependencies"
   lane :localize_binary_deps do | options |
-    merge_strings_tool_file_path = File.join(ENV["PROJECT_ROOT_FOLDER"], 'tools', 'merge_strings_xml.py')
     binary_imported_libraries.each do  | lib |
       download_path = android_download_file_by_version(
         library_name: lib[:name],
@@ -584,7 +592,16 @@ REPOSITORY_NAME="WordPress-Android"
         UI.user_error! "Abort." unless UI.confirm(error_message)
       else
         UI.message("Strings.xml file for #{lib[:name]} downloaded to #{download_path}.")
-        sh(merge_strings_tool_file_path, lib[:name], download_path)
+        if lib.key?(:merge_tool)
+          sh(lib[:merge_tool], lib[:name], download_path) 
+        else 
+          lib_to_merge = [ {
+            library: lib[:name], 
+            strings_path: download_path, 
+            exclusions: lib[:exclusions]
+          }]
+          an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path)
+        end
         File.delete(download_path) if File.exist?(download_path)
       end
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -600,7 +600,7 @@ REPOSITORY_NAME="WordPress-Android"
             strings_path: download_path, 
             exclusions: lib[:exclusions]
           }]
-          an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: libraries_strings_path)
+          an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: lib_to_merge)
         end
         File.delete(download_path) if File.exist?(download_path)
       end


### PR DESCRIPTION
This PR updates `Fastfile` to handle importing strings from binary dependencies. The changes should enable us to switch the importing strategy for all the libraries which are currently subtrees, but currently only the Login Library has been already moved. 

## To test:
_**A. Verify that the strings from the library are imported**_
A.1 Comment out the `Gutenberg Native` section [here](https://github.com/wordpress-mobile/WordPress-Android/blob/fa392f06d703548aac33e83a1923f48a2b383071/fastlane/Fastfile#L534) to make it easier to check the changes in `strings.xml`.
A.2 Comment out the [commit step here](https://github.com/wordpress-mobile/WordPress-Android/blob/fa392f06d703548aac33e83a1923f48a2b383071/fastlane/Fastfile#L574) to avoid unintended
 commits during testing.
A.3 Delete a string which belongs to the Login Library from `strings.xml` (for example: `invalid_verification_code`).
A.4 Update the [version of the LoginLibrary](https://github.com/wordpress-mobile/WordPress-Android/blob/8b1a3133de16a948e286d5225cb8400eae169e84/build.gradle#L9) to the released one (`v0.0.1`) (Currently, the `release-toolkit` doesn't support downloading a file from a commit hash referenced in the way we do in `build.gradle`)
A.5 Run `bundle exec fastlane localize_binary_deps`. 
A.6 Verify that the removed string has been re-added.
A.7 Revert all the changes.

_**B. Verify that the strings from Gutenberg are still imported**_
B.1 Comment out the [commit step here](https://github.com/wordpress-mobile/WordPress-Android/blob/fa392f06d703548aac33e83a1923f48a2b383071/fastlane/Fastfile#L574) to avoid unintended
 commits during testing.
B.2 Update the [version of the LoginLibrary](https://github.com/wordpress-mobile/WordPress-Android/blob/8b1a3133de16a948e286d5225cb8400eae169e84/build.gradle#L9) to the released one (`v0.0.1`).
B.3 Run `bundle exec fastlane localize_binary_deps`. 
B.4 Verify that new strings from Gutenberg have been imported. 
B.5 Revert all the changes.

_**C. Verify that special cases are handled as expected**_
C.1 Comment out the `Gutenberg Native` section [here](https://github.com/wordpress-mobile/WordPress-Android/blob/fa392f06d703548aac33e83a1923f48a2b383071/fastlane/Fastfile#L534) to make it easier to check the changes in `strings.xml`.
C.2 Comment out the [commit step here](https://github.com/wordpress-mobile/WordPress-Android/blob/fa392f06d703548aac33e83a1923f48a2b383071/fastlane/Fastfile#L574) to avoid unintended
 commits during testing.
C.3 Update the [version of the LoginLibrary](https://github.com/wordpress-mobile/WordPress-Android/blob/8b1a3133de16a948e286d5225cb8400eae169e84/build.gradle#L9) to the released one (`v0.0.1`).
C.4 Run `bundle exec fastlane localize_binary_deps`. 
C.5 Verify that nothing changed in `strings.xml`.
A.7 Revert all the changes.

## Regression Notes
1. Potential unintended areas of impact
This PR makes changes to the code which import strings from Gutenberg, so that can be impacted. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I run the tests I described above, which cover the cases I can think of. 

3. What automated tests I added (or what prevented me from doing so)
There are no automated tests for Fastlane in our repo. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
