### PR TITLE
Fix npe on media error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -175,9 +175,9 @@ public class UploadUtils {
         MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR, null, null);
 
         if (uploadModel != null) {
-            MediaError errorFromMediaModel = uploadModel.getMediaError();
-            if (errorFromMediaModel != null) {
-                error = errorFromMediaModel;
+            MediaError errorFromUploadModel = uploadModel.getMediaError();
+            if (errorFromUploadModel != null) {
+                error = errorFromUploadModel;
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.persistence.UploadSqlUtils;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.store.UploadStore.UploadError;
 import org.wordpress.android.fluxc.utils.MimeTypes;
@@ -171,10 +172,13 @@ public class UploadUtils {
     String getErrorMessageFromMedia(Context context, @NonNull MediaModel media) {
         MediaUploadModel uploadModel = UploadSqlUtils.getMediaUploadModelForLocalId(media.getId());
 
-        MediaError error = new MediaError(null, null, null);
+        MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR, null, null);
 
         if (uploadModel != null) {
-            error = uploadModel.getMediaError();
+            MediaError errorFromMediaModel = uploadModel.getMediaError();
+            if (errorFromMediaModel != null) {
+                error = errorFromMediaModel;
+            }
         }
 
         return getErrorMessageFromMediaError(context, media, error);


### PR DESCRIPTION
Fixes #14851 and #14852

I was able to reproduce the isse by forcing conditions by the debugger in the `getErrorMessageFromMedia` function like below.

![image](https://user-images.githubusercontent.com/47797566/122394348-293ebc80-cf76-11eb-9c64-09f33eb2187e.png)

![image](https://user-images.githubusercontent.com/47797566/122394466-4f645c80-cf76-11eb-86f2-e9820e0bea06.png)

### Reproduce 14851

- Create a new post, add a webp image from Google Photos and check the upload fail
- Enable the first breakpoint only above and connect with the debugger
- Retry the image upload in the editor and check you get the error

### Reproduce 14852

- Create a new post, add a webp image from Google Photos and check the upload fail
- Enable the first and second breakpoint above and connect with the debugger
- Retry the image upload in the editor and check you get the error

### To test
- The fix for 14851 can be tested with same steps in `Reproduce 14851` and checking you get the generic message
- The fix for 14852 is mainly adding a null check for `uploadModel.getMediaError()`. You can check that you get the generic error when forcing it to be null in the debugger like below

![image](https://user-images.githubusercontent.com/47797566/122400758-4d050100-cf7c-11eb-9000-9667d5b8b31b.png)

- Smoke test media upload without the debugger both in the editor and in the Media Upload library.

## Regression Notes
1. Potential unintended areas of impact
Showing errors on media upload failure.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + the already in place unit testing.

3. What automated tests I added (or what prevented me from doing so)
WPMediaUtils and UploadUtils are currently static classes, we should move them to be injectable.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
