### PR TITLE
ViewBinding: Refactor: Remove view binding backing fields

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
@@ -13,7 +13,6 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout.LayoutParams
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -42,26 +41,25 @@ abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
     private lateinit var viewModel: LayoutPickerViewModel
     private lateinit var previewModeSelectorPopup: PreviewModeSelectorPopup
 
-    private var _binding: LayoutPickerPreviewFragmentBinding? = null
-    private val binding get() = _binding!!
+    private var binding: LayoutPickerPreviewFragmentBinding? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        _binding = LayoutPickerPreviewFragmentBinding.inflate(inflater, container, false)
-        return binding.root
+        binding = LayoutPickerPreviewFragmentBinding.inflate(inflater, container, false)
+        return binding?.root
     }
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.webView.settings.javaScriptEnabled = true
-        binding.webView.settings.useWideViewPort = true
-        binding.webView.setInitialScale(INITIAL_SCALE)
-        binding.chooseButton.setText(getChooseButtonText())
+        binding?.webView?.settings?.javaScriptEnabled = true
+        binding?.webView?.settings?.useWideViewPort = true
+        binding?.webView?.setInitialScale(INITIAL_SCALE)
+        binding?.chooseButton?.setText(getChooseButtonText())
         initViewModel()
     }
 
@@ -72,54 +70,56 @@ abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
     private fun initViewModel() {
         this.viewModel = getViewModel()
 
-        viewModel.previewState.observe(viewLifecycleOwner, Observer { state ->
+        viewModel.previewState.observe(viewLifecycleOwner, { state ->
             when (state) {
                 is Loading -> {
-                    binding.desktopPreviewHint.setVisible(false)
-                    binding.progressBar.setVisible(true)
-                    binding.webView.setVisible(false)
-                    binding.errorView.setVisible(false)
-                    binding.webView.loadUrl(state.url)
+                    binding?.desktopPreviewHint?.setVisible(false)
+                    binding?.progressBar?.setVisible(true)
+                    binding?.webView?.setVisible(false)
+                    binding?.errorView?.setVisible(false)
+                    binding?.webView?.loadUrl(state.url)
                 }
                 is Loaded -> {
-                    binding.progressBar.setVisible(false)
-                    binding.webView.setVisible(true)
-                    binding.errorView.setVisible(false)
-                    binding.desktopPreviewHint.setText(
+                    binding?.progressBar?.setVisible(false)
+                    binding?.webView?.setVisible(true)
+                    binding?.errorView?.setVisible(false)
+                    binding?.desktopPreviewHint?.setText(
                             when (viewModel.selectedPreviewMode()) {
                                 MOBILE -> R.string.web_preview_mobile
                                 TABLET -> R.string.web_preview_tablet
                                 DESKTOP -> R.string.web_preview_desktop
                             }
                     )
-                    AniUtils.animateBottomBar(binding.desktopPreviewHint, true)
+                    AniUtils.animateBottomBar(binding?.desktopPreviewHint, true)
                 }
                 is Error -> {
-                    binding.progressBar.setVisible(false)
-                    binding.webView.setVisible(false)
-                    binding.errorView.setVisible(true)
+                    binding?.progressBar?.setVisible(false)
+                    binding?.webView?.setVisible(false)
+                    binding?.errorView?.setVisible(true)
                     state.toast?.let { ToastUtils.showToast(requireContext(), it) }
                 }
             }
         })
 
         // We're skipping the first emitted value since it derives from the view model initialization (`start` method)
-        viewModel.previewMode.skip(1).observe(viewLifecycleOwner, Observer { load() })
+        viewModel.previewMode.skip(1).observe(viewLifecycleOwner, { load() })
 
-        viewModel.onPreviewModeButtonPressed.observe(viewLifecycleOwner, Observer {
+        viewModel.onPreviewModeButtonPressed.observe(viewLifecycleOwner, {
             previewModeSelectorPopup.show(viewModel)
         })
 
-        previewModeSelectorPopup = PreviewModeSelectorPopup(requireActivity(), binding.previewTypeSelectorButton)
+        binding?.previewTypeSelectorButton?.let {
+            previewModeSelectorPopup = PreviewModeSelectorPopup(requireActivity(), it)
+        }
 
-        binding.backButton.setOnClickListener { closeModal() }
+        binding?.backButton?.setOnClickListener { closeModal() }
 
-        binding.chooseButton.setOnClickListener { viewModel.onPreviewChooseTapped() }
+        binding?.chooseButton?.setOnClickListener { viewModel.onPreviewChooseTapped() }
 
-        binding.previewTypeSelectorButton.setOnClickListener { viewModel.onPreviewModePressed() }
+        binding?.previewTypeSelectorButton?.setOnClickListener { viewModel.onPreviewModePressed() }
 
-        binding.webView.settings.userAgentString = WordPress.getUserAgent()
-        binding.webView.webViewClient = object : WebViewClient() {
+        binding?.webView?.settings?.userAgentString = WordPress.getUserAgent()
+        binding?.webView?.webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 super.onPageFinished(view, url)
                 if (view == null) return
@@ -139,7 +139,7 @@ abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
             }
         }
 
-        binding.errorView.button.setOnClickListener { load() }
+        binding?.errorView?.button?.setOnClickListener { load() }
         load()
     }
 
@@ -164,6 +164,6 @@ abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        _binding = null
+        binding = null
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/timezone/SiteSettingsTimezoneBottomSheet.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/timezone/SiteSettingsTimezoneBottomSheet.kt
@@ -31,8 +31,7 @@ class SiteSettingsTimezoneBottomSheet : BottomSheetDialogFragment() {
         timezoneViewModel.onTimezoneSelected(timezone.value)
     }
 
-    private var _binding: SiteSettingsTimezoneBottomSheetListBinding? = null
-    private val binding get() = _binding
+    private var binding: SiteSettingsTimezoneBottomSheetListBinding? = null
 
     private var bottomSheet: FrameLayout? = null
 
@@ -54,7 +53,7 @@ class SiteSettingsTimezoneBottomSheet : BottomSheetDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        _binding = SiteSettingsTimezoneBottomSheetListBinding.inflate(inflater, container, false)
+        binding = SiteSettingsTimezoneBottomSheetListBinding.inflate(inflater, container, false)
         return binding?.root
     }
 
@@ -71,9 +70,9 @@ class SiteSettingsTimezoneBottomSheet : BottomSheetDialogFragment() {
     }
 
     override fun onDestroyView() {
-        _binding = null
         callback = null
         super.onDestroyView()
+        binding = null
     }
 
     private fun setupUI() {


### PR DESCRIPTION
Parent #14845 

This PR removes the binding backing fields from `LayoutPreviewFragment` and `SiteSettingsTimezoneBottomSheet`

**To test:**
**LayoutPreviewFragment**

-Launch the app
-Navigate to My Site -> FAB -> Site Page
-(1) Note that the category bar along the top works correctly (select/unselect)
-Select a page layout (you will see the check on the page layout)
-Tap the preview button
-(2) Note that the preview shows as expected
-Navigate back to My Site
-Tap the site chooser
-Select + in the upper right hand corner and tap "Create WordPress.com site"
-(3) Note that the category bar along the top works correctly
-Select a page layout (you will see the check on the page layout)
-Tap the preview button
-(4) Note that the preview shows as expected

----------------
SiteSettingsTimezoneBottomSheet
-Launch the app
-Navigate to My Site -> Settings -> Timezone
-(1) Note the view is shown and works as expected

## Regression Notes
1. Potential unintended areas of impact
The Layout selection preview or timezone settings do not work as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tested both features

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

