### PR TITLE
[Tooling] Fix version names and codes per variant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,10 +136,10 @@ jobs:
             echo "export VERSION_NAME=$VERSION_NAME" >> $BASH_ENV
       - run:
           name: Build WordPress APK
-          command: ./gradlew --stacktrace assembleWordpressJalapenoDebug -PversionName="$VERSION_NAME"
+          command: ./gradlew --stacktrace assembleWordpressJalapenoDebug -PjalapenoWordPressVersionName="$VERSION_NAME"
       - run:
           name: Build Jetpack APK
-          command: ./gradlew --stacktrace assembleJetpackJalapenoDebug -PversionName="$VERSION_NAME"
+          command: ./gradlew --stacktrace assembleJetpackJalapenoDebug -PjalapenoJetpackVersionName="$VERSION_NAME"
       - android/save-gradle-cache
       - run:
           name: Prepare APK

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,10 +136,10 @@ jobs:
             echo "export VERSION_NAME=$VERSION_NAME" >> $BASH_ENV
       - run:
           name: Build WordPress APK
-          command: ./gradlew --stacktrace assembleWordpressJalapenoDebug -PjalapenoWordPressVersionName="$VERSION_NAME"
+          command: ./gradlew --stacktrace assembleWordpressJalapenoDebug -PversionName="$VERSION_NAME"
       - run:
           name: Build Jetpack APK
-          command: ./gradlew --stacktrace assembleJetpackJalapenoDebug -PjalapenoJetpackVersionName="$VERSION_NAME"
+          command: ./gradlew --stacktrace assembleJetpackJalapenoDebug -PversionName="$VERSION_NAME"
       - android/save-gradle-cache
       - run:
           name: Prepare APK

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:wordpress-mobile/release-toolkit.git
-  revision: c78ca386d4efbe7b46ba9c09a4e45ba584b21835
+  revision: 262e6800830abc75c7d9b6817537b4c099588634
   branch: jetpack/fix-crashes
   specs:
     fastlane-plugin-wpmreleasetoolkit (1.3.0)

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -223,39 +223,33 @@ android {
     }
 
     applicationVariants.all { variant ->
+        def app = variant.productFlavors[0].name
+        def buildType = variant.productFlavors[1].name
         variant.outputs.each { output ->
-            output.versionNameOverride = "aa"
-            output.versionCodeOverride = 11231
+            output.versionNameOverride = versionPropertyForVariant(app, buildType, 'versionName')
+            output.versionCodeOverride = versionPropertyForVariant(app, buildType, 'versionCode')?.toInteger()
         }
     }
 }
 
