### PR TITLE
Add Blogging Reminders tracking – Part 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_COMPLETED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_DISMISSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_START
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_SCHEDULED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_SCREEN_SHOWN
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Button.CONTINUE
@@ -51,6 +52,11 @@ class BloggingRemindersAnalyticsTracker @Inject constructor(
 
     fun trackFlowCompleted() = track(BLOGGING_REMINDERS_FLOW_COMPLETED)
 
+    fun trackRemindersScheduled(daysCount: Int) = track(
+            BLOGGING_REMINDERS_SCHEDULED,
+            mapOf(DAYS_OF_WEEK_COUNT_KEY to daysCount)
+    )
+
     private fun track(stat: Stat, properties: Map<String, Any?> = emptyMap()) = analyticsTracker.track(
             stat,
             properties + (BLOG_TYPE_KEY to siteType?.trackingName)
@@ -76,5 +82,6 @@ class BloggingRemindersAnalyticsTracker @Inject constructor(
         private const val SCREEN_KEY = "screen"
         private const val BUTTON_KEY = "button"
         private const val SOURCE_KEY = "source"
+        private const val DAYS_OF_WEEK_COUNT_KEY = "days_of_week_count"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_COMPLETED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_DISMISSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_START
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_NOTIFICATION_RECEIVED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_SCHEDULED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_SCREEN_SHOWN
 import org.wordpress.android.fluxc.store.SiteStore
@@ -59,6 +60,8 @@ class BloggingRemindersAnalyticsTracker @Inject constructor(
     )
 
     fun trackRemindersCancelled() = track(BLOGGING_REMINDERS_CANCELLED)
+
+    fun trackNotificationReceived() = track(BLOGGING_REMINDERS_NOTIFICATION_RECEIVED)
 
     private fun track(stat: Stat, properties: Map<String, Any?> = emptyMap()) = analyticsTracker.track(
             stat,

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTracker.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.bloggingreminders
 
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_BUTTON_PRESSED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_CANCELLED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_COMPLETED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_DISMISSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_START
@@ -56,6 +57,8 @@ class BloggingRemindersAnalyticsTracker @Inject constructor(
             BLOGGING_REMINDERS_SCHEDULED,
             mapOf(DAYS_OF_WEEK_COUNT_KEY to daysCount)
     )
+
+    fun trackRemindersCancelled() = track(BLOGGING_REMINDERS_CANCELLED)
 
     private fun track(stat: Stat, properties: Map<String, Any?> = emptyMap()) = analyticsTracker.track(
             stat,

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -171,7 +171,7 @@ class BloggingRemindersViewModel @Inject constructor(
                 if (daysCount > 0) {
                     analyticsTracker.trackRemindersScheduled(daysCount)
                 } else {
-                    // TODO Track cancelled
+                    analyticsTracker.trackRemindersCancelled()
                 }
                 _selectedScreen.value = EPILOGUE
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -167,6 +167,12 @@ class BloggingRemindersViewModel @Inject constructor(
             launch {
                 bloggingRemindersStore.updateBloggingReminders(bloggingRemindersModel)
                 // TODO Add logic to save state and schedule notifications here
+                val daysCount = bloggingRemindersModel.enabledDays.size
+                if (daysCount > 0) {
+                    analyticsTracker.trackRemindersScheduled(daysCount)
+                } else {
+                    // TODO Track cancelled
+                }
                 _selectedScreen.value = EPILOGUE
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotification.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotification.kt
@@ -1,0 +1,32 @@
+package org.wordpress.android.workers.reminder
+
+import android.app.PendingIntent
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.PRIORITY_DEFAULT
+
+data class ReminderNotification(
+    val channel: String,
+    val contentIntentBuilder: () -> PendingIntent,
+    val contentTitle: String,
+    val contentText: String,
+    val priority: Int = PRIORITY_DEFAULT,
+    val category: String,
+    val autoCancel: Boolean = true,
+    val colorized: Boolean = true,
+    val color: Int,
+    val smallIcon: Int
+) {
+    fun asNotificationCompatBuilder(context: Context): NotificationCompat.Builder {
+        return NotificationCompat.Builder(context, channel)
+                .setContentIntent(contentIntentBuilder.invoke())
+                .setContentTitle(contentTitle)
+                .setContentText(contentText)
+                .setPriority(priority)
+                .setCategory(category)
+                .setAutoCancel(autoCancel)
+                .setColorized(colorized)
+                .setColor(color)
+                .setSmallIcon(smallIcon)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotificationManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotificationManager.kt
@@ -1,0 +1,13 @@
+package org.wordpress.android.workers.reminder
+
+import android.content.Context
+import androidx.core.app.NotificationManagerCompat
+import javax.inject.Inject
+
+class ReminderNotificationManager @Inject constructor(
+    private val context: Context
+) {
+    fun notify(id: Int, notification: ReminderNotification) {
+        NotificationManagerCompat.from(context).notify(id, notification.asNotificationCompatBuilder(context).build())
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
@@ -2,47 +2,55 @@ package org.wordpress.android.workers.reminder
 
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_CANCEL_CURRENT
-import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.CATEGORY_REMINDER
 import androidx.core.app.NotificationCompat.PRIORITY_DEFAULT
-import androidx.core.app.NotificationManagerCompat
-import androidx.core.content.ContextCompat
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.push.NotificationPushIds.REMINDER_NOTIFICATION_ID
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker
 import org.wordpress.android.ui.posts.PostsListActivity
 import org.wordpress.android.viewmodel.ContextProvider
+import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
 class ReminderNotifier @Inject constructor(
     val contextProvider: ContextProvider,
+    val resourceProvider: ResourceProvider,
     val siteStore: SiteStore,
-    val accountStore: AccountStore
+    val accountStore: AccountStore,
+    val reminderNotificationManager: ReminderNotificationManager,
+    val analyticsTracker: BloggingRemindersAnalyticsTracker
 ) {
     fun notify(siteId: Long) {
         val context = contextProvider.getContext()
         val site = siteStore.getSiteBySiteId(siteId)
         val name = accountStore.account.firstName
 
-        val pendingIntent = PendingIntent.getActivity(
-                context,
-                0,
-                PostsListActivity.buildIntent(context, site),
-                FLAG_CANCEL_CURRENT
+        val reminderNotification = ReminderNotification(
+                channel = resourceProvider.getString(R.string.notification_channel_reminder_id),
+                contentIntentBuilder = {
+                    PendingIntent.getActivity(
+                            context,
+                            0,
+                            PostsListActivity.buildIntent(context, site),
+                            FLAG_CANCEL_CURRENT
+                    )
+                },
+                contentTitle = resourceProvider.getString(R.string.blogging_reminders_notification_title, name),
+                contentText = resourceProvider.getString(R.string.blogging_reminders_notification_text),
+                priority = PRIORITY_DEFAULT,
+                category = CATEGORY_REMINDER,
+                autoCancel = true,
+                colorized = true,
+                color = resourceProvider.getColor(R.color.blue_50),
+                smallIcon = R.drawable.ic_app_white_24dp
         )
-        val builder = NotificationCompat.Builder(context, context.getString(R.string.notification_channel_reminder_id))
-                .setContentIntent(pendingIntent)
-                .setContentTitle(context.getString(R.string.blogging_reminders_notification_title, name))
-                .setContentText(context.getString(R.string.blogging_reminders_notification_text))
-                .setPriority(PRIORITY_DEFAULT)
-                .setCategory(CATEGORY_REMINDER)
-                .setAutoCancel(true)
-                .setColorized(true)
-                .setColor(ContextCompat.getColor(context, R.color.blue_50))
-                .setSmallIcon(R.drawable.ic_app_white_24dp)
 
-        NotificationManagerCompat.from(context).notify(REMINDER_NOTIFICATION_ID, builder.build())
+        reminderNotificationManager.notify(REMINDER_NOTIFICATION_ID, reminderNotification)
+
+        analyticsTracker.setSite(site.id)
+        analyticsTracker.trackNotificationReceived()
     }
 
     fun shouldNotify(siteId: Long) = siteId != NO_SITE_ID

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAnalyticsTrackerTest.kt
@@ -13,9 +13,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_BUTTON_PRESSED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_CANCELLED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_COMPLETED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_DISMISSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_FLOW_START
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_NOTIFICATION_RECEIVED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_SCHEDULED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_REMINDERS_SCREEN_SHOWN
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
@@ -121,6 +124,31 @@ class BloggingRemindersAnalyticsTrackerTest {
     fun `trackFlowCompleted tracks correct event and properties`() {
         bloggingRemindersAnalyticsTracker.trackFlowCompleted()
         verify(analyticsTracker).track(eq(BLOGGING_REMINDERS_FLOW_COMPLETED), checkMap {
+            assertThat(it).containsKey("blog_type")
+        })
+    }
+
+    @Test
+    fun `trackRemindersScheduled tracks correct event and properties`() {
+        bloggingRemindersAnalyticsTracker.trackRemindersScheduled(3)
+        verify(analyticsTracker).track(eq(BLOGGING_REMINDERS_SCHEDULED), checkMap {
+            assertThat(it).containsEntry("days_of_week_count", 3)
+            assertThat(it).containsKey("blog_type")
+        })
+    }
+
+    @Test
+    fun `trackRemindersCancelled tracks correct event and properties`() {
+        bloggingRemindersAnalyticsTracker.trackRemindersCancelled()
+        verify(analyticsTracker).track(eq(BLOGGING_REMINDERS_CANCELLED), checkMap {
+            assertThat(it).containsKey("blog_type")
+        })
+    }
+
+    @Test
+    fun `trackNotificationReceived tracks correct event and properties`() {
+        bloggingRemindersAnalyticsTracker.trackNotificationReceived()
+        verify(analyticsTracker).track(eq(BLOGGING_REMINDERS_NOTIFICATION_RECEIVED), checkMap {
             assertThat(it).containsKey("blog_type")
         })
     }

--- a/WordPress/src/test/java/org/wordpress/android/workers/reminder/ReminderNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/reminder/ReminderNotifierTest.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.workers.reminder
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker
+import org.wordpress.android.viewmodel.ContextProvider
+import org.wordpress.android.viewmodel.ResourceProvider
+
+@RunWith(MockitoJUnitRunner::class)
+class ReminderNotifierTest {
+    lateinit var reminderNotifier: ReminderNotifier
+
+    private val contextProvider: ContextProvider = mock()
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) } doReturn ""
+        on { getString(any(), any()) } doReturn ""
+    }
+    private val siteStore: SiteStore = mock {
+        on { getSiteBySiteId(SITE_ID) } doReturn TEST_SITE
+    }
+    private val accountStore: AccountStore = mock {
+        on { account } doReturn TEST_ACCOUNT
+    }
+    private val notificationManager: ReminderNotificationManager = mock()
+    private val analyticsTracker: BloggingRemindersAnalyticsTracker = mock()
+
+    @Before
+    fun setUp() {
+        reminderNotifier = ReminderNotifier(
+                contextProvider,
+                resourceProvider,
+                siteStore,
+                accountStore,
+                notificationManager,
+                analyticsTracker
+        )
+    }
+
+    @Test
+    fun `notify correctly tracks notification received event`() {
+        reminderNotifier.notify(SITE_ID)
+        verify(analyticsTracker).setSite(LOCAL_ID)
+        verify(analyticsTracker).trackNotificationReceived()
+    }
+
+    private companion object {
+        private val TEST_SITE = SiteModel().apply {
+            id = LOCAL_ID
+            siteId = SITE_ID
+        }
+
+        private val TEST_ACCOUNT = AccountModel().apply {
+            userName = "username"
+        }
+
+        private const val LOCAL_ID = 1
+        private const val SITE_ID = 1001L
+    }
+}


### PR DESCRIPTION
Fixes #14846

This PR adds tracking to all Blogging Reminders events that are **not** related to the UI:

- `blogging_reminders_scheduled`
- `blogging_reminders_cancelled`
- `blogging_reminders_notification_received`

The following events were included in Part 1 (#14875):

- `blogging_reminders_screen_shown`
- `blogging_reminders_button_pressed`
- `blogging_reminders_flow_start`
- `blogging_reminders_flow_dismissed`
- `blogging_reminders_flow_completed`

For more information on each event, please check this internal reference: p1624309290237600-slack-C01UWB9GD1Q

Most of the changes in this PR should be pretty straightforward, except for a few changes made to `ReminderNotifier` that were necessary to make testing a bit easier.

### To test

- Clear app data and log in.
- Make sure the feature flag is turned on.

#### Happy path

- **After publishing a post** and going through the entire Blogging Reminders flow, this is what the sequence of tracked events should look like:

```
🔵 Tracked: blogging_reminders_flow_start, Properties: {"blog_type":"wpcom","source":"publish_flow"}
🔵 Tracked: blogging_reminders_screen_shown, Properties: {"blog_type":"wpcom","screen":"main"}
🔵 Tracked: blogging_reminders_button_pressed, Properties: {"blog_type":"wpcom","screen":"main","button":"continue"}
🔵 Tracked: blogging_reminders_screen_shown, Properties: {"blog_type":"wpcom","screen":"day_picker"}
🔵 Tracked: blogging_reminders_button_pressed, Properties: {"blog_type":"wpcom","screen":"day_picker","button":"continue"}
New event → 🔵 Tracked: blogging_reminders_scheduled, Properties: {"blog_type":"wpcom","days_of_week_count":3}
🔵 Tracked: blogging_reminders_screen_shown, Properties: {"blog_type":"wpcom","screen":"all_set"}
🔵 Tracked: blogging_reminders_button_pressed, Properties: {"blog_type":"wpcom","screen":"all_set","button":"continue"}
🔵 Tracked: blogging_reminders_flow_completed, Properties: {"blog_type":"wpcom"}
```

🔵 Tracked: blogging_reminders_cancelled, Properties: {"blog_type":"wpcom"}

- Going through the entire flow **from site settings**, the sequence of tracked events should look like this:

```
🔵 Tracked: blogging_reminders_flow_start, Properties: {"blog_type":"wpcom","source":"blog_settings"}
🔵 Tracked: blogging_reminders_screen_shown, Properties: {"blog_type":"wpcom","screen":"day_picker"}
🔵 Tracked: blogging_reminders_button_pressed, Properties: {"blog_type":"wpcom","screen":"day_picker","button":"continue"}
New event → 🔵 Tracked: blogging_reminders_scheduled, Properties: {"blog_type":"wpcom","days_of_week_count":3}
🔵 Tracked: blogging_reminders_screen_shown, Properties: {"blog_type":"wpcom","screen":"all_set"}
🔵 Tracked: blogging_reminders_button_pressed, Properties: {"blog_type":"wpcom","screen":"all_set","button":"continue"}
🔵 Tracked: blogging_reminders_flow_completed, Properties: {"blog_type":"wpcom"}
```

Make sure the `days_of_week_count` property corresponds to the number of selected days.

#### Cancelling reminders

If no days are selected from the **Day Picker** screen, you should see a `blogging_reminders_cancelled` event instead of `blogging_reminders_scheduled`:

```
🔵 Tracked: blogging_reminders_cancelled, Properties: {"blog_type":"wpcom"}
```

#### Notification received

Whenever a reminder is triggered and a notification is shown to the user, a `blogging_reminders_notification_received` should be tracked. There is no easy way to test this at the moment, but hopefully the unit tests should suffice.

## Regression Notes
1. Potential unintended areas of impact
Other logic related to the Blogging Reminders scheduling logic.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
Unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.