### PR TITLE
Open blogging reminders after story post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -79,7 +79,6 @@ import org.wordpress.android.ui.WPTooltipView;
 import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils;
-import org.wordpress.android.ui.bloggingreminders.BloggingRemindersManager;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
@@ -148,6 +147,7 @@ import javax.inject.Inject;
 
 import static androidx.lifecycle.Lifecycle.State.STARTED;
 import static org.wordpress.android.WordPress.SITE;
+import static org.wordpress.android.editor.gutenberg.GutenbergEditorFragment.ARG_STORY_BLOCK_ID;
 import static org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartVariant.NEXT_STEPS;
 import static org.wordpress.android.login.LoginAnalyticsListener.CreatedAccountSource.EMAIL;
 import static org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE;
@@ -227,7 +227,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Inject QuickStartRepository mQuickStartRepository;
     @Inject QuickStartUtilsWrapper mQuickStartUtilsWrapper;
     @Inject AnalyticsTrackerWrapper mAnalyticsTrackerWrapper;
-    @Inject BloggingRemindersManager mBloggingRemindersManager;
 
     /*
      * fragments implement this if their contents can be scrolled, called when user
@@ -1092,6 +1091,16 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     mBloggingRemindersViewModel.onPostCreated(
                             site.getId(),
                             data.getBooleanExtra(EditPostActivity.EXTRA_IS_NEW_POST, false)
+                    );
+                }
+                break;
+            case RequestCodes.CREATE_STORY:
+                SiteModel selectedSite = mSelectedSiteRepository.getSelectedSite();
+                if (selectedSite != null) {
+                    boolean isNewStory = data == null || data.getStringExtra(ARG_STORY_BLOCK_ID) == null;
+                    mBloggingRemindersViewModel.onPostCreated(
+                            selectedSite.getId(),
+                            isNewStory
                     );
                 }
                 break;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3637,7 +3637,7 @@
     <string name="set_your_blogging_goals_message">Your post is publishing… in the meantime, set up your blogging goals to get reminders, and track your progress.</string>
     <string name="set_your_blogging_goals_button">Set goals</string>
     <string name="blogging_goals_n_a_week">%s a week</string>
-    <string-array name="blogging_goals_count" translatable="false">
+    <string-array name="blogging_goals_count">
         <item>Once</item>
         <item>Twice</item>
         <item>Three times</item>


### PR DESCRIPTION
Fixes #14913 

This PR shows blogging reminders when a new story post is created

To test:
- Make sure you've cleared your app data and turned on the flag
- Create a new story from My Site screen
- Notice the blogging reminders prompt is shown

To test:
- Make sure you've cleared your app data and turned on the flag
- Create a new story from "Blog posts" screen
- Notice the blogging reminders prompt is shown

To test:
- Make sure you've cleared your app data and turned on the flag
- Go to blog posts and edit and save an existing story post
- Notice the blogging reminders prompt is not shown

## Regression Notes
1. Potential unintended areas of impact
- None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
