### PR TITLE
Reverting paging3 migration

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -303,8 +303,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
     // ProcessLifecycleOwner
     implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
-    // Paging Library
-    implementation("androidx.paging:paging-runtime-ktx:$pagingVersion")
 
     testImplementation("androidx.arch.core:core-testing:$androidxArchCoreVersion", {
         exclude group: 'com.android.support', module: 'support-compat'

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentPagingSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentPagingSource.kt
@@ -1,48 +1,55 @@
 package org.wordpress.android.ui.comments.unified
 
-import androidx.paging.PagingSource
-import androidx.paging.PagingState
-import org.wordpress.android.fluxc.model.CommentModel
-import org.wordpress.android.fluxc.model.CommentStatus
-
-class CommentPagingSource : PagingSource<Int, CommentModel>() {
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, CommentModel> {
-        return LoadResult.Page(
-                data = generateComments(params.loadSize),
-                prevKey = null, // Only paging forward
-                nextKey = null // Only one page for now
-        )
-    }
-
-    override fun getRefreshKey(state: PagingState<Int, CommentModel>): Int? {
-        return state.anchorPosition?.let { anchorPosition ->
-            val anchorPage = state.closestPageToPosition(anchorPosition)
-            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
-        }
-    }
-
-    // TODO for testing purposes only. Remove after attaching real data source.
-    @Suppress("MagicNumber")
-    fun generateComments(num: Int): List<CommentModel> {
-        val commentListItems = ArrayList<CommentModel>()
-
-        for (i in 0..num) {
-            val commentModel = CommentModel()
-            commentModel.id = i
-            commentModel.remoteCommentId = i.toLong()
-            commentModel.postTitle = "Post $i"
-            commentModel.authorName = "Author $i"
-            commentModel.authorEmail = "authors_email$i@wordpress.org"
-            commentModel.content = "Generated Comment Content for Comment with remote ID $i"
-            commentModel.authorProfileImageUrl = ""
-            if (i % 3 == 0) {
-                commentModel.status = CommentStatus.UNAPPROVED.toString()
-            } else {
-                commentModel.status = CommentStatus.APPROVED.toString()
-            }
-
-            commentListItems.add(commentModel)
-        }
-        return commentListItems
-    }
+/**
+ * Temporarily commented out until migration between Paging 2 and 3 is sorted out.
+ */
+class CommentPagingSource {
+//    : PagingSource<Int, CommentModel>() {
+//    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, CommentModel> {
+//        return LoadResult.Page(
+//                data = generateComments(params.loadSize),
+//                prevKey = null, // Only paging forward
+//                nextKey = null // Only one page for now
+//        )
+//    }
+//
+//    override fun getRefreshKey(state: PagingState<Int, CommentModel>): Int? {
+//        return state.anchorPosition?.let { anchorPosition ->
+//            val anchorPage = state.closestPageToPosition(anchorPosition)
+//            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+//        }
+//    }
+//
+//    // TODO for testing purposes only. Remove after attaching real data source.
+//    @Suppress("MagicNumber")
+//    fun generateComments(num: Int): List<CommentModel> {
+//        val commentListItems = ArrayList<CommentModel>()
+//        var startTimestamp = System.currentTimeMillis() / 1000 - (30000 * num)
+//
+//        for (i in 0..num) {
+//            val commentModel = CommentModel()
+//            commentModel.id = i
+//            commentModel.remoteCommentId = i.toLong()
+//            commentModel.postTitle = "Post $i"
+//            commentModel.authorName = "Author $i"
+//            commentModel.authorEmail = "authors_email$i@wordpress.org"
+//            commentModel.content = "Generated <b>Comment</b> <i>Content</i> for Comment with remote ID $i"
+//            startTimestamp -= 30000
+//            commentModel.publishedTimestamp = startTimestamp
+//            commentModel.datePublished = DateTimeUtils.iso8601FromDate(Date(startTimestamp * 1000))
+//            commentModel.authorProfileImageUrl = ""
+//            if (i % 3 == 0) {
+//                commentModel.status = CommentStatus.UNAPPROVED.toString()
+//                commentModel.authorProfileImageUrl =
+//                        "https://0.gravatar.com/avatar/cec64efa352617c35743d8ed233ab410?s=96&d=identicon&r=G"
+//            } else {
+//                commentModel.status = CommentStatus.APPROVED.toString()
+//                commentModel.authorProfileImageUrl =
+//                        "https://0.gravatar.com/avatar/cdc72cf084621e5cf7e42913f3197c13?s=256&d=identicon&r=G"
+//            }
+//
+//            commentListItems.add(commentModel)
+//        }
+//        return commentListItems
+//    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListAdapter.kt
@@ -1,49 +1,47 @@
 package org.wordpress.android.ui.comments.unified
 
 import android.content.Context
-import android.view.ViewGroup
-import androidx.paging.PagingDataAdapter
-import org.wordpress.android.WordPress
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.Comment
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.CommentListItemType.COMMENT
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.CommentListItemType.SUB_HEADER
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.SubHeader
-import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.util.image.ImageManager
-import javax.inject.Inject
 
-class UnifiedCommentListAdapter(context: Context) :
-        PagingDataAdapter<UnifiedCommentListItem, UnifiedCommentListViewHolder<*>>(
-        DIFF_CALLBACK
-) {
-    @Inject lateinit var imageManager: ImageManager
-    @Inject lateinit var uiHelpers: UiHelpers
-
-    init {
-        (context.applicationContext as WordPress).component().inject(this)
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UnifiedCommentListViewHolder<*> {
-        return when (viewType) {
-            SUB_HEADER.ordinal -> UnifiedCommentSubHeaderViewHolder(parent)
-            COMMENT.ordinal -> UnifiedCommentViewHolder(parent, imageManager, uiHelpers)
-            else -> throw IllegalArgumentException("Unexpected view holder in UnifiedCommentListAdapter")
-        }
-    }
-
-    override fun onBindViewHolder(holder: UnifiedCommentListViewHolder<*>, position: Int) {
-        if (holder is UnifiedCommentSubHeaderViewHolder) {
-            holder.bind((getItem(position) as SubHeader))
-        } else if (holder is UnifiedCommentViewHolder) {
-            holder.bind(getItem(position) as Comment)
-        }
-    }
-
-    override fun getItemViewType(position: Int): Int {
-        return getItem(position)!!.type.ordinal
-    }
-
-    companion object {
-        private val DIFF_CALLBACK = UnifiedCommentsListDiffCallback()
-    }
+/**
+ * Temporarily commented out untill migration between Paging 2 and 3 is sorted out.
+ */
+class UnifiedCommentListAdapter(context: Context) {
+//: PagingDataAdapter<UnifiedCommentListItem,
+// UnifiedCommentListViewHolder<*>>(
+//                diffCallback
+//        ) {
+//    init {
+//        (context.applicationContext as WordPress).component().inject(this)
+//    }
+//
+//    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UnifiedCommentListViewHolder<*> {
+//        return when (viewType) {
+//            SUB_HEADER.ordinal -> UnifiedCommentSubHeaderViewHolder(parent)
+//            COMMENT.ordinal -> UnifiedCommentViewHolder(
+//                    parent,
+//                    imageManager,
+//                    uiHelpers,
+//                    commentListUiUtils,
+//                    resourceProvider,
+//                    gravatarUtilsWrapper
+//            )
+//            else -> throw IllegalArgumentException("Unexpected view holder in UnifiedCommentListAdapter")
+//        }
+//    }
+//
+//    override fun onBindViewHolder(holder: UnifiedCommentListViewHolder<*>, position: Int) {
+//        if (holder is UnifiedCommentSubHeaderViewHolder) {
+//            holder.bind((getItem(position) as SubHeader))
+//        } else if (holder is UnifiedCommentViewHolder) {
+//            holder.bind(getItem(position) as Comment)
+//        }
+//    }
+//
+//    override fun getItemViewType(position: Int): Int {
+//        return getItem(position)!!.type.ordinal
+//    }
+//
+//    companion object {
+//        private val diffCallback = UnifiedCommentsListDiffCallback()
+//    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListAdapter.kt
@@ -6,7 +6,7 @@ import android.content.Context
  * Temporarily commented out untill migration between Paging 2 and 3 is sorted out.
  */
 class UnifiedCommentListAdapter(context: Context) {
-//: PagingDataAdapter<UnifiedCommentListItem,
+// : PagingDataAdapter<UnifiedCommentListItem,
 // UnifiedCommentListViewHolder<*>>(
 //                diffCallback
 //        ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
@@ -6,17 +6,19 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
-import kotlinx.coroutines.flow.collectLatest
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.CommentListFragmentBinding
-import org.wordpress.android.ui.comments.CommentListItemDecoration
 import javax.inject.Inject
 
+/**
+ * Temporarily commented out until migration between Paging 2 and 3 is sorted out.
+ */
 class UnifiedCommentListFragment : Fragment(R.layout.comment_list_fragment) {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
     private lateinit var viewModel: UnifiedCommentListViewModel
+//    private lateinit var adapter: UnifiedCommentListAdapter
 
     private var binding: CommentListFragmentBinding? = null
 
@@ -37,16 +39,33 @@ class UnifiedCommentListFragment : Fragment(R.layout.comment_list_fragment) {
     private fun CommentListFragmentBinding.setupContentViews() {
         val layoutManager = LinearLayoutManager(context)
         commentsRecyclerView.layoutManager = layoutManager
-        commentsRecyclerView.addItemDecoration(CommentListItemDecoration(commentsRecyclerView.context))
-        commentsRecyclerView.adapter = UnifiedCommentListAdapter(requireContext())
+        commentsRecyclerView.addItemDecoration(UnifiedCommentListItemDecoration(commentsRecyclerView.context))
+
+//        adapter = UnifiedCommentListAdapter(requireContext())
+//        commentsRecyclerView.adapter = adapter
     }
 
     private fun CommentListFragmentBinding.setupObservers() {
         lifecycleScope.launchWhenStarted {
-            viewModel.commentListItems.collectLatest { pagingData ->
-                commentsRecyclerView.adapter?.let { it -> (it as UnifiedCommentListAdapter).submitData(pagingData) }
-            }
+//            viewModel.uiState.collect { uiState ->
+//                setupCommentsList(uiState.commentsListUiModel)
+//            }
         }
+    }
+
+//    private fun CommentListFragmentBinding.setupCommentsList(commentsListUiModel: CommentsListUiModel) {
+//        when (commentsListUiModel) {
+//            is CommentsListUiModel.Data -> {
+//                adapter.submitData(lifecycle, commentsListUiModel.pagingData)
+//            }
+//            else -> {
+//            }
+//        }
+//    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListItemDecoration.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListItemDecoration.kt
@@ -1,0 +1,90 @@
+package org.wordpress.android.ui.comments.unified
+
+import android.R.attr
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ItemDecoration
+import androidx.recyclerview.widget.RecyclerView.State
+import org.wordpress.android.R.dimen
+import org.wordpress.android.util.RtlUtils
+import kotlin.math.roundToInt
+
+/**
+ * CommentListItemDecoration adds margin to the start of the divider and skipp drawing divider for list sub-headers.
+ * Based on DividerItemDecoration.
+ */
+class UnifiedCommentListItemDecoration(val context: Context) : ItemDecoration() {
+    private val divider: Drawable?
+    private val bounds = Rect()
+    private var dividerStartOffset = 0
+
+    override fun onDraw(canvas: Canvas, parent: RecyclerView, state: State) {
+        if (parent.layoutManager == null || divider == null) {
+            return
+        }
+        canvas.save()
+        val left: Int
+        val right: Int
+        if (parent.clipToPadding) {
+            left = parent.paddingStart
+            right = parent.width - parent.paddingEnd
+            canvas.clipRect(
+                    left, parent.paddingTop, right,
+                    parent.height - parent.paddingBottom
+            )
+        } else {
+            left = 0
+            right = parent.width
+        }
+        val childCount = parent.childCount
+        for (i in 0 until childCount) {
+            val child = parent.getChildAt(i)
+            val viewHolder = parent.getChildViewHolder(child)
+            if (viewHolder !is UnifiedCommentSubHeaderViewHolder) {
+                parent.getDecoratedBoundsWithMargins(child, bounds)
+                val bottom = bounds.bottom + child.translationY.roundToInt()
+                val top = bottom - divider.intrinsicHeight
+                if (RtlUtils.isRtl(context)) {
+                    divider.setBounds(left, top, right - dividerStartOffset, bottom)
+                } else {
+                    divider.setBounds(left + dividerStartOffset, top, right, bottom)
+                }
+                divider.draw(canvas)
+            }
+        }
+        canvas.restore()
+    }
+
+    override fun getItemOffsets(
+        outRect: Rect,
+        view: View,
+        parent: RecyclerView,
+        state: State
+    ) {
+        if (divider == null) {
+            outRect[0, 0, 0] = 0
+            return
+        }
+        val viewHolder = parent.getChildViewHolder(view)
+        if (viewHolder is UnifiedCommentSubHeaderViewHolder) {
+            outRect.setEmpty()
+        } else {
+            outRect[0, 0, 0] = divider.intrinsicHeight
+        }
+    }
+
+    companion object {
+        private val ATTRS = intArrayOf(attr.listDivider)
+    }
+
+    init {
+        val attrs = context.obtainStyledAttributes(ATTRS)
+        divider = attrs.getDrawable(0)
+        attrs.recycle()
+        dividerStartOffset = context.resources.getDimensionPixelOffset(dimen.comment_list_divider_start_offset)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListViewModel.kt
@@ -1,55 +1,76 @@
 package org.wordpress.android.ui.comments.unified
 
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.insertSeparators
-import androidx.paging.map
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.map
-import org.wordpress.android.fluxc.model.CommentStatus
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.ClickAction
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.Comment
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.SubHeader
-import org.wordpress.android.ui.comments.unified.UnifiedCommentListItem.ToggleAction
+import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
+/**
+ * Temporarily commented out until migration between Paging 2 and 3 is sorted out.
+ */
 class UnifiedCommentListViewModel @Inject constructor(
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {
     private var isStarted = false
-
-    // TODO we woiuld like to explore moving PagingSource into the repository
-    val commentListItemPager = Pager(PagingConfig(pageSize = 30, initialLoadSize = 30)) { CommentPagingSource() }
-
-    val commentListItems = commentListItemPager.flow
-            .map { pagingData ->
-                pagingData.map { commentModel ->
-                    val toggleAction = ToggleAction(commentModel.remoteCommentId, this::clickItem)
-                    val clickAction = ClickAction(commentModel.remoteCommentId, this::toggleItem)
-                    Comment(
-                            remoteCommentId = commentModel.remoteCommentId,
-                            postTitle = commentModel.postTitle,
-                            authorName = commentModel.authorName,
-                            authorEmail = commentModel.authorEmail,
-                            body = commentModel.content,
-                            avatarUrl = "",
-                            isPending = commentModel.status == CommentStatus.UNAPPROVED.toString(),
-                            isSelected = false,
-                            clickAction = clickAction,
-                            toggleAction = toggleAction
-                    )
-                }
-                        .insertSeparators { before, after ->
-                            when {
-                                before == null -> SubHeader("Date Sub Header", -1)
-                                // TODO add the logic for determining if subheader is necessary or not
-                                else -> null
-                            }
-                        }
-            }
+//
+//    // TODO we would like to explore moving PagingSource into the repository
+//    val commentListItemPager = Pager(PagingConfig(pageSize = 30, initialLoadSize = 30)) { CommentPagingSource() }
+//
+//    private val _selectedIds = MutableStateFlow(emptyList<Long>())
+//    val commentListItems: Flow<PagingData<CommentModel>> = commentListItemPager.flow.cachedIn(viewModelScope)
+//
+//    val uiState: StateFlow<CommentsUiModel> = combine(commentListItems, _selectedIds) { commentListItems,
+//    selectedIds ->
+//        val mappedCommentListItems = commentListItems.map { commentModel ->
+//            val toggleAction = ToggleAction(commentModel.remoteCommentId, this::toggleItem)
+//            val clickAction = ClickAction(commentModel.remoteCommentId, this::clickItem)
+//
+//            val isSelected = selectedIds.contains(commentModel.remoteCommentId)
+//            val isPending = commentModel.status == UNAPPROVED.toString()
+//
+//            Comment(
+//                    remoteCommentId = commentModel.remoteCommentId,
+//                    postTitle = commentModel.postTitle,
+//                    authorName = commentModel.authorName,
+//                    authorEmail = commentModel.authorEmail,
+//                    content = commentModel.content,
+//                    publishedDate = commentModel.datePublished,
+//                    publishedTimestamp = commentModel.publishedTimestamp,
+//                    authorAvatarUrl = commentModel.authorProfileImageUrl,
+//                    isPending = isPending,
+//                    isSelected = isSelected,
+//                    clickAction = clickAction,
+//                    toggleAction = toggleAction
+//            )
+//        }
+//                .insertSeparators { before, current ->
+//                    when {
+//                        before == null && current != null -> SubHeader(getFormattedDate(current), -1)
+//                        before != null && current != null && shouldAddSeparator(before, current) -> SubHeader(
+//                                getFormattedDate(current),
+//                                -1
+//                        )
+//                        else -> null
+//                    }
+//                }
+//
+//        CommentsUiModel(Data(mappedCommentListItems))
+//    }.stateIn(
+//            scope = viewModelScope,
+//            started = SharingStarted.Companion.WhileSubscribed(UI_STATE_FLOW_TIMEOUT_MS),
+//            initialValue = CommentsUiModel.buildInitialState()
+//    )
+//
+//    fun shouldAddSeparator(before: Comment, after: Comment): Boolean {
+//        return getFormattedDate(before) != getFormattedDate(after)
+//    }
+//
+//    private fun getFormattedDate(comment: Comment): String {
+//        return dateTimeUtilsWrapper.javaDateToTimeSpan(DateTimeUtils.dateFromIso8601(comment.publishedDate))
+//    }
 
     fun start() {
         if (isStarted) return
@@ -63,4 +84,27 @@ class UnifiedCommentListViewModel @Inject constructor(
     fun clickItem(remoteCommentId: Long) {
         // TODO open comment details
     }
+
+//    data class CommentsUiModel(
+//        val commentsListUiModel: CommentsListUiModel
+//    ) {
+//        companion object {
+//            fun buildInitialState(): CommentsUiModel {
+//                return CommentsUiModel(
+//                        commentsListUiModel = CommentsListUiModel.Initial
+//                )
+//            }
+//        }
+//    }
+
+//    sealed class CommentsListUiModel {
+//        data class Data(val pagingData: PagingData<UnifiedCommentListItem>) :
+//                CommentsListUiModel()
+//
+//        object Initial : CommentsListUiModel()
+//    }
+//
+//    companion object {
+//        private const val UI_STATE_FLOW_TIMEOUT_MS = 5000L
+//    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,6 @@ ext {
     appCompatVersion = '1.0.2'
     coreVersion = '1.3.2'
     lifecycleVersion = '2.2.0'
-    pagingVersion = '3.0.0'
     constraintLayoutVersion = '1.1.3'
     materialVersion = '1.2.1'
     preferenceVersion = '1.1.0'


### PR DESCRIPTION
This cherry pick changes from #14949 as an hotfix for 17.6

NOTE: code that was cherry picked from 17.7 was slightly ahead respect the original code in 17.6. This required adding the `UnifiedCommentListItemDecoration` that was added in 17.7. All this code is behind a feature flag, so as far as it compiles and we confirm the fix works we should be ok.

Reporting below the description from the original PR for convenience.

Fixes #14860

Migration to Paging 3 is causing some issues with Post List. We need a bit more for a partial or full migration to Paging 3.

This PR removes the Paging 3 dependency and comments out the code that is using it, since it's behind the feature flag.

To test:
- Make sure that the app builds without any issue.
- Go to the post list and scroll down quickly
- Notice that post loading is performed correctly, the list remains visible and nothing crashes.

## Regression Notes
1. Potential unintended areas of impact
We are removing the offending library so should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

