### PR TITLE
ViewBinding: Refactor: call binding=null after super.onDestroyView()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -98,8 +98,8 @@ class HelpActivity : LocaleAwareActivity() {
     }
 
     override fun onDestroy() {
-        binding = null
         super.onDestroy()
+        binding = null
     }
 
     override fun onResume() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -29,7 +29,7 @@ class HelpActivity : LocaleAwareActivity() {
     @Inject lateinit var siteStore: SiteStore
     @Inject lateinit var supportHelper: SupportHelper
     @Inject lateinit var zendeskHelper: ZendeskHelper
-    private var binding: HelpActivityBinding? = null
+    private lateinit var binding: HelpActivityBinding
 
     private val originFromExtras by lazy {
         (intent.extras?.get(ORIGIN_KEY) as Origin?) ?: Origin.UNKNOWN
@@ -97,15 +97,10 @@ class HelpActivity : LocaleAwareActivity() {
         }
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        binding = null
-    }
-
     override fun onResume() {
         super.onResume()
         ActivityId.trackLastActivity(ActivityId.HELP_SCREEN)
-        binding?.refreshContactEmailText()
+        binding.refreshContactEmailText()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {


### PR DESCRIPTION
Parent #14845 

This PR refactors the `binding=null` call to after `super.onDestroyView()` in `HelpActivity`.

To test:
- Launch App
- Navigate to Help
- Ensure that the feature works as expected

## Regression Notes
1. Potential unintended areas of impact N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on) N/A
3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
