### PR TITLE
Fix crash when sharing image to destroyed activity.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -452,6 +452,10 @@ class ImageManager @Inject constructor(
      * loaded for the view.
      */
     fun cancelRequestAndClearImageView(imageView: ImageView) {
+        val context = imageView.context
+        if (context is Activity && (context.isFinishing || context.isDestroyed)) {
+            return
+        }
         GlideApp.with(imageView.context).clear(imageView)
     }
 


### PR DESCRIPTION
Fixes #14759 

This PR checks if the activity context of imageView we are trying to clear is finished or already destroyed before clearing it.

To test:
- Enabled "Do not keep activities" in developer settings.
- Open the app and navigate to media browser.
- Minimize the app and open web browser or any other app where you can share images from.
- Share the image into WordPress app.
- On site picker screen select "Add to media library"
- Confirm that the app is not crashing after image is added. 

## Regression Notes
1. Potential unintended areas of impact
- I believe there should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing.

3. What automated tests I added (or what prevented me from doing so)
- It's a android lifecycle related crash, so we are not testing it automatically.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
