### PR TITLE
Remove unit tests from CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,28 +42,6 @@ commands:
 
 version: 2.1
 jobs:
-  test:
-    executor:
-      name: android/default
-      api-version: "29"
-    steps:
-      - git/shallow-checkout:
-          init-submodules: true
-      - checkout-submodules
-      - android/restore-gradle-cache
-      - copy-gradle-properties
-      - update-gradle-memory
-      - run:
-          name: Test WordPress
-          command: ./gradlew testWordpressVanillaRelease --stacktrace --no-daemon
-      - run:
-          name: Test WordPressProcessors
-          command: ./gradlew :libs:WordPressProcessors:test --stacktrace
-      - run:
-          name: Test ImageEditor
-          command: ./gradlew :libs:image-editor:ImageEditor:test --stacktrace
-      - android/save-gradle-cache
-      - android/save-test-results
   Installable Build:
     executor:
       name: android/default
@@ -406,7 +384,6 @@ workflows:
         - << pipeline.parameters.release_build >>
     jobs:
       - submodules-strings-check
-      - test
       - Installable Build:
           filters:
             branches:


### PR DESCRIPTION
We have ported these jobs to Buildkite in https://github.com/wordpress-mobile/WordPress-Android/pull/14918.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
