### PR TITLE
Fixes MissingSuperCall lint for onRequestPermissionsResult calls

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -152,6 +152,7 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         boolean allGranted = WPPermissionUtils.setPermissionListAsked(
                 this, requestCode, permissions, grantResults, true);
         if (allGranted && requestCode == WPPermissionUtils.SHARE_MEDIA_PERMISSION_REQUEST_CODE) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -554,6 +554,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] results) {
+        super.onRequestPermissionsResult(requestCode, permissions, results);
         boolean allGranted = WPPermissionUtils.setPermissionListAsked(
                 this, requestCode, permissions, results, true);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -840,6 +840,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         boolean allGranted = WPPermissionUtils.setPermissionListAsked(
                 this, requestCode, permissions, grantResults, true);
         if (allGranted && requestCode == WPPermissionUtils.MEDIA_PREVIEW_PERMISSION_REQUEST_CODE) {


### PR DESCRIPTION
Fixes following lint errors in current `develop`:

```
Errors found:
  
  /home/circleci/project/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java:556: Error: Overriding method should call super.onRequestPermissionsResult [MissingSuperCall]
      public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] results) {
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
  /home/circleci/project/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java:841: Error: Overriding method should call super.onRequestPermissionsResult [MissingSuperCall]
      public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
  /home/circleci/project/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java:152: Error: Overriding method should call super.onRequestPermissionsResult [MissingSuperCall]
      public void onRequestPermissionsResult(int requestCode,
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Regression Notes
1. Potential unintended areas of impact
N/A (at least I think it's not)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
