### PR TITLE
Reader: Fix site header layout

### DIFF
--- a/WordPress/src/main/res/layout/reader_site_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_site_header_view.xml
@@ -14,7 +14,7 @@
 
         <RelativeLayout
             android:id="@+id/relativeLayout"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/margin_medium"
             android:paddingEnd="@dimen/margin_extra_large"
@@ -80,6 +80,7 @@
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
             tools:text="Chronicling the adventures of Buddy the Cat and his various criminal activities" />
 


### PR DESCRIPTION
This PR fixes the truncation of the site header layout when the site tagline is small in size.

Before | After
--------|-------
![truncated_site_header](https://user-images.githubusercontent.com/1405144/121168893-112db580-c871-11eb-8bf0-b63dcae39e9f.png) | ![full_site_header](https://user-images.githubusercontent.com/1405144/121168936-1c80e100-c871-11eb-9eaf-e76235e86616.png)

To test:

1. Go to the Reader.
2. Tap the site header section on a reader post having no or a small site tagline.
3. Notice that the site posts are loaded with the site header fully displayed at the top.

## Regression Notes
1. Potential unintended areas of impact 🟢 


2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 


3. What automated tests I added (or what prevented me from doing so) 🟢 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
