### PR TITLE
Fix comment filter and status missmatch

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.kt
@@ -37,8 +37,8 @@ import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCrite
 import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria.ALL
 import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria.APPROVED
 import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria.SPAM
-import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria.TRASHED
-import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria.PENDING
+import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria.TRASH
+import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria.UNAPPROVED
 import org.wordpress.android.ui.comments.CommentsListFragment.CommentStatusCriteria.UNREPLIED
 import org.wordpress.android.ui.comments.CommentsListFragment.OnCommentSelectedListener
 import org.wordpress.android.ui.notifications.NotificationFragment.OnPostClickListener
@@ -51,7 +51,6 @@ import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.setLiftOnScrollTargetViewIdAndRequestLayout
 import org.wordpress.android.widgets.WPSnackbar.Companion.make
 import java.util.HashMap
-import java.util.Locale
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
@@ -67,7 +66,7 @@ class CommentsActivity : LocaleAwareActivity(),
     private lateinit var appBar: AppBarLayout
     private lateinit var site: SiteModel
 
-    private val commentListFilters = listOf(ALL, PENDING, UNREPLIED, APPROVED, SPAM, TRASHED)
+    private val commentListFilters = listOf(ALL, UNAPPROVED, UNREPLIED, APPROVED, SPAM, TRASH)
 
     private var disabledTabsOpacity: Float = 0F
 
@@ -104,8 +103,7 @@ class CommentsActivity : LocaleAwareActivity(),
         viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 val properties: MutableMap<String, String?> = HashMap()
-                properties["selected_filter"] = commentListFilters[position].name.toLowerCase(Locale.US)
-                        .capitalize(Locale.US)
+                properties["selected_filter"] = getString(commentListFilters[position].trackerLabelResId)
                 AnalyticsTracker.track(COMMENT_FILTER_CHANGED, properties)
                 super.onPageSelected(position)
             }
