### PR TITLE
ViewBinding: Replace Synthetic Accessors in Image Editor

### DIFF
--- a/libs/image-editor/ImageEditor/build.gradle
+++ b/libs/image-editor/ImageEditor/build.gradle
@@ -38,6 +38,10 @@ android {
             returnDefaultValues = true
         }
     }
+
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -12,7 +12,6 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.ImageView.ScaleType.CENTER
@@ -43,7 +42,7 @@ import org.wordpress.android.imageeditor.utils.ToastUtils.Duration
 import org.wordpress.android.imageeditor.utils.UiHelpers
 import java.io.File
 
-class PreviewImageFragment : Fragment() {
+class PreviewImageFragment : Fragment(R.layout.preview_image_fragment) {
     private lateinit var viewModel: PreviewImageViewModel
     private lateinit var parentViewModel: EditImageViewModel
     private lateinit var tabLayoutMediator: TabLayoutMediator
@@ -74,12 +73,6 @@ class PreviewImageFragment : Fragment() {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
     }
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? = inflater.inflate(R.layout.preview_image_fragment, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -91,9 +91,9 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment) {
 
     private fun PreviewImageFragmentBinding.initializeViewPager() {
         val previewImageAdapter = PreviewImageAdapter(
-            loadIntoImageViewWithResultListener = { imageData, imageView, position ->
-                loadIntoImageViewWithResultListener(imageData, imageView, position)
-            }
+                loadIntoImageViewWithResultListener = { imageData, imageView, position ->
+                    loadIntoImageViewWithResultListener(imageData, imageView, position)
+                }
         )
         previewImageAdapter.setHasStableIds(true)
         previewImageViewPager.adapter = previewImageAdapter
@@ -109,7 +109,7 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment) {
         val tabConfigurationStrategy = TabLayoutMediator.TabConfigurationStrategy { tab, position ->
             if (tab.customView == null) {
                 val customView = LayoutInflater.from(context)
-                    .inflate(R.layout.preview_image_thumbnail, thumbnailsTabLayout, false)
+                        .inflate(R.layout.preview_image_thumbnail, thumbnailsTabLayout, false)
                 tab.customView = customView
             }
             val imageView = (tab.customView as FrameLayout).findViewById<ImageView>(R.id.thumbnailImageView)
@@ -117,17 +117,17 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment) {
         }
 
         tabLayoutMediator = TabLayoutMediator(
-            thumbnailsTabLayout,
-            previewImageViewPager,
-            false,
-            tabConfigurationStrategy
+                thumbnailsTabLayout,
+                previewImageViewPager,
+                false,
+                tabConfigurationStrategy
         )
         tabLayoutMediator.attach()
 
         pagerAdapterObserver = PagerAdapterObserver(
-            thumbnailsTabLayout,
-            previewImageViewPager,
-            tabConfigurationStrategy
+                thumbnailsTabLayout,
+                previewImageViewPager,
+                tabConfigurationStrategy
         )
         previewImageAdapter.registerAdapterDataObserver(pagerAdapterObserver as PagerAdapterObserver)
 
@@ -219,34 +219,34 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment) {
 
     private fun loadIntoImageViewWithResultListener(imageData: ImageData, imageView: ImageView, position: Int) {
         ImageEditor.instance.loadIntoImageViewWithResultListener(
-            imageData.highResImageUrl,
-            imageView,
-            CENTER,
-            imageData.lowResImageUrl,
-            object : RequestListener<Drawable> {
-                override fun onResourceReady(resource: Drawable, url: String) {
-                    viewModel.onLoadIntoImageViewSuccess(url, position)
-                }
+                imageData.highResImageUrl,
+                imageView,
+                CENTER,
+                imageData.lowResImageUrl,
+                object : RequestListener<Drawable> {
+                    override fun onResourceReady(resource: Drawable, url: String) {
+                        viewModel.onLoadIntoImageViewSuccess(url, position)
+                    }
 
-                override fun onLoadFailed(e: Exception?, url: String) {
-                    viewModel.onLoadIntoImageViewFailed(url, position)
+                    override fun onLoadFailed(e: Exception?, url: String) {
+                        viewModel.onLoadIntoImageViewFailed(url, position)
+                    }
                 }
-            }
         )
     }
 
     private fun loadIntoFile(url: String, position: Int) {
         ImageEditor.instance.loadIntoFileWithResultListener(
-            Uri.parse(url),
-            object : RequestListener<File> {
-                override fun onResourceReady(resource: File, url: String) {
-                    viewModel.onLoadIntoFileSuccess(resource.path, position)
-                }
+                Uri.parse(url),
+                object : RequestListener<File> {
+                    override fun onResourceReady(resource: File, url: String) {
+                        viewModel.onLoadIntoFileSuccess(resource.path, position)
+                    }
 
-                override fun onLoadFailed(e: Exception?, url: String) {
-                    viewModel.onLoadIntoFileFailed(e)
+                    override fun onLoadFailed(e: Exception?, url: String) {
+                        viewModel.onLoadIntoFileFailed(e)
+                    }
                 }
-            }
         )
     }
 
@@ -270,12 +270,12 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment) {
         // https://stackoverflow.com/q/51060762/193545
         if (navController.currentDestination?.id == R.id.preview_dest) {
             navController.navigate(
-                PreviewImageFragmentDirections.actionPreviewFragmentToCropFragment(
-                    inputFilePath,
-                    outputFileExtension,
-                    shouldReturnToPreviewScreen
-                ),
-                navOptions
+                    PreviewImageFragmentDirections.actionPreviewFragmentToCropFragment(
+                            inputFilePath,
+                            outputFileExtension,
+                            shouldReturnToPreviewScreen
+                    ),
+                    navOptions
             )
         }
     }

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -17,7 +17,6 @@ import android.widget.ImageView
 import android.widget.ImageView.ScaleType.CENTER
 import android.widget.ImageView.ScaleType.CENTER_CROP
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
@@ -159,9 +158,9 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment) {
     }
 
     private fun PreviewImageFragmentBinding.setupObservers() {
-        viewModel.uiState.observe(viewLifecycleOwner, Observer { state -> updateUiState(state) })
+        viewModel.uiState.observe(viewLifecycleOwner, { state -> updateUiState(state) })
 
-        viewModel.loadIntoFile.observe(viewLifecycleOwner, Observer { fileStateEvent ->
+        viewModel.loadIntoFile.observe(viewLifecycleOwner, { fileStateEvent ->
             fileStateEvent?.getContentIfNotHandled()?.let { fileState ->
                 when (fileState) {
                     is ImageLoadToFileIdleState -> { // Do nothing
@@ -178,13 +177,13 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment) {
             }
         })
 
-        viewModel.navigateToCropScreenWithFileInfo.observe(viewLifecycleOwner, Observer { fileInfoEvent ->
+        viewModel.navigateToCropScreenWithFileInfo.observe(viewLifecycleOwner, { fileInfoEvent ->
             fileInfoEvent?.getContentIfNotHandled()?.let { fileInfo ->
                 navigateToCropScreenWithFileInfo(fileInfo)
             }
         })
 
-        parentViewModel.cropResult.observe(viewLifecycleOwner, Observer { cropResult ->
+        parentViewModel.cropResult.observe(viewLifecycleOwner, { cropResult ->
             cropResult?.getContentIfNotHandled()?.let {
                 if (it.resultCode == RESULT_OK) {
                     val data: Intent = it.data
@@ -198,7 +197,7 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment) {
             }
         })
 
-        viewModel.finishAction.observe(viewLifecycleOwner, Observer { event ->
+        viewModel.finishAction.observe(viewLifecycleOwner, { event ->
             event.getContentIfNotHandled()?.let {
                 val intent = Intent().apply { putParcelableArrayListExtra(ARG_EDIT_IMAGE_DATA, ArrayList(it)) }
                 requireActivity().setResult(RESULT_OK, intent)


### PR DESCRIPTION
Parent #14845

This PR is part of a larger effort to replace synthetic accessors within WPAndroid and is split into two parts:
- Enabled `ViewBinding` on the `image-editor` lib module.
- Update `PreviewImageFragment`.

To test:
- Launch the app.
- Navigate to `My Site` -> `Blog Posts` -> `FAB` -> `Blog post`.
- Type a `title` and some `content`.
- Click on the `+` 🔵 button on the bottom left, on top of the keyboard, to then select an `Image` block.
- Click `ADD IMAGE` -> `Choose from device` -> Select an image of your choice -> Click the `Confirm` tick on the top right of the screen.
- After the image has been loaded, click the `Media options` icon on the top right of the image -> Select `Edit`.
- The `PreviewImageFragment` edit screen should be launched.
- Note that the preview image shows as expected.

## Regression Notes
1. Potential unintended areas of impact
  - `EditImageActivity` (`image-editor` module)
  - `EditPostActivity` (`WordPress` module)
  - `MediaPickerActivity` (`WordPress` module)
  - `PhotoPickerActivity` (`WordPress` module)

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested as described above in the `To test` section.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
