### PR TITLE
ViewBinding: Fix Binding for `OnDestroyView`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -132,8 +132,8 @@ class DomainRegistrationDetailsFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        binding = null
         super.onDestroyView()
+        binding = null
     }
 
     private fun DomainRegistrationDetailsFragmentBinding.setupInputFieldTextWatchers() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -52,8 +52,8 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), Scrollable
     }
 
     override fun onDestroyView() {
-        binding = null
         super.onDestroyView()
+        binding = null
     }
 
     private fun initDagger() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -40,8 +40,8 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
     }
 
     override fun onDestroyView() {
-        binding = null
         super.onDestroyView()
+        binding = null
     }
 
     private fun initDagger() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -316,8 +316,8 @@ class MediaPickerFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        binding = null
         super.onDestroyView()
+        binding = null
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -133,13 +133,13 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
     }
 
     override fun onDestroyView() {
-        notesAdapter!!.cancelReloadNotesTask()
+        super.onDestroyView()
+        notesAdapter?.cancelReloadNotesTask()
+        notesAdapter = null
         swipeToRefreshHelper = null
         binding?.notificationsList?.adapter = null
         binding?.notificationsList?.removeCallbacks(showNewUnseenNotificationsRunnable)
-        notesAdapter = null
         binding = null
-        super.onDestroyView()
     }
 
     override fun onDataLoaded(itemsCount: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -70,8 +70,8 @@ class PageListFragment : ViewPagerFragment(R.layout.pages_list_fragment) {
     }
 
     override fun onDestroyView() {
-        binding = null
         super.onDestroyView()
+        binding = null
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
@@ -154,8 +154,8 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), CoroutineSco
     }
 
     override fun onDestroyView() {
-        binding = null
         super.onDestroyView()
+        binding = null
     }
 
     private fun PageParentFragmentBinding.initializeViews(activity: FragmentActivity, savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -128,8 +128,8 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
     }
 
     override fun onDestroyView() {
-        binding = null
         super.onDestroyView()
+        binding = null
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -187,8 +187,8 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
     }
 
     override fun onDestroyView() {
-        binding = null
         super.onDestroyView()
+        binding = null
     }
 
     private fun PhotoPickerFragmentBinding.setupSoftAskView(uiModel: SoftAskViewUiModel) {


### PR DESCRIPTION
Parent #14845

This PR is part of a larger effort to replace synthetic accessors within WPAndroid and is split into two parts:
- Refactor multiple screens (small `super.onDestroyView()` vs `binding = null` reorder).
- Refactor `NotificationsListFragmentPage` screen (total `super.onDestroyView()` reorder).

To test:
- The `NotificationsListFragmentPage` class is the only class which during the reorder the whole 'super.onDestroyView()' call was move on top of everything else. As such, this is the one class that might need some testing.
- Launch the app.
- Navigate to `Notifications`.
- The `NotificationsListFragmentPage` screen should be launched.
- Note that the notification lists, per tab, all show as expected, and every functionality within works as expected as well.

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested as described above in the `To test` section.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
