### PR TITLE
Remove CircleCI lint task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,7 +407,6 @@ workflows:
     jobs:
       - submodules-strings-check
       - test
-      - lint
       - Installable Build:
           filters:
             branches:
@@ -451,8 +450,5 @@ workflows:
   Release Build:
     when: << pipeline.parameters.release_build >>
     jobs:
-      - lint
-      - Release Build:
-          requires:
-            - lint
+      - Release Build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,41 +64,6 @@ jobs:
           command: ./gradlew :libs:image-editor:ImageEditor:test --stacktrace
       - android/save-gradle-cache
       - android/save-test-results
-  lint:
-    executor:
-      name: android/default
-      api-version: "29"
-    steps:
-      - git/shallow-checkout:
-          init-submodules: true
-      - checkout-submodules
-      - android/restore-gradle-cache
-      - copy-gradle-properties
-      - update-gradle-memory
-      - run:
-          name: Checkstyle
-          command: ./gradlew --stacktrace checkstyle
-      - run:
-          name: ktlint
-          command: ./gradlew --stacktrace ciktlint
-      - run:
-          name: Detekt
-          command: ./gradlew --stacktrace WordPress:detekt
-      - run:
-          name: Lint
-          command: ./gradlew --stacktrace lintWordpressVanillaRelease || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)
-          no_output_timeout: 40m
-      - run:
-          name: Violations
-          when: on_fail
-          command: |
-            if [ -n "$GITHUB_API_TOKEN" ]; then
-              ./gradlew --stacktrace violationCommentsToGitHub -DGITHUB_PULLREQUESTID=${CIRCLE_PULL_REQUEST##*/} -DGITHUB_OAUTH2TOKEN=$GHHELPER_ACCESS
-            else
-              echo "Not posting lint errors to Github because \$GITHUB_API_TOKEN is not found"
-            fi
-      - android/save-gradle-cache
-      - android/save-lint-results
   Installable Build:
     executor:
       name: android/default


### PR DESCRIPTION
Now that lint task is ported to Buildkite in https://github.com/wordpress-mobile/WordPress-Android/pull/14863, we don't need to run the same task in CircleCI anymore. The only task that hasn't been ported yet is the "Violations". I think this is a low impact port, so I've opened an issue and assigned it to myself. https://github.com/wordpress-mobile/WordPress-Android/issues/14916

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
