### PR TITLE
Introduce Manage Categories settings feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -112,6 +112,7 @@ android {
         buildConfigField "boolean", "UNIFIED_COMMENTS_LIST", "false"
         buildConfigField "boolean", "MP4_COMPOSER_VIDEO_OPTIMIZATION", "false"
         buildConfigField "boolean", "BLOGGING_REMINDERS", "false"
+        buildConfigField "boolean", "MANAGE_CATEGORIES", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -99,6 +99,7 @@ import org.wordpress.android.util.WPPrefUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
 import org.wordpress.android.util.config.BloggingRemindersFeatureConfig;
+import org.wordpress.android.util.config.ManageCategoriesFeatureConfig;
 import org.wordpress.android.widgets.WPSnackbar;
 
 import java.util.HashMap;
@@ -180,6 +181,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Inject ZendeskHelper mZendeskHelper;
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject BloggingRemindersFeatureConfig mBloggingRemindersFeatureConfig;
+    @Inject ManageCategoriesFeatureConfig mManageCategoriesFeatureConfig;
 
     private BloggingRemindersViewModel mBloggingRemindersViewModel;
 
@@ -221,6 +223,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     private Preference mBloggingRemindersPref;
     private Preference mPostsPerPagePref;
     private WPSwitchPreference mAmpPref;
+    private Preference mCategoriesPref;
 
     // Media settings
     private EditTextPreference mSiteQuotaSpacePref;
@@ -612,6 +615,8 @@ public class SiteSettingsFragment extends PreferenceFragment
             requestPurchasesForDeletionCheck();
         } else if (preference == mTagsPref) {
             SiteSettingsTagListActivity.showTagList(getActivity(), mSite);
+        } else if (preference == mCategoriesPref) {
+            Toast.makeText(getAppCompatActivity(), "The Categories pref was tapped", Toast.LENGTH_SHORT).show();
         } else {
             return false;
         }
@@ -996,6 +1001,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
         mJetpackPerformanceMoreSettings =
                 (PreferenceScreen) getClickPref(R.string.pref_key_jetpack_performance_more_settings);
+        mCategoriesPref = getClickPref(R.string.pref_key_site_categories);
 
         boolean isAccessedViaWPComRest = SiteUtils.isAccessedViaWPComRest(mSite);
 
@@ -1035,6 +1041,11 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (SiteUtils.alwaysDefaultToGutenberg(mSite)) {
             removeEditorPreferences();
         }
+
+        // Hide "Manage" Categories if feature is not enabled
+        if (!mManageCategoriesFeatureConfig.isEnabled()) {
+            removeCategoriesPreference();
+        }
     }
 
     private void updateHomepageSummary() {
@@ -1066,7 +1077,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         // excludes mAddressPref, mMorePreference, mJpSecuritySettings
         final Preference[] editablePreference = {
                 mTitlePref, mTaglinePref, mPrivacyPref, mLanguagePref, mUsernamePref,
-                mPasswordPref, mCategoryPref, mTagsPref, mFormatPref, mAllowCommentsPref,
+                mPasswordPref, mCategoryPref, mCategoriesPref, mTagsPref, mFormatPref, mAllowCommentsPref,
                 mAllowCommentsNested, mSendPingbacksPref, mSendPingbacksNested, mReceivePingbacksPref,
                 mReceivePingbacksNested, mIdentityRequiredPreference, mUserAccountRequiredPref,
                 mSortByPref, mAllowlistPref, mRelatedPostsPref, mCloseAfterPref, mPagingPref,
@@ -1975,6 +1986,10 @@ public class SiteSettingsFragment extends PreferenceFragment
                 R.string.pref_key_gutenberg_default_for_new_posts);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen,
                 R.string.pref_key_site_editor);
+    }
+
+    private void removeCategoriesPreference() {
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_categories);
     }
 
     private Preference getChangePref(int id) {

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ManageCategoriesFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ManageCategoriesFeatureConfig.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+/**
+ * Configuration of the my site infrastructure improvements
+ */
+@FeatureInDevelopment
+class ManageCategoriesFeatureConfig
+@Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.MANAGE_CATEGORIES
+)

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -42,6 +42,7 @@
     <string name="pref_key_site_password" translatable="false">wp_pref_site_password</string>
     <string name="pref_key_site_related_posts" translatable="false">wp_pref_site_related_posts</string>
     <string name="pref_key_site_category" translatable="false">wp_pref_site_default_category</string>
+    <string name="pref_key_site_categories" translatable="false">wp_pref_site_categories</string>
     <string name="pref_key_site_tags" translatable="false">wp_pref_site_tags</string>
     <string name="pref_key_site_format" translatable="false">wp_pref_site_default_format</string>
     <string name="pref_key_site_week_start" translatable="false">wp_pref_site_week_start</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -645,7 +645,7 @@
     <string name="site_settings_failed_update_homepage_settings">Homepage settings update failed, check your internet connection</string>
     <string name="site_settings_page_for_posts_and_homepage_cannot_be_equal">Selected homepage and page for posts cannot be the same.</string>
     <string name="site_settings_timezones_manual_offsets" translatable="false">Manual Offsets</string>
-
+    <string name="site_settings_categories_title">Categories</string>
     <!-- Media -->
     <string name="site_settings_quota_header">Media</string>
     <string name="site_settings_quota_space_title">Space Used</string>
@@ -807,6 +807,7 @@
     <string name="site_settings_multiple_links_hint">Ignores link limit from known users</string>
     <string name="site_settings_moderation_hold_hint">Comments that match a filter are put in the moderation queue</string>
     <string name="site_settings_denylist_hint">Comments that match a filter are marked as spam</string>
+    <string name="site_settings_categories_hint">Manage your site\'s categories</string>
 
     <!-- Related Posts -->
     <string name="site_settings_rp_switch_title">Show Related Posts</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -134,6 +134,12 @@
             app:longClickHint="@string/site_settings_category_hint" />
 
         <org.wordpress.android.ui.prefs.WPPreference
+            android:id="@+id/pref_categories"
+            android:key="@string/pref_key_site_categories"
+            android:title="@string/site_settings_categories_title"
+            app:longClickHint="@string/site_settings_categories_hint" />
+
+        <org.wordpress.android.ui.prefs.WPPreference
             android:id="@+id/pref_tags"
             android:key="@string/pref_key_site_tags"
             android:title="@string/site_settings_tags_title"


### PR DESCRIPTION
Parent #5382 

This PR introduces a local feature flag for the Manage Categories settings feature. When the feature flag is enabled a "Categories" row is shown on the Settings view.

<img width="250" height="500" alt="light" src="https://user-images.githubusercontent.com/506707/121267077-9f159a80-c889-11eb-97b1-13d01df599f7.png">

To test:
1. Launch the app
2. From My Site, scroll to Settings and tap
3. Note that the `Categories` row is not present in the Writing section
4. Go to Me -> App Settings -> Test Feature Configuration
5. Enable `ManageCategoriesFeatureConfig` and restart the app
6. When the app relaunches, navigate back to My Site ->  Settings
7. Note that the `Categories` row is present in the Writing section
Note: Tapping on the Categories row will show a toast


## Regression Notes
1. Potential unintended areas of impact 🟢 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested by manually flipping the feature flag on/off
3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
