### PR TITLE
Reader: Fix duplicate "discover" and "blog"/ "feed" posts (duplicate posts issue - part 2)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -300,7 +300,7 @@ public class ReaderPostTable {
             return 0;
         }
         return SqlUtils.intForQuery(ReaderDatabase.getReadableDb(),
-                "SELECT count(*) FROM tbl_posts WHERE blog_id=? AND tag_name=''",
+                "SELECT count(*) FROM tbl_posts WHERE blog_id=? AND tag_name='' AND tag_type=0",
                 new String[]{Long.toString(blogId)});
     }
 
@@ -309,7 +309,7 @@ public class ReaderPostTable {
             return 0;
         }
         return SqlUtils.intForQuery(ReaderDatabase.getReadableDb(),
-                "SELECT count(*) FROM tbl_posts WHERE feed_id=? AND tag_name=''",
+                "SELECT count(*) FROM tbl_posts WHERE feed_id=? AND tag_name='' AND tag_type=0",
                 new String[]{Long.toString(feedId)});
     }
 
@@ -668,14 +668,14 @@ public class ReaderPostTable {
      */
     public static String getOldestPubDateInBlog(long blogId) {
         String sql = "SELECT date_published FROM tbl_posts"
-                     + " WHERE blog_id=? AND tag_name=''"
+                     + " WHERE blog_id=? AND tag_name='' AND tag_type=0"
                      + " ORDER BY date_published LIMIT 1";
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(), sql, new String[]{Long.toString(blogId)});
     }
 
     public static String getOldestPubDateInFeed(long feedId) {
         String sql = "SELECT date_published FROM tbl_posts"
-                     + " WHERE feed_id=? AND tag_name=''"
+                     + " WHERE feed_id=? AND tag_name='' AND tag_type=0"
                      + " ORDER BY date_published LIMIT 1";
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(), sql, new String[]{Long.toString(feedId)});
     }
@@ -988,7 +988,8 @@ public class ReaderPostTable {
     public static ReaderPostList getPostsInBlog(long blogId, int maxPosts, boolean excludeTextColumn) {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "*");
         String sql =
-                "SELECT " + columns + " FROM tbl_posts WHERE blog_id=? AND tag_name='' ORDER BY date_published DESC";
+                "SELECT " + columns + " FROM tbl_posts WHERE blog_id=? AND tag_name='' AND tag_type=0"
+                + " ORDER BY date_published DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + maxPosts;
@@ -1015,7 +1016,8 @@ public class ReaderPostTable {
     public static ReaderPostList getPostsInFeed(long feedId, int maxPosts, boolean excludeTextColumn) {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "*");
         String sql =
-                "SELECT " + columns + " FROM tbl_posts WHERE feed_id=? AND tag_name='' ORDER BY date_published DESC";
+                "SELECT " + columns + " FROM tbl_posts WHERE feed_id=? AND tag_name='' AND tag_type=0"
+                + " ORDER BY date_published DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + maxPosts;
@@ -1091,7 +1093,8 @@ public class ReaderPostTable {
      * same as getPostsInBlog() but only returns the blogId/postId pairs
      */
     public static ReaderBlogIdPostIdList getBlogIdPostIdsInBlog(long blogId, int maxPosts) {
-        String sql = "SELECT post_id FROM tbl_posts WHERE blog_id=? AND tag_name='' ORDER BY date_published DESC";
+        String sql = "SELECT post_id FROM tbl_posts WHERE blog_id=? AND tag_name='' AND tag_type=0"
+                     + " ORDER BY date_published DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + maxPosts;


### PR DESCRIPTION
Issue #12938 Part 2

Part 1: #14813 (discusses the followed-sites duplicate post issue)

Discover posts and blog posts both are saved with the empty `tag_name` but different `tag_type` (7 - discover post, 0 - otherwise). [Blog/ feed posts being queried using an empty `tag_name`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java#L988-L991), discover posts for that blog/ feed also get displayed in the results causing duplicate posts issue. This happens irrespective of the site type (Simple/ Atomic/ Jetpack sites).

**Duplicate posts issue (timestamp `00:50`)** 

https://user-images.githubusercontent.com/1405144/122709669-57751280-d27c-11eb-896f-0b6bc9f4bde5.mp4


This PR adds another condition `tag_type=0` in the queries that fetch posts for the blog/ feed so that discover posts for that blog/ feed are not shown in the results.

To test:

- Go to the Reader -> Discover tab.
- Note down a discover post (and its site).
- Click the above post to see the details on the post details screen.
- Using a different account, search the same post on Calypso and like it.
- Pull-to-refresh the post in the app (this triggers `ReaderPostActions.updatePost` action as the server post is updated.
- Return to the discover tab and click the post's site header.
- Scroll to find the same post in the site's posts.
- Notice that the post is not duplicated.

## Regression Notes
1. Potential unintended areas of impact 🟢

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so) 🟢

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
