### PR TITLE
Use task avoidance in build.gradle & WordPress/build.gradle

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -469,7 +469,7 @@ android.buildTypes.all { buildType ->
     }
 }
 
-task violationCommentsToGitHub(type: se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask) {
+tasks.register("violationCommentsToGitHub", se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask) {
     repositoryOwner = "wordpress-mobile"
     repositoryName = "WordPress-Android"
     pullRequestId = System.properties['GITHUB_PULLREQUESTID']
@@ -495,7 +495,7 @@ task violationCommentsToGitHub(type: se.bjurr.violations.comments.github.plugin.
     ]
 }
 
-task printVersionName {
+tasks.register("printVersionName") {
     doLast {
         println android.productFlavors.vanilla.versionName
     }

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ subprojects {
         args "-F", "src/**/*.kt"
     }
 
-    task.register("ciktlint", JavaExec) {
+    tasks.register("ciktlint", JavaExec) {
         main = "com.github.shyiko.ktlint.Main"
         classpath = configurations.ktlint
         args "src/**/*.kt", "--reporter=checkstyle,output=${buildDir}/ktlint.xml"

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ allprojects {
         }
     }
 
-    task checkstyle(type: Checkstyle) {
+    tasks.register("checkstyle", Checkstyle) {
         source 'src'
 
         classpath = files()
@@ -91,19 +91,19 @@ subprojects {
         ktlint 'com.github.shyiko:ktlint:0.29.0'
     }
 
-    task ktlint(type: JavaExec) {
+    tasks.register("ktlint", JavaExec) {
         main = "com.github.shyiko.ktlint.Main"
         classpath = configurations.ktlint
         args "src/**/*.kt"
     }
 
-    task ktlintFormat(type: JavaExec) {
+    tasks.register("ktlintFormat", JavaExec) {
         main = "com.github.shyiko.ktlint.Main"
         classpath = configurations.ktlint
         args "-F", "src/**/*.kt"
     }
 
-    task ciktlint(type: JavaExec) {
+    task.register("ciktlint", JavaExec) {
         main = "com.github.shyiko.ktlint.Main"
         classpath = configurations.ktlint
         args "src/**/*.kt", "--reporter=checkstyle,output=${buildDir}/ktlint.xml"
@@ -158,7 +158,7 @@ ext {
 }
 
 // Onboarding and dev env setup tasks
-task checkBundler(type:Exec) {
+tasks.register("checkBundler", Exec) {
     doFirst {
         println "Check Bundler"
     }
@@ -176,7 +176,8 @@ task checkBundler(type:Exec) {
     }
 }
 
-task checkBundle(type:Exec, dependsOn:checkBundler) {
+tasks.register("checkBundle", Exec) {
+    dependsOn tasks.named("checkBundler")
     doFirst {
         println "Check Bundle"
     }
@@ -194,7 +195,8 @@ task checkBundle(type:Exec, dependsOn:checkBundler) {
     }
 }
 
-task applyCredentials(type:Exec, dependsOn:checkBundle) {
+tasks.register("applyCredentials", Exec) {
+    dependsOn tasks.named("checkBundle")
     doFirst {
         println "Apply credentials for this branch"
     }


### PR DESCRIPTION
We have a few tasks that take as much as 25+ seconds to setup during _every_ build and these tasks are actually only used in certain scenarios. This PR updates the tasks in `build.gradle` & `WordPress/build.gradle` to use [Task Configuration Avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html).

In [this scan from current develop's checkstyle task](https://scans.gradle.com/s/ybnwjkzwobmsi/performance/configuration?details=code-unit-build.gradle!:&openScriptsAndPlugins=WyJjb2RlLXVuaXQtYnVpbGQuZ3JhZGxlIl0) you can see that `build.gradle` is creating 72 tasks. In comparison, [the scan for the same checkstyle task for `build.gradle` creates 0 tasks](https://scans.gradle.com/s/fk56bi2mm4g4y/performance/configuration?details=code-unit-build.gradle!:&openScriptsAndPlugins=WyJjb2RlLXVuaXQtYnVpbGQuZ3JhZGxlIl0). You can compare the ones from `WordPress/build.gradle` in a similar fashion.

Note that, this PR does not address all configuration issues. It's just one step in the right direction.

**To test:**
No test necessary since CI will run some of these tasks. But, if you want to test something, you can run one of the updated tasks to verify it still works.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