-BuildConfig.VERSION_NAME
+// Search for a variant-specific variation of a property in `version.properties` file based on the
+// variant's app and buildType flavors. The `property` to be searched is typically either 'versionName' or 'versionCode'.
+//
+// This will search the `version.properties` file for "$app.$buildType.$property" first, and fallback on "$app.$property" then just "$property".
+// Note: If the property is overridden at project level (e.g. '-PversionName'), it will take priority over any value in `version.properties`.
+def versionPropertyForVariant(app, buildType, property) {
+    // If we provide -P override from command line, use it in priority.
+    // This is especially used by CI for jalapeno builds, used for Installable Builds on PRs
+    def propertyFromProjectOverride = project.findProperty(property)
+    if (propertyFromProjectOverride != null) {
+        return propertyFromProjectOverride
+    }
 
-def versionNameFromVariantName(variantName) {
+    // Otherwise (common case), read the value from the version.properties file
     def versionProperties = new Properties()
     file("../version.properties").withInputStream { versionProperties.load(it) }
-    def lowerCaseVariantName = variantName.toLowerCase()
-    if (lowerCaseVariantName.contains("wordpress")) {
-        if (lowerCaseVariantName.contains("zalpha")) {
-            return versionProperties.getProperty("wordpress.alpha.versionName")
-        } else if (lowerCaseVariantName.contains("jalapeno")) {
-            return project.findProperty("jalapenoWordPressVersionName") ?: "arst"
-        } else if (lowerCaseVariantName.contains("vanilla")) {
-            return versionProperties.getProperty("wordpress.vanilla.versionName")
-        }
-    } else if (variantName.contains("jetpack")) {
-        if (lowerCaseVariantName.contains("jalapeno")) {
-            return project.findProperty("jalapenoJetpackVersionName") ?: "arst"
-        } else if (lowerCaseVariantName.contains("vanilla")) {
-            return "jetpack-vanilla"
-        }
-    }
-    return "" //maybe set a name here
-}
 
-android.applicationVariants.all { variant ->
-    println "${variant.name}: ${versionNameFromVariantName(variant.name)}"
+    return versionProperties.getProperty("${app}.${buildType}.${property}") ?: versionProperties.getProperty("${app}.${property}") ?: versionProperties.getProperty(property)
 }
 
 // allows us to use cool things like @Parcelize annotations
@@ -537,12 +531,18 @@ tasks.register("updateVersionProperties") {
 
 tasks.register("printVersionName") {
     doLast {
-        def key = "$productKey" + "."
-        if(project.hasProperty('alpha')) {
-            key += "alpha."
+        def app = project.findProperty('productKey') ?: 'wordpress'
+        def buildType = project.findProperty('buildType') ?: ''
+        println versionPropertyForVariant(app, buildType, 'versionName')
+    }
+}
+
+tasks.register("printAllVersions") {
+    doLast {
+        android.applicationVariants.all { variant ->
+            def apkData = variant.outputs[0].apkData
+            println "${variant.name}: ${apkData.versionName} (${apkData.versionCode})"
         }
-        key += "versionName"
-        println versionProperties.getProperty(key)
     }
 }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -225,31 +225,35 @@ android {
     applicationVariants.all { variant ->
         def app = variant.productFlavors[0].name
         def buildType = variant.productFlavors[1].name
+        def version = versionForVariant(app, buildType)
         variant.outputs.each { output ->
-            output.versionNameOverride = versionPropertyForVariant(app, buildType, 'versionName')
-            output.versionCodeOverride = versionPropertyForVariant(app, buildType, 'versionCode')?.toInteger()
+            output.versionNameOverride = version['versionName']
+            output.versionCodeOverride = version['versionCode']?.toInteger()
         }
     }
 }
 
-// Search for a variant-specific variation of a property in `version.properties` file based on the
-// variant's app and buildType flavors. The `property` to be searched is typically either 'versionName' or 'versionCode'.
+// Search for a variant-specific variation of the versionName and versionCode in `version.properties` file, based on the
+// variant's app and buildType flavors.
 //
-// This will search the `version.properties` file for "$app.$buildType.$property" first, and fallback on "$app.$property" then just "$property".
+// This will search the `version.properties` file for "$app.$buildType.versionName" first, and fallback to "$app.versionName" then just "versionName" (and same for versionCode)
 // Note: If the property is overridden at project level (e.g. '-PversionName'), it will take priority over any value in `version.properties`.
-def versionPropertyForVariant(app, buildType, property) {
-    // If we provide -P override from command line, use it in priority.
-    // This is especially used by CI for jalapeno builds, used for Installable Builds on PRs
-    def propertyFromProjectOverride = project.findProperty(property)
-    if (propertyFromProjectOverride != null) {
-        return propertyFromProjectOverride
-    }
-
-    // Otherwise (common case), read the value from the version.properties file
+//
+// Returns a Hash with keys 'versionName' and 'versionCode', with the found values for the app and buildType provided.
+def versionForVariant(app, buildType) {
     def versionProperties = new Properties()
     file("../version.properties").withInputStream { versionProperties.load(it) }
 
-    return versionProperties.getProperty("${app}.${buildType}.${property}") ?: versionProperties.getProperty("${app}.${property}") ?: versionProperties.getProperty(property)
+    def propertyForVariant = { property ->
+        return project.findProperty(property)
+                ?: versionProperties.getProperty("${app}.${buildType}.${property}")
+                ?: versionProperties.getProperty("${app}.${property}")
+                ?: versionProperties.getProperty(property)
+    }
+
+    def versionName = propertyForVariant('versionName')
+    def versionCode = propertyForVariant('versionCode')
+    return [versionName: versionName, versionCode: versionCode]
 }
 
 // allows us to use cool things like @Parcelize annotations
@@ -533,7 +537,7 @@ tasks.register("printVersionName") {
     doLast {
         def app = project.findProperty('productKey') ?: 'wordpress'
         def buildType = project.findProperty('buildType') ?: ''
-        println versionPropertyForVariant(app, buildType, 'versionName')
+        println versionForVariant(app, buildType)['versionName']
     }
 }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -65,9 +65,6 @@ allOpen {
     annotation 'org.wordpress.android.testing.OpenClassAnnotation'
 }
 
-def versionProperties = new Properties()
-file("../version.properties").withInputStream { versionProperties.load(it) }
-
 android {
     useLibrary 'android.test.runner'
 
@@ -85,8 +82,6 @@ android {
         applicationId "org.wordpress.android"
         archivesBaseName = "$applicationId"
 
-        versionName versionProperties.getProperty("wordpress.alpha.versionName")
-        versionCode versionProperties.getProperty("wordpress.alpha.versionCode").toInteger()
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
@@ -128,8 +123,6 @@ android {
             isDefault true
             dimension "app"
 
-            versionName versionProperties.getProperty("wordpress.versionName")
-            versionCode versionProperties.getProperty("wordpress.versionCode").toInteger()
             applicationId "org.wordpress.android"
             buildConfigField "boolean", "IS_JETPACK_APP", "false"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"wpandroid_"'
@@ -141,8 +134,6 @@ android {
         jetpack {
             dimension "app"
 
-            versionName versionProperties.getProperty("jetpack.versionName")
-            versionCode versionProperties.getProperty("jetpack.versionCode").toInteger()
             applicationId "com.jetpack.android"
             buildConfigField "boolean", "IS_JETPACK_APP", "true"
             buildConfigField "String", "TRACKS_EVENT_PREFIX", '"jpandroid_"'
@@ -230,6 +221,41 @@ android {
     buildFeatures {
         viewBinding true
     }
+
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            output.versionNameOverride = "aa"
+            output.versionCodeOverride = 11231
+        }
+    }
+}
+
+BuildConfig.VERSION_NAME
+
+def versionNameFromVariantName(variantName) {
+    def versionProperties = new Properties()
+    file("../version.properties").withInputStream { versionProperties.load(it) }
+    def lowerCaseVariantName = variantName.toLowerCase()
+    if (lowerCaseVariantName.contains("wordpress")) {
+        if (lowerCaseVariantName.contains("zalpha")) {
+            return versionProperties.getProperty("wordpress.alpha.versionName")
+        } else if (lowerCaseVariantName.contains("jalapeno")) {
+            return project.findProperty("jalapenoWordPressVersionName") ?: "arst"
+        } else if (lowerCaseVariantName.contains("vanilla")) {
+            return versionProperties.getProperty("wordpress.vanilla.versionName")
+        }
+    } else if (variantName.contains("jetpack")) {
+        if (lowerCaseVariantName.contains("jalapeno")) {
+            return project.findProperty("jalapenoJetpackVersionName") ?: "arst"
+        } else if (lowerCaseVariantName.contains("vanilla")) {
+            return "jetpack-vanilla"
+        }
+    }
+    return "" //maybe set a name here
+}
+
+android.applicationVariants.all { variant ->
+    println "${variant.name}: ${versionNameFromVariantName(variant.name)}"
 }
 
 // allows us to use cool things like @Parcelize annotations

--- a/version.properties
+++ b/version.properties
@@ -1,8 +1,8 @@
 #Wed, 23 Jun 2021 19:57:48 +0200
 
 # WordPress version information
-wordpress.versionName=17.6-rc-4
-wordpress.versionCode=1065
+wordpress.vanilla.versionName=17.5
+wordpress.vanilla.versionCode=1064
 
 wordpress.alpha.versionName=alpha-301
 wordpress.alpha.versionCode=1066

--- a/version.properties
+++ b/version.properties
@@ -1,8 +1,8 @@
 #Wed, 23 Jun 2021 19:57:48 +0200
 
 # WordPress version information
-wordpress.versionName=17.5
-wordpress.versionCode=1064
+wordpress.versionName=17.6-rc-4
+wordpress.versionCode=1065
 
 wordpress.zalpha.versionName=alpha-301
 wordpress.zalpha.versionCode=1066

--- a/version.properties
+++ b/version.properties
@@ -1,11 +1,11 @@
 #Wed, 23 Jun 2021 19:57:48 +0200
 
 # WordPress version information
-wordpress.vanilla.versionName=17.5
-wordpress.vanilla.versionCode=1064
+wordpress.versionName=17.5
+wordpress.versionCode=1064
 
-wordpress.alpha.versionName=alpha-301
-wordpress.alpha.versionCode=1066
+wordpress.zalpha.versionName=alpha-301
+wordpress.zalpha.versionCode=1066
 
 # Jetpack version information
 jetpack.versionName=17.6-rc-3


### PR DESCRIPTION
This fixes an issue – introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/14613 when we worked on adding support for the Jetpack app to our `build.gradle` and tooling – with the project versioning configuration.

The way the project configuration was modified in https://github.com/wordpress-mobile/WordPress-Android/pull/14613 (to introduce `version.properties`) made the per-variant resolution of `versionName` and `versionCode` incorrect.

Closes #14886

## To test:

#### Test `printVersionName` & `printAllVersions`

 - `./gradlew -q printVersionName -PproductKey="wordpress" ` should return the value of `wordpress.versionName` in `version.properties`, aka `17.6-rc-4`
 - `./gradlew -q printVersionName -PproductKey="wordpress" -PbuildType="zalpha"` should return the value of `wordpress.zalpha.versionName` in `version.properties`, aka `alpha-301`
 - `./gradlew -q printVersionName -PproductKey="jetpack" ` should return the value of `jetpack.versionName` in `version.properties`, aka `17.6-rc-3`
 - `./gradlew -q printVersionName -PproductKey="jetpack" -PbuildType="zalpha"` should fall back to returning the value of `jetpack.versionName` in `version.properties`, aka `17.6-rc-3` – given there is no zalpha-specific versionName defined in `version.properties` for Jetpack
 - `./gradlew -q printAllVersions` should print the expected versionName and versionCode values for each variant

#### Test the version bumps

 - Cut a branch from this one, and name it with `release` in its name, eg. `test/release/version-fix` (because pre_checks look for 'release' in the current branch name)
 - Run `bundle exec fastlane run android_bump_version_beta app:wordpress`. It should fail when trying to commit/push, but should have updated the values in `version.properties` for **both** `wordpress.version{Name,Code}` and `wordpress.zalpha.version{Name,Code}`.
 - Run `bundle exec fastlane run android_bump_version_beta app:jetpack`. It should fail at the step it tries to commit/push, but should have updated the values in `version.properties` for `jetpack.version{Name,Code}` (no alpha for jetpack).

#### Test that an actual alpha build uses the alpha versions

 - Run `./gradlew bundleWordpressZalphaRelease` then open the generated `aab` in Android Studio (`open -a "Android Studio" WordPress/build/outputs/bundle/wordpressZalphaRelease/org.wordpress.android-wordpress-zalpha-release.aab`) and check that its `versionName` is `alpha-301` and its `versionCode` is `1066`

### Regression Notes

1. Potential unintended areas of impact

Wrong versioning used when building various flavors in various contexts (CI: Installable Builds, Beta and Release Builds)

2. What I did to test those areas of impact (or what existing automated tests I relied on)

 - Ran the tests above
 - Waiting to check the status on [the release build I triggered on CI from this branch](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-Android/24953/workflows/c61d93fc-e73d-423c-b8e0-ee15378de355) to check if it uploads the expected versionNames and versionCodes to the expected tracks on PlayStore

3. What automated tests I added (or what prevented me from doing so)

N/A

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.