### PR TITLE
Enable Blogging reminders and add release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 17.7
 -----
-
+* [***] Added blogging reminders to site settings and after a new post has been created
 
 17.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BloggingRemindersFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BloggingRemindersFeatureConfig.kt
@@ -1,9 +1,19 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
 import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.util.config.BloggingRemindersFeatureConfig.Companion.BLOGGING_REMINDERS_REMOTE_FIELD
 import javax.inject.Inject
 
-@FeatureInDevelopment
+@Feature(BLOGGING_REMINDERS_REMOTE_FIELD, true)
 class BloggingRemindersFeatureConfig
-@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.BLOGGING_REMINDERS)
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+        appConfig,
+        BuildConfig.BLOGGING_REMINDERS,
+        BLOGGING_REMINDERS_REMOTE_FIELD
+) {
+    companion object {
+        const val BLOGGING_REMINDERS_REMOTE_FIELD = "blogging_reminders_remote_field"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BloggingRemindersFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BloggingRemindersFeatureConfig.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.annotation.Feature
-import org.wordpress.android.annotation.FeatureInDevelopment
 import org.wordpress.android.util.config.BloggingRemindersFeatureConfig.Companion.BLOGGING_REMINDERS_REMOTE_FIELD
 import javax.inject.Inject
 


### PR DESCRIPTION
This PR enables blogging reminders by default, adds the ability to turn it off remotely and adds release notes.

To test:
- Clear app data
- Go to settings 
- Notice the "Blogging reminders" are available without manually turning off the flag

## Regression Notes
1. Potential unintended areas of impact
- none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