@@ -190,7 +188,7 @@ class CommentsActivity : LocaleAwareActivity(),
         if (oldStatus == CommentStatus.APPROVED || oldStatus == CommentStatus.UNAPPROVED) {
             targetFragments.add(pagerAdapter.getItemAtPosition(commentListFilters.indexOf(ALL)))
             targetFragments.add(pagerAdapter.getItemAtPosition(commentListFilters.indexOf(APPROVED)))
-            targetFragments.add(pagerAdapter.getItemAtPosition(commentListFilters.indexOf(PENDING)))
+            targetFragments.add(pagerAdapter.getItemAtPosition(commentListFilters.indexOf(UNAPPROVED)))
         } else {
             targetFragments.add(
                     pagerAdapter.getItemAtPosition(

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -77,23 +77,30 @@ public class CommentsListFragment extends ViewPagerFragment {
     }
 
     public enum CommentStatusCriteria implements FilterCriteria {
-        ALL(R.string.comment_status_all),
-        PENDING(R.string.comment_status_unapproved),
-        APPROVED(R.string.comment_status_approved),
-        UNREPLIED(R.string.comment_status_unreplied),
-        TRASHED(R.string.comment_status_trash),
-        SPAM(R.string.comment_status_spam),
-        DELETE(R.string.comment_status_trash);
+        ALL(R.string.comment_status_all, R.string.comment_tracker_label_all),
+        UNAPPROVED(R.string.comment_status_unapproved, R.string.comment_tracker_label_pending),
+        APPROVED(R.string.comment_status_approved, R.string.comment_tracker_label_approved),
+        UNREPLIED(R.string.comment_status_unreplied, R.string.comment_tracker_label_unreplied),
+        TRASH(R.string.comment_status_trash, R.string.comment_tracker_label_trashed),
+        SPAM(R.string.comment_status_spam, R.string.comment_tracker_label_spam),
+        DELETE(R.string.comment_status_trash, R.string.comment_tracker_label_trashed);
 
         private final int mLabelResId;
+        private final int mTrackerLabelResId;
 
-        CommentStatusCriteria(@StringRes int labelResId) {
+        CommentStatusCriteria(@StringRes int labelResId, @StringRes int trackerLabelResId) {
             mLabelResId = labelResId;
+            mTrackerLabelResId = trackerLabelResId;
         }
 
         @StringRes
         public int getLabelResId() {
             return mLabelResId;
+        }
+
+        @StringRes
+        public int getTrackerLabelResId() {
+            return mTrackerLabelResId;
         }
 
         @Override
@@ -220,7 +227,7 @@ public class CommentsListFragment extends ViewPagerFragment {
                 case APPROVED:
                     emptyViewMessageStringId = R.string.comments_empty_list_filtered_approved;
                     break;
-                case PENDING:
+                case UNAPPROVED:
                     emptyViewMessageStringId = R.string.comments_empty_list_filtered_pending;
                     break;
                 case UNREPLIED:
@@ -229,7 +236,7 @@ public class CommentsListFragment extends ViewPagerFragment {
                 case SPAM:
                     emptyViewMessageStringId = R.string.comments_empty_list_filtered_spam;
                     break;
-                case TRASHED:
+                case TRASH:
                     emptyViewMessageStringId = R.string.comments_empty_list_filtered_trashed;
                     break;
                 case DELETE:
@@ -410,7 +417,7 @@ public class CommentsListFragment extends ViewPagerFragment {
     }
 
     private void confirmDeleteComments() {
-        if (mCommentStatusFilter == CommentStatusCriteria.TRASHED) {
+        if (mCommentStatusFilter == CommentStatusCriteria.TRASH) {
             AlertDialog.Builder dialogBuilder = new MaterialAlertDialogBuilder(getActivity());
             dialogBuilder.setTitle(getResources().getText(R.string.delete));
             int resId = getAdapter().getSelectedCommentCount() > 1 ? R.string.dlg_sure_to_delete_comments
@@ -606,7 +613,7 @@ public class CommentsListFragment extends ViewPagerFragment {
             setItemEnabled(menu, R.id.menu_trash, hasSelection, true);
 
             final MenuItem trashItem = menu.findItem(R.id.menu_trash);
-            if (trashItem != null && mCommentStatusFilter == CommentStatusCriteria.TRASHED) {
+            if (trashItem != null && mCommentStatusFilter == CommentStatusCriteria.TRASH) {
                 trashItem.setTitle(R.string.mnu_comment_delete_permanently);
             }
             return true;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -430,6 +430,12 @@
     <string name="comment_toast_err_share_intent">Unable to share</string>
     <string name="comment_share_link_via">Share via</string>
     <string name="comment_unable_to_show_error">Unable to show this comment</string>
+    <string name="comment_tracker_label_all" translatable="false">All</string>
+    <string name="comment_tracker_label_pending" translatable="false">Pending</string>
+    <string name="comment_tracker_label_unreplied" translatable="false">Unreplied</string>
+    <string name="comment_tracker_label_approved" translatable="false">Approved</string>
+    <string name="comment_tracker_label_spam" translatable="false">Spam</string>
+    <string name="comment_tracker_label_trashed" translatable="false">Trashed</string>
 
     <!-- comment menu and buttons on comment detail - keep these short! -->
     <string name="mnu_comment_approve">Approve</string>


### PR DESCRIPTION
In #14785 we changed comment filter enum names, which broke their compatibility with Comment Statuses.

I reverted the change to the enum names and added a dedicated tracker label to use with analytics. In unified comments, we should be careful not to depend on enum names for anything.

Steps to reproduce original issue:
- Install the app using code before #14785
- Navigate to comments and visit all the filters.
- Instal the app with #14785 on top of the existing one.
- Navigate to comments and confirm that some filters, like Trashed, contain wrong comments.

To test:
- Using a fresh install of the current `develop` build, navigate to comments and visit all the filters.
- install this PR on top of `develop` build and confirm that the comment filters behave as expected.
- Place breakpoint [here](https://github.com/wordpress-mobile/WordPress-Android/pull/14930/files#diff-e69caa1448202de63f9548fc4d58da2116f62c2f0bad8ea484b0579c0b31d600R107) and using app with non-english locale, confirm that the `selected_filter` properties are All, Pending, Unreplied, Approved, Spam, and Trashed.


PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
