### PR TITLE
Remove outdated onTouch handling in AztecEditorFragment

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -37,7 +37,6 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.BaseInputConnection;
@@ -122,7 +121,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         AztecText.OnVideoTappedListener,
         AztecText.OnMediaDeletedListener,
         AztecText.OnVideoInfoRequestedListener,
-        View.OnTouchListener,
         EditorMediaUploadListener,
         IAztecToolbarClickListener,
         AztecTextChangeObserver,
@@ -252,9 +250,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             ((EditorFragmentActivity) getActivity()).initializeEditorFragment();
         }
 
-        mTitle.setOnTouchListener(this);
-        mContent.setOnTouchListener(this);
-        mSource.setOnTouchListener(this);
 
         mTitle.setOnImeBackListener(new org.wordpress.android.editor.OnImeBackListener() {
             public void onImeBack() {
@@ -426,7 +421,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         if (isEmptyPost() && !hasSeenClassicEditorDeprecationDialog()) {
             showClassicEditorDeprecationDialog();
         }
-        
+
         addOverlayToGifs();
         updateFailedAndUploadingMedia();
     }
@@ -1441,18 +1436,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             mHideActionBarOnSoftKeyboardUp = false;
             showActionBarIfNeeded();
         }
-    }
-
-    @Override
-    public boolean onTouch(View view, MotionEvent event) {
-        // In landscape mode, if the title or content view has received a touch event, the keyboard will be
-        // displayed and the action bar should hide
-        if (event.getAction() == MotionEvent.ACTION_UP
-            && getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            mHideActionBarOnSoftKeyboardUp = true;
-            hideActionBarIfNeeded();
-        }
-        return false;
     }
 
     /**


### PR DESCRIPTION
This is an interesting and a somewhat risky PR. I was trying to fix the [lint issues for `ClickableViewAccessibility`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/lint-baseline.xml#L205-L267) and I didn't fully understand what this on touch listener was supposed to accomplish. I've tracked it down to [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/6730) for [this issue](https://github.com/wordpress-mobile/AztecEditor-Android/issues/412) and when I tried the steps to understand the current behavior, I found out that the landscape orientation for the editor might be "broken". I've then tried it without this touch listener and the behavior didn't change. I am also not sure what I am supposed to touch in this landscape orientation, because it takes up the whole screen. Here is a video of the behavior: https://cloudup.com/ckB42FwE_i6

My suggestion is to remove this most likely unnecessary implementation, open a new issue to report this behavior and ask it to be made a part of Groundskeeping or ask any of the relevant teams to take care of it.

I am going to keep this as a draft for now to collect some feedback. @hypest @ParaskP7 @khaykov Could you take a look at this and let me know what you think?

**To test:**


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
