### PR TITLE
Issue/revert paging3 migration

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -300,8 +300,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
     // ProcessLifecycleOwner
     implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
-    // Paging Library
-    implementation("androidx.paging:paging-runtime-ktx:$pagingVersion")
 
     testImplementation("androidx.arch.core:core-testing:$androidxArchCoreVersion", {
         exclude group: 'com.android.support', module: 'support-compat'

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentPagingSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentPagingSource.kt
@@ -1,58 +1,55 @@
 package org.wordpress.android.ui.comments.unified
 
-import androidx.paging.PagingSource
-import androidx.paging.PagingState
-import org.wordpress.android.fluxc.model.CommentModel
-import org.wordpress.android.fluxc.model.CommentStatus
-import org.wordpress.android.util.DateTimeUtils
-import java.util.Date
-
-class CommentPagingSource : PagingSource<Int, CommentModel>() {
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, CommentModel> {
-        return LoadResult.Page(
-                data = generateComments(params.loadSize),
-                prevKey = null, // Only paging forward
-                nextKey = null // Only one page for now
-        )
-    }
-
-    override fun getRefreshKey(state: PagingState<Int, CommentModel>): Int? {
-        return state.anchorPosition?.let { anchorPosition ->
-            val anchorPage = state.closestPageToPosition(anchorPosition)
-            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
-        }
-    }
-
-    // TODO for testing purposes only. Remove after attaching real data source.
-    @Suppress("MagicNumber")
-    fun generateComments(num: Int): List<CommentModel> {
-        val commentListItems = ArrayList<CommentModel>()
-        var startTimestamp = System.currentTimeMillis() / 1000 - (30000 * num)
-
-        for (i in 0..num) {
-            val commentModel = CommentModel()
-            commentModel.id = i
-            commentModel.remoteCommentId = i.toLong()
-            commentModel.postTitle = "Post $i"
-            commentModel.authorName = "Author $i"
-            commentModel.authorEmail = "authors_email$i@wordpress.org"
-            commentModel.content = "Generated <b>Comment</b> <i>Content</i> for Comment with remote ID $i"
-            startTimestamp -= 30000
-            commentModel.publishedTimestamp = startTimestamp
-            commentModel.datePublished = DateTimeUtils.iso8601FromDate(Date(startTimestamp * 1000))
-            commentModel.authorProfileImageUrl = ""
-            if (i % 3 == 0) {
-                commentModel.status = CommentStatus.UNAPPROVED.toString()
-                commentModel.authorProfileImageUrl =
-                        "https://0.gravatar.com/avatar/cec64efa352617c35743d8ed233ab410?s=96&d=identicon&r=G"
-            } else {
-                commentModel.status = CommentStatus.APPROVED.toString()
-                commentModel.authorProfileImageUrl =
-                        "https://0.gravatar.com/avatar/cdc72cf084621e5cf7e42913f3197c13?s=256&d=identicon&r=G"
-            }
-
-            commentListItems.add(commentModel)
-        }
-        return commentListItems
-    }
+/**
+ * Temporarily commented out until migration between Paging 2 and 3 is sorted out.
+ */
+class CommentPagingSource {
+//    : PagingSource<Int, CommentModel>() {
+//    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, CommentModel> {
+//        return LoadResult.Page(
+//                data = generateComments(params.loadSize),
+//                prevKey = null, // Only paging forward
+//                nextKey = null // Only one page for now
+//        )
+//    }
+//
+//    override fun getRefreshKey(state: PagingState<Int, CommentModel>): Int? {
+//        return state.anchorPosition?.let { anchorPosition ->
+//            val anchorPage = state.closestPageToPosition(anchorPosition)
+//            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+//        }
+//    }
+//
+//    // TODO for testing purposes only. Remove after attaching real data source.
+//    @Suppress("MagicNumber")
+//    fun generateComments(num: Int): List<CommentModel> {
+//        val commentListItems = ArrayList<CommentModel>()
+//        var startTimestamp = System.currentTimeMillis() / 1000 - (30000 * num)
+//
+//        for (i in 0..num) {
+//            val commentModel = CommentModel()
+//            commentModel.id = i
+//            commentModel.remoteCommentId = i.toLong()
+//            commentModel.postTitle = "Post $i"
+//            commentModel.authorName = "Author $i"
+//            commentModel.authorEmail = "authors_email$i@wordpress.org"
+//            commentModel.content = "Generated <b>Comment</b> <i>Content</i> for Comment with remote ID $i"
+//            startTimestamp -= 30000
+//            commentModel.publishedTimestamp = startTimestamp
+//            commentModel.datePublished = DateTimeUtils.iso8601FromDate(Date(startTimestamp * 1000))
+//            commentModel.authorProfileImageUrl = ""
+//            if (i % 3 == 0) {
+//                commentModel.status = CommentStatus.UNAPPROVED.toString()
+//                commentModel.authorProfileImageUrl =
+//                        "https://0.gravatar.com/avatar/cec64efa352617c35743d8ed233ab410?s=96&d=identicon&r=G"
+//            } else {
+//                commentModel.status = CommentStatus.APPROVED.toString()
+//                commentModel.authorProfileImageUrl =
+//                        "https://0.gravatar.com/avatar/cdc72cf084621e5cf7e42913f3197c13?s=256&d=identicon&r=G"
+//            }
+//
+//            commentListItems.add(commentModel)
+//        }
+//        return commentListItems
+//    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListAdapter.kt
@@ -6,7 +6,7 @@ import android.content.Context
  * Temporarily commented out untill migration between Paging 2 and 3 is sorted out.
  */
 class UnifiedCommentListAdapter(context: Context) {
-//: PagingDataAdapter<UnifiedCommentListItem,
+// : PagingDataAdapter<UnifiedCommentListItem,
 // UnifiedCommentListViewHolder<*>>(
 //                diffCallback
 //        ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListAdapter.kt
@@ -1,61 +1,47 @@
 package org.wordpress.android.ui.comments.unified
 
 import android.content.Context
-import android.view.ViewGroup
-import androidx.paging.PagingDataAdapter
-import org.wordpress.android.WordPress
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.Comment
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.CommentListItemType.COMMENT
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.CommentListItemType.SUB_HEADER
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.SubHeader
-import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.util.GravatarUtilsWrapper
-import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.viewmodel.ResourceProvider
-import javax.inject.Inject
 
-class UnifiedCommentListAdapter(context: Context) :
-        PagingDataAdapter<UnifiedCommentListItem, UnifiedCommentListViewHolder<*>>(
-                diffCallback
-        ) {
-    @Inject lateinit var imageManager: ImageManager
-    @Inject lateinit var uiHelpers: UiHelpers
-    @Inject lateinit var commentListUiUtils: CommentListUiUtils
-    @Inject lateinit var resourceProvider: ResourceProvider
-    @Inject lateinit var gravatarUtilsWrapper: GravatarUtilsWrapper
-
-    init {
-        (context.applicationContext as WordPress).component().inject(this)
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UnifiedCommentListViewHolder<*> {
-        return when (viewType) {
-            SUB_HEADER.ordinal -> UnifiedCommentSubHeaderViewHolder(parent)
-            COMMENT.ordinal -> UnifiedCommentViewHolder(
-                    parent,
-                    imageManager,
-                    uiHelpers,
-                    commentListUiUtils,
-                    resourceProvider,
-                    gravatarUtilsWrapper
-            )
-            else -> throw IllegalArgumentException("Unexpected view holder in UnifiedCommentListAdapter")
-        }
-    }
-
-    override fun onBindViewHolder(holder: UnifiedCommentListViewHolder<*>, position: Int) {
-        if (holder is UnifiedCommentSubHeaderViewHolder) {
-            holder.bind((getItem(position) as SubHeader))
-        } else if (holder is UnifiedCommentViewHolder) {
-            holder.bind(getItem(position) as Comment)
-        }
-    }
-
-    override fun getItemViewType(position: Int): Int {
-        return getItem(position)!!.type.ordinal
-    }
-
-    companion object {
-        private val diffCallback = UnifiedCommentsListDiffCallback()
-    }
+/**
+ * Temporarily commented out untill migration between Paging 2 and 3 is sorted out.
+ */
+class UnifiedCommentListAdapter(context: Context) {
+//: PagingDataAdapter<UnifiedCommentListItem,
+// UnifiedCommentListViewHolder<*>>(
+//                diffCallback
+//        ) {
+//    init {
+//        (context.applicationContext as WordPress).component().inject(this)
+//    }
+//
+//    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UnifiedCommentListViewHolder<*> {
+//        return when (viewType) {
+//            SUB_HEADER.ordinal -> UnifiedCommentSubHeaderViewHolder(parent)
+//            COMMENT.ordinal -> UnifiedCommentViewHolder(
+//                    parent,
+//                    imageManager,
+//                    uiHelpers,
+//                    commentListUiUtils,
+//                    resourceProvider,
+//                    gravatarUtilsWrapper
+//            )
+//            else -> throw IllegalArgumentException("Unexpected view holder in UnifiedCommentListAdapter")
+//        }
+//    }
+//
+//    override fun onBindViewHolder(holder: UnifiedCommentListViewHolder<*>, position: Int) {
+//        if (holder is UnifiedCommentSubHeaderViewHolder) {
+//            holder.bind((getItem(position) as SubHeader))
+//        } else if (holder is UnifiedCommentViewHolder) {
+//            holder.bind(getItem(position) as Comment)
+//        }
+//    }
+//
+//    override fun getItemViewType(position: Int): Int {
+//        return getItem(position)!!.type.ordinal
+//    }
+//
+//    companion object {
+//        private val diffCallback = UnifiedCommentsListDiffCallback()
+//    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
@@ -6,18 +6,19 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.coroutines.flow.collect
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.CommentListFragmentBinding
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListViewModel.CommentsListUiModel
 import javax.inject.Inject
 
+/**
+ * Temporarily commented out until migration between Paging 2 and 3 is sorted out.
+ */
 class UnifiedCommentListFragment : Fragment(R.layout.comment_list_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
     private lateinit var viewModel: UnifiedCommentListViewModel
-    private lateinit var adapter: UnifiedCommentListAdapter
+//    private lateinit var adapter: UnifiedCommentListAdapter
 
     private var binding: CommentListFragmentBinding? = null
 
@@ -40,27 +41,27 @@ class UnifiedCommentListFragment : Fragment(R.layout.comment_list_fragment) {
         commentsRecyclerView.layoutManager = layoutManager
         commentsRecyclerView.addItemDecoration(UnifiedCommentListItemDecoration(commentsRecyclerView.context))
 
-        adapter = UnifiedCommentListAdapter(requireContext())
-        commentsRecyclerView.adapter = adapter
+//        adapter = UnifiedCommentListAdapter(requireContext())
+//        commentsRecyclerView.adapter = adapter
     }
 
     private fun CommentListFragmentBinding.setupObservers() {
         lifecycleScope.launchWhenStarted {
-            viewModel.uiState.collect { uiState ->
-                setupCommentsList(uiState.commentsListUiModel)
-            }
+//            viewModel.uiState.collect { uiState ->
+//                setupCommentsList(uiState.commentsListUiModel)
+//            }
         }
     }
 
-    private fun CommentListFragmentBinding.setupCommentsList(commentsListUiModel: CommentsListUiModel) {
-        when (commentsListUiModel) {
-            is CommentsListUiModel.Data -> {
-                adapter.submitData(lifecycle, commentsListUiModel.pagingData)
-            }
-            else -> {
-            }
-        }
-    }
+//    private fun CommentListFragmentBinding.setupCommentsList(commentsListUiModel: CommentsListUiModel) {
+//        when (commentsListUiModel) {
+//            is CommentsListUiModel.Data -> {
+//                adapter.submitData(lifecycle, commentsListUiModel.pagingData)
+//            }
+//            else -> {
+//            }
+//        }
+//    }
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
@@ -1,93 +1,76 @@
 package org.wordpress.android.ui.comments.unified
 
-import androidx.lifecycle.viewModelScope
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
-import androidx.paging.cachedIn
-import androidx.paging.insertSeparators
-import androidx.paging.map
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
-import org.wordpress.android.fluxc.model.CommentModel
-import org.wordpress.android.fluxc.model.CommentStatus.UNAPPROVED
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.ClickAction
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.Comment
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.SubHeader
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.ToggleAction
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListViewModel.CommentsListUiModel.Data
-import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
+/**
+ * Temporarily commented out until migration between Paging 2 and 3 is sorted out.
+ */
 class UnifiedCommentListViewModel @Inject constructor(
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {
     private var isStarted = false
-
-    // TODO we would like to explore moving PagingSource into the repository
-    val commentListItemPager = Pager(PagingConfig(pageSize = 30, initialLoadSize = 30)) { CommentPagingSource() }
-
-    private val _selectedIds = MutableStateFlow(emptyList<Long>())
-    val commentListItems: Flow<PagingData<CommentModel>> = commentListItemPager.flow.cachedIn(viewModelScope)
-
-    val uiState: StateFlow<CommentsUiModel> = combine(commentListItems, _selectedIds) { commentListItems, selectedIds ->
-        val mappedCommentListItems = commentListItems.map { commentModel ->
-            val toggleAction = ToggleAction(commentModel.remoteCommentId, this::toggleItem)
-            val clickAction = ClickAction(commentModel.remoteCommentId, this::clickItem)
-
-            val isSelected = selectedIds.contains(commentModel.remoteCommentId)
-            val isPending = commentModel.status == UNAPPROVED.toString()
-
-            Comment(
-                    remoteCommentId = commentModel.remoteCommentId,
-                    postTitle = commentModel.postTitle,
-                    authorName = commentModel.authorName,
-                    authorEmail = commentModel.authorEmail,
-                    content = commentModel.content,
-                    publishedDate = commentModel.datePublished,
-                    publishedTimestamp = commentModel.publishedTimestamp,
-                    authorAvatarUrl = commentModel.authorProfileImageUrl,
-                    isPending = isPending,
-                    isSelected = isSelected,
-                    clickAction = clickAction,
-                    toggleAction = toggleAction
-            )
-        }
-                .insertSeparators { before, current ->
-                    when {
-                        before == null && current != null -> SubHeader(getFormattedDate(current), -1)
-                        before != null && current != null && shouldAddSeparator(before, current) -> SubHeader(
-                                getFormattedDate(current),
-                                -1
-                        )
-                        else -> null
-                    }
-                }
-
-        CommentsUiModel(Data(mappedCommentListItems))
-    }.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.Companion.WhileSubscribed(UI_STATE_FLOW_TIMEOUT_MS),
-            initialValue = CommentsUiModel.buildInitialState()
-    )
-
-    fun shouldAddSeparator(before: Comment, after: Comment): Boolean {
-        return getFormattedDate(before) != getFormattedDate(after)
-    }
-
-    private fun getFormattedDate(comment: Comment): String {
-        return dateTimeUtilsWrapper.javaDateToTimeSpan(DateTimeUtils.dateFromIso8601(comment.publishedDate))
-    }
+//
+//    // TODO we would like to explore moving PagingSource into the repository
+//    val commentListItemPager = Pager(PagingConfig(pageSize = 30, initialLoadSize = 30)) { CommentPagingSource() }
+//
+//    private val _selectedIds = MutableStateFlow(emptyList<Long>())
+//    val commentListItems: Flow<PagingData<CommentModel>> = commentListItemPager.flow.cachedIn(viewModelScope)
+//
+//    val uiState: StateFlow<CommentsUiModel> = combine(commentListItems, _selectedIds) { commentListItems,
+//    selectedIds ->
+//        val mappedCommentListItems = commentListItems.map { commentModel ->
+//            val toggleAction = ToggleAction(commentModel.remoteCommentId, this::toggleItem)
+//            val clickAction = ClickAction(commentModel.remoteCommentId, this::clickItem)
+//
+//            val isSelected = selectedIds.contains(commentModel.remoteCommentId)
+//            val isPending = commentModel.status == UNAPPROVED.toString()
+//
+//            Comment(
+//                    remoteCommentId = commentModel.remoteCommentId,
+//                    postTitle = commentModel.postTitle,
+//                    authorName = commentModel.authorName,
+//                    authorEmail = commentModel.authorEmail,
+//                    content = commentModel.content,
+//                    publishedDate = commentModel.datePublished,
+//                    publishedTimestamp = commentModel.publishedTimestamp,
+//                    authorAvatarUrl = commentModel.authorProfileImageUrl,
+//                    isPending = isPending,
+//                    isSelected = isSelected,
+//                    clickAction = clickAction,
+//                    toggleAction = toggleAction
+//            )
+//        }
+//                .insertSeparators { before, current ->
+//                    when {
+//                        before == null && current != null -> SubHeader(getFormattedDate(current), -1)
+//                        before != null && current != null && shouldAddSeparator(before, current) -> SubHeader(
+//                                getFormattedDate(current),
+//                                -1
+//                        )
+//                        else -> null
+//                    }
+//                }
+//
+//        CommentsUiModel(Data(mappedCommentListItems))
+//    }.stateIn(
+//            scope = viewModelScope,
+//            started = SharingStarted.Companion.WhileSubscribed(UI_STATE_FLOW_TIMEOUT_MS),
+//            initialValue = CommentsUiModel.buildInitialState()
+//    )
+//
+//    fun shouldAddSeparator(before: Comment, after: Comment): Boolean {
+//        return getFormattedDate(before) != getFormattedDate(after)
+//    }
+//
+//    private fun getFormattedDate(comment: Comment): String {
+//        return dateTimeUtilsWrapper.javaDateToTimeSpan(DateTimeUtils.dateFromIso8601(comment.publishedDate))
+//    }
 
     fun start() {
         if (isStarted) return
@@ -102,26 +85,26 @@ class UnifiedCommentListViewModel @Inject constructor(
         // TODO open comment details
     }
 
-    data class CommentsUiModel(
-        val commentsListUiModel: CommentsListUiModel
-    ) {
-        companion object {
-            fun buildInitialState(): CommentsUiModel {
-                return CommentsUiModel(
-                        commentsListUiModel = CommentsListUiModel.Initial
-                )
-            }
-        }
-    }
+//    data class CommentsUiModel(
+//        val commentsListUiModel: CommentsListUiModel
+//    ) {
+//        companion object {
+//            fun buildInitialState(): CommentsUiModel {
+//                return CommentsUiModel(
+//                        commentsListUiModel = CommentsListUiModel.Initial
+//                )
+//            }
+//        }
+//    }
 
-    sealed class CommentsListUiModel {
-        data class Data(val pagingData: PagingData<UnifiedCommentListItem>) :
-                CommentsListUiModel()
-
-        object Initial : CommentsListUiModel()
-    }
-
-    companion object {
-        private const val UI_STATE_FLOW_TIMEOUT_MS = 5000L
-    }
+//    sealed class CommentsListUiModel {
+//        data class Data(val pagingData: PagingData<UnifiedCommentListItem>) :
+//                CommentsListUiModel()
+//
+//        object Initial : CommentsListUiModel()
+//    }
+//
+//    companion object {
+//        private const val UI_STATE_FLOW_TIMEOUT_MS = 5000L
+//    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,6 @@ ext {
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'
     lifecycleVersion = '2.2.0'
-    pagingVersion = '3.0.0'
     constraintLayoutVersion = '1.1.3'
     materialVersion = '1.2.1'
     preferenceVersion = '1.1.0'


### PR DESCRIPTION
Fixes #14860

Migration to Paging 3 is causing some issues with Post List. We need a bit more for a partial or full migration to Paging 3.

This PR removes the Paging 3 dependency and comments out the code that is using it, since it's behind the feature flag.

To test:
- Make sure that the app builds without any issue.
- Go to the post list and scroll down quickly
- Notice that post loading is performed correctly, the list remains visible and nothing crashes.

## Regression Notes
1. Potential unintended areas of impact
We are removing the offending library so should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
