### PR TITLE
Suppress StaticFieldLeak issues in place

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.comments;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.view.View;
@@ -307,6 +308,7 @@ public class CommentAdapter extends RecyclerView.Adapter<CommentListViewHolder> 
      */
     private boolean mIsLoadTaskRunning = false;
 
+    @SuppressLint("StaticFieldLeak")
     private class LoadCommentsTask extends AsyncTask<LoadCommentsTaskParameters, Void, Boolean> {
         private ArrayList<CommentListItem> mTmpComments;
         final CommentStatus mStatusFilter;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.main;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.text.TextUtils;
@@ -654,6 +655,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     /*
      * AsyncTask which loads sites from database and populates the adapter
      */
+    @SuppressLint("StaticFieldLeak")
     private class LoadSitesTask extends AsyncTask<Void, Void, SiteList[]> {
         @Override
         protected void onPreExecute() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.notifications.adapters;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.AsyncTask.Status;
@@ -354,6 +355,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         mReloadNotesFromDBTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
+    @SuppressLint("StaticFieldLeak")
     private class ReloadNotesFromDBTask extends AsyncTask<Void, Void, ArrayList<Note>> {
         @Override
         protected ArrayList<Note> doInBackground(Void... voids) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
@@ -6,7 +6,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.media.ThumbnailUtils;
 import android.os.AsyncTask;
-import android.provider.MediaStore;
+import android.provider.MediaStore.Images.Thumbnails;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 
@@ -16,18 +16,19 @@ import org.wordpress.android.util.ImageUtils;
 import org.wordpress.aztec.Html;
 
 import java.io.File;
+import java.lang.ref.WeakReference;
 
 import javax.inject.Inject;
 
 public class AztecVideoLoader implements Html.VideoThumbnailGetter {
-    private Context mContext;
+    private final Context mContext;
     private final Drawable mLoadingInProgress;
     @Inject AuthenticationUtils mAuthenticationUtils;
 
     public AztecVideoLoader(Context context, Drawable loadingInProgressDrawable) {
         ((WordPress) WordPress.getContext().getApplicationContext()).component().inject(this);
-        this.mContext = context;
-        this.mLoadingInProgress = loadingInProgressDrawable;
+        mContext = context;
+        mLoadingInProgress = loadingInProgressDrawable;
     }
 
     public void loadVideoThumbnail(final String url, final Html.VideoThumbnailGetter.Callbacks callbacks,
@@ -43,27 +44,51 @@ public class AztecVideoLoader implements Html.VideoThumbnailGetter {
         }
 
         callbacks.onThumbnailLoading(mLoadingInProgress);
+        new LoadAztecVideoTask(mContext, mAuthenticationUtils, url, maxWidth, callbacks).execute();
+    }
 
-        new AsyncTask<Void, Void, Bitmap>() {
-            protected Bitmap doInBackground(Void... params) {
-                // If local file
-                if (new File(url).exists()) {
-                    return ThumbnailUtils.createVideoThumbnail(url, MediaStore.Images.Thumbnails.FULL_SCREEN_KIND);
-                }
+    private static class LoadAztecVideoTask extends AsyncTask<Void, Void, Bitmap> {
+        final String mUrl;
+        final int mMaxWidth;
+        final Html.VideoThumbnailGetter.Callbacks mCallbacks;
+        final AuthenticationUtils mAuthenticationUtils;
+        final WeakReference<Context> mContext;
 
-                return ImageUtils.getVideoFrameFromVideo(url, maxWidth, mAuthenticationUtils.getAuthHeaders(url));
+        LoadAztecVideoTask(Context context,
+                           AuthenticationUtils authenticationUtils,
+                           String url,
+                           int maxWidth,
+                           Html.VideoThumbnailGetter.Callbacks callbacks) {
+            mContext = new WeakReference<>(context);
+            mAuthenticationUtils = authenticationUtils;
+            mUrl = url;
+            mMaxWidth = maxWidth;
+            mCallbacks = callbacks;
+        }
+
+        @Override
+        protected Bitmap doInBackground(Void... params) {
+            // If local file
+            if (new File(mUrl).exists()) {
+                return ThumbnailUtils.createVideoThumbnail(mUrl, Thumbnails.FULL_SCREEN_KIND);
             }
 
-            protected void onPostExecute(Bitmap thumb) {
-                if (thumb == null) {
-                    callbacks.onThumbnailFailed();
-                    return;
-                }
-                thumb = ImageUtils.getScaledBitmapAtLongestSide(thumb, maxWidth);
-                thumb.setDensity(DisplayMetrics.DENSITY_DEFAULT);
-                BitmapDrawable bitmapDrawable = new BitmapDrawable(mContext.getResources(), thumb);
-                callbacks.onThumbnailLoaded(bitmapDrawable);
+            return ImageUtils.getVideoFrameFromVideo(mUrl, mMaxWidth, mAuthenticationUtils.getAuthHeaders(mUrl));
+        }
+
+        @Override
+        protected void onPostExecute(Bitmap thumb) {
+            if (mContext.get() == null) {
+                return;
             }
-        }.execute();
+            if (thumb == null) {
+                mCallbacks.onThumbnailFailed();
+                return;
+            }
+            thumb = ImageUtils.getScaledBitmapAtLongestSide(thumb, mMaxWidth);
+            thumb.setDensity(DisplayMetrics.DENSITY_DEFAULT);
+            BitmapDrawable bitmapDrawable = new BitmapDrawable(mContext.get().getResources(), thumb);
+            mCallbacks.onThumbnailLoaded(bitmapDrawable);
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -419,6 +419,7 @@ public class AccountSettingsFragment extends PreferenceFragment implements OnPre
     /*
      * AsyncTask which loads sites from database for primary site preference
      */
+    @SuppressLint("StaticFieldLeak")
     private class LoadSitesTask extends AsyncTask<Void, Void, Void> {
         @Override
         protected void onPreExecute() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.publicize.adapters;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.ColorFilter;
 import android.graphics.ColorMatrix;
@@ -172,6 +173,7 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
         }
     }
 
+    @SuppressLint("StaticFieldLeak")
     private class LoadServicesTask extends AsyncTask<Void, Void, Boolean> {
         private final PublicizeServiceList mTmpServices = new PublicizeServiceList();
         private final PublicizeConnectionList mTmpConnections = new PublicizeConnectionList();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.adapters;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.text.TextUtils;
@@ -262,6 +263,7 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
     }
 
+    @SuppressLint("StaticFieldLeak")
     private class LoadBlogsTask extends AsyncTask<Void, Void, Boolean> {
         private ReaderBlogList mTmpFollowedBlogs;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.adapters;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.view.LayoutInflater;
@@ -538,6 +539,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
      */
     private boolean mIsTaskRunning = false;
 
+    @SuppressLint("StaticFieldLeak")
     private class LoadCommentsTask extends AsyncTask<Void, Void, Boolean> {
         private ReaderCommentList mTmpComments;
         private boolean mTmpMoreCommentsExist;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.adapters;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.view.LayoutInflater;
@@ -152,6 +153,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
      */
     private boolean mIsTaskRunning = false;
 
+    @SuppressLint("StaticFieldLeak")
     private class LoadTagsTask extends AsyncTask<Void, Void, ReaderTagList> {
         @Override
         protected void onPreExecute() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.uploads;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
@@ -196,6 +197,7 @@ public class PostUploadHandler implements UploadHandler<PostModel>, OnAutoSavePo
         PUSH_POST_DISPATCHED, ERROR, NOTHING_TO_UPLOAD, AUTO_SAVE_OR_UPDATE_DRAFT
     }
 
+    @SuppressLint("StaticFieldLeak")
     private class UploadPostTask extends AsyncTask<PostModel, Boolean, UploadPostTaskResult> {
         private Context mContext;
 


### PR DESCRIPTION
This is the last PR to remove the `WordPress/lint-baseline.xml` file. It moves most of the `StaticFieldLeak` warnings to the code in e2ca65fca59a08ba23ab186fd26a81540ae82653. Since the `AsyncTask` in `AztecVideoLoader` was not a class, I couldn't suppress the warning in place and while converting that to a class, I figured I might as well fix the issue instead of suppressing it. a72bb01c157faab14d038d549f992cef3e0ec068

[Note that `AsyncTask` is deprecated in Android 30, so we'll need to convert these to Kotlin coroutines or use the standard `java.util.concurrent`.](https://developer.android.com/reference/android/os/AsyncTask)

**To test:**
Since the only change is in `AztecVideoLoader`, we just need to test the video block integration of the editor. I've tried uploading a couple videos and didn't see any difference between this version and the current beta.

**One thing I am a little worried about is that I don't see a thumbnail when I upload a video. Also after publishing the post, when I tap on the video it opens the browser.** I don't think it's related to this PR, but I am not 100% sure either.

## Regression Notes
1. Potential unintended areas of impact
Broken video block in editor

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested uploading a few videos in the editor. I don't think we have any automated tests for it.

3. What automated tests I added (or what prevented me from doing so)
That'd be out of scope for this PR.

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
