### PR TITLE
[Global Styles] Fixes WordPress version check crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '1.20.1-beta-1'
+    fluxCVersion = '3384496445b577707ce751030bc9d7377683d732'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ ext {
     androidxWorkVersion = "2.4.0"
 
     daggerVersion = '2.29.1'
-    fluxCVersion = '3384496445b577707ce751030bc9d7377683d732'
+    fluxCVersion = '1.20.1-beta-2'
 
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'


### PR DESCRIPTION
Depends on:
* https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2041
* https://github.com/wordpress-mobile/WordPress-Android/pull/14597

## Description
This PR works around the limitation of our [Version](https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/ceca58fa9ec642014a1f3b5d2396752fb619db72/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/Version.java#L16) utility in handling semantic versions (e.g. `5.8-beta4-51251`) by stripping the extra information and keeping only the numeric version string (e.g. `5.8`). This applies only in the specific use case of checking the WordPress software version number for enabling [GSS](https://github.com/WordPress/gutenberg/issues/29063). 

To test:
Follow the test instructions at https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2041

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
