### PR TITLE
ViewBinding: Update Kotlin version to 1.4.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.4.10'
+    ext.kotlinVersion = '1.4.20'
     ext.serializationVersion = '1.0-M1-1.4.0-rc'
     ext.navComponentVersion = '2.3.5'
     ext.kotlin_coroutines_version = '1.3.9'

--- a/libs/WordPressAnnotations/build.gradle
+++ b/libs/WordPressAnnotations/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    ext.kotlinVersion = '1.4.10'
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }
 


### PR DESCRIPTION
Parent #14845

This PR updates 
- WordPress-Android to Kotlin 1.4.20
- Removes kotlin version from Wordpress-Annotations `build.gradle`

This PR is in preparation for the removal of `kotlin-android-extensions`

To test:
- Install the app
- Perform base actions
- Verify things work as expected

## Regression Notes
1. Potential unintended areas of impact 
App doesn't launch
2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing of app launch, login, and other base actions
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
