### PR TITLE
Open FAB actions by default from blogging reminder

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -164,11 +164,13 @@ class PostsListActivity : LocaleAwareActivity(),
                 LocalId(savedInstanceState.getInt(STATE_KEY_BOTTOMSHEET_POST_ID, 0))
             }
 
+            val actionsShownByDefault = intent.getBooleanExtra(ACTIONS_SHOWN_BY_DEFAULT, false)
+
             setupActionBar()
             setupContent()
             initViewModel(initPreviewState, currentBottomSheetPostId)
             initBloggingReminders()
-            initCreateMenuViewModel()
+            initCreateMenuViewModel(actionsShownByDefault)
             loadIntentData(intent)
         }
     }
@@ -219,7 +221,7 @@ class PostsListActivity : LocaleAwareActivity(),
         postPager.adapter = postsPagerAdapter
     }
 
-    private fun PostListActivityBinding.initCreateMenuViewModel() {
+    private fun PostListActivityBinding.initCreateMenuViewModel(actionsShownByDefault: Boolean) {
         postListCreateMenuViewModel = ViewModelProvider(this@PostsListActivity, viewModelFactory)
                 .get(PostListCreateMenuViewModel::class.java)
 
@@ -261,7 +263,7 @@ class PostsListActivity : LocaleAwareActivity(),
             }
         })
 
-        postListCreateMenuViewModel.start(site)
+        postListCreateMenuViewModel.start(site, actionsShownByDefault)
     }
 
     private fun PostListActivityBinding.initViewModel(
@@ -630,11 +632,20 @@ class PostsListActivity : LocaleAwareActivity(),
 
     companion object {
         private const val BLOGGING_REMINDERS_FRAGMENT_TAG = "blogging_reminders_fragment_tag"
+        private const val ACTIONS_SHOWN_BY_DEFAULT = "actions_shown_by_default"
 
         @JvmStatic
         fun buildIntent(context: Context, site: SiteModel): Intent {
             val intent = Intent(context, PostsListActivity::class.java)
             intent.putExtra(WordPress.SITE, site)
+            return buildIntent(context, site, false)
+        }
+
+        @JvmStatic
+        fun buildIntent(context: Context, site: SiteModel, actionsShownByDefault: Boolean): Intent {
+            val intent = Intent(context, PostsListActivity::class.java)
+            intent.putExtra(WordPress.SITE, site)
+            intent.putExtra(ACTIONS_SHOWN_BY_DEFAULT, actionsShownByDefault)
             return intent
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
@@ -40,7 +40,7 @@ class PostListCreateMenuViewModel @Inject constructor(
     private val _isBottomSheetShowing = MutableLiveData<Event<Boolean>>()
     val isBottomSheetShowing: LiveData<Event<Boolean>> = _isBottomSheetShowing
 
-    fun start(site: SiteModel) {
+    fun start(site: SiteModel, actionsShownByDefault: Boolean) {
         if (isStarted) return
         isStarted = true
 
@@ -49,6 +49,9 @@ class PostListCreateMenuViewModel @Inject constructor(
         setMainFabUiState()
 
         loadMainActions()
+        if (actionsShownByDefault) {
+            onFabClicked()
+        }
     }
 
     private fun loadMainActions() {

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
@@ -33,7 +33,7 @@ class ReminderNotifier @Inject constructor(
                     PendingIntent.getActivity(
                             context,
                             0,
-                            PostsListActivity.buildIntent(context, site),
+                            PostsListActivity.buildIntent(context, site, actionsShownByDefault = true),
                             FLAG_CANCEL_CURRENT
                     )
                 },

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModelTest.kt
@@ -31,7 +31,7 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
 
     @Test
     fun `bottom sheet action is new post when new post is tapped`() {
-        viewModel.start(site)
+        viewModel.start(site, false)
         val action = getCreateAction(CREATE_NEW_POST)
         action.onClickAction?.invoke(CREATE_NEW_POST)
 
@@ -40,7 +40,7 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
 
     @Test
     fun `bottom sheet action is new story when new story is tapped`() {
-        viewModel.start(site)
+        viewModel.start(site, false)
         val action = getCreateAction(CREATE_NEW_STORY)
         action.onClickAction?.invoke(CREATE_NEW_STORY)
 
@@ -49,7 +49,7 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
 
     @Test
     fun `bottom sheet showing is triggered with false once an action is tapped`() {
-        viewModel.start(site)
+        viewModel.start(site, false)
         val action = getCreateAction(CREATE_NEW_POST)
         action.onClickAction?.invoke(CREATE_NEW_POST)
 
@@ -58,7 +58,7 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when onFabClicked then bottom sheet showing is true`() {
-        viewModel.start(site)
+        viewModel.start(site, false)
 
         viewModel.onFabClicked()
 
@@ -66,8 +66,16 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `actions shown by default on start`() {
+        viewModel.start(site, true)
+
+        Assertions.assertThat(viewModel.isBottomSheetShowing.value?.getContentIfNotHandled()).isTrue()
+        verify(appPrefsWrapper).setPostListFabTooltipDisabled(eq(true))
+    }
+
+    @Test
     fun `when onFabClicked then appPrefsWrapper's setPostListFabTooltipDisabled is called with true`() {
-        viewModel.start(site)
+        viewModel.start(site, false)
 
         viewModel.onFabClicked()
 
@@ -77,7 +85,7 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
     @Test
     fun `if appPrefsWrapper's isPostListFabTooltipDisabled is false then isFabTooltipVisible is true`() {
         whenever(appPrefsWrapper.isPostListFabTooltipDisabled()).thenReturn(false)
-        viewModel.start(site)
+        viewModel.start(site, false)
 
         Assertions.assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isTrue()
     }
@@ -85,7 +93,7 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
     @Test
     fun `if appPrefsWrapper's isPostListFabTooltipDisabled is true then isFabTooltipVisible is false`() {
         whenever(appPrefsWrapper.isPostListFabTooltipDisabled()).thenReturn(true)
-        viewModel.start(site)
+        viewModel.start(site, false)
 
         Assertions.assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isFalse()
     }
@@ -99,7 +107,7 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when tooltipTapped then isFabTooltipVisible is false`() {
-        viewModel.start(site)
+        viewModel.start(site, false)
         viewModel.onTooltipTapped()
 
         Assertions.assertThat(viewModel.fabUiState.value?.isFabTooltipVisible).isFalse()
@@ -109,14 +117,14 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
     fun `start set expected content message`() {
         whenever(site.isWPCom).thenReturn(true)
 
-        viewModel.start(site)
+        viewModel.start(site, false)
         Assertions.assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
                 .isEqualTo(R.string.create_post_story_fab_tooltip)
     }
 
     @Test
     fun `bottom sheet actions are sorted in the correct order`() {
-        viewModel.start(site)
+        viewModel.start(site, false)
 
         val expectedOrder = listOf(
                 NO_ACTION,


### PR DESCRIPTION
Fixes #14925 

This PR shows the FAB actions when the user clicks on the blogging reminder notification.

To test (little bit tricky):
- I'd recommend modifying the code in `ActivityLauncher::viewCurrentBlogPosts` and pass `actionsShownByDefault == true` as a parameter to the `buildIntent` call
- Go to My Site/Blog posts
- Notice the blog posts are shown and the  FAB actions are expanded
- Dismiss the bottom sheet
- Try device rotation
- The bottom sheet stays hidden

## Regression Notes
1. Potential unintended areas of impact
- Posts list FAB actions

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Unit tests for the PostListCreateMenuViewModel

 
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
