### PR TITLE
Show blogging reminders bottom sheet from posts list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingReminderUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingReminderUtils.kt
@@ -12,17 +12,16 @@ object BloggingReminderUtils {
         isBottomSheetShowing: LiveData<Event<Boolean>>,
         lifecycleOwner: LifecycleOwner,
         tag: String,
-        getSupportFragmentManager: () -> FragmentManager
+        getSupportFragmentManager: () -> FragmentManager?
     ) {
         isBottomSheetShowing.observeEvent(lifecycleOwner,
             { isShowing: Boolean ->
-                val fm: FragmentManager = getSupportFragmentManager()
-                var bottomSheet = fm
-                    .findFragmentByTag(tag) as BloggingReminderBottomSheetFragment?
+                val fm: FragmentManager = getSupportFragmentManager() ?: return@observeEvent
+                var bottomSheet = fm.findFragmentByTag(tag) as BloggingReminderBottomSheetFragment?
                 if (isShowing && bottomSheet == null) {
                     bottomSheet = BloggingReminderBottomSheetFragment()
                     bottomSheet.show(
-                        getSupportFragmentManager(),
+                        fm,
                         tag
                     )
                 } else if (!isShowing && bottomSheet != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -157,6 +157,12 @@ class BloggingRemindersViewModel @Inject constructor(
         _isFirstTimeFlow.value = state.getBoolean(IS_FIRST_TIME_FLOW)
     }
 
+    fun onPostCreated(siteId: Int, isNewPost: Boolean?) {
+        if (isNewPost == true && bloggingRemindersManager.shouldShowBloggingRemindersPrompt(siteId)) {
+            showBottomSheet(siteId, PROLOGUE)
+        }
+    }
+
     enum class Screen {
         PROLOGUE, SELECTION, EPILOGUE
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1089,10 +1089,11 @@ public class WPMainActivity extends LocaleAwareActivity implements
                                     UploadUtils.publishPost(WPMainActivity.this, post, site, mDispatcher);
                                 }
                             });
-                    boolean isNewPost = data.getBooleanExtra(EditPostActivity.EXTRA_IS_NEW_POST, false);
-                    if (isNewPost && mBloggingRemindersManager.shouldShowBloggingRemindersPrompt(site.getId())) {
-                        mBloggingRemindersViewModel.showBottomSheet(site.getId(), Screen.PROLOGUE);
-                    }
+
+                    mBloggingRemindersViewModel.onPostCreated(
+                            site.getId(),
+                            data.getBooleanExtra(EditPostActivity.EXTRA_IS_NEW_POST, false)
+                    );
                 }
                 break;
             case RequestCodes.CREATE_SITE:

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -81,7 +81,6 @@ import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersManager;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel.Screen;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment;


### PR DESCRIPTION
Fixes #14761 

This PR introduces opening blogging reminders from the posts activity. 

To test:
- Clear the app data and turn on the flag
- Go to the "Blog posts" activity
- Create and publish a new post
- Notice the blogging reminders are started
- Finish the flow
- Notice you're still on the posts list activity

## Regression Notes
1. Potential unintended areas of impact
- none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
