### PR TITLE
Improve transition animation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingReminderBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingReminderBottomSheetFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.RecyclerViewPrimaryButtonBottomSheetBinding
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.disableAnimation
 import javax.inject.Inject
 
 class BloggingReminderBottomSheetFragment : BottomSheetDialogFragment() {
@@ -39,6 +40,7 @@ class BloggingReminderBottomSheetFragment : BottomSheetDialogFragment() {
         with(RecyclerViewPrimaryButtonBottomSheetBinding.bind(view)) {
             contentRecyclerView.layoutManager = LinearLayoutManager(requireActivity())
             contentRecyclerView.adapter = adapter
+            contentRecyclerView.disableAnimation()
             contentRecyclerView.addOnScrollListener(object : OnScrollListener() {
                 override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                     super.onScrolled(recyclerView, dx, dy)
@@ -54,7 +56,7 @@ class BloggingReminderBottomSheetFragment : BottomSheetDialogFragment() {
             viewModel =
                     ViewModelProvider(requireActivity(), viewModelFactory).get(BloggingRemindersViewModel::class.java)
             viewModel.uiState.observe(this@BloggingReminderBottomSheetFragment) { uiState ->
-                (contentRecyclerView.adapter as? BloggingRemindersAdapter)?.update(uiState?.uiItems ?: listOf())
+                (contentRecyclerView.adapter as? BloggingRemindersAdapter)?.submitList(uiState?.uiItems ?: listOf())
                 if (uiState?.primaryButton != null) {
                     primaryButton.visibility = View.VISIBLE
                     uiHelpers.setTextOrHide(primaryButton, uiState.primaryButton.text)

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersAdapter.kt
@@ -1,8 +1,7 @@
 package org.wordpress.android.ui.bloggingreminders
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.RecyclerView.Adapter
+import androidx.recyclerview.widget.ListAdapter
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.Caption
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersDiffCallback.DayButtonsPayload
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons
@@ -29,30 +28,14 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewHolder.Ti
 import org.wordpress.android.ui.utils.UiHelpers
 import javax.inject.Inject
 
-class BloggingRemindersAdapter
-@Inject constructor(private val uiHelpers: UiHelpers) :
-    Adapter<BloggingRemindersViewHolder<*>>() {
-    private var items: List<BloggingRemindersItem> = listOf()
-
-    fun update(newItems: List<BloggingRemindersItem>) {
-        val diffResult = DiffUtil.calculateDiff(
-            BloggingRemindersDiffCallback(
-                items,
-                newItems
-            )
-        )
-        items = newItems
-        diffResult.dispatchUpdatesTo(this)
-    }
-
-    override fun getItemCount(): Int = items.size
-
+class BloggingRemindersAdapter @Inject constructor(private val uiHelpers: UiHelpers) :
+    ListAdapter<BloggingRemindersItem, BloggingRemindersViewHolder<*>>(BloggingRemindersDiffCallback) {
     override fun onBindViewHolder(holder: BloggingRemindersViewHolder<*>, position: Int) {
         onBindViewHolder(holder, position, listOf())
     }
 
     override fun onBindViewHolder(holder: BloggingRemindersViewHolder<*>, position: Int, payloads: List<Any>) {
-        val item = items[position]
+        val item = getItem(position)
         when (holder) {
             is IllustrationViewHolder -> holder.onBind(item as Illustration)
             is TitleViewHolder -> holder.onBind(item as Title)
@@ -77,6 +60,6 @@ class BloggingRemindersAdapter
     }
 
     override fun getItemViewType(position: Int): Int {
-        return items[position].type.ordinal
+        return getItem(position).type.ordinal
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersDiffCallback.kt
@@ -1,37 +1,24 @@
 package org.wordpress.android.ui.bloggingreminders
 
-import androidx.recyclerview.widget.DiffUtil.Callback
+import androidx.recyclerview.widget.DiffUtil
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons
 
-class BloggingRemindersDiffCallback(
-    private val oldList: List<BloggingRemindersItem>,
-    private val newList: List<BloggingRemindersItem>
-) : Callback() {
-    override fun getOldListSize() = oldList.size
-
-    override fun getNewListSize() = newList.size
-
-    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        val oldItem = oldList[oldItemPosition]
-        val newItem = newList[newItemPosition]
+object BloggingRemindersDiffCallback : DiffUtil.ItemCallback<BloggingRemindersItem>(){
+    override fun areItemsTheSame(oldItem: BloggingRemindersItem, newItem: BloggingRemindersItem): Boolean {
         return oldItem.type == newItem.type
     }
 
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        val oldItem = oldList[oldItemPosition]
-        val newItem = newList[newItemPosition]
+    override fun areContentsTheSame(oldItem: BloggingRemindersItem, newItem: BloggingRemindersItem): Boolean {
         return oldItem == newItem
     }
 
-    override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any? {
-        val oldItem = oldList[oldItemPosition]
-        val newItem = newList[newItemPosition]
+    override fun getChangePayload(oldItem: BloggingRemindersItem, newItem: BloggingRemindersItem): Any? {
         if (oldItem is DayButtons && newItem is DayButtons) {
             return DayButtonsPayload(oldItem.dayItems.mapIndexed { index, dayItem ->
                 dayItem != newItem.dayItems[index]
             }.toList())
         }
-        return super.getChangePayload(oldItemPosition, newItemPosition)
+        return super.getChangePayload(oldItem, newItem)
     }
 
     data class DayButtonsPayload(val changedDays: List<Boolean>)

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersDiffCallback.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.bloggingreminders
 import androidx.recyclerview.widget.DiffUtil
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersItem.DayButtons
 
-object BloggingRemindersDiffCallback : DiffUtil.ItemCallback<BloggingRemindersItem>(){
+object BloggingRemindersDiffCallback : DiffUtil.ItemCallback<BloggingRemindersItem>() {
     override fun areItemsTheSame(oldItem: BloggingRemindersItem, newItem: BloggingRemindersItem): Boolean {
         return oldItem.type == newItem.type
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.kt
@@ -9,6 +9,8 @@ import android.view.View
 import android.view.ViewTreeObserver
 import android.view.inputmethod.InputMethodManager
 import androidx.annotation.DimenRes
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SimpleItemAnimator
 
 fun View.setVisible(visible: Boolean) {
     this.visibility = if (visible) View.VISIBLE else View.GONE
@@ -77,4 +79,8 @@ fun View.focusAndShowKeyboard() {
                     }
                 })
     }
+}
+
+fun RecyclerView.disableAnimation() {
+    (itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
 }


### PR DESCRIPTION
Removed transition animation on update in bottom sheet
Refactored code to use ListAdapter

Fixes #14951 

To test:

- Turn on the blogging reminders flag (Me/App settings/Test feature configuration - BloggingRemindersFeatureConfig)
- Notice the blogging goals option appears (My Site > Settings > Blogging reminders)
- Click on for e.g. "Twice a week" button under Blogging goals setting
- Notice the blogging reminders prologue screen is shown for selecting days to blog on
- Select or deselect a few days
- Click on "Update" or "Notify me" button
- Notice the epilogue screen is shown. Done button is enabled, Clicking Done button should dismiss bottom-sheet
- Notice that there will be no animation showing previous items briefly
- Go back and forth to Settings and select, de-select days and see that epilogue shows and previous items do not flicker briefly.


## Regression Notes
1. Potential unintended areas of impact
Site Settings

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Blogging reminders flow from Site Settings

3. What automated tests I added (or what prevented me from doing so)
Unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
