### PR TITLE
Fixing connected tests with SiteStore mock.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '24910cf87b150ec7aa029f0ebde696bee281d159'
+    fluxCVersion = '1.19.2-beta-2'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '04715fa02648ffefe7cd00b0731b82ed2a4cf66e'
+    fluxCVersion = '24910cf87b150ec7aa029f0ebde696bee281d159'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.19.2-beta-1'
+    fluxCVersion = '04715fa02648ffefe7cd00b0731b82ed2a4cf66e'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
This is a companion PR for PR[this FluxC](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2035) and should fix connected tests linked to SiteStore being not mockable.


To test:

Should be enough to trigger optional UI tests and check it's all green.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
