### PR TITLE
Rename validate_login_strings lane to validate_submodules_strings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,7 +390,7 @@ jobs:
           cache_key_prefix: strings-check-v2
       - run:
           name: Validate login strings
-          command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane validate_login_strings pr_url:$CIRCLE_PULL_REQUEST
+          command: FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane validate_submodules_strings pr_url:$CIRCLE_PULL_REQUEST
   translation-review-build:
     executor:
       name: android/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ jobs:
           timeout: 10m
           results-history-name: CircleCI WPUtils Connected Tests
       - android/save-gradle-cache
-  strings-check:
+  submodules-strings-check:
     docker:
       - image: circleci/ruby:2.6.4
     steps:
@@ -440,7 +440,7 @@ workflows:
         - << pipeline.parameters.generate_screenshots >>
         - << pipeline.parameters.release_build >>
     jobs:
-      - strings-check
+      - submodules-strings-check
       - test
       - lint
       - Installable Build:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -593,11 +593,11 @@ REPOSITORY_NAME="WordPress-Android"
       else
         UI.message("Strings.xml file for #{lib[:name]} downloaded to #{download_path}.")
         if lib.key?(:merge_tool)
-          sh(lib[:merge_tool], lib[:name], download_path) 
-        else 
+          sh(lib[:merge_tool], lib[:name], download_path)
+        else
           lib_to_merge = [ {
-            library: lib[:name], 
-            strings_path: download_path, 
+            library: lib[:name],
+            strings_path: download_path,
             exclusions: lib[:exclusions]
           }]
           an_localize_libs(app_strings_path: main_strings_path, libs_strings_path: lib_to_merge)
@@ -612,7 +612,10 @@ REPOSITORY_NAME="WordPress-Android"
     end
   end
 
-  lane :validate_login_strings do | options |
+  # This lane verifies that new strings which have been added to the main strings.xml
+  # and which belongs to features of subtrees and submodules have also been added
+  # to the library strings.xml file.
+  lane :validate_submodules_strings do | options |
     pr_number = options[:pr_number]
     pr_number = options[:pr_url].split('/').last unless options[:pr_url].nil?
 


### PR DESCRIPTION
This PR simply renames `validate_login_strings` to `validate_submodules_strings` to make it clear that the lane nowadays works on more libraries. 
It also updates the CI task name to `submodules-strings-check` to help identify the area of interest. 

To test:
- Check CI is green.

## Regression Notes
1. Potential unintended areas of impact
Nothing I can think about.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
-

3. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
