### PR TITLE
ViewBinding: Refactor Domain Registration and Posts List Activities

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -54,7 +53,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
                 .get(DomainRegistrationMainViewModel::class.java)
         viewModel.start()
 
-        viewModel.domainSuggestionsVisible.observe(this, Observer { isVisible ->
+        viewModel.domainSuggestionsVisible.observe(this, { isVisible ->
             if (isVisible == true) {
                 var fragment = supportFragmentManager.findFragmentByTag(DomainSuggestionsFragment.TAG)
                 if (fragment == null) {
@@ -69,7 +68,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
             }
         })
 
-        viewModel.selectedDomain.observe(this, Observer { selectedDomain ->
+        viewModel.selectedDomain.observe(this, { selectedDomain ->
             selectedDomain?.let {
                 var fragment = supportFragmentManager.findFragmentByTag(
                         DomainRegistrationDetailsFragment.TAG
@@ -82,7 +81,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
             }
         })
 
-        viewModel.domainRegistrationCompleted.observe(this, Observer { event ->
+        viewModel.domainRegistrationCompleted.observe(this, { event ->
             event?.let {
                 if (shouldShowCongratsScreen()) {
                     var fragment = supportFragmentManager.findFragmentByTag(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -28,7 +28,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
     @Inject internal lateinit var viewModelFactory: ViewModelProvider.Factory
     private lateinit var viewModel: DomainRegistrationMainViewModel
     private lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
-    private var binding: DomainSuggestionsActivityBinding? = null
+    private lateinit var binding: DomainSuggestionsActivityBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -47,11 +47,6 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
             }
             setupViewModel()
         }
-    }
-
-    override fun onDestroy() {
-        binding = null
-        super.onDestroy()
     }
 
     private fun setupViewModel() {
@@ -148,7 +143,7 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
     }
 
     override fun onScrollableViewInitialized(containerId: Int) {
-        binding?.apply {
+        binding.apply {
             if (containerId == R.id.domain_suggestions_list) {
                 appbarMain.post {
                     appbarMain.isLiftOnScroll = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -143,19 +143,19 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
     }
 
     override fun onScrollableViewInitialized(containerId: Int) {
-        binding.apply {
+        binding.appbarMain.apply {
             if (containerId == R.id.domain_suggestions_list) {
-                appbarMain.post {
-                    appbarMain.isLiftOnScroll = false
-                    appbarMain.setLifted(false)
-                    appbarMain.elevation = 0F
-                    appbarMain.requestLayout()
+                post {
+                    isLiftOnScroll = false
+                    setLifted(false)
+                    elevation = 0F
+                    requestLayout()
                 }
             } else {
-                appbarMain.post {
-                    appbarMain.isLiftOnScroll = true
-                    appbarMain.liftOnScrollTargetViewId = containerId
-                    appbarMain.requestLayout()
+                post {
+                    isLiftOnScroll = true
+                    liftOnScrollTargetViewId = containerId
+                    requestLayout()
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -596,10 +596,8 @@ class PostsListActivity : LocaleAwareActivity(),
     }
 
     override fun onScrollableViewInitialized(containerId: Int) {
-        with(binding) {
-            appbarMain.setLiftOnScrollTargetViewIdAndRequestLayout(containerId)
-            appbarMain.setTag(R.id.posts_non_search_recycler_view_id_tag_key, containerId)
-        }
+        binding.appbarMain.setLiftOnScrollTargetViewIdAndRequestLayout(containerId)
+        binding.appbarMain.setTag(R.id.posts_non_search_recycler_view_id_tag_key, containerId)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -10,7 +10,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.MenuItem.OnActionExpandListener
 import android.view.View
-import android.view.View.OnClickListener
 import android.widget.AdapterView
 import android.widget.Toast
 import androidx.annotation.DrawableRes
@@ -393,7 +392,7 @@ class PostsListActivity : LocaleAwareActivity(),
                             holder.buttonTitle?.let {
                                 SnackbarItem.Action(
                                         textRes = holder.buttonTitle,
-                                        clickListener = OnClickListener { holder.buttonAction() }
+                                        clickListener = { holder.buttonAction() }
                                 )
                             },
                             dismissCallback = { _, _ -> holder.onDismissAction() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -136,31 +136,31 @@ class PostsListActivity : LocaleAwareActivity(),
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
-        val binding = PostListActivityBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        this.binding = binding
-        site = if (savedInstanceState == null) {
-            checkNotNull(intent.getSerializableExtra(WordPress.SITE) as? SiteModel) {
-                "SiteModel cannot be null, check the PendingIntent starting PostsListActivity"
+        with(PostListActivityBinding.inflate(layoutInflater)) {
+            setContentView(root)
+            binding = this
+
+            site = if (savedInstanceState == null) {
+                checkNotNull(intent.getSerializableExtra(WordPress.SITE) as? SiteModel) {
+                    "SiteModel cannot be null, check the PendingIntent starting PostsListActivity"
+                }
+            } else {
+                restorePreviousSearch = true
+                savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
             }
-        } else {
-            restorePreviousSearch = true
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
-        }
 
-        val initPreviewState = if (savedInstanceState == null) {
-            PostListRemotePreviewState.NONE
-        } else {
-            PostListRemotePreviewState.fromInt(savedInstanceState.getInt(STATE_KEY_PREVIEW_STATE, 0))
-        }
+            val initPreviewState = if (savedInstanceState == null) {
+                PostListRemotePreviewState.NONE
+            } else {
+                PostListRemotePreviewState.fromInt(savedInstanceState.getInt(STATE_KEY_PREVIEW_STATE, 0))
+            }
 
-        val currentBottomSheetPostId = if (savedInstanceState == null) {
-            LocalId(0)
-        } else {
-            LocalId(savedInstanceState.getInt(STATE_KEY_BOTTOMSHEET_POST_ID, 0))
-        }
+            val currentBottomSheetPostId = if (savedInstanceState == null) {
+                LocalId(0)
+            } else {
+                LocalId(savedInstanceState.getInt(STATE_KEY_BOTTOMSHEET_POST_ID, 0))
+            }
 
-        with(binding) {
             setupActionBar()
             setupContent()
             initViewModel(initPreviewState, currentBottomSheetPostId)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -33,8 +33,7 @@ import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.STORY_FROM_POSTS_LIST
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.ScrollableViewInitializedListener
-import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_POST
-import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_STORY
+import org.wordpress.android.ui.main.MainActionListItem.ActionType
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
@@ -249,8 +248,11 @@ class PostsListActivity : LocaleAwareActivity(),
 
         postListCreateMenuViewModel.createAction.observe(this@PostsListActivity, { createAction ->
             when (createAction) {
-                CREATE_NEW_POST -> viewModel.newPost()
-                CREATE_NEW_STORY -> viewModel.newStoryPost()
+                ActionType.CREATE_NEW_POST -> viewModel.newPost()
+                ActionType.CREATE_NEW_STORY -> viewModel.newStoryPost()
+                ActionType.CREATE_NEW_PAGE -> Unit
+                ActionType.NO_ACTION -> Unit
+                null -> Unit
             }
         })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -88,7 +88,7 @@ class PostsListActivity : LocaleAwareActivity(),
     @Inject internal lateinit var storiesMediaPickerResultHandler: StoriesMediaPickerResultHandler
 
     private lateinit var site: SiteModel
-    private var binding: PostListActivityBinding? = null
+    private lateinit var binding: PostListActivityBinding
 
     override fun getSite() = site
     override fun getEditPostRepository() = editPostRepository
@@ -168,11 +168,6 @@ class PostsListActivity : LocaleAwareActivity(),
             initCreateMenuViewModel()
             loadIntentData(intent)
         }
-    }
-
-    override fun onDestroy() {
-        binding = null
-        super.onDestroy()
     }
 
     private fun setupActionBar() {
@@ -476,7 +471,7 @@ class PostsListActivity : LocaleAwareActivity(),
             searchActionButton = it.findItem(R.id.toggle_post_search)
 
             initSearchFragment()
-            binding!!.initSearchView()
+            binding.initSearchView()
         }
         return true
     }
@@ -599,7 +594,7 @@ class PostsListActivity : LocaleAwareActivity(),
     }
 
     override fun onScrollableViewInitialized(containerId: Int) {
-        with(binding!!) {
+        with(binding) {
             appbarMain.setLiftOnScrollTargetViewIdAndRequestLayout(containerId)
             appbarMain.setTag(R.id.posts_non_search_recycler_view_id_tag_key, containerId)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -15,6 +15,7 @@ import android.widget.Toast
 import androidx.annotation.DrawableRes
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
 import com.google.android.material.snackbar.Snackbar
@@ -581,7 +582,7 @@ class PostsListActivity : LocaleAwareActivity(),
     // Menu PostListViewLayoutType handling
 
     private fun updateMenuIcon(@DrawableRes iconRes: Int, menuItem: MenuItem) {
-        getDrawable(iconRes)?.let { drawable ->
+        ContextCompat.getDrawable(this, iconRes)?.let { drawable ->
             menuItem.setIcon(drawable)
         }
     }


### PR DESCRIPTION
Parent #14845

This PR is part of a larger effort to replace synthetic accessors within WPAndroid and is split into two parts:
- Refactor `DomainRegistrationActivity` screen.
- Refactor `PostsListActivity` screen.

To test:
- `DomainRegistrationActivity` screen.
  - Manually enable the `Register Domain` onboarding card.
  - To do so, within the codebase, find the `MySiteFragment` class, go to line `1301` and replace:
    - This `mySiteRegisterDomainCta.visibility = View.GONE` line with
    - This `mySiteRegisterDomainCta.visibility = View.VISIBLE` line.
  - Rebuild and launch the app.
  - Navigate to `My Site` -> `Register Domain`.
  - The `DomainRegistrationActivity` screen should be launched.
  - Note that the choose a premium domain name shows as expected, and every functionality within works as expected as well.
- `PostsListActivity` screen.
  - Launch the app.
  - Navigate to `My Site` -> `Blog Posts`.
  - The `PostsListActivity` screen should be launched.
  - Note that the blog posts shows as expected, and every functionality within works as expected as well.

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested as described above in the `To test` section.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
