### PR TITLE
Connect Blogging Reminders scheduling logic to the UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderConfig.kt
@@ -20,7 +20,6 @@ sealed class ReminderConfig(val type: ReminderType) {
         DAILY, WEEKLY
     }
 
-    // TODO Use site timezone instead of local time
     fun calculateNext(from: LocalDate = LocalDate.now()): LocalDate = when (this) {
         is DailyReminder -> from.plusDays(1)
         is WeeklyReminder -> from.withNextDayOfWeekFrom(days)!! // We know the set won't be empty

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
@@ -22,9 +22,9 @@ class ReminderNotifier @Inject constructor(
     val reminderNotificationManager: ReminderNotificationManager,
     val analyticsTracker: BloggingRemindersAnalyticsTracker
 ) {
-    fun notify(siteId: Long) {
+    fun notify(siteId: Int) {
         val context = contextProvider.getContext()
-        val site = siteStore.getSiteBySiteId(siteId)
+        val site = siteStore.getSiteByLocalId(siteId)
         val name = accountStore.account.firstName
 
         val reminderNotification = ReminderNotification(
@@ -49,15 +49,15 @@ class ReminderNotifier @Inject constructor(
 
         reminderNotificationManager.notify(REMINDER_NOTIFICATION_ID, reminderNotification)
 
-        analyticsTracker.setSite(site.id)
+        analyticsTracker.setSite(siteId)
         analyticsTracker.trackNotificationReceived()
     }
 
-    fun shouldNotify(siteId: Long) = siteId != NO_SITE_ID
-            && siteStore.getSiteBySiteId(siteId) != null
+    fun shouldNotify(siteId: Int) = siteId != NO_SITE_ID
+            && siteStore.getSiteByLocalId(siteId) != null
             && accountStore.hasAccessToken()
 
     companion object {
-        const val NO_SITE_ID = -1L
+        const val NO_SITE_ID = -1
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderScheduler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderScheduler.kt
@@ -16,12 +16,12 @@ class ReminderScheduler @Inject constructor(
 ) {
     val workManager by lazy { WorkManager.getInstance(contextProvider.getContext()) }
 
-    fun schedule(siteId: Long, reminderConfig: ReminderConfig) {
+    fun schedule(siteId: Int, reminderConfig: ReminderConfig) {
         val uniqueName = getUniqueName(siteId)
         val next = reminderConfig.calculateNext().atTime(8, 0)
         val delay = Duration.between(LocalDateTime.now(), next)
         val inputData = Data.Builder()
-                .putLong(REMINDER_SITE_ID, siteId)
+                .putInt(REMINDER_SITE_ID, siteId)
                 .putAll(reminderConfig.toMap())
                 .build()
 
@@ -36,17 +36,17 @@ class ReminderScheduler @Inject constructor(
 
     fun cancelById(id: UUID) = workManager.cancelWorkById(id)
 
-    fun cancelBySiteId(siteId: Long) = workManager.cancelUniqueWork(getUniqueName(siteId))
+    fun cancelBySiteId(siteId: Int) = workManager.cancelUniqueWork(getUniqueName(siteId))
 
     fun cancelAll() = workManager.cancelAllWorkByTag(REMINDER_TAG)
 
     fun getById(id: UUID) = workManager.getWorkInfoByIdLiveData(id)
 
-    fun getBySiteId(siteId: Long) = workManager.getWorkInfosForUniqueWorkLiveData(getUniqueName(siteId))
+    fun getBySiteId(siteId: Int) = workManager.getWorkInfosForUniqueWorkLiveData(getUniqueName(siteId))
 
     fun getAll() = workManager.getWorkInfosByTagLiveData(REMINDER_TAG)
 
-    private fun getUniqueName(siteId: Long) = "${REMINDER_TAG}_$siteId"
+    private fun getUniqueName(siteId: Int) = "${REMINDER_TAG}_$siteId"
 
     companion object {
         private const val REMINDER_TAG = "reminder"

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderWorker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderWorker.kt
@@ -15,7 +15,7 @@ class ReminderWorker(
     workerParameters: WorkerParameters
 ) : CoroutineWorker(context, workerParameters) {
     override suspend fun doWork(): Result = coroutineScope {
-        val siteId = inputData.getLong(REMINDER_SITE_ID, NO_SITE_ID)
+        val siteId = inputData.getInt(REMINDER_SITE_ID, NO_SITE_ID)
         val reminderConfig = ReminderConfig.fromMap(inputData.keyValueMap)
 
         if (notifier.shouldNotify(siteId)) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.viewmodel.ResourceProvider
+import org.wordpress.android.workers.reminder.ReminderScheduler
 
 class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Mock lateinit var bloggingRemindersManager: BloggingRemindersManager
@@ -49,6 +50,7 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Mock lateinit var daySelectionBuilder: DaySelectionBuilder
     @Mock lateinit var dayLabelUtils: DayLabelUtils
     @Mock lateinit var analyticsTracker: BloggingRemindersAnalyticsTracker
+    @Mock lateinit var reminderScheduler: ReminderScheduler
     private lateinit var viewModel: BloggingRemindersViewModel
     private val siteId = 123
     private lateinit var events: MutableList<Boolean>
@@ -66,7 +68,8 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
                 prologueBuilder,
                 daySelectionBuilder,
                 dayLabelUtils,
-                analyticsTracker
+                analyticsTracker,
+                reminderScheduler
         )
         events = mutableListOf()
         events = viewModel.isBottomSheetShowing.eventToList()

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModelTest.kt
@@ -20,8 +20,10 @@ import org.wordpress.android.TEST_DISPATCHER
 import org.wordpress.android.eventToList
 import org.wordpress.android.fluxc.model.BloggingRemindersModel
 import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day
+import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.FRIDAY
 import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.MONDAY
 import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.SUNDAY
+import org.wordpress.android.fluxc.model.BloggingRemindersModel.Day.WEDNESDAY
 import org.wordpress.android.fluxc.store.BloggingRemindersStore
 import org.wordpress.android.toList
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source.BLOG_SETTINGS
@@ -40,7 +42,9 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.viewmodel.ResourceProvider
+import org.wordpress.android.workers.reminder.ReminderConfig.WeeklyReminder
 import org.wordpress.android.workers.reminder.ReminderScheduler
+import java.time.DayOfWeek
 
 class BloggingRemindersViewModelTest : BaseUnitTest() {
     @Mock lateinit var bloggingRemindersManager: BloggingRemindersManager
@@ -266,6 +270,34 @@ class BloggingRemindersViewModelTest : BaseUnitTest() {
         viewModel.onBottomSheetDismissed()
 
         verify(analyticsTracker).trackFlowCompleted()
+    }
+
+    @Test
+    fun `clicking primary button on selection screen schedule reminders with correct days`() {
+        val model = BloggingRemindersModel(siteId, setOf(MONDAY, WEDNESDAY, FRIDAY))
+        whenever(bloggingRemindersStore.bloggingRemindersModel(siteId)).thenReturn(flowOf(model))
+        initDaySelectionBuilder()
+
+        viewModel.showBottomSheet(siteId, SELECTION, BLOG_SETTINGS)
+
+        clickPrimaryButton()
+
+        verify(reminderScheduler).schedule(
+                siteId,
+                WeeklyReminder(setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY))
+        )
+    }
+
+    @Test
+    fun `clicking primary button on empty selection screen cancel reminders`() {
+        initEmptyStore()
+        initDaySelectionBuilder()
+
+        viewModel.showBottomSheet(siteId, SELECTION, BLOG_SETTINGS)
+
+        clickPrimaryButton()
+
+        verify(reminderScheduler).cancelBySiteId(siteId)
     }
 
     private fun initEmptyStore(): BloggingRemindersModel {

--- a/WordPress/src/test/java/org/wordpress/android/workers/reminder/ReminderNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/reminder/ReminderNotifierTest.kt
@@ -26,7 +26,7 @@ class ReminderNotifierTest {
         on { getString(any(), any()) } doReturn ""
     }
     private val siteStore: SiteStore = mock {
-        on { getSiteBySiteId(SITE_ID) } doReturn TEST_SITE
+        on { getSiteByLocalId(SITE_ID) } doReturn TEST_SITE
     }
     private val accountStore: AccountStore = mock {
         on { account } doReturn TEST_ACCOUNT
@@ -49,21 +49,19 @@ class ReminderNotifierTest {
     @Test
     fun `notify correctly tracks notification received event`() {
         reminderNotifier.notify(SITE_ID)
-        verify(analyticsTracker).setSite(LOCAL_ID)
+        verify(analyticsTracker).setSite(SITE_ID)
         verify(analyticsTracker).trackNotificationReceived()
     }
 
     private companion object {
         private val TEST_SITE = SiteModel().apply {
-            id = LOCAL_ID
-            siteId = SITE_ID
+            id = SITE_ID
         }
 
         private val TEST_ACCOUNT = AccountModel().apply {
             userName = "username"
         }
 
-        private const val LOCAL_ID = 1
-        private const val SITE_ID = 1001L
+        private const val SITE_ID = 1
     }
 }


### PR DESCRIPTION
Fixes #14877

This PR is pretty straightforward for the most part. The main change here is that we are now calling the `ReminderScheduler` class to schedule a reminder once the user taps the primary button on the Day Picker screen.

I also had to make one small refactor to the `ReminderScheduler` class, which was to make it work with a _local_ site ID instead of a _remote_ site ID.

### To test

- Make sure you have built a debug variant of the app.
- Clear app data and log in.
- Make sure the feature flag is turned on.

#### Scheduling reminders

- Select a site with no Blogging Reminders scheduled.
- Go through the entire Blogging Reminders flow. 
- On the Day Picker screen, select a few days and tap the Continue button.
- On `logcat`, notice a message like this:

```
WM-SystemJobScheduler: Scheduling work ID b17c6bc7-c8e3-4b70-a1a3-16535b489b65 Job ID 11
```

#### Cancelling reminders

- Select the same site you selected for the previous test.
- Go through the entire Blogging Reminders flow.
- On the Day Picker screen, deselect all days and tap the Continue button.
- On `logcat`, notice a message like this:

```
WM-GreedyScheduler: Cancelling work ID b17c6bc7-c8e3-4b70-a1a3-16535b489b65
```

- Make sure the `UUID` is the same as the one shown when you scheduled the reminders.

## Regression Notes
1. Potential unintended areas of impact
Other logic related to the Blogging Reminders UI and/or scheduling.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
Unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
