### PR TITLE
Layout Grid: Update the config flag so that is available in production

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -151,7 +151,7 @@ android {
             buildConfigField "long", "REMOTE_CONFIG_FETCH_INTERVAL", "3600"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"
             buildConfigField "boolean", "CONTACT_INFO_BLOCK_AVAILABLE", "true"
-            buildConfigField "boolean", "LAYOUT_GRID_BLOCK_AVAILABLE", "false"
+            buildConfigField "boolean", "LAYOUT_GRID_BLOCK_AVAILABLE", "true"
         }
 
         zalpha { // alpha version - enable experimental features


### PR DESCRIPTION
This Pr makes the Layout Grid feature avaialbe in the realese build by turning on the config flag. 
Layout Grid was made available in develop in https://github.com/wordpress-mobile/WordPress-Android/pull/14667

To test:

## Regression Notes
1. Potential unintended areas of impact
None that I can think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I made sure that the layour grid was available in my build.

3. What automated tests I added (or what prevented me from doing so)
I wasn't sure how to add them.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
