### PR TITLE
Fix posts screen fast scroll crash (legacy paging)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.19.2-beta-2'
+    fluxCVersion = '23ee0faa'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Issue #14860

Corresponding FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2036

To test:

1. Go to the post list and scroll down quickly
2. Notice that the posts are there and there's no crash

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
