### PR TITLE
Me View: Fix logout behavior 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1280,7 +1280,15 @@ public class ActivityLauncher {
     }
 
     public static void showSignInForResult(Activity activity) {
+        showSignInForResult(activity, false);
+    }
+
+    public static void showSignInForResult(Activity activity, boolean clearTop) {
         Intent intent = new Intent(activity, LoginActivity.class);
+        if (clearTop) {
+            intent.setFlags(
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        }
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1403,7 +1403,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
             if (BuildConfig.IS_JETPACK_APP) {
                 ActivityLauncher.showSignInForResultJetpackOnly(this);
             } else {
-                ActivityLauncher.showSignInForResult(this);
+                ActivityLauncher.showSignInForResult(this, true);
             }
         } else {
             SiteModel site = getSelectedSite();


### PR DESCRIPTION
Fixes #14632

This PR fixes the redisplay of the Me View after logout from this view and swipe back on the Login Prologue view shown after logout.

To test:

1. Fresh install or delete all data
2. Launch App
3. Login with WP.com account
4. From My Site: Tap Me -> Logout -> Confirm logout
5. Note that you are taken to the Login Prologue view
6. Tap the device Back Button or swipe back
7. The Me View is not shown

## Regression Notes
1. Potential unintended areas of impact 🟢 


2. What I did to test those areas of impact (or what existing automated tests I relied on) 🟢 


3. What automated tests I added (or what prevented me from doing so) 🟢 

Review Instructions:

Only 1 reviewer is needed. Since both of you have context on this issue, anyone relatively free can pick this up for review.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
