### PR TITLE
Editor Onboarding: "The Basics" help section - Menu option and base RN bridge handling

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -153,24 +153,28 @@ android {
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"
             buildConfigField "boolean", "CONTACT_INFO_BLOCK_AVAILABLE", "true"
             buildConfigField "boolean", "LAYOUT_GRID_BLOCK_AVAILABLE", "false"
+            buildConfigField "boolean", "ENABLE_EDITOR_HELP_OPTION", "false"
         }
 
         zalpha { // alpha version - enable experimental features
             dimension "buildType"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"
+            buildConfigField "boolean", "ENABLE_EDITOR_HELP_OPTION", "true"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationIdSuffix ".beta"
             dimension "buildType"
             buildConfigField "boolean", "UNIFIED_COMMENTS_LIST", "true"
+            buildConfigField "boolean", "ENABLE_EDITOR_HELP_OPTION", "true"
         }
 
         jalapeno { // Pre-Alpha version, used for PR builds, can be installed along release, alpha, beta, dev versions
             isDefault true
             applicationIdSuffix ".prealpha"
             dimension "buildType"
+            buildConfigField "boolean", "ENABLE_EDITOR_HELP_OPTION", "true"
         }
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -153,28 +153,24 @@ android {
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"
             buildConfigField "boolean", "CONTACT_INFO_BLOCK_AVAILABLE", "true"
             buildConfigField "boolean", "LAYOUT_GRID_BLOCK_AVAILABLE", "false"
-            buildConfigField "boolean", "ENABLE_EDITOR_HELP_OPTION", "false"
         }
 
         zalpha { // alpha version - enable experimental features
             dimension "buildType"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
             buildConfigField "boolean", "ENABLE_FEATURE_CONFIGURATION", "false"
-            buildConfigField "boolean", "ENABLE_EDITOR_HELP_OPTION", "true"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationIdSuffix ".beta"
             dimension "buildType"
             buildConfigField "boolean", "UNIFIED_COMMENTS_LIST", "true"
-            buildConfigField "boolean", "ENABLE_EDITOR_HELP_OPTION", "true"
         }
 
         jalapeno { // Pre-Alpha version, used for PR builds, can be installed along release, alpha, beta, dev versions
             isDefault true
             applicationIdSuffix ".prealpha"
             dimension "buildType"
-            buildConfigField "boolean", "ENABLE_EDITOR_HELP_OPTION", "true"
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1467,6 +1467,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
             } else if (itemId == R.id.menu_editor_help) {
                 // Display the editor help page -- option should only be available in the GutenbergEditor
                 if (mEditorFragment instanceof GutenbergEditorFragment) {
+                    ((GutenbergEditorFragment) mEditorFragment).showEditorHelp();
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1272,7 +1272,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
         if (helpMenuItem != null) {
             if (mEditorFragment instanceof GutenbergEditorFragment
-                && BuildConfig.ENABLE_EDITOR_HELP_OPTION
+                && BuildConfig.DEBUG
                 && showMenuItems
             ) {
                 helpMenuItem.setVisible(true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1208,6 +1208,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         MenuItem viewHtmlModeMenuItem = menu.findItem(R.id.menu_html_mode);
         MenuItem historyMenuItem = menu.findItem(R.id.menu_history);
         MenuItem settingsMenuItem = menu.findItem(R.id.menu_post_settings);
+        MenuItem helpMenuItem = menu.findItem(R.id.menu_editor_help);
 
         if (secondaryAction != null && mEditPostRepository.hasPost()) {
             secondaryAction.setVisible(showMenuItems && getSecondaryAction().isVisible());
@@ -1267,6 +1268,17 @@ public class EditPostActivity extends LocaleAwareActivity implements
             });
         } else {
             contentInfo.setVisible(false); // only show the menu item when for Gutenberg
+        }
+
+        if (helpMenuItem != null) {
+            if (mEditorFragment instanceof GutenbergEditorFragment
+                && BuildConfig.ENABLE_EDITOR_HELP_OPTION
+                && showMenuItems
+            ) {
+                helpMenuItem.setVisible(true);
+            } else {
+                helpMenuItem.setVisible(false);
+            }
         }
 
         return super.onPrepareOptionsMenu(menu);
@@ -1451,6 +1463,10 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     mViewModel.finish(ActivityFinishState.SAVED_LOCALLY);
                 } else {
                     logWrongMenuState("Wrong state in menu_switch_to_gutenberg: menu should not be visible.");
+                }
+            } else if (itemId == R.id.menu_editor_help) {
+                // Display the editor help page -- option should only be available in the GutenbergEditor
+                if (mEditorFragment instanceof GutenbergEditorFragment) {
                 }
             }
         }

