### PR TITLE
Docs: Update `README.md` and `config-style.md` Docs to Reflect Recent Build Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,32 +46,32 @@ Once you've created your application in the [applications manager][5], you'll
 need to edit the `./gradle.properties` file and change the
 `wp.oauth.app_id` and `wp.oauth.app_secret` fields. Then you can compile and
 run the app on a device or an emulator and try to login with a WordPress.com
-account. Note that authenticating to WordPress.com via Google is not supported 
+account. Note that authenticating to WordPress.com via Google is not supported
 in development builds of the app, only in the official release.
 
-Note that credentials created with our [WordPress.com applications manager][5] 
-allow login only and not signup. New accounts must be created using the [official app][1] 
-or [on the web](https://wordpress.com/start). Login is restricted to the WordPress.com 
-account with which the credentials were created. In other words, if the credentials 
-were created with foo@email.com, you will only be able to login with foo@email.com. 
-Using another account like bar@email.com will cause the `Client cannot use "password" grant_type` error. 
+Note that credentials created with our [WordPress.com applications manager][5]
+allow login only and not signup. New accounts must be created using the [official app][1]
+or [on the web](https://wordpress.com/start). Login is restricted to the WordPress.com
+account with which the credentials were created. In other words, if the credentials
+were created with foo@email.com, you will only be able to login with foo@email.com.
+Using another account like bar@email.com will cause the `Client cannot use "password" grant_type` error.
 
-For security reasons, some account-related actions aren't supported for development 
+For security reasons, some account-related actions aren't supported for development
 builds when using a WordPress.com account with 2-factor authentication enabled.
 
 Read more about [OAuth2][6] and the [WordPress.com REST endpoint][7].
 
-## Build and Test ## 
+## Build and Test ##
 
 To build, install, and test the project from the command line:
 
-    $ ./gradlew assembleVanillaDebug                        # assemble the debug .apk
-    $ ./gradlew installVanillaDebug                         # install the debug .apk if you have an
-                                                            # emulator or an Android device connected
-    $ ./gradlew :WordPress:testVanillaDebugUnitTest         # assemble, install and run unit tests
-    $ ./gradlew :WordPress:connectedVanillaDebugAndroidTest # assemble, install and run Android tests
+    $ ./gradlew assembleWordPressVanillaDebug                        # assemble the debug .apk
+    $ ./gradlew installWordPressVanillaDebug                         # install the debug .apk if you have an
+                                                                     # emulator or an Android device connected
+    $ ./gradlew :WordPress:testWordPressVanillaDebugUnitTest         # assemble, install and run unit tests
+    $ ./gradlew :WordPress:connectedWordPressVanillaDebugAndroidTest # assemble, install and run Android tests
 
-## Directory structure ## 
+## Directory structure ##
     .
     ├── libs                    # dependencies used to build debug variants
     ├── tools                   # script collection
@@ -114,7 +114,7 @@ If you have questions or just want to say hi, join the [WordPress Slack](https:/
 - [Pull Request Guidelines](docs/pull-request-guidelines.md) - branch naming and how to write good pull requests
 - [Subtree'd Library Projects](docs/subtreed-library-projects.md) - how to deal with subtree dependencies
 
-Please read the [docs](docs/) for more. 
+Please read the [docs](docs/) for more.
 
 ## Resources
 

--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -5,7 +5,7 @@ Our code style guidelines are based on the [Android Code Style Guidelines for Co
 * Line length is 120 characters
 * FIXME must not be committed in the repository use TODO instead. FIXME can be used in your own local repository only.
 
-On top of the Android linter rules (best run for this project using `./gradlew lintVanillaRelease`), we use two linters: [Checkstyle](http://checkstyle.sourceforge.net/) (for Java and some language-independent custom project rules), and [ktlint](https://github.com/pinterest/ktlint) (for Kotlin).
+On top of the Android linter rules (best run for this project using `./gradlew lintWordPressVanillaRelease`), we use two linters: [Checkstyle](http://checkstyle.sourceforge.net/) (for Java and some language-independent custom project rules), and [ktlint](https://github.com/pinterest/ktlint) (for Kotlin).
 
 ## Checkstyle
 


### PR DESCRIPTION
A new `app` dimension was recently added to the build, with the `wordpress` and `jetpack` values. However, the `README.md` and
`docs/coding-style.md` weren't updated to reflect this update. This commit updates both those files and adds the default missing `WordPress` word on the relevant instructions.

To test:
- Go through the updated commands within the `README.md` doc and run them to verify correctness.
  - `./gradlew assembleWordPressVanillaDebug`
  - `./gradlew installWordPressVanillaDebug`
  - `./gradlew :WordPress:testWordPressVanillaDebugUnitTest`
  - `./gradlew :WordPress:connectedWordPressVanillaDebugAndroidTest`
- Go through the updated command within the `docs/config-style.md` doc and run it to verify correctness.
  - `./gradlew lintWordPressVanillaRelease`

## Regression Notes
1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested as described above in the `To test` sections.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
