### PR TITLE
Update google-services plugin to 4.3.8

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
     repositories {
+        google()
         jcenter()
         maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.google.gms:google-services:3.2.0'
+        classpath 'com.google.gms:google-services:4.3.8'
         classpath 'se.bjurr.violations:violation-comments-to-github-gradle-plugin:1.67'
         classpath 'io.sentry:sentry-android-gradle-plugin:1.7.28'
     }


### PR DESCRIPTION
Fixes the below warning that happens at every configuration phase and it's driving me crazy. It looks like we were using a very old version of the google services plugin and I just updated it to the latest one. There is some risk to it, but since it's a plugin and its task is to generate files during compilation, I don't think it'd impact anything as long as it's running. The most likely thing it can effect is the Google Login which seems to be working fine for me.

@jkmassel @loremattei Could you please take a look at this one as you two probably have the most experience in this area.

**To test:**
* Test Google login and anything else you can think of that might be impacted by this (I can't think of anything else besides Firebase which is already covered by CI)

```
Could not find google-services.json while looking in [src/wordpress/wasabi/debug, src/wordpressWasabi/debug, src/debug/wordpressWasabi, src/wordpress/debug, src/wordpress/wasabi, src/wordpress/wasabiDebug, src/wordpressWasabi, src/debug, src/wordpressWasabiDebug, src/wordpress, src/wordpressDebug]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/wordpress/zalpha/debug, src/wordpressZalpha/debug, src/debug/wordpressZalpha, src/wordpress/debug, src/wordpress/zalpha, src/wordpress/zalphaDebug, src/wordpressZalpha, src/debug, src/wordpressZalphaDebug, src/wordpress, src/wordpressDebug]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/wordpress/jalapeno/debug, src/wordpressJalapeno/debug, src/debug/wordpressJalapeno, src/wordpress/debug, src/wordpress/jalapeno, src/wordpress/jalapenoDebug, src/wordpressJalapeno, src/debug, src/wordpressJalapenoDebug, src/wordpress, src/wordpressDebug]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/wordpress/vanilla/debug, src/wordpressVanilla/debug, src/debug/wordpressVanilla, src/wordpress/debug, src/wordpress/vanilla, src/wordpress/vanillaDebug, src/wordpressVanilla, src/debug, src/wordpressVanillaDebug, src/wordpress, src/wordpressDebug]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/jetpack/wasabi/debug, src/jetpackWasabi/debug, src/debug/jetpackWasabi, src/jetpack/debug, src/jetpack/wasabi, src/jetpack/wasabiDebug, src/jetpackWasabi, src/debug, src/jetpackWasabiDebug, src/jetpack, src/jetpackDebug]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/jetpack/zalpha/debug, src/jetpackZalpha/debug, src/debug/jetpackZalpha, src/jetpack/debug, src/jetpack/zalpha, src/jetpack/zalphaDebug, src/jetpackZalpha, src/debug, src/jetpackZalphaDebug, src/jetpack, src/jetpackDebug]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/jetpack/jalapeno/debug, src/jetpackJalapeno/debug, src/debug/jetpackJalapeno, src/jetpack/debug, src/jetpack/jalapeno, src/jetpack/jalapenoDebug, src/jetpackJalapeno, src/debug, src/jetpackJalapenoDebug, src/jetpack, src/jetpackDebug]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/jetpack/vanilla/debug, src/jetpackVanilla/debug, src/debug/jetpackVanilla, src/jetpack/debug, src/jetpack/vanilla, src/jetpack/vanillaDebug, src/jetpackVanilla, src/debug, src/jetpackVanillaDebug, src/jetpack, src/jetpackDebug]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/wordpress/wasabi/release, src/wordpressWasabi/release, src/release/wordpressWasabi, src/wordpress/release, src/wordpress/wasabi, src/wordpress/wasabiRelease, src/wordpressWasabi, src/release, src/wordpressWasabiRelease, src/wordpress, src/wordpressRelease]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/wordpress/zalpha/release, src/wordpressZalpha/release, src/release/wordpressZalpha, src/wordpress/release, src/wordpress/zalpha, src/wordpress/zalphaRelease, src/wordpressZalpha, src/release, src/wordpressZalphaRelease, src/wordpress, src/wordpressRelease]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/wordpress/jalapeno/release, src/wordpressJalapeno/release, src/release/wordpressJalapeno, src/wordpress/release, src/wordpress/jalapeno, src/wordpress/jalapenoRelease, src/wordpressJalapeno, src/release, src/wordpressJalapenoRelease, src/wordpress, src/wordpressRelease]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/wordpress/vanilla/release, src/wordpressVanilla/release, src/release/wordpressVanilla, src/wordpress/release, src/wordpress/vanilla, src/wordpress/vanillaRelease, src/wordpressVanilla, src/release, src/wordpressVanillaRelease, src/wordpress, src/wordpressRelease]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/jetpack/wasabi/release, src/jetpackWasabi/release, src/release/jetpackWasabi, src/jetpack/release, src/jetpack/wasabi, src/jetpack/wasabiRelease, src/jetpackWasabi, src/release, src/jetpackWasabiRelease, src/jetpack, src/jetpackRelease]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/jetpack/zalpha/release, src/jetpackZalpha/release, src/release/jetpackZalpha, src/jetpack/release, src/jetpack/zalpha, src/jetpack/zalphaRelease, src/jetpackZalpha, src/release, src/jetpackZalphaRelease, src/jetpack, src/jetpackRelease]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/jetpack/jalapeno/release, src/jetpackJalapeno/release, src/release/jetpackJalapeno, src/jetpack/release, src/jetpack/jalapeno, src/jetpack/jalapenoRelease, src/jetpackJalapeno, src/release, src/jetpackJalapenoRelease, src/jetpack, src/jetpackRelease]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Could not find google-services.json while looking in [src/jetpack/vanilla/release, src/jetpackVanilla/release, src/release/jetpackVanilla, src/jetpack/release, src/jetpack/vanilla, src/jetpack/vanillaRelease, src/jetpackVanilla, src/release, src/jetpackVanillaRelease, src/jetpack, src/jetpackRelease]
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
```

## Regression Notes
1. Potential unintended areas of impact
Google login

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested Google login and ran all the connected tests in the PR

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
