### PR TITLE
Reader: Fix incoherent tag names

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -73,7 +73,7 @@ public class ReaderConstants {
     // JSON key names
     public static final String JSON_TAG_TAGS_ARRAY = "tags";
     public static final String JSON_TAG_TITLE = "title";
-    public static final String JSON_TAG_DISPLAY_NAME = "tag_display_name";
+    public static final String JSON_TAG_DISPLAY_NAME = "display_name";
     public static final String JSON_TAG_SLUG = "slug";
     public static final String JSON_TAG_URL = "URL";
     public static final String JSON_CARDS = "cards";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
@@ -75,6 +75,6 @@ sealed class SubfilterListItem(val type: ItemType, val isTrackedItem: Boolean = 
         override val onClickAction: (filter: SubfilterListItem) -> Unit,
         val tag: ReaderTag
     ) : SubfilterListItem(TAG, true) {
-        override val label: UiString = UiStringText(tag.tagTitle)
+        override val label: UiString = UiStringText(tag.label)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
@@ -72,7 +72,7 @@ class SubFilterViewModelTest {
     @Before
     fun setUp() {
         whenever(initialTag.label).thenReturn("tag-label")
-        whenever(savedTag.tagTitle).thenReturn("tag-title")
+        whenever(savedTag.label).thenReturn("tag-label")
 
         viewModel = SubFilterViewModel(
                 TEST_DISPATCHER,


### PR DESCRIPTION
Fixes #11629

This PR fixes the incoherent tag names issue on the "Manage Topics and Sites" screen.

#### Findings

1. The values that are displayed on the Android app are the `title` field values from the `/read/tags/mine/new` endpoint.
They are sometimes returned incoherently by the endpoint itself. 

    E.g. on adding tag "o-k", the endpoint returns "-o-k" for the `title` field:

    `{"ID":"11574780","slug":"o-k","title":"-o-k","display_name":"o-k","URL":"https:\/\/public-api.wordpress.com\/rest\/v1.2\/read\/tags\/o-k\/posts"}`

2.  iOS app [normalises the `title` field value with the value from `display_name` field](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/develop/WordPressKit/ReaderTopicServiceRemote.m#L337) which doesn't have this problem.

3. Android app does something similar in `readerTag.getLabel()` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/70ce7de8817020d29768074bb408688436320220/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java#L236-L241). Yet it doesn't pick the display name correctly as the key for the field is not set correctly [here](https://github.com/wordpress-mobile/WordPress-Android/blob/644f427bfd83d1be35b56d548fd538556e587dd1/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java#L76). The value from the wrong key is always blank so it picks up the value from the 'title' key.

#### Solution

- Set the key for the `display_name` field correctly.
- Use `readerTag.getLabel()` in the `SubfilterListItem.Tag.label` (to display the same label on the Filter bar on the Following tab)

#### To test
- Go to the "Manage Topics & Sites" screen.
- Add a tag "o-k" or "hfj" (shown incoherently in the linked issue).
- Notice that they are added and displayed correctly similar to the iOS app.

#### Merge Instructions

Can be merged with 17.6, since it is only 4 days away I've set the next milestone 17.7.

## Regression Notes
1. Potential unintended areas of impact 🟢


2. What I did to test those areas of impact (or what existing automated tests I relied on)  🟢


3. What automated tests I added (or what prevented me from doing so)  🟢

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
