### PR TITLE
Reader: Fix duplicate posts issue - part 1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -349,7 +349,7 @@ public class ReaderPost {
     /**
      * copy changes over to the local post - this is done instead of simply overwriting
      * the local post with the server post because the server post was retrieved using
-     * the read/sites/$siteId/posts/$postId endpoint which is missing some information
+     * the read/sites/$siteId/posts/$postId or read/sites/$siteId/posts/ endpoints which are missing some information
      * https://github.com/wordpress-mobile/WordPress-Android/issues/3164
      */
     public void copyFieldsFromPost(ReaderPost post) {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -346,6 +346,24 @@ public class ReaderPost {
         post.setTags(tags);
     }
 
+    /**
+     * copy changes over to the local post - this is done instead of simply overwriting
+     * the local post with the server post because the server post was retrieved using
+     * the read/sites/$siteId/posts/$postId endpoint which is missing some information
+     * https://github.com/wordpress-mobile/WordPress-Android/issues/3164
+     */
+    public void copyFieldsFromPost(ReaderPost post) {
+        numReplies = post.numReplies;
+        numLikes = post.numLikes;
+        isFollowedByCurrentUser = post.isFollowedByCurrentUser;
+        isLikedByCurrentUser = post.isLikedByCurrentUser;
+        isCommentsOpen = post.isCommentsOpen;
+        useExcerpt = post.useExcerpt;
+        setTitle(post.getTitle());
+        setText(post.getText());
+        setExcerpt(post.getExcerpt());
+    }
+
     /*
      * extracts a title from a post's excerpt - used when the post has no title
      */

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -181,19 +181,9 @@ public class ReaderPostActions {
             public void run() {
                 ReaderPost serverPost = ReaderPost.fromJson(jsonObject);
 
-                // TODO: this temporary fix was added 25-Apr-2016 as a workaround for the fact that
-                // the read/sites/{blogId}/posts/{postId} endpoint doesn't contain the feedId or
-                // feedItemId of the post. because of this, we need to copy them from the local post
-                // before calling isSamePost (since the difference in those IDs causes it to return false)
-                if (serverPost.feedId == 0 && localPost.feedId != 0) {
-                    serverPost.feedId = localPost.feedId;
-                }
+                ReaderActions.UpdateResult updateResult = ReaderPostTable.comparePost(serverPost);
 
-                if (serverPost.feedItemId == 0 && localPost.feedItemId != 0) {
-                    serverPost.feedItemId = localPost.feedItemId;
-                }
-
-                boolean hasChanges = !serverPost.isSamePost(localPost);
+                boolean hasChanges = updateResult == UpdateResult.CHANGED;
 
                 if (hasChanges) {
                     AppLog.d(T.READER, "post updated");

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -187,19 +187,7 @@ public class ReaderPostActions {
 
                 if (hasChanges) {
                     AppLog.d(T.READER, "post updated");
-                    // copy changes over to the local post - this is done instead of simply overwriting
-                    // the local post with the server post because the server post was retrieved using
-                    // the read/sites/$siteId/posts/$postId endpoint which is missing some information
-                    // https://github.com/wordpress-mobile/WordPress-Android/issues/3164
-                    localPost.numReplies = serverPost.numReplies;
-                    localPost.numLikes = serverPost.numLikes;
-                    localPost.isFollowedByCurrentUser = serverPost.isFollowedByCurrentUser;
-                    localPost.isLikedByCurrentUser = serverPost.isLikedByCurrentUser;
-                    localPost.isCommentsOpen = serverPost.isCommentsOpen;
-                    localPost.useExcerpt = serverPost.useExcerpt;
-                    localPost.setTitle(serverPost.getTitle());
-                    localPost.setText(serverPost.getText());
-                    localPost.setExcerpt(serverPost.getExcerpt());
+                    localPost.copyFieldsFromPost(serverPost);
                     ReaderPostTable.updatePost(localPost);
                 }
 


### PR DESCRIPTION
Partially fixes #12938

This PR fixes one of the scenarios when duplicate posts are seen in the Reader due to different ways a (followed-blog) post gets updated - see [Findings#1](https://github.com/wordpress-mobile/WordPress-Android/issues/12938#issuecomment-857701866).

See https://github.com/wordpress-mobile/WordPress-Android/issues/12938#issuecomment-856719551 capturing the duplicate post issue for this scenario.

See https://github.com/wordpress-mobile/WordPress-Android/issues/12938#issuecomment-857701866 for context.

#### Review Instructions:
1. There are other scenarios when posts are duplicated, however, I haven't been able to dig deep into them yet. 
E.g. Discover posts and blog posts both are saved with the empty `tag_name` but different `tag_type` (7 - discover post, 0 - otherwise). I see a potential issue here as well ([blog posts being queried using an empty `tag_name`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java#L988-L991)). I plan to tackle it separately. 

2. It's a tricky issue and needs to tested carefully. I've added two reviewers for a sanity check 😅. I'll be happy to pair and go through the issue if needed.

#### To test:

1. Follow a site e.g. https://testatomicsitecode.wpcomstaging.com/ using Calypso.
2. Fresh install the WordPress app and go to the Reader tab.
3. Click the Following tab on the Reader.
4. Click the site header on the post from the above-followed site.
5. Notice that the site's posts are shown and duplicate posts do not exist.
6. Click the same post on the site's posts screen.
7.  Return from the post details screen to the site's posts screen.
8. Notice that posts are not duplicated. 
9. Perform random actions: like, bookmark, etc, and notice that the status is reflected correctly on all instances of the post in the db.

#### Merge Instructions:
This PR is still in draft as I want to discuss this solution first, possible drawbacks (any increased load time due to more db interaction per post), and identify other duplicate post scenarios + wait for fixes. Till that time I've added "Not Ready for Merge" label.

We might also want to investigate if a different `pseudo_id` for the same post (see [Findings#2](https://github.com/wordpress-mobile/WordPress-Android/issues/12938#issuecomment-857701866)) is expected, and if not, we fix it for the endpoint. 

## Regression Notes
1. Potential unintended areas of impact
No. of likes, is_bookmark e.t.c. are copied correctly from the server post to the local posts when the site's posts are requested.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
Areas impacted (`ReaderPostLogic`, `ReaderPostActions`) do not have any tests currently. It might be difficult to add automated tests unless we further refactor them (currently out-of-scope of this PR).

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