--- a/WordPress/src/main/res/menu/edit_post.xml
+++ b/WordPress/src/main/res/menu/edit_post.xml
@@ -48,5 +48,10 @@
             android:title="@string/post_settings" >
         </item>
 
+        <item
+            android:id="@+id/menu_editor_help"
+            android:title="@string/help" >
+        </item>
+
     </group>
 </menu>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
     ext.wordPressLoginVersion = '0.0.2'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3686-89f4f8caaa5291db6a55d165a4b5789e75d43eb1'
+    ext.gutenbergMobileVersion = '3686-819a7a969cf17a52052ec1860bbdcda64f0593f0'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
     ext.wordPressLoginVersion = '0.0.2'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'develop-976e2830586f1679fabc297ebab5fac5b1f5fadf'
+    ext.gutenbergMobileVersion = '3686-3a58f9b9359f02f166bd7ef7d95874eedd2f2a1f'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
     ext.wordPressLoginVersion = '0.0.2'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3686-3a58f9b9359f02f166bd7ef7d95874eedd2f2a1f'
+    ext.gutenbergMobileVersion = '3686-f53c4d26b98bda609c61b19455608888f45bc27b'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
     ext.wordPressLoginVersion = '0.0.2'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3686-29b1d020064a12c2890a00989928cf8ea227e8c9'
+    ext.gutenbergMobileVersion = '3686-89f4f8caaa5291db6a55d165a4b5789e75d43eb1'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
     ext.wordPressLoginVersion = '0.0.2'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3686-f53c4d26b98bda609c61b19455608888f45bc27b'
+    ext.gutenbergMobileVersion = '3686-29b1d020064a12c2890a00989928cf8ea227e8c9'
 
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-bb54ee34c5fec5fa7375ce90a356adb5adbdcae0'
     ext.wordPressLoginVersion = '0.0.2'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = '3686-819a7a969cf17a52052ec1860bbdcda64f0593f0'
+    ext.gutenbergMobileVersion = 'v1.57.0-alpha2'
 
     repositories {
         maven {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1662,6 +1662,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         ToastUtils.showToast(getActivity(), message).show();
     }
 
+    @Override public void showEditorHelp() {
+    }
+
     private void onMediaTapped(@NonNull final AztecAttributes attrs, int naturalWidth, int naturalHeight,
                                final MediaType mediaType) {
         if (mediaType == null || !isAdded()) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -47,6 +47,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract void removeMedia(String mediaId);
     // Called from EditPostActivity to let the block editor know when a media selection is cancelled
     public abstract void mediaSelectionCancelled();
+    public abstract void showEditorHelp();
 
 
     public enum MediaType {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -226,6 +226,10 @@ public class GutenbergContainerFragment extends Fragment {
         mWPAndroidGlueCode.showNotice(message);
     }
 
+    public void showEditorHelp() {
+        mWPAndroidGlueCode.showEditorHelp();
+    }
+
     public void updateCapabilities(GutenbergPropsBuilder gutenbergPropsBuilder) {
         // We want to make sure that activity isn't null
         // as it can make this crash to happen: https://github.com/wordpress-mobile/WordPress-Android/issues/13248

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1398,6 +1398,11 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
+    public void showEditorHelp() {
+        getGutenbergContainerFragment().showEditorHelp();
+    }
+
+    @Override
     public void onGutenbergDialogPositiveClicked(@NotNull String instanceTag, int mediaId) {
         switch (instanceTag) {
             case TAG_REPLACE_FEATURED_DIALOG:


### PR DESCRIPTION
**Gutenberg-Mobile**: https://github.com/wordpress-mobile/gutenberg-mobile/pull/3686
**Gutenberg**: https://github.com/WordPress/gutenberg/pull/33083
**WPiOS**: https://github.com/wordpress-mobile/WordPress-iOS/pull/16795

## Description
Partially implements https://github.com/WordPress/gutenberg/issues/30626. This PR is the first in a series to add the "The Basics" help section to the editor and includes:
- A new "Help" menu option in the editor. This option is only available in DEBUG builds)
- The help topics UI will all be in gutenberg so the bridge code has been added to handle that communication.
- Clicking the "Help" menu option will simply display a "Show Editor Help request received by JS!" notice at this point.

## To Test
1. Open a block post in the Gutenberg Editor
2. Click on the overflow menu option in the AppBar, tap on **Help**.
3. Verify the "Show Editor Help request received by JS!" is displayed.

## Screenshots
Help Option | Response
-- | --
![basic-help-1](https://user-images.githubusercontent.com/5810477/124047518-624d4700-d9e2-11eb-9e9f-08b1608a249b.png)|![basic-help-2](https://user-images.githubusercontent.com/5810477/124047521-65483780-d9e2-11eb-8b62-da5cba0ddda6.png)


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
