### PR TITLE
ViewBinding: Replace synthetic accessors with ViewBinding

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
@@ -2,19 +2,19 @@ package org.wordpress.android.ui
 
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.INSTALL_JETPACK_CANCELLED
+import org.wordpress.android.databinding.JetpackRemoteInstallActivityBinding
 import org.wordpress.android.ui.JetpackConnectionUtils.trackWithSource
 import org.wordpress.android.ui.JetpackRemoteInstallFragment.Companion.TRACKING_SOURCE_KEY
 
 class JetpackRemoteInstallActivity : LocaleAwareActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val binding = JetpackRemoteInstallActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        setContentView(R.layout.jetpack_remote_install_activity)
-
-        setSupportActionBar(toolbar_main)
+        setSupportActionBar(binding.toolbarLayout.toolbarMain)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
@@ -11,10 +11,11 @@ import org.wordpress.android.ui.JetpackRemoteInstallFragment.Companion.TRACKING_
 class JetpackRemoteInstallActivity : LocaleAwareActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = JetpackRemoteInstallActivityBinding.inflate(layoutInflater)
-        setContentView(binding.root)
+        with(JetpackRemoteInstallActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            setSupportActionBar(toolbarLayout.toolbarMain)
+        }
 
-        setSupportActionBar(binding.toolbarLayout.toolbarMain)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -4,16 +4,14 @@ import android.app.Activity
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.synthetic.main.jetpack_remote_install_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.JetpackRemoteInstallFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActionData.Action.CONNECT
@@ -24,48 +22,35 @@ import org.wordpress.android.ui.accounts.LoginActivity
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 
-class JetpackRemoteInstallFragment : Fragment() {
+class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: JetpackRemoteInstallViewModel
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        with(JetpackRemoteInstallFragmentBinding.bind(view)) {
+            initDagger()
+            initViewModel(savedInstanceState)
+        }
+    }
+
+    private fun initDagger() {
         (requireActivity().application as WordPress).component()!!.inject(this)
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    private fun JetpackRemoteInstallFragmentBinding.initViewModel(savedInstanceState: Bundle?) {
         requireActivity().let { activity ->
-            viewModel = ViewModelProvider(this, viewModelFactory).get(JetpackRemoteInstallViewModel::class.java)
-
             val intent = activity.intent
             val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
             val source = intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
             val retrievedState = savedInstanceState?.getSerializable(VIEW_STATE) as? JetpackRemoteInstallViewState.Type
+            viewModel = ViewModelProvider(
+                    this@JetpackRemoteInstallFragment, viewModelFactory
+            ).get(JetpackRemoteInstallViewModel::class.java)
             viewModel.start(site, retrievedState)
-            viewModel.liveViewState.observe(viewLifecycleOwner, Observer { viewState ->
-                if (viewState != null) {
-                    if (viewState is JetpackRemoteInstallViewState.Error) {
-                        AppLog.e(AppLog.T.JETPACK_REMOTE_INSTALL, "An error occurred while installing Jetpack")
-                    }
-                    jetpack_install_icon.setImageResource(viewState.icon)
-                    if (viewState.iconTint != null) {
-                        jetpack_install_icon.imageTintList = ColorStateList.valueOf(ContextCompat.getColor(
-                                jetpack_install_icon.context, viewState.iconTint))
-                    } else {
-                        jetpack_install_icon.imageTintList = null
-                    }
-                    jetpack_install_title.setText(viewState.titleResource)
-                    jetpack_install_message.setText(viewState.messageResource)
-                    if (viewState.buttonResource != null) {
-                        jetpack_install_button.visibility = View.VISIBLE
-                        jetpack_install_button.setText(viewState.buttonResource)
-                    } else {
-                        jetpack_install_button.visibility = View.GONE
-                    }
-                    jetpack_install_button.setOnClickListener { viewState.onClick() }
-                    jetpack_install_progress.visibility = if (viewState.progressBarVisible) View.VISIBLE else View.GONE
-                }
-            })
+
+            initLiveViewStateObserver()
+
             viewModel.liveActionOnResult.observe(viewLifecycleOwner, Observer { result ->
                 if (result != null) {
                     when (result.action) {
@@ -99,6 +84,33 @@ class JetpackRemoteInstallFragment : Fragment() {
         }
     }
 
+    private fun JetpackRemoteInstallFragmentBinding.initLiveViewStateObserver() {
+        viewModel.liveViewState.observe(viewLifecycleOwner, Observer { viewState ->
+            if (viewState != null) {
+                if (viewState is JetpackRemoteInstallViewState.Error) {
+                    AppLog.e(AppLog.T.JETPACK_REMOTE_INSTALL, "An error occurred while installing Jetpack")
+                }
+                jetpackInstallIcon.setImageResource(viewState.icon)
+                if (viewState.iconTint != null) {
+                    jetpackInstallIcon.imageTintList = ColorStateList.valueOf(ContextCompat.getColor(
+                            jetpackInstallIcon.context, viewState.iconTint))
+                } else {
+                    jetpackInstallIcon.imageTintList = null
+                }
+                jetpackInstallTitle.setText(viewState.titleResource)
+                jetpackInstallMessage.setText(viewState.messageResource)
+                if (viewState.buttonResource != null) {
+                    jetpackInstallButton.visibility = View.VISIBLE
+                    jetpackInstallButton.setText(viewState.buttonResource)
+                } else {
+                    jetpackInstallButton.visibility = View.GONE
+                }
+                jetpackInstallButton.setOnClickListener { viewState.onClick() }
+                jetpackInstallProgress.visibility = if (viewState.progressBarVisible) View.VISIBLE else View.GONE
+            }
+        })
+    }
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == JETPACK_LOGIN && resultCode == Activity.RESULT_OK) {
@@ -112,10 +124,6 @@ class JetpackRemoteInstallFragment : Fragment() {
         viewModel.liveViewState.value?.type?.let {
             outState.putSerializable(VIEW_STATE, it)
         }
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.jetpack_remote_install_fragment, container, false)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/PostSignupInterstitialActivity.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.accounts
 import android.os.Bundle
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.button.MaterialButton
-import kotlinx.android.synthetic.main.post_signup_interstitial_landscape.view.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PostSignupInterstitialActivityBinding

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
@@ -9,10 +9,11 @@ class UnifiedCommentsActivity : LocaleAwareActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val binding = UnifiedCommentActivityBinding.inflate(layoutInflater)
-        setContentView(binding.root)
+        with(UnifiedCommentActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            setSupportActionBar(toolbarMain)
+        }
 
-        setSupportActionBar(binding.toolbarMain)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
@@ -2,17 +2,17 @@ package org.wordpress.android.ui.comments.unified
 
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.toolbar_main.*
-import org.wordpress.android.R
+import org.wordpress.android.databinding.UnifiedCommentActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 
 class UnifiedCommentsActivity : LocaleAwareActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setContentView(R.layout.unified_comment_activity)
+        val binding = UnifiedCommentActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        setSupportActionBar(toolbar_main)
+        setSupportActionBar(binding.toolbarMain)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
@@ -2,9 +2,9 @@ package org.wordpress.android.ui.engagement
 
 import android.os.Bundle
 import android.view.MenuItem
-import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.EngagedPeopleListActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import java.lang.IllegalArgumentException
@@ -17,7 +17,8 @@ class EngagedPeopleListActivity : LocaleAwareActivity() {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
 
-        setContentView(R.layout.engaged_people_list_activity)
+        val binding = EngagedPeopleListActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         val listScenario = intent.getParcelableExtra<ListScenario>(KEY_LIST_SCENARIO)
                 ?: throw IllegalArgumentException(
@@ -29,7 +30,7 @@ class EngagedPeopleListActivity : LocaleAwareActivity() {
                 ListScenarioType.getSourceDescription(listScenario.type)
         )
 
-        setSupportActionBar(toolbar_main)
+        setSupportActionBar(binding.toolbarMain)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
@@ -17,8 +17,10 @@ class EngagedPeopleListActivity : LocaleAwareActivity() {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
 
-        val binding = EngagedPeopleListActivityBinding.inflate(layoutInflater)
-        setContentView(binding.root)
+        with(EngagedPeopleListActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            setSupportActionBar(toolbarMain)
+        }
 
         val listScenario = intent.getParcelableExtra<ListScenario>(KEY_LIST_SCENARIO)
                 ?: throw IllegalArgumentException(
@@ -30,7 +32,6 @@ class EngagedPeopleListActivity : LocaleAwareActivity() {
                 ListScenarioType.getSourceDescription(listScenario.type)
         )
 
-        setSupportActionBar(binding.toolbarMain)
         supportActionBar?.let {
             it.setHomeButtonEnabled(true)
             it.setDisplayHomeAsUpEnabled(true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.scan_list_threat_item.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.ActionableEmptyView

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
@@ -13,14 +13,10 @@ class HistoryDetailActivity : LocaleAwareActivity() {
         const val KEY_HISTORY_DETAIL_FRAGMENT = "history_detail_fragment"
     }
 
-    private var binding: HistoryDetailActivityBinding? = null
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         with(HistoryDetailActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
-            binding = this
-
             setSupportActionBar(toolbarMain)
         }
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
@@ -52,10 +48,5 @@ class HistoryDetailActivity : LocaleAwareActivity() {
     override fun onBackPressed() {
         AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED)
         super.onBackPressed()
-    }
-
-    override fun onDestroy() {
-        binding = null
-        super.onDestroy()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
@@ -1,10 +1,10 @@
 package org.wordpress.android.ui.history
 
 import android.os.Bundle
-import kotlinx.android.synthetic.main.toolbar_main.*
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.databinding.HistoryDetailActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.history.HistoryListItem.Revision
 
@@ -13,11 +13,16 @@ class HistoryDetailActivity : LocaleAwareActivity() {
         const val KEY_HISTORY_DETAIL_FRAGMENT = "history_detail_fragment"
     }
 
+    private var binding: HistoryDetailActivityBinding? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.history_detail_activity)
+        with(HistoryDetailActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            binding = this
 
-        setSupportActionBar(toolbar_main)
+            setSupportActionBar(toolbarMain)
+        }
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         val extras = requireNotNull(intent.extras)
@@ -47,5 +52,10 @@ class HistoryDetailActivity : LocaleAwareActivity() {
     override fun onBackPressed() {
         AnalyticsTracker.track(Stat.REVISIONS_DETAIL_CANCELLED)
         super.onBackPressed()
+    }
+
+    override fun onDestroy() {
+        binding = null
+        super.onDestroy()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/BlockLayoutPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/BlockLayoutPreviewFragment.kt
@@ -3,8 +3,8 @@ package org.wordpress.android.ui.mlp
 import android.content.Context
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
 import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.synthetic.main.layout_picker_preview_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.layoutpicker.LayoutPreviewFragment
@@ -27,7 +27,7 @@ class BlockLayoutPreviewFragment : LayoutPreviewFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        chooseButton.setText(R.string.mlp_create_page)
+        (view.findViewById(R.id.chooseButton) as Button).setText(R.string.mlp_create_page)
 
         viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(ModalLayoutPickerViewModel::class.java)
         setViewModel(viewModel)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
@@ -2,18 +2,16 @@ package org.wordpress.android.ui.pages
 
 import android.os.Bundle
 import android.os.Parcelable
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.pages_list_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.PagesListFragmentBinding
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.viewmodel.pages.PagesViewModel
@@ -21,7 +19,7 @@ import org.wordpress.android.viewmodel.pages.SearchListViewModel
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
 
-class SearchListFragment : Fragment() {
+class SearchListFragment : Fragment(R.layout.pages_list_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: SearchListViewModel
     private var linearLayoutManager: LinearLayoutManager? = null
@@ -35,18 +33,16 @@ class SearchListFragment : Fragment() {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.pages_list_fragment, container, false)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val nonNullActivity = requireActivity()
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
 
-        initializeViews(savedInstanceState)
-        initializeViewModels(nonNullActivity)
+        with(PagesListFragmentBinding.bind(view)) {
+            initializeViews(savedInstanceState)
+            initializeViewModels(nonNullActivity)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -56,16 +52,16 @@ class SearchListFragment : Fragment() {
         super.onSaveInstanceState(outState)
     }
 
-    private fun initializeViewModels(activity: FragmentActivity) {
+    private fun PagesListFragmentBinding.initializeViewModels(activity: FragmentActivity) {
         val pagesViewModel = ViewModelProvider(activity, viewModelFactory).get(PagesViewModel::class.java)
 
-        viewModel = ViewModelProvider(this, viewModelFactory).get(SearchListViewModel::class.java)
+        viewModel = ViewModelProvider(this@SearchListFragment, viewModelFactory).get(SearchListViewModel::class.java)
         viewModel.start(pagesViewModel)
 
         setupObservers()
     }
 
-    private fun initializeViews(savedInstanceState: Bundle?) {
+    private fun PagesListFragmentBinding.initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
         savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
@@ -77,13 +73,13 @@ class SearchListFragment : Fragment() {
         recyclerView.id = R.id.pages_search_recycler_view_id
     }
 
-    private fun setupObservers() {
+    private fun PagesListFragmentBinding.setupObservers() {
         viewModel.searchResult.observe(viewLifecycleOwner, Observer { data ->
             data?.let { setSearchResult(data) }
         })
     }
 
-    private fun setSearchResult(pages: List<PageItem>) {
+    private fun PagesListFragmentBinding.setSearchResult(pages: List<PageItem>) {
         val adapter: PageSearchAdapter
         if (recyclerView.adapter == null) {
             adapter = PageSearchAdapter(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/DesignPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/DesignPreviewFragment.kt
@@ -3,8 +3,8 @@ package org.wordpress.android.ui.sitecreation.theme
 import android.content.Context
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
 import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.synthetic.main.layout_picker_preview_fragment.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.layoutpicker.LayoutPreviewFragment
@@ -26,7 +26,7 @@ class DesignPreviewFragment : LayoutPreviewFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        chooseButton.setText(R.string.hpp_choose_button)
+        (view.findViewById(R.id.chooseButton) as Button).setText(R.string.hpp_choose_button)
 
         viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(HomePagePickerViewModel::class.java)
         setViewModel(viewModel)

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
@@ -35,8 +35,10 @@ class SuggestionActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
-        binding = SuggestUsersActivityBinding.inflate(layoutInflater)
-        setContentView(binding.root)
+        with(SuggestUsersActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            binding = this
+        }
 
         val siteModel = intent.getSerializableExtra(INTENT_KEY_SITE_MODEL) as? SiteModel
         val suggestionType = intent.getSerializableExtra(INTENT_KEY_SUGGESTION_TYPE) as? SuggestionType

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
@@ -9,11 +9,11 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
-import kotlinx.android.synthetic.main.suggest_users_activity.*
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.SuggestUsersActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.networking.ConnectionChangeReceiver.ConnectionChangeEvent
 import org.wordpress.android.ui.LocaleAwareActivity
@@ -30,11 +30,13 @@ class SuggestionActivity : LocaleAwareActivity() {
     private var suggestionAdapter: SuggestionAdapter? = null
     private var siteId: Long? = null
     @Inject lateinit var viewModel: SuggestionViewModel
+    private lateinit var binding: SuggestUsersActivityBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
-        setContentView(R.layout.suggest_users_activity)
+        binding = SuggestUsersActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         val siteModel = intent.getSerializableExtra(INTENT_KEY_SITE_MODEL) as? SiteModel
         val suggestionType = intent.getSerializableExtra(INTENT_KEY_SUGGESTION_TYPE) as? SuggestionType
@@ -70,12 +72,12 @@ class SuggestionActivity : LocaleAwareActivity() {
         // The previous activity is visible "behind" this Activity if the list of Suggestions does not fill
         // the entire screen. If the user taps a part of the screen showing the still-visible previous
         // Activity, then finish this Activity and return the user to the previous Activity.
-        rootView.setOnClickListener {
+        binding.rootView.setOnClickListener {
             viewModel.trackExit(false)
             finish()
         }
 
-        autocompleteText.apply {
+        binding.autocompleteText.apply {
             initializeWithPrefix(viewModel.suggestionPrefix)
             setOnItemClickListener { _, _, position, _ ->
                 val suggestionUserId = suggestionAdapter?.getItem(position)?.value
@@ -128,8 +130,8 @@ class SuggestionActivity : LocaleAwareActivity() {
                         } else if (!s.startsWith(prefix)) {
                             // Re-insert prefix if it was deleted
                             val string = "$prefix$s"
-                            autocompleteText.setText(string)
-                            autocompleteText.setSelection(1)
+                            binding.autocompleteText.setText(string)
+                            binding.autocompleteText.setSelection(1)
                             showDropDown()
                         }
                         matchesPrefixBeforeChanged = null
@@ -152,14 +154,14 @@ class SuggestionActivity : LocaleAwareActivity() {
 
             // Calling forceFiltering is needed to force the suggestions list to always
             // immediately refresh when there is new data
-            autocompleteText.forceFiltering(autocompleteText.text)
+            binding.autocompleteText.forceFiltering(binding.autocompleteText.text)
 
             // Ensure that the suggestions list is displayed wth the new data. This is particularly needed when
             // suggestion list was empty before the new data was received, otherwise the no-longer-empty
             // suggestion list will not display when it is updated. Wrapping this in the isAttachedToWindow
             // check avoids a crash if the suggestions are loaded when the view is not attached.
-            if (autocompleteText.isAttachedToWindow) {
-                autocompleteText.showDropDown()
+            if (binding.autocompleteText.isAttachedToWindow) {
+                binding.autocompleteText.showDropDown()
             }
 
             updateEmptyView()
@@ -169,7 +171,7 @@ class SuggestionActivity : LocaleAwareActivity() {
     private fun exitIfOnlyOneMatchingUser() {
         when (val finishAttempt = viewModel.onAttemptToFinish(
                 suggestionAdapter?.filteredSuggestions,
-                autocompleteText.text.toString()
+                binding.autocompleteText.text.toString()
         )) {
             is OnlyOneAvailable -> {
                 finishWithValue(finishAttempt.onlySelectedValue)
@@ -219,11 +221,11 @@ class SuggestionActivity : LocaleAwareActivity() {
             })
         }
 
-        autocompleteText.setAdapter(suggestionAdapter)
+        binding.autocompleteText.setAdapter(suggestionAdapter)
     }
 
     private fun updateEmptyView() {
-        empty_view.apply {
+        binding.emptyView.apply {
             val (newText, newVisibility) = viewModel.getEmptyViewState(suggestionAdapter?.filteredSuggestions)
             text = newText
             visibility = newVisibility
@@ -233,8 +235,8 @@ class SuggestionActivity : LocaleAwareActivity() {
     override fun onResume() {
         super.onResume()
         EventBus.getDefault().register(this)
-        if (autocompleteText.isAttachedToWindow) {
-            autocompleteText.showDropDown()
+        if (binding.autocompleteText.isAttachedToWindow) {
+            binding.autocompleteText.showDropDown()
         }
     }
 

--- a/WordPress/src/main/res/layout/jetpack_remote_install_activity.xml
+++ b/WordPress/src/main/res/layout/jetpack_remote_install_activity.xml
@@ -4,7 +4,8 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/toolbar_main" />
+    <include android:id="@+id/toolbar_layout"
+        layout="@layout/toolbar_main" />
 
     <fragment
         android:id="@+id/fragment_container"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.4.10'
+    ext.kotlinVersion = '1.4.20'
     ext.serializationVersion = '1.0-M1-1.4.0-rc'
     ext.navComponentVersion = '2.3.5'
     ext.kotlin_coroutines_version = '1.3.9'

--- a/libs/WordPressAnnotations/build.gradle
+++ b/libs/WordPressAnnotations/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    ext.kotlinVersion = '1.4.10'
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }
 


### PR DESCRIPTION
Parent #14845

This PR focusing on removing synthetic accessors in standalone WPAndroid classes. 

**WordPress-Android updates**

**Replaced synthetic accessor with viewBinding in**
- EngagedPeopleListActivity
- EngagedPeopleListFragment
- HistoryDetailActivity
- JetpackRemoteInstallActivity
- JetpackRemoteInstallFragment
- SearchListFragment
- SuggestionActivity
- UnifiedCommentsActivity

**Removed unused synthetic accessor import**
- PostSignupInterstitialActivity

--------------------
Note: The following will be created in a separate PR, but I am leaving these notes here for completeness. 
The remaining areas in WPAndroid will be a bit more complex and I did not attempt to address them today. 

These fragments use layout files which have includes within includes + ids are not set for the includes yet. This will need to change.
- ModalLayoutPickerFragment
- HomePagePickerFragment

The next two fragments extend SiteCreationBaseFormFragment and override getContentLayout. This one will take a bit more thought.
- SiteCreationDomainsFragment 
- SiteCreationPreviewFragment 

Use base fragment - needs updating
- CategoryViewHolder
- LayoutPreviewFragment
- LayoutViewHolder
- BlockLayoutPreviewFragment
- DesignPreviewFragment

I started looking into ImageEditor, had some changes, but it wouldn't build. I scrapped them and decided to focus on the easy wins in WPAndroid first. I did not attempt PhotoEditor either today.

P.S. There are a few different to implement ViewBinding, I tried to keep things consistent with the patterns already in use. I am open to changing this if we want to go a different route. Thanks. 


---------------
**To test:**
**EngagedPeopleListActivity/EngagedPeopleListFragment**
- Launch App
- Navigate to Reader
- Tap on a post that has likes
- Scroll to the bottom of the Reader detail view
- Tap on the `x bloggers like this` area
- Note the engaged people list view is shown

-------------
**HistoryDetailActivity**
- Launch App 
- Navigate to Edit Post 
- Tap the More menu
- Tap History
- Tap on a history row item
- Note the history detail view is shown

-------------
**SearchListFragment**
- Launch App
- Navigate to My Site
- Tap Site Pages
- Tap the search icon
- Search for a known page
- Clear search
- Search for gibberish
- Note that the search feature works as expected

-------------
**SuggestionActivity**
- Launch App
- Select a P2-themed site
- Navigate to New Post (use Gutenberg Editor)
- Add a paragraph block and start typing
- Enter a `@` or press the @ button on the format bar
- Observe that the suggestions UI is shown and the suggestions are loaded
- Confirm you  can select and insert a suggestion by tapping on it

-------------
**UnifiedCommentsActivity**
- Launch App
- Navigate to My Site -> Me -> App Settings
- Turn on feature flag for Unified Comments
- Restart the app
- Navigate back to My Site
- Tap on Unified Comments
- Note that the Unified Comments list view is shown

-------------
**PostSignupInterstitialActivity**
- Signup for WP using the app (Enter email address, wait for email, click on link in email, create password, tap done)
- The Post Signup Interstitial is shown (It's the view that says "Welcome to WordPress"



## Regression Notes
1. Potential unintended areas of impact
Feature areas do not work as expected 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tested each view to make sure they still work as expected
3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
