### PR TITLE
ViewBinding: Replace Synthetic Accessors in Model Layout/Hope Page Picker Screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener
-import kotlinx.android.synthetic.main.modal_layout_picker_bottom_toolbar.*
 import kotlinx.android.synthetic.main.modal_layout_picker_categories_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_error.*
 import kotlinx.android.synthetic.main.modal_layout_picker_layouts_skeleton.*
@@ -84,16 +83,16 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
                 closeModal()
             }
 
-            createBlankPageButton.setOnClickListener {
+            modalLayoutPickerBottomToolbar.createBlankPageButton.setOnClickListener {
                 viewModel.onCreatePageClicked()
             }
-            createPageButton.setOnClickListener {
+            modalLayoutPickerBottomToolbar.createPageButton.setOnClickListener {
                 viewModel.onCreatePageClicked()
             }
-            previewButton.setOnClickListener {
+            modalLayoutPickerBottomToolbar.previewButton.setOnClickListener {
                 viewModel.onPreviewTapped()
             }
-            retryButton.setOnClickListener {
+            modalLayoutPickerBottomToolbar.retryButton.setOnClickListener {
                 viewModel.onRetryClicked()
             }
             previewTypeSelectorButton.setOnClickListener {
@@ -177,11 +176,11 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
     }
 
     private fun ModalLayoutPickerFragmentBinding.setButtonsVisibility(uiState: ButtonsUiState) {
-        createBlankPageButton.setVisible(uiState.createBlankPageVisible)
-        createPageButton.setVisible(uiState.createPageVisible)
-        previewButton.setVisible(uiState.previewVisible)
-        retryButton.setVisible(uiState.retryVisible)
-        createOrRetryContainer.setVisible(uiState.createBlankPageVisible || uiState.retryVisible)
+        modalLayoutPickerBottomToolbar.createBlankPageButton.setVisible(uiState.createBlankPageVisible)
+        modalLayoutPickerBottomToolbar.createPageButton.setVisible(uiState.createPageVisible)
+        modalLayoutPickerBottomToolbar.previewButton.setVisible(uiState.previewVisible)
+        modalLayoutPickerBottomToolbar.retryButton.setVisible(uiState.retryVisible)
+        modalLayoutPickerBottomToolbar.createOrRetryContainer.setVisible(uiState.createBlankPageVisible || uiState.retryVisible)
     }
 
     private fun ModalLayoutPickerFragmentBinding.setContentVisibility(skeleton: Boolean, error: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -10,8 +10,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener
-import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
-import kotlinx.android.synthetic.main.modal_layout_picker_title_row.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ModalLayoutPickerFragmentBinding
@@ -165,7 +163,7 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
     private fun ModalLayoutPickerFragmentBinding.setHeaderVisibility(visible: Boolean) {
         uiHelper.fadeInfadeOutViews(
                 modalLayoutPickerTitlebar.title,
-                header,
+                modalLayoutPickerHeaderSection.modalLayoutPickerTitleRow?.header,
                 visible
         )
     }
@@ -175,7 +173,8 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
      * @param visible if true the description is visible else invisible
      */
     private fun ModalLayoutPickerFragmentBinding.setDescriptionVisibility(visible: Boolean) {
-        description?.visibility = if (visible) View.VISIBLE else View.INVISIBLE
+        modalLayoutPickerHeaderSection.modalLayoutPickerSubtitleRow?.description?.visibility =
+                if (visible) View.VISIBLE else View.INVISIBLE
     }
 
     private fun ModalLayoutPickerFragmentBinding.setButtonsVisibility(uiState: ButtonsUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -121,7 +121,7 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
         viewModel.loadSavedState(savedInstanceState)
 
         viewModel.uiState.observe(this, { uiState ->
-            uiHelper.fadeInfadeOutViews(title, header, uiState.isHeaderVisible)
+            setHeaderVisibility(uiState.isHeaderVisible)
             setDescriptionVisibility(uiState.isDescriptionVisible)
             setButtonsVisibility(uiState.buttonsUiState)
             setContentVisibility(uiState.loadingSkeletonVisible, uiState.errorViewVisible)
@@ -160,6 +160,10 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
         viewModel.onCategorySelectionChanged.observeEvent(this, {
             layoutsRecyclerView?.smoothScrollToPosition(0)
         })
+    }
+
+    private fun setHeaderVisibility(visible: Boolean) {
+        uiHelper.fadeInfadeOutViews(title, header, visible)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -13,13 +13,13 @@ import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener
 import kotlinx.android.synthetic.main.modal_layout_picker_bottom_toolbar.*
 import kotlinx.android.synthetic.main.modal_layout_picker_categories_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_error.*
-import kotlinx.android.synthetic.main.modal_layout_picker_fragment.*
 import kotlinx.android.synthetic.main.modal_layout_picker_layouts_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
 import kotlinx.android.synthetic.main.modal_layout_picker_title_row.*
 import kotlinx.android.synthetic.main.modal_layout_picker_titlebar.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.ModalLayoutPickerFragmentBinding
 import org.wordpress.android.ui.FullscreenBottomSheetDialogFragment
 import org.wordpress.android.ui.PreviewModeSelectorPopup
 import org.wordpress.android.ui.layoutpicker.ButtonsUiState
@@ -63,50 +63,52 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        categoriesRecyclerView.apply {
-            layoutManager = LinearLayoutManager(
-                    context,
-                    RecyclerView.HORIZONTAL,
-                    false
-            )
-            setRecycledViewPool(RecyclerView.RecycledViewPool())
-            adapter = CategoriesAdapter()
-            ViewCompat.setNestedScrollingEnabled(this, false)
-        }
+        with(ModalLayoutPickerFragmentBinding.bind(view)) {
+            categoriesRecyclerView.apply {
+                layoutManager = LinearLayoutManager(
+                        context,
+                        RecyclerView.HORIZONTAL,
+                        false
+                )
+                setRecycledViewPool(RecyclerView.RecycledViewPool())
+                adapter = CategoriesAdapter()
+                ViewCompat.setNestedScrollingEnabled(this, false)
+            }
 
-        layoutsRecyclerView.apply {
-            layoutManager = LinearLayoutManager(requireActivity())
-            adapter = LayoutCategoryAdapter()
-        }
+            layoutsRecyclerView.apply {
+                layoutManager = LinearLayoutManager(requireActivity())
+                adapter = LayoutCategoryAdapter()
+            }
 
-        backButton.setOnClickListener {
-            closeModal()
-        }
+            backButton.setOnClickListener {
+                closeModal()
+            }
 
-        createBlankPageButton.setOnClickListener {
-            viewModel.onCreatePageClicked()
-        }
-        createPageButton.setOnClickListener {
-            viewModel.onCreatePageClicked()
-        }
-        previewButton.setOnClickListener {
-            viewModel.onPreviewTapped()
-        }
-        retryButton.setOnClickListener {
-            viewModel.onRetryClicked()
-        }
-        previewTypeSelectorButton.setOnClickListener {
-            viewModel.onThumbnailModePressed()
-        }
+            createBlankPageButton.setOnClickListener {
+                viewModel.onCreatePageClicked()
+            }
+            createPageButton.setOnClickListener {
+                viewModel.onCreatePageClicked()
+            }
+            previewButton.setOnClickListener {
+                viewModel.onPreviewTapped()
+            }
+            retryButton.setOnClickListener {
+                viewModel.onRetryClicked()
+            }
+            previewTypeSelectorButton.setOnClickListener {
+                viewModel.onThumbnailModePressed()
+            }
 
-        setScrollListener()
+            setScrollListener()
 
-        setupViewModel(savedInstanceState)
+            setupViewModel(savedInstanceState)
 
-        previewModeSelectorPopup = PreviewModeSelectorPopup(requireActivity(), previewTypeSelectorButton)
+            previewModeSelectorPopup = PreviewModeSelectorPopup(requireActivity(), previewTypeSelectorButton)
+        }
     }
 
-    private fun setScrollListener() {
+    private fun ModalLayoutPickerFragmentBinding.setScrollListener() {
         if (DisplayUtils.isLandscape(requireContext())) return // Always visible
         val scrollThreshold = resources.getDimension(R.dimen.picker_header_scroll_snap_threshold).toInt()
         appBarLayout.addOnOffsetChangedListener(OnOffsetChangedListener { _, verticalOffset ->
@@ -114,13 +116,13 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
         })
     }
 
-    private fun setupViewModel(savedInstanceState: Bundle?) {
+    private fun ModalLayoutPickerFragmentBinding.setupViewModel(savedInstanceState: Bundle?) {
         viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(ModalLayoutPickerViewModel::class.java)
 
         viewModel.loadSavedState(savedInstanceState)
 
-        viewModel.uiState.observe(this, { uiState ->
+        viewModel.uiState.observe(this@ModalLayoutPickerFragment, { uiState ->
             setHeaderVisibility(uiState.isHeaderVisible)
             setDescriptionVisibility(uiState.isDescriptionVisible)
             setButtonsVisibility(uiState.buttonsUiState)
@@ -130,7 +132,7 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
                 }
                 is Content -> {
                     (categoriesRecyclerView.adapter as CategoriesAdapter).setData(uiState.categories)
-                    (layoutsRecyclerView?.adapter as? LayoutCategoryAdapter)?.update(uiState.layoutCategories)
+                    (layoutsRecyclerView.adapter as? LayoutCategoryAdapter)?.update(uiState.layoutCategories)
                 }
                 is Error -> {
                     uiState.title?.let { actionableEmptyView.title.setText(it) }
@@ -157,12 +159,12 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
             }
         })
 
-        viewModel.onCategorySelectionChanged.observeEvent(this, {
-            layoutsRecyclerView?.smoothScrollToPosition(0)
+        viewModel.onCategorySelectionChanged.observeEvent(this@ModalLayoutPickerFragment, {
+            layoutsRecyclerView.smoothScrollToPosition(0)
         })
     }
 
-    private fun setHeaderVisibility(visible: Boolean) {
+    private fun ModalLayoutPickerFragmentBinding.setHeaderVisibility(visible: Boolean) {
         uiHelper.fadeInfadeOutViews(title, header, visible)
     }
 
@@ -170,11 +172,11 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
      * Sets the header description visibility
      * @param visible if true the description is visible else invisible
      */
-    private fun setDescriptionVisibility(visible: Boolean) {
+    private fun ModalLayoutPickerFragmentBinding.setDescriptionVisibility(visible: Boolean) {
         description?.visibility = if (visible) View.VISIBLE else View.INVISIBLE
     }
 
-    private fun setButtonsVisibility(uiState: ButtonsUiState) {
+    private fun ModalLayoutPickerFragmentBinding.setButtonsVisibility(uiState: ButtonsUiState) {
         createBlankPageButton.setVisible(uiState.createBlankPageVisible)
         createPageButton.setVisible(uiState.createPageVisible)
         previewButton.setVisible(uiState.previewVisible)
@@ -182,7 +184,7 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
         createOrRetryContainer.setVisible(uiState.createBlankPageVisible || uiState.retryVisible)
     }
 
-    private fun setContentVisibility(skeleton: Boolean, error: Boolean) {
+    private fun ModalLayoutPickerFragmentBinding.setContentVisibility(skeleton: Boolean, error: Boolean) {
         categoriesSkeleton.setVisible(skeleton)
         categoriesRecyclerView.setVisible(!skeleton && !error)
         layoutsSkeleton.setVisible(skeleton)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -34,6 +34,7 @@ import javax.inject.Inject
 /**
  * Implements the Modal Layout Picker UI
  */
+@Suppress("TooManyFunctions")
 class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
     @Inject internal lateinit var uiHelper: UiHelpers
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener
-import kotlinx.android.synthetic.main.modal_layout_picker_error.*
 import kotlinx.android.synthetic.main.modal_layout_picker_layouts_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
 import kotlinx.android.synthetic.main.modal_layout_picker_title_row.*
@@ -133,8 +132,8 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
                     (layoutsRecyclerView.adapter as? LayoutCategoryAdapter)?.update(uiState.layoutCategories)
                 }
                 is Error -> {
-                    uiState.title?.let { actionableEmptyView.title.setText(it) }
-                    uiState.subtitle?.let { actionableEmptyView.subtitle.setText(it) }
+                    uiState.title?.let { modalLayoutPickerError.actionableEmptyView.title.setText(it) }
+                    uiState.subtitle?.let { modalLayoutPickerError.actionableEmptyView.subtitle.setText(it) }
                 }
             }
         })
@@ -187,7 +186,7 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
         categoriesRecyclerView.setVisible(!skeleton && !error)
         layoutsSkeleton.setVisible(skeleton)
         layoutsRecyclerView.setVisible(!skeleton && !error)
-        errorLayout.setVisible(error)
+        modalLayoutPickerError.errorLayout.setVisible(error)
     }
 
     override fun closeModal() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -12,7 +12,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener
 import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
 import kotlinx.android.synthetic.main.modal_layout_picker_title_row.*
-import kotlinx.android.synthetic.main.modal_layout_picker_titlebar.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ModalLayoutPickerFragmentBinding
@@ -76,7 +75,7 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
                 adapter = LayoutCategoryAdapter()
             }
 
-            backButton.setOnClickListener {
+            modalLayoutPickerTitlebar.backButton.setOnClickListener {
                 closeModal()
             }
 
@@ -92,7 +91,7 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
             modalLayoutPickerBottomToolbar.retryButton.setOnClickListener {
                 viewModel.onRetryClicked()
             }
-            previewTypeSelectorButton.setOnClickListener {
+            modalLayoutPickerTitlebar.previewTypeSelectorButton.setOnClickListener {
                 viewModel.onThumbnailModePressed()
             }
 
@@ -100,7 +99,10 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
 
             setupViewModel(savedInstanceState)
 
-            previewModeSelectorPopup = PreviewModeSelectorPopup(requireActivity(), previewTypeSelectorButton)
+            previewModeSelectorPopup = PreviewModeSelectorPopup(
+                    requireActivity(),
+                    modalLayoutPickerTitlebar.previewTypeSelectorButton
+            )
         }
     }
 
@@ -161,7 +163,11 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
     }
 
     private fun ModalLayoutPickerFragmentBinding.setHeaderVisibility(visible: Boolean) {
-        uiHelper.fadeInfadeOutViews(title, header, visible)
+        uiHelper.fadeInfadeOutViews(
+                modalLayoutPickerTitlebar.title,
+                header,
+                visible
+        )
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -183,7 +183,9 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
         modalLayoutPickerBottomToolbar.createPageButton.setVisible(uiState.createPageVisible)
         modalLayoutPickerBottomToolbar.previewButton.setVisible(uiState.previewVisible)
         modalLayoutPickerBottomToolbar.retryButton.setVisible(uiState.retryVisible)
-        modalLayoutPickerBottomToolbar.createOrRetryContainer.setVisible(uiState.createBlankPageVisible || uiState.retryVisible)
+        modalLayoutPickerBottomToolbar.createOrRetryContainer.setVisible(
+                uiState.createBlankPageVisible || uiState.retryVisible
+        )
     }
 
     private fun ModalLayoutPickerFragmentBinding.setContentVisibility(skeleton: Boolean, error: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -28,13 +28,13 @@ import org.wordpress.android.ui.layoutpicker.LayoutCategoryAdapter
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Content
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Error
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Loading
+import org.wordpress.android.ui.layoutpicker.LayoutPickerViewModel.DesignPreviewAction.Dismiss
+import org.wordpress.android.ui.layoutpicker.LayoutPickerViewModel.DesignPreviewAction.Show
+import org.wordpress.android.ui.mlp.BlockLayoutPreviewFragment.Companion.BLOCK_LAYOUT_PREVIEW_TAG
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.setVisible
 import org.wordpress.android.viewmodel.mlp.ModalLayoutPickerViewModel
-import org.wordpress.android.ui.layoutpicker.LayoutPickerViewModel.DesignPreviewAction.Dismiss
-import org.wordpress.android.ui.layoutpicker.LayoutPickerViewModel.DesignPreviewAction.Show
-import org.wordpress.android.ui.mlp.BlockLayoutPreviewFragment.Companion.BLOCK_LAYOUT_PREVIEW_TAG
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -47,8 +47,9 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
     private lateinit var viewModel: ModalLayoutPickerViewModel
     private lateinit var previewModeSelectorPopup: PreviewModeSelectorPopup
 
-    companion object {
-        const val MODAL_LAYOUT_PICKER_TAG = "MODAL_LAYOUT_PICKER_TAG"
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
     }
 
     override fun onCreateView(
@@ -113,28 +114,6 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
         })
     }
 
-    /**
-     * Sets the header description visibility
-     * @param visible if true the description is visible else invisible
-     */
-    private fun setDescriptionVisibility(visible: Boolean) {
-        description?.visibility = if (visible) View.VISIBLE else View.INVISIBLE
-    }
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        (requireActivity().applicationContext as WordPress).component().inject(this)
-    }
-
-    override fun closeModal() {
-        viewModel.dismiss()
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        viewModel.writeToBundle(outState)
-    }
-
     private fun setupViewModel(savedInstanceState: Bundle?) {
         viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(ModalLayoutPickerViewModel::class.java)
@@ -183,12 +162,12 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
         })
     }
 
-    private fun setContentVisibility(skeleton: Boolean, error: Boolean) {
-        categoriesSkeleton.setVisible(skeleton)
-        categoriesRecyclerView.setVisible(!skeleton && !error)
-        layoutsSkeleton.setVisible(skeleton)
-        layoutsRecyclerView.setVisible(!skeleton && !error)
-        errorLayout.setVisible(error)
+    /**
+     * Sets the header description visibility
+     * @param visible if true the description is visible else invisible
+     */
+    private fun setDescriptionVisibility(visible: Boolean) {
+        description?.visibility = if (visible) View.VISIBLE else View.INVISIBLE
     }
 
     private fun setButtonsVisibility(uiState: ButtonsUiState) {
@@ -197,5 +176,26 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
         previewButton.setVisible(uiState.previewVisible)
         retryButton.setVisible(uiState.retryVisible)
         createOrRetryContainer.setVisible(uiState.createBlankPageVisible || uiState.retryVisible)
+    }
+
+    private fun setContentVisibility(skeleton: Boolean, error: Boolean) {
+        categoriesSkeleton.setVisible(skeleton)
+        categoriesRecyclerView.setVisible(!skeleton && !error)
+        layoutsSkeleton.setVisible(skeleton)
+        layoutsRecyclerView.setVisible(!skeleton && !error)
+        errorLayout.setVisible(error)
+    }
+
+    override fun closeModal() {
+        viewModel.dismiss()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        viewModel.writeToBundle(outState)
+    }
+
+    companion object {
+        const val MODAL_LAYOUT_PICKER_TAG = "MODAL_LAYOUT_PICKER_TAG"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener
-import kotlinx.android.synthetic.main.modal_layout_picker_layouts_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
 import kotlinx.android.synthetic.main.modal_layout_picker_title_row.*
 import kotlinx.android.synthetic.main.modal_layout_picker_titlebar.*
@@ -184,7 +183,7 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
     private fun ModalLayoutPickerFragmentBinding.setContentVisibility(skeleton: Boolean, error: Boolean) {
         modalLayoutPickerCategoriesSkeleton.categoriesSkeleton.setVisible(skeleton)
         categoriesRecyclerView.setVisible(!skeleton && !error)
-        layoutsSkeleton.setVisible(skeleton)
+        modalLayoutPickerLayoutsSkeleton.layoutsSkeleton.setVisible(skeleton)
         layoutsRecyclerView.setVisible(!skeleton && !error)
         modalLayoutPickerError.errorLayout.setVisible(error)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mlp/ModalLayoutPickerFragment.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout.OnOffsetChangedListener
-import kotlinx.android.synthetic.main.modal_layout_picker_categories_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_error.*
 import kotlinx.android.synthetic.main.modal_layout_picker_layouts_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
@@ -184,7 +183,7 @@ class ModalLayoutPickerFragment : FullscreenBottomSheetDialogFragment() {
     }
 
     private fun ModalLayoutPickerFragmentBinding.setContentVisibility(skeleton: Boolean, error: Boolean) {
-        categoriesSkeleton.setVisible(skeleton)
+        modalLayoutPickerCategoriesSkeleton.categoriesSkeleton.setVisible(skeleton)
         categoriesRecyclerView.setVisible(!skeleton && !error)
         layoutsSkeleton.setVisible(skeleton)
         layoutsRecyclerView.setVisible(!skeleton && !error)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout
-import kotlinx.android.synthetic.main.home_page_picker_titlebar.*
 import kotlinx.android.synthetic.main.modal_layout_picker_categories_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_layouts_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
@@ -82,12 +81,15 @@ class HomePagePickerFragment : Fragment() {
             setupUi()
             setupViewModel()
             setupActionListeners()
-            previewModeSelectorPopup = PreviewModeSelectorPopup(requireActivity(), previewTypeSelectorButton)
+            previewModeSelectorPopup = PreviewModeSelectorPopup(
+                    requireActivity(),
+                    homePagePickerTitlebar.previewTypeSelectorButton
+            )
         }
     }
 
     private fun HomePagePickerFragmentBinding.setupUi() {
-        title?.visibility = if (isPhoneLandscape()) View.VISIBLE else View.INVISIBLE
+        homePagePickerTitlebar.title.visibility = if (isPhoneLandscape()) View.VISIBLE else View.INVISIBLE
         header?.setText(R.string.hpp_title)
         description?.setText(R.string.hpp_subtitle)
     }
@@ -140,7 +142,11 @@ class HomePagePickerFragment : Fragment() {
     }
 
     private fun HomePagePickerFragmentBinding.setHeaderVisibility(visible: Boolean) {
-        uiHelper.fadeInfadeOutViews(title, header, visible)
+        uiHelper.fadeInfadeOutViews(
+                homePagePickerTitlebar.title,
+                header,
+                visible
+        )
     }
 
     private fun HomePagePickerFragmentBinding.setDescriptionVisibility(visible: Boolean) {
@@ -162,10 +168,10 @@ class HomePagePickerFragment : Fragment() {
     private fun HomePagePickerFragmentBinding.setupActionListeners() {
         homePagePickerBottomToolbar.previewButton.setOnClickListener { viewModel.onPreviewTapped() }
         homePagePickerBottomToolbar.chooseButton.setOnClickListener { viewModel.onChooseTapped() }
-        skipButton.setOnClickListener { viewModel.onSkippedTapped() }
+        homePagePickerTitlebar.skipButton.setOnClickListener { viewModel.onSkippedTapped() }
         errorView.button.setOnClickListener { viewModel.onRetryClicked() }
-        backButton.setOnClickListener { viewModel.onBackPressed() }
-        previewTypeSelectorButton.setOnClickListener { viewModel.onThumbnailModePressed() }
+        homePagePickerTitlebar.backButton.setOnClickListener { viewModel.onBackPressed() }
+        homePagePickerTitlebar.previewTypeSelectorButton.setOnClickListener { viewModel.onThumbnailModePressed() }
         setScrollListener()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -99,7 +99,7 @@ class HomePagePickerFragment : Fragment() {
             setHeaderVisibility(uiState.isHeaderVisible)
             setDescriptionVisibility(uiState.isDescriptionVisible)
             setContentVisibility(uiState.loadingSkeletonVisible, uiState.errorViewVisible)
-            AniUtils.animateBottomBar(bottomToolbar, uiState.isToolbarVisible)
+            setToolbarVisibility(uiState.isToolbarVisible)
             when (uiState) {
                 is LayoutPickerUiState.Loading -> { // Nothing more to do here
                 }
@@ -152,6 +152,10 @@ class HomePagePickerFragment : Fragment() {
         layoutsSkeleton.setVisible(skeleton)
         layoutsRecyclerView.setVisible(!skeleton && !error)
         errorView.setVisible(error)
+    }
+
+    private fun setToolbarVisibility(visible: Boolean) {
+        AniUtils.animateBottomBar(bottomToolbar, visible)
     }
 
     private fun setupActionListeners() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -33,6 +33,7 @@ import javax.inject.Inject
 /**
  * Implements the Home Page Picker UI
  */
+@Suppress("TooManyFunctions")
 class HomePagePickerFragment : Fragment() {
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var displayUtils: DisplayUtilsWrapper

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -12,7 +12,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout
 import kotlinx.android.synthetic.main.home_page_picker_bottom_toolbar.*
-import kotlinx.android.synthetic.main.home_page_picker_fragment.*
 import kotlinx.android.synthetic.main.home_page_picker_titlebar.*
 import kotlinx.android.synthetic.main.modal_layout_picker_categories_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_layouts_skeleton.*
@@ -20,6 +19,7 @@ import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
 import kotlinx.android.synthetic.main.modal_layout_picker_title_row.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.HomePagePickerFragmentBinding
 import org.wordpress.android.ui.PreviewModeSelectorPopup
 import org.wordpress.android.ui.layoutpicker.CategoriesAdapter
 import org.wordpress.android.ui.layoutpicker.LayoutCategoryAdapter
@@ -63,35 +63,37 @@ class HomePagePickerFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        categoriesRecyclerView.apply {
-            layoutManager = LinearLayoutManager(
-                    context,
-                    RecyclerView.HORIZONTAL,
-                    false
-            )
-            setRecycledViewPool(RecyclerView.RecycledViewPool())
-            adapter = CategoriesAdapter()
-            ViewCompat.setNestedScrollingEnabled(this, false)
-        }
+        with(HomePagePickerFragmentBinding.bind(view)) {
+            categoriesRecyclerView.apply {
+                layoutManager = LinearLayoutManager(
+                        context,
+                        RecyclerView.HORIZONTAL,
+                        false
+                )
+                setRecycledViewPool(RecyclerView.RecycledViewPool())
+                adapter = CategoriesAdapter()
+                ViewCompat.setNestedScrollingEnabled(this, false)
+            }
 
-        layoutsRecyclerView.apply {
-            layoutManager = LinearLayoutManager(requireActivity())
-            adapter = LayoutCategoryAdapter()
-        }
+            layoutsRecyclerView.apply {
+                layoutManager = LinearLayoutManager(requireActivity())
+                adapter = LayoutCategoryAdapter()
+            }
 
-        setupUi()
-        setupViewModel()
-        setupActionListeners()
-        previewModeSelectorPopup = PreviewModeSelectorPopup(requireActivity(), previewTypeSelectorButton)
+            setupUi()
+            setupViewModel()
+            setupActionListeners()
+            previewModeSelectorPopup = PreviewModeSelectorPopup(requireActivity(), previewTypeSelectorButton)
+        }
     }
 
-    private fun setupUi() {
+    private fun HomePagePickerFragmentBinding.setupUi() {
         title?.visibility = if (isPhoneLandscape()) View.VISIBLE else View.INVISIBLE
         header?.setText(R.string.hpp_title)
         description?.setText(R.string.hpp_subtitle)
     }
 
-    private fun setupViewModel() {
+    private fun HomePagePickerFragmentBinding.setupViewModel() {
         viewModel = ViewModelProvider(requireActivity(), viewModelFactory)
                 .get(HomePagePickerViewModel::class.java)
 
@@ -105,7 +107,7 @@ class HomePagePickerFragment : Fragment() {
                 }
                 is LayoutPickerUiState.Content -> {
                     (categoriesRecyclerView.adapter as CategoriesAdapter).setData(uiState.categories)
-                    (layoutsRecyclerView?.adapter as? LayoutCategoryAdapter)?.update(uiState.layoutCategories)
+                    (layoutsRecyclerView.adapter as? LayoutCategoryAdapter)?.update(uiState.layoutCategories)
                 }
                 is LayoutPickerUiState.Error -> {
                     uiState.toast?.let { ToastUtils.showToast(requireContext(), it) }
@@ -132,21 +134,21 @@ class HomePagePickerFragment : Fragment() {
         })
 
         viewModel.onCategorySelectionChanged.observeEvent(viewLifecycleOwner, {
-            layoutsRecyclerView?.smoothScrollToPosition(0)
+            layoutsRecyclerView.smoothScrollToPosition(0)
         })
 
         viewModel.start(displayUtils.isTablet())
     }
 
-    private fun setHeaderVisibility(visible: Boolean) {
+    private fun HomePagePickerFragmentBinding.setHeaderVisibility(visible: Boolean) {
         uiHelper.fadeInfadeOutViews(title, header, visible)
     }
 
-    private fun setDescriptionVisibility(visible: Boolean) {
+    private fun HomePagePickerFragmentBinding.setDescriptionVisibility(visible: Boolean) {
         description?.visibility = if (visible) View.VISIBLE else View.INVISIBLE
     }
 
-    private fun setContentVisibility(skeleton: Boolean, error: Boolean) {
+    private fun HomePagePickerFragmentBinding.setContentVisibility(skeleton: Boolean, error: Boolean) {
         categoriesSkeleton.setVisible(skeleton)
         categoriesRecyclerView.setVisible(!skeleton && !error)
         layoutsSkeleton.setVisible(skeleton)
@@ -154,11 +156,11 @@ class HomePagePickerFragment : Fragment() {
         errorView.setVisible(error)
     }
 
-    private fun setToolbarVisibility(visible: Boolean) {
+    private fun HomePagePickerFragmentBinding.setToolbarVisibility(visible: Boolean) {
         AniUtils.animateBottomBar(bottomToolbar, visible)
     }
 
-    private fun setupActionListeners() {
+    private fun HomePagePickerFragmentBinding.setupActionListeners() {
         previewButton.setOnClickListener { viewModel.onPreviewTapped() }
         chooseButton.setOnClickListener { viewModel.onChooseTapped() }
         skipButton.setOnClickListener { viewModel.onSkippedTapped() }
@@ -168,7 +170,7 @@ class HomePagePickerFragment : Fragment() {
         setScrollListener()
     }
 
-    private fun setScrollListener() {
+    private fun HomePagePickerFragmentBinding.setScrollListener() {
         if (isPhoneLandscape()) return // Always visible
         val scrollThreshold = resources.getDimension(R.dimen.picker_header_scroll_snap_threshold).toInt()
         appBarLayout.addOnOffsetChangedListener(AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -24,9 +24,9 @@ import org.wordpress.android.ui.PreviewModeSelectorPopup
 import org.wordpress.android.ui.layoutpicker.CategoriesAdapter
 import org.wordpress.android.ui.layoutpicker.LayoutCategoryAdapter
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState
-import org.wordpress.android.ui.sitecreation.theme.DesignPreviewFragment.Companion.DESIGN_PREVIEW_TAG
 import org.wordpress.android.ui.layoutpicker.LayoutPickerViewModel.DesignPreviewAction.Dismiss
 import org.wordpress.android.ui.layoutpicker.LayoutPickerViewModel.DesignPreviewAction.Show
+import org.wordpress.android.ui.sitecreation.theme.DesignPreviewFragment.Companion.DESIGN_PREVIEW_TAG
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.DisplayUtilsWrapper
@@ -46,6 +46,11 @@ class HomePagePickerFragment : Fragment() {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: HomePagePickerViewModel
     private lateinit var previewModeSelectorPopup: PreviewModeSelectorPopup
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        (requireActivity().applicationContext as WordPress).component().inject(this)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -80,17 +85,10 @@ class HomePagePickerFragment : Fragment() {
         previewModeSelectorPopup = PreviewModeSelectorPopup(requireActivity(), previewTypeSelectorButton)
     }
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        (requireActivity().applicationContext as WordPress).component().inject(this)
-    }
-
-    private fun setContentVisibility(skeleton: Boolean, error: Boolean) {
-        categoriesSkeleton.setVisible(skeleton)
-        categoriesRecyclerView.setVisible(!skeleton && !error)
-        layoutsSkeleton.setVisible(skeleton)
-        layoutsRecyclerView.setVisible(!skeleton && !error)
-        errorView.setVisible(error)
+    private fun setupUi() {
+        title?.visibility = if (isPhoneLandscape()) View.VISIBLE else View.INVISIBLE
+        header?.setText(R.string.hpp_title)
+        description?.setText(R.string.hpp_subtitle)
     }
 
     private fun setupViewModel() {
@@ -134,16 +132,18 @@ class HomePagePickerFragment : Fragment() {
         })
 
         viewModel.onCategorySelectionChanged.observeEvent(viewLifecycleOwner, {
-                layoutsRecyclerView?.smoothScrollToPosition(0)
+            layoutsRecyclerView?.smoothScrollToPosition(0)
         })
 
         viewModel.start(displayUtils.isTablet())
     }
 
-    private fun setupUi() {
-        title?.visibility = if (isPhoneLandscape()) View.VISIBLE else View.INVISIBLE
-        header?.setText(R.string.hpp_title)
-        description?.setText(R.string.hpp_subtitle)
+    private fun setContentVisibility(skeleton: Boolean, error: Boolean) {
+        categoriesSkeleton.setVisible(skeleton)
+        categoriesRecyclerView.setVisible(!skeleton && !error)
+        layoutsSkeleton.setVisible(skeleton)
+        layoutsRecyclerView.setVisible(!skeleton && !error)
+        errorView.setVisible(error)
     }
 
     private fun setupActionListeners() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout
-import kotlinx.android.synthetic.main.modal_layout_picker_layouts_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
 import kotlinx.android.synthetic.main.modal_layout_picker_title_row.*
 import org.wordpress.android.R
@@ -155,7 +154,7 @@ class HomePagePickerFragment : Fragment() {
     private fun HomePagePickerFragmentBinding.setContentVisibility(skeleton: Boolean, error: Boolean) {
         modalLayoutPickerCategoriesSkeleton.categoriesSkeleton.setVisible(skeleton)
         categoriesRecyclerView.setVisible(!skeleton && !error)
-        layoutsSkeleton.setVisible(skeleton)
+        modalLayoutPickerLayoutsSkeleton.layoutsSkeleton.setVisible(skeleton)
         layoutsRecyclerView.setVisible(!skeleton && !error)
         errorView.setVisible(error)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -11,8 +11,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout
-import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
-import kotlinx.android.synthetic.main.modal_layout_picker_title_row.*
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.HomePagePickerFragmentBinding
@@ -88,8 +86,8 @@ class HomePagePickerFragment : Fragment() {
 
     private fun HomePagePickerFragmentBinding.setupUi() {
         homePagePickerTitlebar.title.visibility = if (isPhoneLandscape()) View.VISIBLE else View.INVISIBLE
-        header?.setText(R.string.hpp_title)
-        description?.setText(R.string.hpp_subtitle)
+        modalLayoutPickerHeaderSection.modalLayoutPickerTitleRow?.header?.setText(R.string.hpp_title)
+        modalLayoutPickerHeaderSection.modalLayoutPickerSubtitleRow?.description?.setText(R.string.hpp_subtitle)
     }
 
     private fun HomePagePickerFragmentBinding.setupViewModel() {
@@ -142,13 +140,14 @@ class HomePagePickerFragment : Fragment() {
     private fun HomePagePickerFragmentBinding.setHeaderVisibility(visible: Boolean) {
         uiHelper.fadeInfadeOutViews(
                 homePagePickerTitlebar.title,
-                header,
+                modalLayoutPickerHeaderSection.modalLayoutPickerTitleRow?.header,
                 visible
         )
     }
 
     private fun HomePagePickerFragmentBinding.setDescriptionVisibility(visible: Boolean) {
-        description?.visibility = if (visible) View.VISIBLE else View.INVISIBLE
+        modalLayoutPickerHeaderSection.modalLayoutPickerSubtitleRow?.description?.visibility =
+                if (visible) View.VISIBLE else View.INVISIBLE
     }
 
     private fun HomePagePickerFragmentBinding.setContentVisibility(skeleton: Boolean, error: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -145,6 +145,10 @@ class HomePagePickerFragment : Fragment() {
         )
     }
 
+    /**
+     * Sets the header description visibility
+     * @param visible if true the description is visible else invisible
+     */
     private fun HomePagePickerFragmentBinding.setDescriptionVisibility(visible: Boolean) {
         modalLayoutPickerHeaderSection.modalLayoutPickerSubtitleRow?.description?.visibility =
                 if (visible) View.VISIBLE else View.INVISIBLE

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout
-import kotlinx.android.synthetic.main.modal_layout_picker_categories_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_layouts_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_subtitle_row.*
 import kotlinx.android.synthetic.main.modal_layout_picker_title_row.*
@@ -154,7 +153,7 @@ class HomePagePickerFragment : Fragment() {
     }
 
     private fun HomePagePickerFragmentBinding.setContentVisibility(skeleton: Boolean, error: Boolean) {
-        categoriesSkeleton.setVisible(skeleton)
+        modalLayoutPickerCategoriesSkeleton.categoriesSkeleton.setVisible(skeleton)
         categoriesRecyclerView.setVisible(!skeleton && !error)
         layoutsSkeleton.setVisible(skeleton)
         layoutsRecyclerView.setVisible(!skeleton && !error)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -96,7 +96,7 @@ class HomePagePickerFragment : Fragment() {
                 .get(HomePagePickerViewModel::class.java)
 
         viewModel.uiState.observe(viewLifecycleOwner, { uiState ->
-            uiHelper.fadeInfadeOutViews(title, header, uiState.isHeaderVisible)
+            setHeaderVisibility(uiState.isHeaderVisible)
             description?.visibility = if (uiState.isDescriptionVisible) View.VISIBLE else View.INVISIBLE
             setContentVisibility(uiState.loadingSkeletonVisible, uiState.errorViewVisible)
             AniUtils.animateBottomBar(bottomToolbar, uiState.isToolbarVisible)
@@ -136,6 +136,10 @@ class HomePagePickerFragment : Fragment() {
         })
 
         viewModel.start(displayUtils.isTablet())
+    }
+
+    private fun setHeaderVisibility(visible: Boolean) {
+        uiHelper.fadeInfadeOutViews(title, header, visible)
     }
 
     private fun setContentVisibility(skeleton: Boolean, error: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.AppBarLayout
-import kotlinx.android.synthetic.main.home_page_picker_bottom_toolbar.*
 import kotlinx.android.synthetic.main.home_page_picker_titlebar.*
 import kotlinx.android.synthetic.main.modal_layout_picker_categories_skeleton.*
 import kotlinx.android.synthetic.main.modal_layout_picker_layouts_skeleton.*
@@ -157,12 +156,12 @@ class HomePagePickerFragment : Fragment() {
     }
 
     private fun HomePagePickerFragmentBinding.setToolbarVisibility(visible: Boolean) {
-        AniUtils.animateBottomBar(bottomToolbar, visible)
+        AniUtils.animateBottomBar(homePagePickerBottomToolbar.bottomToolbar, visible)
     }
 
     private fun HomePagePickerFragmentBinding.setupActionListeners() {
-        previewButton.setOnClickListener { viewModel.onPreviewTapped() }
-        chooseButton.setOnClickListener { viewModel.onChooseTapped() }
+        homePagePickerBottomToolbar.previewButton.setOnClickListener { viewModel.onPreviewTapped() }
+        homePagePickerBottomToolbar.chooseButton.setOnClickListener { viewModel.onChooseTapped() }
         skipButton.setOnClickListener { viewModel.onSkippedTapped() }
         errorView.button.setOnClickListener { viewModel.onRetryClicked() }
         backButton.setOnClickListener { viewModel.onBackPressed() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerFragment.kt
@@ -97,7 +97,7 @@ class HomePagePickerFragment : Fragment() {
 
         viewModel.uiState.observe(viewLifecycleOwner, { uiState ->
             setHeaderVisibility(uiState.isHeaderVisible)
-            description?.visibility = if (uiState.isDescriptionVisible) View.VISIBLE else View.INVISIBLE
+            setDescriptionVisibility(uiState.isDescriptionVisible)
             setContentVisibility(uiState.loadingSkeletonVisible, uiState.errorViewVisible)
             AniUtils.animateBottomBar(bottomToolbar, uiState.isToolbarVisible)
             when (uiState) {
@@ -140,6 +140,10 @@ class HomePagePickerFragment : Fragment() {
 
     private fun setHeaderVisibility(visible: Boolean) {
         uiHelper.fadeInfadeOutViews(title, header, visible)
+    }
+
+    private fun setDescriptionVisibility(visible: Boolean) {
+        description?.visibility = if (visible) View.VISIBLE else View.INVISIBLE
     }
 
     private fun setContentVisibility(skeleton: Boolean, error: Boolean) {

--- a/WordPress/src/main/res/layout/home_page_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_fragment.xml
@@ -43,6 +43,7 @@
                     android:orientation="vertical">
 
                     <include
+                        android:id="@+id/home_page_picker_titlebar"
                         layout="@layout/home_page_picker_titlebar"
                         android:layout_width="match_parent"
                         android:layout_gravity="center_vertical"

--- a/WordPress/src/main/res/layout/home_page_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_fragment.xml
@@ -76,6 +76,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <include
+        android:id="@+id/modal_layout_picker_layouts_skeleton"
         layout="@layout/modal_layout_picker_layouts_skeleton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/home_page_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_fragment.xml
@@ -56,6 +56,7 @@
         </com.google.android.material.appbar.CollapsingToolbarLayout>
 
         <include
+            android:id="@+id/modal_layout_picker_categories_skeleton"
             layout="@layout/modal_layout_picker_categories_skeleton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />

--- a/WordPress/src/main/res/layout/home_page_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_fragment.xml
@@ -22,6 +22,7 @@
             app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
             <include
+                android:id="@+id/modal_layout_picker_header_section"
                 layout="@layout/modal_layout_picker_header_section"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/home_page_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/home_page_picker_fragment.xml
@@ -103,6 +103,7 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <include
+        android:id="@+id/home_page_picker_bottom_toolbar"
         layout="@layout/home_page_picker_bottom_toolbar"
         android:visibility="gone"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
@@ -114,6 +114,7 @@
             android:background="@drawable/modal_layout_picker_bottom_shadow" />
 
         <include
+            android:id="@+id/modal_layout_picker_bottom_toolbar"
             layout="@layout/modal_layout_picker_bottom_toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />

--- a/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
@@ -81,6 +81,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <include
+        android:id="@+id/modal_layout_picker_layouts_skeleton"
         layout="@layout/modal_layout_picker_layouts_skeleton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
@@ -22,6 +22,7 @@
             app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
             <include
+                android:id="@+id/modal_layout_picker_header_section"
                 layout="@layout/modal_layout_picker_header_section"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
@@ -98,6 +98,7 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <include
+        android:id="@+id/modal_layout_picker_error"
         layout="@layout/modal_layout_picker_error"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
@@ -49,6 +49,7 @@
                         android:layout_gravity="top" />
 
                     <include
+                        android:id="@+id/modal_layout_picker_titlebar"
                         layout="@layout/modal_layout_picker_titlebar"
                         android:layout_width="match_parent"
                         android:layout_gravity="center_vertical"

--- a/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_fragment.xml
@@ -61,6 +61,7 @@
         </com.google.android.material.appbar.CollapsingToolbarLayout>
 
         <include
+            android:id="@+id/modal_layout_picker_categories_skeleton"
             layout="@layout/modal_layout_picker_categories_skeleton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />

--- a/WordPress/src/main/res/layout/modal_layout_picker_header_section.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_header_section.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    tools:ignore="InconsistentLayout">
 
     <include
         android:id="@+id/modal_layout_picker_title_row"

--- a/WordPress/src/main/res/layout/modal_layout_picker_header_section.xml
+++ b/WordPress/src/main/res/layout/modal_layout_picker_header_section.xml
@@ -5,11 +5,13 @@
     android:orientation="vertical">
 
     <include
+        android:id="@+id/modal_layout_picker_title_row"
         layout="@layout/modal_layout_picker_title_row"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <include
+        android:id="@+id/modal_layout_picker_subtitle_row"
         layout="@layout/modal_layout_picker_subtitle_row"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -5,7 +5,6 @@
     <ID>ComplexCondition:AllTimeStatsUseCase.kt$AllTimeStatsUseCase$!hasPosts &amp;&amp; !hasViews &amp;&amp; !hasVisitors &amp;&amp; !hasViewsBestDayTotal</ID>
     <ID>ComplexCondition:FollowersUseCase.kt$FollowersUseCase$wpComModel.followers.size &gt;= VIEW_ALL_PAGE_SIZE &amp;&amp; uiState.selectedTab == 0 || emailModel.followers.size &gt;= VIEW_ALL_PAGE_SIZE &amp;&amp; uiState.selectedTab == 1</ID>
     <ID>ComplexCondition:FollowersUseCase.kt$FollowersUseCase$wpComModel.hasMore &amp;&amp; uiState.selectedTab == 0 || emailModel.hasMore &amp;&amp; uiState.selectedTab == 1</ID>
-    <ID>ComplexCondition:GifPickerActivity.kt$GifPickerActivity$isVisible &amp;&amp; selectionBar.visibility == View.VISIBLE || !isVisible &amp;&amp; selectionBar.visibility != View.VISIBLE</ID>
     <ID>ComplexCondition:MinifiedWidgetUpdater.kt$MinifiedWidgetUpdater$networkAvailable &amp;&amp; hasAccessToken &amp;&amp; siteModel != null &amp;&amp; dataType != null</ID>
     <ID>ComplexCondition:NullCheckExtensions.kt$value1 != null &amp;&amp; value2 != null &amp;&amp; value3 != null &amp;&amp; value4 != null</ID>
     <ID>ComplexCondition:ReaderPostDetailFragment.kt$ReaderPostDetailFragment$activity != null &amp;&amp; requestCode == READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE &amp;&amp; grantResults.isNotEmpty() &amp;&amp; grantResults[0] == PackageManager.PERMISSION_GRANTED</ID>
@@ -92,7 +91,6 @@
     <ID>LongMethod:ClicksUseCase.kt$ClicksUseCase$override fun buildUiModel(domainModel: ClicksModel, uiState: SelectedClicksGroup): List&lt;BlockListItem&gt;</ID>
     <ID>LongMethod:HomepageSettingsDialog.kt$HomepageSettingsDialog$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
     <ID>LongMethod:ImprovedMySiteFragment.kt$ImprovedMySiteFragment$override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?)</ID>
-    <ID>LongMethod:JetpackRemoteInstallFragment.kt$JetpackRemoteInstallFragment$override fun onActivityCreated(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:MediaPickerActivity.kt$MediaPickerActivity$override fun onActivityResult( requestCode: Int, resultCode: Int, data: Intent? )</ID>
     <ID>LongMethod:MediaPickerFragment.kt$MediaPickerFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:MediaPickerViewModel.kt$MediaPickerViewModel$private fun buildUiModel( domainModel: DomainModel?, selectedIds: List&lt;Identifier&gt;?, softAskRequest: SoftAskRequest?, isSearching: Boolean? ): PhotoListUiModel</ID>
@@ -118,7 +116,6 @@
     <ID>LongParameterList:FileDownloadsUseCase.kt$FileDownloadsUseCase$( statsGranularity: StatsGranularity, @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher, @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher, private val store: FileDownloadsStore, statsSiteProvider: StatsSiteProvider, selectedDateProvider: SelectedDateProvider, private val analyticsTracker: AnalyticsTrackerWrapper, private val contentDescriptionHelper: ContentDescriptionHelper, private val localeManagerWrapper: LocaleManagerWrapper, private val statsUtils: StatsUtils, private val useCaseMode: UseCaseMode )</ID>
     <ID>LongParameterList:FollowersUseCase.kt$FollowersUseCase$( @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher, @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher, private val followersStore: FollowersStore, private val statsSiteProvider: StatsSiteProvider, private val statsUtilsWrapper: StatsUtilsWrapper, private val resourceProvider: ResourceProvider, private val analyticsTracker: AnalyticsTrackerWrapper, private val popupMenuHandler: ItemPopupMenuHandler, private val contentDescriptionHelper: ContentDescriptionHelper, private val useCaseMode: UseCaseMode )</ID>
     <ID>LongParameterList:GifMediaInsertUseCase.kt$GifMediaInsertUseCase$( private val context: Context, private val site: SiteModel, private val dispatcher: Dispatcher, private val ioDispatcher: CoroutineDispatcher, private val wpMediaUtilsWrapper: WPMediaUtilsWrapper, private val fluxCUtilsWrapper: FluxCUtilsWrapper, private val mimeTypeMapUtilsWrapper: MimeTypeMapUtilsWrapper )</ID>
-    <ID>LongParameterList:GifMediaViewHolder.kt$GifMediaViewHolder.Companion$( imageManager: ImageManager, onClickListener: (GifMediaViewModel?) -&gt; Unit, onLongClickListener: (GifMediaViewModel) -&gt; Unit, parent: ViewGroup, thumbnailViewDimensions: ThumbnailViewDimensions, isMultiSelectEnabled: Boolean )</ID>
     <ID>LongParameterList:GranularStatefulUseCase.kt$GranularStatefulUseCase$( type: StatsType, mainDispatcher: CoroutineDispatcher, backgroundDispatcher: CoroutineDispatcher, val statsSiteProvider: StatsSiteProvider, val selectedDateProvider: SelectedDateProvider, val statsGranularity: StatsGranularity, defaultUiState: UI_STATE )</ID>
     <ID>LongParameterList:ImageManager.kt$ImageManager$( awt: AppWidgetTarget, context: Context, imageType: ImageType, imgUrl: String = "", scaleType: ScaleType = CENTER, width: Int? = null, height: Int? = null )</ID>
     <ID>LongParameterList:ImageManager.kt$ImageManager$( imageView: ImageView, imageType: ImageType, imgUri: Uri, scaleType: ScaleType = CENTER, thumbnailUrl: String? = null, requestListener: RequestListener&lt;Drawable&gt; )</ID>
@@ -164,7 +161,6 @@
     <ID>LongParameterList:ReferrersUseCase.kt$ReferrersUseCase$( statsGranularity: StatsGranularity, @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher, @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher, private val referrersStore: ReferrersStore, statsSiteProvider: StatsSiteProvider, selectedDateProvider: SelectedDateProvider, private val analyticsTracker: AnalyticsTrackerWrapper, private val contentDescriptionHelper: ContentDescriptionHelper, private val statsUtils: StatsUtils, private val useCaseMode: UseCaseMode, private val popupMenuHandler: ReferrerPopupMenuHandler )</ID>
     <ID>LongParameterList:SearchTermsUseCase.kt$SearchTermsUseCase$( statsGranularity: StatsGranularity, @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher, @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher, private val store: SearchTermsStore, statsSiteProvider: StatsSiteProvider, selectedDateProvider: SelectedDateProvider, private val analyticsTracker: AnalyticsTrackerWrapper, private val contentDescriptionHelper: ContentDescriptionHelper, private val statsUtils: StatsUtils, private val useCaseMode: UseCaseMode )</ID>
     <ID>LongParameterList:SiteInfoBlockBuilder.kt$SiteInfoBlockBuilder$( site: SiteModel, showSiteIconProgressBar: Boolean, titleClick: () -&gt; Unit, iconClick: () -&gt; Unit, urlClick: () -&gt; Unit, switchSiteClick: () -&gt; Unit, showUpdateSiteTitleFocusPoint: Boolean, showUploadSiteIconFocusPoint: Boolean )</ID>
-    <ID>LongParameterList:SiteItemsBuilder.kt$SiteItemsBuilder$( site: SiteModel, onClick: (ListItemAction) -&gt; Unit, isBackupAvailable: Boolean = false, isScanAvailable: Boolean = false, showViewSiteFocusPoint: Boolean = false, showEnablePostSharingFocusPoint: Boolean = false, showExplorePlansFocusPoint: Boolean = false )</ID>
     <ID>LongParameterList:SiteSettingsInterfaceWrapper.kt$SiteSettingsInterfaceWrapper.Factory$( site: SiteModel, onSaveError: ((error: Exception?) -&gt; Unit)? = null, onFetchError: ((error: Exception?) -&gt; Unit)? = null, onSettingsUpdated: (() -&gt; Unit)? = null, onSettingsSaved: (() -&gt; Unit)? = null, onCredentialsValidated: ((error: Exception?) -&gt; Unit)? = null )</ID>
     <ID>LongParameterList:StatsDetailActivity.kt$StatsDetailActivity.Companion$( context: Context, site: SiteModel, postId: Long, postType: String, postTitle: String, postUrl: String? )</ID>
     <ID>LongParameterList:StatsModule.kt$StatsModule$( allTimeStatsUseCase: AllTimeStatsUseCase, latestPostSummaryUseCase: LatestPostSummaryUseCase, todayStatsUseCase: TodayStatsUseCase, followersUseCaseFactory: FollowersUseCaseFactory, commentsUseCase: CommentsUseCase, mostPopularInsightsUseCase: MostPopularInsightsUseCase, tagsAndCategoriesUseCaseFactory: TagsAndCategoriesUseCaseFactory, publicizeUseCaseFactory: PublicizeUseCaseFactory, postingActivityUseCase: PostingActivityUseCase, followerTotalsUseCase: FollowerTotalsUseCase, annualSiteStatsUseCaseFactory: AnnualSiteStatsUseCaseFactory, managementControlUseCase: ManagementControlUseCase, managementNewsCardUseCase: ManagementNewsCardUseCase )</ID>
@@ -180,7 +176,6 @@
     <ID>LongParameterList:VideoPlaysUseCase.kt$VideoPlaysUseCase$( statsGranularity: StatsGranularity, @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher, @Named(BG_THREAD) private val backgroundDispatcher: CoroutineDispatcher, private val store: VideoPlaysStore, statsSiteProvider: StatsSiteProvider, selectedDateProvider: SelectedDateProvider, private val analyticsTracker: AnalyticsTrackerWrapper, private val contentDescriptionHelper: ContentDescriptionHelper, private val statsUtils: StatsUtils, private val useCaseMode: UseCaseMode )</ID>
     <ID>LongParameterList:WidgetUtils.kt$WidgetUtils$( appWidgetManager: AppWidgetManager, views: RemoteViews, appWidgetId: Int, networkAvailable: Boolean, hasAccessToken: Boolean, resourceProvider: ResourceProvider, context: Context, widgetType: Class&lt;*&gt; )</ID>
     <ID>LongParameterList:WidgetUtils.kt$WidgetUtils$( appWidgetManager: AppWidgetManager, views: RemoteViews, context: Context, appWidgetId: Int, colorMode: Color, siteId: Int, widgetType: WidgetType, isWideView: Boolean )</ID>
-    <ID>LongParameterList:ZendeskHelper.kt$( context: Context, allSites: List&lt;SiteModel&gt;?, origin: Origin?, selectedSite: SiteModel? = null, extraTags: List&lt;String&gt;? = null, zendeskPlanFieldHelper: ZendeskPlanFieldHelper )</ID>
     <ID>LoopWithTooManyJumpStatements:RemoveMediaUseCase.kt$RemoveMediaUseCase$for (mediaId in mediaIds) { if (!TextUtils.isEmpty(mediaId)) { // make sure the MediaModel exists val mediaModel = try { mediaStore.getMediaWithLocalId(Integer.valueOf(mediaId)) ?: continue } catch (e: NumberFormatException) { AppLog.e(AppLog.T.MEDIA, "Invalid media id: $mediaId") continue } // also make sure it's not being uploaded anywhere else (maybe on some other Post, // simultaneously) if (mediaModel.uploadState != null &amp;&amp; mediaUtils.isLocalFile(mediaModel.uploadState.toLowerCase(Locale.ROOT)) &amp;&amp; !uploadService.isPendingOrInProgressMediaUpload(mediaModel)) { dispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(mediaModel)) } } }</ID>
     <ID>MagicNumber:ActivityViewHolder.kt$ActivityViewHolder$3</ID>
     <ID>MagicNumber:ActivityViewHolder.kt$ActivityViewHolder$50</ID>
@@ -207,21 +202,14 @@
     <ID>MagicNumber:DateUtils.kt$DateUtils$6</ID>
     <ID>MagicNumber:DeviceMediaLoader.kt$DeviceMediaLoader$1000</ID>
     <ID>MagicNumber:EditorPhotoPicker.kt$EditorPhotoPicker$0.5f</ID>
-    <ID>MagicNumber:EncryptedLogWriter.kt$EncryptedLogWriter$108</ID>
-    <ID>MagicNumber:EncryptedLogWriter.kt$EncryptedLogWriter$32</ID>
     <ID>MagicNumber:ExpandableItemViewHolder.kt$ExpandableItemViewHolder$180</ID>
     <ID>MagicNumber:ExpandableItemViewHolder.kt$ExpandableItemViewHolder$180F</ID>
     <ID>MagicNumber:ExpandableItemViewHolder.kt$ExpandableItemViewHolder$200</ID>
     <ID>MagicNumber:FeatureAnnouncementViewModel.kt$FeatureAnnouncementViewModel$1000</ID>
-    <ID>MagicNumber:GifPickerActivity.kt$GifPickerActivity$0.75</ID>
-    <ID>MagicNumber:GifPickerActivity.kt$GifPickerActivity$3</ID>
-    <ID>MagicNumber:GifPickerActivity.kt$GifPickerActivity$4</ID>
     <ID>MagicNumber:ImprovedMySiteFragment.kt$ImprovedMySiteFragment$100</ID>
     <ID>MagicNumber:LargeValueFormatter.kt$LargeValueFormatter$3</ID>
     <ID>MagicNumber:LargeValueFormatter.kt$LargeValueFormatter$5</ID>
     <ID>MagicNumber:LatestPostSummaryMapper.kt$LatestPostSummaryMapper$30</ID>
-    <ID>MagicNumber:LoginPrologueFragment.kt$LoginPrologueFragment.&lt;no name provided&gt;$0.25f</ID>
-    <ID>MagicNumber:LoginPrologueFragment.kt$LoginPrologueFragment.&lt;no name provided&gt;$0.5f</ID>
     <ID>MagicNumber:MapViewHolder.kt$MapViewHolder$0xffffff</ID>
     <ID>MagicNumber:MapViewHolder.kt$MapViewHolder$100</ID>
     <ID>MagicNumber:MapViewHolder.kt$MapViewHolder$5</ID>
@@ -287,21 +275,15 @@
     <ID>MagicNumber:WPWebView.kt$22</ID>
     <ID>MagicNumber:WidgetUtils.kt$WidgetUtils$300</ID>
     <ID>MaxLineLength:AppConfig.kt$AppConfig$*</ID>
-    <ID>MaxLineLength:EncryptedLogWriter.kt$EncryptedLogWriter$*</ID>
     <ID>MaxLineLength:FeatureAnnouncementViewModel.kt$FeatureAnnouncementViewModel$?:</ID>
-    <ID>MaxLineLength:GifPickerActivity.kt$GifPickerActivity$// Update the "Add" and "Preview" labels to include the number of items. For example, "Add 7" and "Preview 7".</ID>
-    <ID>MaxLineLength:GifPickerActivity.kt$GifPickerActivity$// We do not change to labels back to the original text if the number of items go back to zero because that</ID>
-    <ID>MaxLineLength:GifPickerActivity.kt$GifPickerActivity$// causes a weird UX. The selection bar is animated to disappear at that time and it looks weird if the labels</ID>
     <ID>MaxLineLength:ImageManager.kt$ImageManager$*</ID>
     <ID>MaxLineLength:MySiteFragment.kt$MySiteFragment$private</ID>
     <ID>MaxLineLength:ReaderPostListViewModel.kt$ReaderPostListViewModel$// TODO this is related to tracking time spent in reader - we should move it to the parent but also keep it here for !isTopLevel :(</ID>
     <ID>MaxLineLength:ReaderUtilsWrapper.kt$ReaderUtilsWrapper$*</ID>
     <ID>MaxLineLength:SaveStoryGutenbergBlockUseCase.kt$SaveStoryGutenbergBlockUseCase.&lt;no name provided&gt;$// now replace matching localMediaId with remoteMediaId in the mediaFileObjects, obtain the URLs and replace</ID>
-    <ID>MaxLineLength:SiteStoriesHandler.kt$SiteStoriesHandler$// TODO add NotificationType.MEDIA_SAVE_ERROR param later when integrating with WPAndroid</ID>
     <ID>MaxLineLength:StoryComposerActivity.kt$StoryComposerActivity$// if the frame.id is populated and is not a temporary id, this should be an actual MediaModel mediaId so,</ID>
     <ID>MaxLineLength:StoryMediaSaveUploadBridge.kt$StoryMediaSaveUploadBridge.&lt;no name provided&gt;$// WARNING: don't remove this, we need to call the listener no matter what, so save &amp; upload actually happen</ID>
     <ID>MaxLineLength:StoryMediaSaveUploadBridge.kt$StoryMediaSaveUploadBridge.&lt;no name provided&gt;$// here we change the ids on the actual StoryFrameItems, and also update the flattened / composed image</ID>
-    <ID>MaxLineLength:TenorProvider.kt$TenorProvider$*</ID>
     <ID>MaxLineLength:WPWebViewUsageCategory.kt$WPWebViewUsageCategory$*</ID>
     <ID>MaxLineLength:XPostsCapabilityChecker.kt$XPostsCapabilityChecker$// suggestions, but because the response will almost always be empty, it's not an expensive call.</ID>
     <ID>MemberNameEqualsClassName:ActivityLogTypeFilterViewModel.kt$ActivityLogTypeFilterViewModel.Action$lateinit var action: (() -&gt; Unit)</ID>
@@ -311,7 +293,6 @@
     <ID>MultiLineIfElse:org.wordpress.android.ui.pages.PageItemViewHolder.kt:86</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.posts.PostDatePickerDialogFragment.kt:51</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.posts.PostDatePickerDialogFragment.kt:53</ID>
-    <ID>MultiLineIfElse:org.wordpress.android.ui.posts.PrepublishingHomeViewModel.kt:138</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.posts.prepublishing.visibility.usecases.UpdatePostStatusUseCase.kt:25</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.reader.repository.usecases.FetchDiscoverCardsUseCase.kt:26</ID>
     <ID>MultiLineIfElse:org.wordpress.android.ui.reader.repository.usecases.FetchDiscoverCardsUseCase.kt:28</ID>
@@ -390,7 +371,6 @@
     <ID>TooGenericExceptionCaught:BaseStatsUseCase.kt$BaseStatsUseCase$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ColorUnderlineSpan.kt$ColorUnderlineSpan$e: Exception</ID>
     <ID>TooGenericExceptionCaught:GifMediaInsertUseCase.kt$GifMediaInsertUseCase$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:GifPickerViewModel.kt$GifPickerViewModel$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MediaPickerActivity.kt$MediaPickerActivity$e: RuntimeException</ID>
     <ID>TooGenericExceptionCaught:UploadStarter.kt$UploadStarter$e: Exception</ID>
     <ID>TooGenericExceptionThrown:ActionableEmptyView.kt$ActionableEmptyView$throw RuntimeException("$context: ActionableEmptyView must have a title (aevTitle)")</ID>
@@ -399,9 +379,7 @@
     <ID>TooGenericExceptionThrown:BaseListUseCase.kt$BaseListUseCase$throw RuntimeException("Duplicate stats type in a use case")</ID>
     <ID>TooGenericExceptionThrown:BasicFragmentDialog.kt$BasicFragmentDialog$throw RuntimeException("Hosting activity must implement BasicDialogNegativeClickInterface")</ID>
     <ID>TooGenericExceptionThrown:BasicFragmentDialog.kt$BasicFragmentDialog$throw RuntimeException("Hosting activity must implement BasicDialogPositiveClickInterface")</ID>
-    <ID>TooGenericExceptionThrown:GifMediaFetcher.kt$GifMediaFetcher$throw Exception("Failed to download the image.")</ID>
     <ID>TooGenericExceptionThrown:GifMediaInsertUseCase.kt$GifMediaInsertUseCase$throw Exception("Failed to download the image.")</ID>
-    <ID>TooGenericExceptionThrown:LoginPrologueFragment.kt$LoginPrologueFragment$throw RuntimeException("$context must implement LoginPrologueListener")</ID>
     <ID>TooGenericExceptionThrown:PageListAdapter.kt$PageListAdapter$throw Throwable("Unexpected view type")</ID>
     <ID>TooGenericExceptionThrown:PageParentAdapter.kt$PageParentAdapter$throw Throwable("Unexpected view type")</ID>
     <ID>TooGenericExceptionThrown:PageParentSearchAdapter.kt$PageParentSearchAdapter$throw Throwable("Unexpected view type")</ID>
@@ -433,7 +411,6 @@
     <ID>TooManyFunctions:FollowerTotalsUseCase.kt$FollowerTotalsUseCase : StatelessUseCase</ID>
     <ID>TooManyFunctions:FollowersUseCase.kt$FollowersUseCase : BaseStatsUseCase</ID>
     <ID>TooManyFunctions:FormattableContentUtils.kt$org.wordpress.android.util.FormattableContentUtils.kt</ID>
-    <ID>TooManyFunctions:GifPickerActivity.kt$GifPickerActivity : LocaleAwareActivity</ID>
     <ID>TooManyFunctions:HomepageSettingsViewModel.kt$HomepageSettingsViewModel : ScopedViewModel</ID>
     <ID>TooManyFunctions:ImageManager.kt$ImageManager</ID>
     <ID>TooManyFunctions:ImprovedMySiteFragment.kt$ImprovedMySiteFragment : FragmentCallback</ID>
@@ -553,7 +530,6 @@
     <ID>TopLevelPropertyNaming:ZendeskHelper.kt$private const val zendeskNeedsToBeEnabledError = "Zendesk needs to be setup before this method can be called"</ID>
     <ID>UtilityClassWithPublicConstructor:AppThemeUtils.kt$AppThemeUtils</ID>
     <ID>UtilityClassWithPublicConstructor:DomainPhoneNumberUtils.kt$DomainPhoneNumberUtils</ID>
-    <ID>UtilityClassWithPublicConstructor:EncryptionUtils.kt$EncryptionUtils</ID>
     <ID>UtilityClassWithPublicConstructor:ImageEditorInitializer.kt$ImageEditorInitializer</ID>
     <ID>UtilityClassWithPublicConstructor:QuickStartUtils.kt$QuickStartUtils</ID>
     <ID>UtilityClassWithPublicConstructor:WPSnackbar.kt$WPSnackbar</ID>


### PR DESCRIPTION
Parent #14845 

This PR is part of a larger effort to replace synthetic accessors within WPAndroid and is split into two parts:
- Convert `ModalLayoutPickerFragment` screen.
- Convert `HomePagePickerFragment` screen.

To test:
- `ModalLayoutPickerFragment` screen:
  - Launch the app.
  - Navigate to `My Site` -> `FAB` -> `Site page`.
  - The `ModalLayoutPickerFragment` screen should be launched.
  - Note that the choose layout shows as expected, and every functionality within works as expected as well.
- `HomePagePickerFragment` screen:
  - Launch the app.
  - Navigate to `My Site` -> `Choose site` -> `+` -> `Create WordPress.com site`
  - The `HomePagePickerFragment` screen should be launched.
  - Note that the choose design shows as expected, and every functionality within works as expected as well.

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested as described above in the `To test` section.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
