### PR TITLE
Adds composite build support for WordPress-Login-Flow-Android

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -391,7 +391,7 @@ dependencies {
         exclude group: 'org.wordpress', module: 'utils'
     }
 
-    implementation ("org.wordpress:login:$wordPressLoginVersion") {
+    implementation ("$gradle.ext.loginFlowBinaryPath:$wordPressLoginVersion") {
         exclude group: "com.github.wordpress-mobile.WordPress-FluxC-Android", module: "fluxc"
         exclude group: 'com.github.bumptech.glide'
         exclude group: 'org.wordpress', module: 'utils'

--- a/local-builds.gradle-example
+++ b/local-builds.gradle-example
@@ -17,4 +17,5 @@ ext {
     //localFluxCPath = "../WordPress-FluxC-Android"
     //localWPUtilsPath = "../WordPress-Utils-Android"
     //localGutenbergMobilePath = "../gutenberg-mobile"
+    //localLoginFlowPath = "../WordPress-Login-Flow-Android"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,6 +23,7 @@ project(':WordPressMocks').projectDir = new File(rootProject.projectDir, propert
 gradle.ext.fluxCBinaryPath = "com.github.wordpress-mobile.WordPress-FluxC-Android"
 gradle.ext.wputilsBinaryPath = "org.wordpress:utils"
 gradle.ext.gutenbergMobileBinaryPath = "org.wordpress-mobile.gutenberg-mobile:react-native-gutenberg-bridge"
+gradle.ext.loginFlowBinaryPath = "org.wordpress:login"
 gradle.ext.includedBuildGutenbergMobilePath = null
 
 def localBuilds = new File('local-builds.gradle')
@@ -64,6 +65,15 @@ if (localBuilds.exists()) {
             dependencySubstitution {
                 println "Substituting gutenberg-mobile with the local build"
                 substitute module("$gradle.ext.gutenbergMobileBinaryPath") with project(':react-native-bridge')
+            }
+        }
+    }
+
+    if (ext.has("localLoginFlowPath")) {
+        includeBuild(ext.localLoginFlowPath) {
+            dependencySubstitution {
+                println "Substituting login-flow with the local build"
+                substitute module("$gradle.ext.loginFlowBinaryPath") with project(':WordPressLoginFlow')
             }
         }
     }


### PR DESCRIPTION
**To test:**
1. Copy `local-builds.gradle-example` as `local-builds.gradle` if you haven't done it already
2. Uncomment `localLoginFlowPath` and set it to your local project path
3. In your local checkout of [WordPress-Login-Flow-Android](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/) checkout `test/composite-build-support` branch which adds a test string
4. Apply the following diff and verify that it builds

```
diff --git a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
index c6157aabe7..bc898788ed 100644
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -143,6 +143,7 @@ public class ActivityLauncher {
     public static final String SOURCE_TRACK_EVENT_PROPERTY_KEY = "source";
     public static final String BACKUP_TRACK_EVENT_PROPERTY_VALUE = "backup";
     public static final String ACTIVITY_LOG_TRACK_EVENT_PROPERTY_VALUE = "activity_log";
+    public static final String test_login_mode = LoginMode.TEST_COMPOSITE_BUILD;
 
     public static void showMainActivityAndLoginEpilogue(Activity activity, ArrayList<Integer> oldSitesIds,
                                                         boolean doLoginUpdate) {

```

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
