### PR TITLE
ViewBinding: Remove Kotlin Android Extensions (Replace with Kotlin Parcelize)

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -51,7 +51,7 @@ repositories {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'se.bjurr.violations.violation-comments-to-github-gradle-plugin'
 apply plugin: 'kotlin-allopen'
 apply plugin: 'kotlin-kapt'
@@ -233,11 +233,6 @@ android {
     buildFeatures {
         viewBinding true
     }
-}
-
-// allows us to use cool things like @Parcelize annotations
-androidExtensions {
-    experimental = true
 }
 
 dependencies {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainProductDetails.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainProductDetails.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.ui.domains
 
+import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
+@SuppressLint("ParcelCreator")
 data class DomainProductDetails(
     val productId: Int,
     val domainName: String

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/ListScenario.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/ListScenario.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.ui.engagement
 
+import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
+@SuppressLint("ParcelCreator")
 data class ListScenario(
     val type: ListScenarioType,
     val source: EngagementNavigationSource,
@@ -26,6 +28,7 @@ enum class ListScenarioType(val typeDescription: String) {
 }
 
 @Parcelize
+@SuppressLint("ParcelCreator")
 data class HeaderData constructor(
     val authorName: AuthorName,
     val snippetText: String,
@@ -36,6 +39,7 @@ data class HeaderData constructor(
     val numLikes: Int = 0
 ) : Parcelable
 
+@SuppressLint("ParcelCreator")
 sealed class AuthorName : Parcelable {
     @Parcelize
     data class AuthorNameString(val nameString: String?) : AuthorName()

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryListItem.kt
@@ -2,9 +2,9 @@ package org.wordpress.android.ui.history
 
 import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.RawValue
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.revisions.Diff
 import org.wordpress.android.fluxc.model.revisions.RevisionModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.collect
 import org.json.JSONObject
@@ -447,6 +447,7 @@ class BackupDownloadViewModel @Inject constructor(
         )
     }
 
+    @SuppressLint("ParcelCreator")
     sealed class BackupDownloadWizardState : Parcelable {
         @Parcelize
         object BackupDownloadCanceled : BackupDownloadWizardState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.collect
 import org.json.JSONObject
@@ -535,6 +535,7 @@ class RestoreViewModel @Inject constructor(
                 SnackbarMessageHolder(UiStringRes(R.string.restore_another_process_running))
     }
 
+    @SuppressLint("ParcelCreator")
     sealed class RestoreWizardState : Parcelable {
         @Parcelize
         object RestoreCanceled : RestoreWizardState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryViewModel.kt
@@ -1,10 +1,11 @@
 package org.wordpress.android.ui.jetpack.scan.history
 
+import android.annotation.SuppressLint
 import android.os.Parcelable
 import androidx.annotation.DrawableRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import org.wordpress.android.R
@@ -103,6 +104,7 @@ class ScanHistoryViewModel @Inject constructor(
     }
 
     @Parcelize
+    @SuppressLint("ParcelCreator")
     enum class ScanHistoryTabType : Parcelable {
         ALL, FIXED, IGNORED
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutCategoryModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutCategoryModel.kt
@@ -1,11 +1,13 @@
 package org.wordpress.android.ui.layoutpicker
 
+import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayoutCategory
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.StarterDesignCategory
 
 @Parcelize
+@SuppressLint("ParcelCreator")
 class LayoutCategoryModel(
     private val starterDesignCategory: StarterDesignCategory? = null,
     private val blockLayoutCategory: GutenbergLayoutCategory? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutModel.kt
@@ -1,11 +1,13 @@
 package org.wordpress.android.ui.layoutpicker
 
+import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.site.GutenbergLayout
 import org.wordpress.android.fluxc.network.rest.wpcom.theme.StarterDesign
 
 @Parcelize
+@SuppressLint("ParcelCreator")
 data class LayoutModel(
     val slug: String,
     val title: String,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicDialogViewModel.kt
@@ -1,11 +1,12 @@
 package org.wordpress.android.ui.posts
 
+import android.annotation.SuppressLint
 import android.os.Parcelable
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Dismissed
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Negative
 import org.wordpress.android.ui.posts.BasicDialogViewModel.DialogInteraction.Positive
@@ -35,6 +36,7 @@ class BasicDialogViewModel
     }
 
     @Parcelize
+    @SuppressLint("ParcelCreator")
     data class BasicDialogModel(
         val tag: String,
         val title: String? = null,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingViewModel.kt
@@ -1,11 +1,12 @@
 package org.wordpress.android.ui.posts
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
@@ -155,6 +156,7 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
 }
 
 @Parcelize
+@SuppressLint("ParcelCreator")
 enum class PrepublishingScreen : Parcelable {
     HOME,
     PUBLISH,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts
 
+import android.annotation.SuppressLint
 import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context.ALARM_SERVICE
@@ -18,7 +19,7 @@ import androidx.annotation.LayoutRes
 import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel
@@ -205,6 +206,7 @@ abstract class PublishSettingsFragment : Fragment() {
 }
 
 @Parcelize
+@SuppressLint("ParcelCreator")
 enum class PublishSettingsFragmentType : Parcelable {
     EDIT_POST,
     PREPUBLISHING_NUDGES

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartEvent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartEvent.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.quickstart
 
 import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 
 /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -7,7 +7,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.R
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -1,11 +1,12 @@
 package org.wordpress.android.ui.sitecreation.previews
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -412,6 +413,7 @@ class SitePreviewViewModel @Inject constructor(
         val previousState: SiteCreationServiceState?
     )
 
+    @SuppressLint("ParcelCreator")
     sealed class CreateSiteState : Parcelable {
         /**
          * CreateSite request haven't finished yet or failed.

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceData.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceData.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.sitecreation.services
 
 import android.annotation.SuppressLint
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @SuppressLint("ParcelCreator")

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
@@ -6,8 +6,8 @@ import android.os.Parcel
 import android.os.Parcelable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import kotlinx.android.parcel.Parceler
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parceler
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_NEXT_DATE_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.STATS_PREVIOUS_DATE_TAPPED
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
@@ -182,6 +182,7 @@ class SelectedDateProvider
     private fun buildStateKey(key: StatsSection) = SELECTED_DATE_STATE_KEY + key
 
     @Parcelize
+    @SuppressLint("ParcelCreator")
     data class SelectedDate(
         val dateValue: Date? = null,
         val availableDates: List<Date> = listOf(),

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -38,7 +38,7 @@ repositories {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 
 android {
     compileSdkVersion 29

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergPropsBuilder.kt
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergPropsBuilder.kt
@@ -1,12 +1,14 @@
 package org.wordpress.android.editor.gutenberg
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.Bundle
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.wordpress.mobile.WPAndroidGlue.GutenbergProps
 
 @Parcelize
+@SuppressLint("ParcelCreator")
 data class GutenbergPropsBuilder(
     private val enableContactInfoBlock: Boolean,
     private val enableLayoutGridBlock: Boolean,

--- a/libs/image-editor/ImageEditor/build.gradle
+++ b/libs/image-editor/ImageEditor/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 

--- a/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/ImageEditor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.imageeditor.preview
 
+import android.annotation.SuppressLint
 import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.graphics.drawable.Drawable
@@ -24,7 +25,7 @@ import androidx.viewpager2.widget.ViewPager2
 import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
 import com.google.android.material.tabs.TabLayoutMediator
 import com.yalantis.ucrop.UCrop
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.imageeditor.EditImageViewModel
 import org.wordpress.android.imageeditor.ImageEditor
 import org.wordpress.android.imageeditor.ImageEditor.RequestListener
@@ -56,6 +57,7 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment) {
         const val ARG_EDIT_IMAGE_DATA = "arg_edit_image_data"
         const val PREVIEW_IMAGE_REDUCED_SIZE_FACTOR = 0.1
 
+        @SuppressLint("ParcelCreator")
         sealed class EditImageData : Parcelable {
             @Parcelize
             data class InputData(


### PR DESCRIPTION
Parent #14845

The `kotlin-android-extensions` plugin is no longer necessary and it is preventing us from updating to a newer gradle version. @oguzkocer and @malinajirka I am adding you as the main reviewers since you two are also working on merging the related `stories-android` [draft PR](https://github.com/Automattic/stories-android/pull/702), which (kind of) depends on this PR.

This PR is part of a larger effort to replace synthetic accessors within WPAndroid and is split into three parts:
- Replace the `kotlin-android-extensions` plugin with `kotlin-parcelize` for the `editor` library.
- Replace the `kotlin-android-extensions` plugin with `kotlin-parcelize` for the `image-editor` library.
- Replace the `kotlin-android-extensions` plugin with `kotlin-parcelize` for the `WordPress` module.

Changes in this PR, for each part above:
- Replace `kotlin-android-extensions` plugin with `kotlin-parcelize`.
- Update deprecated `kotlinx.parcelize.Parcelize` import with `kotlinx.parcelize.Parcelize`
- Suppress false positive `ParcelCreator` Lint error.

To test (for `editor` lib):
- Launch the app.
- Navigate to `My Site` -> `Blog Posts`.
- Note that the various tabs with list of posts are shown as expected.
- Navigate to `FAB` -> `Blog post`.
- Note that the draft post has been successfully created and that it is shown as expected.

To test (for `image-editor` lib):
- Launch the app.
- Navigate to `My Site` -> `Blog Posts` -> `FAB` -> `Blog post`.
- Type a `title` and some `content`.
- Click on the `+` 🔵 button on the bottom left, on top of the keyboard, to then select an `Image` block.
- Click `ADD IMAGE` -> `Choose from device` -> Select an image of your choice -> Click the `Confirm` tick on the top right of the screen.
- After the image has been loaded, click the `Media options` icon on the top right of the image -> Select `Edit`.
- The `PreviewImageFragment` edit screen should be launched.
- Note that the preview image shows as expected.

To test (for `WordPress` module):
- Launch the app.
- Navigate to `My Site` -> `Stats`.
- Note that the various tabs with list of stats are shown as expected.
- PS: There have been a number of other changes that can be tested, but testing the `Stats` screen should be enough, since this will verify that all the other similar changes also work as expected. But in case you feel strongly about smoke testing all those other screens as well, please feel free to do it.

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested as described above in the `To test` sections.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
