### PR TITLE
Add `CrashLoggingModule` to `AppComponentTest`

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/modules/AppComponentTest.kt
@@ -36,7 +36,8 @@ import javax.inject.Singleton
             SupportModule::class,
             ThreadModule::class,
             SuggestionSourceModule::class,
-            ExperimentModule::class
+            ExperimentModule::class,
+            CrashLoggingModule::class
         ]
 )
 interface AppComponentTest : AppComponent {


### PR DESCRIPTION
Connected tests started failing on `develop` after we merged #14833. This PR adds `CrashLoggingModule` to `AppComponentTest` in order to fix that.

To test:

Run the optional connected tests and make sure they don't fail.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
