### PR TITLE
Re-enable fetchstyle plugin and request it from s3 repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,13 +11,19 @@ buildscript {
     ext.gutenbergMobileVersion = 'v1.55.0'
 
     repositories {
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android'
+            content {
+                includeGroup "com.automattic.android"
+            }
+        }
         google()
         jcenter()
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.2'
-        //classpath 'com.automattic.android:fetchstyle:1.1'
+        classpath 'com.automattic.android:fetchstyle:1.1'
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlinVersion"
@@ -26,7 +32,7 @@ buildscript {
     }
 }
 
-//apply plugin: 'com.automattic.android.fetchstyle'
+apply plugin: 'com.automattic.android.fetchstyle'
 
 allprojects {
     apply plugin: 'checkstyle'

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -3,17 +3,11 @@ buildscript {
         jcenter()
         google()
     }
-
-    dependencies {
-        classpath 'com.automattic.android:fetchstyle:1.1'
-    }
 }
-
-apply plugin: 'com.automattic.android.fetchstyle'
 
 allprojects {
     apply plugin: 'checkstyle'
-    
+
     if (tasks.findByPath('checkstyle') == null) {
         tasks.create(name: 'checkstyle', type: Checkstyle) {
             source 'src'


### PR DESCRIPTION
Since the [source code for fetchstyle plugin](https://github.com/Automattic/style-config-android) is heavily outdated, I couldn't fully update it in the time I allotted for it. I actually successfully published the plugin to S3, but there was something wrong with the groovy dependency, so it didn't work when I tried to consume it. So, for now, I've manually ported the fetchstyle plugin from jcenter to our s3 repository.

I've also removed the fetchstyle plugin from `libs/editor` since it's already applied to the root project. I imagine this is something that's left from when editor was a separate project. We'll figure out how to approach this when we handle the `libs/editor` build configuration changes.

**To test:**
* Run `./gradlew tasks --all | grep downloadConfigs` to verify the fetchstyle plugin tasks are available. Or you can run the `downloadConfigs` with `./gradlew downloadConfigs`.
* Run `./gradlew --scan` and open the scan. In the `Build Dependencies section`, use the search functionality to find the `fetchstyle` dependency and verify it's repository is our s3 repo and not `jcenter`

![wpandroid](https://user-images.githubusercontent.com/662023/121822251-1bcebd00-cc6c-11eb-9565-e5300620a62c.png)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
