### PR TITLE
Blogging Reminders: Sync flow behavior with latest spec

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -64,7 +64,7 @@ class BloggingRemindersViewModel @Inject constructor(
             }
             val primaryButton = when (screen) {
                 PROLOGUE, PROLOGUE_SETTINGS -> prologueBuilder.buildPrimaryButton(
-                        isFirstTimeFlow ?: false,
+                        isFirstTimeFlow == true,
                         startDaySelection
                 )
                 SELECTION -> daySelectionBuilder.buildPrimaryButton(

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -107,9 +107,8 @@ class BloggingRemindersViewModel @Inject constructor(
         val isPrologueScreen = screen == PROLOGUE || screen == PROLOGUE_SETTINGS
         if (isPrologueScreen) {
             bloggingRemindersManager.bloggingRemindersShown(siteId)
-        } else {
-            _isFirstTimeFlow.value = false
         }
+        _isFirstTimeFlow.value = isPrologueScreen
         _isBottomSheetShowing.value = Event(true)
         _selectedScreen.value = screen
         launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -104,7 +104,8 @@ class BloggingRemindersViewModel @Inject constructor(
     fun showBottomSheet(siteId: Int, screen: Screen, source: Source) {
         analyticsTracker.setSite(siteId)
         analyticsTracker.trackFlowStart(source)
-        if (screen == PROLOGUE) {
+        val isPrologueScreen = screen == PROLOGUE || screen == PROLOGUE_SETTINGS
+        if (isPrologueScreen) {
             bloggingRemindersManager.bloggingRemindersShown(siteId)
         } else {
             _isFirstTimeFlow.value = false


### PR DESCRIPTION
Fixes #14952

Quoting from the issue above:

>We need to make a couple of changes to the behavior of the flow to sync it with the latest spec:
>1. The Selection screen's button should say "Notify me" instead of "Update" when the user has not set reminders before.
>2. The bottom sheet should not appear on the post-publishing flow if the user has started the flow via Site Settings before.

The changes should be pretty straightforward. Also, sorry for the length of the test cases! They should be pretty easy to follow though.

### To test

#### Start flow from Site Settings, dismiss and publish a post

- Clear app data.
- Login.

Start from Site Settings:

1. Go to the Site Settings screen.
1. Tap Blogging Reminders.
1. Notice the bottom sheet appears.
1. Notice the Prologue screen.
1. Dismiss the bottom sheet.

Repeat:

1. Tap Blogging Reminders again.
1. Notice the bottom sheet appears.
1. Notice the Prologue screen.
1. Dismiss the bottom sheet.

Publish a post:

1. Create a new post.
1. Notice the bottom sheet doesn't appear.

#### Start flow from Site Settings, set reminders and publish a post

- Clear app data.
- Login.

Start from Site Settings:

1. Go to the Site Settings screen.
1. Tap Blogging Reminders.
1. Notice the bottom sheet appears.
1. Notice the Prologue screen.
1. Tap "Set reminders".
1. Notice the Selection screen.
1. Notice the disabled "Notify me" button.
1. Select a few days.
1. Notice the "Notify me" button is now enabled.
1. Finish the flow.

Repeat:

1. Tap Blogging Reminders again.
1. Notice the bottom sheet appears.
1. Notice the Selection screen.
1. Notice the Update button.
1. Dismiss the bottom sheet.

Publish a post:

1. Create a new post.
1. Notice the bottom sheet doesn't appear.

#### Publish a post, dismiss and start flow from Site Settings

- Clear app data.
- Login.

Publish a post:

1. Create a new post.
1. Notice the bottom sheet appears.
1. Notice the Prologue screen.
1. Dismiss the bottom sheet.

Repeat:

1. Create another post.
1. Notice the bottom sheet doesn't appear.

Start from Site Settings:

1. Go to the Site Settings screen.
1. Tap Blogging Reminders.
1. Notice the bottom sheet appears.
1. Notice the Prologue screen.
1. Tap "Set reminders".
1. Notice the Selection screen.
1. Notice the disabled "Notify me" button.

#### Publish a post, set reminders and start flow from Site Settings

- Clear app data.
- Login.

Publish a post:

1. Create a new post.
1. Notice the bottom sheet appears.
1. Notice the Prologue screen.
1. Tap "Set reminders".
1. Notice the Selection screen.
1. Notice the disabled "Notify me" button.
1. Select a few days.
1. Notice the "Notify me" button is now enabled.
1. Finish the flow.

Repeat:

1. Create another post.
1. Notice the bottom sheet doesn't appear.

Start from Site Settings:

1. Go to the Site Settings screen.
1. Tap Blogging Reminders.
1. Notice the bottom sheet appears.
1. Notice the Selection screen.
1. Notice the "Update" button.

---

## Regression Notes
1. Potential unintended areas of impact
Other parts of the blogging reminders flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Existing unit tests and manual testing.

3. What automated tests I added (or what prevented me from doing so)
Unit tests.

---

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
