### PR TITLE
Blogging Reminders: Update notification copy

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotifier.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.push.NotificationPushIds.REMINDER_NOTIFICATION_ID
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker
 import org.wordpress.android.ui.posts.PostsListActivity
+import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
@@ -25,7 +26,7 @@ class ReminderNotifier @Inject constructor(
     fun notify(siteId: Int) {
         val context = contextProvider.getContext()
         val site = siteStore.getSiteByLocalId(siteId) ?: return
-        val name = accountStore.account.firstName
+        val siteName = SiteUtils.getSiteNameOrHomeURL(site)
 
         val reminderNotification = ReminderNotification(
                 channel = resourceProvider.getString(R.string.notification_channel_reminder_id),
@@ -37,7 +38,7 @@ class ReminderNotifier @Inject constructor(
                             FLAG_CANCEL_CURRENT
                     )
                 },
-                contentTitle = resourceProvider.getString(R.string.blogging_reminders_notification_title, name),
+                contentTitle = resourceProvider.getString(R.string.blogging_reminders_notification_title, siteName),
                 contentText = resourceProvider.getString(R.string.blogging_reminders_notification_text),
                 priority = PRIORITY_DEFAULT,
                 category = CATEGORY_REMINDER,

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3633,8 +3633,8 @@
     <string name="storage_utils_dialog_dont_show_button">Don\'t Show Again</string>
 
     <!-- Blogging Reminders -->
-    <string name="blogging_reminders_notification_title">%s, it\'s time to blog</string>
-    <string name="blogging_reminders_notification_text">This is your reminder to blog today &#9997;</string>
+    <string name="blogging_reminders_notification_title">It\'s time to blog on %s</string>
+    <string name="blogging_reminders_notification_text">This is your reminder to create something today</string>
     <string name="set_your_blogging_reminders_title">Set your blogging reminders</string>
     <string name="set_your_blogging_reminders_message">Your post is publishing… in the meantime, you can set up blogging reminders on days you want to post.</string>
     <string name="set_your_blogging_reminders_button">Set reminders</string>

--- a/WordPress/src/test/java/org/wordpress/android/workers/reminder/ReminderNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/reminder/ReminderNotifierTest.kt
@@ -8,7 +8,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -28,9 +27,7 @@ class ReminderNotifierTest {
     private val siteStore: SiteStore = mock {
         on { getSiteByLocalId(SITE_ID) } doReturn TEST_SITE
     }
-    private val accountStore: AccountStore = mock {
-        on { account } doReturn TEST_ACCOUNT
-    }
+    private val accountStore: AccountStore = mock()
     private val notificationManager: ReminderNotificationManager = mock()
     private val analyticsTracker: BloggingRemindersAnalyticsTracker = mock()
 
@@ -56,10 +53,6 @@ class ReminderNotifierTest {
     private companion object {
         private val TEST_SITE = SiteModel().apply {
             id = SITE_ID
-        }
-
-        private val TEST_ACCOUNT = AccountModel().apply {
-            userName = "username"
         }
 
         private const val SITE_ID = 1


### PR DESCRIPTION
Fixes #14898

This updates the notification copy according to the latest spec (internal ref: pbArwn-2ox-p2):

<img width=400 src="https://user-images.githubusercontent.com/830056/123360302-97215000-d543-11eb-80fa-a9b79ca902f5.png"/>

To test:

1. Clear app data and log in.
1. Make sure the feature flag is turned on.
1. Comment this line on `ReminderScheduler`:

https://github.com/wordpress-mobile/WordPress-Android/blob/63a72d3f78d01b57ddae5eac6e50730a5f094903/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderScheduler.kt#L31

4. Go through the Blogging Reminders flow and select a few days.
5. Notice the Blogging Reminders notification.

Note: Uncomment the line above and rebuild the app to prevent more notifications from showing up.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.