### PR TITLE
Integrate gutenberg-mobile release 1.55.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,8 @@
 17.6
 -----
 * [*] Disables the ability to open the editor for Post Pages [#14523]
+* [*] Block Editor: "Set as featured" button within image block settings. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3116]
+* [***] Block Editor: Audio block now available on WP.com sites on the free plan. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3523]
 
 17.5
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
     ext.wordPressLoginVersion = '58-bd338e6eadb0eadf640f2320c791ca58f86c0cda'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'develop-b316b2b49f57f08426f1a33418f28480cdc8787b'
+    ext.gutenbergMobileVersion = '3609-4b46e3cd573483cb1a0cac4df8372255ee73ad0b'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
     ext.wordPressLoginVersion = '58-bd338e6eadb0eadf640f2320c791ca58f86c0cda'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3609-4b46e3cd573483cb1a0cac4df8372255ee73ad0b'
+    ext.gutenbergMobileVersion = 'v1.55.0'
 
     repositories {
         google()


### PR DESCRIPTION
## Description
This PR incorporates the 1.55.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3609

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.